### PR TITLE
fix: remove group editor table scrollbars

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1275,7 +1275,7 @@ export function RoutingConfigEditor({
                         ? "bg-rose-50/70 dark:bg-rose-500/10"
                         : ""
                     }
-                    allowWheelPropagationAtBoundary
+                    naturalFlow
                   />
                 </TabsContent>
 

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
@@ -217,43 +217,7 @@ describe("RoutingConfigEditor", () => {
     expect(screen.getByRole("tablist")).toBeInTheDocument();
   });
 
-  test("lets the basic tab continue scrolling when the channel table reaches a wheel boundary", async () => {
-    await i18n.changeLanguage("zh-CN");
-    const user = userEvent.setup();
-
-    render(<Harness />);
-
-    await user.click(screen.getByRole("button", { name: "新增分组" }));
-    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
-    await user.click(screen.getByRole("option", { name: "Team A Claude" }));
-    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
-
-    const channelTable = screen.getByRole("table", { name: "选择渠道" });
-    const scrollContainer = channelTable.closest(".table-scrollbar") as HTMLDivElement | null;
-    expect(scrollContainer).not.toBeNull();
-
-    Object.defineProperties(scrollContainer!, {
-      clientHeight: { configurable: true, value: 248 },
-      scrollHeight: { configurable: true, value: 248 },
-      clientWidth: { configurable: true, value: 640 },
-      scrollWidth: { configurable: true, value: 640 },
-      scrollTop: { configurable: true, writable: true, value: 0 },
-      scrollLeft: { configurable: true, writable: true, value: 0 },
-    });
-
-    const event = createEvent.wheel(scrollContainer!, {
-      deltaY: 120,
-      bubbles: true,
-      cancelable: true,
-    });
-    const preventDefault = vi.spyOn(event, "preventDefault");
-
-    fireEvent(scrollContainer!, event);
-
-    expect(preventDefault).not.toHaveBeenCalled();
-  });
-
-  test("renders the basic tab channel table without a nested vertical scroll region", async () => {
+  test("renders the basic tab channel table without an internal table scroll container", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();
 
@@ -266,13 +230,14 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
 
     const channelTable = screen.getByRole("table", { name: "选择渠道" });
-    const scrollContainer = channelTable.closest(".table-scrollbar") as HTMLDivElement | null;
-    const tableShell = scrollContainer?.parentElement as HTMLDivElement | null;
+    const tableShell = channelTable.closest("[data-vt-natural-flow]") as HTMLDivElement | null;
 
     expect(tableShell).not.toBeNull();
     expect(tableShell).toHaveClass("h-auto");
     expect(tableShell).toHaveClass("min-h-0");
     expect(tableShell).not.toHaveClass("h-[248px]");
+    expect(channelTable.closest(".table-scrollbar")).toBeNull();
+    expect(tableShell!.querySelector("[data-vt-scrollbar]")).toBeNull();
   });
 
   test("keeps the model list table visible while channel models are loading", async () => {

--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -77,6 +77,8 @@ export interface VirtualTableProps<T> {
   rowClassName?: string | ((row: T, index: number) => string);
   /** Let parent scroll containers handle wheel events when this table is already at an edge. */
   allowWheelPropagationAtBoundary?: boolean;
+  /** Render the table in normal document flow without any internal table scrollbars. */
+  naturalFlow?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +125,7 @@ export function VirtualTable<T>({
   showAllLoadedMessage = true,
   rowClassName,
   allowWheelPropagationAtBoundary = false,
+  naturalFlow = false,
 }: VirtualTableProps<T>) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -547,33 +550,46 @@ export function VirtualTable<T>({
   return (
     <div
       aria-busy={loading || loadingMore ? true : undefined}
-      className={`${height} ${minHeight} group relative isolate grid min-w-0 ${vThumb ? "grid-cols-[minmax(0,1fr)_0.75rem]" : "grid-cols-1"} overflow-hidden`}
+      data-vt-natural-flow={naturalFlow ? true : undefined}
+      className={
+        naturalFlow
+          ? `${height} ${minHeight} relative min-w-0 overflow-visible`
+          : `${height} ${minHeight} group relative isolate grid min-w-0 ${vThumb ? "grid-cols-[minmax(0,1fr)_0.75rem]" : "grid-cols-1"} overflow-hidden`
+      }
     >
-      <div
-        data-vt-header-backdrop
-        className="pointer-events-none absolute inset-x-0 top-0 z-0 rounded-xl bg-slate-100 dark:bg-neutral-800"
-        style={{ height: headerHeight }}
-      />
+      {naturalFlow ? null : (
+        <div
+          data-vt-header-backdrop
+          className="pointer-events-none absolute inset-x-0 top-0 z-0 rounded-xl bg-slate-100 dark:bg-neutral-800"
+          style={{ height: headerHeight }}
+        />
+      )}
       <div
         ref={containerRef}
-        onScroll={onScroll}
-        onWheelCapture={onWheelCapture}
-        tabIndex={0}
-        data-scrollbar-visibility="hover"
-        className="relative z-10 col-start-1 row-start-1 h-full min-h-0 table-scrollbar overflow-auto overscroll-x-none overscroll-y-none rounded-tl-xl"
+        onScroll={naturalFlow ? undefined : onScroll}
+        onWheelCapture={naturalFlow ? undefined : onWheelCapture}
+        tabIndex={naturalFlow ? undefined : 0}
+        data-scrollbar-visibility={naturalFlow ? undefined : "hover"}
+        className={
+          naturalFlow
+            ? "relative z-10 min-h-0 overflow-visible rounded-xl"
+            : "relative z-10 col-start-1 row-start-1 h-full min-h-0 table-scrollbar overflow-auto overscroll-x-none overscroll-y-none rounded-tl-xl"
+        }
       >
-        <div
-          data-vt-header-overlay
-          className={`pointer-events-none sticky left-0 top-0 z-10 w-full ${vThumb ? "rounded-l-xl" : "rounded-xl"} bg-slate-100 dark:bg-neutral-800`}
-          style={{ height: headerHeight, marginBottom: -headerHeight }}
-        />
+        {naturalFlow ? null : (
+          <div
+            data-vt-header-overlay
+            className={`pointer-events-none sticky left-0 top-0 z-10 w-full ${vThumb ? "rounded-l-xl" : "rounded-xl"} bg-slate-100 dark:bg-neutral-800`}
+            style={{ height: headerHeight, marginBottom: -headerHeight }}
+          />
+        )}
         <table
           className={`w-full ${minWidth} table-fixed border-separate border-spacing-0 text-sm`}
         >
           <caption className="sr-only">{caption}</caption>
 
           {/* ── HeroUI-styled header ── */}
-          <thead ref={headerRef} className="sticky top-0 z-20">
+          <thead ref={headerRef} className={naturalFlow ? undefined : "sticky top-0 z-20"}>
             <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-white/55">
               {columns.map((col) => {
                 return (
@@ -705,7 +721,7 @@ export function VirtualTable<T>({
         )}
       </div>
 
-      {vThumb ? (
+      {!naturalFlow && vThumb ? (
         <div
           data-vt-scrollbar-gutter
           className="relative z-30 col-start-2 row-start-1 h-full w-3 justify-self-end"
@@ -734,7 +750,7 @@ export function VirtualTable<T>({
         </div>
       ) : null}
 
-      {hThumb ? (
+      {!naturalFlow && hThumb ? (
         <div
           data-vt-scrollbar="x"
           className="pointer-events-auto absolute bottom-1 left-2 right-5 z-30 h-2 opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"


### PR DESCRIPTION
## Summary
- add a natural-flow mode to VirtualTable that renders without internal scroll containers or custom scrollbar overlays
- use natural-flow for the channel member table in the group editor basic tab
- update the regression test to assert the edit modal table no longer creates a nested table scrollbar

## Test Plan
- bun run test src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
- bun run test src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
- bun run build