### PR TITLE
fix: align cc switch modal models with channel owners

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -38,6 +38,7 @@ export interface CcSwitchChannelGroupOption {
   routePath?: string;
   allowedModels?: string[];
   channels?: string[];
+  modelOwnerKeys?: string[];
 }
 
 const iconByType: Record<CcSwitchClientType, string> = {
@@ -98,6 +99,12 @@ function dedupeModels(models: readonly string[]): string[] {
   });
   return result.sort((a, b) => a.localeCompare(b));
 }
+
+const normalizeModelOwnerKey = (value: unknown): string =>
+  String(value ?? "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .toLowerCase();
 
 function pickClaudeRoleModel(role: CcSwitchClaudeModelRole, models: readonly string[]): string {
   const normalized = dedupeModels(models);
@@ -268,6 +275,9 @@ export function CcSwitchImportConfigModal({
     }
 
     const lookupChannels = dedupeModels(selectedGroupOption?.channels ?? []);
+    const modelOwnerKeys = new Set(
+      (selectedGroupOption?.modelOwnerKeys ?? []).map(normalizeModelOwnerKey).filter(Boolean),
+    );
     const lookupParams =
       lookupChannels.length > 0
         ? { allowedChannels: lookupChannels }
@@ -280,7 +290,25 @@ export function CcSwitchImportConfigModal({
         if (cancelled) return;
         const availability = await loadConfiguredModelAvailability();
         if (cancelled) return;
-        const visibleModels = filterByConfiguredModelAvailability(models, availability);
+        let visibleModels = filterByConfiguredModelAvailability(models, availability);
+        if (modelOwnerKeys.size > 0) {
+          const modelConfigs = await modelsApi.getModelConfigs("active").catch(() => []);
+          if (cancelled) return;
+          const allowedModelIds = new Set(
+            modelConfigs
+              .filter(
+                (model) =>
+                  modelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
+                  modelOwnerKeys.has(normalizeModelOwnerKey(model.source)),
+              )
+              .map((model) => model.id.toLowerCase()),
+          );
+          if (allowedModelIds.size > 0) {
+            visibleModels = visibleModels.filter((model) =>
+              allowedModelIds.has(model.id.toLowerCase()),
+            );
+          }
+        }
         const modelIds = visibleModels.map((model) => model.id);
         setAvailableModels(dedupeModels(modelIds));
       })

--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -5,7 +5,10 @@ import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
 import iconGemini from "@/assets/icons/gemini.svg";
 import { detectApiBaseFromLocation } from "@/lib/connection";
-import { channelGroupsApi } from "@/lib/http/apis/channel-groups";
+import {
+  channelGroupsApi,
+  type ChannelGroupChannelDetail,
+} from "@/lib/http/apis/channel-groups";
 import { useOptionalAuth } from "@/modules/auth/AuthProvider";
 import { ccSwitchImportConfigsApi } from "@/lib/http/apis/ccswitch-import-configs";
 import { Button } from "@/modules/ui/Button";
@@ -39,6 +42,28 @@ function createDraft(clientType: CcSwitchClientType = "codex") {
     providerName: "",
   };
 }
+
+const normalizeModelOwnerKey = (value: string): string =>
+  value.trim().replace(/\s+/g, "-").toLowerCase();
+
+const getChannelGroupModelOwnerKeys = (
+  details: readonly ChannelGroupChannelDetail[] | undefined,
+): string[] => {
+  const keys = new Set<string>();
+  for (const detail of details ?? []) {
+    const values = [
+      detail.source,
+      ...(detail.default_tags ?? []),
+      ...(detail.custom_tags ?? []),
+      ...(detail.display_tags ?? []),
+    ];
+    for (const value of values) {
+      const key = normalizeModelOwnerKey(String(value ?? ""));
+      if (key) keys.add(key);
+    }
+  }
+  return Array.from(keys);
+};
 
 export function CcSwitchImportSettingsPage() {
   const { t } = useTranslation();
@@ -75,6 +100,7 @@ export function CcSwitchImportSettingsPage() {
               routePath: Array.isArray(item["path-routes"]) ? item["path-routes"][0] : "",
               allowedModels: Array.isArray(item["allowed-models"]) ? item["allowed-models"] : [],
               channels: Array.isArray(item.channels) ? item.channels : [],
+              modelOwnerKeys: getChannelGroupModelOwnerKeys(item.channelDetails),
             }))
             .filter((item) => item.value)
             .sort((left, right) => left.label.localeCompare(right.label)),

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -9,6 +9,7 @@ import type { CcSwitchImportConfigListItem } from "@/modules/ccswitch/ccswitchIm
 
 const listChannelGroups = vi.fn();
 const listAvailableModels = vi.fn();
+const getModelConfigs = vi.fn();
 const listConfigs = vi.fn();
 const replaceConfigs = vi.fn();
 const loadConfiguredModelAvailability = vi.fn();
@@ -33,6 +34,7 @@ vi.mock("@/lib/http/apis/models", () => ({
       allowedChannelGroups?: string[];
       allowedChannels?: string[];
     }) => listAvailableModels(params),
+    getModelConfigs: (scope: "active" | "library") => getModelConfigs(scope),
   },
 }));
 
@@ -60,6 +62,7 @@ describe("CcSwitchImportSettingsPage", () => {
     window.localStorage.clear();
     listChannelGroups.mockReset();
     listAvailableModels.mockReset();
+    getModelConfigs.mockReset();
     listConfigs.mockReset();
     replaceConfigs.mockReset();
     loadConfiguredModelAvailability.mockReset();
@@ -86,6 +89,7 @@ describe("CcSwitchImportSettingsPage", () => {
       { id: "deepseek-v4-flash" },
       { id: "kimi-k2" },
     ]);
+    getModelConfigs.mockResolvedValue([]);
     listConfigs.mockResolvedValue([]);
     replaceConfigs.mockResolvedValue(undefined);
   });
@@ -250,6 +254,16 @@ describe("CcSwitchImportSettingsPage", () => {
         name: "chatgpt-pro",
         description: "ChatGPT Pro route",
         channels: ["A_GptPro"],
+        channelDetails: [
+          {
+            name: "A_GptPro",
+            source: "codex",
+            default_tags: ["codex", "pro"],
+            custom_tags: ["20x"],
+            hidden_default_tags: [],
+            display_tags: ["codex", "pro", "20x"],
+          },
+        ],
         "path-routes": ["/openai/pro"],
       },
     ]);
@@ -266,8 +280,24 @@ describe("CcSwitchImportSettingsPage", () => {
     loadConfiguredModelAvailability.mockResolvedValue({
       scoped: true,
       items: [],
-      idSet: new Set(["codex-auto-review", "gpt-5", "gpt-5.3-codex", "gpt-5.5"]),
+      idSet: new Set([
+        "codex-auto-review",
+        "gpt-5",
+        "gpt-5-codex",
+        "gpt-5.1",
+        "gpt-5.1-codex",
+        "gpt-5.3-codex",
+        "gpt-5.5",
+        "gpt-image-2",
+      ]),
     });
+    getModelConfigs.mockResolvedValue([
+      { id: "gpt-5", owned_by: "openai" },
+      { id: "gpt-5-codex", owned_by: "openai" },
+      { id: "gpt-5.3-codex", owned_by: "codex" },
+      { id: "gpt-5.5", owned_by: "codex" },
+      { id: "gpt-image-2", owned_by: "openai" },
+    ]);
     renderPage();
     const user = userEvent.setup();
 
@@ -277,14 +307,17 @@ describe("CcSwitchImportSettingsPage", () => {
     await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
     await user.click(await screen.findByRole("option", { name: /chatgpt-pro.*\/openai\/pro/i }));
 
-    expect(await within(dialog).findByLabelText(/cc switch request model for gpt-5\.5/i)).toBeInTheDocument();
     expect(
-      within(dialog).queryByLabelText(/cc switch request model for gpt-5\.1-codex/i),
+      await within(dialog).findByLabelText(/cc switch request model for gpt-5\.5/i),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).queryByLabelText(/cc switch request model for gpt-5-codex/i),
     ).not.toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
       allowedChannels: ["A_GptPro"],
     });
     expect(loadConfiguredModelAvailability).toHaveBeenCalledTimes(1);
+    expect(getModelConfigs).toHaveBeenCalledWith("active");
   });
 
   test("previews the full BaseURL request address from the selected channel group path", async () => {


### PR DESCRIPTION
## Summary
- derive model owner keys from channel group channel details
- filter fallback CC Switch modal models by active model config owner/source when a channel group has no explicit allowed-models
- extend regression coverage for the chatgpt-pro-style Codex owner path

## Verification
- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
- bun run check