### PR TITLE
feat(providers): 模型归属分组下拉改为可搜索的 SearchableSelect

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2863,6 +2863,7 @@
     "models_default_hint": "Leave empty to use default routing; fill in values to enable aliases, priorities, and more.",
     "model_group_label": "Model Category",
     "model_group_placeholder": "Select model category...",
+    "model_group_search_placeholder": "Search model category...",
     "load_models": "Load Models",
     "model_group_hint": "Select a model category and click Load to quickly import common models from that vendor. Existing models will not be duplicated.",
     "excluded_models_label": "Excluded models (optional)",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2372,6 +2372,7 @@
     "models_default_hint": "留空使用默认路由；填写可启用模型别名、优先级等。",
     "model_group_label": "模型归属分组",
     "model_group_placeholder": "选择模型分组...",
+    "model_group_search_placeholder": "搜索模型归属...",
     "load_models": "加载模型",
     "model_group_hint": "选择模型分组后点击加载，可快速导入该厂商的常用模型列表。已存在的模型不会重复添加。",
     "excluded_models_label": "排除模型（可选）",

--- a/src/modules/providers/components/ProviderKeyModal.tsx
+++ b/src/modules/providers/components/ProviderKeyModal.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/modules/ui/Button";
 import { Checkbox } from "@/modules/ui/Checkbox";
 import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
+import { SearchableSelect } from "@/modules/ui/SearchableSelect";
 import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
@@ -809,10 +810,12 @@ export function ProviderKeyModal({
                         {t("providers.model_group_label")}
                       </p>
                       <div className="mt-2">
-                        <Select
+                        <SearchableSelect
                           value={selectedModelGroup}
                           onChange={(value) => setSelectedModelGroup(value)}
                           options={modelGroupOptions}
+                          placeholder={t("providers.model_group_placeholder")}
+                          searchPlaceholder={t("providers.model_group_search_placeholder")}
                           aria-label={t("providers.model_group_label")}
                         />
                       </div>


### PR DESCRIPTION
## 改动内容
将 AI 供应商配置页面的模型归属分组下拉框从普通 Select 改为可搜索的 SearchableSelect。

## 主要变更
- 复用现有的 `SearchableSelect` 组件替换模型归属分组的 `Select`
- 新增 `providers.model_group_search_placeholder` i18n 键（中/英）
- 支持输入关键词快速过滤 `owned_by` 分组选项

## 验证
- [x] 构建通过
- [x] 295 个单元测试全部通过