### PR TITLE
fix: persist model library additions

### DIFF
--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -303,7 +303,7 @@ function buildModelPayload(form: ModelFormState) {
   };
 }
 
-function payloadToModel(payload: ReturnType<typeof buildModelPayload>): ModelItem {
+function payloadToModel(payload: ReturnType<typeof buildModelPayload>, source: string): ModelItem {
   const pricing =
     payload.pricing.mode === "call"
       ? {
@@ -324,24 +324,33 @@ function payloadToModel(payload: ReturnType<typeof buildModelPayload>): ModelIte
     owned_by: payload.owned_by,
     description: payload.description,
     enabled: payload.enabled,
-    source: "user",
+    source,
     pricing,
   };
 }
 
-async function saveModelConfig(form: ModelFormState) {
+function modelConfigCollectionPath(scope: ModelScope): string {
+  return scope === "library" ? "/model-configs?scope=library" : "/model-configs";
+}
+
+function modelConfigItemPath(modelId: string, scope: ModelScope): string {
+  const suffix = scope === "library" ? "?scope=library" : "";
+  return `/model-configs/${encodeURIComponent(modelId)}${suffix}`;
+}
+
+async function saveModelConfig(form: ModelFormState, scope: ModelScope) {
   const payload = buildModelPayload(form);
   if (!payload.id) {
     throw new Error("Model ID is required");
   }
 
   if (form.originalId) {
-    await apiClient.put(`/model-configs/${encodeURIComponent(form.originalId)}`, payload);
+    await apiClient.put(modelConfigItemPath(form.originalId, scope), payload);
   } else {
-    await apiClient.post("/model-configs", payload);
+    await apiClient.post(modelConfigCollectionPath(scope), payload);
   }
 
-  return payloadToModel(payload);
+  return payloadToModel(payload, scope === "library" ? "seed" : "user");
 }
 
 function hasPricing(model: ModelItem): boolean {
@@ -563,7 +572,7 @@ export function ModelsPage() {
     if (!form) return;
     setSaving(true);
     try {
-      const saved = await saveModelConfig(form);
+      const saved = await saveModelConfig(form, modelScope);
       setModels((prev) => {
         const withoutOriginal = prev.filter((model) => model.id !== (form.originalId ?? saved.id));
         return [...withoutOriginal, saved].sort((a, b) => a.id.localeCompare(b.id));
@@ -579,7 +588,7 @@ export function ModelsPage() {
     } finally {
       setSaving(false);
     }
-  }, [form, notify, t]);
+  }, [form, modelScope, notify, t]);
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return;

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -296,6 +296,83 @@ describe("ModelsPage", () => {
     });
   });
 
+  test("keeps a model added from the model library after refreshing that tab", async () => {
+    const libraryModels = [
+      {
+        id: "seed-only-model",
+        owned_by: "openai",
+        description: "Seeded model library entry",
+        enabled: true,
+        source: "seed",
+        pricing: {
+          mode: "token",
+          input_price_per_million: 1,
+          output_price_per_million: 3,
+        },
+      },
+    ];
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/model-configs?scope=active" || path === "/model-configs") {
+        return Promise.resolve({ data: [] });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({ data: libraryModels });
+      }
+      if (path === "/model-owner-presets") {
+        return Promise.resolve({ data: ownerPresetItems });
+      }
+      if (path.startsWith("/usage/logs")) {
+        return Promise.resolve({ stats: { total_cost: 0 } });
+      }
+      return Promise.resolve({});
+    });
+    mocks.apiPost.mockImplementation((path: string, payload: Record<string, unknown>) => {
+      if (path === "/model-configs?scope=library") {
+        libraryModels.push({
+          ...(payload as (typeof libraryModels)[number]),
+          source: "seed",
+        });
+      }
+      return Promise.resolve({ status: "ok" });
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("tab", { name: /model library/i }));
+    const libraryCard = await screen.findByTestId("model-library-card");
+
+    await userEvent.click(within(libraryCard).getByRole("button", { name: /add model/i }));
+    const dialog = await screen.findByRole("dialog", { name: /add model/i });
+    await userEvent.type(within(dialog).getByLabelText(/model id/i), "custom-library-model");
+    await userEvent.click(within(dialog).getByRole("combobox", { name: /owner/i }));
+    await userEvent.click(await screen.findByRole("option", { name: "Anthropic" }));
+    await userEvent.click(within(dialog).getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.apiPost).toHaveBeenCalledWith(
+        "/model-configs?scope=library",
+        expect.objectContaining({
+          id: "custom-library-model",
+          owned_by: "anthropic",
+        }),
+      );
+    });
+
+    const refreshButton = within(libraryCard).getByRole("button", { name: /refresh/i });
+    const libraryFetchesBeforeRefresh = mocks.apiGet.mock.calls.filter(
+      ([path]) => path === "/model-configs?scope=library",
+    ).length;
+    await userEvent.click(refreshButton);
+    await waitFor(() => {
+      expect(
+        mocks.apiGet.mock.calls.filter(([path]) => path === "/model-configs?scope=library").length,
+      ).toBeGreaterThan(libraryFetchesBeforeRefresh);
+    });
+    await waitFor(() => expect(refreshButton).not.toBeDisabled());
+
+    expect(screen.getByText("custom-library-model")).toBeInTheDocument();
+  });
+
   test("maintains owner presets from the model library with an add-owner dialog", async () => {
     renderPage();
 


### PR DESCRIPTION
## Summary
- save model-library additions through the library-scoped model-config API
- add regression coverage for refreshing the model library after adding a model

## Verification
- bun run test
- bun run lint
- bun run build
- bun run check
- bunx oxfmt --check src/modules/models/ModelsPage.tsx src/modules/models/__tests__/ModelsPage.test.tsx