### PR TITLE
fix: align proxy table spacing

### DIFF
--- a/src/modules/proxies/ProxiesPage.tsx
+++ b/src/modules/proxies/ProxiesPage.tsx
@@ -281,11 +281,7 @@ export function ProxiesPage() {
         </div>
       </div>
 
-      <Card
-        padding="none"
-        className="overflow-hidden"
-        loading={loading}
-      >
+      <Card className="overflow-hidden" loading={loading}>
         <VirtualTable<ProxyPoolEntry>
           rows={sortedEntries}
           columns={columns}

--- a/src/modules/proxies/__tests__/ProxiesPage.test.tsx
+++ b/src/modules/proxies/__tests__/ProxiesPage.test.tsx
@@ -71,7 +71,9 @@ describe("ProxiesPage", () => {
 
     renderPage();
 
-    expect(await screen.findByRole("table", { name: /proxy pool table/i })).toBeInTheDocument();
+    const table = await screen.findByRole("table", { name: /proxy pool table/i });
+    expect(table).toBeInTheDocument();
+    expect(table.closest("section")).toHaveClass("p-5");
     expect(screen.queryByText("Proxy Pool")).not.toBeInTheDocument();
     expect(screen.queryByText(/Manage proxy entries in a compact table/i)).not.toBeInTheDocument();
     expect(screen.getByText("No proxies yet")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- restore the proxy table card's default padding so it matches the API Keys page rhythm
- add a regression assertion that the proxy table is rendered inside the padded Card section

## Verification
- bun run test src/modules/proxies/__tests__/ProxiesPage.test.tsx
- bun run lint
- bun run build
- in-app browser visual check at http://127.0.0.1:5176/manage/#/proxies