### PR TITLE
fix: avoid CC Switch protocol false unavailable toast

### DIFF
--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   buildCcSwitchImportUrl,
+  openCcSwitchImportUrl,
   pickCcSwitchDefaultModel,
   resolveCcSwitchImportConfig,
 } from "@/modules/ccswitch/ccswitchImport";
@@ -12,6 +13,11 @@ const decodeUsageScript = (url: string) => {
 };
 
 describe("ccswitchImport", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   test("builds a Claude provider deeplink with the Anthropic API key auth field", () => {
     const url = buildCcSwitchImportUrl({
       apiKey: "sk-ant-test-key",
@@ -113,5 +119,18 @@ describe("ccswitchImport", () => {
     expect(config.homepage).toBe("https://relay.example.com/api");
     expect(config.endpoint).toBe("https://relay.example.com/api/openai/v1");
     expect(config.model).toBe("gpt-5.6");
+  });
+
+  test("does not report the protocol unavailable from retained browser focus alone", () => {
+    vi.useFakeTimers();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    const onProtocolUnavailable = vi.fn();
+
+    openCcSwitchImportUrl("ccswitch://v1/import?resource=provider", { onProtocolUnavailable });
+    vi.advanceTimersByTime(10_000);
+
+    expect(openSpy).toHaveBeenCalledWith("ccswitch://v1/import?resource=provider", "_self");
+    expect(onProtocolUnavailable).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -235,11 +235,6 @@ export function openCcSwitchImportUrl(
 ): void {
   try {
     window.open(url, "_self");
-    window.setTimeout(() => {
-      if (document.hasFocus()) {
-        options.onProtocolUnavailable?.();
-      }
-    }, 100);
   } catch {
     options.onProtocolUnavailable?.();
   }


### PR DESCRIPTION
## Summary
- Remove the focus-based CC Switch protocol failure heuristic that caused false unavailable toasts on Windows browsers.
- Add a regression test proving retained browser focus alone does not trigger the unavailable callback.

## Verification
- bun run test src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
- bun run build
- bun run lint (2 existing warnings, 0 errors)