### PR TITLE
fix: show proxy details in shared selects

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ToastProvider } from "@/modules/ui/ToastProvider";
+import { ThemeProvider } from "@/modules/ui/ThemeProvider";
+import { AuthFilesPage } from "@/modules/auth-files/AuthFilesPage";
+import type { ProxyCheckResult, ProxyPoolEntry } from "@/lib/http/apis/proxies";
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(async () => ({
+    files: [
+      {
+        name: "codex-auth.json",
+        label: "Codex Auth",
+        account_type: "oauth",
+        type: "codex",
+        size: 1024,
+        modified: Date.now(),
+        disabled: false,
+      },
+    ],
+  })),
+  getEntityStats: vi.fn(async () => ({ source: [], auth_index: [] })),
+  downloadText: vi.fn(async () => JSON.stringify({ type: "codex" })),
+  upload: vi.fn(async () => ({})),
+  proxiesList: vi.fn<() => Promise<ProxyPoolEntry[]>>(async () => []),
+  proxiesCheck: vi.fn<() => Promise<ProxyCheckResult>>(async () => ({ ok: true, latencyMs: 420 })),
+}));
+
+vi.mock("@/lib/http/apis", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/http/apis")>();
+  return {
+    ...mod,
+    authFilesApi: {
+      ...mod.authFilesApi,
+      list: mocks.list,
+      downloadText: mocks.downloadText,
+      upload: mocks.upload,
+    },
+    usageApi: { ...mod.usageApi, getEntityStats: mocks.getEntityStats },
+  };
+});
+
+vi.mock("@/lib/http/apis/proxies", () => ({
+  proxiesApi: {
+    list: mocks.proxiesList,
+    check: mocks.proxiesCheck,
+  },
+}));
+
+describe("AuthFilesPage proxy fields editor", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    mocks.list.mockClear();
+    mocks.getEntityStats.mockClear();
+    mocks.downloadText.mockClear();
+    mocks.upload.mockClear();
+    mocks.proxiesList.mockReset();
+    mocks.proxiesCheck.mockReset();
+    mocks.proxiesList.mockResolvedValue([
+      {
+        id: "us-west",
+        name: "US West",
+        url: "socks5://user:pass@203.0.113.8:7893",
+        enabled: true,
+        description: "West edge auth",
+      },
+    ]);
+    mocks.proxiesCheck.mockResolvedValue({ ok: true, latencyMs: 420 });
+  });
+
+  test("shows proxy protocol, IP, latency, and remark in the auth fields dropdown", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Codex Auth")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "View" }));
+    await user.click(await screen.findByRole("tab", { name: "Fields" }));
+
+    const proxySelect = await screen.findByRole("combobox", { name: "proxy_id (proxy pool)" });
+    await waitFor(() => expect(mocks.proxiesCheck).toHaveBeenCalledWith({ id: "us-west" }));
+
+    await user.click(proxySelect);
+
+    expect(await screen.findByText("SOCKS5")).toBeInTheDocument();
+    expect(screen.getByText("203.0.113.8:7893")).toBeInTheDocument();
+    expect(screen.getByText(/420 ms/)).toBeInTheDocument();
+    expect(screen.getByText("West edge auth")).toBeInTheDocument();
+    expect(screen.queryByText(/user:pass/)).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -9,6 +9,7 @@ import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { ProxyPoolSelect } from "@/modules/proxies/ProxyPoolSelect";
+import { useProxyPoolChecks } from "@/modules/proxies/useProxyPoolChecks";
 import {
   downloadTextAsFile,
   formatFileSize,
@@ -72,6 +73,7 @@ export function AuthFileDetailModal({
   saveChannelEditor,
 }: AuthFileDetailModalProps) {
   const { t } = useTranslation();
+  const proxyCheckState = useProxyPoolChecks(proxyPoolEntries, open && detailTab === "fields");
 
   return (
     <Modal
@@ -295,6 +297,8 @@ export function AuthFileDetailModal({
                       label={t("auth_files.proxy_id_label")}
                       hint={t("auth_files.leave_empty_proxy_id")}
                       ariaLabel={t("auth_files.proxy_id_label")}
+                      checkState={proxyCheckState}
+                      showDetails
                     />
                   </div>
 

--- a/src/modules/oauth/OAuthLoginDialog.tsx
+++ b/src/modules/oauth/OAuthLoginDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Copy, ExternalLink, RefreshCw, Send, ShieldCheck, Sparkles, Upload } from "lucide-react";
 import { oauthApi, vertexApi } from "@/lib/http/apis";
 import type { IFlowCookieAuthResponse, OAuthProvider } from "@/lib/http/types";
-import { proxiesApi, type ProxyCheckResult, type ProxyPoolEntry } from "@/lib/http/apis/proxies";
+import type { ProxyPoolEntry } from "@/lib/http/apis/proxies";
 import { Button } from "@/modules/ui/Button";
 import { Card } from "@/modules/ui/Card";
 import { TextInput } from "@/modules/ui/Input";
@@ -11,11 +11,7 @@ import { Modal } from "@/modules/ui/Modal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { ProxyPoolSelect } from "@/modules/proxies/ProxyPoolSelect";
-import {
-  readCachedProxyCheckState,
-  writeCachedProxyCheckState,
-  type ProxyCheckState,
-} from "@/modules/proxies/proxy-utils";
+import { useProxyPoolChecks } from "@/modules/proxies/useProxyPoolChecks";
 
 type ProviderStatus = "idle" | "waiting" | "success" | "error";
 
@@ -87,13 +83,10 @@ export function OAuthLoginDialog({
   const { t } = useTranslation();
   const { notify } = useToast();
   const timers = useRef<Record<string, number>>({});
-  const autoCheckedProxyIDs = useRef<Set<string>>(new Set());
 
   const [tab, setTab] = useState<TabValue>(defaultTab);
   const [selectedProxyID, setSelectedProxyID] = useState("");
-  const [proxyCheckState, setProxyCheckState] = useState<ProxyCheckState>(() =>
-    readCachedProxyCheckState(),
-  );
+  const proxyCheckState = useProxyPoolChecks(proxyPoolEntries, open);
 
   const [states, setStates] = useState<Record<OAuthProvider, ProviderState>>(
     {} as Record<OAuthProvider, ProviderState>,
@@ -121,7 +114,6 @@ export function OAuthLoginDialog({
   useEffect(() => {
     if (!open) {
       clearTimers();
-      autoCheckedProxyIDs.current.clear();
       return;
     }
     return () => clearTimers();
@@ -131,51 +123,7 @@ export function OAuthLoginDialog({
     if (!open) return;
     setTab(defaultTab);
     setSelectedProxyID("");
-    setProxyCheckState(readCachedProxyCheckState());
   }, [defaultTab, open]);
-
-  const storeProxyCheckResult = useCallback((id: string, result: ProxyCheckResult) => {
-    setProxyCheckState((prev) => {
-      const next = { ...prev, [id]: result };
-      writeCachedProxyCheckState(next);
-      return next;
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!open || proxyPoolEntries.length === 0) return;
-
-    const pendingEntries = proxyPoolEntries.filter((entry) => {
-      const id = entry.id.trim();
-      if (!id || autoCheckedProxyIDs.current.has(id)) return false;
-      const result = proxyCheckState[id];
-      return typeof result?.latencyMs !== "number";
-    });
-    if (pendingEntries.length === 0) return;
-
-    setProxyCheckState((prev) => {
-      const next = { ...prev };
-      for (const entry of pendingEntries) {
-        const id = entry.id.trim();
-        autoCheckedProxyIDs.current.add(id);
-        next[id] = { ...next[id], checking: true };
-      }
-      return next;
-    });
-
-    pendingEntries.forEach((entry) => {
-      const id = entry.id.trim();
-      void proxiesApi
-        .check({ id })
-        .then((result) => storeProxyCheckResult(id, result))
-        .catch((error) =>
-          storeProxyCheckResult(id, {
-            ok: false,
-            message: error instanceof Error ? error.message : t("common.error"),
-          }),
-        );
-    });
-  }, [open, proxyCheckState, proxyPoolEntries, storeProxyCheckResult, t]);
 
   const getProviderTitle = useCallback(
     (provider: OAuthProvider) =>

--- a/src/modules/proxies/ProxyPoolSelect.tsx
+++ b/src/modules/proxies/ProxyPoolSelect.tsx
@@ -55,6 +55,9 @@ export function ProxyPoolSelect({
       seen.add(id);
       const result = checkState[id];
       const tone = proxyLatencyTone(result);
+      const protocol = proxyProtocol(entry.url);
+      const endpoint = proxyEndpoint(entry);
+      const displayName = entry.name || id;
       const latencyText =
         typeof result?.latencyMs === "number"
           ? `${result.latencyMs} ms`
@@ -69,19 +72,33 @@ export function ProxyPoolSelect({
           : t("proxies.check_pending");
       base.push({
         value: id,
+        triggerLabel: showDetails ? (
+          <span className="flex min-w-0 items-center gap-2">
+            <Network size={14} className="shrink-0 text-slate-400 dark:text-white/45" />
+            <span className="min-w-0 flex-1 truncate">{displayName}</span>
+            <span className="shrink-0 text-xs font-semibold text-slate-500 dark:text-white/50">
+              {protocol} · {endpoint}
+            </span>
+          </span>
+        ) : undefined,
         label: (
           <span className="flex min-w-0 flex-1 items-center gap-2">
             <Network size={14} className="shrink-0 text-slate-400 dark:text-white/45" />
             <span className="min-w-0 flex-1">
               <span className="block truncate">
-                {entry.name || id}
+                {displayName}
                 <span className="ml-1 text-xs text-slate-500 dark:text-white/50">({id})</span>
               </span>
               {showDetails ? (
                 <span className="mt-0.5 flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] text-slate-500 dark:text-white/50">
-                  <span className="font-semibold">{proxyProtocol(entry.url)}</span>
-                  <span className="font-mono">{proxyEndpoint(entry)}</span>
+                  <span className="font-semibold">{protocol}</span>
+                  <span className="font-mono">{endpoint}</span>
                   {entry.description ? <span className="truncate">{entry.description}</span> : null}
+                  {result?.message && result.ok === false ? (
+                    <span className="truncate text-rose-600 dark:text-rose-300">
+                      {result.message}
+                    </span>
+                  ) : null}
                 </span>
               ) : null}
             </span>

--- a/src/modules/proxies/useProxyPoolChecks.ts
+++ b/src/modules/proxies/useProxyPoolChecks.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { proxiesApi, type ProxyCheckResult, type ProxyPoolEntry } from "@/lib/http/apis/proxies";
+import {
+  readCachedProxyCheckState,
+  writeCachedProxyCheckState,
+  type ProxyCheckState,
+} from "@/modules/proxies/proxy-utils";
+
+export function useProxyPoolChecks(entries: ProxyPoolEntry[], active: boolean): ProxyCheckState {
+  const { t } = useTranslation();
+  const autoCheckedProxyIDs = useRef<Set<string>>(new Set());
+  const [checkState, setCheckState] = useState<ProxyCheckState>(() => readCachedProxyCheckState());
+
+  useEffect(() => {
+    if (!active) {
+      autoCheckedProxyIDs.current.clear();
+      return;
+    }
+    setCheckState(readCachedProxyCheckState());
+  }, [active]);
+
+  const storeProxyCheckResult = useCallback((id: string, result: ProxyCheckResult) => {
+    setCheckState((prev) => {
+      const next = { ...prev, [id]: result };
+      writeCachedProxyCheckState(next);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!active || entries.length === 0) return;
+
+    const pendingEntries = entries.filter((entry) => {
+      const id = entry.id.trim();
+      if (!id || autoCheckedProxyIDs.current.has(id)) return false;
+      const result = checkState[id];
+      return typeof result?.latencyMs !== "number";
+    });
+    if (pendingEntries.length === 0) return;
+
+    setCheckState((prev) => {
+      const next = { ...prev };
+      for (const entry of pendingEntries) {
+        const id = entry.id.trim();
+        autoCheckedProxyIDs.current.add(id);
+        next[id] = { ...next[id], checking: true };
+      }
+      return next;
+    });
+
+    pendingEntries.forEach((entry) => {
+      const id = entry.id.trim();
+      void proxiesApi
+        .check({ id })
+        .then((result) => storeProxyCheckResult(id, result))
+        .catch((error) =>
+          storeProxyCheckResult(id, {
+            ok: false,
+            message: error instanceof Error ? error.message : t("common.error"),
+          }),
+        );
+    });
+  }, [active, checkState, entries, storeProxyCheckResult, t]);
+
+  return checkState;
+}

--- a/src/modules/ui/SearchableSelect.tsx
+++ b/src/modules/ui/SearchableSelect.tsx
@@ -34,6 +34,7 @@ import type { ControlSize } from "@/modules/ui/controlStyles";
 export interface SearchableSelectOption {
   value: string;
   label: ReactNode;
+  triggerLabel?: ReactNode;
   /** searchable text (defaults to value if omitted) */
   searchText?: string;
 }
@@ -130,7 +131,7 @@ export function SearchableSelect({
 
   const selectedLabel = useMemo(() => {
     const match = options.find((o) => o.value === value);
-    return match ? match.label : null;
+    return match ? (match.triggerLabel ?? match.label) : null;
   }, [options, value]);
 
   const filtered = useMemo(() => {
@@ -187,7 +188,7 @@ export function SearchableSelect({
         onClick={() => setOpen((prev) => !prev)}
         className={cn(getSelectTriggerBase(size), open && selectTriggerOpen, className)}
       >
-        <span className="truncate">{selectedLabel ?? placeholder}</span>
+        <span className="min-w-0 flex-1 truncate text-left">{selectedLabel ?? placeholder}</span>
         <ChevronDown
           size={14}
           className={cn(selectChevron, open && "rotate-180")}
@@ -252,7 +253,7 @@ export function SearchableSelect({
                             selected ? selectOptionSelected : selectOptionIdle,
                           )}
                         >
-                          <span className="flex-1 whitespace-nowrap">{opt.label}</span>
+                          <span className="min-w-0 flex-1">{opt.label}</span>
                           {selected ? (
                             <Check
                               size={14}
@@ -279,7 +280,7 @@ export function SearchableSelect({
                           className="shrink-0 text-[#71717A] dark:text-[#A1A1AA]"
                           aria-hidden="true"
                         />
-                        <span className="flex-1 whitespace-nowrap">
+                        <span className="min-w-0 flex-1">
                           {createLabel ? createLabel(createValue) : createValue}
                         </span>
                       </button>

--- a/src/modules/ui/Select.tsx
+++ b/src/modules/ui/Select.tsx
@@ -32,6 +32,7 @@ import type { ControlSize } from "@/modules/ui/controlStyles";
 export interface SelectOption {
   value: string;
   label: ReactNode;
+  triggerLabel?: ReactNode;
 }
 
 export interface SelectProps {
@@ -135,7 +136,7 @@ export function Select({
 
   const selectedLabel = useMemo(() => {
     const match = options.find((o) => o.value === value);
-    return match ? match.label : null;
+    return match ? (match.triggerLabel ?? match.label) : null;
   }, [options, value]);
 
   const handleSelect = useCallback(
@@ -166,7 +167,7 @@ export function Select({
           className,
         )}
       >
-        <span className="truncate">{selectedLabel ?? placeholder}</span>
+        <span className="min-w-0 flex-1 truncate text-left">{selectedLabel ?? placeholder}</span>
         <ChevronDown
           size={14}
           className={cn(selectChevron, open && "rotate-180")}
@@ -208,7 +209,7 @@ export function Select({
                       selected ? selectOptionSelected : selectOptionIdle,
                     )}
                   >
-                    <span className="flex-1 whitespace-nowrap">{opt.label}</span>
+                    <span className="min-w-0 flex-1">{opt.label}</span>
                     {selected ? (
                       <Check
                         size={14}

--- a/src/modules/ui/__tests__/ControlSizing.test.tsx
+++ b/src/modules/ui/__tests__/ControlSizing.test.tsx
@@ -62,9 +62,7 @@ describe("shared control sizing", () => {
       "dark:hover:bg-[#303036]",
       "dark:hover:text-white",
     );
-    expect(screen.getByRole("textbox", { name: "Search" })).not.toHaveClass(
-      "focus-visible:ring-2",
-    );
+    expect(screen.getByRole("textbox", { name: "Search" })).not.toHaveClass("focus-visible:ring-2");
     screen.getAllByRole("combobox").forEach((control) => {
       expect(control).toHaveClass(
         "h-9",
@@ -103,6 +101,33 @@ describe("shared control sizing", () => {
     expect(screen.getByRole("tab", { name: "Small" })).toHaveClass("h-7");
     expect(screen.getByRole("textbox", { name: "Small input" })).toHaveClass("h-8");
     expect(screen.getByRole("textbox", { name: "Large input" })).toHaveClass("h-10");
+  });
+
+  test("keeps shared select chevrons aligned to the right edge", () => {
+    render(
+      <>
+        <Select
+          value=""
+          onChange={vi.fn()}
+          options={[{ value: "", label: "No proxy pool binding" }]}
+          aria-label="Proxy pool"
+          className="w-full"
+        />
+        <SearchableSelect
+          value=""
+          onChange={vi.fn()}
+          options={[{ value: "", label: "All models" }]}
+          aria-label="Model"
+          className="w-full"
+        />
+      </>,
+    );
+
+    for (const control of screen.getAllByRole("combobox")) {
+      expect(control).toHaveClass("justify-between");
+      expect(control.querySelector("span")).toHaveClass("min-w-0", "flex-1", "truncate");
+      expect(control.querySelector("svg")).toHaveClass("ml-auto", "shrink-0");
+    }
   });
 
   test("uses shared select surface for searchable checkbox multi-select dropdown", async () => {

--- a/src/modules/ui/selectStyles.ts
+++ b/src/modules/ui/selectStyles.ts
@@ -11,7 +11,7 @@ export const cn = (...classes: (string | false | undefined | null)[]) =>
 
 export const getSelectTriggerBase = (size: ControlSize = "default") =>
   [
-    "inline-flex items-center gap-1.5 font-medium",
+    "inline-flex min-w-0 items-center justify-between gap-1.5 font-medium",
     controlHeightBySize[size],
     controlTextBySize[size],
     controlPaddingBySize[size],
@@ -29,7 +29,7 @@ export const selectTriggerChip =
   "inline-flex h-7 items-center justify-center gap-1.5 rounded-xl border-0 bg-white px-2.5 text-[11px] font-semibold text-[#71717A] shadow-[0_2px_8px_rgb(0_0_0_/_0.10)] outline-none transition-colors hover:bg-white hover:text-[#18181B] focus-visible:ring-2 focus-visible:ring-black/[0.08] dark:bg-[#27272A] dark:text-[#A1A1AA] dark:shadow-[0_6px_18px_rgb(0_0_0_/_0.22)] dark:hover:bg-[#303036] dark:hover:text-white dark:focus-visible:ring-white/10";
 
 export const selectChevron =
-  "shrink-0 text-[#71717A] transition-transform duration-200 dark:text-[#A1A1AA]";
+  "ml-auto shrink-0 text-[#71717A] transition-transform duration-200 dark:text-[#A1A1AA]";
 
 export const selectPanel =
   "fixed z-[9999] overflow-hidden rounded-2xl border-0 bg-white p-1 shadow-[0_8px_28px_rgb(0_0_0_/_0.16)] dark:bg-[#27272A] dark:shadow-[0_14px_36px_rgb(0_0_0_/_0.38)]";


### PR DESCRIPTION
## Summary
- Align shared Select/SearchableSelect chevrons to the right edge for full-width dropdowns.
- Reuse proxy latency auto-checking across OAuth and auth-file field editors.
- Show protocol, endpoint, latency, remark, and failed check messages in proxy dropdown options.

## Test Plan
- bun run test
- bun run check
- bunx oxfmt <changed files> --check
- git diff --check

Note: full `bunx oxfmt . --check` still reports 39 pre-existing unrelated formatting issues.