### PR TITLE
Fix manage models and provider saves

### DIFF
--- a/src/lib/http/apis/__tests__/providers-opencode-go.test.ts
+++ b/src/lib/http/apis/__tests__/providers-opencode-go.test.ts
@@ -53,6 +53,31 @@ describe("providersApi OpenCode Go", () => {
     ]);
   });
 
+  test("ignores OAuth auth-file rows returned by the OpenCode Go config endpoint", async () => {
+    const { providersApi } = await import("@/lib/http/apis/providers");
+    getMock.mockResolvedValue({
+      "opencode-go-api-key": [
+        {
+          name: "OpenCode Go API key",
+          "api-key": "sk-go",
+        },
+        {
+          name: "user@example.com",
+          "api-key": "oauth-backed-token",
+          account_type: "oauth",
+          type: "opencode-go",
+        },
+      ],
+    });
+
+    await expect(providersApi.getOpenCodeGoConfigs()).resolves.toEqual([
+      {
+        name: "OpenCode Go API key",
+        apiKey: "sk-go",
+      },
+    ]);
+  });
+
   test("serializes and deletes OpenCode Go configs without Base URL or models", async () => {
     const { providersApi } = await import("@/lib/http/apis/providers");
     putMock.mockResolvedValue({ status: "ok" });

--- a/src/lib/http/apis/providers.ts
+++ b/src/lib/http/apis/providers.ts
@@ -20,6 +20,14 @@ import {
   serializeProviderKey,
 } from "@/lib/http/apis/helpers";
 
+const isOauthBackedProviderRow = (item: Record<string, unknown>): boolean => {
+  const accountType = normalizeString(item.account_type ?? item.accountType)?.toLowerCase();
+  if (accountType === "oauth") return true;
+
+  const runtimeOnly = item.runtime_only ?? item.runtimeOnly;
+  return runtimeOnly === true || (typeof runtimeOnly === "string" && runtimeOnly === "true");
+};
+
 export const providersApi = {
   async getGeminiKeys(): Promise<ProviderSimpleConfig[]> {
     const data = await apiClient.get("/gemini-api-key");
@@ -109,6 +117,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const apiKey = normalizeString(item["api-key"] ?? item.apiKey) ?? "";
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -1032,31 +1032,37 @@ export function ModelsPage() {
     }
   }, [loadModels, notify, t]);
 
+  const canDeleteModels = activeTab === "library";
+
   const modelColumns = useMemo<VirtualTableColumn<ModelItem>[]>(
     () => [
-      {
-        key: "select",
-        label: "",
-        width: "w-12",
-        headerClassName: "text-center",
-        cellClassName: "text-center",
-        headerRender: () => (
-          <Checkbox
-            aria-label={t("models_page.select_all_visible_models")}
-            checked={allVisibleModelsSelected}
-            indeterminate={someVisibleModelsSelected && !allVisibleModelsSelected}
-            disabled={filteredModelIds.length === 0}
-            onCheckedChange={toggleVisibleModelSelection}
-          />
-        ),
-        render: (row) => (
-          <Checkbox
-            aria-label={t("models_page.select_model_aria", { model: row.id })}
-            checked={selectedModelIds.has(row.id)}
-            onCheckedChange={(checked) => toggleModelSelection(row.id, checked)}
-          />
-        ),
-      },
+      ...(canDeleteModels
+        ? [
+            {
+              key: "select",
+              label: "",
+              width: "w-12",
+              headerClassName: "text-center",
+              cellClassName: "text-center",
+              headerRender: () => (
+                <Checkbox
+                  aria-label={t("models_page.select_all_visible_models")}
+                  checked={allVisibleModelsSelected}
+                  indeterminate={someVisibleModelsSelected && !allVisibleModelsSelected}
+                  disabled={filteredModelIds.length === 0}
+                  onCheckedChange={toggleVisibleModelSelection}
+                />
+              ),
+              render: (row) => (
+                <Checkbox
+                  aria-label={t("models_page.select_model_aria", { model: row.id })}
+                  checked={selectedModelIds.has(row.id)}
+                  onCheckedChange={(checked) => toggleModelSelection(row.id, checked)}
+                />
+              ),
+            } satisfies VirtualTableColumn<ModelItem>,
+          ]
+        : []),
       {
         key: "model",
         label: t("models_page.col_model"),
@@ -1141,21 +1147,24 @@ export function ModelsPage() {
             >
               <Edit3 size={14} />
             </Button>
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => setDeleteTarget(row)}
-              aria-label={t("models_page.delete_model_aria", { model: row.id })}
-              title={t("models_page.delete_model_aria", { model: row.id })}
-            >
-              <Trash2 size={14} />
-            </Button>
+            {canDeleteModels ? (
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => setDeleteTarget(row)}
+                aria-label={t("models_page.delete_model_aria", { model: row.id })}
+                title={t("models_page.delete_model_aria", { model: row.id })}
+              >
+                <Trash2 size={14} />
+              </Button>
+            ) : null}
           </div>
         ),
       },
     ],
     [
       allVisibleModelsSelected,
+      canDeleteModels,
       filteredModelIds.length,
       openEditModel,
       selectedModelIds,
@@ -1167,7 +1176,7 @@ export function ModelsPage() {
   );
 
   const selectionToolbar =
-    selectedModelCount > 0 ? (
+    canDeleteModels && selectedModelCount > 0 ? (
       <>
         <span className="inline-flex h-8 items-center rounded-full bg-slate-100 px-3 text-xs font-semibold text-slate-600 dark:bg-white/[0.08] dark:text-white/65">
           {t("models_page.selected_models_count", { count: selectedModelCount })}

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -143,6 +143,16 @@ describe("ModelsPage", () => {
     expect(screen.queryByText("seed-only-model")).not.toBeInTheDocument();
   });
 
+  test("renders active models as an availability list without deletion selection controls", async () => {
+    renderPage();
+
+    expect(await screen.findByText("gpt-image-2")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Select all visible models")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Select gpt-image-2")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete gpt-image-2" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Delete selected/ })).not.toBeInTheDocument();
+  });
+
   test("filters current models by auth-file model owner group mapping", async () => {
     window.localStorage.setItem(
       "authFilesPage.modelOwnerGroupMap.v1",
@@ -433,19 +443,20 @@ describe("ModelsPage", () => {
   test("deletes a model only after confirmation", async () => {
     renderPage();
 
-    expect(await screen.findByText("gpt-image-2")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /delete gpt-image-2/i }));
+    await userEvent.click(await screen.findByRole("tab", { name: /model library/i }));
+    expect(await screen.findByText("seed-only-model")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /delete seed-only-model/i }));
 
     const confirmDialog = await screen.findByRole("dialog", {
       name: /delete model configuration/i,
     });
-    expect(within(confirmDialog).getByText(/gpt-image-2/)).toBeInTheDocument();
+    expect(within(confirmDialog).getByText(/seed-only-model/)).toBeInTheDocument();
 
     await userEvent.click(within(confirmDialog).getByRole("button", { name: /^delete$/i }));
 
     await waitFor(() => {
-      expect(mocks.apiDelete).toHaveBeenCalledWith("/model-configs/gpt-image-2");
-      expect(screen.queryByText("gpt-image-2")).not.toBeInTheDocument();
+      expect(mocks.apiDelete).toHaveBeenCalledWith("/model-configs/seed-only-model");
+      expect(screen.queryByText("seed-only-model")).not.toBeInTheDocument();
     });
   });
 

--- a/src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   getCodexConfigs: vi.fn(async () => []),
   getVertexConfigs: vi.fn(async () => []),
   getBedrockConfigs: vi.fn(async () => []),
-  getOpenCodeGoConfigs: vi.fn(async () => []),
+  getOpenCodeGoConfigs: vi.fn(async (): Promise<any[]> => []),
   getOpenAIProviders: vi.fn(async () => []),
   saveOpenCodeGoConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   apiCallRequest: vi.fn(async (_payload: unknown) => ({
@@ -140,6 +140,47 @@ describe("ProvidersPage OpenCode Go tab", () => {
       ]);
     });
     expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty("baseUrl");
+  });
+
+  test("keeps failed OpenCode Go saves out of the rendered provider list", async () => {
+    const user = userEvent.setup();
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "Existing OpenCode Go",
+        apiKey: "sk-existing-opencode-go",
+      },
+    ]);
+    mocks.saveOpenCodeGoConfigs.mockRejectedValue(new Error("channel name already used"));
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/opencode-go/new"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Existing OpenCode Go")).toBeInTheDocument();
+    const dialog = await screen.findByRole("dialog", { name: /Add OpenCode Go configuration/i });
+
+    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "New OpenCode Go");
+    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-new-opencode-go");
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => {
+      expect(mocks.saveOpenCodeGoConfigs).toHaveBeenCalledWith([
+        expect.objectContaining({ name: "Existing OpenCode Go" }),
+        expect.objectContaining({ name: "New OpenCode Go" }),
+      ]);
+    });
+    expect(screen.queryByText("New OpenCode Go")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /Add OpenCode Go configuration/i }),
+    ).toBeInTheDocument();
   });
 
   test("uses fixed tabs and saves OpenCode Go model exclusions from fetched models", async () => {

--- a/src/modules/providers/hooks/useProviderKeyEditor.ts
+++ b/src/modules/providers/hooks/useProviderKeyEditor.ts
@@ -181,28 +181,28 @@ export function useProviderKeyEditor({
     try {
       if (type === "gemini") {
         const next = apply(geminiKeys);
-        setGeminiKeys(next);
         await providersApi.saveGeminiKeys(next);
+        setGeminiKeys(next);
       } else if (type === "claude") {
         const next = apply(claudeKeys);
-        setClaudeKeys(next);
         await providersApi.saveClaudeConfigs(next);
+        setClaudeKeys(next);
       } else if (type === "codex") {
         const next = apply(codexKeys);
-        setCodexKeys(next);
         await providersApi.saveCodexConfigs(next);
+        setCodexKeys(next);
       } else if (type === "opencode-go") {
         const next = apply(openCodeGoKeys);
-        setOpenCodeGoKeys(next);
         await providersApi.saveOpenCodeGoConfigs(next);
+        setOpenCodeGoKeys(next);
       } else if (type === "vertex") {
         const next = apply(vertexKeys);
-        setVertexKeys(next);
         await providersApi.saveVertexConfigs(next);
+        setVertexKeys(next);
       } else {
         const next = apply(bedrockKeys) as BedrockProviderConfig[];
-        setBedrockKeys(next);
         await providersApi.saveBedrockConfigs(next);
+        setBedrockKeys(next);
       }
       notify({ type: "success", message: t("providers.saved") });
       closeKeyEditor();


### PR DESCRIPTION
## Summary
- Hide selection and deletion controls from the active models availability list while keeping model library deletion behavior.
- Filter OAuth-backed OpenCode Go auth-file rows out of provider config saves.
- Avoid optimistic local provider list updates until save APIs succeed, so failed saves do not appear as saved behind the modal.

## Test Plan
- bunx oxfmt src/lib/http/apis/__tests__/providers-opencode-go.test.ts src/lib/http/apis/providers.ts src/modules/models/ModelsPage.tsx src/modules/models/__tests__/ModelsPage.test.tsx src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx src/modules/providers/hooks/useProviderKeyEditor.ts --check
- bun run lint
- bun run build
- bun run test
- bun run bundle:diff
