### PR TITLE
fix: stabilize provider and channel group scrolling

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1161,9 +1161,12 @@ export function RoutingConfigEditor({
 
               <div
                 data-testid="group-editor-tab-viewport"
-                className="mt-4 min-h-0 flex-1 overflow-y-auto pr-1"
+                className="mt-4 min-h-0 flex-1 overflow-hidden"
               >
-                <TabsContent value="basic" className="space-y-5">
+                <TabsContent
+                  value="basic"
+                  className="h-full min-h-0 overflow-y-auto pr-1 space-y-5"
+                >
                   <Field
                     label={t("channel_groups_page.routing_strategy_label")}
                     tooltip={t("channel_groups_page.routing_strategy_tooltip")}
@@ -1274,7 +1277,7 @@ export function RoutingConfigEditor({
                   />
                 </TabsContent>
 
-                <TabsContent value="models" className="flex h-full min-h-0 flex-col gap-3">
+                <TabsContent value="models" className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
                       <div className="text-sm font-semibold text-slate-900 dark:text-white">

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -179,7 +179,7 @@ describe("RoutingConfigEditor", () => {
     expect(screen.getByText("$3 / $15 / $0.3")).toBeInTheDocument();
   });
 
-  test("keeps modal body and tabs fixed while tab content and model list own scrolling", async () => {
+  test("keeps modal body fixed while the basic tab content and model list own scrolling", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();
     const loadModelsForChannels = vi.fn(async () => [
@@ -208,7 +208,8 @@ describe("RoutingConfigEditor", () => {
 
     const tabViewport = screen.getByTestId("group-editor-tab-viewport");
     expect(tabViewport).toHaveClass("flex-1");
-    expect(tabViewport).toHaveClass("overflow-y-auto");
+    expect(tabViewport).toHaveClass("overflow-hidden");
+    expect(screen.getByText("分组内调度策略")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
     expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -77,7 +77,7 @@ export function ProviderKeyListCard({
       title={title}
       description={description}
       className="flex h-full min-h-0 flex-col"
-      bodyClassName="min-h-0 flex-1"
+      bodyClassName="min-h-0 flex flex-1 flex-col"
       actions={
         <Button variant="primary" size="sm" onClick={onAdd}>
           <Plus size={14} />

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -787,8 +787,7 @@ export function ProvidersPage() {
               </TabsTrigger>
             </TabsList>
           </div>
-
-        <TabsContent value="gemini" className="min-h-0 flex-1">
+          <TabsContent value="gemini" className="flex min-h-0 flex-1 flex-col">
           <ProviderKeyListCard
             icon={Globe}
             title={t("providers.gemini_keys")}
@@ -808,7 +807,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="claude" className="min-h-0 flex-1">
+          <TabsContent value="claude" className="flex min-h-0 flex-1 flex-col">
           <ProviderKeyListCard
             icon={Bot}
             title={t("providers.claude_keys")}
@@ -828,7 +827,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="codex" className="min-h-0 flex-1">
+          <TabsContent value="codex" className="flex min-h-0 flex-1 flex-col">
           <ProviderKeyListCard
             icon={FileKey}
             title={t("providers.codex_keys")}
@@ -848,7 +847,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="opencode-go" className="min-h-0 flex-1">
+          <TabsContent value="opencode-go" className="flex min-h-0 flex-1 flex-col">
           <ProviderKeyListCard
             icon={FileKey}
             iconSrc={iconOpenCodeLight}
@@ -871,7 +870,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="vertex" className="min-h-0 flex-1">
+          <TabsContent value="vertex" className="flex min-h-0 flex-1 flex-col">
           <ProviderKeyListCard
             icon={Database}
             title={t("providers.vertex_keys")}
@@ -890,7 +889,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="bedrock" className="min-h-0 flex-1">
+          <TabsContent value="bedrock" className="flex min-h-0 flex-1 flex-col">
           <ProviderKeyListCard
             icon={Cloud}
             title={t("providers.bedrock_keys")}
@@ -910,7 +909,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="openai" className="min-h-0 flex-1">
+          <TabsContent value="openai" className="flex min-h-0 flex-1 flex-col">
           <OpenAIProvidersTab
             providers={openaiProviders}
             openOpenAIEditor={openOpenAIEditor}
@@ -924,7 +923,7 @@ export function ProvidersPage() {
           />
         </TabsContent>
 
-        <TabsContent value="ampcode" className="min-h-0 flex-1">
+          <TabsContent value="ampcode" className="flex min-h-0 flex-1 flex-col">
           <AmpcodePanel
             loading={loading}
             isPending={isPending}

--- a/src/modules/providers/components/AmpcodePanel.tsx
+++ b/src/modules/providers/components/AmpcodePanel.tsx
@@ -42,7 +42,7 @@ export function AmpcodePanel({
       title={t("providers.ampcode_title")}
       description={t("providers.ampcode_desc")}
       className="flex h-full min-h-0 flex-col"
-      bodyClassName="min-h-0 flex-1 overflow-y-auto pr-1"
+      bodyClassName="min-h-0 flex flex-1 flex-col overflow-y-auto pr-1"
       actions={
         <Button
           variant="primary"

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -44,7 +44,7 @@ export function OpenAIProvidersTab({
       title={t("providers.openai_compatible")}
       description={t("providers.claude_desc")}
       className="flex h-full min-h-0 flex-col"
-      bodyClassName="min-h-0 flex-1"
+      bodyClassName="min-h-0 flex flex-1 flex-col"
       actions={
         <Button variant="primary" size="sm" onClick={() => openOpenAIEditor(null)}>
           <Plus size={14} />


### PR DESCRIPTION
## Summary\n- keep the ai-providers toolbar fixed while the card lists own scrolling and hover bulk export selection remains available\n- fix channel-groups edit modal scrolling so the modal body stays fixed and the basic/model tabs each own a single scroll surface\n\n## Verification\n- bun run test src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx\n- bun run test src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx\n- bun run build