### PR TITLE
fix: constrain auth file five hour trend buckets

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -6,6 +6,24 @@ import i18n from "@/i18n";
 
 type DetailModalProps = ComponentProps<typeof AuthFileDetailModal>;
 
+const chartOptions = vi.hoisted(() => [] as any[]);
+
+vi.mock("@/modules/ui/charts/EChart", () => ({
+  EChart: ({ option, className }: { option: any; className?: string }) => {
+    chartOptions.push(option);
+    return (
+      <div
+        className={className}
+        data-testid="auth-file-trend-chart"
+        data-x-axis={JSON.stringify(option?.xAxis?.data ?? [])}
+        data-series={JSON.stringify(option?.series ?? [])}
+      >
+        chart
+      </div>
+    );
+  },
+}));
+
 const basePrefixProxyEditor: DetailModalProps["prefixProxyEditor"] = {
   open: true,
   fileName: "codex.json",
@@ -111,6 +129,7 @@ describe("AuthFileDetailModal", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
     window.localStorage.clear();
+    chartOptions.length = 0;
   });
 
   test("uses usage trend as the primary view for Codex files", () => {
@@ -145,6 +164,54 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByTestId("auth-file-quota-series-list")).not.toBeInTheDocument();
     expect(screen.queryByText(/samples/)).not.toBeInTheDocument();
     expect(screen.queryByText(/resets/)).not.toBeInTheDocument();
+  });
+
+  test("five-hour trend uses only the latest five hourly buckets and maps quota timestamps to local hours", () => {
+    const localQuotaAt15 = new Date(2026, 4, 1, 15, 9, 0).toISOString();
+    const oldQuotaAt22 = new Date(2026, 3, 30, 22, 15, 0).toISOString();
+
+    renderDetailModal({
+      detailTrend: {
+        auth_index: "auth-1",
+        days: 7,
+        hours: 5,
+        request_total: 12,
+        cycle_request_total: 12,
+        cycle_start: "2026-04-28T05:34:34Z",
+        daily_usage: [],
+        hourly_usage: [
+          { hour: "2026-05-01 11:00", requests: 0 },
+          { hour: "2026-05-01 12:00", requests: 2 },
+          { hour: "2026-05-01 13:00", requests: 1 },
+          { hour: "2026-05-01 14:00", requests: 1 },
+          { hour: "2026-05-01 15:00", requests: 10 },
+        ],
+        quota_series: [
+          {
+            quota_key: "code_5h",
+            quota_label: "m_quota.code_5h",
+            window_seconds: 18000,
+            points: [
+              { timestamp: oldQuotaAt22, percent: 100 },
+              { timestamp: localQuotaAt15, percent: 94 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const chart = screen.getByTestId("auth-file-trend-chart");
+    expect(JSON.parse(chart.dataset.xAxis ?? "[]")).toEqual([
+      "05-01 11:00",
+      "05-01 12:00",
+      "05-01 13:00",
+      "05-01 14:00",
+      "05-01 15:00",
+    ]);
+
+    const series = JSON.parse(chart.dataset.series ?? "[]");
+    expect(series[0].data).toEqual([0, 2, 1, 1, 10]);
+    expect(series[1].data).toEqual([null, null, null, null, 94]);
   });
 
   test("renders models as a compact list without raw field labels", () => {

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -31,6 +31,20 @@ import {
 type DetailTab = "usage" | "fields" | "models";
 type DetailTrendWindow = "5h" | "week";
 
+const padTwo = (value: number) => String(value).padStart(2, "0");
+
+const formatLocalDateKey = (timestamp: string) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  return `${date.getFullYear()}-${padTwo(date.getMonth() + 1)}-${padTwo(date.getDate())}`;
+};
+
+const formatLocalHourKey = (timestamp: string) => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  return `${formatLocalDateKey(timestamp)} ${padTwo(date.getHours())}:00`;
+};
+
 interface AuthFileDetailModalProps {
   open: boolean;
   detailFile: AuthFileItem | null;
@@ -165,9 +179,9 @@ export function AuthFileDetailModal({
         if (!point.timestamp) return;
         const key =
           detailTrendWindow === "5h"
-            ? `${point.timestamp.slice(0, 13).replace("T", " ")}:00`
-            : point.timestamp.slice(0, 10);
-        xKeys.add(key);
+            ? formatLocalHourKey(point.timestamp)
+            : formatLocalDateKey(point.timestamp);
+        if (!key || !xKeys.has(key)) return;
         values.set(key, point.percent);
       });
       return { series, values };


### PR DESCRIPTION
## Summary
- keep the 5-hour auth-file trend x-axis limited to the latest five hourly request buckets
- convert quota snapshot timestamps to local chart hours before matching them to request buckets
- add regression coverage for stale quota points and local-hour quota mapping

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
- bun run lint
- bun run build
- bun run check
- bunx oxfmt src/modules/auth-files/components/AuthFileDetailModal.tsx src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx --check

Note: full bunx oxfmt . --check still reports existing unrelated format issues in 37 files.