### PR TITLE
fix: simplify auth file tag visibility controls

### DIFF
--- a/src/lib/http/apis/auth-files.ts
+++ b/src/lib/http/apis/auth-files.ts
@@ -32,6 +32,7 @@ export const authFilesApi = {
     subscription_expires_at?: string;
     custom_tags?: string[];
     hidden_default_tags?: string[];
+    display_tags?: string[];
   }) => apiClient.patch("/auth-files/fields", payload),
 
   getOauthExcludedModels: async (): Promise<Record<string, string[]>> => {

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -376,7 +376,7 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText(/^pro$/i)).not.toBeInTheDocument();
   });
 
-  test("saves auth-file custom tags and hidden default tags from the tags modal", async () => {
+  test("saves auth-file tag visibility and custom tags from the tags modal", async () => {
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     mocks.list.mockImplementation(async () => ({
       files: [
@@ -414,7 +414,7 @@ describe("AuthFilesPage files table", () => {
     const dialog = await screen.findByRole("dialog", { name: "Auth File Tags" });
     fireEvent.change(within(dialog).getByLabelText("Custom tag"), { target: { value: "vip" } });
     fireEvent.click(within(dialog).getByRole("button", { name: "Add tag" }));
-    fireEvent.click(within(dialog).getByRole("button", { name: "Hide pro" }));
+    fireEvent.click(within(dialog).getByRole("checkbox", { name: "pro" }));
     fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
@@ -422,6 +422,7 @@ describe("AuthFilesPage files table", () => {
         name: "codex-pro.json",
         custom_tags: ["vip"],
         hidden_default_tags: ["pro"],
+        display_tags: ["codex", "vip"],
       }),
     );
   });

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -9,6 +9,7 @@ import {
   pickQuotaPreviewItem,
   readAuthFilesDataCache,
   readAuthFilesUiState,
+  resolveAuthFileDisplayTags,
   resolveAuthFileSubscriptionStatus,
   resolveAuthFileStats,
   sanitizeAuthFilesForCache,
@@ -159,7 +160,7 @@ describe("Auth Files helper coverage", () => {
         default_tags: [],
         custom_tags: [],
         hidden_default_tags: [],
-        display_tags: [],
+        display_tags: undefined,
         id_token: {
           chatgpt_account_id: "acct-1",
           plan_type: "pro",
@@ -192,6 +193,24 @@ describe("Auth Files helper coverage", () => {
         },
       },
     });
+  });
+
+  test("treats an explicit empty display tag list as hiding every tag", () => {
+    const file = {
+      name: "codex.json",
+      default_tags: ["codex", "pro"],
+      custom_tags: ["vip"],
+      display_tags: [],
+    } satisfies AuthFileItem;
+
+    expect(resolveAuthFileDisplayTags(file)).toEqual([]);
+    expect(
+      resolveAuthFileDisplayTags({
+        name: "codex.json",
+        default_tags: ["codex", "pro"],
+        custom_tags: ["vip"],
+      }),
+    ).toEqual(["codex", "pro", "vip"]);
   });
 
   test("aggregates auth file usage and picks quota preview entries", () => {

--- a/src/modules/auth-files/components/AuthFileTagsModal.tsx
+++ b/src/modules/auth-files/components/AuthFileTagsModal.tsx
@@ -3,14 +3,15 @@ import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AuthFileItem } from "@/lib/http/types";
 import { Button } from "@/modules/ui/Button";
+import { Checkbox } from "@/modules/ui/Checkbox";
 import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import {
-  buildAuthFileDisplayTags,
   normalizeTagValue,
   readAuthFileCustomTags,
   readAuthFileDefaultTags,
-  readAuthFileHiddenDefaultTags,
+  readAuthFileTagCandidates,
+  resolveAuthFileDisplayTags,
   resolveAuthFileDisplayName,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 
@@ -27,26 +28,33 @@ export function AuthFileTagsModal({
   file: AuthFileItem | null;
   saving?: boolean;
   onClose: () => void;
-  onSave: (file: AuthFileItem, customTags: string[], hiddenDefaultTags: string[]) => Promise<boolean>;
+  onSave: (file: AuthFileItem, customTags: string[], displayTags: string[]) => Promise<boolean>;
 }) {
   const { t } = useTranslation();
   const [customTagInput, setCustomTagInput] = useState("");
   const [customTags, setCustomTags] = useState<string[]>([]);
-  const [hiddenDefaultTags, setHiddenDefaultTags] = useState<string[]>([]);
+  const [selectedDisplayTags, setSelectedDisplayTags] = useState<string[]>([]);
 
   useEffect(() => {
     if (!open || !file) return;
     setCustomTagInput("");
     setCustomTags(readAuthFileCustomTags(file));
-    setHiddenDefaultTags(readAuthFileHiddenDefaultTags(file));
+    setSelectedDisplayTags(resolveAuthFileDisplayTags(file));
   }, [file, open]);
 
   const defaultTags = useMemo(() => (file ? readAuthFileDefaultTags(file) : []), [file]);
-  const hiddenTagSet = useMemo(() => new Set(hiddenDefaultTags), [hiddenDefaultTags]);
-  const displayTags = useMemo(
-    () => buildAuthFileDisplayTags(defaultTags, customTags, hiddenDefaultTags),
-    [customTags, defaultTags, hiddenDefaultTags],
+  const tagOptions = useMemo(
+    () =>
+      file
+        ? readAuthFileTagCandidates({
+            ...file,
+            custom_tags: customTags,
+            display_tags: selectedDisplayTags,
+          })
+        : [],
+    [customTags, file, selectedDisplayTags],
   );
+  const selectedTagSet = useMemo(() => new Set(selectedDisplayTags), [selectedDisplayTags]);
 
   const normalizedCustomTagInput = normalizeTagValue(customTagInput);
   const canAddCustomTag =
@@ -57,12 +65,29 @@ export function AuthFileTagsModal({
   const handleAddCustomTag = () => {
     if (!canAddCustomTag) return;
     setCustomTags((prev) => [...prev, normalizedCustomTagInput]);
+    setSelectedDisplayTags((prev) =>
+      prev.includes(normalizedCustomTagInput) ? prev : [...prev, normalizedCustomTagInput],
+    );
     setCustomTagInput("");
+  };
+
+  const handleRemoveCustomTag = (tag: string) => {
+    setCustomTags((prev) => prev.filter((entry) => entry !== tag));
+    setSelectedDisplayTags((prev) => prev.filter((entry) => entry !== tag));
+  };
+
+  const handleToggleDisplayTag = (tag: string, checked: boolean) => {
+    setSelectedDisplayTags((prev) => {
+      if (checked) return prev.includes(tag) ? prev : [...prev, tag];
+      return prev.filter((entry) => entry !== tag);
+    });
   };
 
   const handleSave = async () => {
     if (!file) return;
-    const saved = await onSave(file, customTags, hiddenDefaultTags);
+    const optionSet = new Set(tagOptions);
+    const displayTags = selectedDisplayTags.filter((tag) => optionSet.has(tag));
+    const saved = await onSave(file, customTags, displayTags);
     if (saved) onClose();
   };
 
@@ -126,7 +151,7 @@ export function AuthFileTagsModal({
                   <span>{tag}</span>
                   <button
                     type="button"
-                    onClick={() => setCustomTags((prev) => prev.filter((entry) => entry !== tag))}
+                    onClick={() => handleRemoveCustomTag(tag)}
                     aria-label={t("auth_files.remove_custom_tag", { tag })}
                     className="rounded-full p-0.5 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/80"
                     disabled={saving}
@@ -143,56 +168,40 @@ export function AuthFileTagsModal({
 
         <div className="space-y-2">
           <div className="text-sm font-semibold text-slate-900 dark:text-white">
-            {t("auth_files.default_tags_label")}
-          </div>
-          {defaultTags.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {defaultTags.map((tag) => {
-                const hidden = hiddenTagSet.has(tag);
-                return (
-                  <Button
-                    key={tag}
-                    variant={hidden ? "secondary" : "ghost"}
-                    size="sm"
-                    onClick={() =>
-                      setHiddenDefaultTags((prev) =>
-                        prev.includes(tag) ? prev.filter((entry) => entry !== tag) : [...prev, tag],
-                      )
-                    }
-                    disabled={saving}
-                    className={[
-                      "!h-auto rounded-full px-3 py-1 text-xs",
-                      hidden
-                        ? "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-200"
-                        : "border-slate-200 bg-white text-slate-700 dark:border-neutral-700/70 dark:bg-neutral-900 dark:text-white/80",
-                    ].join(" ")}
-                  >
-                    {hidden
-                      ? t("auth_files.restore_tag", { tag })
-                      : t("auth_files.hide_tag", { tag })}
-                  </Button>
-                );
-              })}
-            </div>
-          ) : (
-            <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <div className="text-sm font-semibold text-slate-900 dark:text-white">
             {t("auth_files.display_tags_label")}
           </div>
-          {displayTags.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {displayTags.map((tag) => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center rounded-full bg-sky-50 px-2.5 py-1 text-xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
-                >
-                  {tag}
-                </span>
-              ))}
+          {tagOptions.length > 0 ? (
+            <div className="grid gap-2 sm:grid-cols-2">
+              {tagOptions.map((tag) => {
+                const checked = selectedTagSet.has(tag);
+                const custom = customTags.includes(tag);
+                const inherited = defaultTags.includes(tag);
+                return (
+                  <label
+                    key={tag}
+                    className="flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/80 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
+                  >
+                    <span className="min-w-0 truncate font-medium">{tag}</span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {custom ? (
+                        <span className="rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200">
+                          {t("auth_files.custom_tag_label")}
+                        </span>
+                      ) : inherited ? (
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/60">
+                          {t("auth_files.default_tags_label")}
+                        </span>
+                      ) : null}
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={(next) => handleToggleDisplayTag(tag, next)}
+                        aria-label={tag}
+                        disabled={saving}
+                      />
+                    </span>
+                  </label>
+                );
+              })}
             </div>
           ) : (
             <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -166,7 +166,9 @@ export const sanitizeAuthFilesForCache = (files: AuthFileItem[]): AuthFileItem[]
     default_tags: normalizeTagList(file.default_tags),
     custom_tags: normalizeTagList(file.custom_tags),
     hidden_default_tags: normalizeTagList(file.hidden_default_tags),
-    display_tags: normalizeTagList(file.display_tags),
+    display_tags: Array.isArray(file.display_tags)
+      ? normalizeTagList(file.display_tags)
+      : undefined,
     id_token: sanitizeDecodedIdToken(file.id_token),
   }));
 
@@ -571,9 +573,15 @@ export const readAuthFileCustomTags = (file: AuthFileItem): string[] =>
 export const readAuthFileHiddenDefaultTags = (file: AuthFileItem): string[] =>
   normalizeTagList(file.hidden_default_tags);
 
+export const readAuthFileTagCandidates = (file: AuthFileItem): string[] =>
+  normalizeTagList([
+    ...readAuthFileDefaultTags(file),
+    ...readAuthFileCustomTags(file),
+    ...(Array.isArray(file.display_tags) ? normalizeTagList(file.display_tags) : []),
+  ]);
+
 export const resolveAuthFileDisplayTags = (file: AuthFileItem): string[] => {
-  const displayTags = normalizeTagList(file.display_tags);
-  if (displayTags.length > 0) return displayTags;
+  if (Array.isArray(file.display_tags)) return normalizeTagList(file.display_tags);
   return buildAuthFileDisplayTags(
     readAuthFileDefaultTags(file),
     readAuthFileCustomTags(file),

--- a/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
@@ -4,7 +4,6 @@ import { authFilesApi } from "@/lib/http/apis";
 import type { AuthFileItem } from "@/lib/http/types";
 import { useToast } from "@/modules/ui/ToastProvider";
 import {
-  buildAuthFileDisplayTags,
   formatFileSize,
   MAX_AUTH_FILE_SIZE,
   readAuthFileDefaultTags,
@@ -221,17 +220,19 @@ export function useAuthFilesFileActions({
   );
 
   const saveAuthFileTags = useCallback(
-    async (file: AuthFileItem, customTags: string[], hiddenDefaultTags: string[]) => {
+    async (file: AuthFileItem, customTags: string[], displayTags: string[]) => {
       const name = file.name;
       setTagSavingByName((prev) => ({ ...prev, [name]: true }));
       try {
+        const defaultTags = readAuthFileDefaultTags(file);
+        const displayTagSet = new Set(displayTags);
+        const hiddenDefaultTags = defaultTags.filter((tag) => !displayTagSet.has(tag));
         await authFilesApi.patchFields({
           name,
           custom_tags: customTags,
           hidden_default_tags: hiddenDefaultTags,
+          display_tags: displayTags,
         });
-        const defaultTags = readAuthFileDefaultTags(file);
-        const displayTags = buildAuthFileDisplayTags(defaultTags, customTags, hiddenDefaultTags);
         const applyPatch = (item: AuthFileItem): AuthFileItem =>
           item.name === name
             ? {


### PR DESCRIPTION
## Summary
- Replace the auth-file tag modal with one simple visibility checklist for all tag candidates.
- Keep custom tags capped at 3 and save explicit display_tags, including an empty list.
- Preserve legacy hidden_default_tags for compatibility.

## Test Plan
- bun run test
- bun run check
- bunx oxfmt changed auth file tag files --check
- git diff --check