### PR TITLE
fix: avoid duplicate auth file tags

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -335,7 +335,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByText("Code: 5h")).not.toBeInTheDocument();
   });
 
-  test("renders returned auth-file display tags in cards view", async () => {
+  test("cards view only shows non-duplicated auth-file tags", async () => {
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     mocks.list.mockImplementation(async () => ({
       files: [
@@ -344,6 +344,7 @@ describe("AuthFilesPage files table", () => {
           label: "A_GptPro",
           account_type: "oauth",
           type: "codex",
+          plan_type: "pro",
           size: 1024,
           modified: Date.now(),
           disabled: false,
@@ -367,8 +368,12 @@ describe("AuthFilesPage files table", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("A_GptPro")).toBeInTheDocument();
-    expect(screen.getByTestId("auth-files-cards")).toHaveTextContent("vip-team");
+    const title = await screen.findByText("A_GptPro");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).getByText("vip-team")).toBeInTheDocument();
+    expect(within(card as HTMLElement).getAllByText(/^codex$/i)).toHaveLength(1);
+    expect(within(card as HTMLElement).queryByText(/^pro$/i)).not.toBeInTheDocument();
   });
 
   test("saves auth-file custom tags and hidden default tags from the tags modal", async () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -37,8 +37,8 @@ import {
   isRuntimeOnlyAuthFile,
   normalizeProviderKey,
   resolveAuthFileDisplayName,
-  resolveAuthFileDisplayTags,
   resolveAuthFilePlanType,
+  resolveAuthFileSupplementalTags,
   resolveFileType,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import type { QuotaItem, QuotaState } from "@/modules/quota/quota-helpers";
@@ -533,7 +533,7 @@ export function AuthFilesFilesTab({
                   const provider = resolveQuotaProvider(file);
                   const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
                   const planType = resolveAuthFilePlanType(file, state);
-                  const displayTags = resolveAuthFileDisplayTags(file);
+                  const displayTags = resolveAuthFileSupplementalTags(file, state);
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const totalCalls = stats.success + stats.failure;

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -586,6 +586,20 @@ export const resolveAuthFilePlanType = (
   quotaState?: QuotaState | null,
 ): string | null => normalizePlanType(quotaState?.planType) ?? resolveCodexPlanType(file);
 
+export const resolveAuthFileSupplementalTags = (
+  file: AuthFileItem,
+  quotaState?: QuotaState | null,
+): string[] => {
+  const hiddenByPrimaryBadges = new Set<string>();
+  const typeTag = normalizeTagValue(resolveFileType(file));
+  if (typeTag) hiddenByPrimaryBadges.add(typeTag);
+  const planTag = normalizeTagValue(resolveAuthFilePlanType(file, quotaState) ?? "");
+  if (planTag) hiddenByPrimaryBadges.add(planTag);
+  return resolveAuthFileDisplayTags(file).filter(
+    (tag) => !hiddenByPrimaryBadges.has(normalizeTagValue(tag)),
+  );
+};
+
 export const isRuntimeOnlyAuthFile = (file: AuthFileItem): boolean => {
   const raw = (file.runtime_only ?? file.runtimeOnly) as unknown;
   if (typeof raw === "boolean") return raw;

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -21,8 +21,8 @@ import {
   isRuntimeOnlyAuthFile,
   parseAdditionalQuotaWindowLabel,
   resolveAuthFileDisplayName,
-  resolveAuthFileDisplayTags,
   resolveAuthFilePlanType,
+  resolveAuthFileSupplementalTags,
   resolveAuthFileStats,
   resolveAuthFileStatusBar,
   resolveAuthFileSubscriptionStatus,
@@ -434,9 +434,9 @@ export function useAuthFilesFilesPresentation({
             <p className="truncate font-mono text-xs text-slate-900 dark:text-white">
               {resolveAuthFileDisplayName(file) || "--"}
             </p>
-            {resolveAuthFileDisplayTags(file).length > 0 ? (
+            {resolveAuthFileSupplementalTags(file, quotaByFileName[file.name]).length > 0 ? (
               <div className="mt-1 flex flex-wrap gap-1">
-                {resolveAuthFileDisplayTags(file).map((tag) => (
+                {resolveAuthFileSupplementalTags(file, quotaByFileName[file.name]).map((tag) => (
                   <span
                     key={tag}
                     className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"


### PR DESCRIPTION
## Summary
- stop repeating auth-file default tags that are already represented by the type and plan badges
- keep tag editing and channel-group tag rendering unchanged
- cover the deduped card behavior with a focused regression test

## Verification
- bun run vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
- bun run build
- bun run lint