### PR TITLE
fix: keep quota tooltip compact

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1150,6 +1150,10 @@ describe("AuthFilesPage files table", () => {
     );
     expect(resetText).toBeTruthy();
     expect(resetText).not.toHaveClass("truncate");
+    expect(tooltips[0]).not.toHaveClass("sm:max-w-[34rem]");
+    expect(tooltips[0].querySelector(".quota-tooltip-grid")).toHaveClass(
+      "w-[min(26rem,calc(100vw-2rem))]",
+    );
   });
 
   test("table quota preview and hover hide cached antigravity models skipped by the reference implementation", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -299,7 +299,7 @@ export function useAuthFilesFilesPresentation({
           ) : null}
 
           {items.length > 0 ? (
-            <div className="grid w-[min(34rem,calc(100vw-2rem))] grid-cols-[minmax(0,1fr)_0.875rem_max-content_max-content] items-center gap-x-2 gap-y-1">
+            <div className="quota-tooltip-grid grid w-[min(26rem,calc(100vw-2rem))] grid-cols-[minmax(0,1fr)_0.875rem_max-content_max-content] items-center gap-x-2 gap-y-1">
               {items.map((item) => {
                 const tone = resolveQuotaVisualTone(item.percent);
                 const percentText =

--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -263,7 +263,7 @@ export function TooltipBubble({
       role="tooltip"
       className={[
         interactive ? "pointer-events-auto select-text" : "pointer-events-none",
-        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-[34rem] dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
+        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-[28rem] dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
       ].join(" ")}
       style={style}
       onMouseEnter={onMouseEnter}


### PR DESCRIPTION
## Summary
- Revert the oversized 34rem quota tooltip direction and keep the quota hover content at a compact 26rem width
- Keep reset time untruncated while model names remain the flexible truncated column
- Add regression coverage that prevents the oversized 34rem tooltip from coming back

## Verification
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "table quota hover opens only"
- bunx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "quota hover|antigravity|quota preview"
- bunx vitest run src/modules/ui/__tests__/Tooltip.test.tsx
- bun run lint
- bun run build
- git diff --check
- bunx vitest run --no-file-parallelism --maxWorkers=1