### PR TITLE
fix: prevent quota tooltip overlap

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -156,6 +156,7 @@ describe("AuthFilesPage files table", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     window.localStorage.clear();
     window.sessionStorage.clear();
   });
@@ -1072,6 +1073,78 @@ describe("AuthFilesPage files table", () => {
     expect(
       within(tooltip).queryByText(/modelProvider=MODEL_PROVIDER_GOOGLE/),
     ).not.toBeInTheDocument();
+  });
+
+  test("table quota hover opens only the quota details tooltip", async () => {
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(80);
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(320);
+
+    const now = Date.now();
+    const file = {
+      name: "antigravity.json",
+      type: "antigravity",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "ag",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        quotaByFileName: {
+          "antigravity.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              {
+                key: "model:gemini-3.1-pro-high",
+                label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
+                percent: 100,
+                resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+              },
+              {
+                key: "model:claude-sonnet-4-6",
+                label: "Claude Sonnet 4.6 (Thinking) [claude-sonnet-4-6]",
+                percent: 100,
+                resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
+
+    const row = screen.getByText("antigravity.json").closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.mouseEnter(
+      within(row as HTMLElement).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    );
+
+    const tooltips = await screen.findAllByRole("tooltip");
+    expect(tooltips).toHaveLength(1);
+    expect(
+      within(tooltips[0]).getByText("Claude Sonnet 4.6 (Thinking) [claude-sonnet-4-6]"),
+    ).toBeInTheDocument();
   });
 
   test("table quota preview and hover hide cached antigravity models skipped by the reference implementation", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -299,7 +299,7 @@ export function useAuthFilesFilesPresentation({
           ) : null}
 
           {items.length > 0 ? (
-            <div className="grid w-[min(22rem,calc(100vw-2rem))] grid-cols-[auto_0.875rem_2.5rem_1fr] items-center gap-x-1 gap-y-1">
+            <div className="grid w-[min(20rem,calc(100vw-2rem))] grid-cols-[minmax(0,1fr)_0.875rem_2.75rem_3.75rem] items-center gap-x-1.5 gap-y-1">
               {items.map((item) => {
                 const tone = resolveQuotaVisualTone(item.percent);
                 const percentText =
@@ -315,13 +315,14 @@ export function useAuthFilesFilesPresentation({
                       {quotaProgressCircle(item.percent)}
                     </span>
                     <span
-                      className={["text-[10px] font-semibold tabular-nums", tone.percentClass].join(
-                        " ",
-                      )}
+                      className={[
+                        "justify-self-end text-[10px] font-semibold tabular-nums",
+                        tone.percentClass,
+                      ].join(" ")}
                     >
                       {percentText}
                     </span>
-                    <span className="min-w-0 truncate whitespace-nowrap text-[10px] tabular-nums text-slate-500 dark:text-white/40">
+                    <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
                       {resetText ?? "--"}
                     </span>
                     {itemMeta ? (
@@ -566,6 +567,7 @@ export function useAuthFilesFilesPresentation({
         key: "quota",
         label: t("auth_files.col_quota"),
         width: "w-64",
+        overflowTooltip: false,
         headerClassName: "text-center",
         headerRender: () => (
           <div className="flex items-center justify-center gap-2 normal-case">
@@ -603,20 +605,23 @@ export function useAuthFilesFilesPresentation({
             const percentText = tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`;
             const resetText = formatQuotaResetTextCompact(item.resetAtMs) ?? "--";
             return (
-              <div key={item.label} className="flex min-w-0 items-center gap-1">
-                <span className="shrink-0 truncate text-[10px] font-semibold text-slate-600 dark:text-white/70">
+              <div
+                key={item.label}
+                className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_0.875rem_auto_3.25rem] items-center gap-1"
+              >
+                <span className="min-w-0 truncate text-[10px] font-semibold text-slate-600 dark:text-white/70">
                   {translateQuotaText(item.label)}
                 </span>
                 {quotaProgressCircle(item.percent)}
                 <span
                   className={[
-                    "inline-flex shrink-0 items-center gap-1 text-[10px] font-semibold tabular-nums",
+                    "justify-self-end text-[10px] font-semibold tabular-nums",
                     tone.percentClass,
                   ].join(" ")}
                 >
                   {percentText}
                 </span>
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap text-[10px] tabular-nums text-slate-500 dark:text-white/40">
+                <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
                   {resetText}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- Disable the generic table overflow tooltip for the quota column so it no longer competes with the quota details hover
- Use fixed grid columns for quota preview and detail rows so long model names truncate without pushing percent/reset text out
- Add a regression test that forces cell overflow and verifies only one quota tooltip opens

## Verification
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "table quota hover opens only"
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "quota hover|antigravity|quota preview"
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run lint
- bun run build
- git diff --check
- bunx vitest run --no-file-parallelism --maxWorkers=1