### PR TITLE
fix: show table action tooltips below

### DIFF
--- a/src/modules/api-keys/components/ApiKeyColumns.tsx
+++ b/src/modules/api-keys/components/ApiKeyColumns.tsx
@@ -44,7 +44,12 @@ export const createApiKeyColumns = ({
     cellClassName: "text-center",
     render: (row, idx) => (
       <button
+        type="button"
         onClick={() => onToggleDisable(idx)}
+        aria-label={
+          row.disabled ? t("api_keys_page.click_enable") : t("api_keys_page.click_disable")
+        }
+        data-tooltip-placement="bottom"
         title={row.disabled ? t("api_keys_page.click_enable") : t("api_keys_page.click_disable")}
         className={`inline-flex h-7 w-7 items-center justify-center rounded-lg transition-colors ${
           row.disabled
@@ -288,29 +293,41 @@ export const createApiKeyColumns = ({
     render: (row, idx) => (
       <div className="flex items-center gap-1.5">
         <button
+          type="button"
           onClick={() => onViewUsage(row)}
           className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-blue-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-blue-400"
+          aria-label={t("api_keys_page.view_usage")}
+          data-tooltip-placement="bottom"
           title={t("api_keys_page.view_usage")}
         >
           <BarChart3 size={15} />
         </button>
         <button
+          type="button"
           onClick={() => onCopy(row.key)}
           className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-indigo-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400"
+          aria-label={t("api_keys_page.copy_key")}
+          data-tooltip-placement="bottom"
           title={t("api_keys_page.copy_key")}
         >
           <Copy size={15} />
         </button>
         <button
+          type="button"
           onClick={() => onEdit(idx)}
           className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-amber-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-amber-400"
+          aria-label={t("common.edit")}
+          data-tooltip-placement="bottom"
           title={t("common.edit")}
         >
           <Pencil size={15} />
         </button>
         <button
+          type="button"
           onClick={() => onDelete(idx)}
           className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-white/50 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+          aria-label={t("common.delete")}
+          data-tooltip-placement="bottom"
           title={t("common.delete")}
         >
           <Trash2 size={15} />

--- a/src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -1,0 +1,82 @@
+import type { TFunction } from "i18next";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ApiKeyEntry } from "@/lib/http/apis/api-keys";
+import { createApiKeyColumns } from "@/modules/api-keys/components/ApiKeyColumns";
+import { GlobalIconButtonTooltip } from "@/modules/ui/Tooltip";
+
+const t = ((key: string) => {
+  const labels: Record<string, string> = {
+    "api_keys_page.col_actions": "Actions",
+    "api_keys_page.view_usage": "View usage",
+    "api_keys_page.copy_key": "Copy key",
+    "common.edit": "Edit",
+    "common.delete": "Delete",
+  };
+  return labels[key] ?? key;
+}) as TFunction;
+
+const setViewport = (width: number, height: number) => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: height });
+};
+
+const setTooltipSize = (width: number, height: number) => {
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", { configurable: true, value: width });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: height,
+  });
+};
+
+describe("ApiKeyColumns", () => {
+  beforeEach(() => {
+    setViewport(800, 600);
+    setTooltipSize(80, 24);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      bottom: 132,
+      height: 32,
+      left: 100,
+      right: 132,
+      top: 100,
+      width: 32,
+      x: 100,
+      y: 100,
+      toJSON: () => undefined,
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("shows action icon tooltips below each button", async () => {
+    const row: ApiKeyEntry = {
+      key: "sk-test",
+      name: "Test key",
+      "created-at": "2026-04-28T00:00:00Z",
+    };
+    const columns = createApiKeyColumns({
+      t,
+      onCopy: vi.fn(),
+      onDelete: vi.fn(),
+      onEdit: vi.fn(),
+      onToggleDisable: vi.fn(),
+      onViewUsage: vi.fn(),
+    });
+    const actionsColumn = columns.find((column) => column.key === "actions");
+
+    render(
+      <>
+        <GlobalIconButtonTooltip />
+        <div>{actionsColumn?.render(row, 0)}</div>
+      </>,
+    );
+
+    await userEvent.hover(screen.getByRole("button", { name: "View usage" }));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("View usage");
+    expect(screen.getByRole("tooltip")).toHaveStyle({ left: "76px", top: "140px" });
+  });
+});

--- a/src/modules/ui/Button.tsx
+++ b/src/modules/ui/Button.tsx
@@ -87,7 +87,7 @@ export function Button({
   onMouseLeave,
   title,
   tooltip,
-  tooltipPlacement = "right",
+  tooltipPlacement = "bottom",
   variant = "default",
   size = "md",
   ...props

--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -21,16 +21,24 @@ type TooltipPosition = {
 type GlobalTooltipState = {
   anchor: HTMLElement;
   content: string;
+  placement?: TooltipPlacement;
 };
 
 const TOOLTIP_OFFSET = 8;
 const VIEWPORT_PADDING = 8;
-const FALLBACK_PLACEMENTS: TooltipPlacement[] = ["right", "bottom", "left", "top"];
+const FALLBACK_PLACEMENTS: TooltipPlacement[] = ["bottom", "right", "left", "top"];
 
 export const TooltipTriggerContext = createContext(false);
 
 function isEmptyTooltipContent(content: ReactNode) {
   return content === null || content === undefined || content === false || content === "";
+}
+
+function parseTooltipPlacement(value: string | null): TooltipPlacement | undefined {
+  if (value === "top" || value === "right" || value === "bottom" || value === "left") {
+    return value;
+  }
+  return undefined;
 }
 
 function resolveIconButtonTooltip(target: EventTarget | null): GlobalTooltipState | null {
@@ -50,7 +58,11 @@ function resolveIconButtonTooltip(target: EventTarget | null): GlobalTooltipStat
   const trimmedContent = content.trim();
   if (!trimmedContent) return null;
 
-  return { anchor: button, content: trimmedContent };
+  return {
+    anchor: button,
+    content: trimmedContent,
+    placement: parseTooltipPlacement(button.getAttribute("data-tooltip-placement")),
+  };
 }
 
 function hideNativeTitle(button: HTMLElement) {
@@ -165,7 +177,7 @@ export function TooltipBubble({
   content,
   anchorElement,
   anchorRef,
-  placement = "right",
+  placement = "bottom",
 }: {
   id: string;
   open: boolean;
@@ -227,7 +239,7 @@ export function TooltipBubble({
       ref={tooltipRef}
       id={id}
       role="tooltip"
-      className="pointer-events-none w-max max-w-[calc(100vw-2rem)] rounded-2xl border border-slate-200 bg-white/95 px-3 py-2 text-sm shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-80 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white"
+      className="pointer-events-none w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-80 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white"
       style={style}
     >
       <span className="block break-words text-slate-900 dark:text-white">{content}</span>
@@ -241,7 +253,7 @@ export function HoverTooltip({
   children,
   className,
   disabled = false,
-  placement = "right",
+  placement = "bottom",
 }: {
   content: ReactNode;
   children: ReactNode;
@@ -284,7 +296,7 @@ export function OverflowTooltip({
   content,
   children,
   className,
-  placement = "right",
+  placement = "bottom",
 }: {
   content: string;
   children: ReactNode;
@@ -323,7 +335,11 @@ export function OverflowTooltip({
   );
 }
 
-export function GlobalIconButtonTooltip({ placement = "right" }: { placement?: TooltipPlacement }) {
+export function GlobalIconButtonTooltip({
+  placement = "bottom",
+}: {
+  placement?: TooltipPlacement;
+}) {
   const id = useId();
   const activeRef = useRef<GlobalTooltipState | null>(null);
   const [active, setActive] = useState<GlobalTooltipState | null>(null);
@@ -376,7 +392,7 @@ export function GlobalIconButtonTooltip({ placement = "right" }: { placement?: T
       open={Boolean(active)}
       content={active?.content ?? ""}
       anchorElement={active?.anchor}
-      placement={placement}
+      placement={active?.placement ?? placement}
     />
   );
 }

--- a/src/modules/ui/__tests__/Tooltip.test.tsx
+++ b/src/modules/ui/__tests__/Tooltip.test.tsx
@@ -43,7 +43,7 @@ describe("HoverTooltip", () => {
     vi.restoreAllMocks();
   });
 
-  test("defaults to the right side of icon triggers", async () => {
+  test("defaults to the bottom side of icon triggers with compact styling", async () => {
     mockAnchorRect({ left: 100, right: 120, top: 100, bottom: 120, width: 20, height: 20 });
 
     render(
@@ -54,11 +54,12 @@ describe("HoverTooltip", () => {
 
     await userEvent.hover(screen.getByRole("button", { name: "Refresh" }));
 
-    expect(screen.getByRole("tooltip")).toHaveStyle({ left: "128px", top: "98px" });
+    expect(screen.getByRole("tooltip")).toHaveStyle({ left: "70px", top: "128px" });
+    expect(screen.getByRole("tooltip")).toHaveClass("px-2", "py-1.5", "text-xs");
   });
 
-  test("moves away from the right edge before clamping", async () => {
-    mockAnchorRect({ left: 760, right: 792, top: 100, bottom: 132, width: 32, height: 32 });
+  test("moves away from the bottom edge before clamping", async () => {
+    mockAnchorRect({ left: 100, right: 132, top: 560, bottom: 592, width: 32, height: 32 });
     setTooltipSize(120, 24);
 
     render(
@@ -69,7 +70,7 @@ describe("HoverTooltip", () => {
 
     await userEvent.hover(screen.getByRole("button", { name: "Delete" }));
 
-    expect(screen.getByRole("tooltip")).toHaveStyle({ left: "632px", top: "104px" });
+    expect(screen.getByRole("tooltip")).toHaveStyle({ left: "140px", top: "564px" });
   });
 
   test("adds the shared tooltip to unmanaged native icon buttons", async () => {


### PR DESCRIPTION
## Summary
- make the shared tooltip default to bottom placement with smaller text and tighter padding
- keep overflow-aware fallback placement and allow native icon buttons to opt into a placement via data-tooltip-placement
- add accessible labels and explicit bottom tooltip placement for API key table icon actions

## Test Plan
- bun run test
- bun run check
- Playwright hover check on local Vite dev server