### PR TITLE
feat: reuse library models when adding

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2649,6 +2649,7 @@
     "no_model_data": "No model data",
     "config_desc": "All model fields and prices are persisted by the management API.",
     "model_id": "Model ID",
+    "model_id_reuse_placeholder": "Search or reuse model ID…",
     "owner": "Owner",
     "owner_placeholder": "Choose or add owner",
     "owner_search_placeholder": "Search or add owner…",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2948,6 +2948,7 @@
     "no_model_data": "暂无模型数据",
     "config_desc": "模型字段和价格均通过管理 API 持久化。",
     "model_id": "模型 ID",
+    "model_id_reuse_placeholder": "搜索或复用模型 ID…",
     "owner": "归属",
     "owner_placeholder": "选择或新增归属",
     "owner_search_placeholder": "搜索或新增归属…",

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -542,6 +542,7 @@ export function ModelsPage() {
   const [openRouterSyncSaving, setOpenRouterSyncSaving] = useState(false);
   const [openRouterSyncRunning, setOpenRouterSyncRunning] = useState(false);
   const [openRouterSyncError, setOpenRouterSyncError] = useState<string | null>(null);
+  const [modelIdSuggestionsOpen, setModelIdSuggestionsOpen] = useState(false);
   const [syncIntervalHours, setSyncIntervalHours] = useState(
     syncIntervalHoursValue(defaultOpenRouterSyncState.intervalMinutes),
   );
@@ -711,6 +712,28 @@ export function ModelsPage() {
     });
   }, [libraryOwners, ownerSearchFilter]);
 
+  const reusableModelCandidates = useMemo(() => {
+    if (!form || form.originalId || activeTab !== "library") return [];
+    const ownerNeedle = normalizeOwnerValue(form.ownedBy);
+    const modelNeedle = form.id.trim().toLowerCase();
+    const seen = new Set<string>();
+    return models
+      .filter((model) => {
+        if (seen.has(model.id)) return false;
+        seen.add(model.id);
+        if (ownerNeedle && normalizeOwnerValue(model.owned_by) !== ownerNeedle) return false;
+        if (!modelNeedle) return true;
+        const haystack = `${model.id} ${model.owned_by} ${model.description}`.toLowerCase();
+        return haystack.includes(modelNeedle);
+      })
+      .slice(0, 8);
+  }, [activeTab, form, models]);
+
+  const showReusableModelCandidates =
+    modelIdSuggestionsOpen &&
+    reusableModelCandidates.length > 0 &&
+    Boolean(form && !form.originalId);
+
   const openEditModel = useCallback(
     (modelId: string) => {
       const model = models.find((entry) => entry.id === modelId);
@@ -721,10 +744,31 @@ export function ModelsPage() {
 
   const openAddModel = useCallback((ownedBy = "") => {
     setForm({ ...emptyForm, ownedBy });
+    setModelIdSuggestionsOpen(false);
   }, []);
 
   const updateForm = useCallback((patch: Partial<ModelFormState>) => {
     setForm((current) => (current ? { ...current, ...patch } : current));
+  }, []);
+
+  const applyReusableModel = useCallback((model: ModelItem) => {
+    const template = toFormState(model);
+    setForm((current) =>
+      current
+        ? {
+            ...current,
+            id: template.id,
+            ownedBy: current.ownedBy || template.ownedBy,
+            description: template.description,
+            mode: template.mode,
+            inputPrice: template.inputPrice,
+            outputPrice: template.outputPrice,
+            cachedPrice: template.cachedPrice,
+            pricePerCall: template.pricePerCall,
+          }
+        : current,
+    );
+    setModelIdSuggestionsOpen(false);
   }, []);
 
   const handleSave = useCallback(async () => {
@@ -1502,7 +1546,10 @@ export function ModelsPage() {
 
       <Modal
         open={form !== null}
-        onClose={() => setForm(null)}
+        onClose={() => {
+          setForm(null);
+          setModelIdSuggestionsOpen(false);
+        }}
         title={form?.originalId ? t("models_page.edit_model") : t("models_page.add_model")}
         description={t("models_page.config_desc")}
         footer={
@@ -1526,12 +1573,70 @@ export function ModelsPage() {
                 >
                   {t("models_page.model_id")}
                 </label>
-                <TextInput
-                  id="model-config-id"
-                  value={form.id}
-                  onChange={(e) => updateForm({ id: e.target.value })}
-                  placeholder="gpt-4.1"
-                />
+                <div className="relative">
+                  <TextInput
+                    id="model-config-id"
+                    role={!form.originalId && activeTab === "library" ? "combobox" : undefined}
+                    aria-label={t("models_page.model_id")}
+                    aria-autocomplete={
+                      !form.originalId && activeTab === "library" ? "list" : undefined
+                    }
+                    aria-controls={
+                      showReusableModelCandidates ? "model-config-id-reuse-options" : undefined
+                    }
+                    aria-expanded={
+                      !form.originalId && activeTab === "library"
+                        ? showReusableModelCandidates
+                        : undefined
+                    }
+                    value={form.id}
+                    onChange={(e) => {
+                      updateForm({ id: e.target.value });
+                      setModelIdSuggestionsOpen(true);
+                    }}
+                    onFocus={() => setModelIdSuggestionsOpen(true)}
+                    onBlur={() => {
+                      window.setTimeout(() => setModelIdSuggestionsOpen(false), 120);
+                    }}
+                    placeholder={
+                      !form.originalId && activeTab === "library"
+                        ? t("models_page.model_id_reuse_placeholder")
+                        : "gpt-4.1"
+                    }
+                    autoComplete="off"
+                  />
+                  {showReusableModelCandidates ? (
+                    <div
+                      id="model-config-id-reuse-options"
+                      role="listbox"
+                      className="absolute left-0 right-0 top-full z-30 mt-2 max-h-64 overflow-y-auto rounded-2xl bg-white p-1 shadow-[0_8px_28px_rgb(0_0_0_/_0.16)] dark:bg-[#27272A] dark:shadow-[0_14px_36px_rgb(0_0_0_/_0.38)]"
+                    >
+                      {reusableModelCandidates.map((model) => (
+                        <button
+                          key={model.id}
+                          type="button"
+                          role="option"
+                          aria-selected={form.id === model.id}
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={() => applyReusableModel(model)}
+                          className="flex w-full min-w-0 items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:bg-[#F4F4F5] dark:hover:bg-white/[0.06]"
+                        >
+                          <span className="min-w-0">
+                            <span className="block truncate font-medium text-[#18181B] dark:text-white">
+                              {model.id}
+                            </span>
+                            <span className="block truncate text-xs text-[#71717A] dark:text-[#A1A1AA]">
+                              {model.description || model.owned_by}
+                            </span>
+                          </span>
+                          <span className="shrink-0 text-xs font-medium text-[#71717A] dark:text-[#A1A1AA]">
+                            {formatPrice(model, t("models_page.not_priced"))}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -520,6 +520,84 @@ describe("ModelsPage", () => {
     });
   });
 
+  test("reuses a model from the selected owner when adding from the library", async () => {
+    const libraryModels = [
+      {
+        id: "gpt-5.5",
+        owned_by: "openai",
+        description: "Reusable OpenAI model",
+        enabled: true,
+        source: "openrouter",
+        pricing: {
+          mode: "token",
+          input_price_per_million: 1.25,
+          output_price_per_million: 10.5,
+          cached_price_per_million: 0.25,
+        },
+      },
+      {
+        id: "claude-sonnet-4-6",
+        owned_by: "anthropic",
+        description: "Reusable Claude model",
+        enabled: true,
+        source: "openrouter",
+        pricing: {
+          mode: "token",
+          input_price_per_million: 3,
+          output_price_per_million: 15,
+          cached_price_per_million: 0.3,
+        },
+      },
+    ];
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/model-configs?scope=active" || path === "/model-configs") {
+        return Promise.resolve({ data: [] });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({ data: libraryModels });
+      }
+      if (path === "/model-owner-presets") {
+        return Promise.resolve({ data: ownerPresetItems });
+      }
+      if (path === "/model-openrouter-sync") {
+        return Promise.resolve({
+          enabled: false,
+          interval_minutes: 1440,
+          last_seen: 2,
+          last_added: 2,
+          last_updated: 0,
+          last_skipped: 0,
+          running: false,
+        });
+      }
+      if (path.startsWith("/usage/logs")) {
+        return Promise.resolve({ stats: { total_cost: 0 } });
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("tab", { name: /model library/i }));
+    const ownerSidebar = await screen.findByTestId("owner-sidebar-card");
+    await userEvent.click(within(ownerSidebar).getByRole("button", { name: /^openai/i }));
+    const libraryCard = await screen.findByTestId("model-library-card");
+    await userEvent.click(within(libraryCard).getByRole("button", { name: /add model/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /add model/i });
+    await userEvent.click(within(dialog).getByRole("combobox", { name: /model id/i }));
+    await userEvent.type(screen.getByPlaceholderText(/search or reuse model id/i), "gpt-5.5");
+
+    expect(screen.queryByRole("option", { name: /claude-sonnet-4-6/i })).not.toBeInTheDocument();
+    await userEvent.click(await screen.findByRole("option", { name: /gpt-5\.5/i }));
+
+    expect(within(dialog).getByRole("combobox", { name: /owner/i })).toHaveTextContent("OpenAI");
+    expect(within(dialog).getByLabelText(/description/i)).toHaveValue("Reusable OpenAI model");
+    expect(within(dialog).getByLabelText(/input token/i)).toHaveValue(1.25);
+    expect(within(dialog).getByLabelText(/output token/i)).toHaveValue(10.5);
+    expect(within(dialog).getByLabelText(/cache token/i)).toHaveValue(0.25);
+  });
+
   test("keeps a model added from the model library after refreshing that tab", async () => {
     const libraryModels = [
       {


### PR DESCRIPTION
## Summary
- add reusable model ID suggestions while adding models from the library view
- filter reusable candidates by the currently selected owner
- selecting a candidate fills model ID, description, and pricing immediately

## Verification
- bun run test
- bun run lint
- bun run build