### PR TITLE
fix: 移除 ccswitch-import-settings 表格中的 Claude 认证字段列并修复 hover 缺口

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2362,7 +2362,6 @@
     "config_table_provider": "Provider",
     "config_table_model": "Model",
     "config_table_groups": "Allowed channel groups",
-    "config_table_auth_field": "Claude auth field",
     "config_table_actions": "Actions",
     "config_modal_create": "New CC Switch config",
     "config_modal_edit": "Edit CC Switch config",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -106,7 +106,6 @@
     "config_table_provider": "Provider",
     "config_table_model": "Model",
     "config_table_groups": "Allowed channel groups",
-    "config_table_auth_field": "Claude auth field",
     "config_table_actions": "Actions",
     "config_modal_create": "New CC Switch config",
     "config_modal_edit": "Edit CC Switch config",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2574,7 +2574,6 @@
     "config_table_provider": "供应商",
     "config_table_model": "模型",
     "config_table_groups": "允许的渠道分组",
-    "config_table_auth_field": "Claude 认证字段",
     "config_table_actions": "操作",
     "config_modal_create": "新建 CC Switch 配置",
     "config_modal_edit": "编辑 CC Switch 配置",

--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -220,17 +220,6 @@ export function CcSwitchImportSettingsPage() {
           ),
       },
       {
-        key: "authField",
-        label: t("ccswitch.config_table_auth_field"),
-        width: "w-52",
-        overflowTooltip: true,
-        render: (row) => (
-          <span className="font-mono text-xs text-slate-600 dark:text-white/65">
-            {row.clientType === "claude" ? row.apiKeyField : "--"}
-          </span>
-        ),
-      },
-      {
         key: "actions",
         label: t("ccswitch.config_table_actions"),
         width: "w-28",

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -433,7 +433,6 @@
   flex-direction: column;
   min-width: 0;
   overflow-y: auto;
-  scrollbar-gutter: stable;
   height: 100%;
 
   &.content-logs {


### PR DESCRIPTION
移除 VirtualTable 中的 authField 列（Claude 认证字段），清理相关 i18n key，并移除 layout.scss 中的 scrollbar-gutter: stable 修复 hover 右侧缺口问题。