### PR TITLE
fix: sync auth file card labels with current state

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2276,9 +2276,9 @@ describe("AuthFilesPage files table", () => {
     });
   });
 
-  test("cards view uses cached quota plan badge instead of stale auth-file metadata", async () => {
+  test("cards view uses current auth-file plan badge instead of stale cached quota plan", async () => {
     const now = Date.now();
-    const staleFile = {
+    const currentFile = {
       name: "codex.json",
       label: "Codex Main",
       account_type: "oauth",
@@ -2287,10 +2287,10 @@ describe("AuthFilesPage files table", () => {
       modified: now,
       disabled: false,
       auth_index: "1",
-      plan_type: "plus",
+      plan_type: "free",
     } as any;
 
-    mocks.list.mockImplementation(async () => ({ files: [staleFile] }));
+    mocks.list.mockImplementation(async () => ({ files: [currentFile] }));
     mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
@@ -2299,13 +2299,13 @@ describe("AuthFilesPage files table", () => {
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
-        files: [staleFile],
+        files: [currentFile],
         usageData: { source: [], auth_index: [] },
         quotaByFileName: {
           "codex.json": {
             status: "success",
             updatedAt: now,
-            planType: "pro",
+            planType: "plus",
             items: [{ label: "m_quota.code_5h", percent: 20, resetAtMs: now + 30_000 }],
           },
         },
@@ -2325,7 +2325,7 @@ describe("AuthFilesPage files table", () => {
     );
 
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    expect(screen.getByText("Plan Pro")).toBeInTheDocument();
+    expect(screen.getByText("Plan Free")).toBeInTheDocument();
     expect(screen.queryByText("Plan Plus")).not.toBeInTheDocument();
   });
 

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -11,6 +11,8 @@ import {
   readAuthFilesUiState,
   resolveAuthFileRestrictionBadges,
   resolveAuthFileDisplayTags,
+  resolveAuthFilePlanType,
+  resolveAuthFileSupplementalTags,
   resolveAuthFileSubscriptionStatus,
   resolveAuthFileStats,
   sanitizeAuthFilesForCache,
@@ -252,6 +254,19 @@ describe("Auth Files helper coverage", () => {
     ).toBe(true);
   });
 
+  test("drops stale display tags that no longer match current default or custom tags", () => {
+    const file = {
+      name: "codex.json",
+      plan_type: "free",
+      default_tags: ["codex", "free"],
+      custom_tags: ["vip"],
+      display_tags: ["codex", "plus", "vip"],
+    } satisfies AuthFileItem;
+
+    expect(resolveAuthFileDisplayTags(file)).toEqual(["codex", "vip"]);
+    expect(resolveAuthFileSupplementalTags(file)).toEqual(["vip"]);
+  });
+
   test("derives active restriction badges with exact remaining time", () => {
     const nowMs = Date.parse("2026-05-06T08:00:00.000Z");
     const file = {
@@ -278,6 +293,46 @@ describe("Auth Files helper coverage", () => {
         tone: "danger",
       },
     ]);
+  });
+
+  test("does not derive restriction badges from normal auth status", () => {
+    expect(
+      resolveAuthFileRestrictionBadges({
+        name: "codex.json",
+        status: "active",
+        unavailable: false,
+      } as AuthFileItem),
+    ).toEqual([]);
+  });
+
+  test("prefers current auth-file plan metadata over cached quota plan", () => {
+    expect(
+      resolveAuthFilePlanType(
+        {
+          name: "codex.json",
+          plan_type: "free",
+        } as AuthFileItem,
+        {
+          status: "success",
+          planType: "plus",
+          items: [],
+          updatedAt: Date.now(),
+        },
+      ),
+    ).toBe("free");
+    expect(
+      resolveAuthFilePlanType(
+        {
+          name: "codex.json",
+        } as AuthFileItem,
+        {
+          status: "success",
+          planType: "plus",
+          items: [],
+          updatedAt: Date.now(),
+        },
+      ),
+    ).toBe("plus");
   });
 
   test("aggregates auth file usage and picks quota preview entries", () => {

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -383,6 +383,13 @@ export type AuthFileRestrictionBadge = {
 const readRestrictionDateMs = (restriction: AuthFileRestriction): number | null =>
   parseDateLikeMs(restriction.next_retry_after) ?? parseDateLikeMs(restriction.next_recover_at);
 
+const isLegacyAuthRestrictionActive = (file: AuthFileItem): boolean => {
+  if (file.unavailable === true) return true;
+  const status = normalizeTagValue(file.status);
+  if (status === "error") return true;
+  return parseDateLikeMs(file.next_retry_after) !== null;
+};
+
 export const formatAuthFileRestrictionRemaining = (
   recoverAtMs: number,
   nowMs = Date.now(),
@@ -437,7 +444,7 @@ export const resolveAuthFileRestrictionBadges = (
   const restrictions =
     rawRestrictions.length > 0
       ? rawRestrictions
-      : file.status || file.status_message || file.unavailable || file.next_retry_after
+      : isLegacyAuthRestrictionActive(file)
         ? [
             {
               scope: "auth",
@@ -746,11 +753,20 @@ export const readAuthFileTagCandidates = (file: AuthFileItem): string[] =>
   normalizeTagList([
     ...readAuthFileDefaultTags(file),
     ...readAuthFileCustomTags(file),
-    ...(Array.isArray(file.display_tags) ? normalizeTagList(file.display_tags) : []),
+    ...resolveAuthFileDisplayTags(file),
   ]);
 
 export const resolveAuthFileDisplayTags = (file: AuthFileItem): string[] => {
-  if (Array.isArray(file.display_tags)) return normalizeTagList(file.display_tags);
+  if (Array.isArray(file.display_tags)) {
+    const displayTags = normalizeTagList(file.display_tags);
+    const candidates = normalizeTagList([
+      ...readAuthFileDefaultTags(file),
+      ...readAuthFileCustomTags(file),
+    ]);
+    if (candidates.length === 0) return displayTags;
+    const candidateSet = new Set(candidates);
+    return displayTags.filter((tag) => candidateSet.has(normalizeTagValue(tag)));
+  }
   return buildAuthFileDisplayTags(
     readAuthFileDefaultTags(file),
     readAuthFileCustomTags(file),
@@ -763,7 +779,7 @@ export const shouldShowAuthFileDisplayTag = (file: AuthFileItem, tag: unknown): 
   if (!normalizedTag) return false;
 
   if (Array.isArray(file.display_tags)) {
-    return normalizeTagList(file.display_tags).includes(normalizedTag);
+    return resolveAuthFileDisplayTags(file).includes(normalizedTag);
   }
 
   return !readAuthFileHiddenDefaultTags(file).includes(normalizedTag);
@@ -772,7 +788,7 @@ export const shouldShowAuthFileDisplayTag = (file: AuthFileItem, tag: unknown): 
 export const resolveAuthFilePlanType = (
   file: AuthFileItem,
   quotaState?: QuotaState | null,
-): string | null => normalizePlanType(quotaState?.planType) ?? resolveCodexPlanType(file);
+): string | null => resolveCodexPlanType(file) ?? normalizePlanType(quotaState?.planType);
 
 export const resolveAuthFileSupplementalTags = (
   file: AuthFileItem,


### PR DESCRIPTION
## Summary
- Stop deriving restriction badges from normal auth statuses such as active
- Prefer current auth-file plan metadata over stale quota cache plan labels
- Filter stale editable display tags that no longer match current default/custom tags

## Test Plan
- bun run test src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- bun run test src/modules/auth-files
- bun run lint
- bun run build
- bun run test