### PR TITLE
feat: surface auth file tags in management pages

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -609,6 +609,7 @@
     "channel_name_hint": "This name appears in the API key allowed-channels selector and must be globally unique.",
     "channel_name_required": "Please enter a channel name",
     "download": "Download",
+    "edit_tags": "Edit Tags",
     "add": "Add",
     "add_row": "Add Row",
     "save": "Save",
@@ -753,7 +754,18 @@
     "group_overview_no_quota": "No aggregatable quota in current results",
     "quota_auto_refresh": "Auto refresh",
     "quota_refresh_off": "Off",
-    "quota_updated_at": "Updated"
+    "quota_updated_at": "Updated",
+    "tags_modal_title": "Auth File Tags",
+    "custom_tag_label": "Custom tag",
+    "custom_tag_placeholder": "e.g. vip",
+    "custom_tag_add": "Add tag",
+    "custom_tag_limit": "Up to {{count}} custom tags",
+    "default_tags_label": "Default tags",
+    "display_tags_label": "Display tags",
+    "no_tags": "No tags",
+    "hide_tag": "Hide {{tag}}",
+    "restore_tag": "Restore {{tag}}",
+    "remove_custom_tag": "Remove {{tag}}"
   },
   "antigravity_quota": {
     "title": "Antigravity Quota",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -623,6 +623,7 @@
     "channel_name_hint": "该名称会出现在 API Key 的“允许渠道”选项中，且必须全局唯一。",
     "channel_name_required": "请填写渠道名称",
     "download": "下载",
+    "edit_tags": "编辑标签",
     "add": "添加",
     "add_row": "添加一行",
     "save": "保存",
@@ -761,7 +762,18 @@
     "group_overview_no_quota": "当前结果暂无可聚合配额",
     "quota_auto_refresh": "自动刷新",
     "quota_refresh_off": "关闭",
-    "quota_updated_at": "更新于"
+    "quota_updated_at": "更新于",
+    "tags_modal_title": "认证文件标签",
+    "custom_tag_label": "自定义标签",
+    "custom_tag_placeholder": "例如 vip",
+    "custom_tag_add": "添加标签",
+    "custom_tag_limit": "最多 {{count}} 个自定义标签",
+    "default_tags_label": "默认标签",
+    "display_tags_label": "最终显示标签",
+    "no_tags": "暂无标签",
+    "hide_tag": "隐藏 {{tag}}",
+    "restore_tag": "恢复 {{tag}}",
+    "remove_custom_tag": "移除 {{tag}}"
   },
   "antigravity_quota": {
     "title": "Antigravity 额度",

--- a/src/lib/http/apis/auth-files.ts
+++ b/src/lib/http/apis/auth-files.ts
@@ -30,6 +30,8 @@ export const authFilesApi = {
     subscription_started_at?: string;
     subscription_period?: string;
     subscription_expires_at?: string;
+    custom_tags?: string[];
+    hidden_default_tags?: string[];
   }) => apiClient.patch("/auth-files/fields", payload),
 
   getOauthExcludedModels: async (): Promise<Record<string, string[]>> => {

--- a/src/lib/http/apis/channel-groups.ts
+++ b/src/lib/http/apis/channel-groups.ts
@@ -1,4 +1,10 @@
 import { apiClient } from "@/lib/http/client";
+import type { TagDisplayFields } from "@/lib/http/types";
+
+export interface ChannelGroupChannelDetail extends TagDisplayFields {
+  name: string;
+  source?: string;
+}
 
 export interface ChannelGroupItem {
   name: string;
@@ -9,12 +15,67 @@ export interface ChannelGroupItem {
   channels?: string[];
   "allowed-models"?: string[];
   "path-routes"?: string[];
+  channelDetails?: ChannelGroupChannelDetail[];
 }
+
+const normalizeStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const items: string[] = [];
+  value.forEach((entry) => {
+    const normalized = typeof entry === "string" ? entry.trim() : "";
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    items.push(normalized);
+  });
+  return items;
+};
+
+const normalizeChannelDetail = (value: unknown): ChannelGroupChannelDetail | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const detail = value as Record<string, unknown>;
+  const name = typeof detail.name === "string" ? detail.name.trim() : "";
+  if (!name) return null;
+  return {
+    name,
+    source: typeof detail.source === "string" ? detail.source.trim() : undefined,
+    default_tags: normalizeStringList(detail.default_tags),
+    custom_tags: normalizeStringList(detail.custom_tags),
+    hidden_default_tags: normalizeStringList(detail.hidden_default_tags),
+    display_tags: normalizeStringList(detail.display_tags),
+  };
+};
 
 export const channelGroupsApi = {
   async list(): Promise<ChannelGroupItem[]> {
     const data = await apiClient.get<Record<string, unknown>>("/channel-groups");
     const items = data?.items;
-    return Array.isArray(items) ? (items as ChannelGroupItem[]) : [];
+    if (!Array.isArray(items)) return [];
+    return items
+      .map((entry): ChannelGroupItem | null => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+        const item = entry as Record<string, unknown>;
+        const name = typeof item.name === "string" ? item.name.trim() : "";
+        if (!name) return null;
+        return {
+          name,
+          description: typeof item.description === "string" ? item.description.trim() : undefined,
+          priority:
+            typeof item.priority === "number" && Number.isFinite(item.priority)
+              ? item.priority
+              : undefined,
+          implicit: item.implicit === true,
+          prefixes: normalizeStringList(item.prefixes),
+          channels: normalizeStringList(item.channels),
+          "allowed-models": normalizeStringList(item["allowed-models"]),
+          "path-routes": normalizeStringList(item["path-routes"]),
+          channelDetails: Array.isArray(item["channel-details"])
+            ? item["channel-details"]
+                .map(normalizeChannelDetail)
+                .filter((detail): detail is ChannelGroupChannelDetail => Boolean(detail))
+            : [],
+        };
+      })
+      .filter((item): item is ChannelGroupItem => Boolean(item));
   },
 };

--- a/src/lib/http/types.ts
+++ b/src/lib/http/types.ts
@@ -20,7 +20,14 @@ export type AuthFileType =
 
 export type AuthFileSubscriptionPeriod = "monthly" | "yearly";
 
-export interface AuthFileItem {
+export interface TagDisplayFields {
+  default_tags?: string[];
+  custom_tags?: string[];
+  hidden_default_tags?: string[];
+  display_tags?: string[];
+}
+
+export interface AuthFileItem extends TagDisplayFields {
   name: string;
   type?: AuthFileType | string;
   provider?: string;

--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -10,6 +10,7 @@ import { AuthFileDetailModal } from "@/modules/auth-files/components/AuthFileDet
 import { AuthFilesExcludedTab } from "@/modules/auth-files/components/AuthFilesExcludedTab";
 import { AuthFilesAliasTab } from "@/modules/auth-files/components/AuthFilesAliasTab";
 import { AuthFilesFilesTab } from "@/modules/auth-files/components/AuthFilesFilesTab";
+import { AuthFileTagsModal } from "@/modules/auth-files/components/AuthFileTagsModal";
 import { ImportModelsModal } from "@/modules/auth-files/components/ImportModelsModal";
 import { GroupOverviewModal } from "@/modules/auth-files/components/GroupOverviewModal";
 import { useAuthFilesDataState } from "@/modules/auth-files/hooks/useAuthFilesDataState";
@@ -118,6 +119,7 @@ export function AuthFilesPage() {
   const [page, setPage] = useState(1);
   const [selectedFileNames, setSelectedFileNames] = useState<string[]>([]);
   const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>([]);
+  const [tagsEditorFileName, setTagsEditorFileName] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const filesRef = useRef<AuthFileItem[]>(files);
@@ -196,10 +198,12 @@ export function AuthFilesPage() {
     uploading,
     deletingAll,
     statusUpdating,
+    tagSavingByName,
     downloadAuthFile,
     handleUpload,
     handleDeleteSelection,
     setFileEnabled,
+    saveAuthFileTags,
   } = useAuthFilesFileActions({
     loadAll,
     fileInputRef,
@@ -347,6 +351,10 @@ export function AuthFilesPage() {
   });
 
   const filterChips = useMemo(() => ["all", ...providerOptions], [providerOptions]);
+  const tagsEditorFile = useMemo(
+    () => files.find((file) => file.name === tagsEditorFileName) ?? null,
+    [files, tagsEditorFileName],
+  );
   const normalizedFilter = useMemo(() => normalizeProviderKey(filter), [filter]);
   const selectedModelOwner =
     normalizedFilter === "all" ? "" : (modelOwnerByAuthGroup[normalizedFilter] ?? "");
@@ -381,6 +389,7 @@ export function AuthFilesPage() {
     refreshQuota,
     openDetail: openDetailWithQuotaRefresh,
     downloadAuthFile,
+    openTagsEditor: (file) => setTagsEditorFileName(file.name),
     statusUpdating,
     setFileEnabled,
     usageIndex,
@@ -453,6 +462,7 @@ export function AuthFilesPage() {
             translateQuotaText={translateQuotaText}
             renderSubscriptionBadge={renderSubscriptionBadge}
             renderQuotaBar={renderQuotaBar}
+            openTagsEditor={(file) => setTagsEditorFileName(file.name)}
             openDetail={openDetailWithQuotaRefresh}
             downloadAuthFile={downloadAuthFile}
             safePage={safePage}
@@ -543,6 +553,14 @@ export function AuthFilesPage() {
         setImportSelected={setImportSelected}
         setImportOpen={setImportOpen}
         applyImport={applyImport}
+      />
+
+      <AuthFileTagsModal
+        open={tagsEditorFile !== null}
+        file={tagsEditorFile}
+        saving={Boolean(tagsEditorFile && tagSavingByName[tagsEditorFile.name])}
+        onClose={() => setTagsEditorFileName(null)}
+        onSave={saveAuthFileTags}
       />
 
       <OAuthLoginDialog

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   fetchQuota: vi.fn((_provider?: unknown, _file?: { name?: string }) => new Promise(() => {})),
   deleteFile: vi.fn(async () => ({})),
   downloadText: vi.fn(async () => "{}"),
+  patchFields: vi.fn(async () => ({})),
   getModelsForAuthFile: vi.fn(async () => [{ id: "live-only", owned_by: "runtime" }]),
   getModelConfigs: vi.fn(async () => [
     { id: "gpt-4.1", owned_by: "openai" },
@@ -55,6 +56,7 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
       list: mocks.list,
       deleteFile: mocks.deleteFile,
       downloadText: mocks.downloadText,
+      patchFields: mocks.patchFields,
       getModelsForAuthFile: mocks.getModelsForAuthFile,
       upload: mocks.upload,
     },
@@ -145,6 +147,8 @@ describe("AuthFilesPage files table", () => {
     mocks.deleteFile.mockImplementation(async () => ({}));
     mocks.downloadText.mockReset();
     mocks.downloadText.mockImplementation(async () => "{}");
+    mocks.patchFields.mockReset();
+    mocks.patchFields.mockImplementation(async () => ({}));
     mocks.getModelsForAuthFile.mockReset();
     mocks.getModelsForAuthFile.mockImplementation(async () => [
       { id: "live-only", owned_by: "runtime" },
@@ -329,6 +333,92 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     // non-quota providers should not show Codex-specific quota labels
     expect(screen.queryByText("Code: 5h")).not.toBeInTheDocument();
+  });
+
+  test("renders returned auth-file display tags in cards view", async () => {
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          default_tags: ["codex", "pro"],
+          custom_tags: ["vip-team"],
+          hidden_default_tags: [],
+          display_tags: ["codex", "pro", "vip-team"],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("A_GptPro")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-files-cards")).toHaveTextContent("vip-team");
+  });
+
+  test("saves auth-file custom tags and hidden default tags from the tags modal", async () => {
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          default_tags: ["codex", "pro"],
+          custom_tags: [],
+          hidden_default_tags: [],
+          display_tags: ["codex", "pro"],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("A_GptPro")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit Tags" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Auth File Tags" });
+    fireEvent.change(within(dialog).getByLabelText("Custom tag"), { target: { value: "vip" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add tag" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Hide pro" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mocks.patchFields).toHaveBeenCalledWith({
+        name: "codex-pro.json",
+        custom_tags: ["vip"],
+        hidden_default_tags: ["pro"],
+      }),
+    );
   });
 
   test("uses channel name as display name and sorts by channel name", async () => {

--- a/src/modules/auth-files/components/AuthFileTagsModal.tsx
+++ b/src/modules/auth-files/components/AuthFileTagsModal.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { AuthFileItem } from "@/lib/http/types";
+import { Button } from "@/modules/ui/Button";
+import { TextInput } from "@/modules/ui/Input";
+import { Modal } from "@/modules/ui/Modal";
+import {
+  buildAuthFileDisplayTags,
+  normalizeTagValue,
+  readAuthFileCustomTags,
+  readAuthFileDefaultTags,
+  readAuthFileHiddenDefaultTags,
+  resolveAuthFileDisplayName,
+} from "@/modules/auth-files/helpers/authFilesPageUtils";
+
+const MAX_CUSTOM_TAGS = 3;
+
+export function AuthFileTagsModal({
+  open,
+  file,
+  saving,
+  onClose,
+  onSave,
+}: {
+  open: boolean;
+  file: AuthFileItem | null;
+  saving?: boolean;
+  onClose: () => void;
+  onSave: (file: AuthFileItem, customTags: string[], hiddenDefaultTags: string[]) => Promise<boolean>;
+}) {
+  const { t } = useTranslation();
+  const [customTagInput, setCustomTagInput] = useState("");
+  const [customTags, setCustomTags] = useState<string[]>([]);
+  const [hiddenDefaultTags, setHiddenDefaultTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!open || !file) return;
+    setCustomTagInput("");
+    setCustomTags(readAuthFileCustomTags(file));
+    setHiddenDefaultTags(readAuthFileHiddenDefaultTags(file));
+  }, [file, open]);
+
+  const defaultTags = useMemo(() => (file ? readAuthFileDefaultTags(file) : []), [file]);
+  const hiddenTagSet = useMemo(() => new Set(hiddenDefaultTags), [hiddenDefaultTags]);
+  const displayTags = useMemo(
+    () => buildAuthFileDisplayTags(defaultTags, customTags, hiddenDefaultTags),
+    [customTags, defaultTags, hiddenDefaultTags],
+  );
+
+  const normalizedCustomTagInput = normalizeTagValue(customTagInput);
+  const canAddCustomTag =
+    normalizedCustomTagInput.length > 0 &&
+    customTags.length < MAX_CUSTOM_TAGS &&
+    !customTags.includes(normalizedCustomTagInput);
+
+  const handleAddCustomTag = () => {
+    if (!canAddCustomTag) return;
+    setCustomTags((prev) => [...prev, normalizedCustomTagInput]);
+    setCustomTagInput("");
+  };
+
+  const handleSave = async () => {
+    if (!file) return;
+    const saved = await onSave(file, customTags, hiddenDefaultTags);
+    if (saved) onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={t("auth_files.tags_modal_title")}
+      description={file ? resolveAuthFileDisplayName(file) || file.name : undefined}
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={saving}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="primary" onClick={() => void handleSave()} disabled={saving || !file}>
+            {t("common.save")}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <label className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("auth_files.custom_tag_label")}
+            </label>
+            <span className="text-xs text-slate-500 dark:text-white/55">
+              {t("auth_files.custom_tag_limit", { count: MAX_CUSTOM_TAGS })}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <TextInput
+              value={customTagInput}
+              onChange={(event) => setCustomTagInput(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                event.preventDefault();
+                handleAddCustomTag();
+              }}
+              placeholder={t("auth_files.custom_tag_placeholder")}
+              aria-label={t("auth_files.custom_tag_label")}
+              disabled={saving}
+            />
+            <Button
+              variant="secondary"
+              onClick={handleAddCustomTag}
+              disabled={saving || !canAddCustomTag}
+            >
+              {t("auth_files.custom_tag_add")}
+            </Button>
+          </div>
+
+          {customTags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {customTags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-700 dark:border-neutral-700/70 dark:bg-neutral-900 dark:text-white/80"
+                >
+                  <span>{tag}</span>
+                  <button
+                    type="button"
+                    onClick={() => setCustomTags((prev) => prev.filter((entry) => entry !== tag))}
+                    aria-label={t("auth_files.remove_custom_tag", { tag })}
+                    className="rounded-full p-0.5 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/80"
+                    disabled={saving}
+                  >
+                    <X size={12} />
+                  </button>
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-semibold text-slate-900 dark:text-white">
+            {t("auth_files.default_tags_label")}
+          </div>
+          {defaultTags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {defaultTags.map((tag) => {
+                const hidden = hiddenTagSet.has(tag);
+                return (
+                  <Button
+                    key={tag}
+                    variant={hidden ? "secondary" : "ghost"}
+                    size="sm"
+                    onClick={() =>
+                      setHiddenDefaultTags((prev) =>
+                        prev.includes(tag) ? prev.filter((entry) => entry !== tag) : [...prev, tag],
+                      )
+                    }
+                    disabled={saving}
+                    className={[
+                      "!h-auto rounded-full px-3 py-1 text-xs",
+                      hidden
+                        ? "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-200"
+                        : "border-slate-200 bg-white text-slate-700 dark:border-neutral-700/70 dark:bg-neutral-900 dark:text-white/80",
+                    ].join(" ")}
+                  >
+                    {hidden
+                      ? t("auth_files.restore_tag", { tag })
+                      : t("auth_files.hide_tag", { tag })}
+                  </Button>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-semibold text-slate-900 dark:text-white">
+            {t("auth_files.display_tags_label")}
+          </div>
+          {displayTags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {displayTags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-full bg-sky-50 px-2.5 py-1 text-xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   Search,
   Settings2,
+  Tags,
   Upload,
 } from "lucide-react";
 import type { AuthFileItem } from "@/lib/http/types";
@@ -36,6 +37,7 @@ import {
   isRuntimeOnlyAuthFile,
   normalizeProviderKey,
   resolveAuthFileDisplayName,
+  resolveAuthFileDisplayTags,
   resolveAuthFilePlanType,
   resolveFileType,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
@@ -105,6 +107,7 @@ interface AuthFilesFilesTabProps {
   translateQuotaText: (text: string) => string;
   renderSubscriptionBadge: (file: AuthFileItem) => ReactNode | null;
   renderQuotaBar: (label: string, item: QuotaItem | null) => ReactNode;
+  openTagsEditor: (file: AuthFileItem) => void;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
   safePage: number;
@@ -170,6 +173,7 @@ export function AuthFilesFilesTab({
   translateQuotaText,
   renderSubscriptionBadge,
   renderQuotaBar,
+  openTagsEditor,
   openDetail,
   downloadAuthFile,
   safePage,
@@ -529,6 +533,7 @@ export function AuthFilesFilesTab({
                   const provider = resolveQuotaProvider(file);
                   const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
                   const planType = resolveAuthFilePlanType(file, state);
+                  const displayTags = resolveAuthFileDisplayTags(file);
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const totalCalls = stats.success + stats.failure;
@@ -625,6 +630,18 @@ export function AuthFilesFilesTab({
                             </span>
                           ) : null}
                         </div>
+                        {displayTags.length > 0 ? (
+                          <div className="min-w-0 flex flex-wrap gap-1.5">
+                            {displayTags.map((tag) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
                         <p className="truncate text-[11px] text-slate-500 dark:text-white/45">
                           {formatModified(file)}
                         </p>
@@ -669,6 +686,18 @@ export function AuthFilesFilesTab({
                               </Button>
                             </HoverTooltip>
                           ) : null}
+
+                          <HoverTooltip content={t("auth_files.edit_tags")}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => openTagsEditor(file)}
+                              title={t("auth_files.edit_tags")}
+                              aria-label={t("auth_files.edit_tags")}
+                            >
+                              <Tags size={16} />
+                            </Button>
+                          </HoverTooltip>
 
                           <HoverTooltip content={t("auth_files.view")}>
                             <Button

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -163,6 +163,10 @@ export const sanitizeAuthFilesForCache = (files: AuthFileItem[]): AuthFileItem[]
     subscriptionRemainingMinutes: file.subscriptionRemainingMinutes,
     subscription_expired: file.subscription_expired,
     subscriptionExpired: file.subscriptionExpired,
+    default_tags: normalizeTagList(file.default_tags),
+    custom_tags: normalizeTagList(file.custom_tags),
+    hidden_default_tags: normalizeTagList(file.hidden_default_tags),
+    display_tags: normalizeTagList(file.display_tags),
     id_token: sanitizeDecodedIdToken(file.id_token),
   }));
 
@@ -426,6 +430,36 @@ export const dateTimeLocalInputToIso = (value: string): string | null => {
 
 export const normalizeProviderKey = (value: string): string => value.trim().toLowerCase();
 
+export const normalizeTagValue = (value: unknown): string => {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/\s+/g, "-").toLowerCase();
+};
+
+export const normalizeTagList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  value.forEach((entry) => {
+    const normalized = normalizeTagValue(entry);
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    tags.push(normalized);
+  });
+  return tags;
+};
+
+export const buildAuthFileDisplayTags = (
+  defaultTags: string[],
+  customTags: string[],
+  hiddenDefaultTags: string[],
+): string[] => {
+  const hiddenSet = new Set(normalizeTagList(hiddenDefaultTags));
+  return normalizeTagList([
+    ...normalizeTagList(defaultTags).filter((tag) => !hiddenSet.has(tag)),
+    ...normalizeTagList(customTags),
+  ]);
+};
+
 export const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export const matchesModelPattern = (modelId: string, pattern: string): boolean => {
@@ -527,6 +561,25 @@ export const authFilesSortCollator = new Intl.Collator("zh-Hans-CN", {
   numeric: true,
   sensitivity: "base",
 });
+
+export const readAuthFileDefaultTags = (file: AuthFileItem): string[] =>
+  normalizeTagList(file.default_tags);
+
+export const readAuthFileCustomTags = (file: AuthFileItem): string[] =>
+  normalizeTagList(file.custom_tags);
+
+export const readAuthFileHiddenDefaultTags = (file: AuthFileItem): string[] =>
+  normalizeTagList(file.hidden_default_tags);
+
+export const resolveAuthFileDisplayTags = (file: AuthFileItem): string[] => {
+  const displayTags = normalizeTagList(file.display_tags);
+  if (displayTags.length > 0) return displayTags;
+  return buildAuthFileDisplayTags(
+    readAuthFileDefaultTags(file),
+    readAuthFileCustomTags(file),
+    readAuthFileHiddenDefaultTags(file),
+  );
+};
 
 export const resolveAuthFilePlanType = (
   file: AuthFileItem,

--- a/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
@@ -4,8 +4,10 @@ import { authFilesApi } from "@/lib/http/apis";
 import type { AuthFileItem } from "@/lib/http/types";
 import { useToast } from "@/modules/ui/ToastProvider";
 import {
+  buildAuthFileDisplayTags,
   formatFileSize,
   MAX_AUTH_FILE_SIZE,
+  readAuthFileDefaultTags,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 
 interface UseAuthFilesFileActionsOptions {
@@ -33,6 +35,7 @@ export function useAuthFilesFileActions({
   const [uploading, setUploading] = useState(false);
   const [deletingAll, setDeletingAll] = useState(false);
   const [statusUpdating, setStatusUpdating] = useState<Record<string, boolean>>({});
+  const [tagSavingByName, setTagSavingByName] = useState<Record<string, boolean>>({});
 
   const downloadAuthFile = useCallback(
     async (file: AuthFileItem) => {
@@ -217,13 +220,61 @@ export function useAuthFilesFileActions({
     [notify, setFiles, t],
   );
 
+  const saveAuthFileTags = useCallback(
+    async (file: AuthFileItem, customTags: string[], hiddenDefaultTags: string[]) => {
+      const name = file.name;
+      setTagSavingByName((prev) => ({ ...prev, [name]: true }));
+      try {
+        await authFilesApi.patchFields({
+          name,
+          custom_tags: customTags,
+          hidden_default_tags: hiddenDefaultTags,
+        });
+        const defaultTags = readAuthFileDefaultTags(file);
+        const displayTags = buildAuthFileDisplayTags(defaultTags, customTags, hiddenDefaultTags);
+        const applyPatch = (item: AuthFileItem): AuthFileItem =>
+          item.name === name
+            ? {
+                ...item,
+                default_tags: defaultTags,
+                custom_tags: customTags,
+                hidden_default_tags: hiddenDefaultTags,
+                display_tags: displayTags,
+              }
+            : item;
+        setFiles((prev) => prev.map(applyPatch));
+        setDetailFile((prev) => (prev && prev.name === name ? applyPatch(prev) : prev));
+        notify({
+          type: "success",
+          message: t("auth_files.prefix_proxy_saved_success", { name }),
+        });
+        return true;
+      } catch (err: unknown) {
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("auth_files.save_failed"),
+        });
+        return false;
+      } finally {
+        setTagSavingByName((prev) => {
+          const next = { ...prev };
+          delete next[name];
+          return next;
+        });
+      }
+    },
+    [notify, setDetailFile, setFiles, t],
+  );
+
   return {
     uploading,
     deletingAll,
     statusUpdating,
+    tagSavingByName,
     downloadAuthFile,
     handleUpload,
     handleDeleteSelection,
     setFileEnabled,
+    saveAuthFileTags,
   };
 }

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { CalendarClock, Download, Eye, Loader2, RefreshCw, Zap } from "lucide-react";
+import { CalendarClock, Download, Eye, Loader2, RefreshCw, Tags, Zap } from "lucide-react";
 import type { AuthFileItem } from "@/lib/http/types";
 import { formatLatency } from "@/modules/providers/hooks/useProviderLatency";
 import { ProviderStatusBar } from "@/modules/providers/ProviderStatusBar";
@@ -21,6 +21,7 @@ import {
   isRuntimeOnlyAuthFile,
   parseAdditionalQuotaWindowLabel,
   resolveAuthFileDisplayName,
+  resolveAuthFileDisplayTags,
   resolveAuthFilePlanType,
   resolveAuthFileStats,
   resolveAuthFileStatusBar,
@@ -119,6 +120,7 @@ interface UseAuthFilesFilesPresentationOptions {
   refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
+  openTagsEditor: (file: AuthFileItem) => void;
   statusUpdating: Record<string, boolean>;
   setFileEnabled: (file: AuthFileItem, enabled: boolean) => Promise<void>;
   usageIndex: UsageIndex;
@@ -142,6 +144,7 @@ export function useAuthFilesFilesPresentation({
   refreshQuota,
   openDetail,
   downloadAuthFile,
+  openTagsEditor,
   statusUpdating,
   setFileEnabled,
   usageIndex,
@@ -431,6 +434,18 @@ export function useAuthFilesFilesPresentation({
             <p className="truncate font-mono text-xs text-slate-900 dark:text-white">
               {resolveAuthFileDisplayName(file) || "--"}
             </p>
+            {resolveAuthFileDisplayTags(file).length > 0 ? (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {resolveAuthFileDisplayTags(file).map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
           </div>
         ),
       },
@@ -707,6 +722,18 @@ export function useAuthFilesFilesPresentation({
                 </HoverTooltip>
               ) : null}
 
+              <HoverTooltip content={t("auth_files.edit_tags")}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => openTagsEditor(file)}
+                  title={t("auth_files.edit_tags")}
+                  aria-label={t("auth_files.edit_tags")}
+                >
+                  <Tags size={16} />
+                </Button>
+              </HoverTooltip>
+
               <HoverTooltip content={t("auth_files.view")}>
                 <Button
                   variant="ghost"
@@ -743,6 +770,7 @@ export function useAuthFilesFilesPresentation({
     formatPlanTypeLabel,
     formatQuotaResetTextCompact,
     openDetail,
+    openTagsEditor,
     quotaByFileName,
     quotaPreviewMode,
     quotaProgressCircle,

--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { channelGroupsApi } from "@/lib/http/apis/channel-groups";
+import {
+  channelGroupsApi,
+  type ChannelGroupChannelDetail,
+} from "@/lib/http/apis/channel-groups";
 import {
   routingConfigApi,
   type RoutingConfigGroupItem,
@@ -161,17 +164,30 @@ export function ChannelGroupsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [availableChannels, setAvailableChannels] = useState<string[]>([]);
+  const [availableChannelDetails, setAvailableChannelDetails] = useState<
+    Record<string, ChannelGroupChannelDetail>
+  >({});
 
   const loadAvailableChannels = useCallback(async () => {
     const items = await channelGroupsApi.list();
     const known = new Set<string>();
+    const detailsByName: Record<string, ChannelGroupChannelDetail> = {};
     for (const item of items) {
       for (const channel of item.channels ?? []) {
         const name = String(channel ?? "").trim();
         if (name) known.add(name);
       }
+      for (const detail of item.channelDetails ?? []) {
+        const name = String(detail.name ?? "").trim();
+        if (!name) continue;
+        known.add(name);
+        detailsByName[name.trim().toLowerCase()] = detail;
+      }
     }
-    return Array.from(known).sort((a, b) => a.localeCompare(b));
+    return {
+      names: Array.from(known).sort((a, b) => a.localeCompare(b)),
+      detailsByName,
+    };
   }, []);
 
   const loadModelsForChannels = useCallback(async (channels: string[]) => {
@@ -214,11 +230,12 @@ export function ChannelGroupsPage() {
     try {
       const [routing, channels] = await Promise.all([
         routingConfigApi.get(),
-        loadAvailableChannels().catch(() => []),
+        loadAvailableChannels().catch(() => ({ names: [], detailsByName: {} })),
       ]);
       const nextValues = hydrateRoutingValues(routing);
       setVisualValues(nextValues);
-      setAvailableChannels(channels);
+      setAvailableChannels(channels.names);
+      setAvailableChannelDetails(channels.detailsByName);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t("channel_groups_page.load_failed");
       setError(message);
@@ -240,11 +257,15 @@ export function ChannelGroupsPage() {
         await routingConfigApi.update(serializeRoutingValues(nextValues));
         const [latest, channels] = await Promise.all([
           routingConfigApi.get(),
-          loadAvailableChannels().catch(() => availableChannels),
+          loadAvailableChannels().catch(() => ({
+            names: availableChannels,
+            detailsByName: availableChannelDetails,
+          })),
         ]);
         const hydrated = hydrateRoutingValues(latest);
         setVisualValues(hydrated);
-        setAvailableChannels(channels);
+        setAvailableChannels(channels.names);
+        setAvailableChannelDetails(channels.detailsByName);
         notify({ type: "success", message: t("channel_groups_page.saved") });
       } catch (err: unknown) {
         setVisualValues(visualValues);
@@ -258,7 +279,7 @@ export function ChannelGroupsPage() {
         setSaving(false);
       }
     },
-    [availableChannels, loadAvailableChannels, notify, t, visualValues],
+    [availableChannelDetails, availableChannels, loadAvailableChannels, notify, t, visualValues],
   );
 
   const handleEditorChange = useCallback(
@@ -292,6 +313,7 @@ export function ChannelGroupsPage() {
             values={visualValues}
             disabled={loading || saving}
             availableChannels={availableChannels}
+            availableChannelDetails={availableChannelDetails}
             loadModelsForChannels={loadModelsForChannels}
             onChange={handleEditorChange}
           />

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, Pencil, Plus, Trash2, TriangleAlert, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { ChannelGroupChannelDetail } from "@/lib/http/apis/channel-groups";
 import type {
   RoutingChannelGroupEntry,
   RoutingChannelGroupMemberEntry,
@@ -194,16 +195,41 @@ function normalizeRoutingModelOption(model: RoutingModelLoadResult): RoutingMode
   };
 }
 
+function readChannelDisplayTags(detail?: ChannelGroupChannelDetail | null): string[] {
+  if (!detail?.display_tags || !Array.isArray(detail.display_tags)) return [];
+  return detail.display_tags
+    .map((tag) => (typeof tag === "string" ? tag.trim() : ""))
+    .filter((tag, index, list) => Boolean(tag) && list.indexOf(tag) === index);
+}
+
+function renderChannelTags(tags: string[]) {
+  if (tags.length === 0) return null;
+  return (
+    <span aria-hidden="true" className="flex shrink-0 flex-wrap gap-1">
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+        >
+          {tag}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export function RoutingConfigEditor({
   values,
   disabled,
   availableChannels,
+  availableChannelDetails = {},
   loadModelsForChannels,
   onChange,
 }: {
   values: VisualConfigValues;
   disabled?: boolean;
   availableChannels: string[];
+  availableChannelDetails?: Record<string, ChannelGroupChannelDetail>;
   loadModelsForChannels?: (channels: string[]) => Promise<RoutingModelLoadResult[]>;
   onChange: (values: Partial<VisualConfigValues>) => void;
 }) {
@@ -243,10 +269,17 @@ export function RoutingConfigEditor({
       .filter((channel, index, list) => list.indexOf(channel) === index)
       .map((channel) => ({
         value: channel,
-        label: channel,
+        label: (
+          <span className="flex min-w-0 items-center justify-between gap-2">
+            <span className="truncate">{channel}</span>
+            {renderChannelTags(
+              readChannelDisplayTags(availableChannelDetails[normalizeChannelName(channel)]),
+            )}
+          </span>
+        ),
         searchText: channel,
       }));
-  }, [availableChannels]);
+  }, [availableChannelDetails, availableChannels]);
 
   const availableChannelSet = useMemo(() => {
     return new Set(
@@ -779,17 +812,34 @@ export function RoutingConfigEditor({
         cellClassName: "min-w-0 whitespace-nowrap",
         render: (channel) => (
           <OverflowTooltip content={channel.name} className="block min-w-0">
-            <span
-              className={`flex min-w-0 items-center gap-2 truncate text-sm ${
-                draftStaleChannelIds.has(channel.id)
-                  ? "text-rose-700 dark:text-rose-200"
-                  : "text-slate-900 dark:text-white"
-              }`}
-            >
-              <span className="truncate">{channel.name}</span>
-              {draftStaleChannelIds.has(channel.id) ? (
-                <span className="inline-flex shrink-0 items-center rounded-full bg-rose-50 px-2 py-0.5 text-[10px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
-                  {t("channel_groups_page.deleted_badge")}
+            <span className="block min-w-0">
+              <span
+                className={`flex min-w-0 items-center gap-2 truncate text-sm ${
+                  draftStaleChannelIds.has(channel.id)
+                    ? "text-rose-700 dark:text-rose-200"
+                    : "text-slate-900 dark:text-white"
+                }`}
+              >
+                <span className="truncate">{channel.name}</span>
+                {draftStaleChannelIds.has(channel.id) ? (
+                  <span className="inline-flex shrink-0 items-center rounded-full bg-rose-50 px-2 py-0.5 text-[10px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                    {t("channel_groups_page.deleted_badge")}
+                  </span>
+                ) : null}
+              </span>
+              {readChannelDisplayTags(availableChannelDetails[normalizeChannelName(channel.name)])
+                .length > 0 ? (
+                <span className="mt-1 flex flex-wrap gap-1">
+                  {readChannelDisplayTags(
+                    availableChannelDetails[normalizeChannelName(channel.name)],
+                  ).map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                    >
+                      {tag}
+                    </span>
+                  ))}
                 </span>
               ) : null}
             </span>
@@ -837,7 +887,7 @@ export function RoutingConfigEditor({
         ),
       },
     ],
-    [disabled, draftStaleChannelIds, removeDraftChannel, t, updateDraftChannel],
+    [availableChannelDetails, disabled, draftStaleChannelIds, removeDraftChannel, t, updateDraftChannel],
   );
 
   const modelColumns = useMemo<VirtualTableColumn<RoutingModelOption>[]>(

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
@@ -135,5 +135,75 @@ describe("ChannelGroupsPage", () => {
     expect(screen.getByText("Mapped Claude model")).toBeInTheDocument();
     expect(screen.getByText("$3 / $15 / $0.3")).toBeInTheDocument();
     expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
+  });
+
+  test("shows channel tags in the selector options and selected rows", async () => {
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        return Promise.resolve({
+          items: [
+            {
+              name: "Codex Pool",
+              channels: ["A_GptPro"],
+              "channel-details": [
+                {
+                  name: "A_GptPro",
+                  source: "auth-file",
+                  default_tags: ["codex", "pro"],
+                  custom_tags: ["vip"],
+                  hidden_default_tags: [],
+                  display_tags: ["codex", "pro", "vip"],
+                },
+              ],
+            },
+          ],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({ data: [] });
+      }
+      if (
+        path === "/auth-files" ||
+        path === "/model-configs?scope=library" ||
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/opencode-go-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve({ files: [], data: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "新增分组" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+
+    const option = await screen.findByRole("option", { name: "A_GptPro" });
+    expect(option).toHaveTextContent("codex");
+    expect(option).toHaveTextContent("pro");
+    expect(option).toHaveTextContent("vip");
+
+    await user.click(option);
+
+    const selectedChannelsTable = screen.getByRole("table", { name: "选择渠道" });
+    const rowText = within(selectedChannelsTable).getByText("A_GptPro");
+    const row = rowText.closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLTableRowElement).getByText("codex")).toBeInTheDocument();
+    expect(within(row as HTMLTableRowElement).getByText("pro")).toBeInTheDocument();
+    expect(within(row as HTMLTableRowElement).getByText("vip")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- render persisted auth-file tags in auth-files cards/table rows
- add an auth-file tags modal for custom tags and hidden default tags
- surface channel tags inside the channel-group selector and selected channel rows

## Verification
- bun run vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
- bun run build