### PR TITLE
fix: filter antigravity internal models

### DIFF
--- a/src/modules/quota/__tests__/quota-helpers.test.ts
+++ b/src/modules/quota/__tests__/quota-helpers.test.ts
@@ -127,7 +127,7 @@ describe("buildCodexItems", () => {
 });
 
 describe("buildAntigravityItems", () => {
-  test("builds dynamic quota items from fetchAvailableModels instead of static buckets", () => {
+  test("builds dynamic quota items from fetchAvailableModels and skips reference internal models", () => {
     const payload = parseAntigravityPayload(
       JSON.stringify({
         models: {
@@ -136,6 +136,13 @@ describe("buildAntigravityItems", () => {
             maxOutputTokens: 4096,
             quotaInfo: { remainingFraction: 1 },
             model: "MODEL_PLACEHOLDER_M28",
+            apiProvider: "API_PROVIDER_GOOGLE_GEMINI",
+          },
+          tab_flash_lite_preview: {
+            maxTokens: 16384,
+            maxOutputTokens: 4096,
+            quotaInfo: { remainingFraction: 1 },
+            model: "MODEL_PLACEHOLDER_M19",
             apiProvider: "API_PROVIDER_GOOGLE_GEMINI",
           },
           "gemini-3.1-pro-high": {
@@ -183,6 +190,18 @@ describe("buildAntigravityItems", () => {
             quotaInfo: { remainingFraction: 1 },
             isInternal: true,
           },
+          chat_23310: {
+            quotaInfo: { remainingFraction: 1 },
+            isInternal: true,
+          },
+          "gemini-2.5-flash-thinking": {
+            displayName: "Gemini 3.1 Flash Lite",
+            quotaInfo: { remainingFraction: 1 },
+          },
+          "gemini-2.5-pro": {
+            displayName: "Gemini 2.5 Pro",
+            quotaInfo: { remainingFraction: 1 },
+          },
           "gemini-3.1-flash-image": {
             displayName: "Gemini 3.1 Flash Image",
             quotaInfo: { remainingFraction: 0.6 },
@@ -210,7 +229,7 @@ describe("buildAntigravityItems", () => {
           },
         ],
         commandModelIds: ["gemini-3-flash"],
-        tabModelIds: ["chat_20706"],
+        tabModelIds: ["chat_20706", "chat_23310"],
         imageGenerationModelIds: ["gemini-3.1-flash-image"],
         mqueryModelIds: ["gemini-3.1-flash-lite"],
         webSearchModelIds: ["gemini-3.1-flash-lite"],
@@ -230,13 +249,16 @@ describe("buildAntigravityItems", () => {
       "model:claude-sonnet-4-6",
       "model:gpt-oss-120b-medium",
       "model:gemini-3-flash",
-      "model:chat_20706",
       "model:gemini-3.1-flash-image",
       "model:gemini-3.1-flash-lite",
-      "model:tab_jump_flash_lite_preview",
     ]);
     expect(labels).toContain("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]");
-    expect(labels).toContain("chat_20706");
+    expect(labels).not.toContain("chat_20706");
+    expect(labels).not.toContain("chat_23310");
+    expect(labels).not.toContain("tab_flash_lite_preview");
+    expect(labels).not.toContain("tab_jump_flash_lite_preview");
+    expect(labels).not.toContain("Gemini 3.1 Flash Lite [gemini-2.5-flash-thinking]");
+    expect(labels).not.toContain("Gemini 2.5 Pro [gemini-2.5-pro]");
     expect(labels).not.toContain("Claude/GPT");
     expect(labels).not.toContain("Gemini 3 Pro");
     expect(items[0]).toEqual(

--- a/src/modules/quota/quota-antigravity.ts
+++ b/src/modules/quota/quota-antigravity.ts
@@ -36,10 +36,21 @@ const MODEL_ID_LISTS: Array<keyof AntigravityFetchAvailableModelsPayload> = [
   "commitMessageModelIds",
 ];
 
+const REFERENCE_SKIPPED_MODEL_IDS = new Set([
+  "chat_20706",
+  "chat_23310",
+  "tab_flash_lite_preview",
+  "tab_jump_flash_lite_preview",
+  "gemini-2.5-flash-thinking",
+  "gemini-2.5-pro",
+]);
+
 const normalizeModelId = (value: unknown): string | null => normalizeStringValue(value);
 
 const normalizeModelIdList = (value: unknown): string[] =>
   Array.isArray(value) ? value.map(normalizeModelId).filter((id): id is string => Boolean(id)) : [];
+
+const shouldSkipModel = (id: string): boolean => REFERENCE_SKIPPED_MODEL_IDS.has(id);
 
 const resolvePayloadAndModels = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
@@ -71,6 +82,7 @@ const quotaInfo = (entry?: AntigravityQuotaInfo) => {
 
 const addModelToOrder = (id: string | null, order: string[]) => {
   if (!id) return;
+  if (shouldSkipModel(id)) return;
   if (!order.includes(id)) order.push(id);
 };
 
@@ -112,6 +124,7 @@ export const buildAntigravityItems = (
 
   Object.keys(models)
     .filter((id) => !orderedIds.has(id))
+    .filter((id) => !shouldSkipModel(id))
     .sort((a, b) => a.localeCompare(b))
     .forEach((id) => {
       order.push(id);


### PR DESCRIPTION
## Summary
- align Antigravity fetchAvailableModels filtering with router-for-me/CLIProxyAPI
- skip only the six internal/experimental model ids that the reference project explicitly skips
- keep dynamic quota items and existing non-meta UI behavior unchanged

## Reference
CLIProxyAPI cmd/fetch_antigravity_models skips:
- chat_20706
- chat_23310
- tab_flash_lite_preview
- tab_jump_flash_lite_preview
- gemini-2.5-flash-thinking
- gemini-2.5-pro

## Verification
- bunx vitest run src/modules/quota/__tests__/quota-helpers.test.ts -t "skips reference internal models"
- bunx vitest run src/modules/quota/__tests__/quota-helpers.test.ts src/modules/quota/__tests__/quota-fetch.test.ts
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "antigravity"
- bun run lint
- bun run build
- git diff --check
- bunx vitest run --no-file-parallelism --maxWorkers=1