### PR TITLE
fix: normalize proxy check results

### DIFF
--- a/src/lib/http/apis/__tests__/proxies.test.ts
+++ b/src/lib/http/apis/__tests__/proxies.test.ts
@@ -46,17 +46,17 @@ describe("proxiesApi", () => {
     });
   });
 
-  test("checks a proxy entry with a short timeout", async () => {
+  test("checks a proxy entry with a short timeout and normalizes backend field names", async () => {
     const { proxiesApi } = await import("@/lib/http/apis/proxies");
-    postMock.mockResolvedValue({ ok: true, statusCode: 204, latencyMs: 24 });
+    postMock.mockResolvedValue({ ok: true, status_code: 204, latency_ms: 24 });
 
-    await proxiesApi.check({ id: "hk" });
+    const result = await proxiesApi.check({ id: "hk" });
 
     expect(postMock).toHaveBeenCalledWith(
       "/proxy-pool/check",
       { id: "hk" },
       expect.objectContaining({ timeoutMs: 12000 }),
     );
+    expect(result).toEqual({ ok: true, statusCode: 204, latencyMs: 24 });
   });
 });
-

--- a/src/lib/http/apis/proxies.ts
+++ b/src/lib/http/apis/proxies.ts
@@ -32,7 +32,23 @@ type RawProxyPoolEntry = {
   maskedUrl?: unknown;
 };
 
+type RawProxyCheckResult = {
+  ok?: unknown;
+  status_code?: unknown;
+  statusCode?: unknown;
+  latency_ms?: unknown;
+  latencyMs?: unknown;
+  message?: unknown;
+  error?: unknown;
+};
+
 const normalizeString = (value: unknown): string => (typeof value === "string" ? value.trim() : "");
+
+const normalizeNumber = (value: unknown): number | undefined => {
+  const numberValue =
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+};
 
 export const normalizeProxyEntry = (item: RawProxyPoolEntry): ProxyPoolEntry | null => {
   const id = normalizeString(item.id);
@@ -48,6 +64,25 @@ export const normalizeProxyEntry = (item: RawProxyPoolEntry): ProxyPoolEntry | n
     enabled: item.enabled !== false,
     ...(description ? { description } : {}),
     ...(maskedUrl ? { maskedUrl } : {}),
+  };
+};
+
+export const normalizeProxyCheckResult = (item: RawProxyCheckResult): ProxyCheckResult => {
+  const statusCode = normalizeNumber(item.status_code ?? item.statusCode);
+  const latencyMs = normalizeNumber(item.latency_ms ?? item.latencyMs);
+  const message = normalizeString(item.message ?? item.error);
+  const ok =
+    typeof item.ok === "boolean"
+      ? item.ok
+      : typeof statusCode === "number"
+        ? statusCode >= 200 && statusCode < 400
+        : false;
+
+  return {
+    ok,
+    ...(typeof statusCode === "number" ? { statusCode } : {}),
+    ...(typeof latencyMs === "number" ? { latencyMs: Math.round(latencyMs) } : {}),
+    ...(message ? { message } : {}),
   };
 };
 
@@ -72,8 +107,8 @@ export const proxiesApi = {
     });
   },
 
-  check(request: ProxyCheckRequest): Promise<ProxyCheckResult> {
-    return apiClient.post(
+  async check(request: ProxyCheckRequest): Promise<ProxyCheckResult> {
+    const data = await apiClient.post<RawProxyCheckResult>(
       "/proxy-pool/check",
       {
         ...(request.id ? { id: request.id } : {}),
@@ -82,6 +117,6 @@ export const proxiesApi = {
       },
       { timeoutMs: 12000 },
     );
+    return normalizeProxyCheckResult(data ?? {});
   },
 };
-

--- a/src/modules/proxies/ProxiesPage.tsx
+++ b/src/modules/proxies/ProxiesPage.tsx
@@ -39,7 +39,10 @@ export function ProxiesPage() {
     try {
       setEntries(await proxiesApi.list());
     } catch (error) {
-      notify({ type: "error", message: error instanceof Error ? error.message : t("common.error") });
+      notify({
+        type: "error",
+        message: error instanceof Error ? error.message : t("common.error"),
+      });
     } finally {
       setLoading(false);
     }
@@ -91,38 +94,50 @@ export function ProxiesPage() {
       notify({ type: "success", message: t("proxies.saved") });
       closeModal();
     } catch (error) {
-      notify({ type: "error", message: error instanceof Error ? error.message : t("common.error") });
+      notify({
+        type: "error",
+        message: error instanceof Error ? error.message : t("common.error"),
+      });
     } finally {
       setSaving(false);
     }
   };
 
-  const deleteEntry = useCallback(async (id: string) => {
-    const nextEntries = entries.filter((entry) => entry.id !== id);
-    try {
-      await proxiesApi.saveAll(nextEntries);
-      setEntries(nextEntries);
-      notify({ type: "success", message: t("proxies.deleted") });
-    } catch (error) {
-      notify({ type: "error", message: error instanceof Error ? error.message : t("common.error") });
-    }
-  }, [entries, notify, t]);
-
-  const checkEntry = useCallback(async (entry: ProxyPoolEntry) => {
-    setCheckState((prev) => ({ ...prev, [entry.id]: { ...prev[entry.id], checking: true } }));
-    try {
-      const result = await proxiesApi.check({ id: entry.id });
-      setCheckState((prev) => ({ ...prev, [entry.id]: result }));
-    } catch (error) {
-      setCheckState((prev) => ({
-        ...prev,
-        [entry.id]: {
-          ok: false,
+  const deleteEntry = useCallback(
+    async (id: string) => {
+      const nextEntries = entries.filter((entry) => entry.id !== id);
+      try {
+        await proxiesApi.saveAll(nextEntries);
+        setEntries(nextEntries);
+        notify({ type: "success", message: t("proxies.deleted") });
+      } catch (error) {
+        notify({
+          type: "error",
           message: error instanceof Error ? error.message : t("common.error"),
-        },
-      }));
-    }
-  }, [t]);
+        });
+      }
+    },
+    [entries, notify, t],
+  );
+
+  const checkEntry = useCallback(
+    async (entry: ProxyPoolEntry) => {
+      setCheckState((prev) => ({ ...prev, [entry.id]: { ...prev[entry.id], checking: true } }));
+      try {
+        const result = await proxiesApi.check({ id: entry.id });
+        setCheckState((prev) => ({ ...prev, [entry.id]: result }));
+      } catch (error) {
+        setCheckState((prev) => ({
+          ...prev,
+          [entry.id]: {
+            ok: false,
+            message: error instanceof Error ? error.message : t("common.error"),
+          },
+        }));
+      }
+    },
+    [t],
+  );
 
   const columns = useMemo<VirtualTableColumn<ProxyPoolEntry>[]>(
     () => [
@@ -186,19 +201,30 @@ export function ProxiesPage() {
               </span>
             );
           }
+          const summary = [
+            result.ok ? t("proxies.check_ok") : t("proxies.check_failed"),
+            result.statusCode ? String(result.statusCode) : null,
+            typeof result.latencyMs === "number" ? `${result.latencyMs} ms` : null,
+          ]
+            .filter(Boolean)
+            .join(" · ");
           return (
-            <span
+            <div
               className={[
-                "text-xs font-medium",
+                "min-w-0 text-xs font-medium",
                 result.ok
                   ? "text-emerald-700 dark:text-emerald-300"
                   : "text-rose-600 dark:text-rose-300",
               ].join(" ")}
+              title={result.message ? `${summary} · ${result.message}` : summary}
             >
-              {result.ok ? t("proxies.check_ok") : t("proxies.check_failed")}
-              {result.statusCode ? ` · ${result.statusCode}` : ""}
-              {typeof result.latencyMs === "number" ? ` · ${result.latencyMs} ms` : ""}
-            </span>
+              <span className="block truncate">{summary}</span>
+              {result.message ? (
+                <span className="mt-0.5 block truncate font-normal opacity-80">
+                  {result.message}
+                </span>
+              ) : null}
+            </div>
           );
         },
       },

--- a/src/modules/proxies/__tests__/ProxiesPage.test.tsx
+++ b/src/modules/proxies/__tests__/ProxiesPage.test.tsx
@@ -49,7 +49,7 @@ describe("ProxiesPage", () => {
       ],
     });
     mocks.apiPut.mockResolvedValue({ status: "ok" });
-    mocks.apiPost.mockResolvedValue({ ok: true, statusCode: 204, latencyMs: 31 });
+    mocks.apiPost.mockResolvedValue({ ok: true, status_code: 204, latency_ms: 31 });
   });
 
   test("loads proxy entries with masked URLs and status actions", async () => {
@@ -120,5 +120,21 @@ describe("ProxiesPage", () => {
       { id: "hk" },
       expect.objectContaining({ timeoutMs: 12000 }),
     );
+  });
+
+  test("renders failed proxy checks with the backend message", async () => {
+    mocks.apiPost.mockResolvedValue({
+      ok: false,
+      status_code: 0,
+      latency_ms: 12001,
+      message: "proxy dial timeout",
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /check hk proxy/i }));
+
+    expect(await screen.findByText(/unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/proxy dial timeout/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Normalize proxy check responses from backend snake_case and camelCase shapes.
- Show proxy check failure messages in the /proxies table.
- Add regression coverage for status code, latency, and failed check messages.

## Test Plan
- bun run test
- bun run lint
- bun run build
- bun run check
- bunx oxfmt . --check (fails on pre-existing unrelated formatting baseline files; changed proxy files are not listed)
- Browser smoke test on /proxies with mock management API and four proxy rows
- Direct curl checks for the four provided proxies