### PR TITLE
fix: store API key permission profiles in database

### DIFF
--- a/src/lib/http/apis/__tests__/api-key-permission-profiles.test.ts
+++ b/src/lib/http/apis/__tests__/api-key-permission-profiles.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { apiKeyPermissionProfilesApi } from "@/lib/http/apis/api-key-permission-profiles";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  put: vi.fn(),
+  getText: vi.fn(),
+  putRawText: vi.fn(),
+}));
+
+vi.mock("@/lib/http/client", () => ({
+  apiClient: {
+    get: mocks.get,
+    put: mocks.put,
+    getText: mocks.getText,
+    putRawText: mocks.putRawText,
+  },
+}));
+
+describe("apiKeyPermissionProfilesApi", () => {
+  beforeEach(() => {
+    mocks.get.mockReset();
+    mocks.put.mockReset();
+    mocks.getText.mockReset();
+    mocks.putRawText.mockReset();
+  });
+
+  test("loads permission profiles from the management database endpoint", async () => {
+    mocks.get.mockResolvedValue({
+      "api-key-permission-profiles": [
+        {
+          id: "standard",
+          name: "Standard",
+          "daily-limit": 15000,
+          "allowed-channel-groups": ["pro"],
+        },
+      ],
+    });
+
+    await expect(apiKeyPermissionProfilesApi.list()).resolves.toEqual([
+      expect.objectContaining({
+        id: "standard",
+        name: "Standard",
+        "daily-limit": 15000,
+        "allowed-channel-groups": ["pro"],
+      }),
+    ]);
+
+    expect(mocks.get).toHaveBeenCalledWith("/api-key-permission-profiles");
+    expect(mocks.getText).not.toHaveBeenCalled();
+  });
+
+  test("replaces permission profiles through the management database endpoint", async () => {
+    mocks.put.mockResolvedValue({});
+
+    await apiKeyPermissionProfilesApi.replace([
+      {
+        id: "standard",
+        name: "Standard",
+        "daily-limit": 15000,
+        "total-quota": 0,
+        "concurrency-limit": 0,
+        "rpm-limit": 0,
+        "tpm-limit": 0,
+        "allowed-channel-groups": ["pro"],
+        "allowed-channels": [],
+        "allowed-models": [],
+        "system-prompt": "",
+      },
+    ]);
+
+    expect(mocks.put).toHaveBeenCalledWith("/api-key-permission-profiles", [
+      expect.objectContaining({
+        id: "standard",
+        name: "Standard",
+        "daily-limit": 15000,
+        "allowed-channel-groups": ["pro"],
+      }),
+    ]);
+    expect(mocks.putRawText).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/http/apis/api-key-permission-profiles.ts
+++ b/src/lib/http/apis/api-key-permission-profiles.ts
@@ -1,8 +1,5 @@
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { configFileApi } from "@/lib/http/apis/config-file";
 import type { ApiKeyEntry } from "@/lib/http/apis/api-keys";
-
-const CONFIG_KEY = "api-key-permission-profiles";
+import { apiClient } from "@/lib/http/client";
 
 export const CUSTOM_PERMISSION_PROFILE_ID = "__custom__";
 
@@ -185,26 +182,18 @@ export function resolveEntryPermissionProfileId(
   return hasApiKeyPermissionSettings(entry) ? CUSTOM_PERMISSION_PROFILE_ID : "";
 }
 
-function parseProfilesFromYaml(yamlContent: string): ApiKeyPermissionProfile[] {
-  const parsed = asRecord(parseYaml(yamlContent) || {}) ?? {};
-  return normalizeApiKeyPermissionProfiles(parsed[CONFIG_KEY]);
-}
-
 export const apiKeyPermissionProfilesApi = {
   async list(): Promise<ApiKeyPermissionProfile[]> {
-    const yaml = await configFileApi.fetchConfigYaml();
-    return parseProfilesFromYaml(yaml);
+    const data = await apiClient.get<Record<string, unknown>>("/api-key-permission-profiles");
+    return normalizeApiKeyPermissionProfiles(
+      data["api-key-permission-profiles"] ?? data.items ?? data,
+    );
   },
 
   async replace(profiles: ApiKeyPermissionProfile[]): Promise<void> {
-    const yaml = await configFileApi.fetchConfigYaml();
-    const parsed = asRecord(parseYaml(yaml) || {}) ?? {};
-    const serialized = profiles.map(serializeApiKeyPermissionProfile);
-    if (serialized.length > 0) {
-      parsed[CONFIG_KEY] = serialized;
-    } else {
-      delete parsed[CONFIG_KEY];
-    }
-    await configFileApi.saveConfigYaml(stringifyYaml(parsed));
+    await apiClient.put(
+      "/api-key-permission-profiles",
+      profiles.map(serializeApiKeyPermissionProfile),
+    );
   },
 };

--- a/src/modules/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
+++ b/src/modules/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
@@ -10,6 +10,7 @@ const state = vi.hoisted(() => ({
   entries: [] as any[],
   channelGroups: [] as any[],
   configYaml: "",
+  permissionProfiles: [] as any[],
 }));
 
 const mocks = vi.hoisted(() => ({
@@ -23,6 +24,12 @@ const mocks = vi.hoisted(() => ({
     state.configYaml = content;
     return {};
   }),
+  apiClientPut: vi.fn(async (url: string, body: any) => {
+    if (url === "/api-key-permission-profiles") {
+      state.permissionProfiles = body;
+    }
+    return {};
+  }),
   authFilesList: vi.fn(async () => ({ files: [] })),
   getGeminiKeys: vi.fn(async () => []),
   getClaudeConfigs: vi.fn(async () => []),
@@ -30,6 +37,9 @@ const mocks = vi.hoisted(() => ({
   getVertexConfigs: vi.fn(async () => []),
   getOpenAIProviders: vi.fn(async () => []),
   apiClientGet: vi.fn(async (url: string) => {
+    if (url === "/api-key-permission-profiles") {
+      return { "api-key-permission-profiles": state.permissionProfiles };
+    }
     if (url === "/channel-groups") {
       return { items: state.channelGroups };
     }
@@ -82,6 +92,7 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
 vi.mock("@/lib/http/client", () => ({
   apiClient: {
     get: mocks.apiClientGet,
+    put: mocks.apiClientPut,
   },
 }));
 
@@ -115,21 +126,22 @@ describe("ApiKeyPermissionsPage", () => {
         "created-at": "2026-05-02T00:00:00.000Z",
       },
     ];
-    state.configYaml = `
-api-key-permission-profiles:
-  - id: standard
-    name: 标准配置
-    daily-limit: 15000
-    total-quota: 0
-    concurrency-limit: 0
-    rpm-limit: 0
-    tpm-limit: 0
-    allowed-channel-groups:
-      - legacy
-    allowed-channels: []
-    allowed-models: []
-    system-prompt: 标准系统提示词
-`;
+    state.configYaml = "";
+    state.permissionProfiles = [
+      {
+        id: "standard",
+        name: "标准配置",
+        "daily-limit": 15000,
+        "total-quota": 0,
+        "concurrency-limit": 0,
+        "rpm-limit": 0,
+        "tpm-limit": 0,
+        "allowed-channel-groups": ["legacy"],
+        "allowed-channels": [],
+        "allowed-models": [],
+        "system-prompt": "标准系统提示词",
+      },
+    ];
     state.channelGroups = [
       {
         name: "pro",
@@ -146,6 +158,7 @@ api-key-permission-profiles:
     mocks.apiKeyEntriesReplace.mockClear();
     mocks.fetchConfigYaml.mockClear();
     mocks.saveConfigYaml.mockClear();
+    mocks.apiClientPut.mockClear();
     mocks.authFilesList.mockClear();
     mocks.getGeminiKeys.mockResolvedValue([]);
     mocks.getClaudeConfigs.mockResolvedValue([
@@ -182,19 +195,25 @@ api-key-permission-profiles:
     await userEvent.click(within(dialog).getByRole("button", { name: "保存配置" }));
 
     await waitFor(() => {
-      expect(mocks.saveConfigYaml).toHaveBeenCalled();
+      expect(mocks.apiClientPut).toHaveBeenCalledWith(
+        "/api-key-permission-profiles",
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "专业配置",
+            "daily-limit": 15000,
+            "total-quota": 0,
+            "concurrency-limit": 0,
+            "rpm-limit": 0,
+            "tpm-limit": 0,
+            "allowed-channel-groups": ["pro"],
+            "allowed-channels": [],
+            "allowed-models": [],
+            "system-prompt": "专业系统提示词",
+          }),
+        ]),
+      );
     });
-
-    const savedYaml = String(mocks.saveConfigYaml.mock.calls.at(-1)?.[0] ?? "");
-    expect(savedYaml).toContain("api-key-permission-profiles:");
-    expect(savedYaml).toContain("name: 专业配置");
-    expect(savedYaml).toContain("daily-limit: 15000");
-    expect(savedYaml).toContain("total-quota: 0");
-    expect(savedYaml).toContain("concurrency-limit: 0");
-    expect(savedYaml).toContain("rpm-limit: 0");
-    expect(savedYaml).toContain("tpm-limit: 0");
-    expect(savedYaml).toContain("allowed-channel-groups:");
-    expect(savedYaml).toContain("- pro");
-    expect(savedYaml).toContain("system-prompt: 专业系统提示词");
+    expect(mocks.fetchConfigYaml).not.toHaveBeenCalled();
+    expect(mocks.saveConfigYaml).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   entries: [] as any[],
   channelGroups: [] as any[],
   configYaml: "",
+  permissionProfiles: [] as any[],
 }));
 
 const mocks = vi.hoisted(() => ({
@@ -33,6 +34,12 @@ const mocks = vi.hoisted(() => ({
     state.configYaml = content;
     return {};
   }),
+  apiClientPut: vi.fn(async (url: string, body: any) => {
+    if (url === "/api-key-permission-profiles") {
+      state.permissionProfiles = body;
+    }
+    return {};
+  }),
   authFilesList: vi.fn(async () => ({ files: [] })),
   getGeminiKeys: vi.fn(async () => []),
   getClaudeConfigs: vi.fn(async () => []),
@@ -40,6 +47,9 @@ const mocks = vi.hoisted(() => ({
   getVertexConfigs: vi.fn(async () => []),
   getOpenAIProviders: vi.fn(async () => []),
   apiClientGet: vi.fn(async (url: string) => {
+    if (url === "/api-key-permission-profiles") {
+      return { "api-key-permission-profiles": state.permissionProfiles };
+    }
     if (url === "/channel-groups") {
       return { items: state.channelGroups };
     }
@@ -96,6 +106,7 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
 vi.mock("@/lib/http/client", () => ({
   apiClient: {
     get: mocks.apiClientGet,
+    put: mocks.apiClientPut,
   },
 }));
 
@@ -175,6 +186,7 @@ describe("ApiKeysPage", () => {
     ];
     state.channelGroups = [];
     state.configYaml = "";
+    state.permissionProfiles = [];
     mocks.apiKeyEntriesList.mockClear();
     mocks.apiKeyEntriesReplace.mockClear();
     mocks.apiKeyEntriesUpdate.mockClear();
@@ -182,6 +194,7 @@ describe("ApiKeysPage", () => {
     mocks.apiKeysList.mockClear();
     mocks.fetchConfigYaml.mockClear();
     mocks.saveConfigYaml.mockClear();
+    mocks.apiClientPut.mockClear();
     mocks.authFilesList.mockClear();
     mocks.getGeminiKeys.mockClear();
     mocks.getClaudeConfigs.mockClear();
@@ -284,21 +297,21 @@ describe("ApiKeysPage", () => {
   });
 
   test("applies the selected permission config when creating an API key", async () => {
-    state.configYaml = `
-api-key-permission-profiles:
-  - id: standard
-    name: Standard
-    daily-limit: 15000
-    total-quota: 0
-    concurrency-limit: 0
-    rpm-limit: 0
-    tpm-limit: 0
-    allowed-channel-groups:
-      - pro
-    allowed-models:
-      - gpt-5.4
-    system-prompt: Use the standard workspace prompt.
-`;
+    state.permissionProfiles = [
+      {
+        id: "standard",
+        name: "Standard",
+        "daily-limit": 15000,
+        "total-quota": 0,
+        "concurrency-limit": 0,
+        "rpm-limit": 0,
+        "tpm-limit": 0,
+        "allowed-channel-groups": ["pro"],
+        "allowed-channels": [],
+        "allowed-models": ["gpt-5.4"],
+        "system-prompt": "Use the standard workspace prompt.",
+      },
+    ];
 
     render(
       <MemoryRouter>
@@ -344,6 +357,8 @@ api-key-permission-profiles:
         "system-prompt": "Use the standard workspace prompt.",
       }),
     ]);
+    expect(mocks.fetchConfigYaml).not.toHaveBeenCalled();
+    expect(mocks.saveConfigYaml).not.toHaveBeenCalled();
   });
 
   test("shows operation column icon tooltips without relying on the app-level tooltip listener", async () => {


### PR DESCRIPTION
## Summary
- move API key permission profiles off config.yaml and onto the management database endpoint
- update API key permission profile tests to assert no YAML reads/writes

## Verification
- bun run test
- bun run check