### PR TITLE
fix: keep overflow tooltips hoverable

### DIFF
--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -193,6 +193,9 @@ export function TooltipBubble({
   content,
   anchorElement,
   anchorRef,
+  interactive = false,
+  onMouseEnter,
+  onMouseLeave,
   placement = "bottom",
 }: {
   id: string;
@@ -200,6 +203,9 @@ export function TooltipBubble({
   content: ReactNode;
   anchorElement?: HTMLElement | null;
   anchorRef?: React.RefObject<HTMLElement | null>;
+  interactive?: boolean;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
   placement?: TooltipPlacement;
 }) {
   const tooltipRef = useRef<HTMLSpanElement>(null);
@@ -255,8 +261,13 @@ export function TooltipBubble({
       ref={tooltipRef}
       id={id}
       role="tooltip"
-      className="pointer-events-none w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-80 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white"
+      className={[
+        interactive ? "pointer-events-auto select-text" : "pointer-events-none",
+        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-80 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
+      ].join(" ")}
       style={style}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <span className="block break-words text-slate-900 dark:text-white">{content}</span>
     </span>,
@@ -325,16 +336,39 @@ export function OverflowTooltip({
   const id = useId();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLElement | null>(null);
+  const hideTimeoutRef = useRef<number | null>(null);
+
+  const cancelHide = useCallback(() => {
+    if (hideTimeoutRef.current === null) return;
+    window.clearTimeout(hideTimeoutRef.current);
+    hideTimeoutRef.current = null;
+  }, []);
 
   const tryShow = useCallback(() => {
     const el = ref.current;
     if (!el) return;
     if (!content.trim()) return;
     if (!hasOverflowingContent(el)) return;
+    cancelHide();
     setOpen(true);
-  }, [content]);
+  }, [cancelHide, content]);
 
-  const hide = useCallback(() => setOpen(false), []);
+  const hide = useCallback(() => {
+    cancelHide();
+    setOpen(false);
+  }, [cancelHide]);
+
+  const scheduleHide = useCallback(() => {
+    cancelHide();
+    hideTimeoutRef.current = window.setTimeout(() => {
+      hideTimeoutRef.current = null;
+      setOpen(false);
+    }, 120);
+  }, [cancelHide]);
+
+  useEffect(() => {
+    return () => cancelHide();
+  }, [cancelHide]);
 
   return createElement(
     as,
@@ -344,13 +378,22 @@ export function OverflowTooltip({
       "data-tooltip-managed": "true",
       className: ["relative", className].filter(Boolean).join(" "),
       onMouseEnter: tryShow,
-      onMouseLeave: hide,
+      onMouseLeave: scheduleHide,
       onFocus: tryShow,
       onBlur: hide,
       "aria-describedby": id,
     },
     children,
-    <TooltipBubble id={id} open={open} content={content} anchorRef={ref} placement={placement} />,
+    <TooltipBubble
+      id={id}
+      open={open}
+      content={content}
+      anchorRef={ref}
+      interactive
+      placement={placement}
+      onMouseEnter={cancelHide}
+      onMouseLeave={scheduleHide}
+    />,
   );
 }
 

--- a/src/modules/ui/__tests__/Tooltip.test.tsx
+++ b/src/modules/ui/__tests__/Tooltip.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { GlobalIconButtonTooltip, HoverTooltip } from "@/modules/ui/Tooltip";
+import { GlobalIconButtonTooltip, HoverTooltip, OverflowTooltip } from "@/modules/ui/Tooltip";
 
 const setViewport = (width: number, height: number) => {
   Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
@@ -88,5 +88,54 @@ describe("HoverTooltip", () => {
     await userEvent.hover(screen.getByRole("button", { name: "Close" }));
 
     expect(screen.getByRole("tooltip")).toHaveTextContent("Close");
+  });
+});
+
+describe("OverflowTooltip", () => {
+  beforeEach(() => {
+    setViewport(800, 600);
+    setTooltipSize(180, 48);
+    mockAnchorRect({ left: 100, right: 220, top: 100, bottom: 124, width: 120, height: 24 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("stays open when the pointer moves from the trigger into the tooltip", () => {
+    vi.useFakeTimers();
+
+    render(
+      <OverflowTooltip content="Copyable full table cell value" className="block max-w-20 truncate">
+        <span>Copyable full table cell value</span>
+      </OverflowTooltip>,
+    );
+
+    const trigger = screen.getByText("Copyable full table cell value").parentElement!;
+    Object.defineProperties(trigger, {
+      clientWidth: { configurable: true, value: 80 },
+      scrollWidth: { configurable: true, value: 260 },
+    });
+
+    fireEvent.mouseEnter(trigger);
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Copyable full table cell value");
+
+    fireEvent.mouseLeave(trigger, { relatedTarget: tooltip });
+    fireEvent.mouseEnter(tooltip, { relatedTarget: trigger });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.getByRole("tooltip")).toBe(tooltip);
+    expect(tooltip).toHaveClass("pointer-events-auto", "select-text");
+
+    fireEvent.mouseLeave(tooltip, { relatedTarget: document.body });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- make overflow tooltips interactive so users can move into them and select/copy text
- delay closing while moving from the overflowing table cell into the tooltip
- add regression coverage for keeping the tooltip open past the close delay and closing after leaving it

## Test Plan
- bun run test -- src/modules/ui/__tests__/Tooltip.test.tsx
- bun run lint
- bun run test
- bun run build