### PR TITLE
Polish channel group modal loading state

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -926,6 +926,7 @@ export function RoutingConfigEditor({
     let cancelled = false;
     setModelsLoading(true);
     setModelsError("");
+    setModelOptions([]);
     loadModelsForChannels(selectedChannelValues)
       .then((models) => {
         if (cancelled) return;
@@ -1014,7 +1015,7 @@ export function RoutingConfigEditor({
         onClose={closeGroupEditor}
         maxWidth="max-w-4xl"
         bodyTestId="group-editor-modal-body"
-        bodyHeightClassName="h-[680px] max-h-[calc(100vh-10rem)]"
+        bodyHeightClassName="h-[560px] max-h-[calc(100vh-8rem)]"
         bodyOverflowClassName="overflow-hidden"
         bodyClassName="flex flex-col"
         footer={
@@ -1211,14 +1212,6 @@ export function RoutingConfigEditor({
                     <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-400/25 dark:bg-rose-500/10 dark:text-rose-200">
                       {modelsError}
                     </div>
-                  ) : modelsLoading ? (
-                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
-                      {t("common.loading")}
-                    </div>
-                  ) : modelOptions.length === 0 ? (
-                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
-                      {t("channel_groups_page.no_channel_models")}
-                    </div>
                   ) : (
                     <div
                       data-testid="group-editor-model-list"
@@ -1228,6 +1221,7 @@ export function RoutingConfigEditor({
                         rows={modelOptions}
                         columns={modelColumns}
                         rowKey={(model) => model.id}
+                        loading={modelsLoading}
                         virtualize={false}
                         rowHeight={58}
                         height="h-full"

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -176,6 +176,8 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
 
     const modalBody = screen.getByTestId("group-editor-modal-body");
+    expect(modalBody).toHaveClass("h-[560px]");
+    expect(modalBody).toHaveClass("max-h-[calc(100vh-8rem)]");
     expect(modalBody).toHaveClass("overflow-hidden");
     expect(modalBody).toHaveClass("flex");
     expect(modalBody).toHaveClass("flex-col");
@@ -192,6 +194,27 @@ describe("RoutingConfigEditor", () => {
     expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+
+  test("keeps the model list table visible while channel models are loading", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+    const loadModelsForChannels = vi.fn(
+      () => new Promise<Array<string | RoutingModelOption>>(() => {}),
+    );
+
+    render(<Harness loadModelsForChannels={loadModelsForChannels} />);
+
+    await user.click(screen.getByRole("button", { name: "新增分组" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("option", { name: "Team A Claude" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    expect(screen.getByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
+    expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("加载中");
+    expect(screen.getByRole("status")).toHaveClass("sr-only");
   });
 
   test("sets path routes directly inside group editor", async () => {

--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -85,11 +85,7 @@ const DEFAULT_OVERSCAN = 12;
 const DEFAULT_SCROLL_THRESHOLD = 100;
 const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
 
-function resolveCellOverflowTooltip<T>(
-  column: VirtualTableColumn<T>,
-  row: T,
-  index: number,
-) {
+function resolveCellOverflowTooltip<T>(column: VirtualTableColumn<T>, row: T, index: number) {
   if (column.overflowTooltip === false) return false;
 
   if (typeof column.overflowTooltip === "function") {
@@ -546,6 +542,7 @@ export function VirtualTable<T>({
 
   return (
     <div
+      aria-busy={loading || loadingMore ? true : undefined}
       className={`${height} ${minHeight} group relative isolate grid min-w-0 grid-cols-[minmax(0,1fr)_0.75rem] overflow-hidden`}
     >
       <div
@@ -589,7 +586,34 @@ export function VirtualTable<T>({
 
           {/* ── Body ── */}
           <tbody className="text-slate-900 dark:text-white">
-            {!loading && rows.length === 0 ? (
+            {loading && rows.length === 0 ? (
+              <>
+                <tr>
+                  <td colSpan={colCount} className="p-0">
+                    <span role="status" className="sr-only">
+                      {t("common.loading")}
+                    </span>
+                  </td>
+                </tr>
+                {Array.from({ length: 5 }, (_, rowIndex) => (
+                  <tr key={`loading-${rowIndex}`} aria-hidden="true">
+                    {columns.map((col, colIndex) => (
+                      <td
+                        key={col.key}
+                        className={`px-4 py-3 align-middle ${col.cellClassName ?? ""}`}
+                      >
+                        <div
+                          className={[
+                            "h-3 animate-pulse rounded-full bg-slate-200 dark:bg-white/10",
+                            colIndex === 0 ? "w-2/3" : "w-4/5",
+                          ].join(" ")}
+                        />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </>
+            ) : !loading && rows.length === 0 ? (
               <tr>
                 <td
                   colSpan={colCount}

--- a/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
@@ -202,6 +202,24 @@ describe("VirtualTable scrollbar wrapper", () => {
     expect(root).toHaveClass("min-h-0");
   });
 
+  test("renders an in-table initial loading state", () => {
+    render(
+      <VirtualTable
+        rows={[]}
+        columns={columns}
+        rowKey={(row) => row.id}
+        caption="Demo table"
+        emptyText="No data"
+        loading
+      />,
+    );
+
+    const table = screen.getByRole("table", { name: "Demo table" });
+    expect(table.closest("[aria-busy='true']")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Loading");
+    expect(screen.queryByText("No data")).not.toBeInTheDocument();
+  });
+
   test("renders DOM scrollbars only when overflow exists", async () => {
     const { container } = render(
       <VirtualTable


### PR DESCRIPTION
## Summary
- reduce the channel group editor modal body height so it no longer dominates the viewport
- route channel model loading and empty states through VirtualTable instead of standalone message blocks
- add an initial VirtualTable loading skeleton with aria-busy/status semantics

## Verification
- bunx oxfmt src/modules/channel-groups/RoutingConfigEditor.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/ui/VirtualTable.tsx src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx --check
- bun run test src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
- bun run lint (existing warning: src/modules/monitor/RequestLogsPage.tsx:135)
- bun run test
- bun run build
- bun run check (existing warning: src/modules/monitor/RequestLogsPage.tsx:135)