### PR TITLE
fix: make cc switch import client-specific

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2299,6 +2299,7 @@
     "client_gemini_cli": "Gemini CLI",
     "client_gemini_cli_desc": "Gemini-compatible provider for Gemini CLI.",
     "model_hint": "Model: {{model}}",
+    "import_client_type": "Client type",
     "import_provider_name": "Provider name",
     "import_provider_name_placeholder": "CliProxy provider",
     "import_channel_group": "Allowed channel group",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -68,6 +68,7 @@
     "client_gemini_cli": "Gemini CLI",
     "client_gemini_cli_desc": "Gemini-совместимый провайдер для Gemini CLI.",
     "model_hint": "Модель: {{model}}",
+    "import_client_type": "Client type",
     "import_provider_name": "Provider name",
     "import_provider_name_placeholder": "CliProxy provider",
     "import_channel_group": "Allowed channel group",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2506,6 +2506,7 @@
     "client_gemini_cli": "Gemini CLI",
     "client_gemini_cli_desc": "适用于 Gemini CLI 的 Gemini 兼容配置。",
     "model_hint": "模型：{{model}}",
+    "import_client_type": "类型",
     "import_provider_name": "供应商名称",
     "import_provider_name_placeholder": "CliProxy 供应商",
     "import_channel_group": "允许的渠道分组",

--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -33,10 +33,14 @@ import {
 } from "@/modules/ccswitch/CcSwitchImportModal";
 import {
   buildCcSwitchImportUrl,
-  buildCcSwitchProviderName,
   openCcSwitchImportUrl,
+  type CcSwitchClientType,
 } from "@/modules/ccswitch/ccswitchImport";
-import { readCcSwitchImportSettings } from "@/modules/ccswitch/ccswitchImportSettings";
+import {
+  normalizeCcSwitchClaudeAuthField,
+  readCcSwitchImportSettings,
+  type CcSwitchClaudeAuthField,
+} from "@/modules/ccswitch/ccswitchImportSettings";
 import { LogContentModal } from "@/modules/monitor/LogContentModal";
 import { ErrorDetailModal } from "@/modules/monitor/ErrorDetailModal";
 import type { ApiKeyFormValues } from "@/modules/api-keys/types";
@@ -69,7 +73,11 @@ export function ApiKeysPage() {
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [deleteLogsOnDelete, setDeleteLogsOnDelete] = useState(true);
   const [ccSwitchImportEntry, setCcSwitchImportEntry] = useState<ApiKeyEntry | null>(null);
+  const [ccSwitchImportClientType, setCcSwitchImportClientType] =
+    useState<CcSwitchClientType>("claude");
   const [ccSwitchImportGroup, setCcSwitchImportGroup] = useState("");
+  const [ccSwitchImportClaudeApiKeyField, setCcSwitchImportClaudeApiKeyField] =
+    useState<CcSwitchClaudeAuthField>("ANTHROPIC_API_KEY");
   const [ccSwitchImportProviderName, setCcSwitchImportProviderName] = useState("");
   const [ccSwitchImportEnabled, setCcSwitchImportEnabled] = useState(true);
   const [ccSwitchImportModel, setCcSwitchImportModel] = useState("");
@@ -640,7 +648,9 @@ export function ApiKeysPage() {
         .filter(Boolean);
       const initialGroup = entryGroups[0] ?? knownGroups[0] ?? "";
       setCcSwitchImportEntry(entry);
+      setCcSwitchImportClientType("claude");
       setCcSwitchImportGroup(initialGroup);
+      setCcSwitchImportClaudeApiKeyField("ANTHROPIC_API_KEY");
       setCcSwitchImportProviderName(entry.name || "CliProxy");
       setCcSwitchImportEnabled(true);
       setCcSwitchImportModel("");
@@ -663,18 +673,25 @@ export function ApiKeysPage() {
     (selection: CcSwitchImportSelection) => {
       if (!ccSwitchImportEntry) return;
       const settings = readCcSwitchImportSettings();
+      const importSettings =
+        selection.clientType === "claude"
+          ? {
+              ...settings,
+              claude: {
+                ...settings.claude,
+                apiKeyField: normalizeCcSwitchClaudeAuthField(selection.apiKeyField),
+              },
+            }
+          : settings;
       const url = buildCcSwitchImportUrl({
         apiKey: ccSwitchImportEntry.key,
         baseUrl: selection.baseUrl,
         clientType: selection.clientType,
         enabled: selection.enabled,
-        providerName: buildCcSwitchProviderName({
-          rawName: selection.providerName || ccSwitchImportEntry.name,
-          clientType: selection.clientType,
-        }),
+        providerName: selection.providerName || ccSwitchImportEntry.name || "CliProxy",
         model: selection.model,
         models: ccSwitchImportModels,
-        settings,
+        settings: importSettings,
       });
 
       openCcSwitchImportUrl(url, {
@@ -843,13 +860,17 @@ export function ApiKeysPage() {
         baseUrl={ccSwitchImportBaseUrl}
         channelGroup={ccSwitchImportGroup}
         channelGroupOptions={ccSwitchImportGroupOptions}
+        clientType={ccSwitchImportClientType}
+        claudeApiKeyField={ccSwitchImportClaudeApiKeyField}
         enabled={ccSwitchImportEnabled}
         model={ccSwitchImportModel}
         models={ccSwitchImportModels}
         modelsLoading={ccSwitchImportModelsLoading}
         providerName={ccSwitchImportProviderName}
         onChannelGroupChange={handleCcSwitchImportGroupChange}
+        onClientTypeChange={setCcSwitchImportClientType}
         onClose={() => setCcSwitchImportEntry(null)}
+        onClaudeApiKeyFieldChange={setCcSwitchImportClaudeApiKeyField}
         onEnabledChange={setCcSwitchImportEnabled}
         onModelChange={setCcSwitchImportModel}
         onProviderNameChange={setCcSwitchImportProviderName}

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -295,8 +295,9 @@ describe("ApiKeysPage", () => {
 
     const dialog = await screen.findByRole("dialog", { name: /import to cc switch/i });
     expect(dialog).toHaveTextContent(/claude code/i);
-    expect(dialog).toHaveTextContent(/codex/i);
-    expect(dialog).toHaveTextContent(/gemini cli/i);
+
+    await userEvent.click(screen.getByRole("combobox", { name: /client type/i }));
+    await userEvent.click(await screen.findByRole("option", { name: "Codex" }));
 
     await userEvent.click(screen.getByRole("button", { name: /import codex/i }));
 
@@ -315,7 +316,7 @@ describe("ApiKeysPage", () => {
     openSpy.mockRestore();
   });
 
-  test("imports to CC Switch with a selected channel group route, provider name, enabled state, and model", async () => {
+  test("imports a Codex CC Switch provider from the selected client-specific form", async () => {
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
     vi.spyOn(document, "hasFocus").mockReturnValue(false);
     state.entries = [
@@ -354,9 +355,15 @@ describe("ApiKeysPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /import to cc switch/i }));
     await screen.findByRole("dialog", { name: /import to cc switch/i });
 
+    const clientTypeSelect = screen.getByRole("combobox", { name: /client type/i });
+    await userEvent.click(clientTypeSelect);
+    await userEvent.click(await screen.findByRole("option", { name: "Codex" }));
+
+    expect(screen.queryByRole("combobox", { name: /claude code auth field/i })).toBeNull();
+
     const providerNameInput = screen.getByRole("textbox", { name: /provider name/i });
     await userEvent.clear(providerNameInput);
-    await userEvent.type(providerNameInput, "Work Codex");
+    await userEvent.type(providerNameInput, "Work");
 
     await userEvent.click(screen.getByRole("checkbox", { name: /enabled by default/i }));
 
@@ -376,10 +383,77 @@ describe("ApiKeysPage", () => {
     const openedUrl = String(openSpy.mock.calls.at(-1)?.[0] ?? "");
     const parsed = new URL(openedUrl);
     expect(parsed.searchParams.get("app")).toBe("codex");
-    expect(parsed.searchParams.get("name")).toBe("Work Codex");
+    expect(parsed.searchParams.get("name")).toBe("Work");
     expect(parsed.searchParams.get("endpoint")).toBe("http://localhost:3000/pro/v1");
     expect(parsed.searchParams.get("model")).toBe("gpt-5.4");
     expect(parsed.searchParams.get("enabled")).toBe("false");
+    expect(parsed.searchParams.has("apiKeyField")).toBe(false);
+
+    openSpy.mockRestore();
+  });
+
+  test("imports a Claude Code CC Switch provider with its auth field in the selected form", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    state.entries = [
+      {
+        key: "sk-group-1234567890",
+        name: "Claude Key",
+        "allowed-channel-groups": ["team-a"],
+        "created-at": "2026-04-14T00:00:00.000Z",
+      },
+    ];
+    state.channelGroups = [
+      {
+        name: "team-a",
+        description: "Team A route",
+        "path-routes": ["/team-a"],
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Claude Key")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /import to cc switch/i }));
+    await screen.findByRole("dialog", { name: /import to cc switch/i });
+
+    const clientTypeSelect = screen.getByRole("combobox", { name: /client type/i });
+    await userEvent.click(clientTypeSelect);
+    await userEvent.click(await screen.findByRole("option", { name: "Claude Code" }));
+
+    expect(screen.getByRole("combobox", { name: /claude code auth field/i })).toHaveTextContent(
+      "ANTHROPIC_API_KEY",
+    );
+
+    const providerNameInput = screen.getByRole("textbox", { name: /provider name/i });
+    await userEvent.clear(providerNameInput);
+    await userEvent.type(providerNameInput, "Anthropic Work");
+
+    await userEvent.click(screen.getByRole("button", { name: /import claude code/i }));
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining("ccswitch://v1/import?"),
+        "_self",
+      );
+    });
+
+    const openedUrl = String(openSpy.mock.calls.at(-1)?.[0] ?? "");
+    const parsed = new URL(openedUrl);
+    expect(parsed.searchParams.get("app")).toBe("claude");
+    expect(parsed.searchParams.get("name")).toBe("Anthropic Work");
+    expect(parsed.searchParams.get("endpoint")).toBe("http://localhost:3000/team-a");
+    expect(parsed.searchParams.get("model")).toBe("claude-sonnet-4-5");
+    expect(parsed.searchParams.get("apiKeyField")).toBe("ANTHROPIC_API_KEY");
 
     openSpy.mockRestore();
   });

--- a/src/modules/ccswitch/CcSwitchImportModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportModal.tsx
@@ -4,8 +4,15 @@ import { Checkbox } from "@/modules/ui/Checkbox";
 import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import { Select } from "@/modules/ui/Select";
-import { CcSwitchImportOptions } from "@/modules/ccswitch/CcSwitchImportOptions";
-import type { CcSwitchClientType } from "@/modules/ccswitch/ccswitchImport";
+import {
+  CC_SWITCH_CLIENTS,
+  getCcSwitchClientConfig,
+  type CcSwitchClientType,
+} from "@/modules/ccswitch/ccswitchImport";
+import {
+  CC_SWITCH_CLAUDE_AUTH_FIELDS,
+  type CcSwitchClaudeAuthField,
+} from "@/modules/ccswitch/ccswitchImportSettings";
 
 export interface CcSwitchImportGroupOption {
   value: string;
@@ -15,6 +22,7 @@ export interface CcSwitchImportGroupOption {
 }
 
 export interface CcSwitchImportSelection {
+  apiKeyField?: CcSwitchClaudeAuthField;
   baseUrl: string;
   channelGroup: string;
   clientType: CcSwitchClientType;
@@ -29,13 +37,17 @@ export function CcSwitchImportModal({
   baseUrl,
   channelGroup,
   channelGroupOptions = [],
+  clientType,
+  claudeApiKeyField,
   enabled,
   model,
   models = [],
   modelsLoading = false,
   providerName,
   onChannelGroupChange,
+  onClientTypeChange,
   onClose,
+  onClaudeApiKeyFieldChange,
   onEnabledChange,
   onModelChange,
   onProviderNameChange,
@@ -46,18 +58,28 @@ export function CcSwitchImportModal({
   baseUrl: string;
   channelGroup: string;
   channelGroupOptions?: readonly CcSwitchImportGroupOption[];
+  clientType: CcSwitchClientType;
+  claudeApiKeyField: CcSwitchClaudeAuthField;
   enabled: boolean;
   model: string;
   models?: readonly string[];
   modelsLoading?: boolean;
   providerName: string;
   onChannelGroupChange: (value: string) => void;
+  onClientTypeChange: (value: CcSwitchClientType) => void;
   onClose: () => void;
+  onClaudeApiKeyFieldChange: (value: CcSwitchClaudeAuthField) => void;
   onEnabledChange: (enabled: boolean) => void;
   onModelChange: (value: string) => void;
   onProviderNameChange: (value: string) => void;
   onSelect: (selection: CcSwitchImportSelection) => void;
 }) {
+  const client = getCcSwitchClientConfig(clientType);
+  const clientLabel = t(client.labelKey);
+  const clientOptions = CC_SWITCH_CLIENTS.map((item) => ({
+    value: item.type,
+    label: t(item.labelKey),
+  }));
   const groupOptions =
     channelGroupOptions.length > 0
       ? channelGroupOptions.map((option) => ({
@@ -72,6 +94,15 @@ export function CcSwitchImportModal({
           },
         ];
   const modelOptions = models.map((item) => ({ value: item, label: item }));
+  const claudeApiKeyFieldOptions = CC_SWITCH_CLAUDE_AUTH_FIELDS.map((value) => ({
+    value,
+    label: t(
+      value === "ANTHROPIC_AUTH_TOKEN"
+        ? "ccswitch.auth_field_anthropic_auth_token"
+        : "ccswitch.auth_field_anthropic_api_key",
+    ),
+  }));
+  const submitLabel = t("ccswitch.import_client", { client: clientLabel });
 
   return (
     <Modal
@@ -87,6 +118,18 @@ export function CcSwitchImportModal({
       }
     >
       <div className="space-y-4">
+        <label className="space-y-1.5">
+          <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
+            {t("ccswitch.import_client_type")}
+          </span>
+          <Select
+            value={clientType}
+            onChange={(value) => onClientTypeChange(value as CcSwitchClientType)}
+            options={clientOptions}
+            aria-label={t("ccswitch.import_client_type")}
+          />
+        </label>
+
         <div className="grid gap-3 sm:grid-cols-2">
           <label className="space-y-1.5">
             <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
@@ -142,6 +185,20 @@ export function CcSwitchImportModal({
           </label>
         </div>
 
+        {clientType === "claude" ? (
+          <label className="space-y-1.5">
+            <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
+              {t("ccswitch.settings_auth_field", { client: clientLabel })}
+            </span>
+            <Select
+              value={claudeApiKeyField}
+              onChange={(value) => onClaudeApiKeyFieldChange(value as CcSwitchClaudeAuthField)}
+              options={claudeApiKeyFieldOptions}
+              aria-label={t("ccswitch.settings_auth_field", { client: clientLabel })}
+            />
+          </label>
+        ) : null}
+
         <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900/55">
           <div className="text-xs font-semibold text-slate-500 dark:text-white/45">
             {t("ccswitch.import_base_url")}
@@ -151,29 +208,23 @@ export function CcSwitchImportModal({
           </div>
         </div>
 
-        <CcSwitchImportOptions
-          t={t}
-          models={model ? [model] : models}
-          settings={
-            model
-              ? {
-                  claude: { defaultModel: model },
-                  codex: { defaultModel: model },
-                  gemini: { defaultModel: model },
-                }
-              : undefined
-          }
-          onSelect={(clientType) =>
-            onSelect({
-              baseUrl,
-              channelGroup,
-              clientType,
-              enabled,
-              model,
-              providerName,
-            })
-          }
-        />
+        <div className="flex justify-end">
+          <Button
+            onClick={() =>
+              onSelect({
+                apiKeyField: clientType === "claude" ? claudeApiKeyField : undefined,
+                baseUrl,
+                channelGroup,
+                clientType,
+                enabled,
+                model,
+                providerName,
+              })
+            }
+          >
+            {submitLabel}
+          </Button>
+        </div>
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Summary\n- make API key CC Switch import start from a client type selector\n- show client-specific import fields, including Claude Code auth field only for Claude\n- preserve selected group/model/default/provider-name values in import deeplinks\n\n## Tests\n- bun run test src/modules/api-keys/__tests__/ApiKeysPage.test.tsx src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/ccswitch/__tests__/CcSwitchImportOptions.test.tsx src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx\n- bun run build\n- bun run lint