### PR TITLE
fix: smooth auth file quota trend refresh

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -302,7 +302,7 @@ export function AuthFilesPage() {
       if (provider === "codex" || provider === "kimi") {
         void refreshQuota(file, provider)
           .catch(() => undefined)
-          .finally(() => void refreshDetailTrend(file));
+          .finally(() => void refreshDetailTrend(file, { silent: true }));
       }
       return openPromise;
     },

--- a/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -131,6 +131,22 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
   });
 
+  test("keeps the rendered trend visible while a background refresh is running", () => {
+    renderDetailModal({ detailTrendLoading: true });
+
+    expect(screen.getByText("Quota and request trends")).toBeInTheDocument();
+    expect(screen.getByText("Last 7 days requests")).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+  });
+
+  test("does not render quota sample summary cards below the trend chart", () => {
+    renderDetailModal();
+
+    expect(screen.queryByTestId("auth-file-quota-series-list")).not.toBeInTheDocument();
+    expect(screen.queryByText(/samples/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/resets/)).not.toBeInTheDocument();
+  });
+
   test("renders models as a compact list without raw field labels", () => {
     renderDetailModal({ detailTab: "models" });
 

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -1,7 +1,7 @@
 import { useMemo, type Dispatch, type SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
 import { Download, RefreshCw, ShieldCheck } from "lucide-react";
-import type { AuthFileTrendResponse, AuthFileTrendQuotaSeries } from "@/lib/http/apis/usage";
+import type { AuthFileTrendResponse } from "@/lib/http/apis/usage";
 import type { AuthFileItem, AuthFileSubscriptionPeriod } from "@/lib/http/types";
 import type { ProxyPoolEntry } from "@/lib/http/apis/proxies";
 import { Button } from "@/modules/ui/Button";
@@ -44,7 +44,7 @@ interface AuthFileDetailModalProps {
   detailTrend: AuthFileTrendResponse | null;
   detailTrendLoading: boolean;
   detailTrendError: string | null;
-  refreshDetailTrend: (file?: AuthFileItem | null) => Promise<void>;
+  refreshDetailTrend: (file?: AuthFileItem | null, options?: { silent?: boolean }) => Promise<void>;
   loadModelsForDetail: (file: AuthFileItem, options?: { force?: boolean }) => Promise<void>;
   loadModelOwnerGroups: () => Promise<void>;
   modelsLoading: boolean;
@@ -64,14 +64,6 @@ interface AuthFileDetailModalProps {
   setChannelEditor: Dispatch<SetStateAction<ChannelEditorState>>;
   saveChannelEditor: () => Promise<boolean>;
 }
-
-const latestQuotaPoint = (series: AuthFileTrendQuotaSeries) => {
-  for (let index = series.points.length - 1; index >= 0; index -= 1) {
-    const point = series.points[index];
-    if (point) return point;
-  }
-  return null;
-};
 
 export function AuthFileDetailModal({
   open,
@@ -258,7 +250,7 @@ export function AuthFileDetailModal({
   };
 
   const renderUsageTrend = () => {
-    if (detailTrendLoading) {
+    if (detailTrendLoading && !detailTrend) {
       return (
         <div className="text-sm text-slate-600 dark:text-white/65">
           {t("common.loading_ellipsis")}
@@ -342,44 +334,6 @@ export function AuthFileDetailModal({
         <div className="min-w-0 rounded-lg bg-slate-50/70 p-3 dark:bg-white/[0.04]">
           <EChart option={trendChartOption} className="h-72 min-w-0" replaceMerge="series" />
         </div>
-
-        {activeQuotaSeries.length === 0 ? (
-          <div className="rounded-lg bg-slate-50/70 px-3 py-3 text-sm text-slate-600 dark:bg-white/[0.04] dark:text-white/60">
-            {t("auth_files.trend_no_quota_series")}
-          </div>
-        ) : (
-          <div className="grid gap-2 sm:grid-cols-2" data-testid="auth-file-quota-series-list">
-            {activeQuotaSeries.map((series) => {
-              const latest = latestQuotaPoint(series);
-              const percent =
-                latest?.percent === null || latest?.percent === undefined
-                  ? "--"
-                  : `${Math.round(latest.percent)}%`;
-              const resetAt = latest?.reset_at ? new Date(latest.reset_at).toLocaleString() : "";
-              return (
-                <div
-                  key={`${series.quota_key}:${series.window_seconds}`}
-                  className="rounded-lg bg-slate-50/80 px-3 py-2.5 dark:bg-white/[0.04]"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <p className="min-w-0 truncate text-sm font-semibold text-slate-900 dark:text-white">
-                      {translateQuotaLabel(series.quota_label)}
-                    </p>
-                    <span className="shrink-0 text-sm font-semibold text-slate-700 dark:text-white/80">
-                      {percent}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-                    {t("auth_files.trend_quota_samples", {
-                      count: series.points.length,
-                    })}
-                    {resetAt ? ` · ${t("auth_files.trend_reset_at", { time: resetAt })}` : ""}
-                  </p>
-                </div>
-              );
-            })}
-          </div>
-        )}
       </div>
     );
   };

--- a/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -30,6 +30,7 @@ import {
 
 type DetailTab = "usage" | "fields" | "models";
 type DetailTrendWindow = "5h" | "week";
+type RefreshDetailTrendOptions = { silent?: boolean };
 
 const createPrefixProxyEditorState = (): PrefixProxyEditorState => ({
   open: false,
@@ -124,6 +125,7 @@ export function useAuthFilesDetailEditors(
   const { t } = useTranslation();
   const { notify } = useToast();
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
+  const detailTrendInFlightRef = useRef<Map<string, Promise<void>>>(new Map());
 
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailFile, setDetailFile] = useState<AuthFileItem | null>(null);
@@ -194,7 +196,7 @@ export function useAuthFilesDetailEditors(
   );
 
   const refreshDetailTrend = useCallback(
-    async (fileArg?: AuthFileItem | null) => {
+    async (fileArg?: AuthFileItem | null, options?: RefreshDetailTrendOptions) => {
       const file = fileArg ?? detailFile;
       if (!file || !supportsAuthFileTrend(file)) {
         setDetailTrend(null);
@@ -211,20 +213,44 @@ export function useAuthFilesDetailEditors(
         return;
       }
 
-      setDetailTrendLoading(true);
+      const existing = detailTrendInFlightRef.current.get(authIndex);
+      if (existing) {
+        try {
+          await existing;
+        } catch {
+          // 主请求会更新 detailTrendError；重复调用只负责复用同一个请求。
+        }
+        return;
+      }
+
+      const shouldShowLoading = !options?.silent || !detailTrend;
+      if (shouldShowLoading) {
+        setDetailTrendLoading(true);
+      }
       setDetailTrendError(null);
-      try {
+
+      const request = (async () => {
         const trend = await usageApi.getAuthFileTrend(authIndex, { days: 7, hours: 5 });
         setDetailTrend(trend);
+      })();
+      detailTrendInFlightRef.current.set(authIndex, request);
+
+      try {
+        await request;
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : t("auth_files.trend_load_failed");
         setDetailTrend(null);
         setDetailTrendError(message);
       } finally {
-        setDetailTrendLoading(false);
+        if (detailTrendInFlightRef.current.get(authIndex) === request) {
+          detailTrendInFlightRef.current.delete(authIndex);
+        }
+        if (shouldShowLoading) {
+          setDetailTrendLoading(false);
+        }
       }
     },
-    [detailFile, t],
+    [detailFile, detailTrend, t],
   );
 
   const openDetail = useCallback(


### PR DESCRIPTION
## Summary
- keep the auth file trend chart visible during background quota refreshes
- remove the quota sample summary cards below the trend chart
- cover the refreshed behavior in AuthFileDetailModal tests

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
- bun run lint
- bun run build
- bun run check
- bunx oxfmt src/modules/auth-files/AuthFilesPage.tsx src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx src/modules/auth-files/components/AuthFileDetailModal.tsx src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts --check

Note: full bunx oxfmt . --check reports existing format issues outside this change.