### PR TITLE
fix: search all model ids when reusing library models

### DIFF
--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -714,15 +714,13 @@ export function ModelsPage() {
 
   const reusableModelCandidates = useMemo(() => {
     if (!form || form.originalId || activeTab !== "library") return [];
-    const ownerNeedle = normalizeOwnerValue(form.ownedBy);
     const modelNeedle = form.id.trim().toLowerCase();
+    if (!modelNeedle) return [];
     const seen = new Set<string>();
     return models
       .filter((model) => {
         if (seen.has(model.id)) return false;
         seen.add(model.id);
-        if (ownerNeedle && normalizeOwnerValue(model.owned_by) !== ownerNeedle) return false;
-        if (!modelNeedle) return true;
         const haystack = `${model.id} ${model.owned_by} ${model.description}`.toLowerCase();
         return haystack.includes(modelNeedle);
       })
@@ -1591,10 +1589,11 @@ export function ModelsPage() {
                     }
                     value={form.id}
                     onChange={(e) => {
-                      updateForm({ id: e.target.value });
-                      setModelIdSuggestionsOpen(true);
+                      const nextId = e.target.value;
+                      updateForm({ id: nextId });
+                      setModelIdSuggestionsOpen(Boolean(nextId.trim()));
                     }}
-                    onFocus={() => setModelIdSuggestionsOpen(true)}
+                    onFocus={() => setModelIdSuggestionsOpen(Boolean(form.id.trim()))}
                     onBlur={() => {
                       window.setTimeout(() => setModelIdSuggestionsOpen(false), 120);
                     }}

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -520,7 +520,7 @@ describe("ModelsPage", () => {
     });
   });
 
-  test("reuses a model from the selected owner when adding from the library", async () => {
+  test("searches all library models by model id while adding from a selected owner", async () => {
     const libraryModels = [
       {
         id: "gpt-5.5",
@@ -585,17 +585,19 @@ describe("ModelsPage", () => {
     await userEvent.click(within(libraryCard).getByRole("button", { name: /add model/i }));
 
     const dialog = await screen.findByRole("dialog", { name: /add model/i });
-    await userEvent.click(within(dialog).getByRole("combobox", { name: /model id/i }));
-    await userEvent.type(screen.getByPlaceholderText(/search or reuse model id/i), "gpt-5.5");
+    const modelIdInput = within(dialog).getByRole("combobox", { name: /model id/i });
+    await userEvent.click(modelIdInput);
 
-    expect(screen.queryByRole("option", { name: /claude-sonnet-4-6/i })).not.toBeInTheDocument();
-    await userEvent.click(await screen.findByRole("option", { name: /gpt-5\.5/i }));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    await userEvent.type(modelIdInput, "claude");
+    await userEvent.click(await screen.findByRole("option", { name: /claude-sonnet-4-6/i }));
 
     expect(within(dialog).getByRole("combobox", { name: /owner/i })).toHaveTextContent("OpenAI");
-    expect(within(dialog).getByLabelText(/description/i)).toHaveValue("Reusable OpenAI model");
-    expect(within(dialog).getByLabelText(/input token/i)).toHaveValue(1.25);
-    expect(within(dialog).getByLabelText(/output token/i)).toHaveValue(10.5);
-    expect(within(dialog).getByLabelText(/cache token/i)).toHaveValue(0.25);
+    expect(within(dialog).getByLabelText(/description/i)).toHaveValue("Reusable Claude model");
+    expect(within(dialog).getByLabelText(/input token/i)).toHaveValue(3);
+    expect(within(dialog).getByLabelText(/output token/i)).toHaveValue(15);
+    expect(within(dialog).getByLabelText(/cache token/i)).toHaveValue(0.3);
   });
 
   test("keeps a model added from the model library after refreshing that tab", async () => {


### PR DESCRIPTION
## Summary
- Search reusable model ID suggestions across the full model library instead of the selected owner group.
- Only open the model ID suggestion list when the input has text.
- Keep the selected owner as the target owner while reusing model metadata.

## Verification
- bun run test src/modules/models/__tests__/ModelsPage.test.tsx
- bunx oxfmt src/modules/models/ModelsPage.tsx src/modules/models/__tests__/ModelsPage.test.tsx --check
- bun run check

Note: full-repo \Checking formatting...

.vite.proxy.mjs (0ms)
docs/internal-review/bundle-baseline.md (53ms)
docs/internal-review/monorepo-audit-report.md (311ms)
docs/internal-review/quality-baseline.md (20ms)
docs/superpowers/plans/2026-04-27-proxy-pool-management.md (70ms)
docs/superpowers/specs/2026-04-27-proxy-pool-management-design.md (98ms)
e2e/login-lifecycle.spec.ts (0ms)
e2e/request-logs-detail.spec.ts (0ms)
scripts/bundle-diff.mjs (0ms)
src/i18n/index.ts (1ms)
src/lib/http/apis/__tests__/image-generation.test.ts (1ms)
src/lib/http/apis/image-generation.ts (2ms)
src/lib/http/client.ts (2ms)
src/modules/api-keys/components/ApiKeyUsageModal.tsx (0ms)
src/modules/api-keys/hooks/useApiKeyUsageView.ts (0ms)
src/modules/apikey-lookup/api.ts (0ms)
src/modules/apikey-lookup/components/UsageTabSection.tsx (0ms)
src/modules/apikey-lookup/hooks/useApiKeyLookupCharts.ts (0ms)
src/modules/auth-files/hooks/useAuthFilesFileActions.ts (0ms)
src/modules/auth-files/hooks/useAuthFilesGroupOverview.ts (1ms)
src/modules/channel-groups/ChannelGroupsPage.tsx (2ms)
src/modules/config/ConfigPage.tsx (0ms)
src/modules/config/visual/PayloadRuleEditors.tsx (0ms)
src/modules/logs/components/ErrorLogsTab.tsx (0ms)
src/modules/logs/components/LiveLogsTab.tsx (0ms)
src/modules/monitor/MonitorPage.tsx (1ms)
src/modules/monitor/__tests__/requestLogsShared.test.ts (0ms)
src/modules/monitor/log-content/rendering-markdown.tsx (0ms)
src/modules/monitor/requestLogsShared.tsx (0ms)
src/modules/providers/__tests__/providers-helpers.test.ts (0ms)
src/modules/providers/components/AmpcodePanel.tsx (0ms)
src/modules/providers/components/OpenAIProviderModal.tsx (0ms)
src/modules/providers/hooks/useProviderUsageSummary.ts (0ms)
src/modules/quota/quota-antigravity.ts (0ms)
src/modules/quota/quota-codex.ts (0ms)
src/modules/quota/quota-gemini-cli.ts (0ms)
src/modules/ui/ImagePreviewOverlay.tsx (0ms)
src/modules/update/UpdateDetailsModal.tsx (0ms)
src/utils/usage/charts.ts (0ms)

Format issues found in above 39 files. Run without `--check` to fix.
Finished in 886ms on 428 files using 10 threads. still reports existing formatting issues in unrelated files from origin/dev.