### PR TITLE
fix: add OpenAI Compatible key entry toggles

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3039,6 +3039,7 @@
     "priority_label": "Priority (optional)",
     "test_model_label": "Test model (optional)",
     "api_key_entries": "API key entries",
+    "enable_key_entry": "Enable key entry",
     "key_number": "Key #{{num}}",
     "proxy_url_optional": "Proxy URL (optional)",
     "models_label": "Models",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2432,6 +2432,7 @@
     "priority_label": "优先级（可选）",
     "test_model_label": "测试模型（可选）",
     "api_key_entries": "API 密钥条目",
+    "enable_key_entry": "启用密钥条目",
     "key_number": "密钥 #{{num}}",
     "proxy_url_optional": "代理 URL（可选）",
     "models_label": "模型",

--- a/src/lib/http/apis/__tests__/provider-proxy-id.test.ts
+++ b/src/lib/http/apis/__tests__/provider-proxy-id.test.ts
@@ -41,6 +41,7 @@ describe("provider proxy id serialization", () => {
         apiKeyEntries: [
           {
             apiKey: "sk-openai",
+            disabled: true,
             proxyId: "hk",
             proxyUrl: "http://fallback.example:7890",
           },
@@ -50,6 +51,7 @@ describe("provider proxy id serialization", () => {
       expect.objectContaining({
         "api-key-entries": [
           expect.objectContaining({
+            disabled: true,
             "proxy-id": "hk",
             "proxy-url": "http://fallback.example:7890",
           }),

--- a/src/lib/http/apis/helpers.ts
+++ b/src/lib/http/apis/helpers.ts
@@ -227,6 +227,7 @@ export const serializeOpenAIProvider = (provider: OpenAIProvider) => {
         const apiKey = normalizeString(entry.apiKey) ?? "";
         if (!apiKey) return null;
         const entryPayload: Record<string, unknown> = { "api-key": apiKey };
+        if (entry.disabled === true) entryPayload.disabled = true;
         const proxyUrl = normalizeString(entry.proxyUrl);
         if (proxyUrl) entryPayload["proxy-url"] = proxyUrl;
         const proxyId = normalizeString(entry.proxyId);
@@ -312,11 +313,13 @@ export const normalizeApiKeyEntries = (raw: unknown): ProviderApiKeyEntry[] | un
       if (!isRecord(entry)) return null;
       const apiKey = normalizeString(entry["api-key"] ?? entry.apiKey) ?? "";
       if (!apiKey) return null;
+      const disabled = entry.disabled === true;
       const proxyUrl = normalizeString(entry["proxy-url"] ?? entry.proxyUrl) ?? undefined;
       const proxyId = normalizeString(entry["proxy-id"] ?? entry.proxyId) ?? undefined;
       const entryHeaders = normalizeHeaders(entry.headers);
       return {
         apiKey,
+        ...(disabled ? { disabled } : {}),
         ...(proxyUrl ? { proxyUrl } : {}),
         ...(proxyId ? { proxyId } : {}),
         ...(entryHeaders ? { headers: entryHeaders } : {}),

--- a/src/lib/http/types.ts
+++ b/src/lib/http/types.ts
@@ -172,6 +172,7 @@ export interface ProviderModel {
 
 export interface ProviderApiKeyEntry {
   apiKey: string;
+  disabled?: boolean;
   proxyUrl?: string;
   proxyId?: string;
   headers?: Record<string, string>;

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -322,6 +322,7 @@ export function ProvidersPage() {
     openOpenAIEditor,
     saveOpenAIDraft,
     deleteOpenAIProvider,
+    toggleOpenAIKeyEntryEnabled,
     discoverModels,
     applyDiscoveredModels,
   } = useOpenAIProviderEditor({
@@ -916,6 +917,9 @@ export function ProvidersPage() {
             getKeyEntryStats={getOpenAIKeyEntryStats}
             getProviderStats={getOpenAIProviderStats}
             getProviderStatusBar={getOpenAIProviderStatusBar}
+            onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
+              void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
+            }
             selectedKeys={selectedExportKeySet}
             onToggleSelected={toggleExportSelection}
           />

--- a/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ProvidersPage } from "@/modules/providers/ProvidersPage";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getVertexConfigs: vi.fn(async () => []),
   getOpenAIProviders: vi.fn(async () => []),
   saveCodexConfigs: vi.fn(async (_configs: unknown[]) => ({})),
+  saveOpenAIProviders: vi.fn(async (_configs: unknown[]) => ({})),
   getEntityStats: vi.fn(async () => ({ source: [] })),
   apiKeyEntriesList: vi.fn(async () => []),
   channelGroupsList: vi.fn(async () => []),
@@ -31,6 +32,7 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
       getVertexConfigs: mocks.getVertexConfigs,
       getOpenAIProviders: mocks.getOpenAIProviders,
       saveCodexConfigs: mocks.saveCodexConfigs,
+      saveOpenAIProviders: mocks.saveOpenAIProviders,
     },
     usageApi: {
       ...mod.usageApi,
@@ -58,6 +60,10 @@ vi.mock("@/lib/http/apis/proxies", () => ({
 }));
 
 describe("ProvidersPage openai tab", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     mocks.getGeminiKeys.mockReset();
     mocks.getClaudeConfigs.mockReset();
@@ -65,6 +71,7 @@ describe("ProvidersPage openai tab", () => {
     mocks.getVertexConfigs.mockReset();
     mocks.getOpenAIProviders.mockReset();
     mocks.saveCodexConfigs.mockReset();
+    mocks.saveOpenAIProviders.mockReset();
     mocks.getEntityStats.mockReset();
     mocks.apiKeyEntriesList.mockReset();
     mocks.channelGroupsList.mockReset();
@@ -75,6 +82,7 @@ describe("ProvidersPage openai tab", () => {
     mocks.getCodexConfigs.mockImplementation(async () => []);
     mocks.getVertexConfigs.mockImplementation(async () => []);
     mocks.saveCodexConfigs.mockImplementation(async () => ({}));
+    mocks.saveOpenAIProviders.mockImplementation(async () => ({}));
     mocks.apiKeyEntriesList.mockImplementation(async () => []);
     mocks.channelGroupsList.mockImplementation(async () => []);
     mocks.proxiesList.mockImplementation(async () => [
@@ -181,6 +189,58 @@ describe("ProvidersPage openai tab", () => {
           name: "Codex Main",
           apiKey: "sk-codex-provider-1234567890",
           proxyId: "jp",
+        }),
+      ]);
+    });
+  });
+
+  test("toggles an OpenAI Compatible key entry without removing it", async () => {
+    const user = userEvent.setup();
+    const provider = {
+      name: "OpenAI Main",
+      baseUrl: "https://example.com/v1",
+      apiKeyEntries: [
+        { apiKey: "sk-openai-enabled-1234567890" },
+        { apiKey: "sk-openai-disabled-1234567890", disabled: true },
+      ],
+      models: [{ name: "gpt-4.1" }],
+    } as any;
+    mocks.getOpenAIProviders.mockImplementation(async () => [provider] as any);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("OpenAI Main")).toBeInTheDocument();
+    const enabledSwitch = (await screen.findAllByRole("switch", { name: /Enable key entry 1/i }))[0];
+    const disabledSwitch = (await screen.findAllByRole("switch", { name: /Enable key entry 2/i }))[0];
+    expect(enabledSwitch).toHaveAttribute("aria-checked", "true");
+    expect(disabledSwitch).toHaveAttribute("aria-checked", "false");
+
+    await user.click(enabledSwitch);
+
+    await waitFor(() => {
+      expect(mocks.saveOpenAIProviders).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: "OpenAI Main",
+          apiKeyEntries: [
+            expect.objectContaining({
+              apiKey: "sk-openai-enabled-1234567890",
+              disabled: true,
+            }),
+            expect.objectContaining({
+              apiKey: "sk-openai-disabled-1234567890",
+              disabled: true,
+            }),
+          ],
         }),
       ]);
     });

--- a/src/modules/providers/__tests__/providers-helpers.test.ts
+++ b/src/modules/providers/__tests__/providers-helpers.test.ts
@@ -74,6 +74,7 @@ describe("providers helpers", () => {
       {
         id: expect.stringContaining("sk-openai-provider-1234567890"),
         apiKey: "sk-openai-provider-1234567890",
+        disabled: false,
         proxyUrl: "https://proxy.example.com",
         proxyId: "hk",
         headersEntries: [{ id: expect.any(String), key: "x-entry", value: "edge" }],

--- a/src/modules/providers/components/OpenAIProviderModal.tsx
+++ b/src/modules/providers/components/OpenAIProviderModal.tsx
@@ -7,6 +7,7 @@ import { buildModelsEndpoint } from "@/modules/providers/providers-helpers";
 import { Button } from "@/modules/ui/Button";
 import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
+import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 import { KeyValueInputList } from "@/modules/providers/KeyValueInputList";
 import { ModelInputList } from "@/modules/providers/ModelInputList";
 import type { ProxyPoolEntry } from "@/lib/http/apis/proxies";
@@ -221,6 +222,7 @@ export function OpenAIProviderModal({
                     {
                       id: `key-${Date.now()}`,
                       apiKey: "",
+                      disabled: false,
                       proxyUrl: "",
                       proxyId: "",
                       headersEntries: [],
@@ -241,9 +243,26 @@ export function OpenAIProviderModal({
                 className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60"
               >
                 <div className="flex flex-wrap items-center justify-between gap-2">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {t("providers.key_number", { num: idx + 1 })}
-                  </p>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                      {t("providers.key_number", { num: idx + 1 })}
+                    </p>
+                    <ToggleSwitch
+                      checked={!entry.disabled}
+                      ariaLabel={`${t("providers.enable_key_entry")} ${idx + 1}`}
+                      onCheckedChange={(enabled) => {
+                        setOpenaiDraft((prev) => ({
+                          ...prev,
+                          apiKeyEntries: prev.apiKeyEntries.map((it, i) =>
+                            i === idx ? { ...it, disabled: !enabled } : it,
+                          ),
+                        }));
+                      }}
+                    />
+                    <span className="text-xs font-semibold text-slate-500 dark:text-white/55">
+                      {!entry.disabled ? t("providers.enabled") : t("providers.disabled")}
+                    </span>
+                  </div>
                   <Button
                     variant="danger"
                     size="sm"

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/modules/ui/Button";
 import { Card } from "@/modules/ui/Card";
 import { EmptyState } from "@/modules/ui/EmptyState";
 import { ProviderStatusBar } from "@/modules/providers/ProviderStatusBar";
+import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 
 interface OpenAIProvidersTabProps {
   providers: OpenAIProvider[];
@@ -22,6 +23,7 @@ interface OpenAIProvidersTabProps {
     totalSuccess: number;
     totalFailure: number;
   };
+  onToggleKeyEntryEnabled?: (providerIndex: number, entryIndex: number, enabled: boolean) => void;
   selectedKeys?: Set<string>;
   onToggleSelected?: (key: string, checked: boolean) => void;
 }
@@ -34,6 +36,7 @@ export function OpenAIProvidersTab({
   getKeyEntryStats,
   getProviderStats,
   getProviderStatusBar,
+  onToggleKeyEntryEnabled,
   selectedKeys,
   onToggleSelected,
 }: OpenAIProvidersTabProps) {
@@ -113,6 +116,7 @@ export function OpenAIProvidersTab({
                         <div className="space-y-1">
                           {provider.apiKeyEntries.map((entry, entryIndex) => {
                             const entryStats = getKeyEntryStats(entry);
+                            const entryEnabled = entry.disabled !== true;
                             return (
                               <div
                                 key={`${entry.apiKey}:${entryIndex}`}
@@ -128,13 +132,32 @@ export function OpenAIProvidersTab({
                                     </p>
                                   ) : null}
                                 </div>
-                                <div className="flex items-center gap-2 tabular-nums">
+                                <div className="flex flex-wrap items-center gap-2 tabular-nums">
+                                  <span
+                                    className={[
+                                      "rounded-full px-2 py-0.5 font-semibold",
+                                      entryEnabled
+                                        ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
+                                        : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
+                                    ].join(" ")}
+                                  >
+                                    {entryEnabled ? t("providers.enabled") : t("providers.disabled")}
+                                  </span>
                                   <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
                                     {t("providers.success_stats", { count: entryStats.success })}
                                   </span>
                                   <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
                                     {t("providers.failed_stats", { count: entryStats.failure })}
                                   </span>
+                                  {onToggleKeyEntryEnabled ? (
+                                    <ToggleSwitch
+                                      checked={entryEnabled}
+                                      ariaLabel={`${t("providers.enable_key_entry")} ${entryIndex + 1}`}
+                                      onCheckedChange={(enabled) =>
+                                        onToggleKeyEntryEnabled(idx, entryIndex, enabled)
+                                      }
+                                    />
+                                  ) : null}
                                 </div>
                               </div>
                             );

--- a/src/modules/providers/hooks/useOpenAIProviderEditor.ts
+++ b/src/modules/providers/hooks/useOpenAIProviderEditor.ts
@@ -85,6 +85,7 @@ export function useOpenAIProviderEditor({
         const proxyId = entry.proxyId.trim();
         return {
           apiKey,
+          ...(entry.disabled ? { disabled: true } : {}),
           ...(proxyUrl ? { proxyUrl } : {}),
           ...(proxyId ? { proxyId } : {}),
           ...(entryHeaders ? { headers: entryHeaders } : {}),
@@ -171,6 +172,51 @@ export function useOpenAIProviderEditor({
     [notify, openaiProviders, setOpenaiProviders, t],
   );
 
+  const toggleOpenAIKeyEntryEnabled = useCallback(
+    async (providerIndex: number, entryIndex: number, enabled: boolean) => {
+      const provider = openaiProviders[providerIndex];
+      const entry = provider?.apiKeyEntries?.[entryIndex];
+      if (!provider || !entry) return;
+
+      const prev = openaiProviders;
+      const next = prev.map((item, itemIndex) => {
+        if (itemIndex !== providerIndex) return item;
+        return {
+          ...item,
+          apiKeyEntries: (item.apiKeyEntries ?? []).map((keyEntry, keyIndex) =>
+            keyIndex === entryIndex
+              ? { ...keyEntry, ...(enabled ? { disabled: undefined } : { disabled: true }) }
+              : keyEntry,
+          ),
+        };
+      });
+
+      setOpenaiProviders(next);
+      try {
+        await providersApi.saveOpenAIProviders(next);
+        notify({
+          type: "success",
+          message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),
+        });
+        startRefreshTransition(() => void refreshAll());
+      } catch (err: unknown) {
+        setOpenaiProviders(prev);
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("providers.update_failed"),
+        });
+      }
+    },
+    [
+      notify,
+      openaiProviders,
+      refreshAll,
+      setOpenaiProviders,
+      startRefreshTransition,
+      t,
+    ],
+  );
+
   const discoverModels = useCallback(async () => {
     const baseUrl = openaiDraft.baseUrl.trim();
     if (!baseUrl) {
@@ -253,6 +299,7 @@ export function useOpenAIProviderEditor({
     openOpenAIEditor,
     saveOpenAIDraft,
     deleteOpenAIProvider,
+    toggleOpenAIKeyEntryEnabled,
     discoverModels,
     applyDiscoveredModels,
   };

--- a/src/modules/providers/provider-import-export.ts
+++ b/src/modules/providers/provider-import-export.ts
@@ -125,6 +125,7 @@ const normalizeEntryList = (
       const headers = sortRecord(normalizeHeaders(entry.headers));
       return {
         apiKey,
+        ...(entry.disabled ? { disabled: true } : {}),
         ...(normalizeString(entry.proxyUrl) ? { proxyUrl: normalizeString(entry.proxyUrl)! } : {}),
         ...(normalizeString(entry.proxyId) ? { proxyId: normalizeString(entry.proxyId)! } : {}),
         ...(headers ? { headers } : {}),

--- a/src/modules/providers/providers-helpers.ts
+++ b/src/modules/providers/providers-helpers.ts
@@ -193,6 +193,7 @@ export type OpenAIDraft = {
   testModel: string;
   apiKeyEntries: {
     apiKey: string;
+    disabled: boolean;
     proxyUrl: string;
     proxyId: string;
     headersEntries: KeyValueEntry[];
@@ -213,11 +214,21 @@ export const buildOpenAIDraft = (input?: OpenAIProvider | null): OpenAIDraft => 
       ? input.apiKeyEntries.map((entry, idx) => ({
           id: `key-${idx}-${entry.apiKey}`,
           apiKey: entry.apiKey ?? "",
+          disabled: entry.disabled === true,
           proxyUrl: entry.proxyUrl ?? "",
           proxyId: entry.proxyId ?? "",
           headersEntries: recordToKeyValueEntries(entry.headers),
         }))
-      : [{ id: `key-${Date.now()}`, apiKey: "", proxyUrl: "", proxyId: "", headersEntries: [] }],
+      : [
+          {
+            id: `key-${Date.now()}`,
+            apiKey: "",
+            disabled: false,
+            proxyUrl: "",
+            proxyId: "",
+            headersEntries: [],
+          },
+        ],
   modelEntries: buildModelEntries(input?.models),
 });
 


### PR DESCRIPTION
## Summary
- show enabled/disabled status and a switch for each OpenAI Compatible key entry
- preserve disabled through edit, import/export, API normalization, and save payloads
- add tests for the OpenAI Compatible key-entry toggle path

## Validation
- bun run test src/modules/providers/__tests__/ProvidersPage.openai.test.tsx src/lib/http/apis/__tests__/provider-proxy-id.test.ts src/modules/providers/__tests__/provider-import-export.test.ts src/modules/providers/__tests__/providers-helpers.test.ts
- bun run build
- bun run lint (warnings only, pre-existing unused/useless-spread warnings)

## Notes
- bun run test still has the existing ApiKeysPage CC Switch modal failures (6 failures) that were present before this change.