### PR TITLE
fix(auth-files): refresh selected quota only

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -378,7 +378,7 @@ export function AuthFilesPage() {
     connectivityState,
     checkAuthFileConnectivity,
     quotaByFileName,
-    forceRefreshPage,
+    refreshQuota,
     openDetail: openDetailWithQuotaRefresh,
     downloadAuthFile,
     statusUpdating,
@@ -443,7 +443,7 @@ export function AuthFilesPage() {
             quotaByFileName={quotaByFileName}
             resolveQuotaProvider={resolveQuotaProvider}
             resolveQuotaCardSlots={resolveQuotaCardSlots}
-            forceRefreshPage={forceRefreshPage}
+            refreshQuota={refreshQuota}
             setFileEnabled={setFileEnabled}
             statusUpdating={statusUpdating}
             usageIndex={usageIndex}

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -956,6 +956,156 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() => expect(rowRefreshButton.querySelector("svg")).toHaveClass("animate-spin"));
   });
 
+  test("cards view refresh action only refreshes the clicked auth file", async () => {
+    const now = Date.now();
+    const files = [
+      {
+        name: "codex-a.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "1",
+      },
+      {
+        name: "codex-b.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "2",
+      },
+    ] as any[];
+
+    mocks.list.mockImplementation(async () => ({ files }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
+    });
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files,
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex-a.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 22, resetAtMs: now + 30_000 }],
+          },
+          "codex-b.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 44, resetAtMs: now + 30_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-a.json")).toBeInTheDocument();
+    const cards = screen.getByTestId("auth-files-cards");
+    const firstCard = screen.getByText("codex-a.json").closest("section");
+    expect(firstCard).not.toBeNull();
+
+    fireEvent.click(within(firstCard as HTMLElement).getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
+    expect(mocks.fetchQuota).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ name: "codex-a.json" }),
+    );
+    expect(within(cards).getByText("codex-b.json")).toBeInTheDocument();
+  });
+
+  test("table refresh action only refreshes the clicked auth file", async () => {
+    const now = Date.now();
+    const files = [
+      {
+        name: "codex-a.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "1",
+      },
+      {
+        name: "codex-b.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "2",
+      },
+    ] as any[];
+
+    mocks.list.mockImplementation(async () => ({ files }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ label: "m_quota.code_5h", percent: 18, resetAtMs: now + 60_000 }],
+    });
+
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files,
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex-a.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 22, resetAtMs: now + 30_000 }],
+          },
+          "codex-b.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 44, resetAtMs: now + 30_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-a.json")).toBeInTheDocument();
+    const row = screen.getByText("codex-a.json").closest("tr");
+    expect(row).not.toBeNull();
+
+    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
+    expect(mocks.fetchQuota).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ name: "codex-a.json" }),
+    );
+    expect(screen.getByText("codex-b.json")).toBeInTheDocument();
+  });
+
   test("cards view includes returned codex review 5h and additional quota bars", async () => {
     const now = Date.now();
     const file = {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -92,7 +92,7 @@ interface AuthFilesFilesTabProps {
     provider: QuotaProvider,
     items: QuotaItem[],
   ) => { id: string; label: string; item: QuotaItem | null }[];
-  forceRefreshPage: () => Promise<void>;
+  refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   setFileEnabled: (file: AuthFileItem, enabled: boolean) => Promise<void>;
   statusUpdating: Record<string, boolean>;
   usageIndex: UsageIndex;
@@ -160,7 +160,7 @@ export function AuthFilesFilesTab({
   quotaByFileName,
   resolveQuotaProvider,
   resolveQuotaCardSlots,
-  forceRefreshPage,
+  refreshQuota,
   setFileEnabled,
   statusUpdating,
   usageIndex,
@@ -658,7 +658,7 @@ export function AuthFilesFilesTab({
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => void forceRefreshPage()}
+                                onClick={() => void refreshQuota(file, provider)}
                                 title={t("common.refresh")}
                                 aria-label={t("common.refresh")}
                               >

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -27,7 +27,7 @@ import {
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
-import { resolveQuotaProvider } from "@/modules/quota/quota-fetch";
+import { resolveQuotaProvider, type QuotaProvider } from "@/modules/quota/quota-fetch";
 import { clampPercent, type QuotaItem, type QuotaState } from "@/modules/quota/quota-helpers";
 
 const KNOWN_QUOTA_TEXT_KEYS = new Set([
@@ -111,7 +111,7 @@ interface UseAuthFilesFilesPresentationOptions {
   connectivityState: Map<string, { loading: boolean; latencyMs: number | null; error: boolean }>;
   checkAuthFileConnectivity: (name: string) => Promise<void>;
   quotaByFileName: Record<string, QuotaState>;
-  forceRefreshPage: () => Promise<void>;
+  refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
   statusUpdating: Record<string, boolean>;
@@ -134,7 +134,7 @@ export function useAuthFilesFilesPresentation({
   connectivityState,
   checkAuthFileConnectivity,
   quotaByFileName,
-  forceRefreshPage,
+  refreshQuota,
   openDetail,
   downloadAuthFile,
   statusUpdating,
@@ -682,7 +682,7 @@ export function useAuthFilesFilesPresentation({
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => void forceRefreshPage()}
+                    onClick={() => void refreshQuota(file, quotaProvider)}
                     title={t("common.refresh")}
                     aria-label={t("common.refresh")}
                   >
@@ -726,11 +726,11 @@ export function useAuthFilesFilesPresentation({
     downloadAuthFile,
     formatPlanTypeLabel,
     formatQuotaResetTextCompact,
-    forceRefreshPage,
     openDetail,
     quotaByFileName,
     quotaPreviewMode,
     quotaProgressCircle,
+    refreshQuota,
     renderSubscriptionBadge,
     selectCurrentPage,
     selectablePageNames.length,


### PR DESCRIPTION
## Summary
- make card and table row quota refresh buttons refresh only the clicked auth file
- keep page-level toolbar refresh as a full page quota refresh
- add regression coverage for card and table single-item refresh

## Tests
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "only refreshes the clicked auth file"
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bunx oxfmt src/modules/auth-files/AuthFilesPage.tsx src/modules/auth-files/components/AuthFilesFilesTab.tsx src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --check
- bun run lint
- bun run build
- bun run check