### PR TITLE
Restore cached auth file quotas

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { AuthFilesPage } from "@/modules/auth-files/AuthFilesPage";
+import { AUTH_FILES_DATA_CACHE_KEY } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import i18n from "@/i18n";
 
 const mocks = vi.hoisted(() => ({
@@ -756,7 +757,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],
@@ -793,6 +794,59 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  test("cards view restores cached quota while refreshing in the background", async () => {
+    const now = Date.now();
+    const file = {
+      name: "codex.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "1",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "codex.json": {
+            status: "success",
+            updatedAt: now - 60_000,
+            items: [
+              { label: "m_quota.code_5h", percent: 22, resetAtMs: now + 60_000 },
+              { label: "m_quota.code_weekly", percent: 44, resetAtMs: now + 120_000 },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex.json")).toBeInTheDocument();
+    expect(screen.getByText("22%")).toBeInTheDocument();
+    expect(screen.getByText("44%")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("22%")).toBeInTheDocument();
+    expect(screen.getByText("44%")).toBeInTheDocument();
+  });
+
   test("cards view includes returned codex review 5h and additional quota bars", async () => {
     const now = Date.now();
     const file = {
@@ -818,7 +872,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],
@@ -887,7 +941,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files,
@@ -949,7 +1003,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],
@@ -1001,7 +1055,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],
@@ -1104,7 +1158,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],
@@ -1158,7 +1212,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],
@@ -1209,7 +1263,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
-      "authFilesPage.dataCache.v1",
+      AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
         files: [file],

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -150,11 +150,25 @@ describe("Auth Files helper coverage", () => {
     writeAuthFilesDataCache({
       savedAtMs: 123,
       files: sanitized,
+      quotaByFileName: {
+        "codex.json": {
+          status: "success",
+          updatedAt: 456,
+          items: [{ label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
+        },
+      },
     });
     expect(window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain('"savedAtMs":123');
     expect(readAuthFilesDataCache()).toEqual({
       savedAtMs: 123,
       files: sanitized,
+      quotaByFileName: {
+        "codex.json": {
+          status: "success",
+          updatedAt: 456,
+          items: [{ label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
+        },
+      },
     });
   });
 

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -1,10 +1,11 @@
 import type {
   AuthFileItem,
   AuthFileSubscriptionPeriod,
+  EntityStatsResponse,
   OAuthModelAliasEntry,
 } from "@/lib/http/types";
 import { normalizeUsageSourceId, type KeyStatBucket } from "@/modules/providers/provider-usage";
-import type { QuotaItem } from "@/modules/quota/quota-helpers";
+import type { QuotaItem, QuotaState, QuotaStatus } from "@/modules/quota/quota-helpers";
 import { resolveCodexPlanType } from "@/utils/quota/resolvers";
 import type { StatusBarData, StatusBlockDetail, StatusBlockState } from "@/utils/usage";
 
@@ -57,6 +58,8 @@ export type AuthFilesUiState = {
 export type AuthFilesDataCache = {
   savedAtMs: number;
   files: AuthFileItem[];
+  usageData?: EntityStatsResponse | null;
+  quotaByFileName?: Record<string, QuotaState>;
 };
 
 const sanitizeDecodedIdToken = (value: unknown): unknown => {
@@ -162,6 +165,64 @@ export const sanitizeAuthFilesForCache = (files: AuthFileItem[]): AuthFileItem[]
     id_token: sanitizeDecodedIdToken(file.id_token),
   }));
 
+const QUOTA_CACHE_STATUSES = new Set<QuotaStatus>(["idle", "loading", "success", "error"]);
+
+const sanitizeQuotaItemsForCache = (items: unknown): QuotaItem[] => {
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item): QuotaItem | null => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null;
+      const record = item as Record<string, unknown>;
+      const label = typeof record.label === "string" ? record.label : "";
+      if (!label) return null;
+      const percent =
+        record.percent === null ||
+        (typeof record.percent === "number" && Number.isFinite(record.percent))
+          ? record.percent
+          : null;
+      const resetAtMs =
+        typeof record.resetAtMs === "number" && Number.isFinite(record.resetAtMs)
+          ? record.resetAtMs
+          : undefined;
+      const meta = typeof record.meta === "string" ? record.meta : undefined;
+      return { label, percent, resetAtMs, meta };
+    })
+    .filter((item): item is QuotaItem => Boolean(item));
+};
+
+const sanitizeQuotaByFileNameForCache = (
+  quotaByFileName: unknown,
+  fileNames?: Set<string>,
+): Record<string, QuotaState> | undefined => {
+  if (!quotaByFileName || typeof quotaByFileName !== "object" || Array.isArray(quotaByFileName)) {
+    return undefined;
+  }
+
+  const output: Record<string, QuotaState> = {};
+  Object.entries(quotaByFileName as Record<string, unknown>).forEach(([fileName, rawState]) => {
+    if (!fileName || (fileNames && !fileNames.has(fileName))) return;
+    if (!rawState || typeof rawState !== "object" || Array.isArray(rawState)) return;
+    const state = rawState as Record<string, unknown>;
+    const items = sanitizeQuotaItemsForCache(state.items);
+    if (items.length === 0) return;
+    const rawStatus = typeof state.status === "string" ? state.status : "success";
+    const status = QUOTA_CACHE_STATUSES.has(rawStatus as QuotaStatus) ? rawStatus : "success";
+    const updatedAt =
+      typeof state.updatedAt === "number" && Number.isFinite(state.updatedAt)
+        ? state.updatedAt
+        : undefined;
+    const error = typeof state.error === "string" ? state.error : undefined;
+    output[fileName] = {
+      status: status === "loading" ? "success" : (status as QuotaStatus),
+      items,
+      updatedAt,
+      error: status === "error" ? error : undefined,
+    };
+  });
+
+  return Object.keys(output).length > 0 ? output : undefined;
+};
+
 export const readAuthFilesDataCache = (): AuthFilesDataCache | null => {
   if (typeof window === "undefined") return null;
   try {
@@ -178,6 +239,11 @@ export const readAuthFilesDataCache = (): AuthFilesDataCache | null => {
     return {
       savedAtMs,
       files,
+      usageData:
+        parsed?.usageData && typeof parsed.usageData === "object"
+          ? (parsed.usageData as EntityStatsResponse)
+          : undefined,
+      quotaByFileName: sanitizeQuotaByFileNameForCache(parsed?.quotaByFileName),
     };
   } catch {
     return null;
@@ -187,7 +253,22 @@ export const readAuthFilesDataCache = (): AuthFilesDataCache | null => {
 export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
   if (typeof window === "undefined") return;
   try {
-    window.sessionStorage.setItem(AUTH_FILES_DATA_CACHE_KEY, JSON.stringify(cache));
+    const raw = window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
+    const previous = raw ? (JSON.parse(raw) as Partial<AuthFilesDataCache>) : null;
+    const fileNames = new Set(cache.files.map((file) => file.name).filter(Boolean));
+    const quotaByFileName = sanitizeQuotaByFileNameForCache(
+      cache.quotaByFileName ?? previous?.quotaByFileName,
+      fileNames,
+    );
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: cache.savedAtMs,
+        files: cache.files,
+        usageData: cache.usageData ?? previous?.usageData,
+        quotaByFileName,
+      }),
+    );
   } catch {
     // ignore
   }

--- a/src/modules/auth-files/hooks/useAuthFilesDataState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDataState.ts
@@ -19,9 +19,12 @@ export function useAuthFilesDataState() {
   const [loading, setLoading] = useState(() => !((initialDataCache?.files?.length ?? 0) > 0));
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [usageLoading, setUsageLoading] = useState(false);
-  const [usageData, setUsageData] = useState<EntityStatsResponse | null>(null);
+  const [usageData, setUsageData] = useState<EntityStatsResponse | null>(
+    () => initialDataCache?.usageData ?? null,
+  );
 
   const filesRef = useRef<AuthFileItem[]>(files);
+  const usageDataRef = useRef<EntityStatsResponse | null>(usageData);
   const { index: usageIndex } = useMemo(() => buildUsageIndex(usageData), [usageData]);
 
   const loadAll = useCallback(async () => {
@@ -36,7 +39,7 @@ export function useAuthFilesDataState() {
       ]);
       const list = Array.isArray(filesRes?.files) ? filesRes.files : [];
       setFiles(list);
-      setUsageData(usageRes);
+      setUsageData((prev) => usageRes ?? prev);
     } catch (err: unknown) {
       notify({
         type: "error",
@@ -58,21 +61,27 @@ export function useAuthFilesDataState() {
   }, [files]);
 
   useEffect(() => {
+    usageDataRef.current = usageData;
+  }, [usageData]);
+
+  useEffect(() => {
     if (typeof window === "undefined") return undefined;
     const timer = window.setTimeout(() => {
       writeAuthFilesDataCache({
         savedAtMs: Date.now(),
         files: sanitizeAuthFilesForCache(files),
+        usageData,
       });
     }, 250);
     return () => window.clearTimeout(timer);
-  }, [files]);
+  }, [files, usageData]);
 
   useEffect(() => {
     return () => {
       writeAuthFilesDataCache({
         savedAtMs: Date.now(),
         files: sanitizeAuthFilesForCache(filesRef.current),
+        usageData: usageDataRef.current,
       });
     };
   }, []);

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -21,6 +21,8 @@ import {
   normalizeAuthIndexValue,
   normalizeQuotaAutoRefreshMs,
   parseAdditionalQuotaWindowLabel,
+  readAuthFilesDataCache,
+  writeAuthFilesDataCache,
   type FilesViewMode,
   type QuotaPreviewMode,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
@@ -41,11 +43,14 @@ export function useAuthFilesQuotaState({
   setDetailFile,
 }: UseAuthFilesQuotaStateOptions) {
   const { t } = useTranslation();
+  const initialDataCache = useMemo(() => readAuthFilesDataCache(), []);
 
   const [connectivityState, setConnectivityState] = useState<
     Map<string, { loading: boolean; latencyMs: number | null; error: boolean }>
   >(new Map());
-  const [quotaByFileName, setQuotaByFileName] = useState<Record<string, QuotaState>>({});
+  const [quotaByFileName, setQuotaByFileName] = useState<Record<string, QuotaState>>(
+    () => initialDataCache?.quotaByFileName ?? {},
+  );
   const quotaInFlightRef = useRef<Set<string>>(new Set());
   const quotaAutoRefreshingRef = useRef<Set<string>>(new Set());
   const quotaByFileNameRef = useRef<Record<string, QuotaState>>(quotaByFileName);
@@ -78,6 +83,20 @@ export function useAuthFilesQuotaState({
 
   useEffect(() => {
     quotaByFileNameRef.current = quotaByFileName;
+  }, [quotaByFileName]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const timer = window.setTimeout(() => {
+      const current = readAuthFilesDataCache();
+      if (!current?.files?.length) return;
+      writeAuthFilesDataCache({
+        ...current,
+        savedAtMs: Date.now(),
+        quotaByFileName,
+      });
+    }, 250);
+    return () => window.clearTimeout(timer);
   }, [quotaByFileName]);
 
   const patchAuthFileByName = useCallback(
@@ -370,7 +389,7 @@ export function useAuthFilesQuotaState({
     let cancelled = false;
     void (async () => {
       if (!cancelled) {
-        await runQuotaRefreshBatch(toFetch);
+        await runQuotaRefreshBatch(toFetch, { markAsAutoRefreshing: true });
       }
     })();
 


### PR DESCRIPTION
## Summary
- Persist auth-files session cache with usage data and quota state
- Hydrate quota bars from cached state before background refresh starts
- Treat initial quota warmup as low-noise auto refresh and keep stale values visible
- Update auth-files tests to use the current cache key and cover cached quota restore

## Test Plan
- bunx oxfmt src/modules/auth-files/helpers/authFilesPageUtils.ts src/modules/auth-files/hooks/useAuthFilesDataState.ts src/modules/auth-files/hooks/useAuthFilesQuotaState.ts src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx --check
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- bun run lint
- bun run build
- bun run test