### PR TITLE
fix: polish cc switch import modal ui

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2309,6 +2309,8 @@
     "import_model": "Model",
     "import_model_placeholder": "Select a model",
     "import_model_loading": "Loading models...",
+    "import_endpoint_root": "root",
+    "import_endpoint_path_hint": "Endpoint path: {{path}}",
     "settings_title": "CC Switch import settings",
     "settings_description": "Maintain the client-specific defaults used by one-click imports, including endpoint path, default model, and usage refresh interval.",
     "settings_endpoint_path": "{{client}} endpoint path",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -78,6 +78,8 @@
     "import_model": "Model",
     "import_model_placeholder": "Select a model",
     "import_model_loading": "Loading models...",
+    "import_endpoint_root": "root",
+    "import_endpoint_path_hint": "Endpoint path: {{path}}",
     "settings_title": "CC Switch import settings",
     "settings_description": "Maintain the client-specific defaults used by one-click imports, including endpoint path, default model, and usage refresh interval.",
     "settings_endpoint_path": "{{client}} endpoint path",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2516,6 +2516,8 @@
     "import_model": "模型",
     "import_model_placeholder": "选择模型",
     "import_model_loading": "正在加载模型...",
+    "import_endpoint_root": "根路径",
+    "import_endpoint_path_hint": "Endpoint 路径：{{path}}",
     "settings_title": "CC Switch 导入配置",
     "settings_description": "维护一键导入使用的客户端默认值，包括 Endpoint 路径、默认模型和用量刷新间隔。",
     "settings_endpoint_path": "{{client}} Endpoint 路径",

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -392,6 +392,51 @@ describe("ApiKeysPage", () => {
     openSpy.mockRestore();
   });
 
+  test("keeps the CC Switch client-specific panel stable while switching client types", async () => {
+    state.entries = [
+      {
+        key: "sk-group-1234567890",
+        name: "Group Key",
+        "allowed-channel-groups": ["pro"],
+        "created-at": "2026-04-14T00:00:00.000Z",
+      },
+    ];
+    state.channelGroups = [
+      {
+        name: "pro",
+        description: "Pro route",
+        "path-routes": ["/pro"],
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Group Key")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /import to cc switch/i }));
+    await screen.findByRole("dialog", { name: /import to cc switch/i });
+
+    const detailsPanel = screen.getByTestId("ccswitch-client-specific-panel");
+    expect(detailsPanel).toHaveClass("min-h-[76px]");
+    expect(screen.getByRole("combobox", { name: /claude code auth field/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("combobox", { name: /client type/i }));
+    await userEvent.click(await screen.findByRole("option", { name: "Codex" }));
+
+    expect(screen.getByTestId("ccswitch-client-specific-panel")).toBe(detailsPanel);
+    expect(screen.queryByRole("combobox", { name: /claude code auth field/i })).toBeNull();
+    expect(detailsPanel).toHaveTextContent(/openai-compatible/i);
+    expect(detailsPanel).toHaveTextContent(/\/v1/i);
+  });
+
   test("imports a Claude Code CC Switch provider with its auth field in the selected form", async () => {
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
     vi.spyOn(document, "hasFocus").mockReturnValue(false);

--- a/src/modules/ccswitch/CcSwitchImportModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportModal.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/modules/ccswitch/ccswitchImport";
 import {
   CC_SWITCH_CLAUDE_AUTH_FIELDS,
+  DEFAULT_CC_SWITCH_IMPORT_SETTINGS,
   type CcSwitchClaudeAuthField,
 } from "@/modules/ccswitch/ccswitchImportSettings";
 
@@ -30,6 +31,12 @@ export interface CcSwitchImportSelection {
   model: string;
   providerName: string;
 }
+
+const labelClassName =
+  "text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
+const controlClassName =
+  "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
+const fieldClassName = "space-y-1.5";
 
 export function CcSwitchImportModal({
   t,
@@ -103,113 +110,23 @@ export function CcSwitchImportModal({
     ),
   }));
   const submitLabel = t("ccswitch.import_client", { client: clientLabel });
+  const endpointPath = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[clientType].endpointPath;
+  const endpointHint = endpointPath || t("ccswitch.import_endpoint_root");
 
   return (
     <Modal
       open={open}
       title={t("ccswitch.import_to_ccswitch")}
       description={t("ccswitch.import_modal_desc")}
-      maxWidth="max-w-xl"
+      maxWidth="max-w-2xl"
       onClose={onClose}
       footer={
-        <Button variant="secondary" onClick={onClose}>
-          {t("common.cancel")}
-        </Button>
-      }
-    >
-      <div className="space-y-4">
-        <label className="space-y-1.5">
-          <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
-            {t("ccswitch.import_client_type")}
-          </span>
-          <Select
-            value={clientType}
-            onChange={(value) => onClientTypeChange(value as CcSwitchClientType)}
-            options={clientOptions}
-            aria-label={t("ccswitch.import_client_type")}
-          />
-        </label>
-
-        <div className="grid gap-3 sm:grid-cols-2">
-          <label className="space-y-1.5">
-            <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
-              {t("ccswitch.import_provider_name")}
-            </span>
-            <TextInput
-              value={providerName}
-              onChange={(event) => onProviderNameChange(event.currentTarget.value)}
-              placeholder={t("ccswitch.import_provider_name_placeholder")}
-              aria-label={t("ccswitch.import_provider_name")}
-            />
-          </label>
-
-          <label className="space-y-1.5">
-            <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
-              {t("ccswitch.import_channel_group")}
-            </span>
-            <Select
-              value={channelGroup}
-              onChange={onChannelGroupChange}
-              options={groupOptions}
-              aria-label={t("ccswitch.import_channel_group")}
-            />
-          </label>
-        </div>
-
-        <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
-          <label className="space-y-1.5">
-            <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
-              {t("ccswitch.import_model")}
-            </span>
-            <Select
-              value={model}
-              onChange={onModelChange}
-              options={modelOptions}
-              placeholder={
-                modelsLoading
-                  ? t("ccswitch.import_model_loading")
-                  : t("ccswitch.import_model_placeholder")
-              }
-              aria-label={t("ccswitch.import_model")}
-              className="w-full"
-            />
-          </label>
-
-          <label className="inline-flex h-10 items-center gap-2 text-sm font-medium text-slate-700 dark:text-white/70">
-            <Checkbox
-              checked={enabled}
-              onCheckedChange={onEnabledChange}
-              aria-label={t("ccswitch.import_enabled_default")}
-            />
-            {t("ccswitch.import_enabled_default")}
-          </label>
-        </div>
-
-        {clientType === "claude" ? (
-          <label className="space-y-1.5">
-            <span className="text-xs font-semibold text-slate-600 dark:text-white/55">
-              {t("ccswitch.settings_auth_field", { client: clientLabel })}
-            </span>
-            <Select
-              value={claudeApiKeyField}
-              onChange={(value) => onClaudeApiKeyFieldChange(value as CcSwitchClaudeAuthField)}
-              options={claudeApiKeyFieldOptions}
-              aria-label={t("ccswitch.settings_auth_field", { client: clientLabel })}
-            />
-          </label>
-        ) : null}
-
-        <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900/55">
-          <div className="text-xs font-semibold text-slate-500 dark:text-white/45">
-            {t("ccswitch.import_base_url")}
-          </div>
-          <div className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-white/70">
-            {baseUrl || "--"}
-          </div>
-        </div>
-
-        <div className="flex justify-end">
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            {t("common.cancel")}
+          </Button>
           <Button
+            variant="primary"
             onClick={() =>
               onSelect({
                 apiKeyField: clientType === "claude" ? claudeApiKeyField : undefined,
@@ -224,6 +141,113 @@ export function CcSwitchImportModal({
           >
             {submitLabel}
           </Button>
+        </>
+      }
+      bodyClassName="bg-slate-50/45 dark:bg-neutral-950/45"
+    >
+      <div className="space-y-3.5">
+        <section className="grid gap-3 rounded-2xl border border-slate-200/75 bg-white p-3 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] sm:grid-cols-[minmax(0,0.84fr)_minmax(0,1.16fr)] dark:border-neutral-800 dark:bg-neutral-950/70">
+          <label className={fieldClassName}>
+            <span className={labelClassName}>{t("ccswitch.import_client_type")}</span>
+            <Select
+              value={clientType}
+              onChange={(value) => onClientTypeChange(value as CcSwitchClientType)}
+              options={clientOptions}
+              aria-label={t("ccswitch.import_client_type")}
+              className={controlClassName}
+            />
+          </label>
+
+          <div
+            data-testid="ccswitch-client-specific-panel"
+            className="min-h-[76px] rounded-xl border border-slate-200/75 bg-slate-50/70 px-3 py-2.5 dark:border-neutral-800 dark:bg-neutral-900/60"
+          >
+            {clientType === "claude" ? (
+              <label className="block space-y-1.5">
+                <span className={labelClassName}>
+                  {t("ccswitch.settings_auth_field", { client: clientLabel })}
+                </span>
+                <Select
+                  value={claudeApiKeyField}
+                  onChange={(value) => onClaudeApiKeyFieldChange(value as CcSwitchClaudeAuthField)}
+                  options={claudeApiKeyFieldOptions}
+                  aria-label={t("ccswitch.settings_auth_field", { client: clientLabel })}
+                  className={controlClassName}
+                />
+              </label>
+            ) : (
+              <div className="flex h-full min-h-[54px] flex-col justify-center gap-1">
+                <div className="text-sm font-semibold text-slate-900 dark:text-white">
+                  {clientLabel}
+                </div>
+                <div className="text-xs leading-5 text-slate-500 dark:text-white/55">
+                  {t(client.descriptionKey)}
+                </div>
+                <div className="font-mono text-[11px] text-slate-500 dark:text-white/45">
+                  {t("ccswitch.import_endpoint_path_hint", { path: endpointHint })}
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className={fieldClassName}>
+            <span className={labelClassName}>{t("ccswitch.import_provider_name")}</span>
+            <TextInput
+              value={providerName}
+              onChange={(event) => onProviderNameChange(event.currentTarget.value)}
+              placeholder={t("ccswitch.import_provider_name_placeholder")}
+              aria-label={t("ccswitch.import_provider_name")}
+              className={controlClassName}
+            />
+          </label>
+
+          <label className={fieldClassName}>
+            <span className={labelClassName}>{t("ccswitch.import_channel_group")}</span>
+            <Select
+              value={channelGroup}
+              onChange={onChannelGroupChange}
+              options={groupOptions}
+              aria-label={t("ccswitch.import_channel_group")}
+              className={controlClassName}
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+          <label className={fieldClassName}>
+            <span className={labelClassName}>{t("ccswitch.import_model")}</span>
+            <Select
+              value={model}
+              onChange={onModelChange}
+              options={modelOptions}
+              placeholder={
+                modelsLoading
+                  ? t("ccswitch.import_model_loading")
+                  : t("ccswitch.import_model_placeholder")
+              }
+              aria-label={t("ccswitch.import_model")}
+              className={`${controlClassName} w-full`}
+            />
+          </label>
+
+          <label className="inline-flex h-10 items-center gap-2 rounded-xl border border-slate-200/75 bg-white px-3 text-sm font-semibold text-slate-700 shadow-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/70">
+            <Checkbox
+              checked={enabled}
+              onCheckedChange={onEnabledChange}
+              aria-label={t("ccswitch.import_enabled_default")}
+              className="h-4 w-4"
+            />
+            {t("ccswitch.import_enabled_default")}
+          </label>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200/75 bg-white px-3.5 py-3 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-neutral-800 dark:bg-neutral-950/70">
+          <div className={labelClassName}>{t("ccswitch.import_base_url")}</div>
+          <div className="mt-1.5 truncate rounded-lg bg-slate-100/80 px-2.5 py-2 font-mono text-xs text-slate-700 dark:bg-neutral-900 dark:text-white/70">
+            {baseUrl || "--"}
+          </div>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary\n- polish the API key CC Switch import modal into a cleaner fixed structure\n- keep the client-specific panel height stable while switching client types\n- move the import action into the modal footer and tighten input/select/base-url styling\n\n## Tests\n- bun run test src/modules/api-keys/__tests__/ApiKeysPage.test.tsx src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/ccswitch/__tests__/CcSwitchImportOptions.test.tsx src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx\n- bun run build\n- bun run lint