### PR TITLE
fix: align provider actions and channel group scrolling

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1274,6 +1274,7 @@ export function RoutingConfigEditor({
                         ? "bg-rose-50/70 dark:bg-rose-500/10"
                         : ""
                     }
+                    allowWheelPropagationAtBoundary
                   />
                 </TabsContent>
 

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
@@ -215,6 +215,42 @@ describe("RoutingConfigEditor", () => {
     expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+
+  test("lets the basic tab continue scrolling when the channel table reaches a wheel boundary", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "新增分组" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("option", { name: "Team A Claude" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+
+    const channelTable = screen.getByRole("table", { name: "选择渠道" });
+    const scrollContainer = channelTable.closest(".table-scrollbar") as HTMLDivElement | null;
+    expect(scrollContainer).not.toBeNull();
+
+    Object.defineProperties(scrollContainer!, {
+      clientHeight: { configurable: true, value: 248 },
+      scrollHeight: { configurable: true, value: 248 },
+      clientWidth: { configurable: true, value: 640 },
+      scrollWidth: { configurable: true, value: 640 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+      scrollLeft: { configurable: true, writable: true, value: 0 },
+    });
+
+    const event = createEvent.wheel(scrollContainer!, {
+      deltaY: 120,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+
+    fireEvent(scrollContainer!, event);
+
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 
   test("keeps the model list table visible while channel models are loading", async () => {

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -642,7 +642,7 @@ export function ProvidersPage() {
       data-testid="providers-page-shell"
       className="flex h-[calc(100dvh-112px)] min-h-0 flex-col gap-6 overflow-hidden"
     >
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <div className="space-y-0.5">
           <h2 className="text-base font-semibold text-slate-900 dark:text-white">
             {t("providers.config_overview")}
@@ -651,93 +651,91 @@ export function ProvidersPage() {
             {t("providers.config_overview_desc")}
           </p>
         </div>
-        <div data-testid="providers-top-actions" className="flex flex-wrap items-center gap-2">
-          {currentImportKind ? (
-            <>
-              <input
-                ref={importInputRef}
-                type="file"
-                accept="application/json,.json"
-                aria-label={t("providers.import_json")}
-                className="sr-only"
-                onChange={(event) => {
-                  const file = event.currentTarget.files?.[0] ?? null;
-                  void handleImportFile(file);
-                  event.currentTarget.value = "";
-                }}
-              />
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => importInputRef.current?.click()}
-                disabled={loading}
-              >
-                <Upload size={14} />
-                {t("providers.import_json")}
-              </Button>
-            </>
-          ) : null}
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => void refreshTab(tab)}
-            disabled={loading}
-          >
-            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
-            {t("providers.refresh")}
-          </Button>
-        </div>
       </div>
 
-      {currentImportKind ? (
-        <div
-          data-testid="providers-batch-actions"
-          className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]"
+      <div
+        data-testid="providers-batch-actions"
+        className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]"
+      >
+        {currentImportKind ? (
+          <>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept="application/json,.json"
+              aria-label={t("providers.import_json")}
+              className="sr-only"
+              onChange={(event) => {
+                const file = event.currentTarget.files?.[0] ?? null;
+                void handleImportFile(file);
+                event.currentTarget.value = "";
+              }}
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              className="!h-8 px-2 text-xs"
+              onClick={() => importInputRef.current?.click()}
+              disabled={loading}
+            >
+              <Upload size={14} />
+              {t("providers.import_json")}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="!h-8 px-2 text-xs"
+              onClick={handleExport}
+              disabled={currentTabItems.length === 0}
+            >
+              <Download size={14} />
+              {t("providers.export_json")}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="!h-8 px-2 text-xs"
+              onClick={() => selectAllCurrentItems(!allCurrentSelected)}
+              disabled={currentSelectableKeys.length === 0}
+            >
+              {allCurrentSelected
+                ? t("providers.batch_deselect_all")
+                : t("providers.batch_select_all")}
+            </Button>
+            <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
+              {t("providers.batch_selected", { count: selectedExportCount })}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="!h-8 px-2 text-xs"
+              onClick={() => setSelectedExportKeys([])}
+              disabled={selectedExportCount === 0}
+            >
+              {t("providers.batch_clear")}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="!h-8 px-2 text-xs"
+              onClick={handleExportSelected}
+              disabled={selectedExportCount === 0}
+            >
+              {t("providers.export_selected_json")}
+            </Button>
+          </>
+        ) : null}
+        <Button
+          variant="secondary"
+          size="sm"
+          className="!h-8 px-2 text-xs"
+          onClick={() => void refreshTab(tab)}
+          disabled={loading}
         >
-          <Button
-            variant="secondary"
-            size="sm"
-            className="!h-8 px-2 text-xs"
-            onClick={handleExport}
-            disabled={currentTabItems.length === 0}
-          >
-            <Download size={14} />
-            {t("providers.export_json")}
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            className="!h-8 px-2 text-xs"
-            onClick={() => selectAllCurrentItems(!allCurrentSelected)}
-            disabled={currentSelectableKeys.length === 0}
-          >
-            {allCurrentSelected
-              ? t("providers.batch_deselect_all")
-              : t("providers.batch_select_all")}
-          </Button>
-          <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
-            {t("providers.batch_selected", { count: selectedExportCount })}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="!h-8 px-2 text-xs"
-            onClick={() => setSelectedExportKeys([])}
-            disabled={selectedExportCount === 0}
-          >
-            {t("providers.batch_clear")}
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            className="!h-8 px-2 text-xs"
-            onClick={handleExportSelected}
-            disabled={selectedExportCount === 0}
-          >
-            {t("providers.export_selected_json")}
-          </Button>
-        </div>
-      ) : null}
+          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          {t("providers.refresh")}
+        </Button>
+      </div>
 
       <Tabs
         value={tab}

--- a/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -127,7 +127,7 @@ describe("ProvidersPage import/export", () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
-  test("keeps import and refresh in the top toolbar while moving export into the batch actions", async () => {
+  test("keeps provider import, refresh, and export actions together in the batch toolbar", async () => {
     const user = userEvent.setup();
 
     render(
@@ -145,12 +145,9 @@ describe("ProvidersPage import/export", () => {
     await user.click(await screen.findByRole("tab", { name: /Codex/ }));
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
 
-    const topActions = screen.getByTestId("providers-top-actions");
-    expect(within(topActions).queryByRole("button", { name: /Export JSON/i })).not.toBeInTheDocument();
-    expect(within(topActions).getByRole("button", { name: /Import JSON/i })).toBeInTheDocument();
-    expect(within(topActions).getByRole("button", { name: /Refresh/i })).toBeInTheDocument();
-
     const batchActions = screen.getByTestId("providers-batch-actions");
+    expect(within(batchActions).getByRole("button", { name: /Import JSON/i })).toBeInTheDocument();
+    expect(within(batchActions).getByRole("button", { name: /Refresh/i })).toBeInTheDocument();
     expect(within(batchActions).getByRole("button", { name: /^Export JSON$/i })).toBeInTheDocument();
   });
 

--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -75,6 +75,8 @@ export interface VirtualTableProps<T> {
   showAllLoadedMessage?: boolean;
   /** Extra row className */
   rowClassName?: string | ((row: T, index: number) => string);
+  /** Let parent scroll containers handle wheel events when this table is already at an edge. */
+  allowWheelPropagationAtBoundary?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -120,6 +122,7 @@ export function VirtualTable<T>({
   emptyText = "",
   showAllLoadedMessage = true,
   rowClassName,
+  allowWheelPropagationAtBoundary = false,
 }: VirtualTableProps<T>) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -278,10 +281,11 @@ export function VirtualTable<T>({
     }
 
     if (wantsY || wantsX) {
+      if (allowWheelPropagationAtBoundary) return;
       e.preventDefault();
       e.stopPropagation();
     }
-  }, []);
+  }, [allowWheelPropagationAtBoundary]);
 
   const dragRef = useRef<null | {
     axis: "x" | "y";


### PR DESCRIPTION
## Summary\n- move ai-providers import and refresh into the same batch toolbar as export and selected export actions\n- let the channel group editor basic tab keep scrolling when its inner channel table reaches a wheel boundary\n- keep VirtualTable's existing wheel containment as the default and opt in only for this nested modal table\n\n## Verification\n- bun run test src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx\n- bun run test src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx\n- bun run test src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx\n- bun run build