### PR TITLE
fix: wait for OAuth auth file before closing dialog

### DIFF
--- a/e2e/auth-files-oauth-excluded.spec.ts
+++ b/e2e/auth-files-oauth-excluded.spec.ts
@@ -52,7 +52,7 @@ test("Auth Files: OAuth excluded models tab should not stay loading on empty res
   await page.goto("/#/auth-files?tab=excluded");
 
   await expect(
-    page.getByRole("button", { name: /OAuth Excluded Models|OAuth 模型禁用/i }),
+    page.getByRole("tab", { name: /OAuth Excluded Models|OAuth 模型禁用/i }),
   ).toBeVisible();
   await expect(page.getByText(/No config|No configuration|暂无配置/i)).toBeVisible();
 
@@ -109,6 +109,14 @@ test("Auth Files: OAuth dialog should submit callback url through management api
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  await page.route("**/v0/management/get-auth-status**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "wait" }),
     });
   });
 

--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
+import type { AuthFileItem } from "@/lib/http/types";
 import { proxiesApi, type ProxyPoolEntry } from "@/lib/http/apis/proxies";
 import { OAuthLoginDialog } from "@/modules/oauth/OAuthLoginDialog";
 import { AuthFileDetailModal } from "@/modules/auth-files/components/AuthFileDetailModal";
@@ -31,6 +32,36 @@ import {
   writeAuthFilesUiState,
   type OAuthDialogTab,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
+
+const OAUTH_AUTH_FILES_REFRESH_TIMEOUT_MS = 12_000;
+const OAUTH_AUTH_FILES_REFRESH_INTERVAL_MS = 600;
+
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+
+const buildAuthFilesSignature = (items: AuthFileItem[]): string =>
+  items
+    .map((file) =>
+      [
+        file.name,
+        file.type,
+        file.provider,
+        file.label,
+        file.email,
+        file.account_type,
+        file.size,
+        file.modified,
+        file.modtime,
+        file.authIndex,
+        file.auth_index,
+      ]
+        .map((value) => String(value ?? ""))
+        .join("|"),
+    )
+    .sort()
+    .join("\n");
 
 export function AuthFilesPage() {
   const { t } = useTranslation();
@@ -89,6 +120,39 @@ export function AuthFilesPage() {
   const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>([]);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const filesRef = useRef<AuthFileItem[]>(files);
+  const oauthBaselineSignatureRef = useRef("");
+
+  useEffect(() => {
+    filesRef.current = files;
+  }, [files]);
+
+  const setOAuthDialogOpenWithBaseline = useCallback((open: boolean) => {
+    if (open) {
+      oauthBaselineSignatureRef.current = buildAuthFilesSignature(filesRef.current);
+    }
+    setOauthDialogOpen(open);
+  }, []);
+
+  const refreshAfterOAuthAuthorized = useCallback(async () => {
+    const previousSignature =
+      oauthBaselineSignatureRef.current || buildAuthFilesSignature(filesRef.current);
+    const deadline = Date.now() + OAUTH_AUTH_FILES_REFRESH_TIMEOUT_MS;
+
+    while (true) {
+      if (buildAuthFilesSignature(filesRef.current) !== previousSignature) {
+        return;
+      }
+      const nextFiles = await loadAll();
+      if (buildAuthFilesSignature(nextFiles) !== previousSignature) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        return;
+      }
+      await wait(OAUTH_AUTH_FILES_REFRESH_INTERVAL_MS);
+    }
+  }, [loadAll]);
 
   const {
     detailOpen,
@@ -355,7 +419,7 @@ export function AuthFilesPage() {
             refreshingAll={refreshingAll}
             uploading={uploading}
             setOauthDialogDefaultTab={setOauthDialogDefaultTab}
-            setOauthDialogOpen={setOauthDialogOpen}
+            setOauthDialogOpen={setOAuthDialogOpenWithBaseline}
             selectableFilteredFiles={selectableFilteredFiles}
             selectedCount={selectedCount}
             selectCurrentPage={selectCurrentPage}
@@ -482,7 +546,7 @@ export function AuthFilesPage() {
         defaultTab={oauthDialogDefaultTab}
         proxyPoolEntries={proxyPoolEntries}
         onClose={() => setOauthDialogOpen(false)}
-        onAuthorized={loadAll}
+        onAuthorized={refreshAfterOAuthAuthorized}
       />
 
       <GroupOverviewModal

--- a/src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -195,14 +195,28 @@ describe("AuthFilesPage OAuth login dialog", () => {
     expect(scoped.queryByText("oauth.callback")).not.toBeInTheDocument();
   });
 
-  test("keeps the dialog open until callback submission refreshes cards", async () => {
+  test("keeps the dialog open until OAuth completes and the new auth file is listed", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    let resolveRefresh: ((value: { files: AuthFileItem[] }) => void) | undefined;
-    const refreshPromise = new Promise<{ files: AuthFileItem[] }>((resolve) => {
-      resolveRefresh = resolve;
+    mocks.startAuth.mockResolvedValueOnce({
+      url: "https://example.com/oauth",
+      state: "oauth-state",
     });
-    mocks.list.mockResolvedValueOnce({ files: [] }).mockReturnValueOnce(refreshPromise);
+    mocks.getAuthStatus.mockResolvedValue({ status: "wait" });
+    mocks.list
+      .mockResolvedValueOnce({ files: [] })
+      .mockResolvedValueOnce({ files: [] })
+      .mockResolvedValueOnce({
+        files: [
+          {
+            name: "codex-new.json",
+            type: "codex",
+            size: 2048,
+            modified: Date.now(),
+            disabled: false,
+          },
+        ],
+      });
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -220,6 +234,9 @@ describe("AuthFilesPage OAuth login dialog", () => {
 
     const dialog = await screen.findByRole("dialog");
     const scoped = within(dialog);
+    await user.click(scoped.getByRole("button", { name: "Start authorization" }));
+    await waitFor(() => expect(mocks.startAuth).toHaveBeenCalledTimes(1));
+
     await user.type(
       scoped.getByPlaceholderText("Paste the full callback URL from browser"),
       "http://localhost:1455/auth/callback?code=test-code&state=test-state",
@@ -227,23 +244,14 @@ describe("AuthFilesPage OAuth login dialog", () => {
     await user.click(scoped.getByRole("button", { name: "Submit callback" }));
 
     await waitFor(() => expect(mocks.submitCallback).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(2));
     await new Promise((resolve) => window.setTimeout(resolve, 250));
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.queryByText("codex-new.json")).not.toBeInTheDocument();
 
-    resolveRefresh?.({
-      files: [
-        {
-          name: "codex-new.json",
-          type: "codex",
-          size: 2048,
-          modified: Date.now(),
-          disabled: false,
-        },
-      ],
-    });
+    mocks.getAuthStatus.mockResolvedValueOnce({ status: "ok" });
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(3), { timeout: 5000 });
 
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     expect(await screen.findByTestId("auth-files-cards")).toHaveTextContent("codex-new.json");
-  });
+  }, 12000);
 });

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -320,7 +320,7 @@ describe("Auth Files helper coverage", () => {
       return {};
     });
 
-    const loadAll = vi.fn(async () => {});
+    const loadAll = vi.fn(async () => [] as AuthFileItem[]);
     const { result } = renderHook(() => useAuthFilesDetailEditors(loadAll), { wrapper });
 
     await act(async () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -65,7 +65,7 @@ interface AuthFilesFilesTabProps {
   openGroupOverview: () => void;
   groupOverviewLoading: boolean;
   filteredFiles: AuthFileItem[];
-  loadAll: () => Promise<void>;
+  loadAll: () => Promise<AuthFileItem[]>;
   usageLoading: boolean;
   refreshingAll: boolean;
   uploading: boolean;

--- a/src/modules/auth-files/hooks/useAuthFilesDataState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDataState.ts
@@ -27,7 +27,7 @@ export function useAuthFilesDataState() {
   const usageDataRef = useRef<EntityStatsResponse | null>(usageData);
   const { index: usageIndex } = useMemo(() => buildUsageIndex(usageData), [usageData]);
 
-  const loadAll = useCallback(async () => {
+  const loadAll = useCallback(async (): Promise<AuthFileItem[]> => {
     const hasExisting = filesRef.current.length > 0;
     if (hasExisting) setRefreshingAll(true);
     else setLoading(true);
@@ -40,11 +40,13 @@ export function useAuthFilesDataState() {
       const list = Array.isArray(filesRes?.files) ? filesRes.files : [];
       setFiles(list);
       setUsageData((prev) => usageRes ?? prev);
+      return list;
     } catch (err: unknown) {
       notify({
         type: "error",
         message: err instanceof Error ? err.message : t("auth_files.load_failed"),
       });
+      return filesRef.current;
     } finally {
       if (hasExisting) setRefreshingAll(false);
       else setLoading(false);

--- a/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -118,7 +118,7 @@ const supportsAuthFileTrend = (file: AuthFileItem): boolean => {
 };
 
 export function useAuthFilesDetailEditors(
-  loadAll: () => Promise<void>,
+  loadAll: () => Promise<AuthFileItem[]>,
   setFiles?: Dispatch<SetStateAction<AuthFileItem[]>>,
 ) {
   const { t } = useTranslation();

--- a/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
@@ -3,10 +3,13 @@ import { useTranslation } from "react-i18next";
 import { authFilesApi } from "@/lib/http/apis";
 import type { AuthFileItem } from "@/lib/http/types";
 import { useToast } from "@/modules/ui/ToastProvider";
-import { formatFileSize, MAX_AUTH_FILE_SIZE } from "@/modules/auth-files/helpers/authFilesPageUtils";
+import {
+  formatFileSize,
+  MAX_AUTH_FILE_SIZE,
+} from "@/modules/auth-files/helpers/authFilesPageUtils";
 
 interface UseAuthFilesFileActionsOptions {
-  loadAll: () => Promise<void>;
+  loadAll: () => Promise<AuthFileItem[]>;
   fileInputRef: RefObject<HTMLInputElement | null>;
   detailFile: AuthFileItem | null;
   setDetailFile: Dispatch<SetStateAction<AuthFileItem | null>>;

--- a/src/modules/oauth/OAuthLoginDialog.tsx
+++ b/src/modules/oauth/OAuthLoginDialog.tsx
@@ -65,6 +65,20 @@ const getErrorMessage = (err: unknown): string => {
   return "";
 };
 
+const extractCallbackState = (redirectUrl: string): string => {
+  try {
+    const url = new URL(redirectUrl, window.location.origin);
+    const queryState = url.searchParams.get("state")?.trim();
+    if (queryState) return queryState;
+
+    const hash = url.hash.replace(/^#/, "");
+    return new URLSearchParams(hash).get("state")?.trim() ?? "";
+  } catch {
+    const match = redirectUrl.match(/[?#&]state=([^&#]+)/);
+    return match?.[1] ? decodeURIComponent(match[1]).trim() : "";
+  }
+};
+
 type TabValue = OAuthProvider | "iflow" | "vertex";
 
 export function OAuthLoginDialog({
@@ -141,6 +155,13 @@ export function OAuthLoginDialog({
     [],
   );
 
+  const clearProviderTimer = useCallback((provider: OAuthProvider) => {
+    if (timers.current[provider]) {
+      window.clearInterval(timers.current[provider]);
+      delete timers.current[provider];
+    }
+  }, []);
+
   const proxyOptions = useCallback(
     (extra?: { projectId?: string }) => {
       const proxyId = selectedProxyID.trim();
@@ -153,25 +174,40 @@ export function OAuthLoginDialog({
     [selectedProxyID],
   );
 
+  const completeAuthorization = useCallback(
+    async (provider: OAuthProvider) => {
+      clearProviderTimer(provider);
+      updateProviderState(provider, {
+        status: "success",
+        polling: false,
+        callbackSubmitting: false,
+      });
+      notify({
+        type: "success",
+        message: t("oauth.authorization_success", { provider: getProviderTitle(provider) }),
+      });
+      await onAuthorized?.();
+      onClose();
+    },
+    [clearProviderTimer, getProviderTitle, notify, onAuthorized, onClose, t, updateProviderState],
+  );
+
   const startPolling = useCallback(
     (provider: OAuthProvider, state: string) => {
-      if (timers.current[provider]) {
-        window.clearInterval(timers.current[provider]);
-      }
-      const timer = window.setInterval(async () => {
+      clearProviderTimer(provider);
+      const pollOnce = async () => {
         try {
           const res = await oauthApi.getAuthStatus(state);
           if (res.status === "ok") {
-            updateProviderState(provider, { status: "success", polling: false });
-            notify({
-              type: "success",
-              message: t("oauth.authorization_success", { provider: getProviderTitle(provider) }),
-            });
-            onAuthorized?.();
-            window.clearInterval(timer);
-            delete timers.current[provider];
+            await completeAuthorization(provider);
           } else if (res.status === "error") {
-            updateProviderState(provider, { status: "error", error: res.error, polling: false });
+            clearProviderTimer(provider);
+            updateProviderState(provider, {
+              status: "error",
+              error: res.error,
+              polling: false,
+              callbackSubmitting: false,
+            });
             notify({
               type: "error",
               message: t("oauth.authorization_failed", {
@@ -179,22 +215,26 @@ export function OAuthLoginDialog({
                 error: res.error || "",
               }).trim(),
             });
-            window.clearInterval(timer);
-            delete timers.current[provider];
           }
         } catch (err: unknown) {
+          clearProviderTimer(provider);
           updateProviderState(provider, {
             status: "error",
             error: getErrorMessage(err),
             polling: false,
+            callbackSubmitting: false,
           });
-          window.clearInterval(timer);
-          delete timers.current[provider];
         }
+      };
+
+      updateProviderState(provider, { status: "waiting", polling: true });
+      const timer = window.setInterval(() => {
+        void pollOnce();
       }, 3000);
       timers.current[provider] = timer;
+      void pollOnce();
     },
-    [getProviderTitle, notify, onAuthorized, t, updateProviderState],
+    [clearProviderTimer, completeAuthorization, getProviderTitle, notify, t, updateProviderState],
   );
 
   const startAuth = useCallback(
@@ -272,20 +312,22 @@ export function OAuthLoginDialog({
         callbackError: undefined,
       });
       try {
+        const callbackState = states[provider]?.state || extractCallbackState(redirectUrl);
         await oauthApi.submitCallback(provider, redirectUrl, proxyOptions());
-        if (timers.current[provider]) {
-          window.clearInterval(timers.current[provider]);
-          delete timers.current[provider];
-        }
         updateProviderState(provider, {
           callbackStatus: "success",
-          status: "success",
-          polling: false,
+          state: callbackState || states[provider]?.state,
+          status: callbackState ? "waiting" : "success",
+          polling: Boolean(callbackState),
         });
         notify({ type: "success", message: t("oauth.callback_submit_success") });
-        await onAuthorized?.();
-        updateProviderState(provider, { callbackSubmitting: false });
-        onClose();
+        if (callbackState) {
+          startPolling(provider, callbackState);
+        } else {
+          await onAuthorized?.();
+          updateProviderState(provider, { callbackSubmitting: false });
+          onClose();
+        }
       } catch (err: unknown) {
         const message = getErrorMessage(err) || t("oauth.callback_submit_failed");
         updateProviderState(provider, {


### PR DESCRIPTION
## Summary
- keep OAuth callback submission separate from actual OAuth completion
- continue status polling after callback submission and close the dialog only after OAuth completes
- wait for /auth-files to show a changed list before closing so the new card/list item is already rendered
- update focused unit and e2e coverage for the callback flow

## Verification
- bun run test src/modules/auth-files/__tests__
- bun run e2e e2e/auth-files-oauth-excluded.spec.ts
- bun run check
- git diff --check