### PR TITLE
feat(config): add prefer-ipv4 toggle in visual config editor

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3363,6 +3363,8 @@
     "usage_stats_desc": "usage-statistics-enabled",
     "force_prefix_label": "Force Model Prefix",
     "force_prefix_desc": "force-model-prefix",
+    "prefer_ipv4_label": "Prefer IPv4",
+    "prefer_ipv4_desc": "Force all outbound upstream connections over IPv4 only. Useful when IPv6 is via tunnel and has poor quality.",
     "ws_auth_label": "WebSocket Auth",
     "ws_auth_desc": "ws-auth",
     "remote_allow_desc": "remote-management.allow-remote",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3509,6 +3509,8 @@
     "usage_stats_desc": "对应 usage-statistics-enabled",
     "force_prefix_label": "强制模型前缀",
     "force_prefix_desc": "对应 force-model-prefix",
+    "prefer_ipv4_label": "优先使用 IPv4",
+    "prefer_ipv4_desc": "强制所有上游出站连接只使用 IPv4。适用于 IPv6 走隧道且质量较差的情况。",
     "ws_auth_label": "WebSocket 鉴权",
     "ws_auth_desc": "对应 ws-auth",
     "remote_allow_desc": "对应 remote-management.allow-remote",

--- a/src/modules/config/visual/VisualConfigEditor.tsx
+++ b/src/modules/config/visual/VisualConfigEditor.tsx
@@ -310,6 +310,13 @@ export function VisualConfigEditor({
                 disabled={disabled}
               />
             </Field>
+            <ToggleSwitch
+              label={t("visual_config.prefer_ipv4_label")}
+              description={t("visual_config.prefer_ipv4_desc")}
+              checked={values.preferIPv4}
+              onCheckedChange={(next) => update({ preferIPv4: next })}
+              disabled={disabled}
+            />
             <div className="grid gap-3 lg:grid-cols-2">
               <Field label="request-retry" hint={t("visual_config.non_negative_int")}>
                 <TextInput

--- a/src/modules/config/visual/types.ts
+++ b/src/modules/config/visual/types.ts
@@ -93,6 +93,7 @@ export type VisualConfigValues = {
   autoUpdateDockerImage: string;
 
   proxyUrl: string;
+  preferIPv4: boolean;
   forceModelPrefix: boolean;
   requestRetry: string;
   maxRetryInterval: string;
@@ -146,6 +147,7 @@ export const DEFAULT_VISUAL_VALUES: VisualConfigValues = {
   autoUpdateChannel: "main",
   autoUpdateDockerImage: "ghcr.io/kittors/clirelay",
   proxyUrl: "",
+  preferIPv4: false,
   forceModelPrefix: false,
   requestRetry: "",
   maxRetryInterval: "",

--- a/src/modules/config/visual/useVisualConfig.ts
+++ b/src/modules/config/visual/useVisualConfig.ts
@@ -501,6 +501,7 @@ export function useVisualConfig() {
             : DEFAULT_VISUAL_VALUES.autoUpdateDockerImage,
 
         proxyUrl: typeof parsed["proxy-url"] === "string" ? parsed["proxy-url"] : "",
+        preferIPv4: Boolean(parsed["prefer-ipv4"]),
         forceModelPrefix: Boolean(parsed["force-model-prefix"]),
         requestRetry: String(parsed["request-retry"] ?? ""),
         maxRetryInterval: String(parsed["max-retry-interval"] ?? ""),
@@ -620,6 +621,7 @@ export function useVisualConfig() {
         }
 
         setString(parsed, "proxy-url", values.proxyUrl);
+        setBoolean(parsed, "prefer-ipv4", values.preferIPv4);
         setBoolean(parsed, "force-model-prefix", values.forceModelPrefix);
         setIntFromString(parsed, "request-retry", values.requestRetry);
         setIntFromString(parsed, "max-retry-interval", values.maxRetryInterval);


### PR DESCRIPTION
## 改动

在可视化配置编辑器中增加「优先使用 IPv4」开关。

当服务器 IPv6 质量较差（如 BWG 的 SIT 隧道）时，开启此选项可强制所有上游出站连接只使用 IPv4，避免 IPv6 隧道带来的额外延迟和不稳定性。

## 修改内容

- `types.ts`: 增加 `preferIPv4` 字段和默认值
- `useVisualConfig.ts`: 解析和序列化 `prefer-ipv4`
- `VisualConfigEditor.tsx`: 在「代理与重试」卡片中添加 ToggleSwitch
- `i18n/locales/en.json` & `zh-CN.json`: 添加中英文文案