### PR TITLE
fix: render Antigravity quota from fetchAvailableModels

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -797,6 +797,62 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  test("cards view shows all antigravity quota items instead of truncating to three", async () => {
+    const now = Date.now();
+    const file = {
+      name: "antigravity.json",
+      type: "antigravity",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "ag",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "antigravity.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              { key: "model:a", label: "Model A [a]", percent: 91 },
+              { key: "model:b", label: "Model B [b]", percent: 82 },
+              { key: "model:c", label: "Model C [c]", percent: 73 },
+              { key: "model:d", label: "Model D [d]", percent: 64 },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
+    const cards = screen.getByTestId("auth-files-cards");
+
+    expect(within(cards).getByText("Model A [a]")).toBeInTheDocument();
+    expect(within(cards).getByText("Model B [b]")).toBeInTheDocument();
+    expect(within(cards).getByText("Model C [c]")).toBeInTheDocument();
+    expect(within(cards).getByText("Model D [d]")).toBeInTheDocument();
+  });
+
   test("cards view restores cached quota while refreshing in the background", async () => {
     const now = Date.now();
     const file = {

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -130,6 +130,14 @@ export function useAuthFilesQuotaState({
         }));
       }
 
+      if (provider === "antigravity") {
+        return items.map((item, index) => ({
+          id: item.key ?? item.label ?? `antigravity-${index + 1}`,
+          label: translateQuotaLabel(item.label),
+          item,
+        }));
+      }
+
       const supportsStableCodingSlots = provider === "codex" || provider === "kimi";
       if (!supportsStableCodingSlots) {
         return items.slice(0, 3).map((item) => ({

--- a/src/modules/quota/__tests__/quota-helpers.test.ts
+++ b/src/modules/quota/__tests__/quota-helpers.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
 import {
+  buildAntigravityItems,
   buildCodexItems,
   buildKimiItems,
   formatRelativeResetLabel,
+  parseAntigravityPayload,
   parseKimiUsagePayload,
 } from "@/modules/quota/quota-helpers";
 
@@ -121,6 +123,137 @@ describe("buildCodexItems", () => {
         expect.objectContaining({ label: "m_quota.review_weekly", percent: 90 }),
       ]),
     );
+  });
+});
+
+describe("buildAntigravityItems", () => {
+  test("builds dynamic quota items from fetchAvailableModels instead of static buckets", () => {
+    const payload = parseAntigravityPayload(
+      JSON.stringify({
+        models: {
+          tab_jump_flash_lite_preview: {
+            maxTokens: 16384,
+            maxOutputTokens: 4096,
+            quotaInfo: { remainingFraction: 1 },
+            model: "MODEL_PLACEHOLDER_M28",
+            apiProvider: "API_PROVIDER_GOOGLE_GEMINI",
+          },
+          "gemini-3.1-pro-high": {
+            displayName: "Gemini 3.1 Pro (High)",
+            supportsImages: true,
+            supportsThinking: true,
+            supportsVideo: true,
+            maxTokens: 1048576,
+            maxOutputTokens: 65535,
+            quotaInfo: {
+              remainingFraction: 0.75,
+              resetTime: "2026-05-09T15:50:29Z",
+            },
+            model: "MODEL_PLACEHOLDER_M37",
+            apiProvider: "API_PROVIDER_GOOGLE_GEMINI",
+            modelProvider: "MODEL_PROVIDER_GOOGLE",
+          },
+          "gemini-3.1-pro-low": {
+            displayName: "Gemini 3.1 Pro (Low)",
+            maxTokens: 1048576,
+            maxOutputTokens: 65535,
+            quotaInfo: { remainingFraction: 0.5 },
+            model: "MODEL_PLACEHOLDER_M36",
+          },
+          "gemini-3-flash-agent": {
+            displayName: "Gemini 3 Flash",
+            quotaInfo: { remainingFraction: 1 },
+            model: "MODEL_PLACEHOLDER_M84",
+          },
+          "claude-sonnet-4-6": {
+            displayName: "Claude Sonnet 4.6 (Thinking)",
+            quotaInfo: { remainingFraction: 0.9 },
+            apiProvider: "API_PROVIDER_ANTHROPIC_VERTEX",
+          },
+          "gpt-oss-120b-medium": {
+            displayName: "GPT-OSS 120B (Medium)",
+            quotaInfo: { remainingFraction: 0.8 },
+            apiProvider: "API_PROVIDER_OPENAI_VERTEX",
+          },
+          "gemini-3-flash": {
+            displayName: "Gemini 3 Flash",
+            quotaInfo: { remainingFraction: 0.7 },
+          },
+          chat_20706: {
+            quotaInfo: { remainingFraction: 1 },
+            isInternal: true,
+          },
+          "gemini-3.1-flash-image": {
+            displayName: "Gemini 3.1 Flash Image",
+            quotaInfo: { remainingFraction: 0.6 },
+          },
+          "gemini-3.1-flash-lite": {
+            displayName: "Gemini 3.1 Flash Lite",
+            quotaInfo: { remainingFraction: 0.95 },
+          },
+        },
+        defaultAgentModelId: "gemini-3.1-pro-high",
+        agentModelSorts: [
+          {
+            displayName: "Recommended",
+            groups: [
+              {
+                modelIds: [
+                  "gemini-3.1-pro-high",
+                  "gemini-3.1-pro-low",
+                  "gemini-3-flash-agent",
+                  "claude-sonnet-4-6",
+                  "gpt-oss-120b-medium",
+                ],
+              },
+            ],
+          },
+        ],
+        commandModelIds: ["gemini-3-flash"],
+        tabModelIds: ["chat_20706"],
+        imageGenerationModelIds: ["gemini-3.1-flash-image"],
+        mqueryModelIds: ["gemini-3.1-flash-lite"],
+        webSearchModelIds: ["gemini-3.1-flash-lite"],
+        commitMessageModelIds: ["gemini-3.1-flash-lite"],
+      }),
+    );
+
+    expect(payload).not.toBeNull();
+
+    const items = buildAntigravityItems(payload!);
+    const labels = items.map((item) => item.label);
+
+    expect(items.map((item) => item.key)).toEqual([
+      "model:gemini-3.1-pro-high",
+      "model:gemini-3.1-pro-low",
+      "model:gemini-3-flash-agent",
+      "model:claude-sonnet-4-6",
+      "model:gpt-oss-120b-medium",
+      "model:gemini-3-flash",
+      "model:chat_20706",
+      "model:gemini-3.1-flash-image",
+      "model:gemini-3.1-flash-lite",
+      "model:tab_jump_flash_lite_preview",
+    ]);
+    expect(labels).toContain("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]");
+    expect(labels).toContain("chat_20706");
+    expect(labels).not.toContain("Claude/GPT");
+    expect(labels).not.toContain("Gemini 3 Pro");
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        percent: 75,
+        resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+        meta: expect.stringContaining("Default Agent"),
+      }),
+    );
+    expect(items[0].meta).toContain("Recommended");
+    expect(items[0].meta).toContain("maxTokens=1048576");
+    expect(items[0].meta).toContain("maxOutputTokens=65535");
+    expect(items[0].meta).toContain("apiProvider=API_PROVIDER_GOOGLE_GEMINI");
+    expect(items[0].meta).toContain("model=MODEL_PLACEHOLDER_M37");
+    expect(items[0].meta).toContain("thinking");
+    expect(items[0].meta).toContain("images");
+    expect(items[0].meta).toContain("video");
   });
 });
 

--- a/src/modules/quota/quota-antigravity.ts
+++ b/src/modules/quota/quota-antigravity.ts
@@ -1,5 +1,9 @@
 import {
+  clampPercent,
+  isRecord,
+  normalizeNumberValue,
   normalizeQuotaFraction,
+  normalizeStringValue,
   parseResetTimeToMs,
 } from "@/modules/quota/quota-normalizers";
 import type { QuotaItem } from "@/modules/quota/quota-types";
@@ -8,77 +12,210 @@ type AntigravityQuotaInfo = {
   displayName?: string;
   quotaInfo?: Record<string, unknown>;
   quota_info?: Record<string, unknown>;
+  maxTokens?: unknown;
+  maxOutputTokens?: unknown;
+  tokenizerType?: unknown;
+  apiProvider?: unknown;
+  modelProvider?: unknown;
+  model?: unknown;
+  supportsImages?: unknown;
+  supportsThinking?: unknown;
+  supportsVideo?: unknown;
+  recommended?: unknown;
+  isInternal?: unknown;
+  tagTitle?: unknown;
+  thinkingBudget?: unknown;
+  minThinkingBudget?: unknown;
 };
 
 export type AntigravityModelsPayload = Record<string, AntigravityQuotaInfo>;
 
-const GROUPS: Array<{
-  id: string;
-  label: string;
-  identifiers: string[];
-  labelFromModel?: boolean;
-}> = [
-  { id: "claude-gpt", label: "Claude/GPT", identifiers: ["claude-sonnet-4-5-thinking", "claude-opus-4-5-thinking", "claude-sonnet-4-5", "gpt-oss-120b-medium"] },
-  { id: "gemini-3-pro", label: "Gemini 3 Pro", identifiers: ["gemini-3-pro-high", "gemini-3-pro-low"] },
-  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", identifiers: ["gemini-2.5-flash", "gemini-2.5-flash-thinking"] },
-  { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", identifiers: ["gemini-2.5-flash-lite"] },
-  { id: "gemini-2-5-cu", label: "Gemini 2.5 CU", identifiers: ["rev19-uic3-1p"] },
-  { id: "gemini-3-flash", label: "Gemini 3 Flash", identifiers: ["gemini-3-flash"] },
-  { id: "gemini-image", label: "gemini-3-pro-image", identifiers: ["gemini-3-pro-image"], labelFromModel: true },
+export type AntigravityFetchAvailableModelsPayload = {
+  models?: AntigravityModelsPayload;
+  defaultAgentModelId?: unknown;
+  agentModelSorts?: unknown;
+  commandModelIds?: unknown;
+  tabModelIds?: unknown;
+  imageGenerationModelIds?: unknown;
+  mqueryModelIds?: unknown;
+  webSearchModelIds?: unknown;
+  commitMessageModelIds?: unknown;
+};
+
+const MODEL_ID_LISTS: Array<[keyof AntigravityFetchAvailableModelsPayload, string]> = [
+  ["commandModelIds", "Command"],
+  ["tabModelIds", "Tab"],
+  ["imageGenerationModelIds", "Image Generation"],
+  ["mqueryModelIds", "MQuery"],
+  ["webSearchModelIds", "Web Search"],
+  ["commitMessageModelIds", "Commit Message"],
 ];
 
-const findModel = (models: AntigravityModelsPayload, identifier: string) => {
-  const direct = models[identifier];
-  if (direct) return { id: identifier, entry: direct };
-  const match = Object.entries(models).find(([, entry]) =>
-    String(entry?.displayName ?? "").toLowerCase() === identifier.toLowerCase(),
-  );
-  return match ? { id: match[0], entry: match[1] } : null;
+const normalizeModelId = (value: unknown): string | null => normalizeStringValue(value);
+
+const normalizeModelIdList = (value: unknown): string[] =>
+  Array.isArray(value) ? value.map(normalizeModelId).filter((id): id is string => Boolean(id)) : [];
+
+const resolvePayloadAndModels = (
+  input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
+): { payload: AntigravityFetchAvailableModelsPayload; models: AntigravityModelsPayload } => {
+  const maybePayload = input as AntigravityFetchAvailableModelsPayload;
+  if (isRecord(maybePayload.models)) {
+    return {
+      payload: maybePayload,
+      models: maybePayload.models as AntigravityModelsPayload,
+    };
+  }
+
+  return {
+    payload: { models: input as AntigravityModelsPayload },
+    models: input as AntigravityModelsPayload,
+  };
 };
 
 const quotaInfo = (entry?: AntigravityQuotaInfo) => {
   const raw = (entry?.quotaInfo ?? entry?.quota_info ?? {}) as Record<string, unknown>;
+  const resetTimeRaw = raw.resetTime ?? raw.reset_time;
   return {
-    remainingFraction: normalizeQuotaFraction(raw.remainingFraction ?? raw.remaining_fraction ?? raw.remaining),
-    resetTime: typeof (raw.resetTime ?? raw.reset_time) === "string" ? String(raw.resetTime ?? raw.reset_time) : undefined,
-    displayName: typeof entry?.displayName === "string" ? entry.displayName : undefined,
+    remainingFraction: normalizeQuotaFraction(
+      raw.remainingFraction ?? raw.remaining_fraction ?? raw.remaining,
+    ),
+    resetTime: typeof resetTimeRaw === "string" ? resetTimeRaw : undefined,
   };
 };
 
-export const buildAntigravityGroups = (models: AntigravityModelsPayload) => {
-  const groups: { id: string; label: string; remainingFraction: number; resetTime?: string }[] = [];
-  let geminiProResetTime: string | undefined;
-  for (const group of GROUPS) {
-    const entries = group.identifiers
-      .map((identifier) => findModel(models, identifier))
-      .filter(Boolean)
-      .map((match) => {
-        const info = quotaInfo(match?.entry);
-        return {
-          label: group.labelFromModel ? (info.displayName ?? match?.id ?? group.label) : group.label,
-          remainingFraction: info.remainingFraction,
-          resetTime: info.resetTime,
-        };
-      })
-      .filter((item) => item.remainingFraction !== null);
-    const reset = entries.find((item) => item.resetTime)?.resetTime;
-    if (group.id === "gemini-3-pro" && reset) geminiProResetTime = reset;
-    groups.push({
-      id: group.id,
-      label: group.label,
-      remainingFraction: entries.length
-        ? entries.reduce((acc, item) => acc + (item.remainingFraction ?? 0), 0) / entries.length
-        : 0,
-      ...(reset ? { resetTime: reset } : {}),
-    });
-  }
-  if (geminiProResetTime) {
-    groups.forEach((group) => {
-      if (group.id.startsWith("gemini-") && !group.resetTime) group.resetTime = geminiProResetTime;
-    });
-  }
-  return groups;
+const addModelRole = (
+  id: string | null,
+  role: string,
+  order: string[],
+  rolesByModel: Map<string, Set<string>>,
+) => {
+  if (!id) return;
+  if (!rolesByModel.has(id)) rolesByModel.set(id, new Set());
+  rolesByModel.get(id)?.add(role);
+  if (!order.includes(id)) order.push(id);
 };
+
+const collectPayloadModelOrder = (payload: AntigravityFetchAvailableModelsPayload) => {
+  const order: string[] = [];
+  const rolesByModel = new Map<string, Set<string>>();
+
+  addModelRole(normalizeModelId(payload.defaultAgentModelId), "Default Agent", order, rolesByModel);
+
+  if (Array.isArray(payload.agentModelSorts)) {
+    payload.agentModelSorts.forEach((sort) => {
+      if (!isRecord(sort)) return;
+      const sortLabel = normalizeStringValue(sort.displayName) ?? "Agent Models";
+      const groups = Array.isArray(sort.groups) ? sort.groups : [];
+      groups.forEach((group) => {
+        if (!isRecord(group)) return;
+        normalizeModelIdList(group.modelIds).forEach((id) =>
+          addModelRole(id, sortLabel, order, rolesByModel),
+        );
+      });
+    });
+  }
+
+  MODEL_ID_LISTS.forEach(([key, label]) => {
+    normalizeModelIdList(payload[key]).forEach((id) =>
+      addModelRole(id, label, order, rolesByModel),
+    );
+  });
+
+  return { order, rolesByModel };
+};
+
+const buildModelLabel = (id: string, entry: AntigravityQuotaInfo): string => {
+  const displayName = normalizeStringValue(entry.displayName);
+  if (!displayName || displayName === id) return id;
+  return `${displayName} [${id}]`;
+};
+
+const appendStringMeta = (parts: string[], label: string, value: unknown) => {
+  const normalized = normalizeStringValue(value);
+  if (normalized) parts.push(`${label}=${normalized}`);
+};
+
+const appendNumberMeta = (parts: string[], label: string, value: unknown) => {
+  const normalized = normalizeNumberValue(value);
+  if (normalized !== null) parts.push(`${label}=${normalized}`);
+};
+
+const buildModelMeta = (entry: AntigravityQuotaInfo, roles?: Set<string>): string | undefined => {
+  const parts: string[] = [];
+  if (roles) parts.push(...Array.from(roles));
+  appendNumberMeta(parts, "maxTokens", entry.maxTokens);
+  appendNumberMeta(parts, "maxOutputTokens", entry.maxOutputTokens);
+  appendStringMeta(parts, "apiProvider", entry.apiProvider);
+  appendStringMeta(parts, "modelProvider", entry.modelProvider);
+  appendStringMeta(parts, "model", entry.model);
+  appendStringMeta(parts, "tokenizer", entry.tokenizerType);
+  appendStringMeta(parts, "tag", entry.tagTitle);
+  appendNumberMeta(parts, "thinkingBudget", entry.thinkingBudget);
+  appendNumberMeta(parts, "minThinkingBudget", entry.minThinkingBudget);
+
+  if (entry.supportsThinking === true) parts.push("thinking");
+  if (entry.supportsImages === true) parts.push("images");
+  if (entry.supportsVideo === true) parts.push("video");
+  if (entry.recommended === true) parts.push("recommended");
+  if (entry.isInternal === true) parts.push("internal");
+
+  const uniqueParts = parts.filter((part, index, all) => all.indexOf(part) === index);
+  return uniqueParts.length > 0 ? uniqueParts.join(" · ") : undefined;
+};
+
+export const buildAntigravityItems = (
+  input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
+): QuotaItem[] => {
+  const { payload, models } = resolvePayloadAndModels(input);
+  const { order, rolesByModel } = collectPayloadModelOrder(payload);
+  const orderedIds = new Set(order);
+
+  Object.keys(models)
+    .filter((id) => !orderedIds.has(id))
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((id) => {
+      order.push(id);
+      orderedIds.add(id);
+    });
+
+  return order.flatMap((id) => {
+    const entry = models[id];
+    if (!entry) return [];
+    const info = quotaInfo(entry);
+    if (info.remainingFraction === null && !info.resetTime) return [];
+    const percent =
+      info.remainingFraction === null
+        ? null
+        : Math.round(clampPercent(info.remainingFraction * 100));
+
+    return [
+      {
+        key: `model:${id}`,
+        label: buildModelLabel(id, entry),
+        percent,
+        resetAtMs: parseResetTimeToMs(info.resetTime),
+        meta: buildModelMeta(entry, rolesByModel.get(id)),
+      },
+    ];
+  });
+};
+
+export const buildAntigravityGroups = (
+  input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
+) =>
+  buildAntigravityItems(input).map((item) => {
+    const resetTime =
+      typeof item.resetAtMs === "number" && Number.isFinite(item.resetAtMs)
+        ? new Date(item.resetAtMs).toISOString()
+        : undefined;
+    return {
+      id: item.key ?? item.label,
+      label: item.label,
+      remainingFraction: item.percent === null ? 0 : item.percent / 100,
+      ...(resetTime ? { resetTime } : {}),
+    };
+  });
 
 export const parseAntigravityPayload = (payload: unknown): Record<string, unknown> | null => {
   if (payload === undefined || payload === null) return null;
@@ -93,10 +230,3 @@ export const parseAntigravityPayload = (payload: unknown): Record<string, unknow
   }
   return typeof payload === "object" ? (payload as Record<string, unknown>) : null;
 };
-
-export const buildAntigravityItems = (models: AntigravityModelsPayload): QuotaItem[] =>
-  buildAntigravityGroups(models).map((group) => ({
-    label: group.label,
-    percent: Math.round(group.remainingFraction * 100),
-    resetAtMs: parseResetTimeToMs(group.resetTime),
-  }));

--- a/src/modules/quota/quota-fetch.ts
+++ b/src/modules/quota/quota-fetch.ts
@@ -15,7 +15,7 @@ import {
   KIRO_QUOTA_URL,
   KIRO_REQUEST_BODY,
   KIRO_REQUEST_HEADERS,
-  buildAntigravityGroups,
+  buildAntigravityItems,
   buildClaudeItems,
   buildCodexItems,
   buildGeminiCliBuckets,
@@ -38,7 +38,6 @@ import {
   resolveAuthProvider,
   resolveCodexChatgptAccountId,
   resolveGeminiCliProjectId,
-  type AntigravityModelsPayload,
   type QuotaItem,
 } from "@/modules/quota/quota-helpers";
 
@@ -120,13 +119,8 @@ export const fetchQuota = async (
         const parsed = parseAntigravityPayload(result.body ?? result.bodyText);
         const models = parsed?.models;
         if (!models || !isRecord(models)) throw new Error("no_model_quota");
-        const groups = buildAntigravityGroups(models as AntigravityModelsPayload);
         return {
-          items: groups.map((g) => ({
-            label: g.label,
-            percent: Math.round(clampPercent(g.remainingFraction * 100)),
-            resetAtMs: parseResetTimeToMs(g.resetTime),
-          })),
+          items: buildAntigravityItems(parsed),
         };
       }
     }

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -45,13 +45,6 @@ export interface AntigravityQuotaInfo {
 
 export type AntigravityModelsPayload = Record<string, AntigravityQuotaInfo>;
 
-export interface AntigravityQuotaGroupDefinition {
-  id: string;
-  label: string;
-  identifiers: string[];
-  labelFromModel?: boolean;
-}
-
 export interface GeminiCliQuotaGroupDefinition {
   id: string;
   label: string;

--- a/src/utils/quota/builders.ts
+++ b/src/utils/quota/builders.ts
@@ -4,17 +4,12 @@
 
 import type {
   AntigravityQuotaGroup,
-  AntigravityQuotaGroupDefinition,
   AntigravityQuotaInfo,
   AntigravityModelsPayload,
   GeminiCliParsedBucket,
   GeminiCliQuotaBucketState,
 } from "@/types";
-import {
-  ANTIGRAVITY_QUOTA_GROUPS,
-  GEMINI_CLI_GROUP_LOOKUP,
-  GEMINI_CLI_GROUP_ORDER,
-} from "./constants";
+import { GEMINI_CLI_GROUP_LOOKUP, GEMINI_CLI_GROUP_ORDER } from "./constants";
 import { normalizeQuotaFraction } from "./parsers";
 import { isIgnoredGeminiCliModel } from "./validators";
 
@@ -180,85 +175,19 @@ export function findAntigravityModel(
 export function buildAntigravityQuotaGroups(
   models: AntigravityModelsPayload,
 ): AntigravityQuotaGroup[] {
-  const groups: AntigravityQuotaGroup[] = [];
-  let geminiProResetTime: string | undefined;
-  const [claudeDef, geminiProDef, flashDef, flashLiteDef, cuDef, geminiFlashDef, imageDef] =
-    ANTIGRAVITY_QUOTA_GROUPS;
-
-  const buildGroup = (
-    def: AntigravityQuotaGroupDefinition,
-    overrideResetTime?: string,
-  ): AntigravityQuotaGroup | null => {
-    const matches = def.identifiers
-      .map((identifier) => findAntigravityModel(models, identifier))
-      .filter((entry): entry is { id: string; entry: AntigravityQuotaInfo } => Boolean(entry));
-
-    const quotaEntries = matches
-      .map(({ id, entry }) => {
-        const info = getAntigravityQuotaInfo(entry);
-        const remainingFraction = info.remainingFraction ?? (info.resetTime ? 0 : null);
-        if (remainingFraction === null) return null;
-        return {
-          id,
-          remainingFraction,
-          resetTime: info.resetTime,
-          displayName: info.displayName,
-        };
-      })
-      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
-
-    if (quotaEntries.length === 0) return null;
-
-    const remainingFraction = Math.min(...quotaEntries.map((entry) => entry.remainingFraction));
-    const resetTime =
-      overrideResetTime ?? quotaEntries.map((entry) => entry.resetTime).find(Boolean);
-    const displayName = quotaEntries.map((entry) => entry.displayName).find(Boolean);
-    const label = def.labelFromModel && displayName ? displayName : def.label;
-
-    return {
-      id: def.id,
-      label,
-      models: quotaEntries.map((entry) => entry.id),
-      remainingFraction,
-      resetTime,
-    };
-  };
-
-  const claudeGroup = buildGroup(claudeDef);
-  if (claudeGroup) {
-    groups.push(claudeGroup);
-  }
-
-  const geminiProGroup = buildGroup(geminiProDef);
-  if (geminiProGroup) {
-    geminiProResetTime = geminiProGroup.resetTime;
-    groups.push(geminiProGroup);
-  }
-
-  const flashGroup = buildGroup(flashDef);
-  if (flashGroup) {
-    groups.push(flashGroup);
-  }
-
-  const flashLiteGroup = buildGroup(flashLiteDef);
-  if (flashLiteGroup) {
-    groups.push(flashLiteGroup);
-  }
-
-  const cuGroup = buildGroup(cuDef);
-  if (cuGroup) {
-    groups.push(cuGroup);
-  }
-
-  const geminiFlashGroup = buildGroup(geminiFlashDef);
-  if (geminiFlashGroup) {
-    groups.push(geminiFlashGroup);
-  }
-
-  const imageGroup = buildGroup(imageDef, geminiProResetTime);
-  if (imageGroup) {
-    groups.push(imageGroup);
-  }
-
-  return groups;
+  return Object.entries(models).flatMap(([id, entry]) => {
+    const info = getAntigravityQuotaInfo(entry);
+    const remainingFraction = info.remainingFraction ?? (info.resetTime ? 0 : null);
+    if (remainingFraction === null) return [];
+    const label = info.displayName && info.displayName !== id ? `${info.displayName} [${id}]` : id;
+    return [
+      {
+        id: `model:${id}`,
+        label,
+        models: [id],
+        remainingFraction,
+        resetTime: info.resetTime,
+      },
+    ];
+  });
 }

--- a/src/utils/quota/constants.ts
+++ b/src/utils/quota/constants.ts
@@ -2,11 +2,7 @@
  * Quota constants for API URLs, headers, and theme colors.
  */
 
-import type {
-  AntigravityQuotaGroupDefinition,
-  GeminiCliQuotaGroupDefinition,
-  TypeColorSet,
-} from "@/types";
+import type { GeminiCliQuotaGroupDefinition, TypeColorSet } from "@/types";
 
 // Theme colors for type badges
 export const TYPE_COLORS: Record<string, TypeColorSet> = {
@@ -68,50 +64,6 @@ export const ANTIGRAVITY_REQUEST_HEADERS = {
   "Content-Type": "application/json",
   "User-Agent": "antigravity/1.11.5 windows/amd64",
 };
-
-export const ANTIGRAVITY_QUOTA_GROUPS: AntigravityQuotaGroupDefinition[] = [
-  {
-    id: "claude-gpt",
-    label: "Claude/GPT",
-    identifiers: [
-      "claude-sonnet-4-5-thinking",
-      "claude-opus-4-5-thinking",
-      "claude-sonnet-4-5",
-      "gpt-oss-120b-medium",
-    ],
-  },
-  {
-    id: "gemini-3-pro",
-    label: "Gemini 3 Pro",
-    identifiers: ["gemini-3-pro-high", "gemini-3-pro-low"],
-  },
-  {
-    id: "gemini-2-5-flash",
-    label: "Gemini 2.5 Flash",
-    identifiers: ["gemini-2.5-flash", "gemini-2.5-flash-thinking"],
-  },
-  {
-    id: "gemini-2-5-flash-lite",
-    label: "Gemini 2.5 Flash Lite",
-    identifiers: ["gemini-2.5-flash-lite"],
-  },
-  {
-    id: "gemini-2-5-cu",
-    label: "Gemini 2.5 CU",
-    identifiers: ["rev19-uic3-1p"],
-  },
-  {
-    id: "gemini-3-flash",
-    label: "Gemini 3 Flash",
-    identifiers: ["gemini-3-flash"],
-  },
-  {
-    id: "gemini-image",
-    label: "gemini-3-pro-image",
-    identifiers: ["gemini-3-pro-image"],
-    labelFromModel: true,
-  },
-];
 
 // Gemini CLI API configuration
 export const GEMINI_CLI_QUOTA_URL =


### PR DESCRIPTION
## Summary
- Build Antigravity quota cards dynamically from the full fetchAvailableModels payload instead of static buckets.
- Include model roles from agent/command/tab/image/search/commit lists, quota reset time, provider/model metadata, token limits, and capabilities.
- Stop truncating Antigravity auth-file quota cards to three items.

## Test Plan
- bunx vitest run src/modules/quota/__tests__/quota-helpers.test.ts src/modules/quota/__tests__/quota-fetch.test.ts src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run check
- git diff --check