### PR TITLE
feat: add CC Switch import actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@
 - 历史多入口脚本：`src/management.tsx`（默认不再构建产物）
 - 主要模块目录：`src/`
 - OAuth 登录弹窗：`src/modules/oauth/OAuthLoginDialog.tsx`
+- CC Switch 导入：`src/modules/ccswitch/`（deeplink 协议生成与复用入口组件）
 - 自动更新提示：`src/modules/update/AutoUpdatePrompt.tsx`
 - 模型配置管理：`src/modules/models/ModelsPage.tsx`（`/manage/models`，数据库模型配置与计价规则）
 - 代理池管理：`src/modules/proxies/ProxiesPage.tsx`（`/proxies`，集中维护可复用出站代理）

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ src/
 ├── modules/
 │   ├── auth/            # Authentication provider & session
 │   ├── apikey-lookup/   # Public API Key usage lookup
+│   ├── ccswitch/        # CC Switch deeplink import helpers
 │   ├── config/          # Visual config editor (YAML)
 │   ├── dashboard/       # Dashboard overview + system monitor
 │   ├── login/           # Login page

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2235,6 +2235,19 @@
     "last_page": "Last page",
     "rows_per_page": "Rows per page"
   },
+  "ccswitch": {
+    "import_to_ccswitch": "Import to CC Switch",
+    "import_modal_desc": "Choose the client configuration to add to CC Switch.",
+    "import_client": "Import {{client}}",
+    "client_claude_code": "Claude Code",
+    "client_claude_code_desc": "Anthropic-compatible provider for Claude Code.",
+    "client_codex": "Codex",
+    "client_codex_desc": "OpenAI-compatible provider for Codex CLI.",
+    "client_gemini_cli": "Gemini CLI",
+    "client_gemini_cli_desc": "Gemini-compatible provider for Gemini CLI.",
+    "model_hint": "Model: {{model}}",
+    "protocol_unavailable": "CC Switch is not installed or the protocol handler is unavailable."
+  },
   "api_keys_page": {
     "title": "API Keys Management",
     "description": "Create and manage API Keys, set request limits and model permissions. Data persists on server.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -57,6 +57,19 @@
     "rotate_right": "Повернуть вправо",
     "reset_image": "Сбросить изображение"
   },
+  "ccswitch": {
+    "import_to_ccswitch": "Импорт в CC Switch",
+    "import_modal_desc": "Выберите тип клиентской конфигурации для добавления в CC Switch.",
+    "import_client": "Импортировать {{client}}",
+    "client_claude_code": "Claude Code",
+    "client_claude_code_desc": "Anthropic-совместимый провайдер для Claude Code.",
+    "client_codex": "Codex",
+    "client_codex_desc": "OpenAI-совместимый провайдер для Codex CLI.",
+    "client_gemini_cli": "Gemini CLI",
+    "client_gemini_cli_desc": "Gemini-совместимый провайдер для Gemini CLI.",
+    "model_hint": "Модель: {{model}}",
+    "protocol_unavailable": "CC Switch не установлен или обработчик протокола недоступен."
+  },
   "title": {
     "main": "Панель администратора Code Proxy",
     "login": "Панель администратора Code Proxy",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2406,6 +2406,19 @@
     "last_page": "末页",
     "rows_per_page": "每页行数"
   },
+  "ccswitch": {
+    "import_to_ccswitch": "导入到 CC Switch",
+    "import_modal_desc": "选择要添加到 CC Switch 的客户端配置类型。",
+    "import_client": "导入 {{client}}",
+    "client_claude_code": "Claude Code",
+    "client_claude_code_desc": "适用于 Claude Code 的 Anthropic 兼容配置。",
+    "client_codex": "Codex",
+    "client_codex_desc": "适用于 Codex CLI 的 OpenAI 兼容配置。",
+    "client_gemini_cli": "Gemini CLI",
+    "client_gemini_cli_desc": "适用于 Gemini CLI 的 Gemini 兼容配置。",
+    "model_hint": "模型：{{model}}",
+    "protocol_unavailable": "未检测到 CC Switch 或协议处理程序不可用。"
+  },
   "api_keys_page": {
     "title": "API 密钥管理",
     "description": "创建和管理 API 密钥，设置请求限制和模型权限。数据持久化保存在服务器。",

--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -5,6 +5,8 @@ import { apiKeyEntriesApi, apiKeysApi, type ApiKeyEntry } from "@/lib/http/apis/
 import { channelGroupsApi, type ChannelGroupItem } from "@/lib/http/apis/channel-groups";
 import { authFilesApi, providersApi } from "@/lib/http/apis";
 import { apiClient } from "@/lib/http/client";
+import { detectApiBaseFromLocation } from "@/lib/connection";
+import { useOptionalAuth } from "@/modules/auth/AuthProvider";
 import {
   generateApiKey,
   makeEmptyApiKeyForm,
@@ -24,6 +26,14 @@ import { VirtualTable } from "@/modules/ui/VirtualTable";
 import { ApiKeyFormModal } from "@/modules/api-keys/components/ApiKeyFormModal";
 import { ApiKeyUsageModal } from "@/modules/api-keys/components/ApiKeyUsageModal";
 import { useApiKeyUsageView } from "@/modules/api-keys/hooks/useApiKeyUsageView";
+import { CcSwitchImportModal } from "@/modules/ccswitch/CcSwitchImportModal";
+import {
+  buildCcSwitchImportUrl,
+  buildCcSwitchProviderName,
+  openCcSwitchImportUrl,
+  pickCcSwitchDefaultModel,
+  type CcSwitchClientType,
+} from "@/modules/ccswitch/ccswitchImport";
 import { LogContentModal } from "@/modules/monitor/LogContentModal";
 import { ErrorDetailModal } from "@/modules/monitor/ErrorDetailModal";
 import type { ApiKeyFormValues } from "@/modules/api-keys/types";
@@ -31,6 +41,7 @@ import type { ApiKeyFormValues } from "@/modules/api-keys/types";
 export function ApiKeysPage() {
   const { t } = useTranslation();
   const { notify } = useToast();
+  const auth = useOptionalAuth();
 
   const [entries, setEntries] = useState<ApiKeyEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -38,6 +49,7 @@ export function ApiKeysPage() {
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [deleteLogsOnDelete, setDeleteLogsOnDelete] = useState(true);
+  const [ccSwitchImportEntry, setCcSwitchImportEntry] = useState<ApiKeyEntry | null>(null);
   const [saving, setSaving] = useState(false);
   const [availableModels, setAvailableModels] = useState<MultiSelectOption[]>([]);
   const [availableChannels, setAvailableChannels] = useState<MultiSelectOption[]>([]);
@@ -494,6 +506,31 @@ export function ApiKeysPage() {
     }
   };
 
+  const handleImportToCcSwitch = useCallback(
+    (clientType: CcSwitchClientType) => {
+      if (!ccSwitchImportEntry) return;
+      const baseUrl = auth?.state.apiBase || detectApiBaseFromLocation();
+      const models = ccSwitchImportEntry["allowed-models"] ?? [];
+      const url = buildCcSwitchImportUrl({
+        apiKey: ccSwitchImportEntry.key,
+        baseUrl,
+        clientType,
+        providerName: buildCcSwitchProviderName({
+          rawName: ccSwitchImportEntry.name,
+          clientType,
+        }),
+        model: pickCcSwitchDefaultModel(clientType, models),
+      });
+
+      openCcSwitchImportUrl(url, {
+        onProtocolUnavailable: () =>
+          notify({ type: "error", message: t("ccswitch.protocol_unavailable") }),
+      });
+      setCcSwitchImportEntry(null);
+    },
+    [auth?.state.apiBase, ccSwitchImportEntry, notify, t],
+  );
+
   /* ─── column definitions ─── */
 
   const apiKeyColumns = useMemo(
@@ -503,6 +540,7 @@ export function ApiKeysPage() {
         onToggleDisable: (index) => void handleToggleDisable(index),
         onViewUsage: handleViewUsage,
         onCopy: (key) => void handleCopy(key),
+        onImportToCcSwitch: setCcSwitchImportEntry,
         onEdit: handleOpenEdit,
         onDelete: handleOpenDelete,
       }),
@@ -634,6 +672,14 @@ export function ApiKeysPage() {
           setDeleteLogsOnDelete(true);
         }}
         onConfirm={handleDelete}
+      />
+
+      <CcSwitchImportModal
+        t={t}
+        open={ccSwitchImportEntry !== null}
+        models={ccSwitchImportEntry?.["allowed-models"] ?? []}
+        onClose={() => setCcSwitchImportEntry(null)}
+        onSelect={handleImportToCcSwitch}
       />
 
       <ApiKeyUsageModal

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -261,4 +261,44 @@ describe("ApiKeysPage", () => {
 
     expect(screen.getByRole("tooltip")).toHaveTextContent(/copy key/i);
   });
+
+  test("opens CC Switch import modal and launches selected client deeplink", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Existing Key")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /import to cc switch/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /import to cc switch/i });
+    expect(dialog).toHaveTextContent(/claude code/i);
+    expect(dialog).toHaveTextContent(/codex/i);
+    expect(dialog).toHaveTextContent(/gemini cli/i);
+
+    await userEvent.click(screen.getByRole("button", { name: /import codex/i }));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining("ccswitch://v1/import?"),
+        "_self",
+      );
+    });
+
+    const openedUrl = String(openSpy.mock.calls.at(-1)?.[0] ?? "");
+    const parsed = new URL(openedUrl);
+    expect(parsed.searchParams.get("app")).toBe("codex");
+    expect(parsed.searchParams.get("apiKey")).toBe("sk-existing-1234567890");
+
+    openSpy.mockRestore();
+  });
 });

--- a/src/modules/api-keys/components/ApiKeyColumns.tsx
+++ b/src/modules/api-keys/components/ApiKeyColumns.tsx
@@ -8,6 +8,7 @@ import {
   Power,
   ShieldCheck,
   Trash2,
+  Upload,
 } from "lucide-react";
 import type { ApiKeyEntry } from "@/lib/http/apis/api-keys";
 import {
@@ -24,6 +25,7 @@ type CreateApiKeyColumnsOptions = {
   onToggleDisable: (index: number) => void;
   onViewUsage: (entry: ApiKeyEntry) => void;
   onCopy: (key: string) => void;
+  onImportToCcSwitch: (entry: ApiKeyEntry) => void;
   onEdit: (index: number) => void;
   onDelete: (index: number) => void;
 };
@@ -33,6 +35,7 @@ export const createApiKeyColumns = ({
   onToggleDisable,
   onViewUsage,
   onCopy,
+  onImportToCcSwitch,
   onEdit,
   onDelete,
 }: CreateApiKeyColumnsOptions): VirtualTableColumn<ApiKeyEntry>[] => [
@@ -289,10 +292,11 @@ export const createApiKeyColumns = ({
   {
     key: "actions",
     label: t("api_keys_page.col_actions"),
-    width: "w-[152px] min-w-[152px]",
+    width: "w-[188px] min-w-[188px]",
     render: (row, idx) => {
       const viewUsageLabel = t("api_keys_page.view_usage");
       const copyKeyLabel = t("api_keys_page.copy_key");
+      const importLabel = t("ccswitch.import_to_ccswitch");
       const editLabel = t("common.edit");
       const deleteLabel = t("common.delete");
 
@@ -316,6 +320,16 @@ export const createApiKeyColumns = ({
               aria-label={copyKeyLabel}
             >
               <Copy size={15} />
+            </button>
+          </HoverTooltip>
+          <HoverTooltip content={importLabel}>
+            <button
+              type="button"
+              onClick={() => onImportToCcSwitch(row)}
+              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-cyan-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-cyan-400"
+              aria-label={importLabel}
+            >
+              <Upload size={15} />
             </button>
           </HoverTooltip>
           <HoverTooltip content={editLabel}>

--- a/src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -11,6 +11,7 @@ const t = ((key: string) => {
     "api_keys_page.col_actions": "Actions",
     "api_keys_page.view_usage": "View usage",
     "api_keys_page.copy_key": "Copy key",
+    "ccswitch.import_to_ccswitch": "Import to CC Switch",
     "common.edit": "Edit",
     "common.delete": "Delete",
   };
@@ -62,6 +63,7 @@ describe("ApiKeyColumns", () => {
       onCopy: vi.fn(),
       onDelete: vi.fn(),
       onEdit: vi.fn(),
+      onImportToCcSwitch: vi.fn(),
       onToggleDisable: vi.fn(),
       onViewUsage: vi.fn(),
     });

--- a/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
+++ b/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
@@ -9,12 +9,19 @@ import type { TimeRange } from "@/modules/monitor/monitor-constants";
 import { LogContentModal } from "@/modules/monitor/LogContentModal";
 import { MANAGEMENT_API_PREFIX } from "@/lib/constants";
 import { detectApiBaseFromLocation } from "@/lib/connection";
-import { fetchAvailableModels, fetchPublicChartData, fetchPublicLogs } from "@/modules/apikey-lookup/api";
+import {
+  fetchAvailableModels,
+  fetchPublicChartData,
+  fetchPublicLogs,
+} from "@/modules/apikey-lookup/api";
 import { LookupEmptyState } from "@/modules/apikey-lookup/components/LookupEmptyState";
 import { LookupResultsToolbar } from "@/modules/apikey-lookup/components/LookupResultsToolbar";
 import { LookupSearchSection } from "@/modules/apikey-lookup/components/LookupSearchSection";
 import { ModelsTabContent } from "@/modules/apikey-lookup/components/ModelsTabContent";
-import { buildLogColumns, PublicLogsSection } from "@/modules/apikey-lookup/components/PublicLogsSection";
+import {
+  buildLogColumns,
+  PublicLogsSection,
+} from "@/modules/apikey-lookup/components/PublicLogsSection";
 import { UsageTabSection } from "@/modules/apikey-lookup/components/UsageTabSection";
 import { useApiKeyLookupCharts } from "@/modules/apikey-lookup/hooks/useApiKeyLookupCharts";
 import type { ChartDataResponse, LogRow, PublicLogItem } from "@/modules/apikey-lookup/types";
@@ -490,6 +497,7 @@ export function ApiKeyLookupPage() {
                   error={modelsError}
                   searchFilter={modelsSearchFilter}
                   onSearchChange={setModelsSearchFilter}
+                  apiKey={queriedKey}
                 />
               </Reveal>
             ) : null}

--- a/src/modules/apikey-lookup/components/ModelsTabContent.tsx
+++ b/src/modules/apikey-lookup/components/ModelsTabContent.tsx
@@ -1,8 +1,18 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Layers, RefreshCw, Search } from "lucide-react";
+import { detectApiBaseFromLocation } from "@/lib/connection";
+import { CcSwitchImportOptions } from "@/modules/ccswitch/CcSwitchImportOptions";
+import {
+  buildCcSwitchImportUrl,
+  buildCcSwitchProviderName,
+  openCcSwitchImportUrl,
+  pickCcSwitchDefaultModel,
+  type CcSwitchClientType,
+} from "@/modules/ccswitch/ccswitchImport";
 import { Card } from "@/modules/ui/Card";
 import { TextInput } from "@/modules/ui/Input";
+import { useToast } from "@/modules/ui/ToastProvider";
 
 // Vendor SVG icons
 import iconClaude from "@/assets/icons/claude.svg";
@@ -185,14 +195,17 @@ export function ModelsTabContent({
   error,
   searchFilter,
   onSearchChange,
+  apiKey,
 }: {
   models: string[];
   loading: boolean;
   error: string | null;
   searchFilter: string;
   onSearchChange: (value: string) => void;
+  apiKey?: string;
 }) {
   const { t } = useTranslation();
+  const { notify } = useToast();
 
   const filteredModels = useMemo(() => {
     const needle = searchFilter.trim().toLowerCase();
@@ -216,6 +229,24 @@ export function ModelsTabContent({
     return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
   }, [models, t]);
 
+  const handleImportToCcSwitch = (clientType: CcSwitchClientType) => {
+    const key = String(apiKey ?? "").trim();
+    if (!key) return;
+
+    const url = buildCcSwitchImportUrl({
+      apiKey: key,
+      baseUrl: detectApiBaseFromLocation(),
+      clientType,
+      providerName: buildCcSwitchProviderName({ clientType }),
+      model: pickCcSwitchDefaultModel(clientType, models),
+    });
+
+    openCcSwitchImportUrl(url, {
+      onProtocolUnavailable: () =>
+        notify({ type: "error", message: t("ccswitch.protocol_unavailable") }),
+    });
+  };
+
   return (
     <Card padding="none" className="overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-3.5 dark:border-neutral-800">
@@ -231,13 +262,23 @@ export function ModelsTabContent({
             <span className="text-[10px] text-slate-400 dark:text-white/30">/ {models.length}</span>
           ) : null}
         </div>
-        <TextInput
-          value={searchFilter}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder={t("models_page.search")}
-          className="!w-48"
-          startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
-        />
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {apiKey ? (
+            <CcSwitchImportOptions
+              t={t}
+              models={models}
+              compact
+              onSelect={handleImportToCcSwitch}
+            />
+          ) : null}
+          <TextInput
+            value={searchFilter}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={t("models_page.search")}
+            className="!w-48"
+            startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
+          />
+        </div>
       </div>
 
       {vendorStats.length > 0 && !loading ? (

--- a/src/modules/apikey-lookup/components/__tests__/ModelsTabContent.test.tsx
+++ b/src/modules/apikey-lookup/components/__tests__/ModelsTabContent.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import i18n from "@/i18n";
+import { ModelsTabContent } from "@/modules/apikey-lookup/components/ModelsTabContent";
+import { ThemeProvider } from "@/modules/ui/ThemeProvider";
+import { ToastProvider } from "@/modules/ui/ToastProvider";
+
+describe("ModelsTabContent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders CC Switch import cards and launches selected provider deeplink", async () => {
+    await i18n.changeLanguage("en");
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ModelsTabContent
+            models={["claude-sonnet-4-5", "gpt-5.3-codex", "gemini-2.5-pro"]}
+            loading={false}
+            error={null}
+            searchFilter=""
+            onSearchChange={() => {}}
+            apiKey="sk-lookup-key"
+          />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText(/import to cc switch/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /import codex/i }));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining("ccswitch://v1/import?"),
+        "_self",
+      );
+    });
+
+    const openedUrl = String(openSpy.mock.calls.at(-1)?.[0] ?? "");
+    const parsed = new URL(openedUrl);
+    expect(parsed.searchParams.get("app")).toBe("codex");
+    expect(parsed.searchParams.get("model")).toBe("gpt-5.3-codex");
+    expect(parsed.searchParams.get("apiKey")).toBe("sk-lookup-key");
+  });
+});

--- a/src/modules/auth/AuthProvider.tsx
+++ b/src/modules/auth/AuthProvider.tsx
@@ -241,3 +241,5 @@ export const useAuth = (): AuthContextState => {
   }
   return context;
 };
+
+export const useOptionalAuth = (): AuthContextState | null => use(AuthContext);

--- a/src/modules/ccswitch/CcSwitchImportModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportModal.tsx
@@ -1,0 +1,36 @@
+import type { TFunction } from "i18next";
+import { Button } from "@/modules/ui/Button";
+import { Modal } from "@/modules/ui/Modal";
+import { CcSwitchImportOptions } from "@/modules/ccswitch/CcSwitchImportOptions";
+import type { CcSwitchClientType } from "@/modules/ccswitch/ccswitchImport";
+
+export function CcSwitchImportModal({
+  t,
+  open,
+  models = [],
+  onClose,
+  onSelect,
+}: {
+  t: TFunction;
+  open: boolean;
+  models?: readonly string[];
+  onClose: () => void;
+  onSelect: (clientType: CcSwitchClientType) => void;
+}) {
+  return (
+    <Modal
+      open={open}
+      title={t("ccswitch.import_to_ccswitch")}
+      description={t("ccswitch.import_modal_desc")}
+      maxWidth="max-w-2xl"
+      onClose={onClose}
+      footer={
+        <Button variant="secondary" onClick={onClose}>
+          {t("common.cancel")}
+        </Button>
+      }
+    >
+      <CcSwitchImportOptions t={t} models={models} onSelect={onSelect} />
+    </Modal>
+  );
+}

--- a/src/modules/ccswitch/CcSwitchImportOptions.tsx
+++ b/src/modules/ccswitch/CcSwitchImportOptions.tsx
@@ -1,0 +1,96 @@
+import { Bot, Code2, Sparkles } from "lucide-react";
+import type { TFunction } from "i18next";
+import {
+  CC_SWITCH_CLIENTS,
+  pickCcSwitchDefaultModel,
+  type CcSwitchClientConfig,
+  type CcSwitchClientType,
+} from "@/modules/ccswitch/ccswitchImport";
+
+const iconByType: Record<CcSwitchClientType, typeof Bot> = {
+  claude: Bot,
+  codex: Code2,
+  gemini: Sparkles,
+};
+
+function ImportOptionButton({
+  t,
+  client,
+  models,
+  compact,
+  onSelect,
+}: {
+  t: TFunction;
+  client: CcSwitchClientConfig;
+  models: readonly string[];
+  compact?: boolean;
+  onSelect: (clientType: CcSwitchClientType) => void;
+}) {
+  const Icon = iconByType[client.type];
+  const model = pickCcSwitchDefaultModel(client.type, models);
+  const label = t(client.labelKey);
+  const importLabel = t("ccswitch.import_client", { client: label });
+
+  return (
+    <button
+      type="button"
+      aria-label={importLabel}
+      onClick={() => onSelect(client.type)}
+      className={[
+        "group inline-flex min-w-0 items-center gap-2 rounded-lg border border-slate-200 bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:bg-slate-50 hover:shadow-md active:translate-y-0 dark:border-neutral-800 dark:bg-neutral-950/70 dark:hover:border-neutral-700 dark:hover:bg-neutral-900",
+        compact ? "px-2.5 py-2" : "p-3",
+      ].join(" ")}
+    >
+      <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-700 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-white/10 dark:text-white/75 dark:group-hover:bg-white dark:group-hover:text-neutral-950">
+        <Icon size={15} />
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-semibold text-slate-900 dark:text-white">
+          {label}
+        </span>
+        {compact ? null : (
+          <span className="mt-0.5 block text-xs text-slate-500 dark:text-white/55">
+            {t(client.descriptionKey)}
+          </span>
+        )}
+        {model ? (
+          <span className="mt-1 block truncate font-mono text-[10px] text-slate-400 dark:text-white/35">
+            {t("ccswitch.model_hint", { model })}
+          </span>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+export function CcSwitchImportOptions({
+  t,
+  models = [],
+  compact = false,
+  onSelect,
+}: {
+  t: TFunction;
+  models?: readonly string[];
+  compact?: boolean;
+  onSelect: (clientType: CcSwitchClientType) => void;
+}) {
+  return (
+    <div className={compact ? "flex flex-wrap items-center gap-2" : "grid gap-3 sm:grid-cols-3"}>
+      {compact ? (
+        <span className="mr-1 text-xs font-semibold text-slate-500 dark:text-white/45">
+          {t("ccswitch.import_to_ccswitch")}
+        </span>
+      ) : null}
+      {CC_SWITCH_CLIENTS.map((client) => (
+        <ImportOptionButton
+          key={client.type}
+          t={t}
+          client={client}
+          models={models}
+          compact={compact}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildCcSwitchImportUrl,
+  pickCcSwitchDefaultModel,
+} from "@/modules/ccswitch/ccswitchImport";
+
+const decodeUsageScript = (url: string) => {
+  const encoded = new URL(url).searchParams.get("usageScript");
+  expect(encoded).toBeTruthy();
+  return atob(encoded!);
+};
+
+describe("ccswitchImport", () => {
+  test("builds a Codex provider deeplink with endpoint, model, and usage script", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      model: "gpt-5.3-codex",
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.protocol).toBe("ccswitch:");
+    expect(parsed.hostname).toBe("v1");
+    expect(parsed.pathname).toBe("/import");
+    expect(parsed.searchParams.get("resource")).toBe("provider");
+    expect(parsed.searchParams.get("app")).toBe("codex");
+    expect(parsed.searchParams.get("name")).toBe("Relay Provider");
+    expect(parsed.searchParams.get("homepage")).toBe("https://relay.example.com");
+    expect(parsed.searchParams.get("endpoint")).toBe("https://relay.example.com");
+    expect(parsed.searchParams.get("apiKey")).toBe("sk-test-key");
+    expect(parsed.searchParams.get("icon")).toBe("openai");
+    expect(parsed.searchParams.get("model")).toBe("gpt-5.3-codex");
+    expect(parsed.searchParams.get("configFormat")).toBe("json");
+    expect(parsed.searchParams.get("usageEnabled")).toBe("true");
+    expect(parsed.searchParams.get("usageAutoInterval")).toBe("30");
+
+    const usageScript = decodeUsageScript(url);
+    expect(usageScript).toContain("{{baseUrl}}/v0/management/public/usage");
+    expect(usageScript).toContain('method: "POST"');
+    expect(usageScript).toContain('api_key: "{{apiKey}}"');
+  });
+
+  test("selects a client-specific default model from available models", () => {
+    const models = ["gemini-2.5-pro", "gpt-4.1", "claude-sonnet-4-5", "gpt-5.3-codex"];
+
+    expect(pickCcSwitchDefaultModel("claude", models)).toBe("claude-sonnet-4-5");
+    expect(pickCcSwitchDefaultModel("codex", models)).toBe("gpt-5.3-codex");
+    expect(pickCcSwitchDefaultModel("gemini", models)).toBe("gemini-2.5-pro");
+  });
+});

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -1,0 +1,167 @@
+import { normalizeApiBase } from "@/lib/connection";
+
+export type CcSwitchClientType = "claude" | "codex" | "gemini";
+
+export interface CcSwitchClientConfig {
+  type: CcSwitchClientType;
+  app: string;
+  icon: string;
+  labelKey: string;
+  descriptionKey: string;
+  fallbackLabel: string;
+}
+
+export const CC_SWITCH_CLIENTS: CcSwitchClientConfig[] = [
+  {
+    type: "claude",
+    app: "claude",
+    icon: "claude",
+    labelKey: "ccswitch.client_claude_code",
+    descriptionKey: "ccswitch.client_claude_code_desc",
+    fallbackLabel: "Claude Code",
+  },
+  {
+    type: "codex",
+    app: "codex",
+    icon: "openai",
+    labelKey: "ccswitch.client_codex",
+    descriptionKey: "ccswitch.client_codex_desc",
+    fallbackLabel: "Codex",
+  },
+  {
+    type: "gemini",
+    app: "gemini",
+    icon: "gemini",
+    labelKey: "ccswitch.client_gemini_cli",
+    descriptionKey: "ccswitch.client_gemini_cli_desc",
+    fallbackLabel: "Gemini CLI",
+  },
+];
+
+const CLIENT_BY_TYPE = new Map(CC_SWITCH_CLIENTS.map((client) => [client.type, client]));
+
+const MODEL_PRIORITY: Record<CcSwitchClientType, string[]> = {
+  claude: ["claude-sonnet", "claude-opus", "claude-haiku", "claude"],
+  codex: ["gpt-5.3-codex", "gpt-5-codex", "codex", "gpt-5", "gpt-4.1", "gpt-4", "o4", "o3"],
+  gemini: ["gemini-3", "gemini-2.5-pro", "gemini-2.5-flash", "gemini"],
+};
+
+export function getCcSwitchClientConfig(type: CcSwitchClientType): CcSwitchClientConfig {
+  return CLIENT_BY_TYPE.get(type) ?? CC_SWITCH_CLIENTS[0]!;
+}
+
+export function normalizeCcSwitchBaseUrl(input: string): string {
+  return normalizeApiBase(input).replace(/\/+$/, "");
+}
+
+const encodeBase64 = (value: string): string => {
+  if (typeof btoa === "function") return btoa(value);
+  const buffer = (globalThis as { Buffer?: { from: (input: string, encoding: string) => unknown } })
+    .Buffer;
+  if (buffer?.from) {
+    const bytes = buffer.from(value, "utf-8") as { toString: (encoding: string) => string };
+    return bytes.toString("base64");
+  }
+  throw new Error("Base64 encoder is unavailable");
+};
+
+export function buildCcSwitchUsageScript(): string {
+  return `({
+  request: {
+    url: "{{baseUrl}}/v0/management/public/usage",
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ api_key: "{{apiKey}}" })
+  },
+  extractor: function(response) {
+    var usage = response && response.usage ? response.usage : {};
+    var apis = usage.apis || {};
+    var keys = Object.keys(apis);
+    var item = keys.length > 0 ? apis[keys[0]] || {} : {};
+    var requests = Number(item.total_requests || usage.total_requests || 0) || 0;
+    var tokens = Number(item.total_tokens || usage.total_tokens || 0) || 0;
+    return {
+      planName: "CliProxy",
+      isValid: response && response.found === false ? false : true,
+      used: requests,
+      remaining: null,
+      unit: "requests",
+      extra: String(tokens) + " tokens"
+    };
+  }
+})`;
+}
+
+export function pickCcSwitchDefaultModel(
+  clientType: CcSwitchClientType,
+  models: readonly string[] = [],
+): string | undefined {
+  const normalized = models.map((model) => String(model ?? "").trim()).filter(Boolean);
+  if (normalized.length === 0) return undefined;
+
+  const priorities = MODEL_PRIORITY[clientType];
+  for (const priority of priorities) {
+    const match = normalized.find((model) => model.toLowerCase().includes(priority));
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
+export function buildCcSwitchProviderName(input: {
+  rawName?: string;
+  clientType: CcSwitchClientType;
+}): string {
+  const baseName = String(input.rawName ?? "").trim() || "CliProxy";
+  const clientLabel = getCcSwitchClientConfig(input.clientType).fallbackLabel;
+  return baseName.toLowerCase().includes(clientLabel.toLowerCase())
+    ? baseName
+    : `${baseName} ${clientLabel}`;
+}
+
+export function buildCcSwitchImportUrl(input: {
+  apiKey: string;
+  baseUrl: string;
+  clientType: CcSwitchClientType;
+  providerName: string;
+  model?: string;
+}): string {
+  const client = getCcSwitchClientConfig(input.clientType);
+  const baseUrl = normalizeCcSwitchBaseUrl(input.baseUrl);
+  const params = new URLSearchParams({
+    resource: "provider",
+    app: client.app,
+    name: input.providerName.trim() || buildCcSwitchProviderName({ clientType: input.clientType }),
+    homepage: baseUrl,
+    endpoint: baseUrl,
+    apiKey: input.apiKey.trim(),
+    icon: client.icon,
+    configFormat: "json",
+    usageEnabled: "true",
+    usageScript: encodeBase64(buildCcSwitchUsageScript()),
+    usageAutoInterval: "30",
+  });
+
+  const model = String(input.model ?? "").trim();
+  if (model) {
+    params.set("model", model);
+  }
+
+  return `ccswitch://v1/import?${params.toString()}`;
+}
+
+export function openCcSwitchImportUrl(
+  url: string,
+  options: { onProtocolUnavailable?: () => void } = {},
+): void {
+  try {
+    window.open(url, "_self");
+    window.setTimeout(() => {
+      if (document.hasFocus()) {
+        options.onProtocolUnavailable?.();
+      }
+    }, 100);
+  } catch {
+    options.onProtocolUnavailable?.();
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable CC Switch deeplink import helpers and modal/options UI
- add API Keys row action to select Claude Code, Codex, or Gemini CLI imports
- add API Key Lookup model-tab import cards and tests

## Verification
- bun run test
- bun run lint
- bunx oxfmt <changed files> --check
- bun run build
- bun run check

Note: full `bunx oxfmt . --check` still reports pre-existing unrelated formatting issues outside this change set; changed files pass the targeted format check.