### PR TITLE
fix: 将 MiMo 官方图标改为文字 logo（MiMo）

### DIFF
--- a/src/assets/icons/mimo.svg
+++ b/src/assets/icons/mimo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="1em" height="1em" style="flex:none;line-height:1" fill="currentColor">
   <title>MiMo</title>
-  <path d="M12 1.5C17.5 1.5 19.5 1.5 21 3C22.5 4.5 22.5 6.5 22.5 12C22.5 17.5 22.5 19.5 21 21C19.5 22.5 17.5 22.5 12 22.5C6.5 22.5 4.5 22.5 3 21C1.5 19.5 1.5 17.5 1.5 12C1.5 6.5 1.5 4.5 3 3C4.5 1.5 6.5 1.5 12 1.5Z" />
+  <text x="12" y="16" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-weight="700" font-size="10">MiMo</text>
 </svg>


### PR DESCRIPTION
## 修复内容
- 官方的 MiMo logo 是 "MiMo" 文字本身，之前错误地创建了一个臆造的圆角方形 SVG
- 将 SVG 替换为 "MiMo" 文字 logo，忠实于官方设计

## 改动文件
- `src/assets/icons/mimo.svg`：从圆角方形路径改为 "MiMo" 文字

🤖 Generated with [Claude Code](https://claude.com/claude-code)