### PR TITLE
为 MiMo 模型添加官方品牌图标和紫色配色

### DIFF
--- a/src/assets/icons/mimo.svg
+++ b/src/assets/icons/mimo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" style="flex:none;line-height:1" fill="currentColor">
+  <title>MiMo</title>
+  <path d="M12 1.5C17.5 1.5 19.5 1.5 21 3C22.5 4.5 22.5 6.5 22.5 12C22.5 17.5 22.5 19.5 21 21C19.5 22.5 17.5 22.5 12 22.5C6.5 22.5 4.5 22.5 3 21C1.5 19.5 1.5 17.5 1.5 12C1.5 6.5 1.5 4.5 3 3C4.5 1.5 6.5 1.5 12 1.5Z" />
+</svg>

--- a/src/modules/system/SystemPage.tsx
+++ b/src/modules/system/SystemPage.tsx
@@ -37,6 +37,7 @@ import iconGlm from "@/assets/icons/glm.svg";
 import iconKiro from "@/assets/icons/kiro.svg";
 import iconVertex from "@/assets/icons/vertex.svg";
 import iconIflow from "@/assets/icons/iflow.svg";
+import iconMimo from "@/assets/icons/mimo.svg";
 
 /* ═══════════════════════════════════════════════════════════
    Helpers
@@ -148,6 +149,11 @@ const VENDOR_COLORS: Record<string, { bg: string; text: string; border: string }
     text: "text-amber-700 dark:text-amber-300",
     border: "border-amber-200/60 dark:border-amber-800/30",
   },
+  mimo: {
+    bg: "bg-purple-50 dark:bg-purple-950/20",
+    text: "text-purple-700 dark:text-purple-300",
+    border: "border-purple-200/60 dark:border-purple-800/30",
+  },
 };
 
 const DEFAULT_VENDOR = {
@@ -174,6 +180,7 @@ const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
   kiro: { light: iconKiro, dark: iconKiro },
   vertex: { light: iconVertex, dark: iconVertex },
   iflow: { light: iconIflow, dark: iconIflow },
+  mimo: { light: iconMimo, dark: iconMimo },
 };
 
 function getVendorColor(modelId: string) {


### PR DESCRIPTION
## Summary
- 基于官方 MiMo favicon 创建 SVG 图标 (`src/assets/icons/mimo.svg`)
- 在 SystemPage 中注册 `mimo` 厂商前缀的配色（purple）和图标映射
- 使 mimo-v2-omni / mimo-v2-pro / mimo-v2.5 / mimo-v2.5-pro 等模型能正确显示品牌图标

## Test plan
- [ ] 管理/系统页面中 MiMo 模型（mimo-v2-omni 等）显示紫色标签配官方图标
- [ ] 暗色模式下图标和配色正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)