### PR TITLE
fix: format OpenRouter sync prices

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2611,7 +2611,7 @@
     "openrouter_sync_interval": "Sync interval (hours)",
     "openrouter_sync_last_sync": "Last sync: {{value}}",
     "openrouter_sync_never": "Never",
-    "openrouter_sync_result": "Seen {{seen}} · Added {{added}} · Skipped {{skipped}}",
+    "openrouter_sync_result": "Seen {{seen}} · Added {{added}} · Updated {{updated}} · Skipped {{skipped}}",
     "openrouter_sync_error": "Error: {{error}}",
     "openrouter_sync_load_failed": "Failed to load OpenRouter sync state",
     "openrouter_sync_save_failed": "Failed to save OpenRouter sync settings",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2912,7 +2912,7 @@
     "openrouter_sync_interval": "同步间隔（小时）",
     "openrouter_sync_last_sync": "最近同步：{{value}}",
     "openrouter_sync_never": "从未同步",
-    "openrouter_sync_result": "获取 {{seen}} · 新增 {{added}} · 跳过 {{skipped}}",
+    "openrouter_sync_result": "获取 {{seen}} · 新增 {{added}} · 更新 {{updated}} · 跳过 {{skipped}}",
     "openrouter_sync_error": "错误：{{error}}",
     "openrouter_sync_load_failed": "加载 OpenRouter 同步状态失败",
     "openrouter_sync_save_failed": "保存 OpenRouter 同步设置失败",

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -87,6 +87,7 @@ interface OpenRouterModelSyncState {
   lastError: string;
   lastSeen: number;
   lastAdded: number;
+  lastUpdated: number;
   lastSkipped: number;
   running: boolean;
 }
@@ -94,6 +95,7 @@ interface OpenRouterModelSyncState {
 interface OpenRouterModelSyncResult {
   seen: number;
   added: number;
+  updated: number;
   skipped: number;
 }
 
@@ -153,6 +155,7 @@ const defaultOpenRouterSyncState: OpenRouterModelSyncState = {
   lastError: "",
   lastSeen: 0,
   lastAdded: 0,
+  lastUpdated: 0,
   lastSkipped: 0,
   running: false,
 };
@@ -395,12 +398,22 @@ function hasPricing(model: ModelItem): boolean {
 function formatPrice(model: ModelItem, notPricedLabel: string): string {
   if (model.pricing.mode === "call") {
     return model.pricing.pricePerCall > 0
-      ? `$${model.pricing.pricePerCall} / call`
+      ? `$${formatPriceAmount(model.pricing.pricePerCall)} / call`
       : notPricedLabel;
   }
 
   if (!hasPricing(model)) return notPricedLabel;
-  return `$${model.pricing.inputPricePerMillion} / $${model.pricing.outputPricePerMillion} / $${model.pricing.cachedPricePerMillion}`;
+  return `$${formatPriceAmount(model.pricing.inputPricePerMillion)} / $${formatPriceAmount(model.pricing.outputPricePerMillion)} / $${formatPriceAmount(model.pricing.cachedPricePerMillion)}`;
+}
+
+function formatPriceAmount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  const rounded = Math.round((value + Number.EPSILON) * 1_000_000) / 1_000_000;
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 6,
+    minimumFractionDigits: 0,
+    useGrouping: false,
+  }).format(rounded);
 }
 
 function normalizeOwnerValue(value: string): string {
@@ -466,6 +479,7 @@ function normalizeOpenRouterSyncState(payload: unknown): OpenRouterModelSyncStat
     lastError: String(record.last_error ?? ""),
     lastSeen: Math.round(asNumber(record.last_seen)),
     lastAdded: Math.round(asNumber(record.last_added)),
+    lastUpdated: Math.round(asNumber(record.last_updated)),
     lastSkipped: Math.round(asNumber(record.last_skipped)),
     running: record.running === true,
   };
@@ -477,6 +491,7 @@ function normalizeOpenRouterSyncResult(payload: unknown): OpenRouterModelSyncRes
   return {
     seen: Math.round(asNumber(record.seen)),
     added: Math.round(asNumber(record.added)),
+    updated: Math.round(asNumber(record.updated)),
     skipped: Math.round(asNumber(record.skipped)),
   };
 }
@@ -818,6 +833,7 @@ export function ModelsPage() {
           ? {
               lastSeen: result.seen,
               lastAdded: result.added,
+              lastUpdated: result.updated,
               lastSkipped: result.skipped,
             }
           : {}),
@@ -1173,6 +1189,7 @@ export function ModelsPage() {
                         {t("models_page.openrouter_sync_result", {
                           seen: openRouterSyncState.lastSeen,
                           added: openRouterSyncState.lastAdded,
+                          updated: openRouterSyncState.lastUpdated,
                           skipped: openRouterSyncState.lastSkipped,
                         })}
                       </span>

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -147,6 +147,63 @@ describe("ModelsPage", () => {
     expect(mocks.apiGet).toHaveBeenCalledWith("/model-configs?scope=library");
   });
 
+  test("formats synced OpenRouter prices without floating point noise or owner marker prefixes", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/model-configs?scope=active" || path === "/model-configs") {
+        return Promise.resolve({ data: [] });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "~moonshotai/kimi-latest",
+              owned_by: "moonshotai",
+              description: "OpenRouter alias model",
+              enabled: true,
+              source: "openrouter",
+              pricing: {
+                mode: "token",
+                input_price_per_million: 0.19999999999999998,
+                output_price_per_million: 4.655,
+                cached_price_per_million: 0.1463,
+              },
+            },
+          ],
+        });
+      }
+      if (path === "/model-owner-presets") {
+        return Promise.resolve({
+          data: [{ value: "moonshotai", label: "Moonshot AI", description: "" }],
+        });
+      }
+      if (path === "/model-openrouter-sync") {
+        return Promise.resolve({
+          enabled: false,
+          interval_minutes: 1440,
+          last_seen: 1,
+          last_added: 1,
+          last_updated: 0,
+          last_skipped: 0,
+          running: false,
+        });
+      }
+      if (path.startsWith("/usage/logs")) {
+        return Promise.resolve({ stats: { total_cost: 0 } });
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("tab", { name: /model library/i }));
+
+    expect(await screen.findByText("~moonshotai/kimi-latest")).toBeInTheDocument();
+    expect(screen.getByText("$0.2 / $4.655 / $0.1463")).toBeInTheDocument();
+    expect(screen.getAllByText("moonshotai").length).toBeGreaterThan(0);
+    expect(screen.queryByText("~moonshotai")).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.19999999999999998/)).not.toBeInTheDocument();
+  });
+
   test("keeps the owner sidebar constrained while the owner list scrolls internally", async () => {
     ownerPresetItems = Array.from({ length: 32 }, (_, index) => ({
       value: `owner-${index + 1}`,


### PR DESCRIPTION
## Summary\n- Round and format model prices before rendering to avoid floating point noise\n- Show OpenRouter updated counts in sync results\n- Add coverage for OpenRouter alias owner display and formatted prices\n\n## Tests\n- bun run test\n- bun run lint\n- bun run build