### PR TITLE
Fix frontend-only update completion

### DIFF
--- a/src/modules/update/__tests__/updateShared.test.ts
+++ b/src/modules/update/__tests__/updateShared.test.ts
@@ -1,5 +1,26 @@
-import { describe, expect, test } from "vitest";
-import { formatUpdateStatusMessage } from "@/modules/update/updateShared";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { applyUpdateFlow, formatUpdateStatusMessage } from "@/modules/update/updateShared";
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apply: vi.fn(),
+  current: vi.fn(),
+  progress: vi.fn(),
+}));
+
+vi.mock("@/lib/http/client", () => ({
+  apiClient: {
+    get: mocks.apiGet,
+  },
+}));
+
+vi.mock("@/lib/http/apis/update", () => ({
+  updateApi: {
+    apply: mocks.apply,
+    current: mocks.current,
+    progress: mocks.progress,
+  },
+}));
 
 describe("formatUpdateStatusMessage", () => {
   test("splits degraded update status clauses onto separate lines", () => {
@@ -13,5 +34,69 @@ describe("formatUpdateStatusMessage", () => {
 
   test("keeps ordinary status messages unchanged", () => {
     expect(formatUpdateStatusMessage("already up to date")).toBe("already up to date");
+  });
+});
+
+describe("applyUpdateFlow", () => {
+  beforeEach(() => {
+    mocks.apiGet.mockResolvedValue({ uptime: 10 });
+    mocks.apply.mockResolvedValue({ status: "accepted" });
+    mocks.current.mockResolvedValue({
+      enabled: true,
+      update_available: true,
+      current_version: "main-a0ed5c6",
+      current_commit: "a0ed5c63a118412d5b4da8d57ec6d049111b7888",
+      current_ui_version: "panel-main-1111111",
+      current_ui_commit: "1111111",
+      latest_version: "main-a0ed5c6",
+      latest_commit: "a0ed5c63a118412d5b4da8d57ec6d049111b7888",
+      latest_ui_version: "panel-main-9477958",
+      latest_ui_commit: "94779588adb784b1ceff19c662d3ab55155997e1",
+      target_channel: "main",
+      docker_image: "ghcr.io/kittors/clirelay",
+      docker_tag: "latest",
+      updater_available: true,
+    });
+    mocks.progress.mockResolvedValue({
+      status: "completed",
+      stage: "completed",
+      message: "update completed",
+    });
+  });
+
+  test("treats completed frontend-only updates as successful before the page reload sees the new UI commit", async () => {
+    const notify = vi.fn();
+    const onSuccess = vi.fn();
+
+    const result = await applyUpdateFlow({
+      candidate: {
+        enabled: true,
+        update_available: true,
+        current_version: "main-a0ed5c6",
+        current_commit: "a0ed5c63a118412d5b4da8d57ec6d049111b7888",
+        current_ui_version: "panel-main-1111111",
+        current_ui_commit: "1111111",
+        latest_version: "main-a0ed5c6",
+        latest_commit: "a0ed5c63a118412d5b4da8d57ec6d049111b7888",
+        latest_ui_version: "panel-main-9477958",
+        latest_ui_commit: "94779588adb784b1ceff19c662d3ab55155997e1",
+        target_channel: "main",
+        docker_image: "ghcr.io/kittors/clirelay",
+        docker_tag: "latest",
+        updater_available: true,
+      },
+      heartbeatIntervalMs: 1,
+      heartbeatTimeoutMs: 20,
+      notify,
+      onSuccess,
+      t: ((key: string) => key) as never,
+    });
+
+    expect(result).toBe(true);
+    expect(notify).toHaveBeenCalledWith({
+      type: "success",
+      message: "auto_update.success",
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/update/updateShared.ts
+++ b/src/modules/update/updateShared.ts
@@ -86,17 +86,24 @@ export const createPendingUpdateProgress = (
   logs: [],
 });
 
+const targetNeedsBackendChange = (target?: UpdateCheckResponse | null) =>
+  Boolean(target?.latest_commit?.trim()) &&
+  !sameCommit(target?.current_commit, target?.latest_commit);
+
+const targetNeedsUiChange = (target?: UpdateCheckResponse | null) =>
+  Boolean(target?.latest_ui_commit?.trim()) &&
+  !sameCommit(target?.current_ui_commit, target?.latest_ui_commit);
+
+const isFrontendOnlyUpdateTarget = (target?: UpdateCheckResponse | null) =>
+  Boolean(target) && !targetNeedsBackendChange(target) && targetNeedsUiChange(target);
+
 export const matchesAppliedTarget = (
   info: UpdateCheckResponse,
   target?: UpdateCheckResponse | null,
 ) => {
   if (!target) return !info.update_available;
-  const backendNeedsChange =
-    Boolean(target.latest_commit?.trim()) &&
-    !sameCommit(target.current_commit, target.latest_commit);
-  const uiNeedsChange =
-    Boolean(target.latest_ui_commit?.trim()) &&
-    !sameCommit(target.current_ui_commit, target.latest_ui_commit);
+  const backendNeedsChange = targetNeedsBackendChange(target);
+  const uiNeedsChange = targetNeedsUiChange(target);
   const currentVersion = info.current_version?.trim() ?? "";
   const targetVersion = target.latest_version?.trim() ?? "";
   const currentUIVersion = info.current_ui_version?.trim() ?? "";
@@ -146,6 +153,9 @@ const waitForAppliedTarget = async ({
     const progress = await pollProgress();
     if (progress?.status === "failed") {
       return { ok: false as const, latest: lastCheck, progress, failed: true as const };
+    }
+    if (progress?.status === "completed" && isFrontendOnlyUpdateTarget(target)) {
+      return { ok: true as const, latest: lastCheck, progress };
     }
     try {
       await apiClient.get("/system-stats", {


### PR DESCRIPTION
Fix the updater flow so frontend-only updates do not stay stuck in the updating state after updater progress reaches completed.\n\nVerification:\n- bun run test src/modules/update/__tests__/updateShared.test.ts\n- bun run test src/modules/system/__tests__/SystemPage.test.tsx src/modules/update/__tests__/AutoUpdatePrompt.test.tsx src/modules/update/__tests__/UpdateDetailsModal.test.tsx src/modules/update/__tests__/updateShared.test.ts\n- bun run build\n- bun run lint\n- bun run test