### PR TITLE
Simplify auth file detail modal

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -1,0 +1,130 @@
+import type { ComponentProps } from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthFileDetailModal } from "@/modules/auth-files/components/AuthFileDetailModal";
+import i18n from "@/i18n";
+
+type DetailModalProps = ComponentProps<typeof AuthFileDetailModal>;
+
+const basePrefixProxyEditor: DetailModalProps["prefixProxyEditor"] = {
+  open: true,
+  fileName: "codex.json",
+  loading: false,
+  saving: false,
+  error: null,
+  json: { prefix: "team-a", proxy_id: "primary", proxy_url: "http://127.0.0.1:7890" },
+  prefix: "team-a",
+  proxyUrl: "http://127.0.0.1:7890",
+  proxyId: "primary",
+  subscriptionStartedAt: "2026-04-01T08:30",
+  subscriptionPeriod: "monthly",
+};
+
+const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
+  const props: DetailModalProps = {
+    open: true,
+    detailFile: {
+      name: "codex.json",
+      type: "codex",
+      size: 256,
+      account_type: "oauth",
+    },
+    detailLoading: false,
+    detailText: '{"token":"abc","nested":{"enabled":true}}',
+    detailTab: "json",
+    setDetailOpen: vi.fn(),
+    setDetailTab: vi.fn(),
+    loadModelsForDetail: vi.fn(async () => undefined),
+    loadModelOwnerGroups: vi.fn(async () => undefined),
+    modelsLoading: false,
+    modelsError: null,
+    modelsList: [
+      { id: "gpt-5.1", display_name: "GPT 5.1", owned_by: "openai" },
+      { id: "gpt-5.1-mini", owned_by: "openai" },
+    ],
+    modelsFileType: "codex",
+    modelOwnerGroupsLoading: false,
+    mappedModelOwnerGroup: null,
+    mappedModelOwnerValue: "",
+    excluded: {},
+    prefixProxyEditor: basePrefixProxyEditor,
+    setPrefixProxyEditor: vi.fn(),
+    prefixProxyDirty: true,
+    prefixProxyUpdatedText: '{\n  "prefix": "team-a"\n}',
+    savePrefixProxy: vi.fn(async () => undefined),
+    proxyPoolEntries: [
+      {
+        id: "primary",
+        name: "Primary egress",
+        url: "http://127.0.0.1:7890",
+        enabled: true,
+      },
+    ],
+    channelEditor: {
+      open: true,
+      fileName: "codex.json",
+      label: "Codex Primary",
+      saving: false,
+      error: null,
+    },
+    setChannelEditor: vi.fn(),
+    saveChannelEditor: vi.fn(async () => undefined),
+    ...overrides,
+  };
+
+  render(<AuthFileDetailModal {...props} />);
+  return props;
+};
+
+describe("AuthFileDetailModal", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+    window.localStorage.clear();
+  });
+
+  test("formats JSON into a readable viewer without changing the source text", () => {
+    renderDetailModal();
+
+    const reader = screen.getByTestId("auth-file-json-reader");
+    expect(reader).toHaveTextContent('"token": "abc"');
+    expect(reader.textContent).toContain('\n  "nested": {');
+  });
+
+  test("renders models as a compact list without raw field labels", () => {
+    renderDetailModal({ detailTab: "models" });
+
+    const list = screen.getByTestId("auth-file-models-list");
+    expect(within(list).getByText("gpt-5.1")).toBeInTheDocument();
+    expect(within(list).getByText("GPT 5.1")).toBeInTheDocument();
+    expect(within(list).getAllByText("openai")).toHaveLength(2);
+    expect(screen.getByText("2 items")).toBeInTheDocument();
+    expect(screen.queryByText(/display_name:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/owned_by:/)).not.toBeInTheDocument();
+  });
+
+  test("keeps field editing controls and preview in a compact editor surface", () => {
+    renderDetailModal({ detailTab: "fields" });
+
+    const grid = screen.getByTestId("auth-file-fields-grid");
+    expect(within(grid).getByPlaceholderText("e.g. team-a")).toHaveValue("team-a");
+    expect(within(grid).getByLabelText("proxy_id (proxy pool)")).toBeInTheDocument();
+    expect(within(grid).getByPlaceholderText("e.g. http://127.0.0.1:7890")).toHaveValue(
+      "http://127.0.0.1:7890",
+    );
+    expect(within(grid).getByLabelText(/Subscription start/)).toBeInTheDocument();
+
+    const preview = screen.getByTestId("auth-file-fields-preview");
+    expect(preview).toHaveTextContent('"prefix": "team-a"');
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  test("keeps the OAuth channel rename action available", () => {
+    const props = renderDetailModal({ detailTab: "channel" });
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Gemini Primary"), {
+      target: { value: "Codex Team A" },
+    });
+    expect(props.setChannelEditor).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+});

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
+import { useMemo, type Dispatch, type SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import { Download, RefreshCw, ShieldCheck } from "lucide-react";
 import type { AuthFileItem, AuthFileSubscriptionPeriod } from "@/lib/http/types";
@@ -55,6 +55,17 @@ interface AuthFileDetailModalProps {
   saveChannelEditor: () => Promise<void>;
 }
 
+const formatDetailJson = (text: string): string => {
+  const trimmed = text.trim();
+  if (!trimmed) return "--";
+
+  try {
+    return JSON.stringify(JSON.parse(trimmed) as unknown, null, 2);
+  } catch {
+    return text;
+  }
+};
+
 export function AuthFileDetailModal({
   open,
   detailFile,
@@ -91,6 +102,9 @@ export function AuthFileDetailModal({
     : modelsList;
   const visibleModelsLoading = usesMappedModelOwner ? modelOwnerGroupsLoading : modelsLoading;
   const visibleModelsError = usesMappedModelOwner ? null : modelsError;
+  const formattedDetailText = useMemo(() => formatDetailJson(detailText), [detailText]);
+  const providerKey = normalizeProviderKey(modelsFileType);
+  const excludedModels = excluded[providerKey] ?? [];
 
   return (
     <Modal
@@ -182,8 +196,8 @@ export function AuthFileDetailModal({
       {!detailFile ? (
         <EmptyState title={t("auth_files.view_auth_file")} description="--" />
       ) : (
-        <Tabs value={detailTab} onValueChange={(next) => setDetailTab(next as DetailTab)}>
-          <div className="space-y-4">
+        <Tabs value={detailTab} onValueChange={(next) => setDetailTab(next as DetailTab)} size="sm">
+          <div className="space-y-3">
             <TabsList>
               <TabsTrigger value="json">{t("auth_files.detail_tab_json")}</TabsTrigger>
               <TabsTrigger value="models">{t("auth_files.detail_tab_models")}</TabsTrigger>
@@ -195,14 +209,21 @@ export function AuthFileDetailModal({
               ) : null}
             </TabsList>
 
-            <TabsContent value="json" className="space-y-4">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                  {t("auth_files.detail_tab_json")}
-                </p>
-                <p className="mt-1 text-xs text-slate-600 dark:text-white/60">
-                  {t("auth_files.detail_tab_json_desc")}
-                </p>
+            <TabsContent value="json" className="space-y-3">
+              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-3 dark:border-neutral-800">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                    {t("auth_files.detail_tab_json")}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
+                    {t("auth_files.detail_tab_json_desc")}
+                  </p>
+                </div>
+                {typeof detailFile.size === "number" ? (
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                    {formatFileSize(detailFile.size)}
+                  </span>
+                ) : null}
               </div>
 
               {detailLoading ? (
@@ -210,24 +231,34 @@ export function AuthFileDetailModal({
                   {t("common.loading_ellipsis")}
                 </div>
               ) : (
-                <pre className="whitespace-pre-wrap break-words rounded-2xl border border-slate-200 bg-white p-4 font-mono text-xs text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100">
-                  {detailText || "--"}
+                <pre
+                  data-testid="auth-file-json-reader"
+                  className="max-h-[calc(70vh-9rem)] overflow-auto rounded-xl border border-slate-200 bg-white p-4 font-mono text-[12px] leading-5 whitespace-pre text-slate-900 shadow-inner shadow-slate-100/70 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100 dark:shadow-black/20"
+                >
+                  {formattedDetailText}
                 </pre>
               )}
             </TabsContent>
 
-            <TabsContent value="models" className="space-y-4">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                  {t("auth_files.detail_tab_models")}
-                </p>
-                <p className="mt-1 text-xs text-slate-600 dark:text-white/60">
-                  {t("auth_files.detail_tab_models_desc")}
-                </p>
+            <TabsContent value="models" className="space-y-3">
+              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-3 dark:border-neutral-800">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                    {t("auth_files.detail_tab_models")}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
+                    {t("auth_files.detail_tab_models_desc")}
+                  </p>
+                </div>
+                {!visibleModelsLoading && visibleModelsError !== "unsupported" ? (
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                    {t("auth_files.count_items", { count: visibleModelsList.length })}
+                  </span>
+                ) : null}
               </div>
 
               {usesMappedModelOwner ? (
-                <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 text-xs text-slate-600 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/60">
+                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50/70 px-3 py-2 text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-950/50 dark:text-white/60">
                   {mappedModelOwnerGroup
                     ? t("auth_files.model_owner_group_source_desc", {
                         owner: mappedModelOwnerGroup.label,
@@ -256,46 +287,48 @@ export function AuthFileDetailModal({
                   }
                 />
               ) : (
-                <div className="space-y-2">
+                <div className="grid gap-2" data-testid="auth-file-models-list">
                   {visibleModelsList.map((model) => (
                     <div
                       key={model.id}
-                      className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60"
+                      className="grid gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm shadow-slate-100/70 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/20"
                     >
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <p className="font-mono text-xs text-slate-900 dark:text-white">
+                      <div className="min-w-0">
+                        <p className="truncate font-mono text-xs font-semibold text-slate-900 dark:text-white">
                           {model.id}
                         </p>
-                        {(() => {
-                          const providerKey = normalizeProviderKey(modelsFileType);
-                          const excludedModels = excluded[providerKey] ?? [];
-                          const hit = excludedModels.some((pattern) =>
-                            matchesModelPattern(model.id, pattern),
-                          );
-                          if (!hit) return null;
-                          return (
-                            <span className="inline-flex rounded-lg bg-rose-600/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
-                              {t("auth_files.oauth_excluded")}
-                            </span>
-                          );
-                        })()}
+                        {model.display_name ? (
+                          <p className="mt-1 truncate text-xs text-slate-500 dark:text-white/55">
+                            {model.display_name}
+                          </p>
+                        ) : null}
                       </div>
-                      <p className="mt-1 text-xs text-slate-600 dark:text-white/65">
-                        {model.display_name ? `display_name: ${model.display_name}` : ""}
-                        {model.owned_by ? ` · owned_by: ${model.owned_by}` : ""}
-                      </p>
+                      <div className="flex flex-wrap items-center gap-1.5 sm:justify-end">
+                        {model.owned_by ? (
+                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                            {model.owned_by}
+                          </span>
+                        ) : null}
+                        {excludedModels.some((pattern) =>
+                          matchesModelPattern(model.id, pattern),
+                        ) ? (
+                          <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                            {t("auth_files.oauth_excluded")}
+                          </span>
+                        ) : null}
+                      </div>
                     </div>
                   ))}
                 </div>
               )}
             </TabsContent>
 
-            <TabsContent value="fields" className="space-y-4">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <TabsContent value="fields" className="space-y-3">
+              <div className="border-b border-slate-200 pb-3 dark:border-neutral-800">
                 <p className="text-sm font-semibold text-slate-900 dark:text-white">
                   {t("auth_files.detail_tab_fields")}
                 </p>
-                <p className="mt-1 text-xs text-slate-600 dark:text-white/60">
+                <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
                   {t("auth_files.prefix_proxy_desc")}
                 </p>
               </div>
@@ -305,12 +338,15 @@ export function AuthFileDetailModal({
                   {t("common.loading_ellipsis")}
                 </div>
               ) : prefixProxyEditor.json ? (
-                <div className="space-y-4">
-                  <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                      {t("auth_files.prefix_label")}
-                    </p>
-                    <div className="mt-2">
+                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)]">
+                  <div
+                    className="divide-y divide-slate-200 rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-100/70 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/20"
+                    data-testid="auth-file-fields-grid"
+                  >
+                    <div className="grid gap-2 px-4 py-3">
+                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                        {t("auth_files.prefix_label")}
+                      </p>
                       <TextInput
                         value={prefixProxyEditor.prefix}
                         onChange={(e) => {
@@ -319,32 +355,30 @@ export function AuthFileDetailModal({
                         }}
                         placeholder={t("auth_files.prefix_placeholder")}
                       />
+                      <p className="text-xs text-slate-500 dark:text-white/55">
+                        {t("auth_files.leave_empty_prefix")}
+                      </p>
                     </div>
-                    <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-                      {t("auth_files.leave_empty_prefix")}
-                    </p>
-                  </div>
 
-                  <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                    <ProxyPoolSelect
-                      value={prefixProxyEditor.proxyId}
-                      entries={proxyPoolEntries}
-                      onChange={(value) =>
-                        setPrefixProxyEditor((prev) => ({ ...prev, proxyId: value }))
-                      }
-                      label={t("auth_files.proxy_id_label")}
-                      hint={t("auth_files.leave_empty_proxy_id")}
-                      ariaLabel={t("auth_files.proxy_id_label")}
-                      checkState={proxyCheckState}
-                      showDetails
-                    />
-                  </div>
+                    <div className="px-4 py-3">
+                      <ProxyPoolSelect
+                        value={prefixProxyEditor.proxyId}
+                        entries={proxyPoolEntries}
+                        onChange={(value) =>
+                          setPrefixProxyEditor((prev) => ({ ...prev, proxyId: value }))
+                        }
+                        label={t("auth_files.proxy_id_label")}
+                        hint={t("auth_files.leave_empty_proxy_id")}
+                        ariaLabel={t("auth_files.proxy_id_label")}
+                        checkState={proxyCheckState}
+                        showDetails
+                      />
+                    </div>
 
-                  <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                      {t("auth_files.proxy_url_label")}
-                    </p>
-                    <div className="mt-2">
+                    <div className="grid gap-2 px-4 py-3">
+                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                        {t("auth_files.proxy_url_label")}
+                      </p>
                       <TextInput
                         value={prefixProxyEditor.proxyUrl}
                         onChange={(e) => {
@@ -353,69 +387,77 @@ export function AuthFileDetailModal({
                         }}
                         placeholder={t("auth_files.proxy_url_placeholder")}
                       />
+                      <p className="text-xs text-slate-500 dark:text-white/55">
+                        {t("auth_files.leave_empty_proxy")}
+                      </p>
                     </div>
-                    <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-                      {t("auth_files.leave_empty_proxy")}
-                    </p>
+
+                    <div className="grid gap-2 px-4 py-3">
+                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                        {t("auth_files.subscription_started_at_label")}
+                      </p>
+                      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
+                        <DateTimePicker
+                          value={prefixProxyEditor.subscriptionStartedAt}
+                          onChange={(value) => {
+                            setPrefixProxyEditor((prev) => ({
+                              ...prev,
+                              subscriptionStartedAt: value,
+                            }));
+                          }}
+                          aria-label={t("auth_files.subscription_started_at_label")}
+                          locale={i18n.language}
+                          labels={{
+                            picker: t("auth_files.subscription_date_picker"),
+                            open: t("auth_files.subscription_date_picker_open"),
+                            previousMonth: t("auth_files.subscription_date_picker_previous_month"),
+                            nextMonth: t("auth_files.subscription_date_picker_next_month"),
+                            today: t("auth_files.subscription_date_picker_today"),
+                            clear: t("auth_files.subscription_date_picker_clear"),
+                            hour: t("auth_files.subscription_date_picker_hour"),
+                            minute: t("auth_files.subscription_date_picker_minute"),
+                          }}
+                        />
+                        <Select
+                          value={prefixProxyEditor.subscriptionPeriod}
+                          onChange={(value) =>
+                            setPrefixProxyEditor((prev) => ({
+                              ...prev,
+                              subscriptionPeriod: value as AuthFileSubscriptionPeriod,
+                            }))
+                          }
+                          options={[
+                            {
+                              value: "monthly",
+                              label: t("auth_files.subscription_period_monthly"),
+                            },
+                            {
+                              value: "yearly",
+                              label: t("auth_files.subscription_period_yearly"),
+                            },
+                          ]}
+                          aria-label={t("auth_files.subscription_period_label")}
+                        />
+                      </div>
+                      <p className="text-xs text-slate-500 dark:text-white/55">
+                        {t("auth_files.subscription_started_at_hint")}
+                      </p>
+                    </div>
                   </div>
 
-                  <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                      {t("auth_files.subscription_started_at_label")}
-                    </p>
-                    <div className="mt-2 grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
-                      <DateTimePicker
-                        value={prefixProxyEditor.subscriptionStartedAt}
-                        onChange={(value) => {
-                          setPrefixProxyEditor((prev) => ({
-                            ...prev,
-                            subscriptionStartedAt: value,
-                          }));
-                        }}
-                        aria-label={t("auth_files.subscription_started_at_label")}
-                        locale={i18n.language}
-                        labels={{
-                          picker: t("auth_files.subscription_date_picker"),
-                          open: t("auth_files.subscription_date_picker_open"),
-                          previousMonth: t("auth_files.subscription_date_picker_previous_month"),
-                          nextMonth: t("auth_files.subscription_date_picker_next_month"),
-                          today: t("auth_files.subscription_date_picker_today"),
-                          clear: t("auth_files.subscription_date_picker_clear"),
-                          hour: t("auth_files.subscription_date_picker_hour"),
-                          minute: t("auth_files.subscription_date_picker_minute"),
-                        }}
-                      />
-                      <Select
-                        value={prefixProxyEditor.subscriptionPeriod}
-                        onChange={(value) =>
-                          setPrefixProxyEditor((prev) => ({
-                            ...prev,
-                            subscriptionPeriod: value as AuthFileSubscriptionPeriod,
-                          }))
-                        }
-                        options={[
-                          {
-                            value: "monthly",
-                            label: t("auth_files.subscription_period_monthly"),
-                          },
-                          {
-                            value: "yearly",
-                            label: t("auth_files.subscription_period_yearly"),
-                          },
-                        ]}
-                        aria-label={t("auth_files.subscription_period_label")}
-                      />
+                  <div className="rounded-xl border border-slate-200 bg-slate-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-950/60">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {t("auth_files.preview_after_save")}
+                      </p>
+                      <span className="text-xs text-slate-500 dark:text-white/55">
+                        {formatFileSize(MAX_AUTH_FILE_SIZE)}
+                      </span>
                     </div>
-                    <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-                      {t("auth_files.subscription_started_at_hint")}
-                    </p>
-                  </div>
-
-                  <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                      {t("auth_files.preview_after_save")}
-                    </p>
-                    <pre className="mt-3 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-2xl border border-slate-200 bg-white p-3 font-mono text-xs text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100">
+                    <pre
+                      data-testid="auth-file-fields-preview"
+                      className="mt-3 max-h-[24rem] overflow-auto rounded-lg border border-slate-200 bg-white p-3 font-mono text-[12px] leading-5 whitespace-pre text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100"
+                    >
                       {prefixProxyUpdatedText}
                     </pre>
                     <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
@@ -431,17 +473,17 @@ export function AuthFileDetailModal({
               )}
             </TabsContent>
 
-            <TabsContent value="channel" className="space-y-4">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <TabsContent value="channel" className="space-y-3">
+              <div className="border-b border-slate-200 pb-3 dark:border-neutral-800">
                 <p className="text-sm font-semibold text-slate-900 dark:text-white">
                   {t("auth_files.detail_tab_channel")}
                 </p>
-                <p className="mt-1 text-xs text-slate-600 dark:text-white/60">
+                <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
                   {t("auth_files.edit_channel_name_desc")}
                 </p>
               </div>
 
-              <div className="space-y-3">
+              <div className="max-w-2xl space-y-3">
                 <div>
                   <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
                     {t("auth_files.channel_name_label")}


### PR DESCRIPTION
## Summary
- Simplifies the auth file detail modal layout for JSON, models, fields, and OAuth channel tabs.
- Formats JSON for reading while keeping the raw download/source text unchanged.
- Adds focused regression coverage for modal readability and retained actions.

## Test Plan
- bun run test
- bun run lint
- bun run build
- bunx oxfmt src/modules/auth-files/components/AuthFileDetailModal.tsx src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx --check
- Playwright local visual check for desktop/mobile auth file detail modal

## Notes
- bunx oxfmt . --check currently reports 39 pre-existing unrelated formatting issues.
- bun run check currently fails on dev as well because AuthFilesPage already exceeds the bundle delta budget.