### PR TITLE
fix: respect auth file tag visibility for default badges

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -376,6 +376,86 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText(/^pro$/i)).not.toBeInTheDocument();
   });
 
+  test("cards view hides default auth-file badges when display tags are empty", async () => {
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          plan_type: "pro",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          default_tags: ["codex", "pro"],
+          custom_tags: [],
+          hidden_default_tags: ["codex", "pro"],
+          display_tags: [],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("A_GptPro");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).queryByText(/^codex$/i)).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("Plan Pro")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText("0 calls")).toBeInTheDocument();
+  });
+
+  test("table view hides default auth-file badges when display tags are empty", async () => {
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          plan_type: "pro",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          default_tags: ["codex", "pro"],
+          custom_tags: [],
+          hidden_default_tags: ["codex", "pro"],
+          display_tags: [],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("A_GptPro");
+    const row = title.closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).queryByText(/^codex$/i)).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("Plan Pro")).not.toBeInTheDocument();
+  });
+
   test("saves auth-file tag visibility and custom tags from the tags modal", async () => {
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     mocks.list.mockImplementation(async () => ({

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -13,6 +13,7 @@ import {
   resolveAuthFileSubscriptionStatus,
   resolveAuthFileStats,
   sanitizeAuthFilesForCache,
+  shouldShowAuthFileDisplayTag,
   writeAuthFilesDataCache,
   writeAuthFilesUiState,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
@@ -211,6 +212,38 @@ describe("Auth Files helper coverage", () => {
         custom_tags: ["vip"],
       }),
     ).toEqual(["codex", "pro", "vip"]);
+  });
+
+  test("checks default badge visibility from explicit display tags or hidden defaults", () => {
+    expect(
+      shouldShowAuthFileDisplayTag(
+        {
+          name: "codex.json",
+          default_tags: ["codex", "pro"],
+          hidden_default_tags: [],
+          display_tags: ["codex"],
+        } as AuthFileItem,
+        "pro",
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowAuthFileDisplayTag(
+        {
+          name: "codex.json",
+          default_tags: ["codex", "pro"],
+          hidden_default_tags: ["pro"],
+        } as AuthFileItem,
+        "pro",
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowAuthFileDisplayTag(
+        {
+          name: "legacy.json",
+        } as AuthFileItem,
+        "codex",
+      ),
+    ).toBe(true);
   });
 
   test("aggregates auth file usage and picks quota preview entries", () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -40,6 +40,7 @@ import {
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveFileType,
+  shouldShowAuthFileDisplayTag,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import type { QuotaItem, QuotaState } from "@/modules/quota/quota-helpers";
 import type { QuotaProvider } from "@/modules/quota/quota-fetch";
@@ -534,6 +535,10 @@ export function AuthFilesFilesTab({
                   const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
                   const planType = resolveAuthFilePlanType(file, state);
                   const displayTags = resolveAuthFileSupplementalTags(file, state);
+                  const showTypeBadge = shouldShowAuthFileDisplayTag(file, typeKey);
+                  const showPlanBadge = planType
+                    ? shouldShowAuthFileDisplayTag(file, planType)
+                    : false;
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const totalCalls = stats.success + stats.failure;
@@ -607,15 +612,17 @@ export function AuthFilesFilesTab({
                         </div>
 
                         <div className="min-w-0 flex flex-wrap items-center gap-2">
-                          <span
-                            className={[
-                              "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold",
-                              badgeClass,
-                            ].join(" ")}
-                          >
-                            {typeKey}
-                          </span>
-                          {planType ? (
+                          {showTypeBadge ? (
+                            <span
+                              className={[
+                                "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold",
+                                badgeClass,
+                              ].join(" ")}
+                            >
+                              {typeKey}
+                            </span>
+                          ) : null}
+                          {showPlanBadge && planType ? (
                             <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
                               {t("codex_quota.plan_label")} {formatPlanTypeLabel(planType)}
                             </span>

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -589,6 +589,17 @@ export const resolveAuthFileDisplayTags = (file: AuthFileItem): string[] => {
   );
 };
 
+export const shouldShowAuthFileDisplayTag = (file: AuthFileItem, tag: unknown): boolean => {
+  const normalizedTag = normalizeTagValue(tag);
+  if (!normalizedTag) return false;
+
+  if (Array.isArray(file.display_tags)) {
+    return normalizeTagList(file.display_tags).includes(normalizedTag);
+  }
+
+  return !readAuthFileHiddenDefaultTags(file).includes(normalizedTag);
+};
+
 export const resolveAuthFilePlanType = (
   file: AuthFileItem,
   quotaState?: QuotaState | null,

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -27,6 +27,7 @@ import {
   resolveAuthFileStatusBar,
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
+  shouldShowAuthFileDisplayTag,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import { resolveQuotaProvider, type QuotaProvider } from "@/modules/quota/quota-fetch";
 import {
@@ -458,16 +459,20 @@ export function useAuthFilesFilesPresentation({
           const badgeClass = TYPE_BADGE_CLASSES[typeKey] ?? TYPE_BADGE_CLASSES.unknown;
           const planType = resolveAuthFilePlanType(file, quotaByFileName[file.name]);
           const runtimeOnly = isRuntimeOnlyAuthFile(file);
+          const showTypeBadge = shouldShowAuthFileDisplayTag(file, typeKey);
+          const showPlanBadge = planType ? shouldShowAuthFileDisplayTag(file, planType) : false;
 
           return (
             <div className="flex flex-col gap-1">
               <div className="flex flex-wrap items-center gap-2">
-                <span
-                  className={`inline-flex rounded-lg px-2 py-1 text-xs font-semibold ${badgeClass}`}
-                >
-                  {typeKey}
-                </span>
-                {planType ? (
+                {showTypeBadge ? (
+                  <span
+                    className={`inline-flex rounded-lg px-2 py-1 text-xs font-semibold ${badgeClass}`}
+                  >
+                    {typeKey}
+                  </span>
+                ) : null}
+                {showPlanBadge && planType ? (
                   <span className="inline-flex rounded-lg bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
                     {t("codex_quota.plan_label")} {formatPlanTypeLabel(planType)}
                   </span>


### PR DESCRIPTION
## Summary
- make auth-file type and plan badges follow the saved display tag visibility
- keep legacy auth files showing default badges when no tag visibility config exists
- add card/table coverage for hiding default badges

## Verification
- bun run test
- bun run check
- bunx oxfmt --check src/modules/auth-files/helpers/authFilesPageUtils.ts src/modules/auth-files/components/AuthFilesFilesTab.tsx src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- git diff --check