### PR TITLE
fix: widen api key column

### DIFF
--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -611,7 +611,7 @@ export function ApiKeysPage() {
             rowHeight={44}
             height="h-[calc(100dvh-260px)] max-h-[70vh]"
             minHeight="min-h-[320px]"
-            minWidth="min-w-[1740px]"
+            minWidth="min-w-[1820px]"
             caption={t("api_keys_page.table_caption")}
             emptyText={t("api_keys_page.no_api_keys")}
             rowClassName={(row) => (row.disabled ? "opacity-50" : "")}

--- a/src/modules/api-keys/components/ApiKeyColumns.tsx
+++ b/src/modules/api-keys/components/ApiKeyColumns.tsx
@@ -82,7 +82,7 @@ export const createApiKeyColumns = ({
   {
     key: "key",
     label: t("api_keys_page.col_key"),
-    width: "w-[240px] min-w-[240px]",
+    width: "w-[320px] min-w-[320px]",
     cellClassName: "whitespace-nowrap",
     render: (row) => (
       <code className="rounded-md bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-700 dark:bg-neutral-800 dark:text-white/70">

--- a/src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -81,4 +81,19 @@ describe("ApiKeyColumns", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent("View usage");
     expect(screen.getByRole("tooltip")).toHaveStyle({ left: "76px", top: "140px" });
   });
+
+  test("keeps the API key column at the wider fixed width", () => {
+    const columns = createApiKeyColumns({
+      t,
+      onCopy: vi.fn(),
+      onDelete: vi.fn(),
+      onEdit: vi.fn(),
+      onImportToCcSwitch: vi.fn(),
+      onToggleDisable: vi.fn(),
+      onViewUsage: vi.fn(),
+    });
+    const keyColumn = columns.find((column) => column.key === "key");
+
+    expect(keyColumn?.width).toBe("w-[320px] min-w-[320px]");
+  });
 });


### PR DESCRIPTION
## Summary
- Widen the manage/api-keys API key table column from 240px to 320px.
- Increase the API keys table minimum width by the same 80px so other fixed columns are not squeezed.
- Add a regression test for the fixed API key column width.

## Test Plan
- bun run test -- src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- bunx oxfmt src/modules/api-keys/ApiKeysPage.tsx src/modules/api-keys/components/ApiKeyColumns.tsx src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx --check
- bun run lint
- bun run build
- bun run test
- bun run check

## Notes
- Full `bunx oxfmt . --check` currently reports pre-existing formatting differences in 38 unrelated files, so only the touched files were kept formatted in this PR.