### PR TITLE
fix: simplify auth file detail modal layout

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -111,7 +111,14 @@ describe("AuthFileDetailModal", () => {
   test("keeps field editing controls without showing JSON in the modal", () => {
     renderDetailModal({ detailTab: "fields" });
 
+    const body = screen.getByTestId("auth-file-detail-body");
+    const scroller = screen.getByTestId("auth-file-detail-scroll");
     const grid = screen.getByTestId("auth-file-fields-grid");
+    expect(body.className).toContain("!overflow-hidden");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller).not.toContainElement(screen.getByRole("tablist"));
+    expect(grid.className).not.toMatch(/\bborder\b/);
+    expect(grid.className).not.toContain("divide-y");
     expect(within(grid).getByPlaceholderText("e.g. team-a")).toHaveValue("team-a");
     expect(within(grid).getByLabelText("proxy_id (proxy pool)")).toBeInTheDocument();
     expect(within(grid).getByPlaceholderText("e.g. http://127.0.0.1:7890")).toHaveValue(

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -130,7 +130,9 @@ export function AuthFileDetailModal({
           : t("auth_files.view_auth_file")
       }
       maxWidth="max-w-4xl"
-      bodyHeightClassName="max-h-[70vh]"
+      bodyHeightClassName="h-[70vh]"
+      bodyClassName="flex flex-col !overflow-hidden"
+      bodyTestId="auth-file-detail-body"
       onClose={closeModal}
       footer={
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -183,251 +185,253 @@ export function AuthFileDetailModal({
         <EmptyState title={t("auth_files.view_auth_file")} description="--" />
       ) : (
         <Tabs value={detailTab} onValueChange={(next) => setDetailTab(next as DetailTab)} size="sm">
-          <div className="space-y-3">
-            <TabsList>
-              <TabsTrigger value="fields">{t("auth_files.detail_tab_fields")}</TabsTrigger>
-              <TabsTrigger value="models">{t("auth_files.detail_tab_models")}</TabsTrigger>
-            </TabsList>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0">
+              <TabsList>
+                <TabsTrigger value="fields">{t("auth_files.detail_tab_fields")}</TabsTrigger>
+                <TabsTrigger value="models">{t("auth_files.detail_tab_models")}</TabsTrigger>
+              </TabsList>
+            </div>
 
-            <TabsContent value="fields" className="space-y-3">
-              {prefixProxyEditor.loading ? (
-                <div className="text-sm text-slate-600 dark:text-white/65">
-                  {t("common.loading_ellipsis")}
-                </div>
-              ) : (
-                <div
-                  className="max-w-3xl divide-y divide-slate-200 rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-100/70 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/20"
-                  data-testid="auth-file-fields-grid"
-                >
-                  {isOauthDetailFile ? (
-                    <div className="grid gap-2 px-4 py-3">
-                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                        {t("auth_files.channel_name_label")}
-                      </p>
-                      <TextInput
-                        value={channelLabelValue}
-                        onChange={(e) => {
-                          const value = e.currentTarget.value;
-                          setChannelEditor((prev) => ({
-                            ...prev,
-                            fileName: detailFile.name,
-                            label: value,
-                            error: null,
-                          }));
-                        }}
-                        placeholder={t("auth_files.channel_name_placeholder")}
-                      />
-                      {channelEditor.error ? (
-                        <p className="text-sm text-rose-600 dark:text-rose-300">
-                          {channelEditor.error}
-                        </p>
-                      ) : (
-                        <p className="text-xs text-slate-500 dark:text-white/55">
-                          {t("auth_files.channel_name_hint")}
-                        </p>
-                      )}
-                    </div>
-                  ) : null}
-
-                  {prefixProxyEditor.json ? (
-                    <>
-                      <div className="grid gap-2 px-4 py-3">
+            <div
+              className="mt-4 min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1"
+              data-testid="auth-file-detail-scroll"
+            >
+              <TabsContent value="fields" className="pb-1">
+                {prefixProxyEditor.loading ? (
+                  <div className="text-sm text-slate-600 dark:text-white/65">
+                    {t("common.loading_ellipsis")}
+                  </div>
+                ) : (
+                  <div className="max-w-3xl space-y-5" data-testid="auth-file-fields-grid">
+                    {isOauthDetailFile ? (
+                      <div className="grid gap-2">
                         <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                          {t("auth_files.prefix_label")}
+                          {t("auth_files.channel_name_label")}
                         </p>
                         <TextInput
-                          value={prefixProxyEditor.prefix}
+                          value={channelLabelValue}
                           onChange={(e) => {
                             const value = e.currentTarget.value;
-                            setPrefixProxyEditor((prev) => ({ ...prev, prefix: value }));
+                            setChannelEditor((prev) => ({
+                              ...prev,
+                              fileName: detailFile.name,
+                              label: value,
+                              error: null,
+                            }));
                           }}
-                          placeholder={t("auth_files.prefix_placeholder")}
+                          placeholder={t("auth_files.channel_name_placeholder")}
                         />
-                        <p className="text-xs text-slate-500 dark:text-white/55">
-                          {t("auth_files.leave_empty_prefix")}
-                        </p>
+                        {channelEditor.error ? (
+                          <p className="text-sm text-rose-600 dark:text-rose-300">
+                            {channelEditor.error}
+                          </p>
+                        ) : (
+                          <p className="text-xs text-slate-500 dark:text-white/55">
+                            {t("auth_files.channel_name_hint")}
+                          </p>
+                        )}
                       </div>
+                    ) : null}
 
-                      <div className="px-4 py-3">
-                        <ProxyPoolSelect
-                          value={prefixProxyEditor.proxyId}
-                          entries={proxyPoolEntries}
-                          onChange={(value) =>
-                            setPrefixProxyEditor((prev) => ({ ...prev, proxyId: value }))
-                          }
-                          label={t("auth_files.proxy_id_label")}
-                          hint={t("auth_files.leave_empty_proxy_id")}
-                          ariaLabel={t("auth_files.proxy_id_label")}
-                          checkState={proxyCheckState}
-                          showDetails
-                        />
-                      </div>
-
-                      <div className="grid gap-2 px-4 py-3">
-                        <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                          {t("auth_files.proxy_url_label")}
-                        </p>
-                        <TextInput
-                          value={prefixProxyEditor.proxyUrl}
-                          onChange={(e) => {
-                            const value = e.currentTarget.value;
-                            setPrefixProxyEditor((prev) => ({ ...prev, proxyUrl: value }));
-                          }}
-                          placeholder={t("auth_files.proxy_url_placeholder")}
-                        />
-                        <p className="text-xs text-slate-500 dark:text-white/55">
-                          {t("auth_files.leave_empty_proxy")}
-                        </p>
-                      </div>
-
-                      <div className="grid gap-2 px-4 py-3">
-                        <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                          {t("auth_files.subscription_started_at_label")}
-                        </p>
-                        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
-                          <DateTimePicker
-                            value={prefixProxyEditor.subscriptionStartedAt}
-                            onChange={(value) => {
-                              setPrefixProxyEditor((prev) => ({
-                                ...prev,
-                                subscriptionStartedAt: value,
-                              }));
+                    {prefixProxyEditor.json ? (
+                      <>
+                        <div className="grid gap-2">
+                          <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                            {t("auth_files.prefix_label")}
+                          </p>
+                          <TextInput
+                            value={prefixProxyEditor.prefix}
+                            onChange={(e) => {
+                              const value = e.currentTarget.value;
+                              setPrefixProxyEditor((prev) => ({ ...prev, prefix: value }));
                             }}
-                            aria-label={t("auth_files.subscription_started_at_label")}
-                            locale={i18n.language}
-                            labels={{
-                              picker: t("auth_files.subscription_date_picker"),
-                              open: t("auth_files.subscription_date_picker_open"),
-                              previousMonth: t(
-                                "auth_files.subscription_date_picker_previous_month",
-                              ),
-                              nextMonth: t("auth_files.subscription_date_picker_next_month"),
-                              today: t("auth_files.subscription_date_picker_today"),
-                              clear: t("auth_files.subscription_date_picker_clear"),
-                              hour: t("auth_files.subscription_date_picker_hour"),
-                              minute: t("auth_files.subscription_date_picker_minute"),
-                            }}
+                            placeholder={t("auth_files.prefix_placeholder")}
                           />
-                          <Select
-                            value={prefixProxyEditor.subscriptionPeriod}
+                          <p className="text-xs text-slate-500 dark:text-white/55">
+                            {t("auth_files.leave_empty_prefix")}
+                          </p>
+                        </div>
+
+                        <div className="grid gap-2">
+                          <ProxyPoolSelect
+                            value={prefixProxyEditor.proxyId}
+                            entries={proxyPoolEntries}
                             onChange={(value) =>
-                              setPrefixProxyEditor((prev) => ({
-                                ...prev,
-                                subscriptionPeriod: value as AuthFileSubscriptionPeriod,
-                              }))
+                              setPrefixProxyEditor((prev) => ({ ...prev, proxyId: value }))
                             }
-                            options={[
-                              {
-                                value: "monthly",
-                                label: t("auth_files.subscription_period_monthly"),
-                              },
-                              {
-                                value: "yearly",
-                                label: t("auth_files.subscription_period_yearly"),
-                              },
-                            ]}
-                            aria-label={t("auth_files.subscription_period_label")}
+                            label={t("auth_files.proxy_id_label")}
+                            hint={t("auth_files.leave_empty_proxy_id")}
+                            ariaLabel={t("auth_files.proxy_id_label")}
+                            checkState={proxyCheckState}
+                            showDetails
                           />
                         </div>
-                        <p className="text-xs text-slate-500 dark:text-white/55">
-                          {t("auth_files.subscription_started_at_hint")}
-                        </p>
-                      </div>
-                    </>
-                  ) : (
-                    <div className="px-4 py-4">
+
+                        <div className="grid gap-2">
+                          <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                            {t("auth_files.proxy_url_label")}
+                          </p>
+                          <TextInput
+                            value={prefixProxyEditor.proxyUrl}
+                            onChange={(e) => {
+                              const value = e.currentTarget.value;
+                              setPrefixProxyEditor((prev) => ({ ...prev, proxyUrl: value }));
+                            }}
+                            placeholder={t("auth_files.proxy_url_placeholder")}
+                          />
+                          <p className="text-xs text-slate-500 dark:text-white/55">
+                            {t("auth_files.leave_empty_proxy")}
+                          </p>
+                        </div>
+
+                        <div className="grid gap-2">
+                          <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                            {t("auth_files.subscription_started_at_label")}
+                          </p>
+                          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
+                            <DateTimePicker
+                              value={prefixProxyEditor.subscriptionStartedAt}
+                              onChange={(value) => {
+                                setPrefixProxyEditor((prev) => ({
+                                  ...prev,
+                                  subscriptionStartedAt: value,
+                                }));
+                              }}
+                              aria-label={t("auth_files.subscription_started_at_label")}
+                              locale={i18n.language}
+                              labels={{
+                                picker: t("auth_files.subscription_date_picker"),
+                                open: t("auth_files.subscription_date_picker_open"),
+                                previousMonth: t(
+                                  "auth_files.subscription_date_picker_previous_month",
+                                ),
+                                nextMonth: t("auth_files.subscription_date_picker_next_month"),
+                                today: t("auth_files.subscription_date_picker_today"),
+                                clear: t("auth_files.subscription_date_picker_clear"),
+                                hour: t("auth_files.subscription_date_picker_hour"),
+                                minute: t("auth_files.subscription_date_picker_minute"),
+                              }}
+                            />
+                            <Select
+                              value={prefixProxyEditor.subscriptionPeriod}
+                              onChange={(value) =>
+                                setPrefixProxyEditor((prev) => ({
+                                  ...prev,
+                                  subscriptionPeriod: value as AuthFileSubscriptionPeriod,
+                                }))
+                              }
+                              options={[
+                                {
+                                  value: "monthly",
+                                  label: t("auth_files.subscription_period_monthly"),
+                                },
+                                {
+                                  value: "yearly",
+                                  label: t("auth_files.subscription_period_yearly"),
+                                },
+                              ]}
+                              aria-label={t("auth_files.subscription_period_label")}
+                            />
+                          </div>
+                          <p className="text-xs text-slate-500 dark:text-white/55">
+                            {t("auth_files.subscription_started_at_hint")}
+                          </p>
+                        </div>
+                      </>
+                    ) : (
                       <EmptyState
                         title={t("auth_files_page.cannot_edit")}
                         description={prefixProxyEditor.error || t("auth_files.unknown_error")}
                       />
-                    </div>
-                  )}
-                </div>
-              )}
-            </TabsContent>
+                    )}
+                  </div>
+                )}
+              </TabsContent>
 
-            <TabsContent value="models" className="space-y-3">
-              <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-3 dark:border-neutral-800">
-                <div className="min-w-0">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {t("auth_files.detail_tab_models")}
-                  </p>
-                  <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-                    {t("auth_files.detail_tab_models_desc")}
-                  </p>
+              <TabsContent value="models" className="space-y-3 pb-1">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                      {t("auth_files.detail_tab_models")}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
+                      {t("auth_files.detail_tab_models_desc")}
+                    </p>
+                  </div>
+                  {!visibleModelsLoading && visibleModelsError !== "unsupported" ? (
+                    <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                      {t("auth_files.count_items", { count: visibleModelsList.length })}
+                    </span>
+                  ) : null}
                 </div>
-                {!visibleModelsLoading && visibleModelsError !== "unsupported" ? (
-                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
-                    {t("auth_files.count_items", { count: visibleModelsList.length })}
-                  </span>
+
+                {usesMappedModelOwner ? (
+                  <div className="rounded-lg bg-slate-50/70 px-3 py-2 text-xs text-slate-600 dark:bg-white/[0.04] dark:text-white/60">
+                    {mappedModelOwnerGroup
+                      ? t("auth_files.model_owner_group_source_desc", {
+                          owner: mappedModelOwnerGroup.label,
+                          count: mappedModelOwnerGroup.models.length,
+                        })
+                      : t("auth_files.model_owner_group_unavailable")}
+                  </div>
                 ) : null}
-              </div>
 
-              {usesMappedModelOwner ? (
-                <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50/70 px-3 py-2 text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-950/50 dark:text-white/60">
-                  {mappedModelOwnerGroup
-                    ? t("auth_files.model_owner_group_source_desc", {
-                        owner: mappedModelOwnerGroup.label,
-                        count: mappedModelOwnerGroup.models.length,
-                      })
-                    : t("auth_files.model_owner_group_unavailable")}
-                </div>
-              ) : null}
-
-              {visibleModelsLoading ? (
-                <div className="text-sm text-slate-600 dark:text-white/65">
-                  {t("common.loading_ellipsis")}
-                </div>
-              ) : visibleModelsError === "unsupported" ? (
-                <EmptyState
-                  title={t("auth_files.api_not_supported")}
-                  description={t("auth_files.no_models_api")}
-                />
-              ) : visibleModelsList.length === 0 ? (
-                <EmptyState
-                  title={t("common.no_model_data")}
-                  description={
-                    usesMappedModelOwner
-                      ? t("auth_files.no_owner_group_models")
-                      : t("auth_files_page.models_hint")
-                  }
-                />
-              ) : (
-                <div className="grid gap-2" data-testid="auth-file-models-list">
-                  {visibleModelsList.map((model) => (
-                    <div
-                      key={model.id}
-                      className="grid gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm shadow-slate-100/70 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/20"
-                    >
-                      <div className="min-w-0">
-                        <p className="truncate font-mono text-xs font-semibold text-slate-900 dark:text-white">
-                          {model.id}
-                        </p>
-                        {model.display_name ? (
-                          <p className="mt-1 truncate text-xs text-slate-500 dark:text-white/55">
-                            {model.display_name}
+                {visibleModelsLoading ? (
+                  <div className="text-sm text-slate-600 dark:text-white/65">
+                    {t("common.loading_ellipsis")}
+                  </div>
+                ) : visibleModelsError === "unsupported" ? (
+                  <EmptyState
+                    title={t("auth_files.api_not_supported")}
+                    description={t("auth_files.no_models_api")}
+                  />
+                ) : visibleModelsList.length === 0 ? (
+                  <EmptyState
+                    title={t("common.no_model_data")}
+                    description={
+                      usesMappedModelOwner
+                        ? t("auth_files.no_owner_group_models")
+                        : t("auth_files_page.models_hint")
+                    }
+                  />
+                ) : (
+                  <div className="grid gap-2" data-testid="auth-file-models-list">
+                    {visibleModelsList.map((model) => (
+                      <div
+                        key={model.id}
+                        className="grid gap-2 rounded-lg bg-slate-50/80 px-3 py-2.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center dark:bg-white/[0.04]"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate font-mono text-xs font-semibold text-slate-900 dark:text-white">
+                            {model.id}
                           </p>
-                        ) : null}
+                          {model.display_name ? (
+                            <p className="mt-1 truncate text-xs text-slate-500 dark:text-white/55">
+                              {model.display_name}
+                            </p>
+                          ) : null}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-1.5 sm:justify-end">
+                          {model.owned_by ? (
+                            <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                              {model.owned_by}
+                            </span>
+                          ) : null}
+                          {excludedModels.some((pattern) =>
+                            matchesModelPattern(model.id, pattern),
+                          ) ? (
+                            <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                              {t("auth_files.oauth_excluded")}
+                            </span>
+                          ) : null}
+                        </div>
                       </div>
-                      <div className="flex flex-wrap items-center gap-1.5 sm:justify-end">
-                        {model.owned_by ? (
-                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
-                            {model.owned_by}
-                          </span>
-                        ) : null}
-                        {excludedModels.some((pattern) =>
-                          matchesModelPattern(model.id, pattern),
-                        ) ? (
-                          <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
-                            {t("auth_files.oauth_excluded")}
-                          </span>
-                        ) : null}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </TabsContent>
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+            </div>
           </div>
         </Tabs>
       )}


### PR DESCRIPTION
## Summary
- keep auth file detail tabs fixed while only the content area scrolls
- remove field section borders/dividers and keep JSON out of the modal
- keep field editing, channel rename, download, save, and models list behavior intact

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
- bun run test src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- bunx oxfmt src/modules/auth-files/components/AuthFileDetailModal.tsx src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx --check
- git diff --check
- bun run lint
- bun run build
- Playwright local check on /manage/#/auth-files with mocked management APIs

## Known Check Note
- bun run check still fails at bundle:diff because AuthFilesPage gzip delta is +5.13 kB over the existing 5 kB tolerance; lint and build portions pass.