### PR TITLE
fix: prevent quota reset text truncation

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1145,6 +1145,11 @@ describe("AuthFilesPage files table", () => {
     expect(
       within(tooltips[0]).getByText("Claude Sonnet 4.6 (Thinking) [claude-sonnet-4-6]"),
     ).toBeInTheDocument();
+    const resetText = Array.from(tooltips[0].querySelectorAll("span")).find(
+      (element) => element.textContent?.includes("秒") && element.className.includes("tabular-nums"),
+    );
+    expect(resetText).toBeTruthy();
+    expect(resetText).not.toHaveClass("truncate");
   });
 
   test("table quota preview and hover hide cached antigravity models skipped by the reference implementation", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -299,7 +299,7 @@ export function useAuthFilesFilesPresentation({
           ) : null}
 
           {items.length > 0 ? (
-            <div className="grid w-[min(20rem,calc(100vw-2rem))] grid-cols-[minmax(0,1fr)_0.875rem_2.75rem_3.75rem] items-center gap-x-1.5 gap-y-1">
+            <div className="grid w-[min(34rem,calc(100vw-2rem))] grid-cols-[minmax(0,1fr)_0.875rem_max-content_max-content] items-center gap-x-2 gap-y-1">
               {items.map((item) => {
                 const tone = resolveQuotaVisualTone(item.percent);
                 const percentText =
@@ -316,13 +316,13 @@ export function useAuthFilesFilesPresentation({
                     </span>
                     <span
                       className={[
-                        "justify-self-end text-[10px] font-semibold tabular-nums",
+                        "justify-self-end whitespace-nowrap text-[10px] font-semibold tabular-nums",
                         tone.percentClass,
                       ].join(" ")}
                     >
                       {percentText}
                     </span>
-                    <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
+                    <span className="whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
                       {resetText ?? "--"}
                     </span>
                     {itemMeta ? (

--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -263,7 +263,7 @@ export function TooltipBubble({
       role="tooltip"
       className={[
         interactive ? "pointer-events-auto select-text" : "pointer-events-none",
-        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-80 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
+        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-[34rem] dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
       ].join(" ")}
       style={style}
       onMouseEnter={onMouseEnter}


### PR DESCRIPTION
## Summary
- Keep quota hover reset time in a max-content column instead of truncating it
- Let quota hover tooltips grow wider, while long model names continue to truncate inside their own column
- Add regression coverage that fails when the reset time span carries the truncate class

## Verification
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "table quota hover opens only"
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "quota hover|antigravity|quota preview"
- bunx vitest run src/modules/ui/__tests__/Tooltip.test.tsx
- bun run lint
- bun run build
- git diff --check
- bunx vitest run --no-file-parallelism --maxWorkers=1