### PR TITLE
fix: use BrowserRouter for /manage/ to remove # from URLs

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html lang="zh-CN">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CLI Proxy API Management Center</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CLI Proxy API Management Center</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/manage-entry.tsx"></script>
+</body>
+
 </html>

--- a/src/manage-entry.tsx
+++ b/src/manage-entry.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { AppRouter } from "@/app/AppRouter";
+import "@/styles/index.css";
+import "goey-toast/styles.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+    throw new Error("根节点 #root 不存在");
+}
+
+createRoot(rootElement).render(
+    <StrictMode>
+        <BrowserRouter basename="/manage">
+            <AppRouter />
+        </BrowserRouter>
+    </StrictMode>,
+);

--- a/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
+++ b/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
@@ -272,9 +272,10 @@ export function ApiKeyLookupPage() {
             : "****"
         : "";
 
-    // 读取 URL 中的 api_key 参数进行自动查询
+    // 读取 URL 中的 api_key 参数进行自动查询（兼容 BrowserRouter 和 HashRouter）
     useEffect(() => {
-        const params = new URLSearchParams(window.location.hash.split("?")[1] ?? "");
+        const searchStr = window.location.search || window.location.hash.split("?")[1] || "";
+        const params = new URLSearchParams(searchStr.startsWith("?") ? searchStr : `?${searchStr}`);
         const key = params.get("api_key") ?? params.get("key") ?? "";
         if (key) {
             setApiKeyInput(key);


### PR DESCRIPTION
## Changes

- Create `manage-entry.tsx` with `BrowserRouter` + `basename=/manage`（无 # 号的清洁 URL）
- Update `manage.html` to reference `manage-entry.tsx`
- Update `ApiKeyLookupPage` URL param parsing for BrowserRouter compatibility

## Result

| Before | After |
|--------|-------|
| `/manage/#/apikey-lookup` | `/manage/apikey-lookup` |
| `/manage/#/system` | `/manage/system` |