### PR TITLE
fix: scope model lists to configured providers

### DIFF
--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -28,6 +28,12 @@ import iconKiro from "@/assets/icons/kiro.svg";
 import iconMinimax from "@/assets/icons/minimax.svg";
 import iconOpenai from "@/assets/icons/openai.svg";
 import iconQwen from "@/assets/icons/qwen.svg";
+import {
+  filterByConfiguredModelAvailability,
+  loadConfiguredModelAvailability,
+  type ConfiguredModelAvailability,
+  type ModelAvailabilityItem,
+} from "@/modules/models/modelAvailability";
 import iconVertex from "@/assets/icons/vertex.svg";
 
 type PricingMode = "token" | "call";
@@ -285,6 +291,33 @@ async function fetchModelConfigs(scope: ModelScope): Promise<ModelItem[]> {
 
 async function fetchOwnerPresets(): Promise<ModelOwnerPreset[]> {
   return normalizeOwnerPresetResponse(await apiClient.get("/model-owner-presets"));
+}
+
+function availabilityItemToModel(item: ModelAvailabilityItem): ModelItem {
+  return {
+    id: item.id,
+    owned_by: item.owned_by ?? "",
+    description: item.description ?? "",
+    enabled: true,
+    source: item.source ?? "configured",
+    pricing: { ...emptyPricing },
+  };
+}
+
+function mergeConfiguredModelAvailability(
+  data: ModelItem[],
+  availability: ConfiguredModelAvailability | null,
+): ModelItem[] {
+  if (!availability?.scoped) return data;
+  const visible = filterByConfiguredModelAvailability(data, availability);
+  const seen = new Set(visible.map((model) => model.id.toLowerCase()));
+  for (const item of availability.items) {
+    const key = item.id.toLowerCase();
+    if (seen.has(key)) continue;
+    visible.push(availabilityItemToModel(item));
+    seen.add(key);
+  }
+  return visible.sort((a, b) => a.id.localeCompare(b.id));
 }
 
 function toFormState(model: ModelItem): ModelFormState {
@@ -553,15 +586,17 @@ export function ModelsPage() {
   const loadModels = useCallback(async () => {
     setLoading(true);
     try {
-      const [data, presets] = await Promise.all([
+      const [data, presets, availability] = await Promise.all([
         fetchModelConfigs(modelScope),
         fetchOwnerPresets(),
+        modelScope === "active" ? loadConfiguredModelAvailability() : Promise.resolve(null),
       ]);
-      setModels(data);
+      const visibleData = mergeConfiguredModelAvailability(data, availability);
+      setModels(visibleData);
       setOwnerPresets(presets);
       setOwnerFilter((current) => {
         if (!current) return "";
-        return buildOwnerPresetDrafts(data, presets).some((owner) => owner.value === current)
+        return buildOwnerPresetDrafts(visibleData, presets).some((owner) => owner.value === current)
           ? current
           : "";
       });

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -42,6 +42,7 @@ describe("ModelsPage", () => {
 
   beforeEach(async () => {
     await i18n.changeLanguage("en");
+    window.localStorage.clear();
     ownerPresetItems = [
       { value: "openai", label: "OpenAI", description: "OpenAI official models" },
       { value: "anthropic", label: "Anthropic", description: "Claude models" },
@@ -86,6 +87,18 @@ describe("ModelsPage", () => {
           ],
         });
       }
+      if (path === "/auth-files") {
+        return Promise.resolve({ files: [] });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
       if (path === "/model-owner-presets") {
         return Promise.resolve({
           data: ownerPresetItems,
@@ -128,6 +141,139 @@ describe("ModelsPage", () => {
     expect(screen.getByText("$0.04 / call")).toBeInTheDocument();
     expect(mocks.apiGet).toHaveBeenCalledWith("/model-configs?scope=active");
     expect(screen.queryByText("seed-only-model")).not.toBeInTheDocument();
+  });
+
+  test("filters current models by auth-file model owner group mapping", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ claude: "anthropic" }),
+    );
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/model-configs?scope=active" || path === "/model-configs") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+              enabled: true,
+              source: "seed",
+              pricing: { mode: "token" },
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+              enabled: true,
+              source: "seed",
+              pricing: { mode: "token" },
+            },
+          ],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+              enabled: true,
+              source: "seed",
+              pricing: { mode: "token" },
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+              enabled: true,
+              source: "seed",
+              pricing: { mode: "token" },
+            },
+          ],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "claude-account.json", type: "claude", disabled: false }],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      if (path === "/model-owner-presets") {
+        return Promise.resolve({ data: ownerPresetItems });
+      }
+      if (path.startsWith("/usage/logs")) {
+        return Promise.resolve({ stats: { total_cost: 0 } });
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("claude-3-7-sonnet-latest")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-should-not-leak")).not.toBeInTheDocument();
+  });
+
+  test("adds configured ai-provider models missing from active model configs", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/model-configs?scope=active" || path === "/model-configs") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unconfigured registry model",
+              enabled: true,
+              source: "seed",
+              pricing: { mode: "token" },
+            },
+          ],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({ data: [] });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({ files: [] });
+      }
+      if (path === "/claude-api-key") {
+        return Promise.resolve([
+          {
+            "api-key": "sk-claude",
+            name: "Claude Team",
+            models: [{ name: "claude-raw-upstream", alias: "claude-main" }],
+          },
+        ]);
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      if (path === "/model-owner-presets") {
+        return Promise.resolve({ data: ownerPresetItems });
+      }
+      if (path.startsWith("/usage/logs")) {
+        return Promise.resolve({ stats: { total_cost: 0 } });
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("claude-main")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-should-not-leak")).not.toBeInTheDocument();
   });
 
   test("loads the full model library only after switching to the library tab", async () => {

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -1,0 +1,305 @@
+import { authFilesApi, providersApi } from "@/lib/http/apis";
+import { apiClient } from "@/lib/http/client";
+import type {
+  AuthFileItem,
+  OpenAIProvider,
+  ProviderModel,
+  ProviderSimpleConfig,
+} from "@/lib/http/types";
+import {
+  matchesModelPattern,
+  normalizeProviderKey,
+  readAuthFilesModelOwnerGroupMap,
+  resolveFileType,
+} from "@/modules/auth-files/helpers/authFilesPageUtils";
+
+export type ModelAvailabilityItem = {
+  id: string;
+  owned_by?: string;
+  description?: string;
+  source?: string;
+};
+
+export type ConfiguredModelAvailability = {
+  scoped: boolean;
+  items: ModelAvailabilityItem[];
+  idSet: Set<string>;
+};
+
+type ModelDefinition = {
+  id: string;
+  display_name?: string;
+  owned_by?: string;
+};
+
+const PROVIDER_CHANNELS = [
+  { key: "gemini", load: providersApi.getGeminiKeys },
+  { key: "claude", load: providersApi.getClaudeConfigs },
+  { key: "codex", load: providersApi.getCodexConfigs },
+  { key: "vertex", load: providersApi.getVertexConfigs },
+] as const;
+
+const emptyAvailability = (): ConfiguredModelAvailability => ({
+  scoped: false,
+  items: [],
+  idSet: new Set(),
+});
+
+const normalizeOwnerValue = (value: string): string =>
+  value.trim().replace(/\s+/g, "-").toLowerCase();
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const normalizeModelConfigRows = (payload: unknown): ModelAvailabilityItem[] => {
+  const record = isRecord(payload) ? payload : {};
+  const rawList = Array.isArray(record.data)
+    ? record.data
+    : Array.isArray(record.models)
+      ? record.models
+      : Array.isArray(payload)
+        ? payload
+        : [];
+
+  return rawList
+    .map((item) => {
+      if (!isRecord(item)) return null;
+      const id = String(item.id ?? item.model_id ?? item.name ?? "").trim();
+      if (!id) return null;
+      const ownedBy = String(item.owned_by ?? item.owner ?? "").trim();
+      const description = String(item.description ?? item.display_name ?? "").trim();
+      const source = String(item.source ?? "").trim();
+      return {
+        id,
+        ...(ownedBy ? { owned_by: ownedBy } : {}),
+        ...(description ? { description } : {}),
+        ...(source ? { source } : {}),
+      } satisfies ModelAvailabilityItem;
+    })
+    .filter((item): item is ModelAvailabilityItem => Boolean(item));
+};
+
+const addModel = (
+  map: Map<string, ModelAvailabilityItem>,
+  item: ModelAvailabilityItem | null | undefined,
+) => {
+  const id = String(item?.id ?? "").trim();
+  if (!id) return;
+  const key = id.toLowerCase();
+  if (map.has(key)) return;
+  map.set(key, { ...item, id });
+};
+
+const withOptionalPrefix = (id: string, prefix?: string): string[] => {
+  const trimmedId = id.trim();
+  const trimmedPrefix = String(prefix ?? "").trim();
+  if (!trimmedId) return [];
+  if (!trimmedPrefix) return [trimmedId];
+  return [trimmedId, `${trimmedPrefix}/${trimmedId}`];
+};
+
+const providerModelId = (model: ProviderModel): string => {
+  const alias = String(model.alias ?? "").trim();
+  if (alias) return alias;
+  return String(model.name ?? "").trim();
+};
+
+const isExcluded = (modelId: string, excludedModels?: string[]) => {
+  if (!Array.isArray(excludedModels) || excludedModels.length === 0) return false;
+  return excludedModels.some((pattern) => matchesModelPattern(modelId, pattern));
+};
+
+const addExplicitProviderModels = (
+  map: Map<string, ModelAvailabilityItem>,
+  models: ProviderModel[] | undefined,
+  provider: string,
+  prefix?: string,
+  excludedModels?: string[],
+) => {
+  if (!Array.isArray(models) || models.length === 0) return;
+  for (const model of models) {
+    const id = providerModelId(model);
+    if (!id || isExcluded(id, excludedModels)) continue;
+    for (const candidate of withOptionalPrefix(id, prefix)) {
+      addModel(map, {
+        id: candidate,
+        owned_by: provider,
+        source: "provider",
+      });
+    }
+  }
+};
+
+const addStaticProviderModels = (
+  map: Map<string, ModelAvailabilityItem>,
+  models: ModelDefinition[],
+  provider: string,
+  prefix?: string,
+  excludedModels?: string[],
+) => {
+  for (const model of models) {
+    const id = String(model.id ?? "").trim();
+    if (!id || isExcluded(id, excludedModels)) continue;
+    for (const candidate of withOptionalPrefix(id, prefix)) {
+      addModel(map, {
+        id: candidate,
+        owned_by: model.owned_by || provider,
+        description: model.display_name,
+        source: "provider",
+      });
+    }
+  }
+};
+
+const hasCredential = (config: ProviderSimpleConfig): boolean =>
+  String(config.apiKey ?? "").trim().length > 0;
+
+const hasOpenAIProviderCredential = (provider: OpenAIProvider): boolean =>
+  Array.isArray(provider.apiKeyEntries) &&
+  provider.apiKeyEntries.some((entry) => String(entry.apiKey ?? "").trim());
+
+const loadStaticDefinitions = async (provider: string): Promise<ModelDefinition[]> => {
+  try {
+    return await authFilesApi.getModelDefinitions(provider);
+  } catch {
+    return [];
+  }
+};
+
+const loadProviderModelItems = async (): Promise<ModelAvailabilityItem[]> => {
+  const map = new Map<string, ModelAvailabilityItem>();
+
+  await Promise.all(
+    PROVIDER_CHANNELS.map(async ({ key, load }) => {
+      let configs: ProviderSimpleConfig[] = [];
+      try {
+        configs = (await load()).filter(hasCredential);
+      } catch {
+        configs = [];
+      }
+
+      const needsStaticModels = configs.some(
+        (config) => !Array.isArray(config.models) || config.models.length === 0,
+      );
+      const staticModels = needsStaticModels ? await loadStaticDefinitions(key) : [];
+
+      for (const config of configs) {
+        if (Array.isArray(config.models) && config.models.length > 0) {
+          addExplicitProviderModels(map, config.models, key, config.prefix, config.excludedModels);
+          continue;
+        }
+        addStaticProviderModels(map, staticModels, key, config.prefix, config.excludedModels);
+      }
+    }),
+  );
+
+  let openAIProviders: OpenAIProvider[] = [];
+  try {
+    openAIProviders = (await providersApi.getOpenAIProviders()).filter(hasOpenAIProviderCredential);
+  } catch {
+    openAIProviders = [];
+  }
+
+  for (const provider of openAIProviders) {
+    addExplicitProviderModels(map, provider.models, provider.name, provider.prefix);
+  }
+
+  return Array.from(map.values());
+};
+
+const loadAuthFiles = async (): Promise<AuthFileItem[]> => {
+  try {
+    const payload = await authFilesApi.list();
+    return Array.isArray(payload.files) ? payload.files : [];
+  } catch {
+    return [];
+  }
+};
+
+const authFileDisabled = (file: AuthFileItem): boolean => {
+  const value = file.disabled;
+  return value === true || String(value ?? "").toLowerCase() === "true";
+};
+
+const loadAuthFileModelItems = async (
+  authFiles: AuthFileItem[],
+  libraryModels: ModelAvailabilityItem[],
+): Promise<{ items: ModelAvailabilityItem[]; scoped: boolean }> => {
+  const map = new Map<string, ModelAvailabilityItem>();
+  const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
+  const modelsByOwner = new Map<string, ModelAvailabilityItem[]>();
+  const activeAuthFiles = authFiles.filter((file) => !authFileDisabled(file));
+  let scoped = authFiles.length > 0 && activeAuthFiles.length === 0;
+
+  for (const model of libraryModels) {
+    const owner = normalizeOwnerValue(model.owned_by ?? "");
+    if (!owner) continue;
+    const list = modelsByOwner.get(owner) ?? [];
+    list.push(model);
+    modelsByOwner.set(owner, list);
+  }
+
+  await Promise.all(
+    activeAuthFiles.map(async (file) => {
+      const group = normalizeProviderKey(resolveFileType(file));
+      const owner = normalizeOwnerValue(ownerByAuthGroup[group] ?? "");
+      if (owner) {
+        scoped = true;
+        for (const model of modelsByOwner.get(owner) ?? []) {
+          addModel(map, { ...model, source: model.source || "auth-file-owner" });
+        }
+        return;
+      }
+
+      try {
+        const liveModels = await authFilesApi.getModelsForAuthFile(file.name);
+        scoped = true;
+        for (const model of liveModels) {
+          addModel(map, {
+            id: model.id,
+            owned_by: model.owned_by,
+            description: model.display_name,
+            source: "auth-file",
+          });
+        }
+      } catch {
+        // Older backends may not expose per-file model lookup. Keep the caller on its fallback path.
+      }
+    }),
+  );
+
+  return { items: Array.from(map.values()), scoped };
+};
+
+export const loadConfiguredModelAvailability = async (): Promise<ConfiguredModelAvailability> => {
+  const [authFiles, libraryPayload, providerItems] = await Promise.all([
+    loadAuthFiles(),
+    apiClient.get("/model-configs?scope=library").catch(() => null),
+    loadProviderModelItems(),
+  ]);
+  const libraryModels = normalizeModelConfigRows(libraryPayload);
+  const authFileAvailability = await loadAuthFileModelItems(authFiles, libraryModels);
+
+  const map = new Map<string, ModelAvailabilityItem>();
+  for (const item of authFileAvailability.items) addModel(map, item);
+  for (const item of providerItems) addModel(map, item);
+
+  if (!authFileAvailability.scoped && providerItems.length === 0) {
+    return emptyAvailability();
+  }
+
+  const items = Array.from(map.values()).sort((a, b) => a.id.localeCompare(b.id));
+  return {
+    scoped: true,
+    items,
+    idSet: new Set(items.map((item) => item.id.toLowerCase())),
+  };
+};
+
+export const filterByConfiguredModelAvailability = <T extends { id: string }>(
+  models: T[],
+  availability: ConfiguredModelAvailability,
+): T[] => {
+  if (!availability.scoped) return models;
+  return models.filter((model) => availability.idSet.has(model.id.toLowerCase()));
+};

--- a/src/modules/system/SystemPage.tsx
+++ b/src/modules/system/SystemPage.tsx
@@ -21,6 +21,7 @@ import { Card } from "@/modules/ui/Card";
 import { TextInput } from "@/modules/ui/Input";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { UpdateDetailsCard } from "@/modules/update/UpdateDetailsCard";
+import { loadConfiguredModelAvailability } from "@/modules/models/modelAvailability";
 
 // Vendor SVG icons
 import iconClaude from "@/assets/icons/claude.svg";
@@ -354,6 +355,11 @@ export function SystemPage({
     setModelsLoading(true);
     setModelsError(null);
     try {
+      const availability = await loadConfiguredModelAvailability();
+      if (availability.scoped) {
+        setModels(availability.items.map((item) => item.id));
+        return;
+      }
       const payload = await apiClient.get<V1ModelsResponse>("/models");
       setModels(extractModelIds(payload));
     } catch (err: unknown) {

--- a/src/modules/system/__tests__/SystemPage.test.tsx
+++ b/src/modules/system/__tests__/SystemPage.test.tsx
@@ -55,8 +55,20 @@ function renderPage() {
 describe("SystemPage", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
+    window.localStorage.clear();
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/models") return Promise.resolve({ data: [] });
+      if (path === "/model-configs?scope=library") return Promise.resolve({ data: [] });
+      if (path === "/auth-files") return Promise.resolve({ files: [] });
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
       if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
       return Promise.resolve({});
     });
@@ -125,6 +137,59 @@ describe("SystemPage", () => {
       expect(mocks.current).toHaveBeenCalled();
     });
     expect(mocks.check).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses auth-file model owner groups instead of raw registry models", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ claude: "anthropic" }),
+    );
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/models") {
+        return Promise.resolve({
+          data: [{ id: "claude-ghost-model" }, { id: "gpt-should-not-leak" }],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "claude-account.json", type: "claude", disabled: false }],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+              enabled: true,
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+              enabled: true,
+            },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("claude-3-7-sonnet-latest")).toBeInTheDocument();
+    expect(screen.queryByText("claude-ghost-model")).not.toBeInTheDocument();
+    expect(screen.queryByText("gpt-should-not-leak")).not.toBeInTheDocument();
   });
 
   test("rechecks the target version before treating the update as successful", async () => {


### PR DESCRIPTION
## Summary
- Add shared configured model availability loading from auth-file owner group mappings and AI provider configs.
- Scope System Info model display to that configured availability before falling back to raw /models.
- Update Manage Models current tab to filter ghost registry rows and include configured provider models missing from active configs.

## Test Plan
- bun run test
- bun run lint
- bun run build
- bun run check
- bunx oxfmt . --check (fails on 39 pre-existing unrelated files; touched files are not listed)