### PR TITLE
fix: filter cc switch modal models by availability

### DIFF
--- a/src/lib/http/apis/models.ts
+++ b/src/lib/http/apis/models.ts
@@ -190,13 +190,21 @@ const normalizeOwnerPresetResponse = (payload: unknown): ModelOwnerPresetItem[] 
 export const modelsApi = {
   buildClaudeModelsEndpoint,
 
-  async listAvailableModels(params: { allowedChannelGroups?: string[] } = {}) {
+  async listAvailableModels(
+    params: { allowedChannelGroups?: string[]; allowedChannels?: string[] } = {},
+  ) {
     const query = new URLSearchParams();
     const groups = (params.allowedChannelGroups ?? [])
       .map((group) => String(group ?? "").trim())
       .filter(Boolean);
     if (groups.length > 0) {
       query.set("allowed_channel_groups", groups.join(","));
+    }
+    const channels = (params.allowedChannels ?? [])
+      .map((channel) => String(channel ?? "").trim())
+      .filter(Boolean);
+    if (channels.length > 0) {
+      query.set("allowed_channels", channels.join(","));
     }
     const qs = query.toString();
     return normalizeModelList(await apiClient.get(`/models${qs ? `?${qs}` : ""}`));

--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -16,6 +16,10 @@ import {
   type CcSwitchClientType,
 } from "@/modules/ccswitch/ccswitchImport";
 import {
+  filterByConfiguredModelAvailability,
+  loadConfiguredModelAvailability,
+} from "@/modules/models/modelAvailability";
+import {
   CC_SWITCH_CLAUDE_AUTH_FIELDS,
   DEFAULT_CC_SWITCH_IMPORT_SETTINGS,
   normalizeCcSwitchClaudeAuthField,
@@ -33,6 +37,7 @@ export interface CcSwitchChannelGroupOption {
   description?: string;
   routePath?: string;
   allowedModels?: string[];
+  channels?: string[];
 }
 
 const iconByType: Record<CcSwitchClientType, string> = {
@@ -262,12 +267,21 @@ export function CcSwitchImportConfigModal({
       return;
     }
 
+    const lookupChannels = dedupeModels(selectedGroupOption?.channels ?? []);
+    const lookupParams =
+      lookupChannels.length > 0
+        ? { allowedChannels: lookupChannels }
+        : { allowedChannelGroups: [selectedGroup] };
+
     setModelsLoading(true);
     modelsApi
-      .listAvailableModels({ allowedChannelGroups: [selectedGroup] })
-      .then((models) => {
+      .listAvailableModels(lookupParams)
+      .then(async (models) => {
         if (cancelled) return;
-        const modelIds = models.map((model) => model.id);
+        const availability = await loadConfiguredModelAvailability();
+        if (cancelled) return;
+        const visibleModels = filterByConfiguredModelAvailability(models, availability);
+        const modelIds = visibleModels.map((model) => model.id);
         setAvailableModels(dedupeModels(modelIds));
       })
       .catch(() => {

--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -74,6 +74,7 @@ export function CcSwitchImportSettingsPage() {
                   : undefined,
               routePath: Array.isArray(item["path-routes"]) ? item["path-routes"][0] : "",
               allowedModels: Array.isArray(item["allowed-models"]) ? item["allowed-models"] : [],
+              channels: Array.isArray(item.channels) ? item.channels : [],
             }))
             .filter((item) => item.value)
             .sort((left, right) => left.label.localeCompare(right.label)),

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -11,6 +11,8 @@ const listChannelGroups = vi.fn();
 const listAvailableModels = vi.fn();
 const listConfigs = vi.fn();
 const replaceConfigs = vi.fn();
+const loadConfiguredModelAvailability = vi.fn();
+const filterByConfiguredModelAvailability = vi.fn();
 
 vi.mock("@/lib/http/apis/channel-groups", () => ({
   channelGroupsApi: {
@@ -27,9 +29,19 @@ vi.mock("@/lib/http/apis/ccswitch-import-configs", () => ({
 
 vi.mock("@/lib/http/apis/models", () => ({
   modelsApi: {
-    listAvailableModels: (params: { allowedChannelGroups?: string[] }) =>
-      listAvailableModels(params),
+    listAvailableModels: (params: {
+      allowedChannelGroups?: string[];
+      allowedChannels?: string[];
+    }) => listAvailableModels(params),
   },
+}));
+
+vi.mock("@/modules/models/modelAvailability", () => ({
+  loadConfiguredModelAvailability: () => loadConfiguredModelAvailability(),
+  filterByConfiguredModelAvailability: <T extends { id: string }>(
+    models: T[],
+    availability: { scoped: boolean; idSet: Set<string> },
+  ) => filterByConfiguredModelAvailability(models, availability),
 }));
 
 function renderPage() {
@@ -50,6 +62,22 @@ describe("CcSwitchImportSettingsPage", () => {
     listAvailableModels.mockReset();
     listConfigs.mockReset();
     replaceConfigs.mockReset();
+    loadConfiguredModelAvailability.mockReset();
+    filterByConfiguredModelAvailability.mockReset();
+    loadConfiguredModelAvailability.mockResolvedValue({
+      scoped: false,
+      items: [],
+      idSet: new Set<string>(),
+    });
+    filterByConfiguredModelAvailability.mockImplementation(
+      <T extends { id: string }>(
+        models: T[],
+        availability: { scoped: boolean; idSet: Set<string> },
+      ) =>
+        availability.scoped
+          ? models.filter((model) => availability.idSet.has(model.id.toLowerCase()))
+          : models,
+    );
     listChannelGroups.mockResolvedValue([
       { name: "pro", description: "Pro route", "path-routes": ["/pro"] },
       { name: "team-a", description: "Team A route", "path-routes": ["/team-a"] },
@@ -207,11 +235,56 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(groupSelect).toHaveTextContent("/openai/pro");
     expect(within(dialog).queryByText(/path address/i)).not.toBeInTheDocument();
 
-    expect(await within(dialog).findByLabelText(/cc switch request model for gpt-5\.5/i)).toBeInTheDocument();
+    expect(
+      await within(dialog).findByLabelText(/cc switch request model for gpt-5\.5/i),
+    ).toBeInTheDocument();
     expect(
       within(dialog).queryByLabelText(/cc switch request model for unexpected-extra-model/i),
     ).not.toBeInTheDocument();
     expect(listAvailableModels).not.toHaveBeenCalled();
+  });
+
+  test("filters fallback channel group models by configured model availability", async () => {
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "chatgpt-pro",
+        description: "ChatGPT Pro route",
+        channels: ["A_GptPro"],
+        "path-routes": ["/openai/pro"],
+      },
+    ]);
+    listAvailableModels.mockResolvedValue([
+      { id: "codex-auto-review" },
+      { id: "gpt-5" },
+      { id: "gpt-5-codex" },
+      { id: "gpt-5.1" },
+      { id: "gpt-5.1-codex" },
+      { id: "gpt-5.3-codex" },
+      { id: "gpt-5.5" },
+      { id: "gpt-image-2" },
+    ]);
+    loadConfiguredModelAvailability.mockResolvedValue({
+      scoped: true,
+      items: [],
+      idSet: new Set(["codex-auto-review", "gpt-5", "gpt-5.3-codex", "gpt-5.5"]),
+    });
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /new config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /new cc switch config/i });
+    await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
+    await user.click(await screen.findByRole("option", { name: /chatgpt-pro.*\/openai\/pro/i }));
+
+    expect(await within(dialog).findByLabelText(/cc switch request model for gpt-5\.5/i)).toBeInTheDocument();
+    expect(
+      within(dialog).queryByLabelText(/cc switch request model for gpt-5\.1-codex/i),
+    ).not.toBeInTheDocument();
+    expect(listAvailableModels).toHaveBeenCalledWith({
+      allowedChannels: ["A_GptPro"],
+    });
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledTimes(1);
   });
 
   test("previews the full BaseURL request address from the selected channel group path", async () => {


### PR DESCRIPTION
## Summary
- when a channel group has no explicit allowed-models, query models by its channels instead of only the group name
- reuse configured model availability filtering so the modal matches the channel group editor's visible model set
- add regression coverage for the chatgpt-pro-style fallback path

## Verification
- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
- bun run check