### PR TITLE
fix: 统一主题色 + 修复下载按钮换行 + 添加 API Key 查询链接

### DIFF
--- a/manage.html
+++ b/manage.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html lang="zh-CN">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CLI Proxy API Management Center</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CLI Proxy API Management Center</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/manage-entry.tsx"></script>
+</body>
+
 </html>

--- a/src/manage-entry.tsx
+++ b/src/manage-entry.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { AppRouter } from "@/app/AppRouter";
+import "@/styles/index.css";
+import "goey-toast/styles.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+    throw new Error("根节点 #root 不存在");
+}
+
+createRoot(rootElement).render(
+    <StrictMode>
+        <BrowserRouter basename="/manage">
+            <AppRouter />
+        </BrowserRouter>
+    </StrictMode>,
+);

--- a/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
+++ b/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
@@ -272,9 +272,10 @@ export function ApiKeyLookupPage() {
             : "****"
         : "";
 
-    // 读取 URL 中的 api_key 参数进行自动查询
+    // 读取 URL 中的 api_key 参数进行自动查询（兼容 BrowserRouter 和 HashRouter）
     useEffect(() => {
-        const params = new URLSearchParams(window.location.hash.split("?")[1] ?? "");
+        const searchStr = window.location.search || window.location.hash.split("?")[1] || "";
+        const params = new URLSearchParams(searchStr.startsWith("?") ? searchStr : `?${searchStr}`);
         const key = params.get("api_key") ?? params.get("key") ?? "";
         if (key) {
             setApiKeyInput(key);

--- a/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
+++ b/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
@@ -314,8 +314,8 @@ export function ApiKeyLookupPage() {
             <header className="sticky top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70">
                 <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-4 sm:px-6">
                     <div className="flex items-center gap-2.5">
-                        <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 shadow-sm">
-                            <Key size={16} className="text-white" />
+                        <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-slate-900 shadow-sm dark:bg-white">
+                            <Key size={16} className="text-white dark:text-neutral-950" />
                         </div>
                         <span className="text-base font-bold tracking-tight text-slate-900 dark:text-white">
                             API Key 使用查询
@@ -350,7 +350,7 @@ export function ApiKeyLookupPage() {
                         <button
                             type="submit"
                             disabled={busy || !apiKeyInput.trim()}
-                            className="inline-flex min-w-[120px] items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-violet-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:from-indigo-600 hover:to-violet-700 disabled:cursor-not-allowed disabled:opacity-60"
+                            className="inline-flex min-w-[120px] items-center justify-center gap-2 rounded-xl bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-slate-400/35 disabled:cursor-not-allowed disabled:bg-slate-400/70 dark:bg-white dark:text-neutral-950 dark:hover:bg-slate-200 dark:disabled:bg-white/50"
                         >
                             <Search size={16} />
                             {busy ? "查询中…" : "查询"}
@@ -376,8 +376,8 @@ export function ApiKeyLookupPage() {
                         <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70">
                             <div className="flex flex-wrap items-center justify-between gap-4">
                                 <div className="flex items-center gap-3">
-                                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-green-400 to-emerald-500 shadow-sm">
-                                        <Key size={18} className="text-white" />
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900 shadow-sm dark:bg-white">
+                                        <Key size={18} className="text-white dark:text-neutral-950" />
                                     </div>
                                     <div>
                                         <p className="text-sm font-medium text-slate-500 dark:text-white/55">
@@ -692,8 +692,8 @@ export function ApiKeyLookupPage() {
                 {!queriedKey && !error && (
                     <section className="rounded-2xl border border-dashed border-slate-200 bg-white p-16 text-center shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
                         <div className="mx-auto flex max-w-sm flex-col items-center gap-4">
-                            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-100 to-violet-100 dark:from-indigo-950/60 dark:to-violet-950/60">
-                                <Search size={28} className="text-indigo-500 dark:text-indigo-400" />
+                            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 dark:bg-white/10">
+                                <Search size={28} className="text-slate-600 dark:text-white/70" />
                             </div>
                             <h3 className="text-base font-semibold text-slate-900 dark:text-white">
                                 查询您的 API Key 使用情况

--- a/src/modules/system/SystemPage.tsx
+++ b/src/modules/system/SystemPage.tsx
@@ -183,6 +183,17 @@ export function SystemPage() {
               </span>
             </div>
           ))}
+          <div className="flex items-center justify-between gap-4 px-5 py-2.5 text-sm">
+            <span className="text-slate-500 dark:text-white/55">API Key 查询</span>
+            <a
+              href={`${window.location.origin}/manage/apikey-lookup`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="truncate font-mono text-xs text-indigo-600 underline decoration-indigo-600/30 hover:text-indigo-500 hover:decoration-indigo-500/50 dark:text-indigo-400 dark:decoration-indigo-400/30 dark:hover:text-indigo-300"
+            >
+              {`${window.location.origin}/manage/apikey-lookup`}
+            </a>
+          </div>
         </div>
       </div>
 

--- a/src/modules/ui/Button.tsx
+++ b/src/modules/ui/Button.tsx
@@ -16,7 +16,7 @@ export function Button({
   }
 >) {
   const base =
-    "inline-flex items-center justify-center gap-2 rounded-xl font-semibold transition focus-visible:outline-none focus-visible:ring-2";
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-semibold transition focus-visible:outline-none focus-visible:ring-2";
 
   const sizeClass = size === "sm" ? "h-9 px-3 text-sm" : "h-10 px-4 text-sm";
 


### PR DESCRIPTION
- Button: 添加 whitespace-nowrap 防止下载按钮文字垂直换行
- SystemPage: 连接与版本信息中添加 API Key 查询页面链接
- ApiKeyLookupPage: 主题色从 indigo-violet 渐变统一为 slate-900/white