### PR TITLE
fix: raise virtual table scrollbar layers

### DIFF
--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -528,7 +528,7 @@ export function VirtualTable<T>({
 
   return (
     <div
-      className={`${height} ${minHeight} relative grid min-w-0 grid-cols-[minmax(0,1fr)_0.75rem] overflow-hidden group`}
+      className={`${height} ${minHeight} group relative isolate grid min-w-0 grid-cols-[minmax(0,1fr)_0.75rem] overflow-hidden`}
     >
       <div
         data-vt-header-backdrop
@@ -654,7 +654,7 @@ export function VirtualTable<T>({
 
       <div
         data-vt-scrollbar-gutter
-        className="relative z-20 col-start-2 row-start-1 h-full w-3 justify-self-end"
+        className="relative z-30 col-start-2 row-start-1 h-full w-3 justify-self-end"
       >
         <div
           data-vt-header-gutter
@@ -664,7 +664,7 @@ export function VirtualTable<T>({
         {vThumb ? (
           <div
             data-vt-scrollbar="y"
-            className="pointer-events-auto absolute right-0 w-2 opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+            className="pointer-events-auto absolute right-0 z-30 w-2 opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
             style={{ top: headerHeight + 8, bottom: 8 }}
           >
             <div className="absolute inset-0 rounded-full bg-slate-200/40 dark:bg-white/10" />
@@ -684,7 +684,7 @@ export function VirtualTable<T>({
       {hThumb ? (
         <div
           data-vt-scrollbar="x"
-          className="pointer-events-auto absolute bottom-1 left-2 right-5 h-2 opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+          className="pointer-events-auto absolute bottom-1 left-2 right-5 z-30 h-2 opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
         >
           <div className="absolute inset-0 rounded-full bg-slate-200/40 dark:bg-white/10" />
           <div

--- a/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
@@ -137,6 +137,44 @@ describe("VirtualTable scrollbar wrapper", () => {
     });
   });
 
+  test("keeps custom scrollbar layers above row content badges", async () => {
+    const { container } = render(
+      <VirtualTable
+        rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
+        columns={columns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const scrollContainer = container.querySelector(".table-scrollbar") as HTMLDivElement | null;
+    expect(scrollContainer).not.toBeNull();
+
+    setScrollMetrics(scrollContainer!, {
+      clientHeight: 160,
+      scrollHeight: 640,
+      clientWidth: 260,
+      scrollWidth: 780,
+    });
+
+    window.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      const root = scrollContainer!.parentElement as HTMLDivElement | null;
+      const gutter = container.querySelector("[data-vt-scrollbar-gutter]") as HTMLDivElement | null;
+      const yTrack = container.querySelector('[data-vt-scrollbar="y"]') as HTMLDivElement | null;
+      const xTrack = container.querySelector('[data-vt-scrollbar="x"]') as HTMLDivElement | null;
+
+      expect(root).toHaveClass("isolate");
+      expect(scrollContainer).toHaveClass("z-10");
+      expect(gutter).toHaveClass("z-30");
+      expect(yTrack).toHaveClass("z-30");
+      expect(xTrack).toHaveClass("z-30");
+    });
+  });
+
   test("keeps the vertical scrollbar in a gutter outside the table viewport", async () => {
     const { container } = render(
       <VirtualTable


### PR DESCRIPTION
## Summary
- isolate the VirtualTable stacking context so internal z-index rules stay local
- raise vertical and horizontal custom scrollbar layers above table row content and sticky elements
- add regression coverage to prevent row badges/tags from covering scrollbar tracks

## Verification
- bun run test -- src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
- bunx oxfmt src/modules/ui/VirtualTable.tsx src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx --check
- bun run lint
- bun run build
- bun run check

## Note
- bunx oxfmt . --check still reports existing formatting issues in 48 unrelated files on the current dev baseline, so this PR keeps formatting scoped to the touched files.