### PR TITLE
fix: VirtualTable 无滚动条时不再保留 12px 沟槽，解决 hover 右侧被截断问题

### DIFF
--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -543,7 +543,7 @@ export function VirtualTable<T>({
   return (
     <div
       aria-busy={loading || loadingMore ? true : undefined}
-      className={`${height} ${minHeight} group relative isolate grid min-w-0 grid-cols-[minmax(0,1fr)_0.75rem] overflow-hidden`}
+      className={`${height} ${minHeight} group relative isolate grid min-w-0 ${vThumb ? "grid-cols-[minmax(0,1fr)_0.75rem]" : "grid-cols-1"} overflow-hidden`}
     >
       <div
         data-vt-header-backdrop
@@ -701,16 +701,16 @@ export function VirtualTable<T>({
         )}
       </div>
 
-      <div
-        data-vt-scrollbar-gutter
-        className="relative z-30 col-start-2 row-start-1 h-full w-3 justify-self-end"
-      >
+      {vThumb ? (
         <div
-          data-vt-header-gutter
-          className="absolute inset-x-0 top-0 rounded-r-xl bg-slate-100 dark:bg-neutral-800"
-          style={{ height: headerHeight }}
-        />
-        {vThumb ? (
+          data-vt-scrollbar-gutter
+          className="relative z-30 col-start-2 row-start-1 h-full w-3 justify-self-end"
+        >
+          <div
+            data-vt-header-gutter
+            className="absolute inset-x-0 top-0 rounded-r-xl bg-slate-100 dark:bg-neutral-800"
+            style={{ height: headerHeight }}
+          />
           <div
             data-vt-scrollbar="y"
             className="pointer-events-auto absolute right-0 z-30 w-2 opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
@@ -727,8 +727,8 @@ export function VirtualTable<T>({
               onPointerCancel={handleThumbPointerUp}
             />
           </div>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       {hThumb ? (
         <div


### PR DESCRIPTION
VirtualTable 的 CSS grid 始终预留了 0.75rem（12px）的滚动条沟槽列，即使没有垂直滚动条也占据空间，导致行 hover 背景无法延伸到最右边缘。修复方案：无垂直滚动条时（vThumb 为 null），grid 改用单列布局，且不渲染沟槽 div。