### PR TITLE
fix: keep channel group modal tabs fixed

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -886,6 +886,10 @@ export function RoutingConfigEditor({
         description={t("channel_groups_page.group_modal_desc")}
         onClose={closeGroupEditor}
         maxWidth="max-w-4xl"
+        bodyTestId="group-editor-modal-body"
+        bodyHeightClassName="h-[680px] max-h-[calc(100vh-10rem)]"
+        bodyOverflowClassName="overflow-hidden"
+        bodyClassName="flex flex-col"
         footer={
           <div className="flex flex-wrap items-center gap-2">
             {groupDraftError ? (
@@ -906,7 +910,7 @@ export function RoutingConfigEditor({
           </div>
         }
       >
-        <div className="space-y-5">
+        <div className="flex min-h-0 flex-1 flex-col gap-5">
           {draftStaleChannels.length > 0 ? (
             <div
               role="alert"
@@ -943,168 +947,178 @@ export function RoutingConfigEditor({
             value={groupEditorTab}
             onValueChange={(value) => setGroupEditorTab(value as "basic" | "models")}
           >
-            <TabsList>
-              <TabsTrigger value="basic">{t("channel_groups_page.basic_config_tab")}</TabsTrigger>
-              <TabsTrigger value="models">{t("channel_groups_page.models_tab")}</TabsTrigger>
-            </TabsList>
+            <div data-testid="group-editor-tabs-shell" className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0">
+                <TabsList>
+                  <TabsTrigger value="basic">
+                    {t("channel_groups_page.basic_config_tab")}
+                  </TabsTrigger>
+                  <TabsTrigger value="models">{t("channel_groups_page.models_tab")}</TabsTrigger>
+                </TabsList>
+              </div>
 
-            <div
-              data-testid="group-editor-tab-viewport"
-              className="mt-4 h-[520px] min-h-0 overflow-y-auto pr-1"
-            >
-              <TabsContent value="basic" className="space-y-5">
-                <div className="grid gap-4 md:grid-cols-2">
-                  <Field label={t("channel_groups_page.group_name_label")}>
-                    <TextInput
-                      value={groupDraft.name}
-                      onChange={(event) => {
-                        const value = event.currentTarget.value;
-                        setGroupDraft((current) => ({ ...current, name: value }));
-                      }}
-                      placeholder="pro"
-                      disabled={disabled}
-                    />
-                  </Field>
-                  <Field label={t("channel_groups_page.description_label")}>
-                    <TextInput
-                      value={groupDraft.description}
-                      onChange={(event) => {
-                        const value = event.currentTarget.value;
-                        setGroupDraft((current) => ({ ...current, description: value }));
-                      }}
-                      placeholder={t("channel_groups_page.description_placeholder")}
-                      disabled={disabled}
-                    />
-                  </Field>
-                </div>
-
-                <div className="grid gap-4 md:grid-cols-1">
-                  <Field
-                    label={t("channel_groups_page.route_path_label")}
-                    hint={t("channel_groups_page.route_path_hint")}
-                  >
-                    <TextInput
-                      value={primaryRoute.path}
-                      onChange={(event) => updatePrimaryRoute({ path: event.currentTarget.value })}
-                      placeholder="/pro"
-                      disabled={disabled}
-                    />
-                  </Field>
-                </div>
-
-                <div className="space-y-3">
-                  <Field
-                    label={t("channel_groups_page.select_channel_label")}
-                    hint={t("channel_groups_page.select_channel_hint")}
-                  >
-                    <SearchableCheckboxMultiSelect
-                      value={selectedChannelValues}
-                      onChange={updateDraftChannels}
-                      options={channelOptions}
-                      placeholder={t("channel_groups_page.select_channel_placeholder")}
-                      searchPlaceholder={t("channel_groups_page.search_channel_placeholder")}
-                      selectFilteredLabel={t("channel_groups_page.select_filtered_channels")}
-                      deselectFilteredLabel={t("channel_groups_page.deselect_filtered_channels")}
-                      selectedCountLabel={(count) =>
-                        t("channel_groups_page.selected_channels_count", { count })
-                      }
-                      noResultsLabel={t("channel_groups_page.no_search_results")}
-                      aria-label={t("channel_groups_page.select_channel_label")}
-                      disabled={disabled}
-                    />
-                  </Field>
-                </div>
-
-                <VirtualTable<RoutingChannelGroupMemberEntry>
-                  rows={groupDraft.channels}
-                  columns={groupMemberColumns}
-                  rowKey={(channel) => channel.id}
-                  virtualize={false}
-                  rowHeight={52}
-                  height="h-[248px]"
-                  minWidth="min-w-[640px]"
-                  caption={t("channel_groups_page.select_channel_label")}
-                  emptyText={t("channel_groups_page.empty_group_channels")}
-                  rowClassName={(channel) =>
-                    draftStaleChannelIds.has(channel.id) ? "bg-rose-50/70 dark:bg-rose-500/10" : ""
-                  }
-                />
-              </TabsContent>
-
-              <TabsContent value="models" className="flex h-full min-h-0 flex-col gap-3">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="space-y-1">
-                    <div className="text-sm font-semibold text-slate-900 dark:text-white">
-                      {t("channel_groups_page.allowed_models_label")}
-                    </div>
-                    <div className="text-xs text-slate-500 dark:text-white/55">
-                      {t("channel_groups_page.allowed_models_hint")}
-                    </div>
+              <div
+                data-testid="group-editor-tab-viewport"
+                className="mt-4 min-h-0 flex-1 overflow-y-auto pr-1"
+              >
+                <TabsContent value="basic" className="space-y-5">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <Field label={t("channel_groups_page.group_name_label")}>
+                      <TextInput
+                        value={groupDraft.name}
+                        onChange={(event) => {
+                          const value = event.currentTarget.value;
+                          setGroupDraft((current) => ({ ...current, name: value }));
+                        }}
+                        placeholder="pro"
+                        disabled={disabled}
+                      />
+                    </Field>
+                    <Field label={t("channel_groups_page.description_label")}>
+                      <TextInput
+                        value={groupDraft.description}
+                        onChange={(event) => {
+                          const value = event.currentTarget.value;
+                          setGroupDraft((current) => ({ ...current, description: value }));
+                        }}
+                        placeholder={t("channel_groups_page.description_placeholder")}
+                        disabled={disabled}
+                      />
+                    </Field>
                   </div>
-                  <div className="flex shrink-0 gap-2">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={selectAllDraftModels}
-                      disabled={disabled || modelOptions.length === 0}
+
+                  <div className="grid gap-4 md:grid-cols-1">
+                    <Field
+                      label={t("channel_groups_page.route_path_label")}
+                      hint={t("channel_groups_page.route_path_hint")}
                     >
-                      <Check size={14} />
-                      {t("channel_groups_page.select_all_models")}
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={clearDraftModels}
-                      disabled={disabled || groupDraft.allowedModels.length === 0}
-                    >
-                      <X size={14} />
-                      {t("channel_groups_page.clear_models")}
-                    </Button>
+                      <TextInput
+                        value={primaryRoute.path}
+                        onChange={(event) =>
+                          updatePrimaryRoute({ path: event.currentTarget.value })
+                        }
+                        placeholder="/pro"
+                        disabled={disabled}
+                      />
+                    </Field>
                   </div>
-                </div>
 
-                {selectedChannelValues.length === 0 ? (
-                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
-                    {t("channel_groups_page.models_need_channels")}
+                  <div className="space-y-3">
+                    <Field
+                      label={t("channel_groups_page.select_channel_label")}
+                      hint={t("channel_groups_page.select_channel_hint")}
+                    >
+                      <SearchableCheckboxMultiSelect
+                        value={selectedChannelValues}
+                        onChange={updateDraftChannels}
+                        options={channelOptions}
+                        placeholder={t("channel_groups_page.select_channel_placeholder")}
+                        searchPlaceholder={t("channel_groups_page.search_channel_placeholder")}
+                        selectFilteredLabel={t("channel_groups_page.select_filtered_channels")}
+                        deselectFilteredLabel={t("channel_groups_page.deselect_filtered_channels")}
+                        selectedCountLabel={(count) =>
+                          t("channel_groups_page.selected_channels_count", { count })
+                        }
+                        noResultsLabel={t("channel_groups_page.no_search_results")}
+                        aria-label={t("channel_groups_page.select_channel_label")}
+                        disabled={disabled}
+                      />
+                    </Field>
                   </div>
-                ) : modelsError ? (
-                  <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-400/25 dark:bg-rose-500/10 dark:text-rose-200">
-                    {modelsError}
+
+                  <VirtualTable<RoutingChannelGroupMemberEntry>
+                    rows={groupDraft.channels}
+                    columns={groupMemberColumns}
+                    rowKey={(channel) => channel.id}
+                    virtualize={false}
+                    rowHeight={52}
+                    height="h-[248px]"
+                    minWidth="min-w-[640px]"
+                    caption={t("channel_groups_page.select_channel_label")}
+                    emptyText={t("channel_groups_page.empty_group_channels")}
+                    rowClassName={(channel) =>
+                      draftStaleChannelIds.has(channel.id)
+                        ? "bg-rose-50/70 dark:bg-rose-500/10"
+                        : ""
+                    }
+                  />
+                </TabsContent>
+
+                <TabsContent value="models" className="flex h-full min-h-0 flex-col gap-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {t("channel_groups_page.allowed_models_label")}
+                      </div>
+                      <div className="text-xs text-slate-500 dark:text-white/55">
+                        {t("channel_groups_page.allowed_models_hint")}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 gap-2">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={selectAllDraftModels}
+                        disabled={disabled || modelOptions.length === 0}
+                      >
+                        <Check size={14} />
+                        {t("channel_groups_page.select_all_models")}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={clearDraftModels}
+                        disabled={disabled || groupDraft.allowedModels.length === 0}
+                      >
+                        <X size={14} />
+                        {t("channel_groups_page.clear_models")}
+                      </Button>
+                    </div>
                   </div>
-                ) : modelsLoading ? (
-                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
-                    {t("common.loading")}
-                  </div>
-                ) : modelOptions.length === 0 ? (
-                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
-                    {t("channel_groups_page.no_channel_models")}
-                  </div>
-                ) : (
-                  <div
-                    data-testid="group-editor-model-list"
-                    className="grid min-h-0 flex-1 gap-2 overflow-y-auto rounded-2xl border border-slate-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950 sm:grid-cols-2"
-                  >
-                    {modelOptions.map((model) => {
-                      const checked = selectedModelSet.has(model);
-                      return (
-                        <label
-                          key={model}
-                          className="flex min-w-0 items-center gap-3 rounded-xl px-3 py-2 text-sm text-slate-800 transition-colors hover:bg-slate-50 dark:text-white/80 dark:hover:bg-white/[0.04]"
-                        >
-                          <Checkbox
-                            checked={checked}
-                            onCheckedChange={(next) => toggleDraftModel(model, next)}
-                            disabled={disabled}
-                            aria-label={model}
-                          />
-                          <VendorIcon modelId={model} size={14} />
-                          <span className="min-w-0 flex-1 truncate">{model}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                )}
-              </TabsContent>
+
+                  {selectedChannelValues.length === 0 ? (
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
+                      {t("channel_groups_page.models_need_channels")}
+                    </div>
+                  ) : modelsError ? (
+                    <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-400/25 dark:bg-rose-500/10 dark:text-rose-200">
+                      {modelsError}
+                    </div>
+                  ) : modelsLoading ? (
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
+                      {t("common.loading")}
+                    </div>
+                  ) : modelOptions.length === 0 ? (
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
+                      {t("channel_groups_page.no_channel_models")}
+                    </div>
+                  ) : (
+                    <div
+                      data-testid="group-editor-model-list"
+                      className="grid min-h-0 flex-1 gap-2 overflow-y-auto rounded-2xl border border-slate-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950 sm:grid-cols-2"
+                    >
+                      {modelOptions.map((model) => {
+                        const checked = selectedModelSet.has(model);
+                        return (
+                          <label
+                            key={model}
+                            className="flex min-w-0 items-center gap-3 rounded-xl px-3 py-2 text-sm text-slate-800 transition-colors hover:bg-slate-50 dark:text-white/80 dark:hover:bg-white/[0.04]"
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={(next) => toggleDraftModel(model, next)}
+                              disabled={disabled}
+                              aria-label={model}
+                            />
+                            <VendorIcon modelId={model} size={14} />
+                            <span className="min-w-0 flex-1 truncate">{model}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </TabsContent>
+              </div>
             </div>
           </Tabs>
         </div>

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -124,7 +124,7 @@ describe("RoutingConfigEditor", () => {
     );
   });
 
-  test("keeps tabs fixed while tab content and model list own scrolling", async () => {
+  test("keeps modal body and tabs fixed while tab content and model list own scrolling", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();
     const loadModelsForChannels = vi.fn(async () => [
@@ -140,8 +140,17 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("option", { name: "Team A Claude" }));
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
 
+    const modalBody = screen.getByTestId("group-editor-modal-body");
+    expect(modalBody).toHaveClass("overflow-hidden");
+    expect(modalBody).toHaveClass("flex");
+    expect(modalBody).toHaveClass("flex-col");
+
+    const tabShell = screen.getByTestId("group-editor-tabs-shell");
+    expect(tabShell).toHaveClass("flex");
+    expect(tabShell).toHaveClass("flex-col");
+
     const tabViewport = screen.getByTestId("group-editor-tab-viewport");
-    expect(tabViewport).toHaveClass("h-[520px]");
+    expect(tabViewport).toHaveClass("flex-1");
     expect(tabViewport).toHaveClass("overflow-y-auto");
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));

--- a/src/modules/ui/Modal.tsx
+++ b/src/modules/ui/Modal.tsx
@@ -12,6 +12,7 @@ export function Modal({
   maxWidth = "max-w-3xl",
   panelClassName,
   bodyHeightClassName,
+  bodyOverflowClassName,
   bodyClassName,
   bodyTestId,
   hideHeader = false,
@@ -25,6 +26,7 @@ export function Modal({
   maxWidth?: string;
   panelClassName?: string;
   bodyHeightClassName?: string;
+  bodyOverflowClassName?: string;
   bodyClassName?: string;
   bodyTestId?: string;
   hideHeader?: boolean;
@@ -77,6 +79,7 @@ export function Modal({
   if (!mounted) return null;
 
   const bodyHeightCls = bodyHeightClassName ?? "max-h-[70vh]";
+  const bodyOverflowCls = bodyOverflowClassName ?? "overflow-y-auto";
 
   return createPortal(
     <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
@@ -140,7 +143,7 @@ export function Modal({
 
         <div
           data-testid={bodyTestId}
-          className={`${bodyHeightCls} overflow-y-auto overscroll-contain px-5 py-4 ${bodyClassName ?? ""}`}
+          className={`${bodyHeightCls} ${bodyOverflowCls} overscroll-contain px-5 py-4 ${bodyClassName ?? ""}`}
         >
           {children}
         </div>


### PR DESCRIPTION
## Summary
- make the channel group editor modal body non-scrollable so the tab bar stays fixed
- move scrolling to the tab viewport below the tabs, with the model list owning its own internal scroll
- keep model-scope regression coverage for default all-model selection and fixed-tab layout

## Verification
- bun run test -- src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
- bun run lint
- bun run check
- bun run build
- bunx oxfmt src/modules/ui/Modal.tsx src/modules/channel-groups/RoutingConfigEditor.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx --check
- git diff --check