### PR TITLE
fix: API Keys 页面导入 CC Switch 改为卡片列表选择

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2353,6 +2353,8 @@
     "settings_saved": "CC Switch import settings saved",
     "settings_reset": "CC Switch import settings restored to defaults",
     "protocol_unavailable": "CC Switch is not installed or the protocol handler is unavailable.",
+    "import_card_list_desc": "Select a CC Switch preset to import",
+    "import_no_compatible_configs": "No compatible CC Switch configs found. Create one in CC Switch import settings first.",
     "config_new": "New config",
     "config_table_title": "Config list",
     "config_table_description": "{{count}} saved preset(s) for CC Switch imports.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -97,6 +97,8 @@
     "settings_saved": "CC Switch import settings saved",
     "settings_reset": "CC Switch import settings restored to defaults",
     "protocol_unavailable": "CC Switch не установлен или обработчик протокола недоступен.",
+    "import_card_list_desc": "Выберите пресет CC Switch для импорта",
+    "import_no_compatible_configs": "Нет совместимых конфигураций CC Switch. Сначала создайте пресет в настройках импорта CC Switch.",
     "config_new": "New config",
     "config_table_title": "Config list",
     "config_table_description": "{{count}} saved preset(s) for CC Switch imports.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2565,6 +2565,8 @@
     "settings_saved": "CC Switch 导入配置已保存",
     "settings_reset": "CC Switch 导入配置已恢复默认",
     "protocol_unavailable": "未检测到 CC Switch 或协议处理程序不可用。",
+    "import_card_list_desc": "选择要导入的 CC Switch 配置预设",
+    "import_no_compatible_configs": "没有可用的 CC Switch 配置，请先在 CC Switch 导入设置中创建预设。",
     "config_new": "新建配置",
     "config_table_title": "配置列表",
     "config_table_description": "当前共有 {{count}} 条可复用的 CC Switch 导入预设。",

--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -29,21 +29,14 @@ import { ApiKeyFormModal } from "@/modules/api-keys/components/ApiKeyFormModal";
 import { ApiKeyUsageModal } from "@/modules/api-keys/components/ApiKeyUsageModal";
 import { useApiKeyPermissionOptions } from "@/modules/api-keys/hooks/useApiKeyPermissionOptions";
 import { useApiKeyUsageView } from "@/modules/api-keys/hooks/useApiKeyUsageView";
-import {
-  CcSwitchImportModal,
-  type CcSwitchImportConfigOption,
-  type CcSwitchImportGroupOption,
-  type CcSwitchImportSelection,
-} from "@/modules/ccswitch/CcSwitchImportModal";
+import { CcSwitchImportCardList } from "@/modules/api-keys/components/CcSwitchImportCardList";
 import {
   buildCcSwitchImportUrl,
   openCcSwitchImportUrl,
-  type CcSwitchClientType,
 } from "@/modules/ccswitch/ccswitchImport";
 import {
   normalizeCcSwitchClaudeAuthField,
   normalizeCcSwitchImportSettings,
-  type CcSwitchClaudeAuthField,
 } from "@/modules/ccswitch/ccswitchImportSettings";
 import {
   deriveCcSwitchImportSettingsFromConfigList,
@@ -105,17 +98,6 @@ export function ApiKeysPage() {
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [deleteLogsOnDelete, setDeleteLogsOnDelete] = useState(true);
   const [ccSwitchImportEntry, setCcSwitchImportEntry] = useState<ApiKeyEntry | null>(null);
-  const [ccSwitchImportClientType, setCcSwitchImportClientType] =
-    useState<CcSwitchClientType>("claude");
-  const [ccSwitchImportGroup, setCcSwitchImportGroup] = useState("");
-  const [ccSwitchImportClaudeApiKeyField, setCcSwitchImportClaudeApiKeyField] =
-    useState<CcSwitchClaudeAuthField>("ANTHROPIC_API_KEY");
-  const [ccSwitchImportProviderName, setCcSwitchImportProviderName] = useState("");
-  const [ccSwitchImportEnabled, setCcSwitchImportEnabled] = useState(true);
-  const [ccSwitchImportModel, setCcSwitchImportModel] = useState("");
-  const [ccSwitchImportModels, setCcSwitchImportModels] = useState<string[]>([]);
-  const [ccSwitchImportModelsLoading, setCcSwitchImportModelsLoading] = useState(false);
-  const [ccSwitchImportConfigId, setCcSwitchImportConfigId] = useState("");
   const [ccSwitchImportConfigs, setCcSwitchImportConfigs] = useState<
     CcSwitchImportConfigListItem[]
   >([]);
@@ -432,259 +414,86 @@ export function ApiKeysPage() {
     notify({ type: "error", message: t("api_keys_page.copy_failed") });
   };
 
-  const ccSwitchImportBaseApiUrl = useMemo(
-    () => auth?.state.apiBase || detectApiBaseFromLocation(),
-    [auth?.state.apiBase],
-  );
-  const ccSwitchImportConfigsForClient = useMemo(
-    () => ccSwitchImportConfigs.filter((config) => config.clientType === ccSwitchImportClientType),
-    [ccSwitchImportClientType, ccSwitchImportConfigs],
-  );
-
-  const ccSwitchImportAllowedGroups = useMemo(() => {
-    const entryGroups = (ccSwitchImportEntry?.["allowed-channel-groups"] ?? [])
-      .map((group) =>
-        String(group ?? "")
+  const compatibleConfigs = useMemo(() => {
+    if (!ccSwitchImportEntry) return [];
+    const entryGroups = (ccSwitchImportEntry["allowed-channel-groups"] ?? [])
+      .map((g) =>
+        String(g ?? "")
           .trim()
           .toLowerCase(),
       )
       .filter(Boolean);
-    if (entryGroups.length > 0) {
-      return Array.from(new Set(entryGroups));
-    }
-    return Array.from(
-      new Set(
-        channelGroupItems
-          .map((group) =>
-            String(group.name ?? "")
-              .trim()
-              .toLowerCase(),
-          )
-          .filter(Boolean),
-      ),
-    );
-  }, [ccSwitchImportEntry, channelGroupItems]);
-
-  const ccSwitchImportGroupOptions = useMemo<CcSwitchImportGroupOption[]>(() => {
-    const groupByName = new Map(
-      channelGroupItems
-        .map((group) => {
-          const name = String(group.name ?? "")
-            .trim()
-            .toLowerCase();
-          return name ? ([name, group] as const) : null;
-        })
-        .filter((item): item is readonly [string, ChannelGroupItem] => Boolean(item)),
-    );
-    return ccSwitchImportAllowedGroups.map((groupName) => {
-      const group = groupByName.get(groupName);
-      const routePath = Array.isArray(group?.["path-routes"]) ? group["path-routes"][0] : "";
-      return {
-        value: groupName,
-        label: groupName,
-        baseUrl: appendRoutePath(ccSwitchImportBaseApiUrl, routePath || ""),
-        description:
-          typeof group?.description === "string" && group.description.trim()
-            ? group.description.trim()
-            : undefined,
-      };
+    return ccSwitchImportConfigs.filter((config) => {
+      if (entryGroups.length === 0) return true;
+      return config.allowedChannelGroups.some((g) => entryGroups.includes(g));
     });
-  }, [ccSwitchImportAllowedGroups, ccSwitchImportBaseApiUrl, channelGroupItems]);
+  }, [ccSwitchImportEntry, ccSwitchImportConfigs]);
 
-  const ccSwitchImportBaseUrl = useMemo(() => {
-    return (
-      ccSwitchImportGroupOptions.find((option) => option.value === ccSwitchImportGroup)?.baseUrl ??
-      ccSwitchImportBaseApiUrl
-    );
-  }, [ccSwitchImportBaseApiUrl, ccSwitchImportGroup, ccSwitchImportGroupOptions]);
+  const handleOpenCcSwitchImport = useCallback((entry: ApiKeyEntry) => {
+    setCcSwitchImportEntry(entry);
+  }, []);
 
-  const loadCcSwitchImportModels = useCallback(
-    async (groupName: string, preferredModel?: string) => {
-      setCcSwitchImportModelsLoading(true);
-      try {
-        const opts = await fetchModelOptions([], groupName ? [groupName] : []);
-        const nextModels = opts.map((option) => option.value);
-        setCcSwitchImportModels(nextModels);
-        setCcSwitchImportModel((current) =>
-          preferredModel?.trim()
-            ? preferredModel.trim()
-            : current && nextModels.includes(current)
-              ? current
-              : (nextModels[0] ?? ""),
-        );
-      } finally {
-        setCcSwitchImportModelsLoading(false);
-      }
-    },
-    [fetchModelOptions],
-  );
-
-  const applyCcSwitchImportConfig = useCallback(
-    (config: CcSwitchImportConfigListItem | null, fallbackGroup = "") => {
-      if (!config) {
-        setCcSwitchImportConfigId("");
-        setCcSwitchImportClaudeApiKeyField("ANTHROPIC_API_KEY");
-        return fallbackGroup;
-      }
-
-      const nextGroup =
-        config.allowedChannelGroups.find((group) => ccSwitchImportAllowedGroups.includes(group)) ??
-        config.allowedChannelGroups[0] ??
-        fallbackGroup;
-
-      setCcSwitchImportConfigId(config.id);
-      setCcSwitchImportClaudeApiKeyField(config.apiKeyField ?? "ANTHROPIC_API_KEY");
-      setCcSwitchImportProviderName(config.providerName || "CliProxy");
-      setCcSwitchImportModel(config.defaultModel);
-      setCcSwitchImportGroup(nextGroup);
-      void loadCcSwitchImportModels(nextGroup, config.defaultModel);
-      return nextGroup;
-    },
-    [ccSwitchImportAllowedGroups, loadCcSwitchImportModels],
-  );
-
-  const handleCcSwitchImportClientTypeChange = useCallback(
-    (clientType: CcSwitchClientType) => {
-      setCcSwitchImportClientType(clientType);
-      const preset =
-        ccSwitchImportConfigs.find((config) => config.clientType === clientType) ?? null;
-      if (!preset) {
-        setCcSwitchImportConfigId("");
-        setCcSwitchImportClaudeApiKeyField("ANTHROPIC_API_KEY");
-        setCcSwitchImportProviderName(ccSwitchImportEntry?.name || "CliProxy");
-        setCcSwitchImportModel("");
-        void loadCcSwitchImportModels(ccSwitchImportGroup);
-        return;
-      }
-      applyCcSwitchImportConfig(preset, ccSwitchImportGroup);
-    },
-    [
-      applyCcSwitchImportConfig,
-      ccSwitchImportConfigs,
-      ccSwitchImportEntry?.name,
-      ccSwitchImportGroup,
-      loadCcSwitchImportModels,
-    ],
-  );
-
-  const handleOpenCcSwitchImport = useCallback(
-    (entry: ApiKeyEntry) => {
-      const entryGroups = (entry["allowed-channel-groups"] ?? [])
-        .map((group) =>
-          String(group ?? "")
-            .trim()
-            .toLowerCase(),
-        )
-        .filter(Boolean);
-      const knownGroups = channelGroupItems
-        .map((group) =>
-          String(group.name ?? "")
-            .trim()
-            .toLowerCase(),
-        )
-        .filter(Boolean);
-      const initialGroup = entryGroups[0] ?? knownGroups[0] ?? "";
-      setCcSwitchImportEntry(entry);
-      setCcSwitchImportClientType("claude");
-      setCcSwitchImportEnabled(true);
-      setCcSwitchImportModels([]);
-      const initialPreset =
-        ccSwitchImportConfigs.find((config) => config.clientType === "claude") ?? null;
-      if (initialPreset) {
-        applyCcSwitchImportConfig(initialPreset, initialGroup);
-      } else {
-        setCcSwitchImportConfigId("");
-        setCcSwitchImportGroup(initialGroup);
-        setCcSwitchImportClaudeApiKeyField("ANTHROPIC_API_KEY");
-        setCcSwitchImportProviderName(entry.name || "CliProxy");
-        setCcSwitchImportModel("");
-        void loadCcSwitchImportModels(initialGroup);
-      }
-    },
-    [applyCcSwitchImportConfig, ccSwitchImportConfigs, channelGroupItems, loadCcSwitchImportModels],
-  );
-
-  const handleCcSwitchImportGroupChange = useCallback(
-    (groupName: string) => {
-      setCcSwitchImportGroup(groupName);
-      setCcSwitchImportModel((current) => current);
-      void loadCcSwitchImportModels(groupName);
-    },
-    [loadCcSwitchImportModels],
-  );
-
-  const handleCcSwitchImportConfigChange = useCallback(
-    (configId: string) => {
-      if (!configId) {
-        setCcSwitchImportConfigId("");
-        return;
-      }
-      const config = ccSwitchImportConfigsForClient.find((item) => item.id === configId) ?? null;
-      applyCcSwitchImportConfig(config, ccSwitchImportGroup);
-    },
-    [applyCcSwitchImportConfig, ccSwitchImportConfigsForClient, ccSwitchImportGroup],
-  );
-
-  const ccSwitchImportConfigOptions = useMemo<CcSwitchImportConfigOption[]>(
-    () =>
-      ccSwitchImportConfigsForClient.length > 0
-        ? [
-            {
-              value: "",
-              label: t("ccswitch.import_saved_config_none"),
-            },
-            ...ccSwitchImportConfigsForClient.map((config) => ({
-              value: config.id,
-              label: config.note ? `${config.providerName} · ${config.note}` : config.providerName,
-            })),
-          ]
-        : [],
-    [ccSwitchImportConfigsForClient, t],
-  );
-
-  const handleImportToCcSwitch = useCallback(
-    (selection: CcSwitchImportSelection) => {
+  const handleImportWithConfig = useCallback(
+    (config: CcSwitchImportConfigListItem) => {
       if (!ccSwitchImportEntry) return;
+
+      const entryGroups = (ccSwitchImportEntry["allowed-channel-groups"] ?? [])
+        .map((g) =>
+          String(g ?? "")
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean);
+      const matchingGroup =
+        config.allowedChannelGroups.find((g) => entryGroups.includes(g)) ??
+        config.allowedChannelGroups[0] ??
+        "";
+      const groupItem = channelGroupItems.find(
+        (g) =>
+          String(g.name ?? "")
+            .trim()
+            .toLowerCase() === matchingGroup,
+      );
+      const routePath = Array.isArray(groupItem?.["path-routes"])
+        ? groupItem["path-routes"][0]
+        : "";
+      const baseApiUrl = auth?.state.apiBase || detectApiBaseFromLocation();
+      const baseUrl = appendRoutePath(baseApiUrl, routePath || "");
+
       const settings =
         ccSwitchImportConfigs.length > 0
           ? deriveCcSwitchImportSettingsFromConfigList(ccSwitchImportConfigs)
           : normalizeCcSwitchImportSettings();
-      const selectedPreset =
-        ccSwitchImportConfigId && ccSwitchImportConfigsForClient.length > 0
-          ? (ccSwitchImportConfigsForClient.find((item) => item.id === ccSwitchImportConfigId) ??
-            null)
-          : null;
       const clientSettings = {
-        ...settings[selection.clientType],
-        endpointPath: selectedPreset?.endpointPath ?? settings[selection.clientType].endpointPath,
+        ...settings[config.clientType],
+        endpointPath: config.endpointPath ?? settings[config.clientType].endpointPath,
         usageAutoInterval:
-          selectedPreset?.usageAutoInterval ?? settings[selection.clientType].usageAutoInterval,
-        defaultModel: selectedPreset?.defaultModel ?? settings[selection.clientType].defaultModel,
+          config.usageAutoInterval ?? settings[config.clientType].usageAutoInterval,
+        defaultModel: config.defaultModel ?? settings[config.clientType].defaultModel,
       };
       const importSettings =
-        selection.clientType === "claude"
+        config.clientType === "claude"
           ? {
               ...settings,
               claude: {
                 ...clientSettings,
-                apiKeyField: normalizeCcSwitchClaudeAuthField(
-                  selection.apiKeyField ?? selectedPreset?.apiKeyField,
-                ),
+                apiKeyField: normalizeCcSwitchClaudeAuthField(config.apiKeyField),
               },
             }
           : {
               ...settings,
-              [selection.clientType]: clientSettings,
+              [config.clientType]: clientSettings,
             };
+
       const url = buildCcSwitchImportUrl({
         apiKey: ccSwitchImportEntry.key,
-        baseUrl: selection.baseUrl,
-        clientType: selection.clientType,
-        enabled: selection.enabled,
-        providerName: selection.providerName || ccSwitchImportEntry.name || "CliProxy",
-        model: selection.model,
-        modelMappings: selectedPreset?.modelMappings,
-        models: ccSwitchImportModels,
+        baseUrl,
+        clientType: config.clientType,
+        enabled: true,
+        providerName: config.providerName || ccSwitchImportEntry.name || "CliProxy",
+        model: config.defaultModel,
+        modelMappings: config.modelMappings,
+        models: [],
         settings: importSettings,
       });
 
@@ -694,15 +503,7 @@ export function ApiKeysPage() {
       });
       setCcSwitchImportEntry(null);
     },
-    [
-      ccSwitchImportConfigId,
-      ccSwitchImportConfigs,
-      ccSwitchImportConfigsForClient,
-      ccSwitchImportEntry,
-      ccSwitchImportModels,
-      notify,
-      t,
-    ],
+    [ccSwitchImportEntry, ccSwitchImportConfigs, channelGroupItems, auth, notify, t],
   );
 
   /* ─── column definitions ─── */
@@ -817,30 +618,11 @@ export function ApiKeysPage() {
         onConfirm={handleDelete}
       />
 
-      <CcSwitchImportModal
-        t={t}
+      <CcSwitchImportCardList
         open={ccSwitchImportEntry !== null}
-        baseUrl={ccSwitchImportBaseUrl}
-        channelGroup={ccSwitchImportGroup}
-        channelGroupOptions={ccSwitchImportGroupOptions}
-        configOptions={ccSwitchImportConfigOptions}
-        clientType={ccSwitchImportClientType}
-        claudeApiKeyField={ccSwitchImportClaudeApiKeyField}
-        enabled={ccSwitchImportEnabled}
-        model={ccSwitchImportModel}
-        models={ccSwitchImportModels}
-        modelsLoading={ccSwitchImportModelsLoading}
-        providerName={ccSwitchImportProviderName}
-        selectedConfigId={ccSwitchImportConfigId}
-        onChannelGroupChange={handleCcSwitchImportGroupChange}
-        onConfigChange={handleCcSwitchImportConfigChange}
-        onClientTypeChange={handleCcSwitchImportClientTypeChange}
+        configs={compatibleConfigs}
+        onSelect={handleImportWithConfig}
         onClose={() => setCcSwitchImportEntry(null)}
-        onClaudeApiKeyFieldChange={setCcSwitchImportClaudeApiKeyField}
-        onEnabledChange={setCcSwitchImportEnabled}
-        onModelChange={setCcSwitchImportModel}
-        onProviderNameChange={setCcSwitchImportProviderName}
-        onSelect={handleImportToCcSwitch}
       />
 
       <ApiKeyUsageModal

--- a/src/modules/api-keys/components/CcSwitchImportCardList.tsx
+++ b/src/modules/api-keys/components/CcSwitchImportCardList.tsx
@@ -1,0 +1,88 @@
+import { useTranslation } from "react-i18next";
+import iconClaude from "@/assets/icons/claude.svg";
+import iconCodex from "@/assets/icons/codex.svg";
+import iconGemini from "@/assets/icons/gemini.svg";
+import { Modal } from "@/modules/ui/Modal";
+import type { CcSwitchImportConfigListItem } from "@/modules/ccswitch/ccswitchImportConfigList";
+import type { CcSwitchClientType } from "@/modules/ccswitch/ccswitchImport";
+
+const iconByType: Record<CcSwitchClientType, string> = {
+  claude: iconClaude,
+  codex: iconCodex,
+  gemini: iconGemini,
+};
+
+export interface CcSwitchImportCardListProps {
+  open: boolean;
+  configs: CcSwitchImportConfigListItem[];
+  onSelect: (config: CcSwitchImportConfigListItem) => void;
+  onClose: () => void;
+}
+
+export function CcSwitchImportCardList({
+  open,
+  configs,
+  onSelect,
+  onClose,
+}: CcSwitchImportCardListProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      open={open}
+      title={t("ccswitch.import_to_ccswitch")}
+      description={t("ccswitch.import_card_list_desc")}
+      maxWidth="max-w-xl"
+      onClose={onClose}
+      bodyClassName="bg-slate-50/45 dark:bg-neutral-950/45"
+    >
+      <div className="space-y-3">
+        {configs.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-500 dark:text-white/55">
+            {t("ccswitch.import_no_compatible_configs")}
+          </p>
+        ) : (
+          configs.map((config) => (
+            <button
+              key={config.id}
+              type="button"
+              onClick={() => onSelect(config)}
+              className="flex w-full items-start gap-4 rounded-2xl border border-black/[0.06] bg-white p-4 text-left shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm active:translate-y-px dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-200/70 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-950">
+                <img src={iconByType[config.clientType]} alt="" className="h-5 w-5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                    {config.providerName}
+                  </span>
+                  {config.clientType === "claude" && config.apiKeyField ? (
+                    <span className="shrink-0 rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+                      {config.apiKeyField}
+                    </span>
+                  ) : null}
+                </div>
+                {config.note ? (
+                  <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-white/55">
+                    {config.note}
+                  </p>
+                ) : null}
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+                    {config.defaultModel}
+                  </span>
+                  {config.allowedChannelGroups.length > 0 ? (
+                    <span className="truncate text-[10px] text-slate-400 dark:text-white/35">
+                      {config.allowedChannelGroups.join(", ")}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
将 API Keys 页面中点击「导入到 CC Switch」时显示的复杂表单对话框替换为简单的卡片列表组件，直接选择预设后触发导入。

- 新增 CcSwitchImportCardList 组件：展示当前 API Key 的 allowed-channel-groups 可用的配置预设
- 按 allowed-channel-groups 交集过滤可用的 CC Switch 预设
- 删除大量不再需要的 state/memo/callback（~270 行 → ~80 行）
- 更新中/英/俄语 i18n