### PR TITLE
fix: cache auth file plan badges

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1276,6 +1276,7 @@ describe("AuthFilesPage files table", () => {
           "codex.json": {
             status: "success",
             updatedAt: now,
+            planType: "free",
             items: [{ label: "m_quota.code_5h", percent: 20, resetAtMs: now + 30_000 }],
           },
         },
@@ -1303,6 +1304,64 @@ describe("AuthFilesPage files table", () => {
       (await screen.findAllByText((_, node) => node?.textContent?.includes("Plan Plus") ?? false))
         .length,
     ).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      const raw = window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
+      expect(raw).toContain('"planType":"plus"');
+    });
+  });
+
+  test("cards view uses cached quota plan badge instead of stale auth-file metadata", async () => {
+    const now = Date.now();
+    const staleFile = {
+      name: "codex.json",
+      label: "Codex Main",
+      account_type: "oauth",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "1",
+      plan_type: "plus",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [staleFile] }));
+    mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [staleFile],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex.json": {
+            status: "success",
+            updatedAt: now,
+            planType: "pro",
+            items: [{ label: "m_quota.code_5h", percent: 20, resetAtMs: now + 30_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Codex Main")).toBeInTheDocument();
+    expect(screen.getByText("Plan Pro")).toBeInTheDocument();
+    expect(screen.queryByText("Plan Plus")).not.toBeInTheDocument();
   });
 
   test("cards view exposes quota refresh for Anthropic OAuth files", async () => {

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -154,6 +154,7 @@ describe("Auth Files helper coverage", () => {
         "codex.json": {
           status: "success",
           updatedAt: 456,
+          planType: "pro",
           items: [{ label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
         },
       },
@@ -166,6 +167,7 @@ describe("Auth Files helper coverage", () => {
         "codex.json": {
           status: "success",
           updatedAt: 456,
+          planType: "pro",
           items: [{ label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
         },
       },

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -526,13 +526,13 @@ export function AuthFilesFilesTab({
                   const typeKey = resolveFileType(file);
                   const badgeClass = TYPE_BADGE_CLASSES[typeKey] ?? TYPE_BADGE_CLASSES.unknown;
                   const displayTitle = resolveAuthFileDisplayName(file) || String(file.name || "");
-                  const planType = resolveAuthFilePlanType(file);
+                  const provider = resolveQuotaProvider(file);
+                  const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
+                  const planType = resolveAuthFilePlanType(file, state);
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const totalCalls = stats.success + stats.failure;
 
-                  const provider = resolveQuotaProvider(file);
-                  const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
                   const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
                   const slots = provider ? resolveQuotaCardSlots(provider, items) : [];
 

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -7,6 +7,7 @@ import type {
 import { normalizeUsageSourceId, type KeyStatBucket } from "@/modules/providers/provider-usage";
 import type { QuotaItem, QuotaState, QuotaStatus } from "@/modules/quota/quota-helpers";
 import { resolveCodexPlanType } from "@/utils/quota/resolvers";
+import { normalizePlanType } from "@/utils/quota/parsers";
 import type { StatusBarData, StatusBlockDetail, StatusBlockState } from "@/utils/usage";
 
 export type AuthFileModelItem = {
@@ -211,10 +212,12 @@ const sanitizeQuotaByFileNameForCache = (
       typeof state.updatedAt === "number" && Number.isFinite(state.updatedAt)
         ? state.updatedAt
         : undefined;
+    const planType = normalizePlanType(state.planType ?? state.plan_type);
     const error = typeof state.error === "string" ? state.error : undefined;
     output[fileName] = {
       status: status === "loading" ? "success" : (status as QuotaStatus),
       items,
+      planType: planType ?? undefined,
       updatedAt,
       error: status === "error" ? error : undefined,
     };
@@ -525,8 +528,10 @@ export const authFilesSortCollator = new Intl.Collator("zh-Hans-CN", {
   sensitivity: "base",
 });
 
-export const resolveAuthFilePlanType = (file: AuthFileItem): string | null =>
-  resolveCodexPlanType(file);
+export const resolveAuthFilePlanType = (
+  file: AuthFileItem,
+  quotaState?: QuotaState | null,
+): string | null => normalizePlanType(quotaState?.planType) ?? resolveCodexPlanType(file);
 
 export const isRuntimeOnlyAuthFile = (file: AuthFileItem): boolean => {
   const raw = (file.runtime_only ?? file.runtimeOnly) as unknown;

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -434,7 +434,7 @@ export function useAuthFilesFilesPresentation({
         render: (file) => {
           const typeKey = resolveFileType(file);
           const badgeClass = TYPE_BADGE_CLASSES[typeKey] ?? TYPE_BADGE_CLASSES.unknown;
-          const planType = resolveAuthFilePlanType(file);
+          const planType = resolveAuthFilePlanType(file, quotaByFileName[file.name]);
           const runtimeOnly = isRuntimeOnlyAuthFile(file);
 
           return (

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -229,6 +229,7 @@ export function useAuthFilesQuotaState({
         [name]: {
           status: "loading",
           items: prev[name]?.items ?? [],
+          planType: prev[name]?.planType,
           error: prev[name]?.error,
           updatedAt: prev[name]?.updatedAt,
         },
@@ -285,7 +286,12 @@ export function useAuthFilesQuotaState({
         }
         setQuotaByFileName((prev) => ({
           ...prev,
-          [name]: { status: "success", items, updatedAt: Date.now() },
+          [name]: {
+            status: "success",
+            items,
+            planType: nextPlanType ?? prev[name]?.planType,
+            updatedAt: Date.now(),
+          },
         }));
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : t("auth_files.unknown_error");
@@ -294,6 +300,7 @@ export function useAuthFilesQuotaState({
           [name]: {
             status: "error",
             items: prev[name]?.items ?? [],
+            planType: prev[name]?.planType,
             error: message,
             updatedAt: Date.now(),
           },
@@ -420,6 +427,7 @@ export function useAuthFilesQuotaState({
         next[item.name] = {
           status: "loading",
           items: prev[item.name]?.items ?? [],
+          planType: prev[item.name]?.planType,
           error: prev[item.name]?.error,
           updatedAt: prev[item.name]?.updatedAt,
         };
@@ -470,6 +478,7 @@ export function useAuthFilesQuotaState({
         next[item.name] = {
           status: "loading",
           items: prev[item.name]?.items ?? [],
+          planType: prev[item.name]?.planType,
           error: prev[item.name]?.error,
           updatedAt: prev[item.name]?.updatedAt,
         };
@@ -499,6 +508,7 @@ export function useAuthFilesQuotaState({
         next[item.name] = {
           status: "loading",
           items: prev[item.name]?.items ?? [],
+          planType: prev[item.name]?.planType,
           error: prev[item.name]?.error,
           updatedAt: prev[item.name]?.updatedAt,
         };

--- a/src/modules/quota/quota-types.ts
+++ b/src/modules/quota/quota-types.ts
@@ -12,6 +12,7 @@ export type QuotaItem = {
 export type QuotaState = {
   status: QuotaStatus;
   items: QuotaItem[];
+  planType?: string;
   error?: string;
   updatedAt?: number;
 };


### PR DESCRIPTION
## Summary
- persist quota-derived planType in the auth-files quota cache
- render plan badges from cached quota planType before falling back to auth-file metadata
- preserve planType during loading/error states and update it after manual quota refresh

## Verification
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- bun run lint
- bunx oxfmt <changed auth-files/quota files> --check
- bun run build
- bun run check

Note: full bunx oxfmt . --check still reports 37 existing unrelated formatting issues on origin/dev; none are in this change set.