### PR TITLE
fix: show codex additional quotas

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -791,6 +791,61 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  test("cards view includes returned codex review 5h and additional quota bars", async () => {
+    const now = Date.now();
+    const file = {
+      name: "codex-spark.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "7",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [
+        { label: "m_quota.code_5h", percent: 90, resetAtMs: now + 60_000 },
+        { label: "m_quota.code_weekly", percent: 80, resetAtMs: now + 120_000 },
+        { label: "m_quota.review_5h", percent: 70, resetAtMs: now + 180_000 },
+        { label: "m_quota.review_weekly", percent: 60, resetAtMs: now + 240_000 },
+        { label: "GPT-5.3-Codex-Spark: 5h", percent: 100, resetAtMs: now + 300_000 },
+        { label: "GPT-5.3-Codex-Spark: Weekly", percent: 96, resetAtMs: now + 360_000 },
+      ],
+    });
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      "authFilesPage.dataCache.v1",
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-spark.json")).toBeInTheDocument();
+    fireEvent.click(
+      within(screen.getByTestId("auth-files-cards")).getByRole("button", { name: "Refresh" }),
+    );
+
+    expect(await screen.findByText("Review: 5h")).toBeInTheDocument();
+    expect(screen.getByText("GPT-5.3-Codex-Spark: 5h")).toBeInTheDocument();
+    expect(screen.getByText("GPT-5.3-Codex-Spark: Weekly")).toBeInTheDocument();
+    expect(screen.getByText("96%")).toBeInTheDocument();
+  });
+
   test("cards view shows only kimi coding quotas and marks depleted weekly quota red", async () => {
     const now = Date.now();
     const file = {

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -123,32 +123,60 @@ export function useAuthFilesQuotaState({
         findExact("m_quota.code_5h") ?? find(/(mquotacode5h|code5h|5h|5小时|fivehour|5hour)/i);
       const codeWeek =
         findExact("m_quota.code_weekly") ?? find(/(mquotacodeweekly|codeweekly|weekly|week|周)/i);
+      const reviewFiveHour =
+        findExact("m_quota.review_5h") ??
+        find(/(mquotareview5h|review5h|review5hour|reviewfivehour|审查5小时|审查：5小时)/i);
       const reviewWeek =
         findExact("m_quota.review_weekly") ??
         find(/(mquotareviewweekly|reviewweekly|reviewweek|review_week|审查周|审查：周)/i);
 
-      const codingSlots = [
+      const knownItems = new Set<QuotaItem>();
+      [codeFiveHour, codeWeek, reviewFiveHour, reviewWeek].forEach((item) => {
+        if (item) knownItems.add(item);
+      });
+
+      const codingSlots: { id: string; label: string; item: QuotaItem | null }[] = [
         {
-          id: "code_5h" as const,
+          id: "code_5h",
           label: translateQuotaLabel("m_quota.code_5h"),
           item: codeFiveHour,
         },
         {
-          id: "code_week" as const,
+          id: "code_week",
           label: translateQuotaLabel("m_quota.code_weekly"),
           item: codeWeek,
         },
       ];
       if (provider === "kimi") return codingSlots;
 
-      return [
-        ...codingSlots,
-        {
-          id: "review_week" as const,
+      const codexSlots = [...codingSlots];
+      if (reviewFiveHour) {
+        codexSlots.push({
+          id: "review_5h",
+          label: translateQuotaLabel("m_quota.review_5h"),
+          item: reviewFiveHour,
+        });
+      }
+      if (reviewWeek) {
+        codexSlots.push({
+          id: "review_week",
           label: translateQuotaLabel("m_quota.review_weekly"),
           item: reviewWeek,
-        },
-      ];
+        });
+      }
+
+      const extraSlots = items
+        .filter((item) => !knownItems.has(item))
+        .map((item, index) => {
+          const idKey = normalize(String(item.label ?? "")) || `quota${index + 1}`;
+          return {
+            id: `extra_${idKey}` as const,
+            label: translateQuotaLabel(item.label),
+            item,
+          };
+        });
+
+      return [...codexSlots, ...extraSlots];
     },
     [t],
   );

--- a/src/modules/quota/__tests__/quota-helpers.test.ts
+++ b/src/modules/quota/__tests__/quota-helpers.test.ts
@@ -33,7 +33,7 @@ describe("formatRelativeResetLabel", () => {
 });
 
 describe("buildCodexItems", () => {
-  test("treats null code_review_rate_limit as 100% remaining", () => {
+  test("omits code review quota items when the API does not return review limits", () => {
     const items = buildCodexItems({
       rate_limit: {
         allowed: true,
@@ -52,8 +52,71 @@ describe("buildCodexItems", () => {
       code_review_rate_limit: null,
     });
 
-    const reviewWeekly = items.find((item) => item.label === "m_quota.review_weekly");
-    expect(reviewWeekly?.percent).toBe(100);
+    expect(items.map((item) => item.label)).toEqual(["m_quota.code_5h", "m_quota.code_weekly"]);
+  });
+
+  test("maps Codex Spark additional rate limits into displayable quota items", () => {
+    const items = buildCodexItems({
+      additional_rate_limits: [
+        {
+          limit_name: "GPT-5.3-Codex-Spark",
+          rate_limit: {
+            allowed: true,
+            limit_reached: false,
+            primary_window: {
+              used_percent: 25,
+              limit_window_seconds: 18000,
+              reset_after_seconds: 60,
+            },
+            secondary_window: {
+              used_percent: 4,
+              limit_window_seconds: 604800,
+              reset_at: 1778140862,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "GPT-5.3-Codex-Spark: 5h",
+          percent: 75,
+        }),
+        expect.objectContaining({
+          label: "GPT-5.3-Codex-Spark: Weekly",
+          percent: 96,
+          resetAtMs: 1778140862000,
+        }),
+      ]),
+    );
+  });
+
+  test("maps returned code review 5-hour and weekly limits", () => {
+    const items = buildCodexItems({
+      code_review_rate_limit: {
+        allowed: true,
+        limit_reached: false,
+        primary_window: {
+          used_percent: 60,
+          limit_window_seconds: 18000,
+          reset_after_seconds: 60,
+        },
+        secondary_window: {
+          used_percent: 10,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 120,
+        },
+      },
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "m_quota.review_5h", percent: 40 }),
+        expect.objectContaining({ label: "m_quota.review_weekly", percent: 90 }),
+      ]),
+    );
   });
 });
 

--- a/src/modules/quota/quota-codex.ts
+++ b/src/modules/quota/quota-codex.ts
@@ -30,6 +30,13 @@ type CodexRateLimitInfo = {
   secondaryWindow?: CodexUsageWindow | null;
 };
 
+type CodexAdditionalRateLimit = {
+  limit_name?: string;
+  limitName?: string;
+  rate_limit?: CodexRateLimitInfo | null;
+  rateLimit?: CodexRateLimitInfo | null;
+};
+
 export type CodexUsagePayload = {
   plan_type?: string;
   planType?: string;
@@ -37,6 +44,8 @@ export type CodexUsagePayload = {
   rateLimit?: CodexRateLimitInfo | null;
   code_review_rate_limit?: CodexRateLimitInfo | null;
   codeReviewRateLimit?: CodexRateLimitInfo | null;
+  additional_rate_limits?: CodexAdditionalRateLimit[];
+  additionalRateLimits?: CodexAdditionalRateLimit[];
 };
 
 export const resolveCodexChatgptAccountId = (file: AuthFileItem): string | null => {
@@ -83,6 +92,11 @@ export const buildCodexItems = (payload: CodexUsagePayload): QuotaItem[] => {
   const weekSeconds = 604800;
   const rate = payload.rate_limit ?? payload.rateLimit ?? null;
   const codeReview = payload.code_review_rate_limit ?? payload.codeReviewRateLimit ?? null;
+  const additionalRateLimits = Array.isArray(payload.additional_rate_limits)
+    ? payload.additional_rate_limits
+    : Array.isArray(payload.additionalRateLimits)
+      ? payload.additionalRateLimits
+      : [];
   const items: QuotaItem[] = [];
 
   const pickWindows = (limitInfo?: CodexRateLimitInfo | null) => {
@@ -94,7 +108,9 @@ export const buildCodexItems = (payload: CodexUsagePayload): QuotaItem[] => {
     let weekly: CodexUsageWindow | null = null;
     for (const window of rawWindows) {
       if (!window) continue;
-      const seconds = normalizeNumberValue(window.limit_window_seconds ?? window.limitWindowSeconds);
+      const seconds = normalizeNumberValue(
+        window.limit_window_seconds ?? window.limitWindowSeconds,
+      );
       if (seconds === fiveHourSeconds && !fiveHour) fiveHour = window;
       if (seconds === weekSeconds && !weekly) weekly = window;
     }
@@ -110,7 +126,11 @@ export const buildCodexItems = (payload: CodexUsagePayload): QuotaItem[] => {
     const usedRaw = normalizeNumberValue(window.used_percent ?? window.usedPercent);
     const limitReached = limitInfo?.limit_reached ?? limitInfo?.limitReached;
     const used =
-      usedRaw !== null ? clampPercent(usedRaw) : limitInfo?.allowed === false || limitReached ? 100 : null;
+      usedRaw !== null
+        ? clampPercent(usedRaw)
+        : limitInfo?.allowed === false || limitReached
+          ? 100
+          : null;
     items.push({
       label,
       percent: used === null ? null : clampPercent(100 - used),
@@ -125,13 +145,17 @@ export const buildCodexItems = (payload: CodexUsagePayload): QuotaItem[] => {
     const reviewWindows = pickWindows(codeReview);
     addWindow("m_quota.review_5h", reviewWindows.fiveHour, codeReview);
     addWindow("m_quota.review_weekly", reviewWindows.weekly, codeReview);
-  } else {
-    if (rateWindows.fiveHour) {
-      items.push({ label: "m_quota.review_5h", percent: 100, resetAtMs: resolveCodexResetAtMs(rateWindows.fiveHour) });
-    }
-    if (rateWindows.weekly) {
-      items.push({ label: "m_quota.review_weekly", percent: 100, resetAtMs: resolveCodexResetAtMs(rateWindows.weekly) });
-    }
   }
+
+  additionalRateLimits.forEach((entry) => {
+    const limitInfo = entry.rate_limit ?? entry.rateLimit ?? null;
+    if (!limitInfo) return;
+    const name =
+      normalizeStringValue(entry.limit_name ?? entry.limitName) ?? "Additional Codex quota";
+    const windows = pickWindows(limitInfo);
+    addWindow(`${name}: 5h`, windows.fiveHour, limitInfo);
+    addWindow(`${name}: Weekly`, windows.weekly, limitInfo);
+  });
+
   return items;
 };


### PR DESCRIPTION
## Summary
- Parse Codex additional_rate_limits such as GPT-5.3-Codex-Spark into standard quota rows.
- Stop fabricating code review quota rows when code_review_rate_limit is null.
- Show returned Codex review 5h and additional quota bars in auth-files cards.

## Test Plan
- bun run test src/modules/quota/__tests__/quota-helpers.test.ts src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run lint
- bun run build
- bunx oxfmt src/modules/quota/quota-codex.ts src/modules/quota/__tests__/quota-helpers.test.ts src/modules/auth-files/hooks/useAuthFilesQuotaState.ts src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --check
- bun run check

Note: full bunx oxfmt . --check reports pre-existing formatting issues in 39 unrelated files; not included in this PR.