### PR TITLE
feat: add overflow tooltips to virtual table cells

### DIFF
--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -6,6 +6,7 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type HTMLAttributes,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -297,12 +298,13 @@ export function OverflowTooltip({
   children,
   className,
   placement = "bottom",
+  ...triggerProps
 }: {
   content: string;
   children: ReactNode;
   className?: string;
   placement?: TooltipPlacement;
-}) {
+} & Omit<HTMLAttributes<HTMLSpanElement>, "children" | "content">) {
   const id = useId();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLSpanElement | null>(null);
@@ -320,6 +322,7 @@ export function OverflowTooltip({
 
   return (
     <span
+      {...triggerProps}
       ref={ref}
       data-tooltip-managed="true"
       className={["relative", className].filter(Boolean).join(" ")}

--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -10,6 +10,7 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { OverflowTooltip } from "@/modules/ui/Tooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -27,6 +28,8 @@ export interface VirtualTableColumn<T> {
   headerClassName?: string;
   /** Extra cell class */
   cellClassName?: string;
+  /** Overflow tooltip text for a truncated cell. Primitive render output is used by default. */
+  overflowTooltip?: boolean | ((row: T, index: number) => string | null | undefined);
   /** Custom header render function (overrides label) */
   headerRender?: () => ReactNode;
   /** Render function for cell content */
@@ -81,6 +84,29 @@ const DEFAULT_ROW_HEIGHT = 44;
 const DEFAULT_OVERSCAN = 12;
 const DEFAULT_SCROLL_THRESHOLD = 100;
 const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
+
+function primitiveTooltipContent(content: ReactNode) {
+  if (typeof content === "string" || typeof content === "number") {
+    return String(content);
+  }
+  return null;
+}
+
+function resolveCellOverflowTooltip<T>(
+  column: VirtualTableColumn<T>,
+  row: T,
+  index: number,
+  content: ReactNode,
+) {
+  if (column.overflowTooltip === false) return null;
+
+  if (typeof column.overflowTooltip === "function") {
+    const value = column.overflowTooltip(row, index);
+    return value === null || value === undefined ? null : String(value);
+  }
+
+  return primitiveTooltipContent(content);
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -603,6 +629,13 @@ export function VirtualTable<T>({
                       {columns.map((col, colIdx) => {
                         const isFirst = colIdx === 0;
                         const isLast = colIdx === columns.length - 1;
+                        const content = col.render(row, globalIdx);
+                        const overflowTooltip = resolveCellOverflowTooltip(
+                          col,
+                          row,
+                          globalIdx,
+                          content,
+                        );
                         const roundCls = [
                           isFirst ? "first:rounded-l-lg" : "",
                           isLast ? "last:rounded-r-lg" : "",
@@ -614,7 +647,17 @@ export function VirtualTable<T>({
                             key={col.key}
                             className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${roundCls}`}
                           >
-                            {col.render(row, globalIdx)}
+                            {overflowTooltip === null ? (
+                              content
+                            ) : (
+                              <OverflowTooltip
+                                content={overflowTooltip}
+                                data-vt-cell-content
+                                className={`block min-w-0 max-w-full truncate ${col.cellClassName ?? ""}`}
+                              >
+                                {content}
+                              </OverflowTooltip>
+                            )}
                           </td>
                         );
                       })}

--- a/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
@@ -1,4 +1,4 @@
-import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
 
@@ -32,7 +32,107 @@ function setScrollMetrics(
   });
 }
 
+function setElementOverflow(
+  element: HTMLElement,
+  metrics: {
+    clientWidth: number;
+    scrollWidth: number;
+  },
+) {
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: metrics.clientWidth },
+    scrollWidth: { configurable: true, value: metrics.scrollWidth },
+  });
+}
+
 describe("VirtualTable scrollbar wrapper", () => {
+  test("truncates primitive cell content and shows the full value on overflow hover", () => {
+    const longName = "Very long table cell value that should be visible in the tooltip";
+
+    render(
+      <VirtualTable
+        rows={[{ id: "1", name: longName }]}
+        columns={columns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const cellContent = screen
+      .getByText(longName)
+      .closest("[data-vt-cell-content]") as HTMLElement | null;
+    expect(cellContent).not.toBeNull();
+    expect(cellContent).toHaveClass("truncate");
+
+    setElementOverflow(cellContent!, { clientWidth: 120, scrollWidth: 420 });
+    fireEvent.mouseEnter(cellContent!);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(longName);
+  });
+
+  test("does not show a primitive cell tooltip when the content fits", () => {
+    render(
+      <VirtualTable
+        rows={[{ id: "1", name: "Short" }]}
+        columns={columns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const cellContent = screen
+      .getByText("Short")
+      .closest("[data-vt-cell-content]") as HTMLElement | null;
+    expect(cellContent).not.toBeNull();
+
+    setElementOverflow(cellContent!, { clientWidth: 120, scrollWidth: 120 });
+    fireEvent.mouseEnter(cellContent!);
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  test("uses column-provided overflow tooltip text for complex cell content", () => {
+    const fullValue = "Complex rendered value with supporting markup";
+    const complexColumns: VirtualTableColumn<DemoRow>[] = [
+      {
+        key: "name",
+        label: "Name",
+        width: "w-40",
+        overflowTooltip: (row) => row.name,
+        render: (row) => (
+          <span>
+            <strong>{row.name}</strong>
+          </span>
+        ),
+      },
+    ];
+
+    render(
+      <VirtualTable
+        rows={[{ id: "1", name: fullValue }]}
+        columns={complexColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const cellContent = screen
+      .getByText(fullValue)
+      .closest("[data-vt-cell-content]") as HTMLElement | null;
+    expect(cellContent).not.toBeNull();
+
+    setElementOverflow(cellContent!, { clientWidth: 120, scrollWidth: 420 });
+    fireEvent.mouseEnter(cellContent!);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(fullValue);
+  });
+
   test("uses a focusable scroll container with hover-reveal metadata", () => {
     const { container } = render(
       <VirtualTable


### PR DESCRIPTION
## Summary
- Wrap primitive VirtualTable cell content in a one-line overflow tooltip trigger
- Add column-level overflowTooltip support for complex rendered cells
- Extend coverage for overflow-only tooltip behavior

## Test Plan
- bun run lint
- bun run test
- bun run build