### PR TITLE
fix: set Claude CC Switch auth field

### DIFF
--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -12,6 +12,21 @@ const decodeUsageScript = (url: string) => {
 };
 
 describe("ccswitchImport", () => {
+  test("builds a Claude provider deeplink with the Anthropic API key auth field", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-ant-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "claude",
+      providerName: "Relay Claude",
+      model: "claude-sonnet-4-5",
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("app")).toBe("claude");
+    expect(parsed.searchParams.get("apiKey")).toBe("sk-ant-test-key");
+    expect(parsed.searchParams.get("apiKeyField")).toBe("ANTHROPIC_API_KEY");
+  });
+
   test("builds a Codex provider deeplink with endpoint, model, and usage script", () => {
     const url = buildCcSwitchImportUrl({
       apiKey: "sk-test-key",

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -217,6 +217,10 @@ export function buildCcSwitchImportUrl(input: {
     params.set("model", model);
   }
 
+  if (input.clientType === "claude") {
+    params.set("apiKeyField", "ANTHROPIC_API_KEY");
+  }
+
   return `ccswitch://v1/import?${params.toString()}`;
 }
 


### PR DESCRIPTION
## Summary
- Add `apiKeyField=ANTHROPIC_API_KEY` to Claude Code CC Switch provider deeplinks.
- Add a regression test for the Claude import URL.

## Test Plan
- `bun test src/modules/ccswitch/__tests__/ccswitchImport.test.ts`
- `bunx oxfmt src/modules/ccswitch/ccswitchImport.ts src/modules/ccswitch/__tests__/ccswitchImport.test.ts --check`
- `bun run lint`
- `bun run build`
- `bun run check`

## Notes
- Full `bunx oxfmt . --check` currently reports pre-existing formatting differences outside this change.