### PR TITLE
fix: cover JSX table cell overflow tooltips

### DIFF
--- a/src/modules/api-keys/components/ApiKeyUsageModal.tsx
+++ b/src/modules/api-keys/components/ApiKeyUsageModal.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from "lucide-react";
 import { Modal } from "@/modules/ui/Modal";
 import { SearchableSelect } from "@/modules/ui/SearchableSelect";
 import { Select } from "@/modules/ui/Select";
+import { TableCellOverflowTooltip } from "@/modules/ui/TableCellOverflowTooltip";
 import {
   RequestLogsPaginationBar,
   RequestLogsTimeRangeSelector,
@@ -213,7 +214,9 @@ export function ApiKeyUsageModal({
                             key={col.key}
                             className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${roundCls}`}
                           >
-                            {col.render(row, rowIndex)}
+                            <TableCellOverflowTooltip className={col.cellClassName}>
+                              {col.render(row, rowIndex)}
+                            </TableCellOverflowTooltip>
                           </td>
                         );
                       })}

--- a/src/modules/apikey-lookup/components/PublicLogsSection.tsx
+++ b/src/modules/apikey-lookup/components/PublicLogsSection.tsx
@@ -4,6 +4,7 @@ import { Card } from "@/modules/ui/Card";
 import { Reveal } from "@/modules/ui/Reveal";
 import { SearchableSelect } from "@/modules/ui/SearchableSelect";
 import { Select } from "@/modules/ui/Select";
+import { TableCellOverflowTooltip } from "@/modules/ui/TableCellOverflowTooltip";
 import { OverflowTooltip } from "@/modules/ui/Tooltip";
 import type { LogRow, TableColumn } from "@/modules/apikey-lookup/types";
 
@@ -403,7 +404,9 @@ export function PublicLogsSection({
                           key={col.key}
                           className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${colIndex === 0 ? "first:rounded-l-lg" : ""} ${colIndex === logColumns.length - 1 ? "last:rounded-r-lg" : ""}`}
                         >
-                          {col.render(row, rowIndex)}
+                          <TableCellOverflowTooltip className={col.cellClassName}>
+                            {col.render(row, rowIndex)}
+                          </TableCellOverflowTooltip>
                         </td>
                       ))}
                     </tr>

--- a/src/modules/ui/TableCellOverflowTooltip.tsx
+++ b/src/modules/ui/TableCellOverflowTooltip.tsx
@@ -1,0 +1,80 @@
+import { isValidElement, type ReactNode } from "react";
+import { OverflowTooltip } from "@/modules/ui/Tooltip";
+
+function normalizeTooltipText(parts: string[]) {
+  const text = parts.join(" ").replace(/\s+/g, " ").trim();
+  return text || null;
+}
+
+function collectTextParts(node: ReactNode, parts: string[]) {
+  if (node === null || node === undefined || typeof node === "boolean") return;
+
+  if (typeof node === "string" || typeof node === "number") {
+    parts.push(String(node));
+    return;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectTextParts(child, parts));
+    return;
+  }
+
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode };
+    collectTextParts(props.children, parts);
+  }
+}
+
+function containsManagedTooltip(node: ReactNode): boolean {
+  if (node === null || node === undefined || typeof node === "boolean") return false;
+
+  if (Array.isArray(node)) return node.some(containsManagedTooltip);
+
+  if (!isValidElement(node)) return false;
+
+  if (node.type === OverflowTooltip) return true;
+
+  const props = node.props as {
+    children?: ReactNode;
+    "data-tooltip-managed"?: unknown;
+  };
+
+  if (props["data-tooltip-managed"]) return true;
+
+  return containsManagedTooltip(props.children);
+}
+
+export function extractTableCellTextContent(content: ReactNode) {
+  const parts: string[] = [];
+  collectTextParts(content, parts);
+  return normalizeTooltipText(parts);
+}
+
+export function TableCellOverflowTooltip({
+  children,
+  className,
+  tooltipContent,
+}: {
+  children: ReactNode;
+  className?: string;
+  tooltipContent?: string | null | false;
+}) {
+  const resolvedContent =
+    tooltipContent === undefined ? extractTableCellTextContent(children) : tooltipContent;
+
+  if (resolvedContent === false) return <>{children}</>;
+  if (!resolvedContent?.trim()) return <>{children}</>;
+  if (tooltipContent === undefined && containsManagedTooltip(children)) return <>{children}</>;
+
+  return (
+    <OverflowTooltip
+      as="div"
+      content={resolvedContent}
+      data-table-cell-overflow
+      data-vt-cell-content
+      className={["block min-w-0 max-w-full truncate", className].filter(Boolean).join(" ")}
+    >
+      {children}
+    </OverflowTooltip>
+  );
+}

--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -1,4 +1,5 @@
 import {
+  createElement,
   createContext,
   useCallback,
   useEffect,
@@ -171,6 +172,20 @@ function resolveTooltipPosition({
   };
 }
 
+function isElementOverflowing(element: HTMLElement) {
+  return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
+}
+
+function hasOverflowingContent(element: HTMLElement) {
+  if (isElementOverflowing(element)) return true;
+
+  for (const child of element.querySelectorAll("*")) {
+    if (child instanceof HTMLElement && isElementOverflowing(child)) return true;
+  }
+
+  return false;
+}
+
 /** Fixed-position tooltip rendered via portal — never clipped by overflow containers */
 export function TooltipBubble({
   id,
@@ -294,47 +309,48 @@ export function HoverTooltip({
 }
 
 export function OverflowTooltip({
+  as = "span",
   content,
   children,
   className,
   placement = "bottom",
   ...triggerProps
 }: {
+  as?: "div" | "span";
   content: string;
   children: ReactNode;
   className?: string;
   placement?: TooltipPlacement;
-} & Omit<HTMLAttributes<HTMLSpanElement>, "children" | "content">) {
+} & Omit<HTMLAttributes<HTMLElement>, "children" | "content">) {
   const id = useId();
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLSpanElement | null>(null);
+  const ref = useRef<HTMLElement | null>(null);
 
   const tryShow = useCallback(() => {
     const el = ref.current;
     if (!el) return;
     if (!content.trim()) return;
-    const isOverflowing = el.scrollWidth > el.clientWidth;
-    if (!isOverflowing) return;
+    if (!hasOverflowingContent(el)) return;
     setOpen(true);
   }, [content]);
 
   const hide = useCallback(() => setOpen(false), []);
 
-  return (
-    <span
-      {...triggerProps}
-      ref={ref}
-      data-tooltip-managed="true"
-      className={["relative", className].filter(Boolean).join(" ")}
-      onMouseEnter={tryShow}
-      onMouseLeave={hide}
-      onFocus={tryShow}
-      onBlur={hide}
-      aria-describedby={id}
-    >
-      {children}
-      <TooltipBubble id={id} open={open} content={content} anchorRef={ref} placement={placement} />
-    </span>
+  return createElement(
+    as,
+    {
+      ...triggerProps,
+      ref,
+      "data-tooltip-managed": "true",
+      className: ["relative", className].filter(Boolean).join(" "),
+      onMouseEnter: tryShow,
+      onMouseLeave: hide,
+      onFocus: tryShow,
+      onBlur: hide,
+      "aria-describedby": id,
+    },
+    children,
+    <TooltipBubble id={id} open={open} content={content} anchorRef={ref} placement={placement} />,
   );
 }
 

--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -10,7 +10,7 @@ import {
   type WheelEvent as ReactWheelEvent,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { OverflowTooltip } from "@/modules/ui/Tooltip";
+import { TableCellOverflowTooltip } from "@/modules/ui/TableCellOverflowTooltip";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,27 +85,19 @@ const DEFAULT_OVERSCAN = 12;
 const DEFAULT_SCROLL_THRESHOLD = 100;
 const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
 
-function primitiveTooltipContent(content: ReactNode) {
-  if (typeof content === "string" || typeof content === "number") {
-    return String(content);
-  }
-  return null;
-}
-
 function resolveCellOverflowTooltip<T>(
   column: VirtualTableColumn<T>,
   row: T,
   index: number,
-  content: ReactNode,
 ) {
-  if (column.overflowTooltip === false) return null;
+  if (column.overflowTooltip === false) return false;
 
   if (typeof column.overflowTooltip === "function") {
     const value = column.overflowTooltip(row, index);
     return value === null || value === undefined ? null : String(value);
   }
 
-  return primitiveTooltipContent(content);
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -630,12 +622,7 @@ export function VirtualTable<T>({
                         const isFirst = colIdx === 0;
                         const isLast = colIdx === columns.length - 1;
                         const content = col.render(row, globalIdx);
-                        const overflowTooltip = resolveCellOverflowTooltip(
-                          col,
-                          row,
-                          globalIdx,
-                          content,
-                        );
+                        const overflowTooltip = resolveCellOverflowTooltip(col, row, globalIdx);
                         const roundCls = [
                           isFirst ? "first:rounded-l-lg" : "",
                           isLast ? "last:rounded-r-lg" : "",
@@ -647,17 +634,12 @@ export function VirtualTable<T>({
                             key={col.key}
                             className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${roundCls}`}
                           >
-                            {overflowTooltip === null ? (
-                              content
-                            ) : (
-                              <OverflowTooltip
-                                content={overflowTooltip}
-                                data-vt-cell-content
-                                className={`block min-w-0 max-w-full truncate ${col.cellClassName ?? ""}`}
-                              >
-                                {content}
-                              </OverflowTooltip>
-                            )}
+                            <TableCellOverflowTooltip
+                              tooltipContent={overflowTooltip}
+                              className={col.cellClassName}
+                            >
+                              {content}
+                            </TableCellOverflowTooltip>
                           </td>
                         );
                       })}

--- a/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
@@ -133,6 +133,46 @@ describe("VirtualTable scrollbar wrapper", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent(fullValue);
   });
 
+  test("infers overflow tooltip text from JSX cell content", () => {
+    const fullValue = "JSX-rendered table cell value";
+    const jsxColumns: VirtualTableColumn<DemoRow>[] = [
+      {
+        key: "name",
+        label: "Name",
+        width: "w-40",
+        render: (row) => (
+          <span className="block min-w-0 truncate">
+            <strong>{row.name}</strong>
+          </span>
+        ),
+      },
+    ];
+
+    render(
+      <VirtualTable
+        rows={[{ id: "1", name: fullValue }]}
+        columns={jsxColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const cellContent = screen
+      .getByText(fullValue)
+      .closest("[data-table-cell-overflow]") as HTMLElement | null;
+    expect(cellContent).not.toBeNull();
+    const innerContent = screen.getByText(fullValue).closest("span") as HTMLElement | null;
+    expect(innerContent).not.toBeNull();
+
+    setElementOverflow(cellContent!, { clientWidth: 120, scrollWidth: 120 });
+    setElementOverflow(innerContent!, { clientWidth: 120, scrollWidth: 420 });
+    fireEvent.mouseEnter(cellContent!);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(fullValue);
+  });
+
   test("uses a focusable scroll container with hover-reveal metadata", () => {
     const { container } = render(
       <VirtualTable


### PR DESCRIPTION
## Summary
- Add a shared TableCellOverflowTooltip that derives tooltip text from JSX cell content
- Detect overflow on nested truncated descendants, not only the outer trigger
- Apply the shared wrapper to VirtualTable and the two remaining hand-written tables

## Test Plan
- bun run lint
- bun run test
- bun run build

## Audit
- rg "<table" src shows only VirtualTable, ApiKeyUsageModal, and PublicLogsSection; all data cells now use the shared wrapper.