### PR TITLE
fix: filter cached antigravity quota models

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -853,6 +853,92 @@ describe("AuthFilesPage files table", () => {
     expect(within(cards).getByText("Model D [d]")).toBeInTheDocument();
   });
 
+  test("cards view hides cached antigravity models skipped by the reference implementation", async () => {
+    const now = Date.now();
+    const file = {
+      name: "antigravity.json",
+      type: "antigravity",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "ag",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "antigravity.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              {
+                key: "model:gemini-3.1-pro-high",
+                label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
+                percent: 91,
+              },
+              { key: "model:chat_20706", label: "chat_20706", percent: 100 },
+              { key: "model:chat_23310", label: "chat_23310", percent: 100 },
+              {
+                key: "model:tab_flash_lite_preview",
+                label: "tab_flash_lite_preview",
+                percent: 100,
+              },
+              {
+                key: "model:tab_jump_flash_lite_preview",
+                label: "tab_jump_flash_lite_preview",
+                percent: 100,
+              },
+              {
+                key: "model:gemini-2.5-flash-thinking",
+                label: "Gemini 3.1 Flash Lite [gemini-2.5-flash-thinking]",
+                percent: 100,
+              },
+              {
+                key: "model:gemini-2.5-pro",
+                label: "Gemini 2.5 Pro [gemini-2.5-pro]",
+                percent: 100,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
+    const cards = screen.getByTestId("auth-files-cards");
+
+    expect(
+      within(cards).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).toBeInTheDocument();
+    expect(within(cards).queryByText("chat_20706")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("chat_23310")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("tab_flash_lite_preview")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("tab_jump_flash_lite_preview")).not.toBeInTheDocument();
+    expect(
+      within(cards).queryByText("Gemini 3.1 Flash Lite [gemini-2.5-flash-thinking]"),
+    ).not.toBeInTheDocument();
+    expect(within(cards).queryByText("Gemini 2.5 Pro [gemini-2.5-pro]")).not.toBeInTheDocument();
+  });
+
   test("cards view does not show verbose antigravity model metadata under quota bars", async () => {
     const now = Date.now();
     const file = {
@@ -986,6 +1072,73 @@ describe("AuthFilesPage files table", () => {
     expect(
       within(tooltip).queryByText(/modelProvider=MODEL_PROVIDER_GOOGLE/),
     ).not.toBeInTheDocument();
+  });
+
+  test("table quota preview and hover hide cached antigravity models skipped by the reference implementation", async () => {
+    const now = Date.now();
+    const file = {
+      name: "antigravity.json",
+      type: "antigravity",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "ag",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "antigravity.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              { key: "model:chat_20706", label: "chat_20706", percent: 100 },
+              {
+                key: "model:gemini-3.1-pro-high",
+                label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
+                percent: 91,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
+
+    const row = screen.getByText("antigravity.json").closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).queryByText("chat_20706")).not.toBeInTheDocument();
+    const visibleModel = within(row as HTMLElement).getByText(
+      "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
+    );
+    expect(visibleModel).toBeInTheDocument();
+
+    fireEvent.mouseEnter(visibleModel);
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(within(tooltip).queryByText("chat_20706")).not.toBeInTheDocument();
+    expect(
+      within(tooltip).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).toBeInTheDocument();
   });
 
   test("cards view restores cached quota while refreshing in the background", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -28,7 +28,12 @@ import {
   resolveFileType,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import { resolveQuotaProvider, type QuotaProvider } from "@/modules/quota/quota-fetch";
-import { clampPercent, type QuotaItem, type QuotaState } from "@/modules/quota/quota-helpers";
+import {
+  clampPercent,
+  filterAntigravityQuotaItems,
+  type QuotaItem,
+  type QuotaState,
+} from "@/modules/quota/quota-helpers";
 
 const KNOWN_QUOTA_TEXT_KEYS = new Set([
   "missing_auth_index",
@@ -587,7 +592,10 @@ export function useAuthFilesFilesPresentation({
           }
 
           const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
-          const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
+          const rawItems = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
+          const items =
+            provider === "antigravity" ? filterAntigravityQuotaItems(rawItems) : rawItems;
+          const displayState = items === rawItems ? state : { ...state, items };
           const hasError = state.status === "error";
 
           const renderQuotaLinePreview = (item: QuotaItem) => {
@@ -619,7 +627,7 @@ export function useAuthFilesFilesPresentation({
             <HoverTooltip
               disabled={!hasError && items.length === 0}
               className="w-full min-w-0"
-              content={renderQuotaHoverContent(state, {
+              content={renderQuotaHoverContent(displayState, {
                 suppressItemMeta: provider === "antigravity",
               })}
             >

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -13,7 +13,11 @@ import type { AuthFileItem } from "@/lib/http/types";
 import { useInterval } from "@/hooks/useInterval";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { fetchQuota, resolveQuotaProvider, type QuotaProvider } from "@/modules/quota/quota-fetch";
-import { type QuotaItem, type QuotaState } from "@/modules/quota/quota-helpers";
+import {
+  filterAntigravityQuotaItems,
+  type QuotaItem,
+  type QuotaState,
+} from "@/modules/quota/quota-helpers";
 import {
   AUTH_FILES_FILES_VIEW_MODE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
@@ -131,7 +135,7 @@ export function useAuthFilesQuotaState({
       }
 
       if (provider === "antigravity") {
-        return items.map((item, index) => ({
+        return filterAntigravityQuotaItems(items).map((item, index) => ({
           id: item.key ?? item.label ?? `antigravity-${index + 1}`,
           label: translateQuotaLabel(item.label),
           item,

--- a/src/modules/quota/quota-antigravity.ts
+++ b/src/modules/quota/quota-antigravity.ts
@@ -50,7 +50,29 @@ const normalizeModelId = (value: unknown): string | null => normalizeStringValue
 const normalizeModelIdList = (value: unknown): string[] =>
   Array.isArray(value) ? value.map(normalizeModelId).filter((id): id is string => Boolean(id)) : [];
 
-const shouldSkipModel = (id: string): boolean => REFERENCE_SKIPPED_MODEL_IDS.has(id);
+export const shouldSkipAntigravityModelId = (id: string): boolean =>
+  REFERENCE_SKIPPED_MODEL_IDS.has(id);
+
+const ANTIGRAVITY_MODEL_KEY_PREFIX = "model:";
+
+const resolveAntigravityModelIdFromQuotaItem = (item: QuotaItem): string | null => {
+  const key = typeof item.key === "string" ? item.key.trim() : "";
+  if (key.startsWith(ANTIGRAVITY_MODEL_KEY_PREFIX)) {
+    return key.slice(ANTIGRAVITY_MODEL_KEY_PREFIX.length).trim() || null;
+  }
+  if (key && shouldSkipAntigravityModelId(key)) return key;
+
+  const label = String(item.label ?? "").trim();
+  const bracketModelId = label.match(/\[([^\]]+)\]\s*$/)?.[1]?.trim();
+  if (bracketModelId) return bracketModelId;
+  return label && shouldSkipAntigravityModelId(label) ? label : null;
+};
+
+export const filterAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] =>
+  items.filter((item) => {
+    const modelId = resolveAntigravityModelIdFromQuotaItem(item);
+    return !modelId || !shouldSkipAntigravityModelId(modelId);
+  });
 
 const resolvePayloadAndModels = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
@@ -82,7 +104,7 @@ const quotaInfo = (entry?: AntigravityQuotaInfo) => {
 
 const addModelToOrder = (id: string | null, order: string[]) => {
   if (!id) return;
-  if (shouldSkipModel(id)) return;
+  if (shouldSkipAntigravityModelId(id)) return;
   if (!order.includes(id)) order.push(id);
 };
 
@@ -124,7 +146,7 @@ export const buildAntigravityItems = (
 
   Object.keys(models)
     .filter((id) => !orderedIds.has(id))
-    .filter((id) => !shouldSkipModel(id))
+    .filter((id) => !shouldSkipAntigravityModelId(id))
     .sort((a, b) => a.localeCompare(b))
     .forEach((id) => {
       order.push(id);

--- a/src/modules/quota/quota-helpers.ts
+++ b/src/modules/quota/quota-helpers.ts
@@ -4,7 +4,9 @@ export { type AntigravityModelsPayload } from "@/modules/quota/quota-antigravity
 export {
   buildAntigravityGroups,
   buildAntigravityItems,
+  filterAntigravityQuotaItems,
   parseAntigravityPayload,
+  shouldSkipAntigravityModelId,
 } from "@/modules/quota/quota-antigravity";
 export { type CodexUsagePayload } from "@/modules/quota/quota-codex";
 export {


### PR DESCRIPTION
## Summary
- Reuse the reference Antigravity skip list for cached quota items rendered in cards and table quota UI
- Keep Antigravity cards untruncated, but hide only the six model IDs skipped by router-for-me/CLIProxyAPI
- Add regression coverage for stale cached cards, table preview, and hover content

## Verification
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "hides cached antigravity models"
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "table quota preview and hover hide cached antigravity"
- bunx vitest run src/modules/quota/__tests__/quota-helpers.test.ts src/modules/quota/__tests__/quota-fetch.test.ts
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "antigravity"
- bun run lint
- bun run build
- git diff --check
- bunx vitest run --no-file-parallelism --maxWorkers=1