### PR TITLE
fix(auth-files): show visible card loading on group switch

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -97,6 +97,16 @@ const toDateTimeLocalInput = (date: Date): string =>
     padDatePart(date.getMinutes()),
   ].join("");
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("AuthFilesPage files table", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
@@ -1146,7 +1156,8 @@ describe("AuthFilesPage files table", () => {
       within(tooltips[0]).getByText("Claude Sonnet 4.6 (Thinking) [claude-sonnet-4-6]"),
     ).toBeInTheDocument();
     const resetText = Array.from(tooltips[0].querySelectorAll("span")).find(
-      (element) => element.textContent?.includes("秒") && element.className.includes("tabular-nums"),
+      (element) =>
+        element.textContent?.includes("秒") && element.className.includes("tabular-nums"),
     );
     expect(resetText).toBeTruthy();
     expect(resetText).not.toHaveClass("truncate");
@@ -1276,7 +1287,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("44%")).toBeInTheDocument();
   });
 
-  test("cards view does not spin card refresh actions for tab-switch background quota refresh", async () => {
+  test("cards view spins current-page refresh actions when switching provider tabs and clears them per card", async () => {
     const now = Date.now();
     const files = [
       {
@@ -1312,8 +1323,26 @@ describe("AuthFilesPage files table", () => {
       },
     ] as any[];
 
+    const codexDeferreds = {
+      "codex-a.json": createDeferred<{
+        items: { label: string; percent: number; resetAtMs: number }[];
+      }>(),
+      "codex-b.json": createDeferred<{
+        items: { label: string; percent: number; resetAtMs: number }[];
+      }>(),
+      "codex-c.json": createDeferred<{
+        items: { label: string; percent: number; resetAtMs: number }[];
+      }>(),
+    };
+
     mocks.list.mockImplementation(async () => ({ files }));
-    mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
+    mocks.fetchQuota.mockImplementation((_provider, file) => {
+      const target = codexDeferreds[file?.name as keyof typeof codexDeferreds];
+      if (target) return target.promise;
+      return Promise.resolve({
+        items: [{ label: "m_quota.code_5h", percent: 88, resetAtMs: now + 60_000 }],
+      });
+    });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
@@ -1346,17 +1375,69 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("codex-a.json")).toBeInTheDocument();
 
     await waitFor(() =>
-      expect(mocks.fetchQuota).toHaveBeenCalledWith(
-        "codex",
-        expect.objectContaining({ name: "codex-a.json" }),
-      ),
+      expect(
+        mocks.fetchQuota.mock.calls
+          .filter(([, file]) =>
+            String((file as { name?: string } | undefined)?.name).startsWith("codex-"),
+          )
+          .map(([, file]) => (file as { name: string }).name),
+      ).toEqual(["codex-a.json", "codex-b.json", "codex-c.json"]),
     );
 
     const cards = screen.getByTestId("auth-files-cards");
-    const cardRefreshButtons = within(cards).getAllByRole("button", { name: "Refresh" });
-    expect(cardRefreshButtons).toHaveLength(3);
-    cardRefreshButtons.forEach((button) => {
-      expect(button.querySelector("svg")).not.toHaveClass("animate-spin");
+    expect(
+      within(cards)
+        .getAllByText(/^codex-[abc]\.json$/)
+        .map((node) => node.textContent),
+    ).toEqual(["codex-a.json", "codex-b.json", "codex-c.json"]);
+
+    const cardA = screen.getByText("codex-a.json").closest("section");
+    const cardB = screen.getByText("codex-b.json").closest("section");
+    const cardC = screen.getByText("codex-c.json").closest("section");
+    expect(cardA).not.toBeNull();
+    expect(cardB).not.toBeNull();
+    expect(cardC).not.toBeNull();
+
+    const refreshButtonA = within(cardA as HTMLElement).getByRole("button", { name: "Refresh" });
+    const refreshButtonB = within(cardB as HTMLElement).getByRole("button", { name: "Refresh" });
+    const refreshButtonC = within(cardC as HTMLElement).getByRole("button", { name: "Refresh" });
+
+    await waitFor(() => {
+      expect(refreshButtonA.querySelector("svg")).toHaveClass("animate-spin");
+      expect(refreshButtonB.querySelector("svg")).toHaveClass("animate-spin");
+      expect(refreshButtonC.querySelector("svg")).toHaveClass("animate-spin");
+    });
+
+    await act(async () => {
+      codexDeferreds["codex-a.json"].resolve({
+        items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
+      });
+      await codexDeferreds["codex-a.json"].promise;
+    });
+
+    await waitFor(() =>
+      expect(refreshButtonA.querySelector("svg")).not.toHaveClass("animate-spin"),
+    );
+    expect(refreshButtonB.querySelector("svg")).toHaveClass("animate-spin");
+    expect(refreshButtonC.querySelector("svg")).toHaveClass("animate-spin");
+
+    await act(async () => {
+      codexDeferreds["codex-b.json"].resolve({
+        items: [{ label: "m_quota.code_5h", percent: 34, resetAtMs: now + 60_000 }],
+      });
+      codexDeferreds["codex-c.json"].resolve({
+        items: [{ label: "m_quota.code_5h", percent: 56, resetAtMs: now + 60_000 }],
+      });
+      await Promise.all([
+        codexDeferreds["codex-b.json"].promise,
+        codexDeferreds["codex-c.json"].promise,
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(refreshButtonA.querySelector("svg")).not.toHaveClass("animate-spin");
+      expect(refreshButtonB.querySelector("svg")).not.toHaveClass("animate-spin");
+      expect(refreshButtonC.querySelector("svg")).not.toHaveClass("animate-spin");
     });
   });
 

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -59,6 +59,7 @@ export function useAuthFilesQuotaState({
   const quotaAutoRefreshingRef = useRef<Set<string>>(new Set());
   const quotaByFileNameRef = useRef<Record<string, QuotaState>>(quotaByFileName);
   const quotaWarmupAttemptRef = useRef<Map<string, number>>(new Map());
+  const visiblePageSignatureRef = useRef<string | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   const [quotaPreviewMode, setQuotaPreviewMode] = useLocalStorage<QuotaPreviewMode>(
@@ -362,33 +363,56 @@ export function useAuthFilesQuotaState({
     [connectivityState],
   );
 
+  const resolveQuotaTargets = useCallback((targetFiles: AuthFileItem[]) => {
+    return targetFiles
+      .map((file) => {
+        const provider = resolveQuotaProvider(file);
+        return provider ? { file, provider } : null;
+      })
+      .filter(Boolean) as { file: AuthFileItem; provider: QuotaProvider }[];
+  }, []);
+
+  const markQuotaTargetsLoading = useCallback(
+    (targets: { file: AuthFileItem; provider: QuotaProvider }[]) => {
+      if (!targets.length) return;
+      setQuotaByFileName((prev) => {
+        const next = { ...prev };
+        for (const target of targets) {
+          next[target.file.name] = {
+            status: "loading",
+            items: prev[target.file.name]?.items ?? [],
+            planType: prev[target.file.name]?.planType,
+            error: prev[target.file.name]?.error,
+            updatedAt: prev[target.file.name]?.updatedAt,
+          };
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   const collectQuotaFetchTargets = useCallback(
     (targetFiles: AuthFileItem[]) => {
       const staleMs = Math.max(15_000, quotaAutoRefreshMs || 30_000);
       const now = Date.now();
 
-      return targetFiles
-        .map((file) => {
-          const provider = resolveQuotaProvider(file);
-          return provider ? { file, provider } : null;
-        })
-        .filter(Boolean)
-        .filter((candidate) => {
-          const current = candidate as { file: AuthFileItem; provider: QuotaProvider };
-          if (quotaInFlightRef.current.has(current.file.name)) return false;
-          const state = quotaByFileNameRef.current[current.file.name];
-          const items = Array.isArray(state?.items) ? state.items : [];
-          const updatedAt = state?.updatedAt ?? 0;
-          const isStale =
-            typeof updatedAt === "number" && updatedAt > 0 ? now - updatedAt > staleMs : true;
-          const needs = !state || state.status === "error" || items.length === 0 || isStale;
-          if (!needs) return false;
+      return resolveQuotaTargets(targetFiles).filter((candidate) => {
+        const current = candidate as { file: AuthFileItem; provider: QuotaProvider };
+        if (quotaInFlightRef.current.has(current.file.name)) return false;
+        const state = quotaByFileNameRef.current[current.file.name];
+        const items = Array.isArray(state?.items) ? state.items : [];
+        const updatedAt = state?.updatedAt ?? 0;
+        const isStale =
+          typeof updatedAt === "number" && updatedAt > 0 ? now - updatedAt > staleMs : true;
+        const needs = !state || state.status === "error" || items.length === 0 || isStale;
+        if (!needs) return false;
 
-          const lastAttempt = quotaWarmupAttemptRef.current.get(current.file.name) ?? 0;
-          return now - lastAttempt >= 5_000;
-        }) as { file: AuthFileItem; provider: QuotaProvider }[];
+        const lastAttempt = quotaWarmupAttemptRef.current.get(current.file.name) ?? 0;
+        return now - lastAttempt >= 5_000;
+      }) as { file: AuthFileItem; provider: QuotaProvider }[];
     },
-    [quotaAutoRefreshMs],
+    [quotaAutoRefreshMs, resolveQuotaTargets],
   );
 
   const runQuotaRefreshBatch = useCallback(
@@ -434,15 +458,27 @@ export function useAuthFilesQuotaState({
     if (tab !== "files") return;
     if (loading) return;
 
-    const toFetch = collectQuotaFetchTargets(pageItems);
+    const visibleSignature = pageItems.map((file) => file.name).join("\n");
+    const previousVisibleSignature = visiblePageSignatureRef.current;
+    visiblePageSignatureRef.current = visibleSignature;
+
+    const switchedVisiblePage =
+      previousVisibleSignature !== null && previousVisibleSignature !== visibleSignature;
+    const toFetch = switchedVisiblePage
+      ? resolveQuotaTargets(pageItems)
+      : collectQuotaFetchTargets(pageItems);
     if (!toFetch.length) return;
+
+    if (switchedVisiblePage) {
+      markQuotaTargetsLoading(toFetch);
+    }
 
     let cancelled = false;
     void (async () => {
       if (!cancelled) {
         await runQuotaRefreshBatch(toFetch, {
           markAsAutoRefreshing: true,
-          showLoading: false,
+          showLoading: switchedVisiblePage,
         });
       }
     })();
@@ -450,7 +486,15 @@ export function useAuthFilesQuotaState({
     return () => {
       cancelled = true;
     };
-  }, [collectQuotaFetchTargets, loading, pageItems, runQuotaRefreshBatch, tab]);
+  }, [
+    collectQuotaFetchTargets,
+    loading,
+    markQuotaTargetsLoading,
+    pageItems,
+    resolveQuotaTargets,
+    runQuotaRefreshBatch,
+    tab,
+  ]);
 
   const quotaLastUpdatedAtMs = useMemo(() => {
     let latest = 0;
@@ -487,31 +531,13 @@ export function useAuthFilesQuotaState({
     if (tab !== "files") return;
     if (loading) return;
 
-    const targets = pageItems
-      .map((file) => {
-        const provider = resolveQuotaProvider(file);
-        return provider ? { file, provider } : null;
-      })
-      .filter(Boolean) as { file: AuthFileItem; provider: QuotaProvider }[];
-
+    const targets = resolveQuotaTargets(pageItems);
     if (!targets.length) return;
 
-    setQuotaByFileName((prev) => {
-      const next = { ...prev };
-      for (const target of targets) {
-        next[target.file.name] = {
-          status: "loading",
-          items: prev[target.file.name]?.items ?? [],
-          planType: prev[target.file.name]?.planType,
-          error: prev[target.file.name]?.error,
-          updatedAt: prev[target.file.name]?.updatedAt,
-        };
-      }
-      return next;
-    });
+    markQuotaTargetsLoading(targets);
 
     await runQuotaRefreshBatch(targets, { markAsAutoRefreshing: true });
-  }, [loading, pageItems, runQuotaRefreshBatch, tab]);
+  }, [loading, markQuotaTargetsLoading, pageItems, resolveQuotaTargets, runQuotaRefreshBatch, tab]);
 
   useInterval(
     () => {


### PR DESCRIPTION
## Summary
- show per-card loading when switching auth-file provider tabs for the current visible page
- force-refresh visible quota cards on group switch while preserving existing card order
- cover the tab-switch loading lifecycle with a focused auth-files test

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run build
- bun run lint (repo has 2 pre-existing warnings unrelated to this change)
- bunx oxfmt src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/hooks/useAuthFilesQuotaState.ts .helloagents/plan/2026-05-05-auth-files-tab-visible-refresh/tasks.md --check