### PR TITLE
Improve channel group model selection

### DIFF
--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -8,7 +8,10 @@ import {
   type RoutingConfigPathRouteItem,
 } from "@/lib/http/apis/routing-config";
 import { apiClient } from "@/lib/http/client";
-import { RoutingConfigEditor } from "@/modules/channel-groups/RoutingConfigEditor";
+import {
+  RoutingConfigEditor,
+  type RoutingModelOption,
+} from "@/modules/channel-groups/RoutingConfigEditor";
 import {
   DEFAULT_VISUAL_VALUES,
   makeClientId,
@@ -189,9 +192,20 @@ export function ChannelGroupsPage() {
       ids.map((id) => ({ id })),
       availability,
     );
-    return Array.from(new Set(visibleModels.map((model) => model.id))).sort((a, b) =>
-      a.localeCompare(b),
+    const metadataById = new Map(
+      availability.items.map((model) => [model.id.toLowerCase(), model] as const),
     );
+    return Array.from(new Set(visibleModels.map((model) => model.id)))
+      .sort((a, b) => a.localeCompare(b))
+      .map((id): RoutingModelOption => {
+        const metadata = metadataById.get(id.toLowerCase());
+        return {
+          id,
+          owned_by: metadata?.owned_by,
+          description: metadata?.description,
+          pricing: metadata?.pricing,
+        };
+      });
   }, []);
 
   const loadPage = useCallback(async () => {

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -18,6 +18,11 @@ import { useToast } from "@/modules/ui/ToastProvider";
 import { HoverTooltip, OverflowTooltip } from "@/modules/ui/Tooltip";
 import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
 import { VendorIcon } from "@/modules/api-keys/apiKeyPageUtils";
+import {
+  emptyModelPricing,
+  formatModelPrice,
+  type ModelPricing,
+} from "@/modules/models/modelAvailability";
 
 type GroupDraft = {
   name: string;
@@ -26,6 +31,15 @@ type GroupDraft = {
   allowedModels: string[];
   routes: RoutingPathRouteEntry[];
 };
+
+export type RoutingModelOption = {
+  id: string;
+  owned_by?: string;
+  description?: string;
+  pricing?: ModelPricing;
+};
+
+type RoutingModelLoadResult = string | RoutingModelOption;
 
 const createEmptyGroupDraft = (): GroupDraft => ({
   name: "",
@@ -164,6 +178,21 @@ function normalizeChannelName(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function normalizeRoutingModelOption(model: RoutingModelLoadResult): RoutingModelOption | null {
+  if (typeof model === "string") {
+    const id = model.trim();
+    return id ? { id } : null;
+  }
+  const id = String(model.id ?? "").trim();
+  if (!id) return null;
+  return {
+    id,
+    owned_by: model.owned_by,
+    description: model.description,
+    pricing: model.pricing,
+  };
+}
+
 export function RoutingConfigEditor({
   values,
   disabled,
@@ -174,7 +203,7 @@ export function RoutingConfigEditor({
   values: VisualConfigValues;
   disabled?: boolean;
   availableChannels: string[];
-  loadModelsForChannels?: (channels: string[]) => Promise<string[]>;
+  loadModelsForChannels?: (channels: string[]) => Promise<RoutingModelLoadResult[]>;
   onChange: (values: Partial<VisualConfigValues>) => void;
 }) {
   const { t } = useTranslation();
@@ -183,7 +212,7 @@ export function RoutingConfigEditor({
   const [groupEditorId, setGroupEditorId] = useState<string | null>(null);
   const [groupDraft, setGroupDraft] = useState<GroupDraft>(() => createEmptyGroupDraft());
   const [groupEditorTab, setGroupEditorTab] = useState<"basic" | "models">("basic");
-  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [modelOptions, setModelOptions] = useState<RoutingModelOption[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState("");
   const [modelsSelectionTouched, setModelsSelectionTouched] = useState(false);
@@ -249,6 +278,16 @@ export function RoutingConfigEditor({
     () => new Set(groupDraft.allowedModels.map((model) => model.trim()).filter(Boolean)),
     [groupDraft.allowedModels],
   );
+
+  const modelOptionIds = useMemo(() => modelOptions.map((model) => model.id), [modelOptions]);
+  const selectedVisibleModelCount = useMemo(
+    () => modelOptionIds.filter((model) => selectedModelSet.has(model)).length,
+    [modelOptionIds, selectedModelSet],
+  );
+  const allVisibleModelsSelected =
+    modelOptionIds.length > 0 && selectedVisibleModelCount === modelOptionIds.length;
+  const someVisibleModelsSelected =
+    selectedVisibleModelCount > 0 && selectedVisibleModelCount < modelOptionIds.length;
 
   const primaryRoute = groupDraft.routes[0] ?? EMPTY_ROUTE_DRAFT();
   const normalizedPrimaryRoutePath = useMemo(
@@ -403,9 +442,9 @@ export function RoutingConfigEditor({
     setModelsSelectionTouched(true);
     setGroupDraft((current) => ({
       ...current,
-      allowedModels: Array.from(new Set(modelOptions)),
+      allowedModels: Array.from(new Set(modelOptionIds)),
     }));
-  }, [modelOptions]);
+  }, [modelOptionIds]);
 
   const clearDraftModels = useCallback(() => {
     setModelsSelectionTouched(true);
@@ -793,6 +832,89 @@ export function RoutingConfigEditor({
     [disabled, draftStaleChannelIds, removeDraftChannel, t, updateDraftChannel],
   );
 
+  const modelColumns = useMemo<VirtualTableColumn<RoutingModelOption>[]>(
+    () => [
+      {
+        key: "select",
+        label: "",
+        width: "w-12",
+        headerClassName: "text-center",
+        cellClassName: "text-center",
+        headerRender: () => (
+          <Checkbox
+            checked={allVisibleModelsSelected}
+            indeterminate={someVisibleModelsSelected}
+            disabled={disabled || modelOptions.length === 0}
+            onCheckedChange={(checked) => {
+              if (checked) selectAllDraftModels();
+              else clearDraftModels();
+            }}
+            aria-label={t("channel_groups_page.allowed_models_label")}
+          />
+        ),
+        render: (model) => (
+          <Checkbox
+            checked={selectedModelSet.has(model.id)}
+            onCheckedChange={(checked) => toggleDraftModel(model.id, checked)}
+            disabled={disabled}
+            aria-label={model.id}
+          />
+        ),
+      },
+      {
+        key: "model",
+        label: t("models_page.col_model"),
+        width: "w-[28rem]",
+        cellClassName: "min-w-0",
+        render: (model) => (
+          <div className="flex min-w-0 items-center gap-2">
+            <VendorIcon modelId={model.id} size={16} />
+            <div className="min-w-0">
+              <OverflowTooltip content={model.id} className="block min-w-0">
+                <span className="block min-w-0 truncate font-medium">{model.id}</span>
+              </OverflowTooltip>
+              {model.description ? (
+                <OverflowTooltip content={model.description} className="block min-w-0">
+                  <span className="block min-w-0 truncate text-[11px] text-slate-500 dark:text-white/45">
+                    {model.description}
+                  </span>
+                </OverflowTooltip>
+              ) : null}
+            </div>
+          </div>
+        ),
+      },
+      {
+        key: "owner",
+        label: t("models_page.col_owner"),
+        width: "w-36",
+        cellClassName: "min-w-0 whitespace-nowrap text-slate-600 dark:text-white/60",
+        render: (model) => model.owned_by || "-",
+        overflowTooltip: (model) => model.owned_by || "-",
+      },
+      {
+        key: "price",
+        label: t("models_page.col_price"),
+        width: "w-56",
+        cellClassName:
+          "whitespace-nowrap font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
+        render: (model) =>
+          formatModelPrice(model.pricing ?? emptyModelPricing(), t("models_page.not_priced")),
+      },
+    ],
+    [
+      allVisibleModelsSelected,
+      clearDraftModels,
+      disabled,
+      modelOptions.length,
+      selectAllDraftModels,
+      selectedModelSet,
+      someVisibleModelsSelected,
+      t,
+      toggleDraftModel,
+    ],
+  );
+
   useEffect(() => {
     if (!groupEditorOpen || groupEditorTab !== "models") return;
     if (selectedChannelValues.length === 0 || !loadModelsForChannels) {
@@ -807,16 +929,21 @@ export function RoutingConfigEditor({
     loadModelsForChannels(selectedChannelValues)
       .then((models) => {
         if (cancelled) return;
-        const normalized = Array.from(
-          new Set(models.map((model) => String(model ?? "").trim()).filter(Boolean)),
-        ).sort((a, b) => a.localeCompare(b));
+        const optionMap = new Map<string, RoutingModelOption>();
+        for (const model of models) {
+          const option = normalizeRoutingModelOption(model);
+          if (!option) continue;
+          const key = option.id.toLowerCase();
+          if (!optionMap.has(key)) optionMap.set(key, option);
+        }
+        const normalized = Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
         setModelOptions(normalized);
-        const allowed = new Set(normalized);
+        const allowed = new Set(normalized.map((model) => model.id));
         setGroupDraft((current) => ({
           ...current,
           allowedModels: modelsSelectionTouched
             ? current.allowedModels.filter((model) => allowed.has(model))
-            : normalized,
+            : normalized.map((model) => model.id),
         }));
       })
       .catch((err: unknown) => {
@@ -1095,26 +1222,21 @@ export function RoutingConfigEditor({
                   ) : (
                     <div
                       data-testid="group-editor-model-list"
-                      className="grid min-h-0 flex-1 gap-2 overflow-y-auto rounded-2xl border border-slate-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950 sm:grid-cols-2"
+                      className="min-h-0 flex-1 overflow-hidden"
                     >
-                      {modelOptions.map((model) => {
-                        const checked = selectedModelSet.has(model);
-                        return (
-                          <label
-                            key={model}
-                            className="flex min-w-0 items-center gap-3 rounded-xl px-3 py-2 text-sm text-slate-800 transition-colors hover:bg-slate-50 dark:text-white/80 dark:hover:bg-white/[0.04]"
-                          >
-                            <Checkbox
-                              checked={checked}
-                              onCheckedChange={(next) => toggleDraftModel(model, next)}
-                              disabled={disabled}
-                              aria-label={model}
-                            />
-                            <VendorIcon modelId={model} size={14} />
-                            <span className="min-w-0 flex-1 truncate">{model}</span>
-                          </label>
-                        );
-                      })}
+                      <VirtualTable<RoutingModelOption>
+                        rows={modelOptions}
+                        columns={modelColumns}
+                        rowKey={(model) => model.id}
+                        virtualize={false}
+                        rowHeight={58}
+                        height="h-full"
+                        minHeight="min-h-[360px]"
+                        minWidth="min-w-[760px]"
+                        caption={t("channel_groups_page.allowed_models_label")}
+                        emptyText={t("channel_groups_page.no_channel_models")}
+                        showAllLoadedMessage={false}
+                      />
                     </div>
                   )}
                 </TabsContent>

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -83,6 +83,12 @@ describe("ChannelGroupsPage", () => {
               id: "claude-3-7-sonnet-latest",
               owned_by: "anthropic",
               description: "Mapped Claude model",
+              pricing: {
+                mode: "token",
+                input_price_per_million: 3,
+                output_price_per_million: 15,
+                cached_price_per_million: 0.3,
+              },
             },
             {
               id: "gpt-should-not-leak",
@@ -124,7 +130,10 @@ describe("ChannelGroupsPage", () => {
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
 
+    expect(await screen.findByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(await screen.findByLabelText("claude-3-7-sonnet-latest")).toBeInTheDocument();
+    expect(screen.getByText("Mapped Claude model")).toBeInTheDocument();
+    expect(screen.getByText("$3 / $15 / $0.3")).toBeInTheDocument();
     expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -4,7 +4,10 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
 import { DEFAULT_VISUAL_VALUES, type VisualConfigValues } from "@/modules/config/visual/types";
-import { RoutingConfigEditor } from "@/modules/channel-groups/RoutingConfigEditor";
+import {
+  RoutingConfigEditor,
+  type RoutingModelOption,
+} from "@/modules/channel-groups/RoutingConfigEditor";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 
@@ -30,7 +33,7 @@ function Harness({
   loadModelsForChannels,
 }: {
   initialValues?: VisualConfigValues;
-  loadModelsForChannels?: (channels: string[]) => Promise<string[]>;
+  loadModelsForChannels?: (channels: string[]) => Promise<Array<string | RoutingModelOption>>;
 }) {
   const [values, setValues] = useState<VisualConfigValues>({
     ...DEFAULT_VISUAL_VALUES,
@@ -124,6 +127,38 @@ describe("RoutingConfigEditor", () => {
     );
   });
 
+  test("renders channel-scoped models as a checkbox table with descriptions and prices", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+    const loadModelsForChannels = vi.fn(async () => [
+      {
+        id: "claude-sonnet-4-5",
+        owned_by: "anthropic",
+        description: "Fast Claude model",
+        pricing: {
+          mode: "token" as const,
+          inputPricePerMillion: 3,
+          outputPricePerMillion: 15,
+          cachedPricePerMillion: 0.3,
+          pricePerCall: 0,
+        },
+      },
+    ]);
+
+    render(<Harness loadModelsForChannels={loadModelsForChannels} />);
+
+    await user.click(screen.getByRole("button", { name: "新增分组" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("option", { name: "Team A Claude" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    expect(await screen.findByRole("table", { name: "允许模型" })).toBeInTheDocument();
+    expect(screen.getByLabelText("claude-sonnet-4-5")).toBeChecked();
+    expect(screen.getByText("Fast Claude model")).toBeInTheDocument();
+    expect(screen.getByText("$3 / $15 / $0.3")).toBeInTheDocument();
+  });
+
   test("keeps modal body and tabs fixed while tab content and model list own scrolling", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();
@@ -154,7 +189,8 @@ describe("RoutingConfigEditor", () => {
     expect(tabViewport).toHaveClass("overflow-y-auto");
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
-    expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-y-auto");
+    expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
+    expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
   });
 

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -29,24 +29,22 @@ import iconMinimax from "@/assets/icons/minimax.svg";
 import iconOpenai from "@/assets/icons/openai.svg";
 import iconQwen from "@/assets/icons/qwen.svg";
 import {
+  emptyModelPricing,
   filterByConfiguredModelAvailability,
+  formatModelPrice,
+  hasModelPricing,
   loadConfiguredModelAvailability,
   type ConfiguredModelAvailability,
   type ModelAvailabilityItem,
+  type ModelConfigMetadataItem,
+  type ModelPricing,
+  type ModelPricingMode,
+  normalizeModelConfigMetadataRows,
 } from "@/modules/models/modelAvailability";
 import iconVertex from "@/assets/icons/vertex.svg";
 
-type PricingMode = "token" | "call";
 type ModelScope = "active" | "library";
 type ModelPageTab = ModelScope;
-
-interface ModelPricing {
-  mode: PricingMode;
-  inputPricePerMillion: number;
-  outputPricePerMillion: number;
-  cachedPricePerMillion: number;
-  pricePerCall: number;
-}
 
 interface ModelItem {
   id: string;
@@ -71,7 +69,7 @@ interface ModelFormState {
   ownedBy: string;
   description: string;
   enabled: boolean;
-  mode: PricingMode;
+  mode: ModelPricingMode;
   inputPrice: string;
   outputPrice: string;
   cachedPrice: string;
@@ -123,14 +121,6 @@ const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
   o4: { light: iconOpenai, dark: iconOpenai },
   qwen: { light: iconQwen, dark: iconQwen },
   vertex: { light: iconVertex, dark: iconVertex },
-};
-
-const emptyPricing: ModelPricing = {
-  mode: "token",
-  inputPricePerMillion: 0,
-  outputPricePerMillion: 0,
-  cachedPricePerMillion: 0,
-  pricePerCall: 0,
 };
 
 const emptyForm: ModelFormState = {
@@ -187,63 +177,29 @@ function VendorIcon({ modelId, size = 14 }: { modelId: string; size?: number }) 
   );
 }
 
-function asNumber(value: unknown): number {
-  const num = Number(value);
-  return Number.isFinite(num) && num >= 0 ? num : 0;
-}
-
 function parsePriceInput(value: string): number {
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
 
-function normalizeModelConfig(raw: Record<string, unknown>): ModelItem | null {
-  const id = String(raw.id ?? raw.model_id ?? raw.name ?? "").trim();
-  if (!id) return null;
+function asNumber(value: unknown): number {
+  const num = Number(value);
+  return Number.isFinite(num) && num >= 0 ? num : 0;
+}
 
-  const pricing = raw.pricing && typeof raw.pricing === "object" ? raw.pricing : {};
-  const pricingRecord = pricing as Record<string, unknown>;
-  const mode: PricingMode =
-    pricingRecord.mode === "call" || raw.pricing_mode === "call" ? "call" : "token";
-
+function metadataToModel(item: ModelConfigMetadataItem): ModelItem {
   return {
-    id,
-    owned_by: String(raw.owned_by ?? raw.owner ?? ""),
-    description: String(raw.description ?? ""),
-    enabled: raw.enabled === false ? false : true,
-    source: String(raw.source ?? ""),
-    pricing: {
-      mode,
-      inputPricePerMillion: asNumber(pricingRecord.input_price_per_million ?? pricingRecord.prompt),
-      outputPricePerMillion: asNumber(
-        pricingRecord.output_price_per_million ?? pricingRecord.completion,
-      ),
-      cachedPricePerMillion: asNumber(
-        pricingRecord.cached_price_per_million ?? pricingRecord.cache,
-      ),
-      pricePerCall: asNumber(pricingRecord.price_per_call ?? pricingRecord.perCall),
-    },
+    id: item.id,
+    owned_by: item.owned_by,
+    description: item.description,
+    enabled: item.enabled,
+    source: item.source,
+    pricing: item.pricing,
   };
 }
 
 function normalizeModelConfigResponse(payload: unknown): ModelItem[] {
-  const record = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-  const rawList = Array.isArray(record.data)
-    ? record.data
-    : Array.isArray(record.models)
-      ? record.models
-      : Array.isArray(payload)
-        ? payload
-        : [];
-
-  return rawList
-    .map((item) =>
-      item && typeof item === "object"
-        ? normalizeModelConfig(item as Record<string, unknown>)
-        : null,
-    )
-    .filter((item): item is ModelItem => Boolean(item))
-    .sort((a, b) => a.id.localeCompare(b.id));
+  return normalizeModelConfigMetadataRows(payload).map(metadataToModel);
 }
 
 function normalizeOwnerPreset(raw: Record<string, unknown>): ModelOwnerPreset | null {
@@ -300,7 +256,7 @@ function availabilityItemToModel(item: ModelAvailabilityItem): ModelItem {
     description: item.description ?? "",
     enabled: true,
     source: item.source ?? "configured",
-    pricing: { ...emptyPricing },
+    pricing: item.pricing ?? emptyModelPricing(),
   };
 }
 
@@ -374,7 +330,7 @@ function payloadToModel(payload: ReturnType<typeof buildModelPayload>, source: s
   const pricing =
     payload.pricing.mode === "call"
       ? {
-          ...emptyPricing,
+          ...emptyModelPricing(),
           mode: "call" as const,
           pricePerCall: payload.pricing.price_per_call,
         }
@@ -420,34 +376,12 @@ async function saveModelConfig(form: ModelFormState, scope: ModelScope) {
   return payloadToModel(payload, scope === "library" ? "seed" : "user");
 }
 
-function hasPricing(model: ModelItem): boolean {
-  if (model.pricing.mode === "call") return model.pricing.pricePerCall > 0;
-  return (
-    model.pricing.inputPricePerMillion > 0 ||
-    model.pricing.outputPricePerMillion > 0 ||
-    model.pricing.cachedPricePerMillion > 0
-  );
-}
-
 function formatPrice(model: ModelItem, notPricedLabel: string): string {
-  if (model.pricing.mode === "call") {
-    return model.pricing.pricePerCall > 0
-      ? `$${formatPriceAmount(model.pricing.pricePerCall)} / call`
-      : notPricedLabel;
-  }
-
-  if (!hasPricing(model)) return notPricedLabel;
-  return `$${formatPriceAmount(model.pricing.inputPricePerMillion)} / $${formatPriceAmount(model.pricing.outputPricePerMillion)} / $${formatPriceAmount(model.pricing.cachedPricePerMillion)}`;
+  return formatModelPrice(model.pricing, notPricedLabel);
 }
 
-function formatPriceAmount(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return "0";
-  const rounded = Math.round((value + Number.EPSILON) * 1_000_000) / 1_000_000;
-  return new Intl.NumberFormat("en-US", {
-    maximumFractionDigits: 6,
-    minimumFractionDigits: 0,
-    useGrouping: false,
-  }).format(rounded);
+function hasPricing(model: ModelItem): boolean {
+  return hasModelPricing(model.pricing);
 }
 
 function normalizeOwnerValue(value: string): string {
@@ -1731,7 +1665,7 @@ export function ModelsPage() {
               </label>
               <Select
                 value={form.mode}
-                onChange={(mode) => updateForm({ mode: mode as PricingMode })}
+                onChange={(mode) => updateForm({ mode: mode as ModelPricingMode })}
                 aria-label={t("models_page.pricing_mode")}
                 options={[
                   { value: "token", label: t("models_page.mode_token") },

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -18,6 +18,8 @@ export type ModelAvailabilityItem = {
   owned_by?: string;
   description?: string;
   source?: string;
+  enabled?: boolean;
+  pricing?: ModelPricing;
 };
 
 export type ConfiguredModelAvailability = {
@@ -25,6 +27,25 @@ export type ConfiguredModelAvailability = {
   items: ModelAvailabilityItem[];
   idSet: Set<string>;
 };
+
+export type ModelPricingMode = "token" | "call";
+
+export interface ModelPricing {
+  mode: ModelPricingMode;
+  inputPricePerMillion: number;
+  outputPricePerMillion: number;
+  cachedPricePerMillion: number;
+  pricePerCall: number;
+}
+
+export interface ModelConfigMetadataItem {
+  id: string;
+  owned_by: string;
+  description: string;
+  enabled: boolean;
+  source: string;
+  pricing: ModelPricing;
+}
 
 type ModelDefinition = {
   id: string;
@@ -46,13 +67,54 @@ const emptyAvailability = (): ConfiguredModelAvailability => ({
   idSet: new Set(),
 });
 
+export const emptyModelPricing = (): ModelPricing => ({
+  mode: "token",
+  inputPricePerMillion: 0,
+  outputPricePerMillion: 0,
+  cachedPricePerMillion: 0,
+  pricePerCall: 0,
+});
+
 const normalizeOwnerValue = (value: string): string =>
   value.trim().replace(/\s+/g, "-").toLowerCase();
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
-const normalizeModelConfigRows = (payload: unknown): ModelAvailabilityItem[] => {
+const asNumber = (value: unknown): number => {
+  const num = Number(value);
+  return Number.isFinite(num) && num >= 0 ? num : 0;
+};
+
+export const normalizeModelPricing = (raw: Record<string, unknown>): ModelPricing => {
+  const pricing = isRecord(raw.pricing) ? raw.pricing : {};
+  const mode: ModelPricingMode =
+    pricing.mode === "call" || raw.pricing_mode === "call" ? "call" : "token";
+
+  return {
+    mode,
+    inputPricePerMillion: asNumber(pricing.input_price_per_million ?? pricing.prompt),
+    outputPricePerMillion: asNumber(pricing.output_price_per_million ?? pricing.completion),
+    cachedPricePerMillion: asNumber(pricing.cached_price_per_million ?? pricing.cache),
+    pricePerCall: asNumber(pricing.price_per_call ?? pricing.perCall),
+  };
+};
+
+export const normalizeModelConfigMetadata = (item: unknown): ModelConfigMetadataItem | null => {
+  if (!isRecord(item)) return null;
+  const id = String(item.id ?? item.model_id ?? item.name ?? "").trim();
+  if (!id) return null;
+  return {
+    id,
+    owned_by: String(item.owned_by ?? item.owner ?? ""),
+    description: String(item.description ?? item.display_name ?? ""),
+    enabled: item.enabled === false ? false : true,
+    source: String(item.source ?? ""),
+    pricing: normalizeModelPricing(item),
+  };
+};
+
+export const normalizeModelConfigMetadataRows = (payload: unknown): ModelConfigMetadataItem[] => {
   const record = isRecord(payload) ? payload : {};
   const rawList = Array.isArray(record.data)
     ? record.data
@@ -63,22 +125,13 @@ const normalizeModelConfigRows = (payload: unknown): ModelAvailabilityItem[] => 
         : [];
 
   return rawList
-    .map((item) => {
-      if (!isRecord(item)) return null;
-      const id = String(item.id ?? item.model_id ?? item.name ?? "").trim();
-      if (!id) return null;
-      const ownedBy = String(item.owned_by ?? item.owner ?? "").trim();
-      const description = String(item.description ?? item.display_name ?? "").trim();
-      const source = String(item.source ?? "").trim();
-      return {
-        id,
-        ...(ownedBy ? { owned_by: ownedBy } : {}),
-        ...(description ? { description } : {}),
-        ...(source ? { source } : {}),
-      } satisfies ModelAvailabilityItem;
-    })
-    .filter((item): item is ModelAvailabilityItem => Boolean(item));
+    .map((item) => normalizeModelConfigMetadata(item))
+    .filter((item): item is ModelConfigMetadataItem => Boolean(item))
+    .sort((a, b) => a.id.localeCompare(b.id));
 };
+
+const normalizeModelConfigRows = (payload: unknown): ModelAvailabilityItem[] =>
+  normalizeModelConfigMetadataRows(payload);
 
 const addModel = (
   map: Map<string, ModelAvailabilityItem>,
@@ -303,4 +356,34 @@ export const filterByConfiguredModelAvailability = <T extends { id: string }>(
 ): T[] => {
   if (!availability.scoped) return models;
   return models.filter((model) => availability.idSet.has(model.id.toLowerCase()));
+};
+
+export const hasModelPricing = (pricing: ModelPricing): boolean => {
+  if (pricing.mode === "call") return pricing.pricePerCall > 0;
+  return (
+    pricing.inputPricePerMillion > 0 ||
+    pricing.outputPricePerMillion > 0 ||
+    pricing.cachedPricePerMillion > 0
+  );
+};
+
+export const formatModelPriceAmount = (value: number): string => {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  const rounded = Math.round((value + Number.EPSILON) * 1_000_000) / 1_000_000;
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 6,
+    minimumFractionDigits: 0,
+    useGrouping: false,
+  }).format(rounded);
+};
+
+export const formatModelPrice = (pricing: ModelPricing, notPricedLabel: string): string => {
+  if (pricing.mode === "call") {
+    return pricing.pricePerCall > 0
+      ? `$${formatModelPriceAmount(pricing.pricePerCall)} / call`
+      : notPricedLabel;
+  }
+
+  if (!hasModelPricing(pricing)) return notPricedLabel;
+  return `$${formatModelPriceAmount(pricing.inputPricePerMillion)} / $${formatModelPriceAmount(pricing.outputPricePerMillion)} / $${formatModelPriceAmount(pricing.cachedPricePerMillion)}`;
 };


### PR DESCRIPTION
## Summary
- reuse the shared model availability metadata for channel group model filtering
- render the group editor model list with the shared table, checkboxes, model description, owner, and price
- add regression coverage for auth-file owner group filtering and the table model list

## Verification
- bunx oxfmt src/modules/models/modelAvailability.ts src/modules/models/ModelsPage.tsx src/modules/channel-groups/ChannelGroupsPage.tsx src/modules/channel-groups/RoutingConfigEditor.tsx src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx --check
- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx
- bun run lint (existing warning: src/modules/monitor/RequestLogsPage.tsx:135)
- bun run test
- bun run build
- bun run check (existing warning: src/modules/monitor/RequestLogsPage.tsx:135)