### PR TITLE
fix: wait for oauth callback refresh before closing dialog

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -482,7 +482,7 @@ export function AuthFilesPage() {
         defaultTab={oauthDialogDefaultTab}
         proxyPoolEntries={proxyPoolEntries}
         onClose={() => setOauthDialogOpen(false)}
-        onAuthorized={() => void loadAll()}
+        onAuthorized={loadAll}
       />
 
       <GroupOverviewModal

--- a/src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -195,20 +195,14 @@ describe("AuthFilesPage OAuth login dialog", () => {
     expect(scoped.queryByText("oauth.callback")).not.toBeInTheDocument();
   });
 
-  test("closes the dialog and refreshes cards after callback submission succeeds", async () => {
+  test("keeps the dialog open until callback submission refreshes cards", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    mocks.list.mockResolvedValueOnce({ files: [] }).mockResolvedValueOnce({
-      files: [
-        {
-          name: "codex-new.json",
-          type: "codex",
-          size: 2048,
-          modified: Date.now(),
-          disabled: false,
-        },
-      ],
+    let resolveRefresh: ((value: { files: AuthFileItem[] }) => void) | undefined;
+    const refreshPromise = new Promise<{ files: AuthFileItem[] }>((resolve) => {
+      resolveRefresh = resolve;
     });
+    mocks.list.mockResolvedValueOnce({ files: [] }).mockReturnValueOnce(refreshPromise);
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -233,8 +227,23 @@ describe("AuthFilesPage OAuth login dialog", () => {
     await user.click(scoped.getByRole("button", { name: "Submit callback" }));
 
     await waitFor(() => expect(mocks.submitCallback).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(2));
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    resolveRefresh?.({
+      files: [
+        {
+          name: "codex-new.json",
+          type: "codex",
+          size: 2048,
+          modified: Date.now(),
+          disabled: false,
+        },
+      ],
+    });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     expect(await screen.findByTestId("auth-files-cards")).toHaveTextContent("codex-new.json");
   });
 });

--- a/src/modules/oauth/OAuthLoginDialog.tsx
+++ b/src/modules/oauth/OAuthLoginDialog.tsx
@@ -76,7 +76,7 @@ export function OAuthLoginDialog({
 }: {
   open: boolean;
   onClose: () => void;
-  onAuthorized?: () => void;
+  onAuthorized?: () => void | Promise<void>;
   defaultTab?: TabValue;
   proxyPoolEntries?: ProxyPoolEntry[];
 }) {
@@ -278,14 +278,14 @@ export function OAuthLoginDialog({
           delete timers.current[provider];
         }
         updateProviderState(provider, {
-          callbackSubmitting: false,
           callbackStatus: "success",
           status: "success",
           polling: false,
         });
         notify({ type: "success", message: t("oauth.callback_submit_success") });
+        await onAuthorized?.();
+        updateProviderState(provider, { callbackSubmitting: false });
         onClose();
-        onAuthorized?.();
       } catch (err: unknown) {
         const message = getErrorMessage(err) || t("oauth.callback_submit_failed");
         updateProviderState(provider, {


### PR DESCRIPTION
## Summary
- wait for auth file refresh after OAuth callback submission before closing the dialog
- preserve the existing modal close animation by closing only after refreshed data is loaded
- cover the refresh-before-close behavior with an OAuth dialog regression test

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
- bun run check
- git diff --check