### PR TITLE
Streamline auth file detail modal

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -110,7 +110,6 @@ export function AuthFilesPage() {
     loadModelsForDetail,
     openDetail,
     prefixProxyDirty,
-    prefixProxyUpdatedText,
     savePrefixProxy,
     saveChannelEditor,
   } = useAuthFilesDetailEditors(loadAll, setFiles);
@@ -431,7 +430,6 @@ export function AuthFilesPage() {
         prefixProxyEditor={prefixProxyEditor}
         setPrefixProxyEditor={setPrefixProxyEditor}
         prefixProxyDirty={prefixProxyDirty}
-        prefixProxyUpdatedText={prefixProxyUpdatedText}
         savePrefixProxy={savePrefixProxy}
         proxyPoolEntries={proxyPoolEntries}
         channelEditor={channelEditor}

--- a/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -25,13 +25,14 @@ const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
     open: true,
     detailFile: {
       name: "codex.json",
+      label: "Codex Primary",
       type: "codex",
       size: 256,
       account_type: "oauth",
     },
     detailLoading: false,
     detailText: '{"token":"abc","nested":{"enabled":true}}',
-    detailTab: "json",
+    detailTab: "fields",
     setDetailOpen: vi.fn(),
     setDetailTab: vi.fn(),
     loadModelsForDetail: vi.fn(async () => undefined),
@@ -50,7 +51,6 @@ const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
     prefixProxyEditor: basePrefixProxyEditor,
     setPrefixProxyEditor: vi.fn(),
     prefixProxyDirty: true,
-    prefixProxyUpdatedText: '{\n  "prefix": "team-a"\n}',
     savePrefixProxy: vi.fn(async () => undefined),
     proxyPoolEntries: [
       {
@@ -68,7 +68,7 @@ const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
       error: null,
     },
     setChannelEditor: vi.fn(),
-    saveChannelEditor: vi.fn(async () => undefined),
+    saveChannelEditor: vi.fn(async () => true),
     ...overrides,
   };
 
@@ -82,12 +82,18 @@ describe("AuthFileDetailModal", () => {
     window.localStorage.clear();
   });
 
-  test("formats JSON into a readable viewer without changing the source text", () => {
+  test("uses fields as the primary view without content or channel tabs", () => {
     renderDetailModal();
 
-    const reader = screen.getByTestId("auth-file-json-reader");
-    expect(reader).toHaveTextContent('"token": "abc"');
-    expect(reader.textContent).toContain('\n  "nested": {');
+    expect(screen.queryByTestId("auth-file-json-reader")).not.toBeInTheDocument();
+    expect(screen.queryByText(/"token"/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Content" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Info" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Channel" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Fields" })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g. Gemini Primary")).toHaveValue("Codex Primary");
+    expect(screen.getByRole("dialog", { name: "View: codex.json" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
   });
 
   test("renders models as a compact list without raw field labels", () => {
@@ -102,7 +108,7 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByText(/owned_by:/)).not.toBeInTheDocument();
   });
 
-  test("keeps field editing controls and preview in a compact editor surface", () => {
+  test("keeps field editing controls without showing JSON in the modal", () => {
     renderDetailModal({ detailTab: "fields" });
 
     const grid = screen.getByTestId("auth-file-fields-grid");
@@ -112,19 +118,31 @@ describe("AuthFileDetailModal", () => {
       "http://127.0.0.1:7890",
     );
     expect(within(grid).getByLabelText(/Subscription start/)).toBeInTheDocument();
-
-    const preview = screen.getByTestId("auth-file-fields-preview");
-    expect(preview).toHaveTextContent('"prefix": "team-a"');
+    expect(screen.queryByTestId("auth-file-fields-preview")).not.toBeInTheDocument();
+    expect(screen.queryByText(/"prefix"/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
   });
 
-  test("keeps the OAuth channel rename action available", () => {
-    const props = renderDetailModal({ detailTab: "channel" });
+  test("keeps the OAuth channel rename action available in fields", () => {
+    const saveChannelEditor = vi.fn(async () => true);
+    const props = renderDetailModal({
+      detailTab: "fields",
+      channelEditor: {
+        open: true,
+        fileName: "codex.json",
+        label: "Codex Team A",
+        saving: false,
+        error: null,
+      },
+      saveChannelEditor,
+    });
 
     fireEvent.change(screen.getByPlaceholderText("e.g. Gemini Primary"), {
-      target: { value: "Codex Team A" },
+      target: { value: "Codex Team B" },
     });
     expect(props.setChannelEditor).toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(saveChannelEditor).toHaveBeenCalled();
   });
 });

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type Dispatch, type SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import { Download, RefreshCw, ShieldCheck } from "lucide-react";
 import type { AuthFileItem, AuthFileSubscriptionPeriod } from "@/lib/http/types";
@@ -14,17 +14,17 @@ import { ProxyPoolSelect } from "@/modules/proxies/ProxyPoolSelect";
 import { useProxyPoolChecks } from "@/modules/proxies/useProxyPoolChecks";
 import {
   downloadTextAsFile,
-  formatFileSize,
-  MAX_AUTH_FILE_SIZE,
+  isOauthAuthFile,
   matchesModelPattern,
   normalizeProviderKey,
+  readAuthFileChannelName,
   type AuthFileModelItem,
   type AuthFileModelOwnerGroup,
   type ChannelEditorState,
   type PrefixProxyEditorState,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 
-type DetailTab = "json" | "models" | "fields" | "channel";
+type DetailTab = "fields" | "models";
 
 interface AuthFileDetailModalProps {
   open: boolean;
@@ -47,24 +47,12 @@ interface AuthFileDetailModalProps {
   prefixProxyEditor: PrefixProxyEditorState;
   setPrefixProxyEditor: Dispatch<SetStateAction<PrefixProxyEditorState>>;
   prefixProxyDirty: boolean;
-  prefixProxyUpdatedText: string;
   savePrefixProxy: () => Promise<void>;
   proxyPoolEntries: ProxyPoolEntry[];
   channelEditor: ChannelEditorState;
   setChannelEditor: Dispatch<SetStateAction<ChannelEditorState>>;
-  saveChannelEditor: () => Promise<void>;
+  saveChannelEditor: () => Promise<boolean>;
 }
-
-const formatDetailJson = (text: string): string => {
-  const trimmed = text.trim();
-  if (!trimmed) return "--";
-
-  try {
-    return JSON.stringify(JSON.parse(trimmed) as unknown, null, 2);
-  } catch {
-    return text;
-  }
-};
 
 export function AuthFileDetailModal({
   open,
@@ -87,7 +75,6 @@ export function AuthFileDetailModal({
   prefixProxyEditor,
   setPrefixProxyEditor,
   prefixProxyDirty,
-  prefixProxyUpdatedText,
   savePrefixProxy,
   proxyPoolEntries,
   channelEditor,
@@ -102,9 +89,37 @@ export function AuthFileDetailModal({
     : modelsList;
   const visibleModelsLoading = usesMappedModelOwner ? modelOwnerGroupsLoading : modelsLoading;
   const visibleModelsError = usesMappedModelOwner ? null : modelsError;
-  const formattedDetailText = useMemo(() => formatDetailJson(detailText), [detailText]);
   const providerKey = normalizeProviderKey(modelsFileType);
   const excludedModels = excluded[providerKey] ?? [];
+  const isOauthDetailFile = detailFile ? isOauthAuthFile(detailFile) : false;
+  const channelBaseline = detailFile ? readAuthFileChannelName(detailFile) : "";
+  const channelEditorMatchesFile = Boolean(
+    detailFile && channelEditor.fileName === detailFile.name,
+  );
+  const channelLabelValue =
+    isOauthDetailFile && channelEditorMatchesFile ? channelEditor.label : channelBaseline;
+  const channelDirty =
+    isOauthDetailFile && channelEditorMatchesFile && channelEditor.label.trim() !== channelBaseline;
+  const saveFieldsDisabled =
+    prefixProxyEditor.loading ||
+    prefixProxyEditor.saving ||
+    channelEditor.saving ||
+    !((prefixProxyDirty && prefixProxyEditor.json) || channelDirty);
+
+  const closeModal = () => {
+    setDetailOpen(false);
+    setDetailTab("fields");
+  };
+
+  const saveFields = async () => {
+    if (channelDirty) {
+      const saved = await saveChannelEditor();
+      if (!saved) return;
+    }
+    if (prefixProxyDirty) {
+      await savePrefixProxy();
+    }
+  };
 
   return (
     <Modal
@@ -114,12 +129,9 @@ export function AuthFileDetailModal({
           ? t("auth_files.view_file_title", { name: detailFile.name })
           : t("auth_files.view_auth_file")
       }
-      maxWidth="max-w-5xl"
-      bodyHeightClassName="h-[70vh]"
-      onClose={() => {
-        setDetailOpen(false);
-        setDetailTab("json");
-      }}
+      maxWidth="max-w-4xl"
+      bodyHeightClassName="max-h-[70vh]"
+      onClose={closeModal}
       footer={
         <div className="flex flex-wrap items-center justify-end gap-2">
           {detailTab === "models" && detailFile ? (
@@ -139,15 +151,11 @@ export function AuthFileDetailModal({
             </Button>
           ) : null}
 
-          {detailTab === "json" ? (
+          {detailFile ? (
             <Button
               variant="secondary"
-              onClick={() => {
-                if (detailFile) {
-                  downloadTextAsFile(detailText, detailFile.name);
-                }
-              }}
-              disabled={!detailFile || detailLoading}
+              onClick={() => downloadTextAsFile(detailText, detailFile.name)}
+              disabled={detailLoading}
             >
               <Download size={14} />
               {t("auth_files.download")}
@@ -157,37 +165,15 @@ export function AuthFileDetailModal({
           {detailTab === "fields" ? (
             <Button
               variant="primary"
-              onClick={() => void savePrefixProxy()}
-              disabled={
-                prefixProxyEditor.loading ||
-                prefixProxyEditor.saving ||
-                !prefixProxyEditor.json ||
-                !prefixProxyDirty
-              }
+              onClick={() => void saveFields()}
+              disabled={saveFieldsDisabled}
             >
               <ShieldCheck size={14} />
               {t("auth_files.save")}
             </Button>
           ) : null}
 
-          {detailTab === "channel" ? (
-            <Button
-              variant="primary"
-              onClick={() => void saveChannelEditor()}
-              disabled={channelEditor.saving}
-            >
-              <ShieldCheck size={14} />
-              {t("auth_files.save")}
-            </Button>
-          ) : null}
-
-          <Button
-            variant="secondary"
-            onClick={() => {
-              setDetailOpen(false);
-              setDetailTab("json");
-            }}
-          >
+          <Button variant="secondary" onClick={closeModal}>
             {t("auth_files.close")}
           </Button>
         </div>
@@ -199,44 +185,164 @@ export function AuthFileDetailModal({
         <Tabs value={detailTab} onValueChange={(next) => setDetailTab(next as DetailTab)} size="sm">
           <div className="space-y-3">
             <TabsList>
-              <TabsTrigger value="json">{t("auth_files.detail_tab_json")}</TabsTrigger>
-              <TabsTrigger value="models">{t("auth_files.detail_tab_models")}</TabsTrigger>
               <TabsTrigger value="fields">{t("auth_files.detail_tab_fields")}</TabsTrigger>
-              {String(detailFile.account_type || "")
-                .trim()
-                .toLowerCase() === "oauth" ? (
-                <TabsTrigger value="channel">{t("auth_files.detail_tab_channel")}</TabsTrigger>
-              ) : null}
+              <TabsTrigger value="models">{t("auth_files.detail_tab_models")}</TabsTrigger>
             </TabsList>
 
-            <TabsContent value="json" className="space-y-3">
-              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-3 dark:border-neutral-800">
-                <div className="min-w-0">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {t("auth_files.detail_tab_json")}
-                  </p>
-                  <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-                    {t("auth_files.detail_tab_json_desc")}
-                  </p>
-                </div>
-                {typeof detailFile.size === "number" ? (
-                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
-                    {formatFileSize(detailFile.size)}
-                  </span>
-                ) : null}
-              </div>
-
-              {detailLoading ? (
+            <TabsContent value="fields" className="space-y-3">
+              {prefixProxyEditor.loading ? (
                 <div className="text-sm text-slate-600 dark:text-white/65">
                   {t("common.loading_ellipsis")}
                 </div>
               ) : (
-                <pre
-                  data-testid="auth-file-json-reader"
-                  className="max-h-[calc(70vh-9rem)] overflow-auto rounded-xl border border-slate-200 bg-white p-4 font-mono text-[12px] leading-5 whitespace-pre text-slate-900 shadow-inner shadow-slate-100/70 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100 dark:shadow-black/20"
+                <div
+                  className="max-w-3xl divide-y divide-slate-200 rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-100/70 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/20"
+                  data-testid="auth-file-fields-grid"
                 >
-                  {formattedDetailText}
-                </pre>
+                  {isOauthDetailFile ? (
+                    <div className="grid gap-2 px-4 py-3">
+                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                        {t("auth_files.channel_name_label")}
+                      </p>
+                      <TextInput
+                        value={channelLabelValue}
+                        onChange={(e) => {
+                          const value = e.currentTarget.value;
+                          setChannelEditor((prev) => ({
+                            ...prev,
+                            fileName: detailFile.name,
+                            label: value,
+                            error: null,
+                          }));
+                        }}
+                        placeholder={t("auth_files.channel_name_placeholder")}
+                      />
+                      {channelEditor.error ? (
+                        <p className="text-sm text-rose-600 dark:text-rose-300">
+                          {channelEditor.error}
+                        </p>
+                      ) : (
+                        <p className="text-xs text-slate-500 dark:text-white/55">
+                          {t("auth_files.channel_name_hint")}
+                        </p>
+                      )}
+                    </div>
+                  ) : null}
+
+                  {prefixProxyEditor.json ? (
+                    <>
+                      <div className="grid gap-2 px-4 py-3">
+                        <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                          {t("auth_files.prefix_label")}
+                        </p>
+                        <TextInput
+                          value={prefixProxyEditor.prefix}
+                          onChange={(e) => {
+                            const value = e.currentTarget.value;
+                            setPrefixProxyEditor((prev) => ({ ...prev, prefix: value }));
+                          }}
+                          placeholder={t("auth_files.prefix_placeholder")}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-white/55">
+                          {t("auth_files.leave_empty_prefix")}
+                        </p>
+                      </div>
+
+                      <div className="px-4 py-3">
+                        <ProxyPoolSelect
+                          value={prefixProxyEditor.proxyId}
+                          entries={proxyPoolEntries}
+                          onChange={(value) =>
+                            setPrefixProxyEditor((prev) => ({ ...prev, proxyId: value }))
+                          }
+                          label={t("auth_files.proxy_id_label")}
+                          hint={t("auth_files.leave_empty_proxy_id")}
+                          ariaLabel={t("auth_files.proxy_id_label")}
+                          checkState={proxyCheckState}
+                          showDetails
+                        />
+                      </div>
+
+                      <div className="grid gap-2 px-4 py-3">
+                        <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                          {t("auth_files.proxy_url_label")}
+                        </p>
+                        <TextInput
+                          value={prefixProxyEditor.proxyUrl}
+                          onChange={(e) => {
+                            const value = e.currentTarget.value;
+                            setPrefixProxyEditor((prev) => ({ ...prev, proxyUrl: value }));
+                          }}
+                          placeholder={t("auth_files.proxy_url_placeholder")}
+                        />
+                        <p className="text-xs text-slate-500 dark:text-white/55">
+                          {t("auth_files.leave_empty_proxy")}
+                        </p>
+                      </div>
+
+                      <div className="grid gap-2 px-4 py-3">
+                        <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                          {t("auth_files.subscription_started_at_label")}
+                        </p>
+                        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
+                          <DateTimePicker
+                            value={prefixProxyEditor.subscriptionStartedAt}
+                            onChange={(value) => {
+                              setPrefixProxyEditor((prev) => ({
+                                ...prev,
+                                subscriptionStartedAt: value,
+                              }));
+                            }}
+                            aria-label={t("auth_files.subscription_started_at_label")}
+                            locale={i18n.language}
+                            labels={{
+                              picker: t("auth_files.subscription_date_picker"),
+                              open: t("auth_files.subscription_date_picker_open"),
+                              previousMonth: t(
+                                "auth_files.subscription_date_picker_previous_month",
+                              ),
+                              nextMonth: t("auth_files.subscription_date_picker_next_month"),
+                              today: t("auth_files.subscription_date_picker_today"),
+                              clear: t("auth_files.subscription_date_picker_clear"),
+                              hour: t("auth_files.subscription_date_picker_hour"),
+                              minute: t("auth_files.subscription_date_picker_minute"),
+                            }}
+                          />
+                          <Select
+                            value={prefixProxyEditor.subscriptionPeriod}
+                            onChange={(value) =>
+                              setPrefixProxyEditor((prev) => ({
+                                ...prev,
+                                subscriptionPeriod: value as AuthFileSubscriptionPeriod,
+                              }))
+                            }
+                            options={[
+                              {
+                                value: "monthly",
+                                label: t("auth_files.subscription_period_monthly"),
+                              },
+                              {
+                                value: "yearly",
+                                label: t("auth_files.subscription_period_yearly"),
+                              },
+                            ]}
+                            aria-label={t("auth_files.subscription_period_label")}
+                          />
+                        </div>
+                        <p className="text-xs text-slate-500 dark:text-white/55">
+                          {t("auth_files.subscription_started_at_hint")}
+                        </p>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="px-4 py-4">
+                      <EmptyState
+                        title={t("auth_files_page.cannot_edit")}
+                        description={prefixProxyEditor.error || t("auth_files.unknown_error")}
+                      />
+                    </div>
+                  )}
+                </div>
               )}
             </TabsContent>
 
@@ -321,190 +427,6 @@ export function AuthFileDetailModal({
                   ))}
                 </div>
               )}
-            </TabsContent>
-
-            <TabsContent value="fields" className="space-y-3">
-              <div className="border-b border-slate-200 pb-3 dark:border-neutral-800">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                  {t("auth_files.detail_tab_fields")}
-                </p>
-                <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-                  {t("auth_files.prefix_proxy_desc")}
-                </p>
-              </div>
-
-              {prefixProxyEditor.loading ? (
-                <div className="text-sm text-slate-600 dark:text-white/65">
-                  {t("common.loading_ellipsis")}
-                </div>
-              ) : prefixProxyEditor.json ? (
-                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)]">
-                  <div
-                    className="divide-y divide-slate-200 rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-100/70 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/20"
-                    data-testid="auth-file-fields-grid"
-                  >
-                    <div className="grid gap-2 px-4 py-3">
-                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                        {t("auth_files.prefix_label")}
-                      </p>
-                      <TextInput
-                        value={prefixProxyEditor.prefix}
-                        onChange={(e) => {
-                          const value = e.currentTarget.value;
-                          setPrefixProxyEditor((prev) => ({ ...prev, prefix: value }));
-                        }}
-                        placeholder={t("auth_files.prefix_placeholder")}
-                      />
-                      <p className="text-xs text-slate-500 dark:text-white/55">
-                        {t("auth_files.leave_empty_prefix")}
-                      </p>
-                    </div>
-
-                    <div className="px-4 py-3">
-                      <ProxyPoolSelect
-                        value={prefixProxyEditor.proxyId}
-                        entries={proxyPoolEntries}
-                        onChange={(value) =>
-                          setPrefixProxyEditor((prev) => ({ ...prev, proxyId: value }))
-                        }
-                        label={t("auth_files.proxy_id_label")}
-                        hint={t("auth_files.leave_empty_proxy_id")}
-                        ariaLabel={t("auth_files.proxy_id_label")}
-                        checkState={proxyCheckState}
-                        showDetails
-                      />
-                    </div>
-
-                    <div className="grid gap-2 px-4 py-3">
-                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                        {t("auth_files.proxy_url_label")}
-                      </p>
-                      <TextInput
-                        value={prefixProxyEditor.proxyUrl}
-                        onChange={(e) => {
-                          const value = e.currentTarget.value;
-                          setPrefixProxyEditor((prev) => ({ ...prev, proxyUrl: value }));
-                        }}
-                        placeholder={t("auth_files.proxy_url_placeholder")}
-                      />
-                      <p className="text-xs text-slate-500 dark:text-white/55">
-                        {t("auth_files.leave_empty_proxy")}
-                      </p>
-                    </div>
-
-                    <div className="grid gap-2 px-4 py-3">
-                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                        {t("auth_files.subscription_started_at_label")}
-                      </p>
-                      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
-                        <DateTimePicker
-                          value={prefixProxyEditor.subscriptionStartedAt}
-                          onChange={(value) => {
-                            setPrefixProxyEditor((prev) => ({
-                              ...prev,
-                              subscriptionStartedAt: value,
-                            }));
-                          }}
-                          aria-label={t("auth_files.subscription_started_at_label")}
-                          locale={i18n.language}
-                          labels={{
-                            picker: t("auth_files.subscription_date_picker"),
-                            open: t("auth_files.subscription_date_picker_open"),
-                            previousMonth: t("auth_files.subscription_date_picker_previous_month"),
-                            nextMonth: t("auth_files.subscription_date_picker_next_month"),
-                            today: t("auth_files.subscription_date_picker_today"),
-                            clear: t("auth_files.subscription_date_picker_clear"),
-                            hour: t("auth_files.subscription_date_picker_hour"),
-                            minute: t("auth_files.subscription_date_picker_minute"),
-                          }}
-                        />
-                        <Select
-                          value={prefixProxyEditor.subscriptionPeriod}
-                          onChange={(value) =>
-                            setPrefixProxyEditor((prev) => ({
-                              ...prev,
-                              subscriptionPeriod: value as AuthFileSubscriptionPeriod,
-                            }))
-                          }
-                          options={[
-                            {
-                              value: "monthly",
-                              label: t("auth_files.subscription_period_monthly"),
-                            },
-                            {
-                              value: "yearly",
-                              label: t("auth_files.subscription_period_yearly"),
-                            },
-                          ]}
-                          aria-label={t("auth_files.subscription_period_label")}
-                        />
-                      </div>
-                      <p className="text-xs text-slate-500 dark:text-white/55">
-                        {t("auth_files.subscription_started_at_hint")}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="rounded-xl border border-slate-200 bg-slate-50/80 p-4 dark:border-neutral-800 dark:bg-neutral-950/60">
-                    <div className="flex flex-wrap items-start justify-between gap-2">
-                      <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                        {t("auth_files.preview_after_save")}
-                      </p>
-                      <span className="text-xs text-slate-500 dark:text-white/55">
-                        {formatFileSize(MAX_AUTH_FILE_SIZE)}
-                      </span>
-                    </div>
-                    <pre
-                      data-testid="auth-file-fields-preview"
-                      className="mt-3 max-h-[24rem] overflow-auto rounded-lg border border-slate-200 bg-white p-3 font-mono text-[12px] leading-5 whitespace-pre text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100"
-                    >
-                      {prefixProxyUpdatedText}
-                    </pre>
-                    <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-                      {t("auth_files.save_note", { size: formatFileSize(MAX_AUTH_FILE_SIZE) })}
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <EmptyState
-                  title={t("auth_files_page.cannot_edit")}
-                  description={prefixProxyEditor.error || t("auth_files.unknown_error")}
-                />
-              )}
-            </TabsContent>
-
-            <TabsContent value="channel" className="space-y-3">
-              <div className="border-b border-slate-200 pb-3 dark:border-neutral-800">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                  {t("auth_files.detail_tab_channel")}
-                </p>
-                <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-                  {t("auth_files.edit_channel_name_desc")}
-                </p>
-              </div>
-
-              <div className="max-w-2xl space-y-3">
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
-                    {t("auth_files.channel_name_label")}
-                  </label>
-                  <TextInput
-                    value={channelEditor.label}
-                    onChange={(e) => {
-                      const value = e.currentTarget.value;
-                      setChannelEditor((prev) => ({ ...prev, label: value, error: null }));
-                    }}
-                    placeholder={t("auth_files.channel_name_placeholder")}
-                  />
-                </div>
-                {channelEditor.error ? (
-                  <p className="text-sm text-rose-600 dark:text-rose-300">{channelEditor.error}</p>
-                ) : (
-                  <p className="text-xs text-slate-500 dark:text-white/55">
-                    {t("auth_files.channel_name_hint")}
-                  </p>
-                )}
-              </div>
             </TabsContent>
           </div>
         </Tabs>

--- a/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -16,6 +16,7 @@ import {
   dateTimeLocalInputToIso,
   formatFileSize,
   MAX_AUTH_FILE_SIZE,
+  isOauthAuthFile,
   normalizeAuthFileSubscriptionPeriod,
   readAuthFileChannelName,
   resolveFileType,
@@ -24,7 +25,7 @@ import {
   type PrefixProxyEditorState,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 
-type DetailTab = "json" | "models" | "fields" | "channel";
+type DetailTab = "fields" | "models";
 
 const createPrefixProxyEditorState = (): PrefixProxyEditorState => ({
   open: false,
@@ -119,7 +120,7 @@ export function useAuthFilesDetailEditors(
   const [detailFile, setDetailFile] = useState<AuthFileItem | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailText, setDetailText] = useState("");
-  const [detailTab, setDetailTab] = useState<DetailTab>("json");
+  const [detailTab, setDetailTab] = useState<DetailTab>("fields");
 
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsFileType, setModelsFileType] = useState("");
@@ -182,7 +183,7 @@ export function useAuthFilesDetailEditors(
   const openDetail = useCallback(
     async (file: AuthFileItem) => {
       setDetailOpen(true);
-      setDetailTab("json");
+      setDetailTab("fields");
       setDetailFile(file);
       setDetailLoading(true);
       setDetailText("");
@@ -289,13 +290,13 @@ export function useAuthFilesDetailEditors(
     });
   }, []);
 
-  const saveChannelEditor = useCallback(async () => {
+  const saveChannelEditor = useCallback(async (): Promise<boolean> => {
     const fileName = channelEditor.fileName.trim();
     const label = channelEditor.label.trim();
-    if (!fileName) return;
+    if (!fileName) return false;
     if (!label) {
       setChannelEditor((prev) => ({ ...prev, error: t("auth_files.channel_name_required") }));
-      return;
+      return false;
     }
 
     setChannelEditor((prev) => ({ ...prev, saving: true, error: null }));
@@ -304,10 +305,12 @@ export function useAuthFilesDetailEditors(
       notify({ type: "success", message: t("auth_files.saved") });
       await loadAll();
       setChannelEditor((prev) => ({ ...prev, saving: false, error: null }));
+      return true;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t("auth_files.save_failed");
       setChannelEditor((prev) => ({ ...prev, saving: false, error: message }));
       notify({ type: "error", message });
+      return false;
     }
   }, [channelEditor.fileName, channelEditor.label, loadAll, notify, t]);
 
@@ -321,12 +324,10 @@ export function useAuthFilesDetailEditors(
       if (prefixProxyEditor.fileName !== detailFile.name) {
         void openPrefixProxyEditor(detailFile);
       }
-      return;
-    }
-    if (detailTab === "channel") {
-      if (channelEditor.fileName !== detailFile.name) {
+      if (isOauthAuthFile(detailFile) && channelEditor.fileName !== detailFile.name) {
         openChannelEditor(detailFile);
       }
+      return;
     }
   }, [
     channelEditor.fileName,
@@ -446,7 +447,7 @@ export function useAuthFilesDetailEditors(
       }));
       setDetailText((prev) => (name && detailFile?.name === name ? payload : prev));
       setDetailOpen(false);
-      setDetailTab("json");
+      setDetailTab("fields");
       void loadAll().finally(() => applySavedAuthFilePatch(name, parsedPayload));
     } catch (err: unknown) {
       notify({


### PR DESCRIPTION
## Summary
- Remove the raw content/Info tab from the auth file detail modal; raw JSON remains available through Download.
- Remove the fields JSON preview surface.
- Merge OAuth channel-name editing into the Fields tab so the modal only has Fields and Models.

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- bunx oxfmt src/modules/auth-files/AuthFilesPage.tsx src/modules/auth-files/components/AuthFileDetailModal.tsx src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx --check
- git diff --check
- bun run lint
- bun run build
- Playwright local mock check: rawVisible=false, previewVisible=false, jsonReaderVisible=false, contentTabVisible=false, channelTabVisible=false; Fields/Models, channel input, Download, Save visible.

## Note
- bun run check still fails at bundle:diff because AuthFilesPage is +5.13 kB over the existing gzip delta budget versus docs/internal-review/bundle-baseline.md. lint and build portions pass, and this change reduces the built AuthFilesPage chunk compared with the prior modal iteration.