### PR TITLE
Use OpenCode logo for provider

### DIFF
--- a/src/assets/icons/opencode-dark.svg
+++ b/src/assets/icons/opencode-dark.svg
@@ -1,0 +1,6 @@
+<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(30 0)">
+    <path d="M180 240H60V120H180V240Z" fill="#4B4646"/>
+    <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#F1ECEC"/>
+  </g>
+</svg>

--- a/src/assets/icons/opencode-light.svg
+++ b/src/assets/icons/opencode-light.svg
@@ -1,0 +1,6 @@
+<svg width="300" height="300" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(30 0)">
+    <path d="M180 240H60V120H180V240Z" fill="#CFCECD"/>
+    <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#211E1E"/>
+  </g>
+</svg>

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -19,6 +19,9 @@ import { useTranslation } from "react-i18next";
 
 export function ProviderKeyListCard({
   icon: Icon,
+  iconSrc,
+  iconDarkSrc,
+  iconAlt = "",
   title,
   description,
   items,
@@ -35,6 +38,9 @@ export function ProviderKeyListCard({
   showBaseUrl = true,
 }: {
   icon: LucideIcon;
+  iconSrc?: string;
+  iconDarkSrc?: string;
+  iconAlt?: string;
   title: string;
   description: string;
   items: ProviderSimpleConfig[];
@@ -50,6 +56,18 @@ export function ProviderKeyListCard({
   showBaseUrl?: boolean;
 }) {
   const { t } = useTranslation();
+  const renderIcon = () =>
+    iconSrc ? (
+      <>
+        <img src={iconSrc} alt={iconAlt} className={`size-4 ${iconDarkSrc ? "dark:hidden" : ""}`} />
+        {iconDarkSrc ? (
+          <img src={iconDarkSrc} alt={iconAlt} className="hidden size-4 dark:block" />
+        ) : null}
+      </>
+    ) : (
+      <Icon size={16} className="text-slate-900 dark:text-white" />
+    );
+
   return (
     <Card
       title={title}
@@ -90,7 +108,7 @@ export function ProviderKeyListCard({
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0">
                     <p className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
-                      <Icon size={16} className="text-slate-900 dark:text-white" />
+                      {renderIcon()}
                       <span className="truncate">{item.name || maskApiKey(item.apiKey)}</span>
                       {disabled ? (
                         <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[11px] font-semibold text-amber-700 dark:text-amber-200">

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -8,6 +8,8 @@ import iconCodex from "@/assets/icons/codex.svg";
 import iconVertex from "@/assets/icons/vertex.svg";
 import iconAmp from "@/assets/icons/amp.svg";
 import iconOpenai from "@/assets/icons/openai.svg";
+import iconOpenCodeDark from "@/assets/icons/opencode-dark.svg";
+import iconOpenCodeLight from "@/assets/icons/opencode-light.svg";
 import { ampcodeApi, providersApi, usageApi } from "@/lib/http/apis";
 import { apiKeyEntriesApi, type ApiKeyEntry } from "@/lib/http/apis/api-keys";
 import { channelGroupsApi, type ChannelGroupItem } from "@/lib/http/apis/channel-groups";
@@ -447,7 +449,8 @@ export function ProvidersPage() {
             Codex
           </TabsTrigger>
           <TabsTrigger value="opencode-go">
-            <FileKey size={16} />
+            <img src={iconOpenCodeLight} alt="" className="size-4 dark:hidden" />
+            <img src={iconOpenCodeDark} alt="" className="hidden size-4 dark:block" />
             OpenCode Go
           </TabsTrigger>
           <TabsTrigger value="vertex">
@@ -526,6 +529,8 @@ export function ProvidersPage() {
         <TabsContent value="opencode-go" className="mt-6">
           <ProviderKeyListCard
             icon={FileKey}
+            iconSrc={iconOpenCodeLight}
+            iconDarkSrc={iconOpenCodeDark}
             title={t("providers.opencode_go_keys")}
             description={t("providers.opencode_go_desc")}
             items={openCodeGoKeys}


### PR DESCRIPTION
## Summary
- add official OpenCode light/dark square logo assets
- use the OpenCode logo in the provider tab and key list card
- keep ProviderKeyListCard compatible with existing lucide icons

## Verification
- bunx oxfmt src/modules/providers/ProviderKeyListCard.tsx src/modules/providers/ProvidersPage.tsx --check
- bun run test src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- bun run lint
- bun run build
- bun run check