### PR TITLE
fix: remove nested scroll from channel group editor table

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1265,7 +1265,8 @@ export function RoutingConfigEditor({
                     rowKey={(channel) => channel.id}
                     virtualize={false}
                     rowHeight={52}
-                    height="h-[248px]"
+                    height="h-auto"
+                    minHeight="min-h-0"
                     minWidth="min-w-[640px]"
                     caption={t("channel_groups_page.select_channel_label")}
                     emptyText={t("channel_groups_page.empty_group_channels")}

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -253,6 +253,28 @@ describe("RoutingConfigEditor", () => {
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
+  test("renders the basic tab channel table without a nested vertical scroll region", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "新增分组" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("option", { name: "Team A Claude" }));
+    await user.click(screen.getByRole("option", { name: "Main Codex" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+
+    const channelTable = screen.getByRole("table", { name: "选择渠道" });
+    const scrollContainer = channelTable.closest(".table-scrollbar") as HTMLDivElement | null;
+    const tableShell = scrollContainer?.parentElement as HTMLDivElement | null;
+
+    expect(tableShell).not.toBeNull();
+    expect(tableShell).toHaveClass("h-auto");
+    expect(tableShell).toHaveClass("min-h-0");
+    expect(tableShell).not.toHaveClass("h-[248px]");
+  });
+
   test("keeps the model list table visible while channel models are loading", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary\n- make the basic tab channel table in the group editor natural-height instead of a fixed-height nested vertical scroll region\n- add a regression test that asserts the channel table no longer creates the nested vertical scroll shell\n\n## Verification\n- bun run test src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx\n- bun run build