### PR TITLE
Filter OAuth rows from provider config APIs

### DIFF
--- a/src/lib/http/apis/__tests__/providers-opencode-go.test.ts
+++ b/src/lib/http/apis/__tests__/providers-opencode-go.test.ts
@@ -115,4 +115,90 @@ describe("providersApi OpenCode Go", () => {
       params: { "api-key": "sk-go" },
     });
   });
+
+  test("ignores OAuth auth-file rows from every provider config endpoint", async () => {
+    const { providersApi } = await import("@/lib/http/apis/providers");
+    const oauthRow = {
+      name: "yuan364299311@gmail.com",
+      "api-key": "oauth-backed-token",
+      account_type: "oauth",
+      type: "claude",
+    };
+    const runtimeOnlyRow = {
+      name: "runtime-only-channel",
+      "api-key": "runtime-backed-token",
+      runtime_only: true,
+    };
+
+    getMock.mockImplementation(async (path: string) => {
+      if (path === "/gemini-api-key") {
+        return {
+          "gemini-api-key": [{ name: "Gemini API", "api-key": "sk-gemini" }, oauthRow],
+        };
+      }
+      if (path === "/codex-api-key") {
+        return {
+          "codex-api-key": [{ name: "Codex API", "api-key": "sk-codex" }, oauthRow],
+        };
+      }
+      if (path === "/claude-api-key") {
+        return {
+          "claude-api-key": [
+            { name: "Claude API", "api-key": "sk-claude" },
+            oauthRow,
+            runtimeOnlyRow,
+          ],
+        };
+      }
+      if (path === "/vertex-api-key") {
+        return {
+          "vertex-api-key": [{ name: "Vertex API", "api-key": "sk-vertex" }, oauthRow],
+        };
+      }
+      if (path === "/bedrock-api-key") {
+        return {
+          "bedrock-api-key": [
+            { name: "Bedrock API", "api-key": "sk-bedrock", "auth-mode": "api-key" },
+            oauthRow,
+          ],
+        };
+      }
+      if (path === "/openai-compatibility") {
+        return {
+          "openai-compatibility": [
+            {
+              name: "OpenAI compatible API",
+              "base-url": "https://example.com/v1",
+              "api-key-entries": [{ "api-key": "sk-openai" }],
+            },
+            oauthRow,
+          ],
+        };
+      }
+      return {};
+    });
+
+    await expect(providersApi.getGeminiKeys()).resolves.toEqual([
+      { name: "Gemini API", apiKey: "sk-gemini" },
+    ]);
+    await expect(providersApi.getCodexConfigs()).resolves.toEqual([
+      { name: "Codex API", apiKey: "sk-codex" },
+    ]);
+    await expect(providersApi.getClaudeConfigs()).resolves.toEqual([
+      { name: "Claude API", apiKey: "sk-claude" },
+    ]);
+    await expect(providersApi.getVertexConfigs()).resolves.toEqual([
+      { name: "Vertex API", apiKey: "sk-vertex" },
+    ]);
+    await expect(providersApi.getBedrockConfigs()).resolves.toEqual([
+      { name: "Bedrock API", apiKey: "sk-bedrock", authMode: "api-key" },
+    ]);
+    await expect(providersApi.getOpenAIProviders()).resolves.toEqual([
+      {
+        name: "OpenAI compatible API",
+        baseUrl: "https://example.com/v1",
+        apiKeyEntries: [{ apiKey: "sk-openai" }],
+      },
+    ]);
+  });
 });

--- a/src/lib/http/apis/providers.ts
+++ b/src/lib/http/apis/providers.ts
@@ -25,7 +25,10 @@ const isOauthBackedProviderRow = (item: Record<string, unknown>): boolean => {
   if (accountType === "oauth") return true;
 
   const runtimeOnly = item.runtime_only ?? item.runtimeOnly;
-  return runtimeOnly === true || (typeof runtimeOnly === "string" && runtimeOnly === "true");
+  return (
+    runtimeOnly === true ||
+    (typeof runtimeOnly === "string" && runtimeOnly.trim().toLowerCase() === "true")
+  );
 };
 
 export const providersApi = {
@@ -35,6 +38,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const apiKey = normalizeString(item["api-key"] ?? item.apiKey) ?? "";
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
@@ -75,6 +79,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const apiKey = normalizeString(item["api-key"] ?? item.apiKey) ?? "";
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
@@ -156,6 +161,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const apiKey = normalizeString(item["api-key"] ?? item.apiKey) ?? "";
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
@@ -201,6 +207,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const rawMode = normalizeString(item["auth-mode"] ?? item.authMode) ?? "sigv4";
         const authMode: BedrockAuthMode =
           rawMode === "apikey" || rawMode === "api_key" || rawMode === "api-key"
@@ -262,6 +269,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const apiKey = normalizeString(item["api-key"] ?? item.apiKey) ?? "";
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
@@ -300,6 +308,7 @@ export const providersApi = {
     return list
       .map((item) => {
         if (!isRecord(item)) return null;
+        if (isOauthBackedProviderRow(item)) return null;
         const name = normalizeString(item.name) ?? "";
         if (!name) return null;
         const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;


### PR DESCRIPTION
## Summary
- Filter OAuth-backed and runtime-only auth-file rows from every provider config getter before UI state can save them back.
- Extend coverage across Gemini, Codex, Claude, OpenCode Go, Vertex, Bedrock, and OpenAI-compatible provider endpoints.

## Test Plan
- bunx oxfmt src/lib/http/apis/__tests__/providers-opencode-go.test.ts src/lib/http/apis/providers.ts --check
- bun run lint
- bun run build
- bun run test
- bun run bundle:diff
