### PR TITLE
Fix auth file card quota layout

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2137,6 +2137,8 @@
     "code_weekly": "Code: Weekly",
     "review_5h": "Review: 5h",
     "review_weekly": "Review: Weekly",
+    "additional_5h": "{{name}}: 5h",
+    "additional_weekly": "{{name}}: Weekly",
     "base_quota": "Base Quota",
     "trial_quota": "Trial Quota",
     "subscription": "Subscription"

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1830,6 +1830,8 @@
     "code_weekly": "Code: Weekly",
     "review_5h": "Review: 5h",
     "review_weekly": "Review: Weekly",
+    "additional_5h": "{{name}}: 5h",
+    "additional_weekly": "{{name}}: Weekly",
     "base_quota": "Base Quota",
     "trial_quota": "Trial Quota",
     "subscription": "Subscription"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2152,6 +2152,8 @@
     "code_weekly": "代码：周",
     "review_5h": "审查：5小时",
     "review_weekly": "审查：周",
+    "additional_5h": "{{name}}: 五小时",
+    "additional_weekly": "{{name}}: 周",
     "base_quota": "基础额度",
     "trial_quota": "试用额度",
     "subscription": "订阅"

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { AuthFilesPage } from "@/modules/auth-files/AuthFilesPage";
+import i18n from "@/i18n";
 
 const mocks = vi.hoisted(() => ({
   list: vi.fn(async () => ({
@@ -25,7 +26,7 @@ const mocks = vi.hoisted(() => ({
     group: "all",
     points: [{ date: new Date().toISOString().slice(0, 10), requests: 9 }],
   })),
-  fetchQuota: vi.fn(() => new Promise(() => {})),
+  fetchQuota: vi.fn((_provider?: unknown, _file?: { name?: string }) => new Promise(() => {})),
   deleteFile: vi.fn(async () => ({})),
   downloadText: vi.fn(async () => "{}"),
   getModelsForAuthFile: vi.fn(async () => [{ id: "live-only", owned_by: "runtime" }]),
@@ -93,7 +94,8 @@ const toDateTimeLocalInput = (date: Date): string =>
   ].join("");
 
 describe("AuthFilesPage files table", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     window.localStorage.clear();
     window.sessionStorage.clear();
     mocks.list.mockReset();
@@ -844,6 +846,137 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("GPT-5.3-Codex-Spark: 5h")).toBeInTheDocument();
     expect(screen.getByText("GPT-5.3-Codex-Spark: Weekly")).toBeInTheDocument();
     expect(screen.getByText("96%")).toBeInTheDocument();
+  });
+
+  test("cards keep action buttons pinned to the bottom with mixed quota heights", async () => {
+    const now = Date.now();
+    const files = [
+      {
+        name: "codex-basic.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "7",
+      },
+      {
+        name: "codex-spark.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "8",
+      },
+    ] as any[];
+
+    mocks.list.mockImplementation(async () => ({ files }));
+    mocks.fetchQuota.mockImplementation(async (_provider, file) => ({
+      items:
+        file?.name === "codex-spark.json"
+          ? [
+              { label: "m_quota.code_5h", percent: 90, resetAtMs: now + 60_000 },
+              { label: "m_quota.code_weekly", percent: 80, resetAtMs: now + 120_000 },
+              { label: "m_quota.review_5h", percent: 70, resetAtMs: now + 180_000 },
+              { label: "GPT-5.3-Codex-Spark: Weekly", percent: 96, resetAtMs: now + 240_000 },
+            ]
+          : [
+              { label: "m_quota.code_5h", percent: 90, resetAtMs: now + 60_000 },
+              { label: "m_quota.code_weekly", percent: 80, resetAtMs: now + 120_000 },
+            ],
+    }));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      "authFilesPage.dataCache.v1",
+      JSON.stringify({
+        savedAtMs: now,
+        files,
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const cards = await screen.findByTestId("auth-files-cards");
+    expect(cards).toHaveClass("items-stretch");
+
+    const refreshButtons = within(cards).getAllByRole("button", { name: "Refresh" });
+    refreshButtons.forEach((button) => fireEvent.click(button));
+
+    expect(await screen.findByText("GPT-5.3-Codex-Spark: Weekly")).toBeInTheDocument();
+
+    const card = screen.getByText("codex-basic.json").closest("section");
+    expect(card).not.toBeNull();
+    expect(card).toHaveClass("flex", "h-full", "flex-col");
+
+    const quota = within(card as HTMLElement).getByTestId("auth-file-card-quota");
+    const actions = quota.nextElementSibling;
+    expect(actions).not.toBeNull();
+    expect(actions).toHaveClass("mt-auto");
+  });
+
+  test("cards localize codex additional quota window labels in Chinese", async () => {
+    await act(async () => {
+      await i18n.changeLanguage("zh-CN");
+    });
+
+    const now = Date.now();
+    const file = {
+      name: "codex-spark.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "8",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [
+        { label: "GPT-5.3-Codex-Spark: 5h", percent: 100, resetAtMs: now + 60_000 },
+        { label: "GPT-5.3-Codex-Spark: Weekly", percent: 96, resetAtMs: now + 120_000 },
+      ],
+    });
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      "authFilesPage.dataCache.v1",
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-spark.json")).toBeInTheDocument();
+    fireEvent.click(
+      within(screen.getByTestId("auth-files-cards")).getByRole("button", { name: "刷新" }),
+    );
+
+    expect(await screen.findByText("GPT-5.3-Codex-Spark: 五小时")).toBeInTheDocument();
+    expect(screen.getByText("GPT-5.3-Codex-Spark: 周")).toBeInTheDocument();
+    expect(screen.queryByText("GPT-5.3-Codex-Spark: 5h")).not.toBeInTheDocument();
+    expect(screen.queryByText("GPT-5.3-Codex-Spark: Weekly")).not.toBeInTheDocument();
   });
 
   test("cards view shows only kimi coding quotas and marks depleted weekly quota red", async () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -519,7 +519,7 @@ export function AuthFilesFilesTab({
             ) : (
               <div
                 data-testid="auth-files-cards"
-                className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3"
+                className="grid grid-cols-1 items-stretch gap-5 md:grid-cols-2 xl:grid-cols-3"
               >
                 {pageItems.map((file) => {
                   const runtimeOnly = isRuntimeOnlyAuthFile(file);
@@ -548,9 +548,9 @@ export function AuthFilesFilesTab({
                     <Card
                       key={file.name}
                       padding="default"
-                      bodyClassName="mt-0"
+                      bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[
-                        "group transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+                        "group flex h-full flex-col transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
                         fileSelected
                           ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                           : "",
@@ -646,7 +646,7 @@ export function AuthFilesFilesTab({
                         {!provider ? (
                           <div className="text-xs text-slate-400 dark:text-white/40">--</div>
                         ) : slots.length > 0 ? (
-                          <div className="space-y-3">
+                          <div className="space-y-2.5">
                             {slots.map((slot) => renderQuotaBar(slot.label, slot.item))}
                           </div>
                         ) : (
@@ -654,7 +654,7 @@ export function AuthFilesFilesTab({
                         )}
                       </div>
 
-                      <div className="mt-3 flex items-center justify-between gap-2">
+                      <div className="mt-auto flex items-center justify-between gap-2 pt-3">
                         <div className="inline-flex items-center gap-1">
                           {provider ? (
                             <HoverTooltip content={t("common.refresh")}>

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -482,6 +482,19 @@ export const normalizeQuotaLabel = (label: string): string =>
     .trim()
     .toLowerCase();
 
+export const parseAdditionalQuotaWindowLabel = (
+  label: string,
+): { name: string; window: "5h" | "weekly" } | null => {
+  const match = String(label ?? "").match(/^(.+?)\s*[:：]\s*(5h|weekly)$/i);
+  if (!match) return null;
+  const name = match[1]?.trim();
+  if (!name) return null;
+  return {
+    name,
+    window: match[2]?.toLowerCase() === "5h" ? "5h" : "weekly",
+  };
+};
+
 export const pickQuotaPreviewItem = (
   items: QuotaItem[],
   mode: QuotaPreviewMode,

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -19,6 +19,7 @@ import {
   formatFileSize,
   formatModified,
   isRuntimeOnlyAuthFile,
+  parseAdditionalQuotaWindowLabel,
   resolveAuthFileDisplayName,
   resolveAuthFilePlanType,
   resolveAuthFileStats,
@@ -149,6 +150,12 @@ export function useAuthFilesFilesPresentation({
       if (!text) return text;
       if (text.startsWith("m_quota.")) return t(text);
       if (KNOWN_QUOTA_TEXT_KEYS.has(text)) return t(`m_quota.${text}`);
+      const additionalQuota = parseAdditionalQuotaWindowLabel(text);
+      if (additionalQuota) {
+        return t(`m_quota.additional_${additionalQuota.window}`, {
+          name: additionalQuota.name,
+        });
+      }
       return text;
     },
     [t],
@@ -339,7 +346,7 @@ export function useAuthFilesFilesPresentation({
         <div key={label} className="space-y-1">
           <div className="flex items-center justify-between gap-2">
             <span className="min-w-0 truncate text-[11px] font-semibold text-slate-700 dark:text-white/80">
-              {label}
+              {translateQuotaText(label)}
             </span>
             <span
               className={[
@@ -363,7 +370,7 @@ export function useAuthFilesFilesPresentation({
         </div>
       );
     },
-    [formatQuotaResetTextCompact],
+    [formatQuotaResetTextCompact, translateQuotaText],
   );
 
   const fileColumns = useMemo<VirtualTableColumn<AuthFileItem>[]>(() => {

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -20,6 +20,7 @@ import {
   AUTH_FILES_QUOTA_PREVIEW_KEY,
   normalizeAuthIndexValue,
   normalizeQuotaAutoRefreshMs,
+  parseAdditionalQuotaWindowLabel,
   type FilesViewMode,
   type QuotaPreviewMode,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
@@ -92,6 +93,12 @@ export function useAuthFilesQuotaState({
       const translateQuotaLabel = (text: string) => {
         if (!text) return text;
         if (text.startsWith("m_quota.")) return t(text);
+        const additionalQuota = parseAdditionalQuotaWindowLabel(text);
+        if (additionalQuota) {
+          return t(`m_quota.additional_${additionalQuota.window}`, {
+            name: additionalQuota.name,
+          });
+        }
         return text;
       };
 
@@ -110,10 +117,12 @@ export function useAuthFilesQuotaState({
           .toLowerCase()
           .replaceAll(/[^a-z0-9\u4e00-\u9fff]/g, "");
 
-      const candidates = items.map((item) => ({
-        item,
-        key: normalize(String(item.label ?? "")),
-      }));
+      const candidates = items
+        .filter((item) => !parseAdditionalQuotaWindowLabel(String(item.label ?? "")))
+        .map((item) => ({
+          item,
+          key: normalize(String(item.label ?? "")),
+        }));
 
       const findExact = (label: string) => items.find((item) => item.label === label) ?? null;
       const find = (re: RegExp) =>


### PR DESCRIPTION
## Summary
- Pin auth file card action buttons to the card bottom for mixed quota heights
- Localize Codex Spark additional quota windows, including Chinese 5h/weekly text
- Avoid matching additional quota labels as primary Codex quota slots

## Test Plan
- bun run test
- bun run lint
- bunx oxfmt src/modules/auth-files/components/AuthFilesFilesTab.tsx src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx src/modules/auth-files/hooks/useAuthFilesQuotaState.ts src/modules/auth-files/helpers/authFilesPageUtils.ts src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/i18n/locales/en.json src/i18n/locales/zh-CN.json src/i18n/locales/ru.json --check
- bun run build