### PR TITLE
fix: 调整请求日志表格状态列宽度和对齐方式

### DIFF
--- a/src/modules/monitor/requestLogsShared.tsx
+++ b/src/modules/monitor/requestLogsShared.tsx
@@ -274,7 +274,9 @@ export function buildRequestLogsColumns(
     {
       key: "status",
       label: t("request_logs.col_status"),
-      width: "w-20",
+      width: "w-28",
+      headerClassName: "text-center",
+      cellClassName: "text-center",
       render: (row) =>
         row.failed ? (
           <button


### PR DESCRIPTION
## 改动内容
修复 monitor/request-logs 页面表格中状态列内容被遮挡的问题，并让列标题和内容水平居中。

## 修改
- 状态列宽度 `w-20` (80px) → `w-28` (112px)，给状态徽章足够的显示空间
- 列标题添加 `text-center` 水平居中
- 单元格内容添加 `text-center` 水平居中

## 修改文件
| 文件 | 改动说明 |
|------|---------|
| `src/modules/monitor/requestLogsShared.tsx` | 状态列宽度和居中样式调整 |

## 验证状态
- [x] 编译通过
- [ ] 测试通过（可选）

🤖 Generated with [Claude Code](https://claude.com/claude-code)