### PR TITLE
fix: support Claude OAuth quota refresh

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1196,6 +1196,68 @@ describe("AuthFilesPage files table", () => {
     ).toBeGreaterThan(0);
   });
 
+  test("cards view exposes quota refresh for Anthropic OAuth files", async () => {
+    const now = Date.now();
+    const file = {
+      name: "claude-oauth.json",
+      label: "Claude Pro",
+      account_type: "oauth",
+      type: "claude",
+      provider: "anthropic",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "claude-1",
+    } as any;
+
+    mocks.list.mockImplementationOnce(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ label: "claude_quota.five_hour", percent: 88, resetAtMs: now + 60_000 }],
+    });
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "claude-oauth.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "claude_quota.five_hour", percent: 72, resetAtMs: now + 30_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Claude Pro")).toBeInTheDocument();
+    const refreshButton = within(screen.getByTestId("auth-files-cards")).getByRole("button", {
+      name: "Refresh",
+    });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(mocks.fetchQuota).toHaveBeenCalledWith(
+        "claude",
+        expect.objectContaining({ name: "claude-oauth.json" }),
+      );
+    });
+  });
+
   test("cards view shows inline error when quota fetch fails", async () => {
     const now = Date.now();
     const file = {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -149,6 +149,7 @@ export function useAuthFilesFilesPresentation({
     (text: string) => {
       if (!text) return text;
       if (text.startsWith("m_quota.")) return t(text);
+      if (text.startsWith("claude_quota.")) return t(text);
       if (KNOWN_QUOTA_TEXT_KEYS.has(text)) return t(`m_quota.${text}`);
       const additionalQuota = parseAdditionalQuotaWindowLabel(text);
       if (additionalQuota) {

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -118,8 +118,17 @@ export function useAuthFilesQuotaState({
             name: additionalQuota.name,
           });
         }
+        if (text.startsWith("claude_quota.")) return t(text);
         return text;
       };
+
+      if (provider === "claude") {
+        return items.map((item) => ({
+          id: item.key ?? item.label,
+          label: translateQuotaLabel(item.label),
+          item,
+        }));
+      }
 
       const supportsStableCodingSlots = provider === "codex" || provider === "kimi";
       if (!supportsStableCodingSlots) {

--- a/src/modules/quota/__tests__/quota-fetch.test.ts
+++ b/src/modules/quota/__tests__/quota-fetch.test.ts
@@ -26,6 +26,84 @@ describe("resolveQuotaProvider", () => {
   test("supports kimi auth files", () => {
     expect(resolveQuotaProvider({ name: "kimi.json", provider: "kimi" } as any)).toBe("kimi");
   });
+
+  test("supports Anthropic OAuth auth files as Claude quota files", () => {
+    expect(
+      resolveQuotaProvider({
+        name: "claude-oauth.json",
+        provider: "anthropic",
+        type: "claude",
+        account_type: "oauth",
+      } as any),
+    ).toBe("claude");
+  });
+
+  test("does not treat Claude API key auth files as quota files", () => {
+    expect(
+      resolveQuotaProvider({
+        name: "claude-api-key.json",
+        provider: "claude",
+        account_type: "api-key",
+      } as any),
+    ).toBeNull();
+  });
+});
+
+describe("fetchQuota for claude", () => {
+  test("requests Anthropic OAuth usage endpoint and maps remaining percentages", async () => {
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: {
+        five_hour: { utilization: 12.5, resets_at: "2026-05-01T05:00:00Z" },
+        seven_day: { utilization: 34, resets_at: "2026-05-08T05:00:00Z" },
+        seven_day_sonnet: { utilization: 56, resets_at: "2026-05-08T05:00:00Z" },
+      },
+    });
+
+    const result = await fetchQuota("claude", {
+      name: "claude-oauth.json",
+      provider: "anthropic",
+      type: "claude",
+      account_type: "oauth",
+      auth_index: "claude-1",
+    } as any);
+
+    expect(mocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authIndex: "claude-1",
+        method: "GET",
+        url: "https://api.anthropic.com/api/oauth/usage",
+        header: expect.objectContaining({
+          Accept: "application/json, text/plain, */*",
+          Authorization: "Bearer $TOKEN$",
+          "User-Agent": "claude-code/2.1.7",
+          "anthropic-beta": "oauth-2025-04-20",
+        }),
+      }),
+    );
+    expect(result.items).toEqual([
+      {
+        key: "five_hour",
+        label: "claude_quota.five_hour",
+        percent: 87.5,
+        resetAtMs: Date.parse("2026-05-01T05:00:00Z"),
+      },
+      {
+        key: "seven_day",
+        label: "claude_quota.seven_day",
+        percent: 66,
+        resetAtMs: Date.parse("2026-05-08T05:00:00Z"),
+      },
+      {
+        key: "seven_day_sonnet",
+        label: "claude_quota.seven_day_sonnet",
+        percent: 44,
+        resetAtMs: Date.parse("2026-05-08T05:00:00Z"),
+      },
+    ]);
+  });
 });
 
 describe("fetchQuota for kimi", () => {

--- a/src/modules/quota/quota-claude.ts
+++ b/src/modules/quota/quota-claude.ts
@@ -1,0 +1,98 @@
+import type { QuotaItem } from "@/modules/quota/quota-types";
+import {
+  clampPercent,
+  normalizeNumberValue,
+  normalizeStringValue,
+  parseResetTimeToMs,
+} from "@/modules/quota/quota-normalizers";
+
+type ClaudeUsageWindow = {
+  utilization?: number | string;
+  resets_at?: string;
+  resetsAt?: string;
+};
+
+export type ClaudeUsagePayload = {
+  five_hour?: ClaudeUsageWindow | null;
+  seven_day?: ClaudeUsageWindow | null;
+  seven_day_oauth_apps?: ClaudeUsageWindow | null;
+  seven_day_opus?: ClaudeUsageWindow | null;
+  seven_day_sonnet?: ClaudeUsageWindow | null;
+  seven_day_cowork?: ClaudeUsageWindow | null;
+  iguana_necktie?: ClaudeUsageWindow | null;
+  extra_usage?: {
+    is_enabled?: boolean;
+    monthly_limit?: number | string;
+    used_credits?: number | string;
+    utilization?: number | string | null;
+  } | null;
+};
+
+const CLAUDE_USAGE_WINDOW_KEYS = [
+  { key: "five_hour", id: "five_hour", label: "claude_quota.five_hour" },
+  { key: "seven_day", id: "seven_day", label: "claude_quota.seven_day" },
+  {
+    key: "seven_day_oauth_apps",
+    id: "seven_day_oauth_apps",
+    label: "claude_quota.seven_day_oauth_apps",
+  },
+  { key: "seven_day_opus", id: "seven_day_opus", label: "claude_quota.seven_day_opus" },
+  { key: "seven_day_sonnet", id: "seven_day_sonnet", label: "claude_quota.seven_day_sonnet" },
+  { key: "seven_day_cowork", id: "seven_day_cowork", label: "claude_quota.seven_day_cowork" },
+  { key: "iguana_necktie", id: "iguana_necktie", label: "claude_quota.iguana_necktie" },
+] as const;
+
+export const parseClaudeUsagePayload = (payload: unknown): ClaudeUsagePayload | null => {
+  if (payload === undefined || payload === null) return null;
+  if (typeof payload === "string") {
+    const trimmed = payload.trim();
+    if (!trimmed) return null;
+    try {
+      return JSON.parse(trimmed) as ClaudeUsagePayload;
+    } catch {
+      return null;
+    }
+  }
+  return typeof payload === "object" ? (payload as ClaudeUsagePayload) : null;
+};
+
+const resolveRemainingPercent = (window?: ClaudeUsageWindow | null): number | null => {
+  if (!window) return null;
+  const utilization = normalizeNumberValue(window.utilization);
+  return utilization === null ? null : clampPercent(100 - clampPercent(utilization));
+};
+
+export const buildClaudeItems = (payload: ClaudeUsagePayload): QuotaItem[] => {
+  const items: QuotaItem[] = CLAUDE_USAGE_WINDOW_KEYS.flatMap((definition) => {
+    const window = payload[definition.key];
+    if (!window) return [];
+    const percent = resolveRemainingPercent(window);
+    const resetAtMs = parseResetTimeToMs(window.resets_at ?? window.resetsAt);
+    if (percent === null && !resetAtMs) return [];
+    return [
+      {
+        key: definition.id,
+        label: definition.label,
+        percent,
+        resetAtMs,
+      },
+    ];
+  });
+
+  const extra = payload.extra_usage;
+  const extraUtilization = normalizeNumberValue(extra?.utilization);
+  if (extra?.is_enabled && extraUtilization !== null) {
+    const usedCredits = normalizeStringValue(extra.used_credits);
+    const monthlyLimit = normalizeStringValue(extra.monthly_limit);
+    const meta =
+      usedCredits && monthlyLimit ? `${usedCredits} / ${monthlyLimit} credits` : undefined;
+    items.push({
+      key: "extra_usage",
+      label: "claude_quota.extra_usage_label",
+      percent: clampPercent(100 - clampPercent(extraUtilization)),
+      meta,
+    });
+  }
+
+  return items;
+};

--- a/src/modules/quota/quota-fetch.ts
+++ b/src/modules/quota/quota-fetch.ts
@@ -3,6 +3,8 @@ import type { ApiCallResult, AuthFileItem } from "@/lib/http/types";
 import {
   ANTIGRAVITY_QUOTA_URLS,
   ANTIGRAVITY_REQUEST_HEADERS,
+  CLAUDE_REQUEST_HEADERS,
+  CLAUDE_USAGE_URL,
   CODEX_REQUEST_HEADERS,
   CODEX_USAGE_URL,
   DEFAULT_ANTIGRAVITY_PROJECT_ID,
@@ -14,6 +16,7 @@ import {
   KIRO_REQUEST_BODY,
   KIRO_REQUEST_HEADERS,
   buildAntigravityGroups,
+  buildClaudeItems,
   buildCodexItems,
   buildGeminiCliBuckets,
   buildKimiItems,
@@ -26,6 +29,7 @@ import {
   normalizeQuotaFraction,
   normalizeStringValue,
   parseAntigravityPayload,
+  parseClaudeUsagePayload,
   parseCodexUsagePayload,
   parseGeminiCliQuotaPayload,
   parseKimiUsagePayload,
@@ -38,7 +42,7 @@ import {
   type QuotaItem,
 } from "@/modules/quota/quota-helpers";
 
-export type QuotaProvider = "antigravity" | "codex" | "gemini-cli" | "kimi" | "kiro";
+export type QuotaProvider = "antigravity" | "claude" | "codex" | "gemini-cli" | "kimi" | "kiro";
 export type QuotaFetchResult = {
   items: QuotaItem[];
   planType?: string | null;
@@ -47,6 +51,8 @@ export type QuotaFetchResult = {
 export const resolveQuotaProvider = (file: AuthFileItem): QuotaProvider | null => {
   const provider = resolveAuthProvider(file);
   if (provider === "antigravity") return "antigravity";
+  if ((provider === "anthropic" || provider === "claude") && isClaudeOAuthLikeFile(file))
+    return "claude";
   if (provider === "codex") return "codex";
   if (provider === "gemini-cli") return "gemini-cli";
   if (provider === "kimi") return "kimi";
@@ -79,6 +85,14 @@ const resolveAntigravityProjectId = async (file: AuthFileItem): Promise<string> 
     return DEFAULT_ANTIGRAVITY_PROJECT_ID;
   }
   return DEFAULT_ANTIGRAVITY_PROJECT_ID;
+};
+
+const isClaudeOAuthLikeFile = (file: AuthFileItem): boolean => {
+  const accountType = normalizeStringValue(file.account_type ?? file.accountType)?.toLowerCase();
+  if (accountType === "api-key" || accountType === "apikey" || accountType === "api_key") {
+    return false;
+  }
+  return true;
 };
 
 export const fetchQuota = async (
@@ -137,6 +151,20 @@ export const fetchQuota = async (
       items: buildCodexItems(payload),
       planType: normalizeStringValue(payload.plan_type ?? payload.planType)?.toLowerCase() ?? null,
     };
+  }
+
+  if (type === "claude") {
+    const result = await apiCallApi.request({
+      authIndex,
+      method: "GET",
+      url: CLAUDE_USAGE_URL,
+      header: { ...CLAUDE_REQUEST_HEADERS },
+    });
+    if (result.statusCode < 200 || result.statusCode >= 300)
+      throw new Error(getApiCallErrorMessage(result));
+    const payload = parseClaudeUsagePayload(result.body ?? result.bodyText);
+    if (!payload) throw new Error("parse_claude_failed");
+    return { items: buildClaudeItems(payload) };
   }
 
   if (type === "gemini-cli") {

--- a/src/modules/quota/quota-helpers.ts
+++ b/src/modules/quota/quota-helpers.ts
@@ -12,6 +12,8 @@ export {
   parseCodexUsagePayload,
   resolveCodexChatgptAccountId,
 } from "@/modules/quota/quota-codex";
+export { type ClaudeUsagePayload } from "@/modules/quota/quota-claude";
+export { buildClaudeItems, parseClaudeUsagePayload } from "@/modules/quota/quota-claude";
 export { type GeminiCliQuotaPayload } from "@/modules/quota/quota-gemini-cli";
 export {
   buildGeminiCliBuckets,
@@ -64,6 +66,15 @@ export const CODEX_REQUEST_HEADERS = {
   Authorization: "Bearer $TOKEN$",
   "Content-Type": "application/json",
   "User-Agent": "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+};
+
+export const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+export const CLAUDE_REQUEST_HEADERS = {
+  Accept: "application/json, text/plain, */*",
+  Authorization: "Bearer $TOKEN$",
+  "Content-Type": "application/json",
+  "User-Agent": "claude-code/2.1.7",
+  "anthropic-beta": "oauth-2025-04-20",
 };
 
 export const KIRO_QUOTA_URL = "https://codewhisperer.us-east-1.amazonaws.com";


### PR DESCRIPTION
## Summary
- add Claude OAuth quota provider support for Anthropic/Claude auth files
- map Anthropic OAuth usage windows into auth-file quota bars
- keep card refresh action visible for Anthropic OAuth files and cover it with tests

## Verification
- bun run test -- src/modules/auth-files/__tests__ src/modules/quota/__tests__
- bun run lint
- bun run build
- bun run check

Note: bunx oxfmt . --check still reports existing baseline formatting differences in 37 unrelated files; this PR keeps those out of scope.