### PR TITLE
fix: align channel group models with auth owner mapping

### DIFF
--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -14,6 +14,10 @@ import {
   makeClientId,
   type VisualConfigValues,
 } from "@/modules/config/visual/types";
+import {
+  filterByConfiguredModelAvailability,
+  loadConfiguredModelAvailability,
+} from "@/modules/models/modelAvailability";
 import { Card } from "@/modules/ui/Card";
 import { useToast } from "@/modules/ui/ToastProvider";
 
@@ -180,7 +184,14 @@ export function ChannelGroupsPage() {
     const ids = Array.isArray(data?.data)
       ? data.data.map((model) => String(model.id ?? "").trim()).filter(Boolean)
       : [];
-    return Array.from(new Set(ids)).sort((a, b) => a.localeCompare(b));
+    const availability = await loadConfiguredModelAvailability();
+    const visibleModels = filterByConfiguredModelAvailability(
+      ids.map((id) => ({ id })),
+      availability,
+    );
+    return Array.from(new Set(visibleModels.map((model) => model.id))).sort((a, b) =>
+      a.localeCompare(b),
+    );
   }, []);
 
   const loadPage = useCallback(async () => {

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import i18n from "@/i18n";
+import { apiClient } from "@/lib/http/client";
+import { ChannelGroupsPage } from "@/modules/channel-groups/ChannelGroupsPage";
+import { ThemeProvider } from "@/modules/ui/ThemeProvider";
+import { ToastProvider } from "@/modules/ui/ToastProvider";
+
+const toastMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("goey-toast", () => ({
+  GoeyToaster: () => null,
+  goeyToast: {
+    info: toastMocks.info,
+    success: toastMocks.success,
+    warning: toastMocks.warning,
+    error: toastMocks.error,
+  },
+}));
+
+vi.mock("@/lib/http/client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+const mockedApiGet = vi.mocked(apiClient.get);
+
+function renderPage() {
+  return render(
+    <ThemeProvider>
+      <ToastProvider>
+        <ChannelGroupsPage />
+      </ToastProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("ChannelGroupsPage", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("zh-CN");
+    window.localStorage.clear();
+    toastMocks.info.mockReset();
+    toastMocks.success.mockReset();
+    toastMocks.warning.mockReset();
+    toastMocks.error.mockReset();
+    mockedApiGet.mockReset();
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        return Promise.resolve({
+          items: [{ name: "Claude Pool", channels: ["Team A Claude"] }],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({
+          data: [{ id: "claude-3-7-sonnet-latest" }, { id: "gpt-should-not-leak" }],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "claude-account.json", type: "claude", disabled: false }],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+            },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/opencode-go-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  test("filters group editor models by the auth-file model owner group mapping", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ claude: "anthropic" }),
+    );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "新增分组" }));
+    await user.type(screen.getByPlaceholderText("pro"), "team-claude");
+    await user.type(screen.getByPlaceholderText("/pro"), "/team-claude");
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(await screen.findByRole("option", { name: "Team A Claude" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    expect(await screen.findByLabelText("claude-3-7-sonnet-latest")).toBeInTheDocument();
+    expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Filter channel group editor model candidates through the existing configured model availability rules
- Add a regression test for auth-file model owner group mappings so unrelated owner models do not appear

## Verification
- bunx oxfmt src/modules/channel-groups/ChannelGroupsPage.tsx src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx --check
- bunx oxfmt . --check (fails on 37 pre-existing unrelated files)
- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx
- bun run test
- bun run lint (passes with existing RequestLogsPage warning)
- bun run build
- bun run check (passes with existing RequestLogsPage warning)