### PR TITLE
fix: auth file quota refresh button always show loading state

### DIFF
--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -541,7 +541,6 @@ export function AuthFilesFilesTab({
                   const quotaRefreshing = provider
                     ? quotaByFileName[file.name]?.status === "loading"
                     : false;
-                  const quotaAutoRefreshing = quotaAutoRefreshingRef.current.has(file.name);
                   const showSelectionControl = fileSelected;
 
                   return (
@@ -664,13 +663,10 @@ export function AuthFilesFilesTab({
                                 onClick={() => void refreshQuota(file, provider)}
                                 title={t("common.refresh")}
                                 aria-label={t("common.refresh")}
-                                disabled={quotaRefreshing}
                               >
                                 <RefreshCw
                                   size={16}
-                                  className={
-                                    quotaRefreshing && !quotaAutoRefreshing ? "animate-spin" : ""
-                                  }
+                                  className={quotaRefreshing ? "animate-spin" : ""}
                                 />
                               </Button>
                             </HoverTooltip>

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -676,7 +676,6 @@ export function useAuthFilesFilesPresentation({
           const quotaRefreshing = quotaProvider
             ? quotaByFileName[file.name]?.status === "loading"
             : false;
-          const quotaAutoRefreshing = quotaAutoRefreshingRef.current.has(file.name);
 
           return (
             <div className="inline-flex flex-wrap items-center justify-center gap-1">
@@ -688,11 +687,10 @@ export function useAuthFilesFilesPresentation({
                     onClick={() => void refreshQuota(file, quotaProvider)}
                     title={t("common.refresh")}
                     aria-label={t("common.refresh")}
-                    disabled={quotaRefreshing}
                   >
                     <RefreshCw
                       size={16}
-                      className={quotaRefreshing && !quotaAutoRefreshing ? "animate-spin" : ""}
+                      className={quotaRefreshing ? "animate-spin" : ""}
                     />
                   </Button>
                 </HoverTooltip>


### PR DESCRIPTION
## Summary
- 修复 auth files 页面额度刷新按钮在自动刷新期间不显示 spinner 动画
- 移除自动刷新期间对按钮的 disabled 限制，用户始终可手动点击刷新

## Changes
- spinner 动画不再被 auto-refresh 状态抑制
- 移除按钮 disabled 属性，允许手动刷新覆盖自动刷新

## Test plan
- [ ] 在 auth-files 页面观察刷新按钮，自动刷新期间应显示旋转动画
- [ ] 自动刷新期间可手动点击刷新按钮