### PR TITLE
chore: remove legacy management center traces

### DIFF
--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -60,28 +60,28 @@ CliRelay 后端新增 Docker-first 自动更新能力，需要前端在用户登
 - 删除 `src/modules/update/` 和 `src/lib/http/apis/update.ts`。
 - 从配置页移除 `auto-update.enabled` 开关，并保留 YAML 手动配置能力。
 
-## 2026-02-22 · 引入 CPAMC 兼容管理中心（多页面构建）
+## 2026-02-22 · 引入历史兼容管理入口（多页面构建）
 
 ### 背景
 
-需要将上游项目 `Cli-Proxy-API-Management-Center` 的完整功能移植到本仓库，作为兼容入口补齐仪表盘/系统信息/使用统计等能力。
+需要在当前仓库内补齐早期兼容管理入口，覆盖仪表盘、系统信息、使用统计等能力，并为后续重写后的主入口演进预留过渡空间。
 
 ### 结论
 
 - 保留现有 Tailwind 后台（`index.html` / `src/main.tsx`）。
-- 新增第二页面入口 `management.html` / `src/management.tsx`，承载 CPAMC 兼容管理中心（HashRouter + SCSS Modules）。
+- 新增第二页面入口 `management.html` / `src/management.tsx`，承载历史兼容管理入口（HashRouter + SCSS Modules）。
 - `vite.config.ts` 改为多页面构建，并补齐 `__APP_VERSION__`、SCSS 预处理与 CSS Modules 配置。
 
 ### 影响范围
 
-- 新增大量 CPAMC 相关目录：`src/pages/`、`src/components/`、`src/services/`、`src/stores/`、`src/i18n/` 等。
+- 新增历史兼容入口相关目录：`src/pages/`、`src/components/`、`src/services/`、`src/stores/`、`src/i18n/` 等。
 - `dist/` 产物新增 `management.html` 及对应静态资源。
 - 依赖新增：`axios`、`zustand`、`i18next`、`react-i18next`、`@uiw/react-codemirror`、`@codemirror/*`、`chart.js`、`react-chartjs-2`、`@tanstack/react-virtual`、`gsap`、`sass` 等。
 
 ### 回滚策略（如适用）
 
 - 删除 `management.html`、`src/management.tsx`，并从 `vite.config.ts` 移除多页面 `rollupOptions.input` 与 SCSS/CSS Modules 配置。
-- 移除 CPAMC 移植目录（`src/pages/` 等）及对应新增依赖后重新 `bun install`。
+- 移除历史兼容入口目录（`src/pages/` 等）及对应新增依赖后重新 `bun install`。
 
 ## 2026-02-22 · 业务功能补齐（保持默认入口为 Tailwind 后台）
 

--- a/manage.html
+++ b/manage.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CLI Proxy API Management Center</title>
+    <title>Code Proxy Admin Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/build/panelMetadata.test.ts
+++ b/src/build/panelMetadata.test.ts
@@ -10,14 +10,14 @@ describe("createPanelMetadata", () => {
       buildDate: "2026-04-20T12:00:00.000Z",
       commit: "a28920de945ac13611eb88315cf5aff895bb8c78",
       ref: "dev",
-      repository: "https://github.com/router-for-me/Cli-Proxy-API-Management-Center.git",
+      repository: "https://github.com/kittors/codeProxy.git",
     });
 
     expect(metadata).toEqual({
       build_date: "2026-04-20T12:00:00.000Z",
       commit: "a28920de945ac13611eb88315cf5aff895bb8c78",
       ref: "dev",
-      repository: "https://github.com/router-for-me/Cli-Proxy-API-Management-Center.git",
+      repository: "https://github.com/kittors/codeProxy.git",
       version: "panel-dev-a28920d",
     });
   });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -76,9 +76,9 @@
     "reset_image": "Reset image"
   },
   "title": {
-    "main": "CLI Proxy API Management Center",
-    "login": "CLI Proxy API Management Center",
-    "abbr": "CPAMC"
+    "main": "Code Proxy Admin Dashboard",
+    "login": "Code Proxy Admin Dashboard",
+    "abbr": "CPAD"
   },
   "splash": {
     "title": "CLI Proxy API",
@@ -155,7 +155,7 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "subtitle": "Welcome to CLI Proxy API Management Center",
+    "subtitle": "Welcome to Code Proxy Admin Dashboard",
     "openai_providers": "OpenAI Providers",
     "quick_actions": "Quick Actions",
     "current_config": "Current Configuration",
@@ -1378,7 +1378,7 @@
   },
   "system_info": {
     "title": "Management Center Info",
-    "about_title": "CLI Proxy API Management Center",
+    "about_title": "Code Proxy Admin Dashboard",
     "connection_status_title": "Connection Status",
     "api_status_label": "API Status:",
     "config_status_label": "Config Status:",
@@ -1410,7 +1410,7 @@
     "link_main_repo": "Main Repository",
     "link_main_repo_desc": "CLI Proxy API core program source code",
     "link_webui_repo": "WebUI Repository",
-    "link_webui_repo_desc": "Management Center frontend source code",
+    "link_webui_repo_desc": "Code Proxy admin frontend source code",
     "link_docs": "Documentation",
     "link_docs_desc": "Usage tutorials and configuration guides",
     "clear_login_title": "Local Login Data",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -58,9 +58,9 @@
     "reset_image": "Сбросить изображение"
   },
   "title": {
-    "main": "Центр управления CLI Proxy API",
-    "login": "Центр управления CLI Proxy API",
-    "abbr": "CPAMC"
+    "main": "Панель администратора Code Proxy",
+    "login": "Панель администратора Code Proxy",
+    "abbr": "CPAD"
   },
   "splash": {
     "title": "CLI Proxy API",
@@ -1178,7 +1178,7 @@
   },
   "system_info": {
     "title": "Информация о центре управления",
-    "about_title": "CLI Proxy API Management Center",
+    "about_title": "Панель администратора Code Proxy",
     "connection_status_title": "Статус подключения",
     "api_status_label": "Статус API:",
     "config_status_label": "Статус конфигурации:",
@@ -1210,7 +1210,7 @@
     "link_main_repo": "Основной репозиторий",
     "link_main_repo_desc": "Исходный код основной программы CLI Proxy API",
     "link_webui_repo": "Репозиторий WebUI",
-    "link_webui_repo_desc": "Исходный код фронтенда центра управления",
+    "link_webui_repo_desc": "Исходный код панели администратора Code Proxy",
     "link_docs": "Документация",
     "link_docs_desc": "Учебные пособия и руководства по настройке",
     "clear_login_title": "Локальные данные входа",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -78,9 +78,9 @@
     "reset_image": "还原图片"
   },
   "title": {
-    "main": "CLI Proxy API Management Center",
-    "login": "CLI Proxy API Management Center",
-    "abbr": "CPAMC"
+    "main": "Code Proxy 管理后台",
+    "login": "Code Proxy 管理后台",
+    "abbr": "CPAD"
   },
   "splash": {
     "title": "CLI Proxy API",
@@ -1389,7 +1389,7 @@
   },
   "system_info": {
     "title": "管理中心信息",
-    "about_title": "CLI Proxy API Management Center",
+    "about_title": "Code Proxy 管理后台",
     "connection_status_title": "连接状态",
     "api_status_label": "API 状态:",
     "config_status_label": "配置状态:",
@@ -1421,7 +1421,7 @@
     "link_main_repo": "主程序仓库",
     "link_main_repo_desc": "CLI Proxy API 核心程序源代码",
     "link_webui_repo": "WebUI 仓库",
-    "link_webui_repo_desc": "管理中心前端界面源代码",
+    "link_webui_repo_desc": "Code Proxy 管理后台前端源代码",
     "link_docs": "使用教程",
     "link_docs_desc": "配置指南和使用说明",
     "clear_login_title": "本地登录信息",


### PR DESCRIPTION
## Summary
- Replace old Management Center branding in frontend titles and i18n strings with Code Proxy admin branding.
- Remove the legacy upstream management-center repository URL from panel metadata tests.
- Rewrite the evolution note so it no longer references the old CPAMC/fork origin.

## Test Plan
- bun run lint
- bun run test src/build/panelMetadata.test.ts
- bun run check
- rg legacy fork source strings (0 matches)

## Notes
- Preserved functional OAuth alias `fork` fields; those are business data, not old project-origin references.