### PR TITLE
fix: place OAuth proxy selector below tabs

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -86,6 +86,32 @@ describe("AuthFilesPage OAuth login dialog", () => {
     expect(scoped.getByRole("tab", { name: "Vertex Credential Import" })).toBeInTheDocument();
   });
 
+  test("places the authorization proxy selector below the OAuth provider tabs", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Add OAuth Login" }));
+
+    const dialog = await screen.findByRole("dialog");
+    const scoped = within(dialog);
+    const tabs = scoped.getByRole("tablist");
+    const proxySelect = await scoped.findByRole("combobox", { name: "Authorization Proxy" });
+
+    expect(tabs.compareDocumentPosition(proxySelect) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(
+      0,
+    );
+  });
+
   test("selects a proxy with IP, latency, and remark before starting OAuth authorization", async () => {
     const user = userEvent.setup();
     mocks.proxiesList.mockResolvedValue([

--- a/src/modules/oauth/OAuthLoginDialog.tsx
+++ b/src/modules/oauth/OAuthLoginDialog.tsx
@@ -500,20 +500,6 @@ export function OAuthLoginDialog({
       }
     >
       <div className="space-y-4">
-        <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-          <ProxyPoolSelect
-            value={selectedProxyID}
-            onChange={setSelectedProxyID}
-            entries={proxyPoolEntries}
-            checkState={proxyCheckState}
-            showDetails
-            noneLabel={t("oauth.proxy_default_local")}
-            label={t("oauth.authorization_proxy")}
-            hint={t("oauth.authorization_proxy_hint")}
-            ariaLabel={t("oauth.authorization_proxy")}
-          />
-        </div>
-
         <Tabs value={tab} onValueChange={(next) => setTab(next as TabValue)}>
           <TabsList>
             {PROVIDER_TAB_IDS.map((providerId) => {
@@ -527,6 +513,20 @@ export function OAuthLoginDialog({
             <TabsTrigger value="iflow">{t("oauth.iflow_title")}</TabsTrigger>
             <TabsTrigger value="vertex">{t("oauth.vertex_title")}</TabsTrigger>
           </TabsList>
+
+          <div className="mt-4 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <ProxyPoolSelect
+              value={selectedProxyID}
+              onChange={setSelectedProxyID}
+              entries={proxyPoolEntries}
+              checkState={proxyCheckState}
+              showDetails
+              noneLabel={t("oauth.proxy_default_local")}
+              label={t("oauth.authorization_proxy")}
+              hint={t("oauth.authorization_proxy_hint")}
+              ariaLabel={t("oauth.authorization_proxy")}
+            />
+          </div>
 
           {PROVIDER_TAB_IDS.map((providerId) => (
             <TabsContent key={providerId} value={providerId} className="mt-4">


### PR DESCRIPTION
## Summary
- Move the OAuth authorization proxy selector below the provider tab list.
- Add a regression test that asserts the proxy selector follows the tablist in the dialog DOM.

## Test Plan
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
- bun run lint
- bunx oxfmt src/modules/oauth/OAuthLoginDialog.tsx src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx --check
- bun run build
- bun run test
- bun run check

Note: global `bunx oxfmt . --check` still reports pre-existing formatting issues in unrelated files on the latest dev baseline, so only the two changed files were format-checked.