### PR TITLE
fix: add api key action tooltips

### DIFF
--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -184,7 +184,7 @@ describe("ApiKeysPage", () => {
     });
     expect(await screen.findByText("New Key")).toBeInTheDocument();
 
-    await userEvent.click(screen.getAllByTitle("Edit")[1]!);
+    await userEvent.click(screen.getAllByRole("button", { name: "Edit" })[1]!);
     const nameInput = screen.getAllByPlaceholderText(/team-a/i).at(-1)!;
     await userEvent.clear(nameInput);
     await userEvent.type(nameInput, "Renamed Key");
@@ -194,7 +194,7 @@ describe("ApiKeysPage", () => {
       expect(mocks.apiKeyEntriesUpdate).toHaveBeenCalled();
     });
 
-    await userEvent.click(screen.getAllByTitle("Delete")[1]!);
+    await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[1]!);
     await userEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
 
     await waitFor(() => {
@@ -226,7 +226,7 @@ describe("ApiKeysPage", () => {
 
     expect(await screen.findByText("Pinned Key")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTitle("Edit"));
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
     await userEvent.click(screen.getByRole("switch", { name: /exact channel override/i }));
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
@@ -242,5 +242,23 @@ describe("ApiKeysPage", () => {
         }),
       }),
     );
+  });
+
+  test("shows operation column icon tooltips without relying on the app-level tooltip listener", async () => {
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Existing Key")).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByRole("button", { name: /copy key/i }));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(/copy key/i);
   });
 });

--- a/src/modules/api-keys/components/ApiKeyColumns.tsx
+++ b/src/modules/api-keys/components/ApiKeyColumns.tsx
@@ -290,49 +290,56 @@ export const createApiKeyColumns = ({
     key: "actions",
     label: t("api_keys_page.col_actions"),
     width: "w-[152px] min-w-[152px]",
-    render: (row, idx) => (
-      <div className="flex items-center gap-1.5">
-        <button
-          type="button"
-          onClick={() => onViewUsage(row)}
-          className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-blue-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-blue-400"
-          aria-label={t("api_keys_page.view_usage")}
-          data-tooltip-placement="bottom"
-          title={t("api_keys_page.view_usage")}
-        >
-          <BarChart3 size={15} />
-        </button>
-        <button
-          type="button"
-          onClick={() => onCopy(row.key)}
-          className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-indigo-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400"
-          aria-label={t("api_keys_page.copy_key")}
-          data-tooltip-placement="bottom"
-          title={t("api_keys_page.copy_key")}
-        >
-          <Copy size={15} />
-        </button>
-        <button
-          type="button"
-          onClick={() => onEdit(idx)}
-          className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-amber-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-amber-400"
-          aria-label={t("common.edit")}
-          data-tooltip-placement="bottom"
-          title={t("common.edit")}
-        >
-          <Pencil size={15} />
-        </button>
-        <button
-          type="button"
-          onClick={() => onDelete(idx)}
-          className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-white/50 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-          aria-label={t("common.delete")}
-          data-tooltip-placement="bottom"
-          title={t("common.delete")}
-        >
-          <Trash2 size={15} />
-        </button>
-      </div>
-    ),
+    render: (row, idx) => {
+      const viewUsageLabel = t("api_keys_page.view_usage");
+      const copyKeyLabel = t("api_keys_page.copy_key");
+      const editLabel = t("common.edit");
+      const deleteLabel = t("common.delete");
+
+      return (
+        <div className="flex items-center gap-1.5">
+          <HoverTooltip content={viewUsageLabel}>
+            <button
+              type="button"
+              onClick={() => onViewUsage(row)}
+              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-blue-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-blue-400"
+              aria-label={viewUsageLabel}
+            >
+              <BarChart3 size={15} />
+            </button>
+          </HoverTooltip>
+          <HoverTooltip content={copyKeyLabel}>
+            <button
+              type="button"
+              onClick={() => onCopy(row.key)}
+              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-indigo-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400"
+              aria-label={copyKeyLabel}
+            >
+              <Copy size={15} />
+            </button>
+          </HoverTooltip>
+          <HoverTooltip content={editLabel}>
+            <button
+              type="button"
+              onClick={() => onEdit(idx)}
+              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-amber-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-amber-400"
+              aria-label={editLabel}
+            >
+              <Pencil size={15} />
+            </button>
+          </HoverTooltip>
+          <HoverTooltip content={deleteLabel}>
+            <button
+              type="button"
+              onClick={() => onDelete(idx)}
+              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-white/50 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+              aria-label={deleteLabel}
+            >
+              <Trash2 size={15} />
+            </button>
+          </HoverTooltip>
+        </div>
+      );
+    },
   },
 ];


### PR DESCRIPTION
## Summary
- wrap manage/api-keys operation column icon buttons with the shared HoverTooltip
- remove reliance on the app-level global tooltip listener for those actions
- add a page-level regression test for operation column hover tooltips

## Test Plan
- bun run test -- src/modules/api-keys/__tests__/ApiKeysPage.test.tsx src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- bun run test
- bun run check