### PR TITLE
fix: force all visible auth-file quota cards to refresh on any click

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -285,6 +285,7 @@ export function AuthFilesPage() {
     refreshQuota,
     checkAuthFileConnectivity,
     collectQuotaFetchTargets,
+    forceRefreshPage,
     runQuotaRefreshBatch,
     quotaLastUpdatedText,
   } = useAuthFilesQuotaState({
@@ -374,6 +375,7 @@ export function AuthFilesPage() {
     quotaByFileName,
     quotaAutoRefreshingRef,
     refreshQuota,
+    forceRefreshPage,
     openDetail: openDetailWithQuotaRefresh,
     downloadAuthFile,
     statusUpdating,
@@ -440,6 +442,7 @@ export function AuthFilesPage() {
             resolveQuotaCardSlots={resolveQuotaCardSlots}
             quotaAutoRefreshingRef={quotaAutoRefreshingRef}
             refreshQuota={refreshQuota}
+            forceRefreshPage={forceRefreshPage}
             setFileEnabled={setFileEnabled}
             statusUpdating={statusUpdating}
             usageIndex={usageIndex}

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -94,6 +94,7 @@ interface AuthFilesFilesTabProps {
   ) => { id: string; label: string; item: QuotaItem | null }[];
   quotaAutoRefreshingRef: RefObject<Set<string>>;
   refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
+  forceRefreshPage: () => Promise<void>;
   setFileEnabled: (file: AuthFileItem, enabled: boolean) => Promise<void>;
   statusUpdating: Record<string, boolean>;
   usageIndex: UsageIndex;
@@ -163,6 +164,7 @@ export function AuthFilesFilesTab({
   resolveQuotaCardSlots,
   quotaAutoRefreshingRef,
   refreshQuota,
+  forceRefreshPage,
   setFileEnabled,
   statusUpdating,
   usageIndex,
@@ -660,7 +662,7 @@ export function AuthFilesFilesTab({
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => void refreshQuota(file, provider)}
+                                onClick={() => void forceRefreshPage()}
                                 title={t("common.refresh")}
                                 aria-label={t("common.refresh")}
                               >

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -113,6 +113,7 @@ interface UseAuthFilesFilesPresentationOptions {
   quotaByFileName: Record<string, QuotaState>;
   quotaAutoRefreshingRef: RefObject<Set<string>>;
   refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
+  forceRefreshPage: () => Promise<void>;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
   statusUpdating: Record<string, boolean>;
@@ -137,6 +138,7 @@ export function useAuthFilesFilesPresentation({
   quotaByFileName,
   quotaAutoRefreshingRef,
   refreshQuota,
+  forceRefreshPage,
   openDetail,
   downloadAuthFile,
   statusUpdating,
@@ -684,7 +686,7 @@ export function useAuthFilesFilesPresentation({
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => void refreshQuota(file, quotaProvider)}
+                    onClick={() => void forceRefreshPage()}
                     title={t("common.refresh")}
                     aria-label={t("common.refresh")}
                   >

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -414,6 +414,19 @@ export function useAuthFilesQuotaState({
     const toFetch = collectQuotaFetchTargets(pageItems);
     if (!toFetch.length) return;
 
+    setQuotaByFileName((prev) => {
+      const next = { ...prev };
+      for (const item of pageItems) {
+        next[item.name] = {
+          status: "loading",
+          items: prev[item.name]?.items ?? [],
+          error: prev[item.name]?.error,
+          updatedAt: prev[item.name]?.updatedAt,
+        };
+      }
+      return next;
+    });
+
     let cancelled = false;
     void (async () => {
       if (!cancelled) {
@@ -451,8 +464,50 @@ export function useAuthFilesQuotaState({
     const candidates = collectQuotaFetchTargets(pageItems);
     if (!candidates.length) return;
 
+    setQuotaByFileName((prev) => {
+      const next = { ...prev };
+      for (const item of pageItems) {
+        next[item.name] = {
+          status: "loading",
+          items: prev[item.name]?.items ?? [],
+          error: prev[item.name]?.error,
+          updatedAt: prev[item.name]?.updatedAt,
+        };
+      }
+      return next;
+    });
+
     await runQuotaRefreshBatch(candidates, { markAsAutoRefreshing: true });
   }, [collectQuotaFetchTargets, loading, pageItems, runQuotaRefreshBatch, tab]);
+
+  const forceRefreshPage = useCallback(async () => {
+    if (tab !== "files") return;
+    if (loading) return;
+
+    const targets = pageItems
+      .map((file) => {
+        const provider = resolveQuotaProvider(file);
+        return provider ? { file, provider } : null;
+      })
+      .filter(Boolean) as { file: AuthFileItem; provider: QuotaProvider }[];
+
+    if (!targets.length) return;
+
+    setQuotaByFileName((prev) => {
+      const next = { ...prev };
+      for (const item of pageItems) {
+        next[item.name] = {
+          status: "loading",
+          items: prev[item.name]?.items ?? [],
+          error: prev[item.name]?.error,
+          updatedAt: prev[item.name]?.updatedAt,
+        };
+      }
+      return next;
+    });
+
+    await runQuotaRefreshBatch(targets, { markAsAutoRefreshing: true });
+  }, [loading, pageItems, runQuotaRefreshBatch, tab]);
 
   useInterval(
     () => {
@@ -476,6 +531,7 @@ export function useAuthFilesQuotaState({
     refreshQuota,
     checkAuthFileConnectivity,
     collectQuotaFetchTargets,
+    forceRefreshPage,
     runQuotaRefreshBatch,
     quotaLastUpdatedText,
   };


### PR DESCRIPTION
## Summary

- Previously, clicking a single card's refresh button only refreshed that one file. All other cards on the page showed no activity.
- Now clicking any individual refresh button forces ALL quota-supported files on the current page to show loading and refresh immediately.
- Page navigation (auto-refresh effect and interval) also now sets all visible items to loading before fetching.

## Changes

- Added `forceRefreshPage` function in `useAuthFilesQuotaState` that sets all page items to loading, then runs `runQuotaRefreshBatch` for all quota-supported targets
- Wired `forceRefreshPage` through `AuthFilesPage` → presentation hook + tab component
- Replaced `refreshQuota(file, provider)` calls in both table and cards view with `forceRefreshPage()`
- Auto-refresh effect and interval also now set all visible items to loading before fetching

## Test plan

- [ ] Click individual card refresh button → all cards on page show spinner and refresh
- [ ] Navigate to next page → all cards show loading while auto-refreshing
- [ ] Verify existing `openDetailWithQuotaRefresh` still works (uses `refreshQuota` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)