### PR TITLE
feat: refresh proxy checks on page entry

### DIFF
--- a/src/modules/proxies/ProxiesPage.tsx
+++ b/src/modules/proxies/ProxiesPage.tsx
@@ -17,7 +17,61 @@ import {
   validateProxyDraft,
 } from "@/modules/proxies/proxy-utils";
 
-type CheckState = Record<string, ProxyCheckResult & { checking?: boolean }>;
+type CheckStateEntry = Partial<ProxyCheckResult> & { checking?: boolean };
+type CheckState = Record<string, CheckStateEntry>;
+
+const PROXIES_CHECK_STATE_CACHE_KEY = "proxiesPage.checkState.v1";
+
+const readCachedNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? Math.round(value) : undefined;
+
+const readCachedCheckState = (): CheckState => {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.sessionStorage.getItem(PROXIES_CHECK_STATE_CACHE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    const next: CheckState = {};
+    for (const [id, value] of Object.entries(parsed)) {
+      if (!id || !value || typeof value !== "object" || Array.isArray(value)) continue;
+      const item = value as Record<string, unknown>;
+      if (typeof item.ok !== "boolean") continue;
+      const statusCode = readCachedNumber(item.statusCode);
+      const latencyMs = readCachedNumber(item.latencyMs);
+      const message = typeof item.message === "string" ? item.message : "";
+      next[id] = {
+        ok: item.ok,
+        ...(typeof statusCode === "number" ? { statusCode } : {}),
+        ...(typeof latencyMs === "number" ? { latencyMs } : {}),
+        ...(message ? { message } : {}),
+      };
+    }
+    return next;
+  } catch {
+    return {};
+  }
+};
+
+const writeCachedCheckState = (state: CheckState) => {
+  if (typeof window === "undefined") return;
+  try {
+    const cache: Record<string, ProxyCheckResult> = {};
+    for (const [id, result] of Object.entries(state)) {
+      if (typeof result.ok !== "boolean") continue;
+      cache[id] = {
+        ok: result.ok,
+        ...(typeof result.statusCode === "number" ? { statusCode: result.statusCode } : {}),
+        ...(typeof result.latencyMs === "number" ? { latencyMs: result.latencyMs } : {}),
+        ...(result.message ? { message: result.message } : {}),
+      };
+    }
+    window.sessionStorage.setItem(PROXIES_CHECK_STATE_CACHE_KEY, JSON.stringify(cache));
+  } catch {
+    // 忽略缓存写入失败。
+  }
+};
 
 export function ProxiesPage() {
   const { t } = useTranslation();
@@ -27,17 +81,56 @@ export function ProxiesPage() {
   const [saving, setSaving] = useState(false);
   const [draft, setDraft] = useState<ProxyPoolEntry>(() => emptyProxyDraft());
   const [editingID, setEditingID] = useState<string | null>(null);
-  const [checkState, setCheckState] = useState<CheckState>({});
+  const [checkState, setCheckState] = useState<CheckState>(() => readCachedCheckState());
 
   const sortedEntries = useMemo(
     () => [...entries].sort((a, b) => a.name.localeCompare(b.name)),
     [entries],
   );
 
+  const storeCheckResult = useCallback((id: string, result: ProxyCheckResult) => {
+    setCheckState((prev) => {
+      const next = { ...prev, [id]: result };
+      writeCachedCheckState(next);
+      return next;
+    });
+  }, []);
+
+  const refreshCheckResults = useCallback(
+    async (items: ProxyPoolEntry[]) => {
+      if (!items.length) return;
+
+      setCheckState((prev) => {
+        const next = { ...prev };
+        for (const entry of items) {
+          next[entry.id] = { ...next[entry.id], checking: true };
+        }
+        return next;
+      });
+
+      await Promise.all(
+        items.map(async (entry) => {
+          try {
+            const result = await proxiesApi.check({ id: entry.id });
+            storeCheckResult(entry.id, result);
+          } catch (error) {
+            storeCheckResult(entry.id, {
+              ok: false,
+              message: error instanceof Error ? error.message : t("common.error"),
+            });
+          }
+        }),
+      );
+    },
+    [storeCheckResult, t],
+  );
+
   const loadEntries = useCallback(async () => {
     setLoading(true);
     try {
-      setEntries(await proxiesApi.list());
+      const nextEntries = await proxiesApi.list();
+      setEntries(nextEntries);
+      void refreshCheckResults(nextEntries);
     } catch (error) {
       notify({
         type: "error",
@@ -46,7 +139,7 @@ export function ProxiesPage() {
     } finally {
       setLoading(false);
     }
-  }, [notify, t]);
+  }, [notify, refreshCheckResults, t]);
 
   useEffect(() => {
     void loadEntries();
@@ -91,6 +184,14 @@ export function ProxiesPage() {
     try {
       await proxiesApi.saveAll(nextEntries);
       setEntries(nextEntries);
+      if (editingID && editingID !== normalized.id) {
+        setCheckState((prev) => {
+          const next = { ...prev };
+          delete next[editingID];
+          writeCachedCheckState(next);
+          return next;
+        });
+      }
       notify({ type: "success", message: t("proxies.saved") });
       closeModal();
     } catch (error) {
@@ -109,6 +210,12 @@ export function ProxiesPage() {
       try {
         await proxiesApi.saveAll(nextEntries);
         setEntries(nextEntries);
+        setCheckState((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          writeCachedCheckState(next);
+          return next;
+        });
         notify({ type: "success", message: t("proxies.deleted") });
       } catch (error) {
         notify({
@@ -122,21 +229,9 @@ export function ProxiesPage() {
 
   const checkEntry = useCallback(
     async (entry: ProxyPoolEntry) => {
-      setCheckState((prev) => ({ ...prev, [entry.id]: { ...prev[entry.id], checking: true } }));
-      try {
-        const result = await proxiesApi.check({ id: entry.id });
-        setCheckState((prev) => ({ ...prev, [entry.id]: result }));
-      } catch (error) {
-        setCheckState((prev) => ({
-          ...prev,
-          [entry.id]: {
-            ok: false,
-            message: error instanceof Error ? error.message : t("common.error"),
-          },
-        }));
-      }
+      await refreshCheckResults([entry]);
     },
-    [t],
+    [refreshCheckResults],
   );
 
   const columns = useMemo<VirtualTableColumn<ProxyPoolEntry>[]>(
@@ -194,7 +289,8 @@ export function ProxiesPage() {
         width: "w-32",
         render: (entry) => {
           const result = checkState[entry.id];
-          if (!result || result.checking) {
+          const hasCheckResult = typeof result?.ok === "boolean";
+          if (!result || !hasCheckResult) {
             return (
               <span className="text-xs text-slate-500 dark:text-white/45">
                 {result?.checking ? t("common.loading_ellipsis") : "--"}
@@ -307,7 +403,7 @@ export function ProxiesPage() {
         </div>
       </div>
 
-      <Card className="overflow-hidden" loading={loading}>
+      <Card className="overflow-hidden" loading={loading && entries.length === 0}>
         <VirtualTable<ProxyPoolEntry>
           rows={sortedEntries}
           columns={columns}

--- a/src/modules/proxies/__tests__/ProxiesPage.test.tsx
+++ b/src/modules/proxies/__tests__/ProxiesPage.test.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   apiPost: vi.fn(),
 }));
 
+const proxyCheckCacheKey = "proxiesPage.checkState.v1";
+
 vi.mock("@/lib/http/client", () => ({
   apiClient: {
     get: mocks.apiGet,
@@ -33,6 +35,7 @@ function renderPage() {
 describe("ProxiesPage", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
+    window.sessionStorage.clear();
     mocks.apiGet.mockReset();
     mocks.apiPut.mockReset();
     mocks.apiPost.mockReset();
@@ -64,6 +67,92 @@ describe("ProxiesPage", () => {
     expect(screen.getByText("socks5://127.0.0.1:1080")).toBeInTheDocument();
     expect(screen.getByText("Codex egress")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /check hk proxy/i })).toBeInTheDocument();
+  });
+
+  test("checks all proxy entries after loading the page", async () => {
+    mocks.apiGet.mockResolvedValue({
+      items: [
+        {
+          id: "hk",
+          name: "HK Proxy",
+          url: "socks5://user:pass@127.0.0.1:1080",
+          enabled: true,
+        },
+        {
+          id: "us",
+          name: "US Proxy",
+          url: "http://127.0.0.1:7890",
+          enabled: true,
+        },
+      ],
+    });
+
+    renderPage();
+
+    await screen.findByText("HK Proxy");
+    await waitFor(() => expect(mocks.apiPost).toHaveBeenCalledTimes(2));
+    expect(mocks.apiPost).toHaveBeenCalledWith(
+      "/proxy-pool/check",
+      { id: "hk" },
+      expect.objectContaining({ timeoutMs: 12000 }),
+    );
+    expect(mocks.apiPost).toHaveBeenCalledWith(
+      "/proxy-pool/check",
+      { id: "us" },
+      expect.objectContaining({ timeoutMs: 12000 }),
+    );
+  });
+
+  test("keeps the previous check result visible while refreshing checks", async () => {
+    let resolveNextCheck: ((value: unknown) => void) | undefined;
+    mocks.apiPost
+      .mockResolvedValueOnce({ ok: true, status_code: 204, latency_ms: 31 })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNextCheck = resolve;
+          }),
+      );
+
+    renderPage();
+
+    expect(await screen.findByText(/31 ms/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /^refresh$/i }));
+
+    await waitFor(() => expect(mocks.apiPost).toHaveBeenCalledTimes(2));
+    expect(screen.getByText(/31 ms/i)).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+
+    resolveNextCheck?.({ ok: true, status_code: 204, latency_ms: 44 });
+
+    expect(await screen.findByText(/44 ms/i)).toBeInTheDocument();
+  });
+
+  test("renders cached check results on page entry while refreshing them in the background", async () => {
+    let resolveNextCheck: ((value: unknown) => void) | undefined;
+    window.sessionStorage.setItem(
+      proxyCheckCacheKey,
+      JSON.stringify({
+        hk: { ok: true, statusCode: 204, latencyMs: 31 },
+      }),
+    );
+    mocks.apiPost.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveNextCheck = resolve;
+        }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText(/31 ms/i)).toBeInTheDocument();
+    await waitFor(() => expect(mocks.apiPost).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+
+    resolveNextCheck?.({ ok: true, status_code: 204, latency_ms: 44 });
+
+    expect(await screen.findByText(/44 ms/i)).toBeInTheDocument();
   });
 
   test("keeps the proxy table chrome minimal when empty", async () => {


### PR DESCRIPTION
## Summary
- Trigger proxy connectivity checks for all loaded proxy pool entries when the proxies page loads or refreshes.
- Keep previous check results visible while a new refresh is in flight.
- Cache recent check results in sessionStorage so revisiting the page can show stale data immediately while refreshing in the background.

## Test Plan
- bun run test
- bun run lint
- bun run build
- bunx oxfmt src/modules/proxies/ProxiesPage.tsx src/modules/proxies/__tests__/ProxiesPage.test.tsx --check
- bun run bundle:diff

Note: full bunx oxfmt . --check still reports existing formatting issues in 42 unrelated files.