### PR TITLE
fix: show antigravity quota model metadata

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -853,6 +853,68 @@ describe("AuthFilesPage files table", () => {
     expect(within(cards).getByText("Model D [d]")).toBeInTheDocument();
   });
 
+  test("cards view shows antigravity model metadata from fetchAvailableModels", async () => {
+    const now = Date.now();
+    const file = {
+      name: "antigravity.json",
+      type: "antigravity",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "ag",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "antigravity.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              {
+                key: "model:gemini-3.1-pro-high",
+                label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
+                percent: 91,
+                resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+                meta: "Default Agent · Recommended · maxTokens=1048576 · maxOutputTokens=65535 · apiProvider=API_PROVIDER_GOOGLE_GEMINI · model=MODEL_PLACEHOLDER_M37 · thinking · images · video",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
+    const cards = screen.getByTestId("auth-files-cards");
+
+    expect(
+      within(cards).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).toBeInTheDocument();
+    expect(within(cards).getByText(/maxTokens=1048576/)).toBeInTheDocument();
+    expect(within(cards).getByText(/maxOutputTokens=65535/)).toBeInTheDocument();
+    expect(within(cards).getByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/)).toBeInTheDocument();
+    expect(within(cards).getByText(/model=MODEL_PLACEHOLDER_M37/)).toBeInTheDocument();
+  });
+
   test("cards view restores cached quota while refreshing in the background", async () => {
     const now = Date.now();
     const file = {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -366,6 +366,11 @@ export function useAuthFilesFilesPresentation({
           <div className="truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
             {resetText}
           </div>
+          {item?.meta ? (
+            <div className="break-words text-[10px] leading-snug text-slate-500 dark:text-white/55">
+              {item.meta}
+            </div>
+          ) : null}
         </div>
       );
     },

--- a/src/modules/quota/__tests__/quota-fetch.test.ts
+++ b/src/modules/quota/__tests__/quota-fetch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   request: vi.fn(),
@@ -21,6 +21,11 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
 });
 
 import { fetchQuota, resolveQuotaProvider } from "@/modules/quota/quota-fetch";
+
+beforeEach(() => {
+  mocks.request.mockReset();
+  mocks.downloadText.mockReset();
+});
 
 describe("resolveQuotaProvider", () => {
   test("supports kimi auth files", () => {
@@ -46,6 +51,117 @@ describe("resolveQuotaProvider", () => {
         account_type: "api-key",
       } as any),
     ).toBeNull();
+  });
+});
+
+describe("fetchQuota for antigravity", () => {
+  test("requests fetchAvailableModels with the auth project and returns dynamic model metrics", async () => {
+    mocks.downloadText.mockResolvedValueOnce(
+      JSON.stringify({ project_id: "bamboo-precept-lgxtn" }),
+    );
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: JSON.stringify({
+        models: {
+          "gemini-3.1-pro-high": {
+            displayName: "Gemini 3.1 Pro (High)",
+            supportsImages: true,
+            supportsThinking: true,
+            supportsVideo: true,
+            recommended: true,
+            maxTokens: 1048576,
+            maxOutputTokens: 65535,
+            quotaInfo: {
+              remainingFraction: 1,
+              resetTime: "2026-05-09T15:50:29Z",
+            },
+            model: "MODEL_PLACEHOLDER_M37",
+            apiProvider: "API_PROVIDER_GOOGLE_GEMINI",
+            modelProvider: "MODEL_PROVIDER_GOOGLE",
+          },
+          "gemini-3.1-pro-low": {
+            displayName: "Gemini 3.1 Pro (Low)",
+            maxTokens: 1048576,
+            maxOutputTokens: 65535,
+            quotaInfo: { remainingFraction: 0.8 },
+            model: "MODEL_PLACEHOLDER_M36",
+          },
+          "gemini-3-flash-agent": {
+            displayName: "Gemini 3 Flash",
+            quotaInfo: { remainingFraction: 0.7 },
+            model: "MODEL_PLACEHOLDER_M84",
+          },
+          "claude-sonnet-4-6": {
+            displayName: "Claude Sonnet 4.6 (Thinking)",
+            quotaInfo: { remainingFraction: 0.6 },
+            apiProvider: "API_PROVIDER_ANTHROPIC_VERTEX",
+          },
+          "gpt-oss-120b-medium": {
+            displayName: "GPT-OSS 120B (Medium)",
+            quotaInfo: { remainingFraction: 0.5 },
+            apiProvider: "API_PROVIDER_OPENAI_VERTEX",
+          },
+        },
+        defaultAgentModelId: "gemini-3.1-pro-high",
+        agentModelSorts: [
+          {
+            displayName: "Recommended",
+            groups: [
+              {
+                modelIds: [
+                  "gemini-3.1-pro-high",
+                  "gemini-3.1-pro-low",
+                  "gemini-3-flash-agent",
+                  "claude-sonnet-4-6",
+                  "gpt-oss-120b-medium",
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const result = await fetchQuota("antigravity", {
+      name: "antigravity.json",
+      provider: "antigravity",
+      auth_index: "ag-1",
+    } as any);
+
+    expect(mocks.downloadText).toHaveBeenCalledWith("antigravity.json");
+    expect(mocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authIndex: "ag-1",
+        method: "POST",
+        url: "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+        data: JSON.stringify({ project: "bamboo-precept-lgxtn" }),
+        header: expect.objectContaining({
+          Authorization: "Bearer $TOKEN$",
+          "User-Agent": "antigravity/1.11.5 windows/amd64",
+        }),
+      }),
+    );
+    expect(result.items.map((item) => item.key)).toEqual([
+      "model:gemini-3.1-pro-high",
+      "model:gemini-3.1-pro-low",
+      "model:gemini-3-flash-agent",
+      "model:claude-sonnet-4-6",
+      "model:gpt-oss-120b-medium",
+    ]);
+    expect(result.items[0]).toEqual(
+      expect.objectContaining({
+        label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
+        percent: 100,
+        resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+        meta: expect.stringContaining("maxTokens=1048576"),
+      }),
+    );
+    expect(result.items[0].meta).toContain("Default Agent");
+    expect(result.items[0].meta).toContain("Recommended");
+    expect(result.items[0].meta).toContain("apiProvider=API_PROVIDER_GOOGLE_GEMINI");
+    expect(result.items[0].meta).toContain("model=MODEL_PLACEHOLDER_M37");
   });
 });
 


### PR DESCRIPTION
## Summary
- render Antigravity fetchAvailableModels model metadata in auth file quota cards
- add a fetchQuota regression test for Antigravity project-based fetchAvailableModels responses
- cover card rendering for maxTokens/maxOutputTokens/apiProvider/model metadata

## Verification
- bun run test
- bun run lint
- bun run build
- dist marker check for maxTokens/agentModelSorts and absence of old Claude/GPT bucket