### PR TITLE
fix: refresh auth file quota from toolbar

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -273,7 +273,6 @@ export function AuthFilesPage() {
   const {
     connectivityState,
     quotaByFileName,
-    quotaAutoRefreshingRef,
     nowMs,
     quotaPreviewMode,
     setQuotaPreviewMode,
@@ -309,6 +308,12 @@ export function AuthFilesPage() {
     },
     [openDetail, refreshDetailTrend, refreshQuota],
   );
+
+  const refreshFilesAndQuota = useCallback(async () => {
+    const quotaRefreshPromise = forceRefreshPage();
+    const filesRefreshPromise = loadAll();
+    await Promise.all([filesRefreshPromise, quotaRefreshPromise]);
+  }, [forceRefreshPage, loadAll]);
 
   const {
     groupOverviewOpen,
@@ -373,8 +378,6 @@ export function AuthFilesPage() {
     connectivityState,
     checkAuthFileConnectivity,
     quotaByFileName,
-    quotaAutoRefreshingRef,
-    refreshQuota,
     forceRefreshPage,
     openDetail: openDetailWithQuotaRefresh,
     downloadAuthFile,
@@ -416,7 +419,7 @@ export function AuthFilesPage() {
             openGroupOverview={openGroupOverview}
             groupOverviewLoading={groupOverviewLoading}
             filteredFiles={filteredFiles}
-            loadAll={loadAll}
+            refreshFilesAndQuota={refreshFilesAndQuota}
             usageLoading={usageLoading}
             refreshingAll={refreshingAll}
             uploading={uploading}
@@ -440,8 +443,6 @@ export function AuthFilesPage() {
             quotaByFileName={quotaByFileName}
             resolveQuotaProvider={resolveQuotaProvider}
             resolveQuotaCardSlots={resolveQuotaCardSlots}
-            quotaAutoRefreshingRef={quotaAutoRefreshingRef}
-            refreshQuota={refreshQuota}
             forceRefreshPage={forceRefreshPage}
             setFileEnabled={setFileEnabled}
             statusUpdating={statusUpdating}

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -847,6 +847,115 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("44%")).toBeInTheDocument();
   });
 
+  test("toolbar refresh immediately spins the visible card quota refresh action", async () => {
+    const now = Date.now();
+    const file = {
+      name: "codex.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "1",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 22, resetAtMs: now + 60_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const cards = await screen.findByTestId("auth-files-cards");
+    const toolbarRefreshButton = screen.getAllByRole("button", { name: "Refresh" })[0];
+    await waitFor(() => expect(toolbarRefreshButton).toBeEnabled());
+
+    fireEvent.click(toolbarRefreshButton);
+
+    const cardRefreshButton = within(cards).getByRole("button", { name: "Refresh" });
+    await waitFor(() => expect(cardRefreshButton.querySelector("svg")).toHaveClass("animate-spin"));
+  });
+
+  test("toolbar refresh immediately spins the visible table quota refresh action", async () => {
+    const now = Date.now();
+    const file = {
+      name: "codex-table.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "3",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
+
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex-table.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 64, resetAtMs: now + 60_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-table.json")).toBeInTheDocument();
+    const toolbarRefreshButton = screen.getAllByRole("button", { name: "Refresh" })[0];
+    await waitFor(() => expect(toolbarRefreshButton).toBeEnabled());
+
+    fireEvent.click(toolbarRefreshButton);
+
+    const row = screen.getByText("codex-table.json").closest("tr");
+    expect(row).not.toBeNull();
+    const rowRefreshButton = within(row as HTMLElement).getByRole("button", { name: "Refresh" });
+    await waitFor(() => expect(rowRefreshButton.querySelector("svg")).toHaveClass("animate-spin"));
+  });
+
   test("cards view includes returned codex review 5h and additional quota bars", async () => {
     const now = Date.now();
     const file = {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -65,7 +65,7 @@ interface AuthFilesFilesTabProps {
   openGroupOverview: () => void;
   groupOverviewLoading: boolean;
   filteredFiles: AuthFileItem[];
-  loadAll: () => Promise<AuthFileItem[]>;
+  refreshFilesAndQuota: () => Promise<void>;
   usageLoading: boolean;
   refreshingAll: boolean;
   uploading: boolean;
@@ -92,8 +92,6 @@ interface AuthFilesFilesTabProps {
     provider: QuotaProvider,
     items: QuotaItem[],
   ) => { id: string; label: string; item: QuotaItem | null }[];
-  quotaAutoRefreshingRef: RefObject<Set<string>>;
-  refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   forceRefreshPage: () => Promise<void>;
   setFileEnabled: (file: AuthFileItem, enabled: boolean) => Promise<void>;
   statusUpdating: Record<string, boolean>;
@@ -138,7 +136,7 @@ export function AuthFilesFilesTab({
   openGroupOverview,
   groupOverviewLoading,
   filteredFiles,
-  loadAll,
+  refreshFilesAndQuota,
   usageLoading,
   refreshingAll,
   uploading,
@@ -162,8 +160,6 @@ export function AuthFilesFilesTab({
   quotaByFileName,
   resolveQuotaProvider,
   resolveQuotaCardSlots,
-  quotaAutoRefreshingRef,
-  refreshQuota,
   forceRefreshPage,
   setFileEnabled,
   statusUpdating,
@@ -365,7 +361,7 @@ export function AuthFilesFilesTab({
                   <Button
                     variant="secondary"
                     size="sm"
-                    onClick={() => void loadAll()}
+                    onClick={() => void refreshFilesAndQuota()}
                     disabled={loading || usageLoading || refreshingAll}
                     aria-label={t("auth_files.refresh")}
                     title={t("auth_files.refresh")}

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type ReactNode, type RefObject } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { CalendarClock, Download, Eye, Loader2, RefreshCw, Zap } from "lucide-react";
 import type { AuthFileItem } from "@/lib/http/types";
@@ -27,7 +27,7 @@ import {
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
-import { resolveQuotaProvider, type QuotaProvider } from "@/modules/quota/quota-fetch";
+import { resolveQuotaProvider } from "@/modules/quota/quota-fetch";
 import { clampPercent, type QuotaItem, type QuotaState } from "@/modules/quota/quota-helpers";
 
 const KNOWN_QUOTA_TEXT_KEYS = new Set([
@@ -111,8 +111,6 @@ interface UseAuthFilesFilesPresentationOptions {
   connectivityState: Map<string, { loading: boolean; latencyMs: number | null; error: boolean }>;
   checkAuthFileConnectivity: (name: string) => Promise<void>;
   quotaByFileName: Record<string, QuotaState>;
-  quotaAutoRefreshingRef: RefObject<Set<string>>;
-  refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   forceRefreshPage: () => Promise<void>;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
@@ -136,8 +134,6 @@ export function useAuthFilesFilesPresentation({
   connectivityState,
   checkAuthFileConnectivity,
   quotaByFileName,
-  quotaAutoRefreshingRef,
-  refreshQuota,
   forceRefreshPage,
   openDetail,
   downloadAuthFile,
@@ -690,10 +686,7 @@ export function useAuthFilesFilesPresentation({
                     title={t("common.refresh")}
                     aria-label={t("common.refresh")}
                   >
-                    <RefreshCw
-                      size={16}
-                      className={quotaRefreshing ? "animate-spin" : ""}
-                    />
+                    <RefreshCw size={16} className={quotaRefreshing ? "animate-spin" : ""} />
                   </Button>
                 </HoverTooltip>
               ) : null}
@@ -733,12 +726,11 @@ export function useAuthFilesFilesPresentation({
     downloadAuthFile,
     formatPlanTypeLabel,
     formatQuotaResetTextCompact,
+    forceRefreshPage,
     openDetail,
-    quotaAutoRefreshingRef,
     quotaByFileName,
     quotaPreviewMode,
     quotaProgressCircle,
-    refreshQuota,
     renderSubscriptionBadge,
     selectCurrentPage,
     selectablePageNames.length,


### PR DESCRIPTION
## Summary
- make the Auth Files toolbar refresh also trigger the currently visible quota refresh state
- keep table action columns wired to the current force refresh callback
- add card and table regression tests for immediate refresh icon loading

## Verification
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run lint
- bun run build
- bun run check

Note: bunx oxfmt . --check reports existing unrelated formatting issues on origin/dev outside this change set; modified auth-files files are not listed.