### PR TITLE
Channel groups: add in-group scheduling selector

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Check, Pencil, Plus, Trash2, TriangleAlert, X } from "lucide-react";
+import { Check, CircleAlert, Pencil, Plus, Trash2, TriangleAlert, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ChannelGroupChannelDetail } from "@/lib/http/apis/channel-groups";
 import type {
@@ -16,6 +16,7 @@ import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import { SearchableCheckboxMultiSelect } from "@/modules/ui/SearchableCheckboxMultiSelect";
+import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { HoverTooltip, OverflowTooltip } from "@/modules/ui/Tooltip";
@@ -45,9 +46,6 @@ export type RoutingModelOption = {
 
 type RoutingModelLoadResult = string | RoutingModelOption;
 
-const ROUTING_STRATEGY_ASSET_MARKER =
-  'strategy:t.currentTarget.value==="fill-first"?"fill-first":"round-robin"';
-
 const createEmptyGroupDraft = (): GroupDraft => ({
   name: "",
   description: "",
@@ -68,15 +66,26 @@ const EMPTY_ROUTE_DRAFT = (): RoutingPathRouteEntry => ({
 function Field({
   label,
   hint,
+  tooltip,
   children,
 }: {
   label: string;
   hint?: string;
+  tooltip?: string;
   children: React.ReactNode;
 }) {
   return (
     <div className="space-y-2">
-      <div className="text-sm font-semibold text-slate-900 dark:text-white">{label}</div>
+      <div className="flex items-center gap-2">
+        <div className="text-sm font-semibold text-slate-900 dark:text-white">{label}</div>
+        {tooltip ? (
+          <HoverTooltip content={tooltip} placement="bottom">
+            <span className="inline-flex h-6 w-6 items-center justify-center text-slate-400 dark:text-white/45">
+              <CircleAlert size={16} aria-hidden="true" />
+            </span>
+          </HoverTooltip>
+        ) : null}
+      </div>
       {hint ? <div className="text-xs text-slate-500 dark:text-white/55">{hint}</div> : null}
       {children}
     </div>
@@ -1157,31 +1166,30 @@ export function RoutingConfigEditor({
                 <TabsContent value="basic" className="space-y-5">
                   <Field
                     label={t("channel_groups_page.routing_strategy_label")}
-                    hint={t("channel_groups_page.routing_strategy_tooltip")}
+                    tooltip={t("channel_groups_page.routing_strategy_tooltip")}
                   >
-                    <select
-                      data-testid="routing-strategy-select"
-                      data-asset-marker={ROUTING_STRATEGY_ASSET_MARKER}
+                    <Select
+                      aria-label={t("channel_groups_page.routing_strategy_label")}
                       value={groupDraft.strategy}
-                      onChange={(event) => {
+                      disabled={disabled}
+                      className="w-full"
+                      options={[
+                        {
+                          value: "round-robin",
+                          label: t("channel_groups_page.routing_strategy_round_robin"),
+                        },
+                        {
+                          value: "fill-first",
+                          label: t("channel_groups_page.routing_strategy_fill_first"),
+                        },
+                      ]}
+                      onChange={(value) => {
                         setGroupDraft((current) => ({
                           ...current,
-                          strategy:
-                            event.currentTarget.value === "fill-first"
-                              ? "fill-first"
-                              : "round-robin",
+                          strategy: value === "fill-first" ? "fill-first" : "round-robin",
                         }));
                       }}
-                      disabled={disabled}
-                      className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition-colors focus:border-indigo-400 focus:ring-2 focus:ring-indigo-500/15 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10 dark:bg-neutral-950 dark:text-white dark:focus:border-indigo-300"
-                    >
-                      <option value="round-robin">
-                        {t("channel_groups_page.routing_strategy_round_robin")}
-                      </option>
-                      <option value="fill-first">
-                        {t("channel_groups_page.routing_strategy_fill_first")}
-                      </option>
-                    </select>
+                    />
                   </Field>
 
                   <div className="grid gap-4 md:grid-cols-2">

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -108,7 +108,8 @@ describe("RoutingConfigEditor", () => {
     render(<Harness />);
 
     await user.click(screen.getByRole("button", { name: "新增分组" }));
-    await user.selectOptions(screen.getByTestId("routing-strategy-select"), "fill-first");
+    await user.click(screen.getByRole("combobox", { name: "分组内调度策略" }));
+    await user.click(screen.getByRole("option", { name: "优先首个可用渠道" }));
     await user.type(screen.getByPlaceholderText("pro"), "team-fill-first");
     await user.type(screen.getByPlaceholderText("/pro"), "/team-fill-first");
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));

--- a/src/modules/config/ConfigPage.tsx
+++ b/src/modules/config/ConfigPage.tsx
@@ -1,14 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  ChevronDown,
-  ChevronUp,
-  Code2,
-  Eye,
-  Layers,
-  Search,
-  Settings,
-} from "lucide-react";
-import { Link } from "react-router-dom";
+import { ChevronDown, ChevronUp, Code2, Eye, Search, Settings } from "lucide-react";
 import { parse as parseYaml } from "yaml";
 import { configFileApi } from "@/lib/http/apis";
 import { FloatingSaveBar } from "@/modules/config/FloatingSaveBar";
@@ -61,7 +52,6 @@ function useStickyTab(): [ConfigTab, (next: ConfigTab) => void] {
 
   return [tab, update];
 }
-
 
 export function ConfigPage() {
   const { t } = useTranslation();
@@ -342,19 +332,6 @@ export function ConfigPage() {
                   ) : null}
 
                   <div className={error ? "mt-4" : ""}>
-                    <div className="mb-4 rounded-2xl border border-sky-200 bg-sky-50/80 px-4 py-3 text-sm text-sky-900 dark:border-sky-400/20 dark:bg-sky-500/10 dark:text-sky-100">
-                      <div className="flex items-center gap-2">
-                        <Layers size={16} className="shrink-0" />
-                        <span>{t("config_page.channel_groups_moved")}</span>
-                        <Link
-                          to="/channel-groups"
-                          viewTransition
-                          className="font-semibold underline underline-offset-2"
-                        >
-                          {t("config_page.open_channel_groups")}
-                        </Link>
-                      </div>
-                    </div>
                     <VisualConfigEditor
                       values={visualValues}
                       disabled={disableControls || loading || saving}

--- a/src/modules/ui/Select.tsx
+++ b/src/modules/ui/Select.tsx
@@ -21,6 +21,7 @@ import {
   selectOptionSelected,
   selectPanel,
   selectTriggerChip,
+  selectTriggerDisabled,
   selectTriggerOpen,
 } from "./selectStyles";
 import type { ControlSize } from "@/modules/ui/controlStyles";
@@ -50,6 +51,8 @@ export interface SelectProps {
   name?: string;
   /** Extra className on the trigger button */
   className?: string;
+  /** Disable interactions */
+  disabled?: boolean;
   /** Visual style variant */
   variant?: "default" | "chip";
   /** Shared control size */
@@ -68,6 +71,7 @@ export function Select({
   "aria-label": ariaLabel,
   name,
   className,
+  disabled = false,
   variant = "default",
   size = "default",
 }: SelectProps) {
@@ -160,10 +164,12 @@ export function Select({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={ariaLabel}
+        disabled={disabled}
         onClick={() => setOpen((prev) => !prev)}
         className={cn(
           variant === "chip" ? selectTriggerChip : getSelectTriggerBase(size),
           open && selectTriggerOpen,
+          disabled && selectTriggerDisabled,
           className,
         )}
       >
@@ -178,7 +184,7 @@ export function Select({
       {/* Dropdown (portal) */}
       {createPortal(
         <AnimatePresence>
-          {open ? (
+          {open && !disabled ? (
             <motion.div
               ref={listRef}
               role="listbox"


### PR DESCRIPTION
- Add "In-group scheduling" selector to the Create/Edit group modal (uses shared Select, not native <select>)\n- Show business meaning via tooltip on the label\n- Remove the channel-groups migration banner from Config page\n\nVerified: bun run build, bun run test