### PR TITLE
fix: clean up auth file restriction badges

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -244,6 +244,109 @@ describe("AuthFilesPage files table", () => {
     expect(tooltip).toHaveTextContent("Auto recovery in");
   });
 
+  test("keeps verbose restriction errors out of table badges and opens one tooltip", async () => {
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(80);
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(640);
+
+    const now = Date.now();
+    const rawError =
+      'Post "https://chatgpt.com/backend-api/codex/responses": read tcp [2607:8700:5500:8131::2]:44434->[2a06:98c1:310b::ac40:9bd1]:443: read: connection reset by peer';
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          plan_type: "free",
+          size: 1024,
+          modified: now,
+          disabled: false,
+          restrictions: [
+            {
+              scope: "model",
+              model: "gpt-5.4",
+              status: "error",
+              status_message: rawError,
+            },
+          ],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("A_GptPro");
+    const row = title.closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("Restricted")).toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText(rawError)).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(within(row as HTMLElement).getByText("Restricted"));
+
+    const tooltips = await screen.findAllByRole("tooltip");
+    expect(tooltips).toHaveLength(1);
+    expect(tooltips[0]).toHaveTextContent("gpt-5.4");
+    expect(tooltips[0]).toHaveTextContent(rawError);
+    expect(tooltips[0]).not.toHaveTextContent("A_GptPro");
+  });
+
+  test("cards view keeps verbose restriction errors out of badge rows", async () => {
+    const now = Date.now();
+    const rawError = "context canceled";
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          plan_type: "free",
+          size: 1024,
+          modified: now,
+          disabled: false,
+          restrictions: [
+            {
+              scope: "model",
+              model: "gpt-5.4",
+              status: "error",
+              status_message: rawError,
+            },
+          ],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("A_GptPro");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).getByText("Restricted")).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText(rawError)).not.toBeInTheDocument();
+  });
+
   test("supports multi-select delete from the toolbar", async () => {
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -295,6 +295,28 @@ describe("Auth Files helper coverage", () => {
     ]);
   });
 
+  test("keeps verbose transport errors out of restriction badge labels", () => {
+    const rawError =
+      'Post "https://chatgpt.com/backend-api/codex/responses": read tcp [2607:8700:5500:8131::2]:44434->[2a06:98c1:310b::ac40:9bd1]:443: read: connection reset by peer';
+    const file = {
+      name: "codex.json",
+      restrictions: [
+        {
+          scope: "model",
+          model: "gpt-5.4",
+          status: "error",
+          status_message: rawError,
+        },
+      ],
+    } as AuthFileItem;
+
+    expect(resolveAuthFileRestrictionBadges(file, Date.now())[0]).toMatchObject({
+      label: "Restricted",
+      model: "gpt-5.4",
+      reason: rawError,
+    });
+  });
+
   test("does not derive restriction badges from normal auth status", () => {
     expect(
       resolveAuthFileRestrictionBadges({

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -420,8 +420,6 @@ const resolveRestrictionLabel = (restriction: AuthFileRestriction): string => {
   const status = Number(restriction.http_status);
   if (Number.isFinite(status) && status > 0) return `${Math.round(status)} Error`;
   if (restriction.quota_exceeded || restriction.reason === "quota") return "Quota Limited";
-  if (restriction.status_message) return restriction.status_message;
-  if (restriction.reason) return restriction.reason;
   return "Restricted";
 };
 

--- a/src/modules/ui/TableCellOverflowTooltip.tsx
+++ b/src/modules/ui/TableCellOverflowTooltip.tsx
@@ -1,5 +1,5 @@
 import { isValidElement, type ReactNode } from "react";
-import { OverflowTooltip } from "@/modules/ui/Tooltip";
+import { HoverTooltip, OverflowTooltip } from "@/modules/ui/Tooltip";
 
 function normalizeTooltipText(parts: string[]) {
   const text = parts.join(" ").replace(/\s+/g, " ").trim();
@@ -32,7 +32,7 @@ function containsManagedTooltip(node: ReactNode): boolean {
 
   if (!isValidElement(node)) return false;
 
-  if (node.type === OverflowTooltip) return true;
+  if (node.type === HoverTooltip || node.type === OverflowTooltip) return true;
 
   const props = node.props as {
     children?: ReactNode;


### PR DESCRIPTION
## Summary
- Keep auth-file restriction badges compact instead of rendering verbose transport errors as table/card labels.
- Preserve detailed restriction messages in the badge tooltip.
- Treat HoverTooltip as a managed tooltip so virtual-table overflow tooltips do not stack with badge tooltips.

## Test Plan
- bun run test
- bun run build
- bun run check
- bunx oxfmt src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx src/modules/auth-files/helpers/authFilesPageUtils.ts src/modules/ui/TableCellOverflowTooltip.tsx --check
- git diff --check