### PR TITLE
fix(auth-files): keep tab-switch quota refresh silent

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -5,7 +5,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { AuthFilesPage } from "@/modules/auth-files/AuthFilesPage";
-import { AUTH_FILES_DATA_CACHE_KEY } from "@/modules/auth-files/helpers/authFilesPageUtils";
+import {
+  AUTH_FILES_DATA_CACHE_KEY,
+  AUTH_FILES_UI_STATE_KEY,
+} from "@/modules/auth-files/helpers/authFilesPageUtils";
 import i18n from "@/i18n";
 
 const mocks = vi.hoisted(() => ({
@@ -845,6 +848,90 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
     expect(screen.getByText("22%")).toBeInTheDocument();
     expect(screen.getByText("44%")).toBeInTheDocument();
+  });
+
+  test("cards view does not spin card refresh actions for tab-switch background quota refresh", async () => {
+    const now = Date.now();
+    const files = [
+      {
+        name: "qwen.json",
+        type: "qwen",
+        size: 1024,
+        modified: now,
+        disabled: false,
+      },
+      {
+        name: "codex-a.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "1",
+      },
+      {
+        name: "codex-b.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "2",
+      },
+      {
+        name: "codex-c.json",
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: "3",
+      },
+    ] as any[];
+
+    mocks.list.mockImplementation(async () => ({ files }));
+    mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      AUTH_FILES_UI_STATE_KEY,
+      JSON.stringify({ tab: "files", filter: "qwen", search: "", page: 1 }),
+    );
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files,
+        usageData: { source: [], auth_index: [] },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: /codex/i }));
+    expect(await screen.findByText("codex-a.json")).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(mocks.fetchQuota).toHaveBeenCalledWith(
+        "codex",
+        expect.objectContaining({ name: "codex-a.json" }),
+      ),
+    );
+
+    const cards = screen.getByTestId("auth-files-cards");
+    const cardRefreshButtons = within(cards).getAllByRole("button", { name: "Refresh" });
+    expect(cardRefreshButtons).toHaveLength(3);
+    cardRefreshButtons.forEach((button) => {
+      expect(button.querySelector("svg")).not.toHaveClass("animate-spin");
+    });
   });
 
   test("toolbar refresh immediately spins the visible card quota refresh action", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -219,21 +219,23 @@ export function useAuthFilesQuotaState({
   );
 
   const refreshQuota = useCallback(
-    async (file: AuthFileItem, provider: QuotaProvider) => {
+    async (file: AuthFileItem, provider: QuotaProvider, options?: { showLoading?: boolean }) => {
       const name = file.name;
       if (quotaInFlightRef.current.has(name)) return;
       quotaInFlightRef.current.add(name);
 
-      setQuotaByFileName((prev) => ({
-        ...prev,
-        [name]: {
-          status: "loading",
-          items: prev[name]?.items ?? [],
-          planType: prev[name]?.planType,
-          error: prev[name]?.error,
-          updatedAt: prev[name]?.updatedAt,
-        },
-      }));
+      if (options?.showLoading !== false) {
+        setQuotaByFileName((prev) => ({
+          ...prev,
+          [name]: {
+            status: "loading",
+            items: prev[name]?.items ?? [],
+            planType: prev[name]?.planType,
+            error: prev[name]?.error,
+            updatedAt: prev[name]?.updatedAt,
+          },
+        }));
+      }
 
       try {
         const result = await fetchQuota(provider, file);
@@ -380,7 +382,7 @@ export function useAuthFilesQuotaState({
   const runQuotaRefreshBatch = useCallback(
     async (
       targets: { file: AuthFileItem; provider: QuotaProvider }[],
-      options?: { markAsAutoRefreshing?: boolean },
+      options?: { markAsAutoRefreshing?: boolean; showLoading?: boolean },
     ) => {
       if (!targets.length) return;
 
@@ -399,7 +401,9 @@ export function useAuthFilesQuotaState({
               quotaAutoRefreshingRef.current.add(current.file.name);
             }
             try {
-              await refreshQuota(current.file, current.provider);
+              await refreshQuota(current.file, current.provider, {
+                showLoading: options?.showLoading,
+              });
             } finally {
               if (markAsAutoRefreshing) {
                 quotaAutoRefreshingRef.current.delete(current.file.name);
@@ -421,24 +425,13 @@ export function useAuthFilesQuotaState({
     const toFetch = collectQuotaFetchTargets(pageItems);
     if (!toFetch.length) return;
 
-    setQuotaByFileName((prev) => {
-      const next = { ...prev };
-      for (const item of pageItems) {
-        next[item.name] = {
-          status: "loading",
-          items: prev[item.name]?.items ?? [],
-          planType: prev[item.name]?.planType,
-          error: prev[item.name]?.error,
-          updatedAt: prev[item.name]?.updatedAt,
-        };
-      }
-      return next;
-    });
-
     let cancelled = false;
     void (async () => {
       if (!cancelled) {
-        await runQuotaRefreshBatch(toFetch, { markAsAutoRefreshing: true });
+        await runQuotaRefreshBatch(toFetch, {
+          markAsAutoRefreshing: true,
+          showLoading: false,
+        });
       }
     })();
 
@@ -472,21 +465,10 @@ export function useAuthFilesQuotaState({
     const candidates = collectQuotaFetchTargets(pageItems);
     if (!candidates.length) return;
 
-    setQuotaByFileName((prev) => {
-      const next = { ...prev };
-      for (const item of pageItems) {
-        next[item.name] = {
-          status: "loading",
-          items: prev[item.name]?.items ?? [],
-          planType: prev[item.name]?.planType,
-          error: prev[item.name]?.error,
-          updatedAt: prev[item.name]?.updatedAt,
-        };
-      }
-      return next;
+    await runQuotaRefreshBatch(candidates, {
+      markAsAutoRefreshing: true,
+      showLoading: false,
     });
-
-    await runQuotaRefreshBatch(candidates, { markAsAutoRefreshing: true });
   }, [collectQuotaFetchTargets, loading, pageItems, runQuotaRefreshBatch, tab]);
 
   const forceRefreshPage = useCallback(async () => {
@@ -504,13 +486,13 @@ export function useAuthFilesQuotaState({
 
     setQuotaByFileName((prev) => {
       const next = { ...prev };
-      for (const item of pageItems) {
-        next[item.name] = {
+      for (const target of targets) {
+        next[target.file.name] = {
           status: "loading",
-          items: prev[item.name]?.items ?? [],
-          planType: prev[item.name]?.planType,
-          error: prev[item.name]?.error,
-          updatedAt: prev[item.name]?.updatedAt,
+          items: prev[target.file.name]?.items ?? [],
+          planType: prev[target.file.name]?.planType,
+          error: prev[target.file.name]?.error,
+          updatedAt: prev[target.file.name]?.updatedAt,
         };
       }
       return next;


### PR DESCRIPTION
## Summary
- keep tab-switch and interval background quota refresh from setting card refresh buttons into loading state
- preserve loading feedback for manual card/table refresh and toolbar full-page refresh
- add regression coverage for switching from another provider tab to codex cards while background quota requests are pending

## Tests
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "tab-switch background quota refresh"
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "toolbar refresh immediately spins|only refreshes the clicked auth file|tab-switch background quota refresh"
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bunx oxfmt src/modules/auth-files/hooks/useAuthFilesQuotaState.ts src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --check
- bun run lint
- bun run build
- bun run check