### PR TITLE
fix: polish subscription picker save flow

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -113,7 +113,7 @@ export function AuthFilesPage() {
     prefixProxyUpdatedText,
     savePrefixProxy,
     saveChannelEditor,
-  } = useAuthFilesDetailEditors(loadAll);
+  } = useAuthFilesDetailEditors(loadAll, setFiles);
 
   const {
     modelOwnerGroupsLoading,

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -77,6 +77,21 @@ vi.mock("@/modules/ui/charts/EChart", () => ({
   EChart: ({ className }: { className?: string }) => <div className={className}>chart</div>,
 }));
 
+const padDatePart = (value: number): string => String(value).padStart(2, "0");
+
+const toDateTimeLocalInput = (date: Date): string =>
+  [
+    date.getFullYear(),
+    "-",
+    padDatePart(date.getMonth() + 1),
+    "-",
+    padDatePart(date.getDate()),
+    "T",
+    padDatePart(date.getHours()),
+    ":",
+    padDatePart(date.getMinutes()),
+  ].join("");
+
 describe("AuthFilesPage files table", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -590,6 +605,60 @@ describe("AuthFilesPage files table", () => {
     const uploaded = uploadCalls[0][0];
     const uploadedJson = JSON.parse(await uploaded.text()) as Record<string, unknown>;
     expect(uploadedJson.subscription_started_at).toBe(expectedStartedAt.toISOString());
+  });
+
+  test("closes the fields modal and refreshes the card subscription badge after saving", async () => {
+    const startedAt = new Date(Date.now() - 25 * 24 * 60 * 60 * 1000);
+    startedAt.setSeconds(0, 0);
+    const startedAtInput = toDateTimeLocalInput(startedAt);
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-subscription.json",
+          label: "Codex Subscriber",
+          account_type: "oauth",
+          type: "codex",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+        },
+      ],
+    }));
+    mocks.downloadText.mockImplementation(async () => JSON.stringify({ type: "codex" }, null, 2));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const cards = await screen.findByTestId("auth-files-cards");
+    expect(cards).not.toHaveTextContent(/d left/);
+    fireEvent.click(within(cards).getByRole("button", { name: "View" }));
+    const dialog = await screen.findByRole("dialog", { name: "View: codex-subscription.json" });
+    fireEvent.click(within(dialog).getByRole("tab", { name: "Fields" }));
+
+    const input = await within(dialog).findByLabelText("Subscription start date");
+    fireEvent.change(input, { target: { value: startedAtInput } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(1));
+    const uploadCalls = mocks.upload.mock.calls as unknown as [[File]];
+    const uploadedJson = JSON.parse(await uploadCalls[0][0].text()) as Record<string, unknown>;
+    expect(uploadedJson.subscription_started_at).toBe(new Date(startedAtInput).toISOString());
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "View: codex-subscription.json" }),
+      ).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(screen.getByTestId("auth-files-cards")).toHaveTextContent(/d left/));
   });
 
   test("sets model owner group from an icon modal after confirmation", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { authFilesApi } from "@/lib/http/apis";
 import type { AuthFileItem } from "@/lib/http/types";
@@ -65,7 +73,44 @@ const removeSubscriptionFields = (json: Record<string, unknown>) => {
   delete json.subscriptionExpired;
 };
 
-export function useAuthFilesDetailEditors(loadAll: () => Promise<void>) {
+const mergeSavedSubscriptionFields = (
+  file: AuthFileItem,
+  json: Record<string, unknown>,
+): AuthFileItem => {
+  const next = { ...file };
+  const startedAt = readSubscriptionStartValue(json);
+
+  delete next.subscription_started_at;
+  delete next.subscriptionStartedAt;
+  delete next.subscription_start_at;
+  delete next.subscriptionStartAt;
+  delete next.subscription_started_at_ms;
+  delete next.subscriptionStartedAtMs;
+  delete next.subscription_period;
+  delete next.subscriptionPeriod;
+  delete next.subscription_expires_at;
+  delete next.subscriptionExpiresAt;
+  delete next.subscription_expires_at_ms;
+  delete next.subscriptionExpiresAtMs;
+  delete next.subscription_remaining_minutes;
+  delete next.subscriptionRemainingMinutes;
+  delete next.subscription_expired;
+  delete next.subscriptionExpired;
+
+  if (typeof startedAt === "string" && startedAt.trim()) {
+    next.subscription_started_at = startedAt;
+    next.subscription_period = normalizeAuthFileSubscriptionPeriod(
+      json.subscription_period ?? json.subscriptionPeriod,
+    );
+  }
+
+  return next;
+};
+
+export function useAuthFilesDetailEditors(
+  loadAll: () => Promise<void>,
+  setFiles?: Dispatch<SetStateAction<AuthFileItem[]>>,
+) {
   const { t } = useTranslation();
   const { notify } = useToast();
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
@@ -86,6 +131,17 @@ export function useAuthFilesDetailEditors(loadAll: () => Promise<void>) {
   );
   const [channelEditor, setChannelEditor] = useState<ChannelEditorState>(() =>
     createChannelEditorState(),
+  );
+
+  const applySavedAuthFilePatch = useCallback(
+    (fileName: string, json: Record<string, unknown>) => {
+      const applyPatch = (file: AuthFileItem): AuthFileItem =>
+        file.name === fileName ? mergeSavedSubscriptionFields(file, json) : file;
+
+      setFiles?.((prev) => prev.map(applyPatch));
+      setDetailFile((prev) => (prev && prev.name === fileName ? applyPatch(prev) : prev));
+    },
+    [setFiles],
   );
 
   const loadModelsForDetail = useCallback(
@@ -375,21 +431,23 @@ export function useAuthFilesDetailEditors(loadAll: () => Promise<void>) {
     try {
       const file = new File([payload], name, { type: "application/json" });
       await authFilesApi.upload(file);
+      const parsedPayload = JSON.parse(payload) as Record<string, unknown>;
+      applySavedAuthFilePatch(name, parsedPayload);
       notify({ type: "success", message: t("auth_files.saved") });
-      await loadAll();
-      try {
-        const parsed = JSON.parse(payload) as Record<string, unknown>;
-        setPrefixProxyEditor((prev) => ({
-          ...prev,
-          loading: false,
-          saving: false,
-          error: null,
-          json: parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : prev.json,
-        }));
-      } catch {
-        setPrefixProxyEditor((prev) => ({ ...prev, saving: false, error: null }));
-      }
+      setPrefixProxyEditor((prev) => ({
+        ...prev,
+        loading: false,
+        saving: false,
+        error: null,
+        json:
+          parsedPayload && typeof parsedPayload === "object" && !Array.isArray(parsedPayload)
+            ? parsedPayload
+            : prev.json,
+      }));
       setDetailText((prev) => (name && detailFile?.name === name ? payload : prev));
+      setDetailOpen(false);
+      setDetailTab("json");
+      void loadAll().finally(() => applySavedAuthFilePatch(name, parsedPayload));
     } catch (err: unknown) {
       notify({
         type: "error",
@@ -398,6 +456,7 @@ export function useAuthFilesDetailEditors(loadAll: () => Promise<void>) {
       setPrefixProxyEditor((prev) => ({ ...prev, saving: false }));
     }
   }, [
+    applySavedAuthFilePatch,
     detailFile?.name,
     loadAll,
     notify,

--- a/src/modules/ui/DateTimePicker.tsx
+++ b/src/modules/ui/DateTimePicker.tsx
@@ -41,8 +41,8 @@ interface DateTimePickerProps {
 const VIEWPORT_MARGIN = 12;
 const POPOVER_GAP = 8;
 const POPOVER_WIDTH = 320;
-const POPOVER_HEIGHT = 360;
-const MIN_POPOVER_HEIGHT = 180;
+const FIVE_WEEK_POPOVER_HEIGHT = 392;
+const SIX_WEEK_POPOVER_HEIGHT = 428;
 
 const pad2 = (value: number): string => String(value).padStart(2, "0");
 
@@ -96,6 +96,12 @@ const clamp = (value: number, min: number, max: number): number =>
 const getDaysInMonth = (year: number, month: number): number =>
   new Date(year, month + 1, 0).getDate();
 
+const getCalendarCellCount = (year: number, month: number): number => {
+  const startOffset = new Date(year, month, 1).getDay();
+  const currentMonthDays = getDaysInMonth(year, month);
+  return Math.max(35, Math.ceil((startOffset + currentMonthDays) / 7) * 7);
+};
+
 export function DateTimePicker({
   value,
   onChange,
@@ -128,6 +134,13 @@ export function DateTimePicker({
     setVisibleMonth(new Date(date.getFullYear(), date.getMonth(), 1));
   }, [open, parsedValue]);
 
+  const calendarCellCount = useMemo(
+    () => getCalendarCellCount(visibleMonth.getFullYear(), visibleMonth.getMonth()),
+    [visibleMonth],
+  );
+  const estimatedPopoverHeight =
+    calendarCellCount > 35 ? SIX_WEEK_POPOVER_HEIGHT : FIVE_WEEK_POPOVER_HEIGHT;
+
   const updatePosition = useCallback(() => {
     const root = rootRef.current;
     if (!root) return;
@@ -141,19 +154,14 @@ export function DateTimePicker({
     const left = clamp(rect.left, minLeft, maxLeft);
     const spaceBelow = viewportHeight - rect.bottom - POPOVER_GAP - VIEWPORT_MARGIN;
     const spaceAbove = rect.top - POPOVER_GAP - VIEWPORT_MARGIN;
-    const openAbove = spaceBelow < POPOVER_HEIGHT && spaceAbove > spaceBelow;
-    const maxUsableHeight = Math.max(0, viewportHeight - VIEWPORT_MARGIN * 2);
-    const minUsableHeight = Math.min(MIN_POPOVER_HEIGHT, maxUsableHeight);
-    const preferredSpace = openAbove ? spaceAbove : spaceBelow;
-    const availableHeight = clamp(
-      Math.min(POPOVER_HEIGHT, preferredSpace),
-      minUsableHeight,
-      Math.max(minUsableHeight, maxUsableHeight),
-    );
+    const openAbove = spaceBelow < estimatedPopoverHeight && spaceAbove > spaceBelow;
     const minTop = VIEWPORT_MARGIN;
-    const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - VIEWPORT_MARGIN - availableHeight);
+    const maxTop = Math.max(
+      VIEWPORT_MARGIN,
+      viewportHeight - VIEWPORT_MARGIN - estimatedPopoverHeight,
+    );
     const top = openAbove
-      ? clamp(rect.top - POPOVER_GAP - availableHeight, minTop, maxTop)
+      ? clamp(rect.top - POPOVER_GAP - estimatedPopoverHeight, minTop, maxTop)
       : clamp(rect.bottom + POPOVER_GAP, minTop, maxTop);
 
     setPlacement(openAbove ? "top" : "bottom");
@@ -162,10 +170,9 @@ export function DateTimePicker({
       top,
       left,
       width,
-      maxHeight: availableHeight,
       zIndex: 99999,
     });
-  }, []);
+  }, [estimatedPopoverHeight]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -220,7 +227,7 @@ export function DateTimePicker({
     const previousMonthDays = getDaysInMonth(year, month - 1);
     const startOffset = new Date(year, month, 1).getDay();
 
-    return Array.from({ length: 42 }, (_, index) => {
+    return Array.from({ length: calendarCellCount }, (_, index) => {
       const dayOffset = index - startOffset + 1;
       if (dayOffset < 1) {
         const day = previousMonthDays + dayOffset;
@@ -232,7 +239,7 @@ export function DateTimePicker({
       }
       return { date: new Date(year, month, dayOffset), inMonth: true };
     });
-  }, [visibleMonth]);
+  }, [calendarCellCount, visibleMonth]);
 
   const selectedDateKey = parsedValue
     ? `${parsedValue.getFullYear()}-${parsedValue.getMonth()}-${parsedValue.getDate()}`
@@ -312,7 +319,7 @@ export function DateTimePicker({
               role="dialog"
               aria-label={labels.picker}
               data-placement={placement}
-              className={cn(selectPanel, "overflow-y-auto p-3 text-[#18181B] dark:text-white")}
+              className={cn(selectPanel, "p-3 text-[#18181B] dark:text-white")}
               style={panelStyle}
               {...getSelectDropdownMotion(placement)}
               transition={selectDropdownTransition}

--- a/src/modules/ui/__tests__/DateTimePicker.test.tsx
+++ b/src/modules/ui/__tests__/DateTimePicker.test.tsx
@@ -117,4 +117,26 @@ describe("DateTimePicker", () => {
     expect(dialog).toHaveAttribute("data-placement", "top");
     expect(dialog).toHaveStyle({ left: "12px", width: "296px" });
   });
+
+  test("renders as a complete popover without an internal vertical scrollbar", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    setViewport(900, 700);
+    mockAnchorRect({ bottom: 80, top: 40 });
+
+    render(
+      <DateTimePicker
+        value="2026-04-30T14:40"
+        onChange={onChange}
+        aria-label="Subscription start date"
+        labels={labels}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Subscription start date"));
+
+    const dialog = screen.getByRole("dialog", { name: "Date picker" });
+    expect(dialog).not.toHaveClass("overflow-y-auto");
+    expect(dialog).not.toHaveStyle({ maxHeight: "360px" });
+  });
 });


### PR DESCRIPTION
## Summary
- remove the subscription date picker internal scrollbar by sizing/positioning the full popover instead of clipping it to 360px
- render only the needed calendar weeks so months like April do not show an extra stale row
- close the auth-file detail modal after a successful fields save and optimistically refresh the current file subscription badge in table/cards

## Verification
- bun run test -- src/modules/ui/__tests__/DateTimePicker.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- bunx oxfmt src/modules/ui/DateTimePicker.tsx src/modules/ui/__tests__/DateTimePicker.test.tsx src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts src/modules/auth-files/AuthFilesPage.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --check
- git diff --check
- bun run test
- bun run check

Note: full `bunx oxfmt . --check` still reports 40 pre-existing unrelated files outside this change set.