### PR TITLE
fix: polish proxy table chrome

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1751,8 +1751,6 @@
     "name": "Name",
     "url": "Proxy URL",
     "description_label": "Description",
-    "table_title": "Proxy Pool",
-    "table_description": "Manage proxy entries in a compact table. Use row actions to check, edit, or delete a proxy.",
     "table_caption": "Proxy pool table",
     "status": "Status",
     "last_check": "Last check",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1350,8 +1350,6 @@
     "name": "Name",
     "url": "Proxy URL",
     "description_label": "Description",
-    "table_title": "Proxy Pool",
-    "table_description": "Manage proxy entries in a compact table. Use row actions to check, edit, or delete a proxy.",
     "table_caption": "Proxy pool table",
     "status": "Status",
     "last_check": "Last check",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1766,8 +1766,6 @@
     "name": "名称",
     "url": "代理 URL",
     "description_label": "说明",
-    "table_title": "代理池",
-    "table_description": "以表格方式管理代理条目，可在行内执行检测、编辑和删除操作。",
     "table_caption": "代理池表格",
     "status": "状态",
     "last_check": "最近检测",

--- a/src/modules/proxies/ProxiesPage.tsx
+++ b/src/modules/proxies/ProxiesPage.tsx
@@ -129,7 +129,7 @@ export function ProxiesPage() {
       {
         key: "name",
         label: t("proxies.name"),
-        width: "w-56",
+        width: "w-44",
         render: (entry) => (
           <div className="min-w-0">
             <div className="flex min-w-0 items-center gap-2">
@@ -149,7 +149,7 @@ export function ProxiesPage() {
       {
         key: "url",
         label: t("proxies.url"),
-        width: "w-[360px]",
+        width: "w-[280px]",
         render: (entry) => (
           <p className="truncate font-mono text-xs text-slate-700 dark:text-white/70">
             {proxyDisplayURL(entry)}
@@ -159,7 +159,7 @@ export function ProxiesPage() {
       {
         key: "status",
         label: t("proxies.status"),
-        width: "w-32",
+        width: "w-24",
         render: (entry) => (
           <span
             className={[
@@ -176,7 +176,7 @@ export function ProxiesPage() {
       {
         key: "check",
         label: t("proxies.last_check"),
-        width: "w-44",
+        width: "w-32",
         render: (entry) => {
           const result = checkState[entry.id];
           if (!result || result.checking) {
@@ -205,7 +205,7 @@ export function ProxiesPage() {
       {
         key: "description",
         label: t("proxies.description_label"),
-        width: "w-[280px]",
+        width: "w-[180px]",
         render: (entry) => (
           <p className="truncate text-xs text-slate-600 dark:text-white/60">
             {entry.description || "--"}
@@ -215,7 +215,7 @@ export function ProxiesPage() {
       {
         key: "actions",
         label: t("proxies.actions"),
-        width: "w-36",
+        width: "w-28",
         headerClassName: "text-right",
         cellClassName: "text-right",
         render: (entry) => {
@@ -282,21 +282,20 @@ export function ProxiesPage() {
       </div>
 
       <Card
-        title={t("proxies.table_title")}
-        description={t("proxies.table_description")}
         padding="none"
-        bodyClassName="mt-0"
+        className="overflow-hidden"
         loading={loading}
       >
         <VirtualTable<ProxyPoolEntry>
           rows={sortedEntries}
           columns={columns}
           rowKey={(entry) => entry.id}
-          rowHeight={58}
+          rowHeight={56}
           height="h-auto max-h-[70vh]"
-          minWidth="min-w-[1320px]"
+          minHeight="min-h-[240px]"
+          minWidth="min-w-[960px]"
           caption={t("proxies.table_caption")}
-          emptyText={t("proxies.empty_desc")}
+          emptyText={t("proxies.empty_title")}
           showAllLoadedMessage={false}
         />
       </Card>

--- a/src/modules/proxies/__tests__/ProxiesPage.test.tsx
+++ b/src/modules/proxies/__tests__/ProxiesPage.test.tsx
@@ -66,6 +66,18 @@ describe("ProxiesPage", () => {
     expect(screen.getByRole("button", { name: /check hk proxy/i })).toBeInTheDocument();
   });
 
+  test("keeps the proxy table chrome minimal when empty", async () => {
+    mocks.apiGet.mockResolvedValue({ items: [] });
+
+    renderPage();
+
+    expect(await screen.findByRole("table", { name: /proxy pool table/i })).toBeInTheDocument();
+    expect(screen.queryByText("Proxy Pool")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Manage proxy entries in a compact table/i)).not.toBeInTheDocument();
+    expect(screen.getByText("No proxies yet")).toBeInTheDocument();
+    expect(screen.queryByText(/Add HTTP, HTTPS, or SOCKS5 proxies/i)).not.toBeInTheDocument();
+  });
+
   test("adds a proxy and persists through the proxy pool API", async () => {
     renderPage();
 


### PR DESCRIPTION
## Summary
- Remove the redundant proxy table title and explanatory copy
- Use a short empty-state message inside the table
- Tighten proxy table column widths so the actions column stays visible on narrower desktop widths

## Verification
- bun run test src/modules/proxies/__tests__/ProxiesPage.test.tsx
- bun run lint
- bun run test
- bun run build
- Browser check against local dev server with a mocked management API
