### PR TITLE
fix(ccswitch): 修复表单 label 与控件之间的间距问题

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -45,7 +45,7 @@ const labelClassName =
   "text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
 const controlClassName =
   "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
-const fieldClassName = "space-y-1.5";
+const fieldClassName = "flex flex-col gap-1.5";
 
 const CLAUDE_ROLE_ORDER: CcSwitchClaudeModelRole[] = ["main", "haiku", "sonnet", "opus"];
 

--- a/src/modules/ccswitch/CcSwitchImportModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportModal.tsx
@@ -45,7 +45,7 @@ const labelClassName =
   "text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
 const controlClassName =
   "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
-const fieldClassName = "space-y-1.5";
+const fieldClassName = "flex flex-col gap-1.5";
 
 const iconByType: Record<CcSwitchClientType, string> = {
   claude: iconClaude,


### PR DESCRIPTION
## 修复内容

将 fieldClassName 从 \"space-y-1.5\" 改为 \"flex flex-col gap-1.5\"，确保 label 和控件之间的垂直间距正确生效。

## 问题原因

- space-y-* 需要 flex/grid 容器才能生效
- label 默认是 inline 元素，不是 flex 容器
- 导致 label 和 Select/Input 之间没有垂直间距

## 修改文件

- CcSwitchImportConfigModal.tsx
- CcSwitchImportModal.tsx