### PR TITLE
fix: VirtualTable 无滚动条时表头右上角丢失圆角

### DIFF
--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -560,7 +560,7 @@ export function VirtualTable<T>({
       >
         <div
           data-vt-header-overlay
-          className="pointer-events-none sticky left-0 top-0 z-10 w-full rounded-l-xl bg-slate-100 dark:bg-neutral-800"
+          className={`pointer-events-none sticky left-0 top-0 z-10 w-full ${vThumb ? "rounded-l-xl" : "rounded-xl"} bg-slate-100 dark:bg-neutral-800`}
           style={{ height: headerHeight, marginBottom: -headerHeight }}
         />
         <table


### PR DESCRIPTION
沟槽 div 承载了表头右上圆角 rounded-r-xl，但在无垂直滚动条时不渲染，导致表头右上角变为直角。修复：header overlay 根据是否有滚动条决定圆角，有滚动条时用 rounded-l-xl（右侧由沟槽补），无滚动条时用 rounded-xl（自己补右侧）。