### PR TITLE
fix: simplify antigravity quota cards

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -853,7 +853,7 @@ describe("AuthFilesPage files table", () => {
     expect(within(cards).getByText("Model D [d]")).toBeInTheDocument();
   });
 
-  test("cards view shows antigravity model metadata from fetchAvailableModels", async () => {
+  test("cards view does not show verbose antigravity model metadata under quota bars", async () => {
     const now = Date.now();
     const file = {
       name: "antigravity.json",
@@ -909,10 +909,83 @@ describe("AuthFilesPage files table", () => {
     expect(
       within(cards).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
     ).toBeInTheDocument();
-    expect(within(cards).getByText(/maxTokens=1048576/)).toBeInTheDocument();
-    expect(within(cards).getByText(/maxOutputTokens=65535/)).toBeInTheDocument();
-    expect(within(cards).getByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/)).toBeInTheDocument();
-    expect(within(cards).getByText(/model=MODEL_PLACEHOLDER_M37/)).toBeInTheDocument();
+    expect(within(cards).getByText("91%")).toBeInTheDocument();
+    expect(within(cards).queryByText(/maxTokens=1048576/)).not.toBeInTheDocument();
+    expect(within(cards).queryByText(/maxOutputTokens=65535/)).not.toBeInTheDocument();
+    expect(
+      within(cards).queryByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/),
+    ).not.toBeInTheDocument();
+    expect(within(cards).queryByText(/model=MODEL_PLACEHOLDER_M37/)).not.toBeInTheDocument();
+  });
+
+  test("table quota hover does not show cached antigravity model metadata", async () => {
+    const now = Date.now();
+    const file = {
+      name: "antigravity.json",
+      type: "antigravity",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "ag",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "antigravity.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              {
+                key: "model:gemini-3.1-pro-low",
+                label: "Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]",
+                percent: 91,
+                resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+                meta: "Recommended · maxTokens=1048576 · maxOutputTokens=65535 · apiProvider=API_PROVIDER_GOOGLE_GEMINI · modelProvider=MODEL_PROVIDER_GOOGLE · model=MODEL_PLACEHOLDER_M36 · tokenizer=LLAMA_WITH_SPECIAL · tag=New · thinkingBudget=1001 · minThinkingBudget=128 · thinking · images · video · recommended",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
+
+    const row = screen.getByText("antigravity.json").closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.mouseEnter(
+      within(row as HTMLElement).getByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
+    );
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(
+      within(tooltip).getByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
+    ).toBeInTheDocument();
+    expect(within(tooltip).queryByText(/maxTokens=1048576/)).not.toBeInTheDocument();
+    expect(
+      within(tooltip).queryByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/),
+    ).not.toBeInTheDocument();
+    expect(
+      within(tooltip).queryByText(/modelProvider=MODEL_PROVIDER_GOOGLE/),
+    ).not.toBeInTheDocument();
   });
 
   test("cards view restores cached quota while refreshing in the background", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -281,7 +281,7 @@ export function useAuthFilesFilesPresentation({
   }, []);
 
   const renderQuotaHoverContent = useCallback(
-    (state: QuotaState) => {
+    (state: QuotaState, options?: { suppressItemMeta?: boolean }) => {
       const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
       const hasError = state.status === "error";
 
@@ -300,6 +300,7 @@ export function useAuthFilesFilesPresentation({
                 const percentText =
                   tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`;
                 const resetText = formatQuotaResetTextCompact(item.resetAtMs);
+                const itemMeta = options?.suppressItemMeta ? undefined : item.meta;
                 return (
                   <div key={item.label} className="contents">
                     <span className="min-w-0 truncate text-[10px] font-semibold text-slate-600 dark:text-white/70">
@@ -318,9 +319,9 @@ export function useAuthFilesFilesPresentation({
                     <span className="min-w-0 truncate whitespace-nowrap text-[10px] tabular-nums text-slate-500 dark:text-white/40">
                       {resetText ?? "--"}
                     </span>
-                    {item.meta ? (
+                    {itemMeta ? (
                       <span className="col-span-4 truncate text-[10px] text-slate-500 dark:text-white/55">
-                        {item.meta}
+                        {itemMeta}
                       </span>
                     ) : null}
                   </div>
@@ -366,11 +367,6 @@ export function useAuthFilesFilesPresentation({
           <div className="truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
             {resetText}
           </div>
-          {item?.meta ? (
-            <div className="break-words text-[10px] leading-snug text-slate-500 dark:text-white/55">
-              {item.meta}
-            </div>
-          ) : null}
         </div>
       );
     },
@@ -623,7 +619,9 @@ export function useAuthFilesFilesPresentation({
             <HoverTooltip
               disabled={!hasError && items.length === 0}
               className="w-full min-w-0"
-              content={renderQuotaHoverContent(state)}
+              content={renderQuotaHoverContent(state, {
+                suppressItemMeta: provider === "antigravity",
+              })}
             >
               <div className="w-full min-w-0">
                 {hasError && items.length === 0 ? (

--- a/src/modules/quota/__tests__/quota-fetch.test.ts
+++ b/src/modules/quota/__tests__/quota-fetch.test.ts
@@ -55,7 +55,7 @@ describe("resolveQuotaProvider", () => {
 });
 
 describe("fetchQuota for antigravity", () => {
-  test("requests fetchAvailableModels with the auth project and returns dynamic model metrics", async () => {
+  test("requests fetchAvailableModels with the auth project and returns dynamic quota items", async () => {
     mocks.downloadText.mockResolvedValueOnce(
       JSON.stringify({ project_id: "bamboo-precept-lgxtn" }),
     );
@@ -155,13 +155,9 @@ describe("fetchQuota for antigravity", () => {
         label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
         percent: 100,
         resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
-        meta: expect.stringContaining("maxTokens=1048576"),
       }),
     );
-    expect(result.items[0].meta).toContain("Default Agent");
-    expect(result.items[0].meta).toContain("Recommended");
-    expect(result.items[0].meta).toContain("apiProvider=API_PROVIDER_GOOGLE_GEMINI");
-    expect(result.items[0].meta).toContain("model=MODEL_PLACEHOLDER_M37");
+    expect(result.items[0].meta).toBeUndefined();
   });
 });
 

--- a/src/modules/quota/__tests__/quota-helpers.test.ts
+++ b/src/modules/quota/__tests__/quota-helpers.test.ts
@@ -243,17 +243,9 @@ describe("buildAntigravityItems", () => {
       expect.objectContaining({
         percent: 75,
         resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
-        meta: expect.stringContaining("Default Agent"),
       }),
     );
-    expect(items[0].meta).toContain("Recommended");
-    expect(items[0].meta).toContain("maxTokens=1048576");
-    expect(items[0].meta).toContain("maxOutputTokens=65535");
-    expect(items[0].meta).toContain("apiProvider=API_PROVIDER_GOOGLE_GEMINI");
-    expect(items[0].meta).toContain("model=MODEL_PLACEHOLDER_M37");
-    expect(items[0].meta).toContain("thinking");
-    expect(items[0].meta).toContain("images");
-    expect(items[0].meta).toContain("video");
+    expect(items[0].meta).toBeUndefined();
   });
 });
 

--- a/src/modules/quota/quota-antigravity.ts
+++ b/src/modules/quota/quota-antigravity.ts
@@ -1,7 +1,6 @@
 import {
   clampPercent,
   isRecord,
-  normalizeNumberValue,
   normalizeQuotaFraction,
   normalizeStringValue,
   parseResetTimeToMs,
@@ -12,20 +11,6 @@ type AntigravityQuotaInfo = {
   displayName?: string;
   quotaInfo?: Record<string, unknown>;
   quota_info?: Record<string, unknown>;
-  maxTokens?: unknown;
-  maxOutputTokens?: unknown;
-  tokenizerType?: unknown;
-  apiProvider?: unknown;
-  modelProvider?: unknown;
-  model?: unknown;
-  supportsImages?: unknown;
-  supportsThinking?: unknown;
-  supportsVideo?: unknown;
-  recommended?: unknown;
-  isInternal?: unknown;
-  tagTitle?: unknown;
-  thinkingBudget?: unknown;
-  minThinkingBudget?: unknown;
 };
 
 export type AntigravityModelsPayload = Record<string, AntigravityQuotaInfo>;
@@ -42,13 +27,13 @@ export type AntigravityFetchAvailableModelsPayload = {
   commitMessageModelIds?: unknown;
 };
 
-const MODEL_ID_LISTS: Array<[keyof AntigravityFetchAvailableModelsPayload, string]> = [
-  ["commandModelIds", "Command"],
-  ["tabModelIds", "Tab"],
-  ["imageGenerationModelIds", "Image Generation"],
-  ["mqueryModelIds", "MQuery"],
-  ["webSearchModelIds", "Web Search"],
-  ["commitMessageModelIds", "Commit Message"],
+const MODEL_ID_LISTS: Array<keyof AntigravityFetchAvailableModelsPayload> = [
+  "commandModelIds",
+  "tabModelIds",
+  "imageGenerationModelIds",
+  "mqueryModelIds",
+  "webSearchModelIds",
+  "commitMessageModelIds",
 ];
 
 const normalizeModelId = (value: unknown): string | null => normalizeStringValue(value);
@@ -84,45 +69,32 @@ const quotaInfo = (entry?: AntigravityQuotaInfo) => {
   };
 };
 
-const addModelRole = (
-  id: string | null,
-  role: string,
-  order: string[],
-  rolesByModel: Map<string, Set<string>>,
-) => {
+const addModelToOrder = (id: string | null, order: string[]) => {
   if (!id) return;
-  if (!rolesByModel.has(id)) rolesByModel.set(id, new Set());
-  rolesByModel.get(id)?.add(role);
   if (!order.includes(id)) order.push(id);
 };
 
 const collectPayloadModelOrder = (payload: AntigravityFetchAvailableModelsPayload) => {
   const order: string[] = [];
-  const rolesByModel = new Map<string, Set<string>>();
 
-  addModelRole(normalizeModelId(payload.defaultAgentModelId), "Default Agent", order, rolesByModel);
+  addModelToOrder(normalizeModelId(payload.defaultAgentModelId), order);
 
   if (Array.isArray(payload.agentModelSorts)) {
     payload.agentModelSorts.forEach((sort) => {
       if (!isRecord(sort)) return;
-      const sortLabel = normalizeStringValue(sort.displayName) ?? "Agent Models";
       const groups = Array.isArray(sort.groups) ? sort.groups : [];
       groups.forEach((group) => {
         if (!isRecord(group)) return;
-        normalizeModelIdList(group.modelIds).forEach((id) =>
-          addModelRole(id, sortLabel, order, rolesByModel),
-        );
+        normalizeModelIdList(group.modelIds).forEach((id) => addModelToOrder(id, order));
       });
     });
   }
 
-  MODEL_ID_LISTS.forEach(([key, label]) => {
-    normalizeModelIdList(payload[key]).forEach((id) =>
-      addModelRole(id, label, order, rolesByModel),
-    );
+  MODEL_ID_LISTS.forEach((key) => {
+    normalizeModelIdList(payload[key]).forEach((id) => addModelToOrder(id, order));
   });
 
-  return { order, rolesByModel };
+  return order;
 };
 
 const buildModelLabel = (id: string, entry: AntigravityQuotaInfo): string => {
@@ -131,44 +103,11 @@ const buildModelLabel = (id: string, entry: AntigravityQuotaInfo): string => {
   return `${displayName} [${id}]`;
 };
 
-const appendStringMeta = (parts: string[], label: string, value: unknown) => {
-  const normalized = normalizeStringValue(value);
-  if (normalized) parts.push(`${label}=${normalized}`);
-};
-
-const appendNumberMeta = (parts: string[], label: string, value: unknown) => {
-  const normalized = normalizeNumberValue(value);
-  if (normalized !== null) parts.push(`${label}=${normalized}`);
-};
-
-const buildModelMeta = (entry: AntigravityQuotaInfo, roles?: Set<string>): string | undefined => {
-  const parts: string[] = [];
-  if (roles) parts.push(...Array.from(roles));
-  appendNumberMeta(parts, "maxTokens", entry.maxTokens);
-  appendNumberMeta(parts, "maxOutputTokens", entry.maxOutputTokens);
-  appendStringMeta(parts, "apiProvider", entry.apiProvider);
-  appendStringMeta(parts, "modelProvider", entry.modelProvider);
-  appendStringMeta(parts, "model", entry.model);
-  appendStringMeta(parts, "tokenizer", entry.tokenizerType);
-  appendStringMeta(parts, "tag", entry.tagTitle);
-  appendNumberMeta(parts, "thinkingBudget", entry.thinkingBudget);
-  appendNumberMeta(parts, "minThinkingBudget", entry.minThinkingBudget);
-
-  if (entry.supportsThinking === true) parts.push("thinking");
-  if (entry.supportsImages === true) parts.push("images");
-  if (entry.supportsVideo === true) parts.push("video");
-  if (entry.recommended === true) parts.push("recommended");
-  if (entry.isInternal === true) parts.push("internal");
-
-  const uniqueParts = parts.filter((part, index, all) => all.indexOf(part) === index);
-  return uniqueParts.length > 0 ? uniqueParts.join(" · ") : undefined;
-};
-
 export const buildAntigravityItems = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
 ): QuotaItem[] => {
   const { payload, models } = resolvePayloadAndModels(input);
-  const { order, rolesByModel } = collectPayloadModelOrder(payload);
+  const order = collectPayloadModelOrder(payload);
   const orderedIds = new Set(order);
 
   Object.keys(models)
@@ -195,7 +134,6 @@ export const buildAntigravityItems = (
         label: buildModelLabel(id, entry),
         percent,
         resetAtMs: parseResetTimeToMs(info.resetTime),
-        meta: buildModelMeta(entry, rolesByModel.get(id)),
       },
     ];
   });


### PR DESCRIPTION
## Summary
- keep Antigravity quota items dynamic from fetchAvailableModels
- stop generating visible verbose model metadata for Antigravity quota rows
- suppress old cached Antigravity item metadata in quota hover content

## Verification
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "antigravity"
- bunx vitest run src/modules/quota/__tests__/quota-helpers.test.ts src/modules/quota/__tests__/quota-fetch.test.ts
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bunx vitest run --no-file-parallelism --maxWorkers=1
- bun run lint
- bun run build
- git diff --check