### PR TITLE
fix: polish CC Switch import UX

### DIFF
--- a/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
+++ b/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
@@ -27,6 +27,7 @@ import { useApiKeyLookupCharts } from "@/modules/apikey-lookup/hooks/useApiKeyLo
 import type { ChartDataResponse, LogRow, PublicLogItem } from "@/modules/apikey-lookup/types";
 
 const DEFAULT_PAGE_SIZE = 50;
+const LOOKUP_LAST_API_KEY_STORAGE_KEY = "apiKeyLookup.lastApiKey.v1";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -38,6 +39,35 @@ const formatLatencyMs = (value: number): string => {
   const fixed = seconds.toFixed(seconds < 10 ? 2 : 1);
   const trimmed = fixed.endsWith(".0") ? fixed.slice(0, -2) : fixed;
   return `${trimmed}s`;
+};
+
+const readStoredLookupKey = (): string => {
+  try {
+    return window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ?? "";
+  } catch {
+    return "";
+  }
+};
+
+const writeStoredLookupKey = (value: string): void => {
+  try {
+    if (value) {
+      window.sessionStorage.setItem(LOOKUP_LAST_API_KEY_STORAGE_KEY, value);
+    } else {
+      window.sessionStorage.removeItem(LOOKUP_LAST_API_KEY_STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const readLegacyLookupKeyFromUrl = (): string => {
+  try {
+    const url = new URL(window.location.href);
+    return (url.searchParams.get("api_key") || url.searchParams.get("key") || "").trim();
+  } catch {
+    return "";
+  }
 };
 
 function toLogRow(item: PublicLogItem): LogRow {
@@ -75,8 +105,9 @@ export function ApiKeyLookupPage() {
     return () => mq.removeEventListener("change", handler);
   }, []);
 
-  const [apiKeyInput, setApiKeyInput] = useState("");
-  const [queriedKey, setQueriedKey] = useState("");
+  const initialLookupKey = useMemo(() => readLegacyLookupKeyFromUrl() || readStoredLookupKey(), []);
+  const [apiKeyInput, setApiKeyInput] = useState(initialLookupKey);
+  const [queriedKey, setQueriedKey] = useState(initialLookupKey);
 
   // ── Content modal state ──
   const [contentModalOpen, setContentModalOpen] = useState(false);
@@ -139,6 +170,7 @@ export function ApiKeyLookupPage() {
   const abortControllerRef = useRef<AbortController | null>(null);
   const fetchIdRef = useRef(0);
   const paginationInFlightRef = useRef(false);
+  const restoredLookupFetchedRef = useRef(false);
 
   // ================================================================
   //  Logs fetching (with infinite scroll support)
@@ -179,6 +211,7 @@ export function ApiKeyLookupPage() {
         setModelOptions(resp.filters?.models ?? []);
         setLastUpdatedAt(Date.now());
         setQueriedKey(key.trim());
+        writeStoredLookupKey(key.trim());
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (myFetchId !== fetchIdRef.current) return;
@@ -278,6 +311,7 @@ export function ApiKeyLookupPage() {
   // When tab changes, fetch the appropriate data
   useEffect(() => {
     if (!queriedKey) return;
+    if (initialLookupKey && !restoredLookupFetchedRef.current) return;
     if (activeTab === "usage") {
       void fetchChartDataFn(queriedKey, timeRange);
     } else if (activeTab === "models") {
@@ -292,11 +326,21 @@ export function ApiKeyLookupPage() {
   // When time range changes, refetch current tab
   useEffect(() => {
     if (!queriedKey) return;
+    if (initialLookupKey && !restoredLookupFetchedRef.current) return;
     chartCacheRef.current = {};
     if (activeTab === "usage") {
       void fetchChartDataFn(queriedKey, timeRange);
     }
   }, [timeRange]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!initialLookupKey || restoredLookupFetchedRef.current) return;
+
+    restoredLookupFetchedRef.current = true;
+    chartCacheRef.current = {};
+    void fetchChartDataFn(initialLookupKey, timeRange);
+    fetchLogs(initialLookupKey, 1);
+  }, [fetchChartDataFn, fetchLogs, initialLookupKey, timeRange]);
 
   const handleSubmit = useCallback(
     (event?: React.FormEvent) => {
@@ -317,6 +361,7 @@ export function ApiKeyLookupPage() {
           fetchLogs(val, 1);
           void fetchChartDataFn(val, timeRange);
         }
+        writeStoredLookupKey(val);
       }
     },
     [apiKeyInput, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn],
@@ -337,6 +382,9 @@ export function ApiKeyLookupPage() {
 
   // Strip legacy sensitive query params from the URL on mount.
   useEffect(() => {
+    if (initialLookupKey) {
+      writeStoredLookupKey(initialLookupKey);
+    }
     try {
       const url = new URL(window.location.href);
       let changed = false;
@@ -354,7 +402,7 @@ export function ApiKeyLookupPage() {
     } catch {
       // ignore
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialLookupKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const {
     chartStats,

--- a/src/modules/apikey-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/src/modules/apikey-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiKeyLookupPage } from "@/modules/apikey-lookup/ApiKeyLookupPage";
+import { ThemeProvider } from "@/modules/ui/ThemeProvider";
+import { ToastProvider } from "@/modules/ui/ToastProvider";
+
+const mocks = vi.hoisted(() => ({
+  fetchPublicLogs: vi.fn(async () => ({
+    items: [],
+    total: 0,
+    page: 1,
+    size: 50,
+    stats: { total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 },
+    filters: { models: [] },
+  })),
+  fetchPublicChartData: vi.fn(async () => ({
+    daily_series: [],
+    model_distribution: [],
+    stats: { total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 },
+  })),
+  fetchAvailableModels: vi.fn(async () => [] as string[]),
+}));
+
+vi.mock("@/modules/apikey-lookup/api", () => ({
+  fetchPublicLogs: mocks.fetchPublicLogs,
+  fetchPublicChartData: mocks.fetchPublicChartData,
+  fetchAvailableModels: mocks.fetchAvailableModels,
+}));
+
+vi.mock("@/modules/apikey-lookup/components/UsageTabSection", () => ({
+  UsageTabSection: () => <div data-testid="usage-tab" />,
+}));
+
+vi.mock("@/modules/monitor/LogContentModal", () => ({
+  LogContentModal: () => null,
+}));
+
+describe("ApiKeyLookupPage", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState({}, "", "/manage/apikey-lookup");
+    vi.clearAllMocks();
+  });
+
+  test("restores the last looked up API key after page refresh and queries immediately", async () => {
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByLabelText(/api key/i)).toHaveValue("sk-restored-key");
+    await waitFor(() => {
+      expect(mocks.fetchPublicLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "sk-restored-key" }),
+      );
+      expect(mocks.fetchPublicChartData).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "sk-restored-key" }),
+      );
+    });
+  });
+});

--- a/src/modules/ccswitch/CcSwitchImportModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportModal.tsx
@@ -22,7 +22,7 @@ export function CcSwitchImportModal({
       open={open}
       title={t("ccswitch.import_to_ccswitch")}
       description={t("ccswitch.import_modal_desc")}
-      maxWidth="max-w-2xl"
+      maxWidth="max-w-xl"
       onClose={onClose}
       footer={
         <Button variant="secondary" onClick={onClose}>

--- a/src/modules/ccswitch/CcSwitchImportOptions.tsx
+++ b/src/modules/ccswitch/CcSwitchImportOptions.tsx
@@ -1,4 +1,3 @@
-import { Bot, Code2, Sparkles } from "lucide-react";
 import type { TFunction } from "i18next";
 import {
   CC_SWITCH_CLIENTS,
@@ -6,11 +5,14 @@ import {
   type CcSwitchClientConfig,
   type CcSwitchClientType,
 } from "@/modules/ccswitch/ccswitchImport";
+import iconClaude from "@/assets/icons/claude.svg";
+import iconCodex from "@/assets/icons/codex.svg";
+import iconGemini from "@/assets/icons/gemini.svg";
 
-const iconByType: Record<CcSwitchClientType, typeof Bot> = {
-  claude: Bot,
-  codex: Code2,
-  gemini: Sparkles,
+const iconByType: Record<CcSwitchClientType, string> = {
+  claude: iconClaude,
+  codex: iconCodex,
+  gemini: iconGemini,
 };
 
 function ImportOptionButton({
@@ -26,7 +28,7 @@ function ImportOptionButton({
   compact?: boolean;
   onSelect: (clientType: CcSwitchClientType) => void;
 }) {
-  const Icon = iconByType[client.type];
+  const icon = iconByType[client.type];
   const model = pickCcSwitchDefaultModel(client.type, models);
   const label = t(client.labelKey);
   const importLabel = t("ccswitch.import_client", { client: label });
@@ -35,17 +37,37 @@ function ImportOptionButton({
     <button
       type="button"
       aria-label={importLabel}
+      title={model ? `${importLabel} · ${model}` : importLabel}
       onClick={() => onSelect(client.type)}
       className={[
-        "group inline-flex min-w-0 items-center gap-2 rounded-lg border border-slate-200 bg-white text-left shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:bg-slate-50 hover:shadow-md active:translate-y-0 dark:border-neutral-800 dark:bg-neutral-950/70 dark:hover:border-neutral-700 dark:hover:bg-neutral-900",
-        compact ? "px-2.5 py-2" : "p-3",
+        "group inline-flex min-w-0 items-center text-left transition active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:focus-visible:ring-white/15",
+        compact
+          ? "h-8 gap-1.5 rounded-lg border border-transparent bg-white/80 px-2 text-slate-700 hover:border-slate-200 hover:bg-white hover:text-slate-950 dark:bg-neutral-950/60 dark:text-white/70 dark:hover:border-neutral-700 dark:hover:bg-neutral-900 dark:hover:text-white"
+          : "gap-3 rounded-xl border border-black/[0.06] bg-slate-50/55 p-3 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] hover:border-slate-200 hover:bg-white hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900/55 dark:hover:border-neutral-700 dark:hover:bg-neutral-900",
       ].join(" ")}
     >
-      <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-700 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-white/10 dark:text-white/75 dark:group-hover:bg-white dark:group-hover:text-neutral-950">
-        <Icon size={15} />
+      <span
+        className={[
+          "inline-flex shrink-0 items-center justify-center rounded-lg border bg-white dark:bg-neutral-950",
+          compact
+            ? "h-5 w-5 border-transparent"
+            : "h-10 w-10 border-slate-200/70 shadow-xs dark:border-neutral-800",
+        ].join(" ")}
+      >
+        <img
+          src={icon}
+          alt=""
+          data-testid={`ccswitch-client-icon-${client.type}`}
+          className={compact ? "h-4 w-4" : "h-5 w-5"}
+        />
       </span>
       <span className="min-w-0">
-        <span className="block truncate text-sm font-semibold text-slate-900 dark:text-white">
+        <span
+          className={[
+            "block truncate font-semibold text-slate-900 dark:text-white",
+            compact ? "text-xs" : "text-sm",
+          ].join(" ")}
+        >
           {label}
         </span>
         {compact ? null : (
@@ -53,8 +75,8 @@ function ImportOptionButton({
             {t(client.descriptionKey)}
           </span>
         )}
-        {model ? (
-          <span className="mt-1 block truncate font-mono text-[10px] text-slate-400 dark:text-white/35">
+        {model && !compact ? (
+          <span className="mt-2 inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
             {t("ccswitch.model_hint", { model })}
           </span>
         ) : null}
@@ -75,9 +97,17 @@ export function CcSwitchImportOptions({
   onSelect: (clientType: CcSwitchClientType) => void;
 }) {
   return (
-    <div className={compact ? "flex flex-wrap items-center gap-2" : "grid gap-3 sm:grid-cols-3"}>
+    <div
+      role={compact ? "group" : undefined}
+      aria-label={compact ? t("ccswitch.import_to_ccswitch") : undefined}
+      className={
+        compact
+          ? "inline-flex min-w-0 flex-wrap items-center gap-1 rounded-xl border border-slate-200/70 bg-slate-50/75 p-1 dark:border-neutral-800 dark:bg-neutral-900/45"
+          : "grid gap-2.5 sm:grid-cols-3"
+      }
+    >
       {compact ? (
-        <span className="mr-1 text-xs font-semibold text-slate-500 dark:text-white/45">
+        <span className="px-1.5 text-[11px] font-semibold text-slate-500 dark:text-white/45">
           {t("ccswitch.import_to_ccswitch")}
         </span>
       ) : null}

--- a/src/modules/ccswitch/__tests__/CcSwitchImportOptions.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportOptions.test.tsx
@@ -1,0 +1,43 @@
+import type { TFunction } from "i18next";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { CcSwitchImportOptions } from "@/modules/ccswitch/CcSwitchImportOptions";
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  const labels: Record<string, string> = {
+    "ccswitch.import_to_ccswitch": "Import to CC Switch",
+    "ccswitch.import_client": `Import ${String(options?.client ?? "")}`,
+    "ccswitch.client_claude_code": "Claude Code",
+    "ccswitch.client_claude_code_desc": "Claude Code config",
+    "ccswitch.client_codex": "Codex",
+    "ccswitch.client_codex_desc": "Codex config",
+    "ccswitch.client_gemini_cli": "Gemini CLI",
+    "ccswitch.client_gemini_cli_desc": "Gemini CLI config",
+    "ccswitch.model_hint": `Model: ${String(options?.model ?? "")}`,
+  };
+  return labels[key] ?? key;
+}) as TFunction;
+
+const expectIconToContainTitle = (testId: string, title: string) => {
+  const src = screen.getByTestId(testId).getAttribute("src") ?? "";
+  expect(decodeURIComponent(src)).toContain(`<title>${title}</title>`);
+};
+
+describe("CcSwitchImportOptions", () => {
+  test("uses provider brand icons for all import choices", () => {
+    render(
+      <CcSwitchImportOptions
+        t={t}
+        models={["claude-sonnet-4-20250514", "gpt-5.3-codex", "gemini-2.5-pro"]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Import Claude Code" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import Codex" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import Gemini CLI" })).toBeInTheDocument();
+    expectIconToContainTitle("ccswitch-client-icon-claude", "Claude");
+    expectIconToContainTitle("ccswitch-client-icon-codex", "Codex");
+    expectIconToContainTitle("ccswitch-client-icon-gemini", "Gemini");
+  });
+});


### PR DESCRIPTION
## Summary
- Use existing Claude Code, Codex, and Gemini brand SVG icons in CC Switch import choices.
- Persist and restore the last API key lookup in session storage so refresh does not require re-entry.
- Restyle the API key lookup import actions as compact chips aligned with the existing card UI.

## Test Plan
- bun run test
- bun run lint
- bunx oxfmt src/modules/apikey-lookup/ApiKeyLookupPage.tsx src/modules/apikey-lookup/__tests__/ApiKeyLookupPage.test.tsx src/modules/ccswitch/CcSwitchImportModal.tsx src/modules/ccswitch/CcSwitchImportOptions.tsx src/modules/ccswitch/__tests__/CcSwitchImportOptions.test.tsx --check
- bun run build
- bun run check
- bunx oxfmt . --check (fails on 41 pre-existing unrelated files; changed files pass targeted format check)
- Local Playwright visual check for /#/apikey-lookup models tab with mocked public usage/models APIs