### PR TITLE
fix: keep request log cleanup dialog pending

### DIFF
--- a/src/modules/monitor/RequestLogsPage.tsx
+++ b/src/modules/monitor/RequestLogsPage.tsx
@@ -1,12 +1,8 @@
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Filter, RefreshCw, ScrollText } from "lucide-react";
+import { Filter, LoaderCircle, RefreshCw, ScrollText } from "lucide-react";
 import { usageApi } from "@/lib/http/apis";
-import type {
-  ClearUsageLogsPayload,
-  UsageLogItem,
-  UsageLogsResponse,
-} from "@/lib/http/apis/usage";
+import type { ClearUsageLogsPayload, UsageLogItem, UsageLogsResponse } from "@/lib/http/apis/usage";
 import { Button } from "@/modules/ui/Button";
 import { Checkbox } from "@/modules/ui/Checkbox";
 import { Modal } from "@/modules/ui/Modal";
@@ -147,7 +143,7 @@ export function RequestLogsPage() {
         });
         setStats({
           ...DEFAULT_LOG_STATS,
-          ...(resp.stats ?? {}),
+          ...resp.stats,
         });
         setLastUpdatedAt(Date.now());
       } catch (err) {
@@ -274,6 +270,7 @@ export function RequestLogsPage() {
         type: "success",
         message: successMessage,
       });
+      setConfirmClearOpen(false);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : t("request_logs.clear_database_logs_failed");
@@ -461,20 +458,31 @@ export function RequestLogsPage() {
         title={t("request_logs.clear_database_logs")}
         description={t("request_logs.clear_database_logs_modal_desc")}
         maxWidth="max-w-xl"
-        onClose={() => setConfirmClearOpen(false)}
+        onClose={() => {
+          if (!clearingLogs) setConfirmClearOpen(false);
+        }}
         footer={
           <>
-            <Button variant="secondary" onClick={() => setConfirmClearOpen(false)} disabled={clearingLogs}>
+            <Button
+              variant="secondary"
+              onClick={() => setConfirmClearOpen(false)}
+              disabled={clearingLogs}
+            >
               {t("common.cancel")}
             </Button>
             <Button
               variant="danger"
-              onClick={() => {
-                setConfirmClearOpen(false);
-                void handleClearDatabaseLogs();
-              }}
+              onClick={() => void handleClearDatabaseLogs()}
               disabled={clearingLogs || !canSubmitCleanup}
+              aria-busy={clearingLogs}
             >
+              {clearingLogs ? (
+                <LoaderCircle
+                  size={14}
+                  className="motion-reduce:animate-none motion-safe:animate-spin"
+                  aria-hidden="true"
+                />
+              ) : null}
               {t("request_logs.clear_database_logs_confirm_button")}
             </Button>
           </>
@@ -489,7 +497,7 @@ export function RequestLogsPage() {
             <Checkbox
               checked={clearOptions.clear_body_content}
               onCheckedChange={handleClearBodyContentChange}
-              disabled={clearOptions.clear_request_records}
+              disabled={clearingLogs || clearOptions.clear_request_records}
               aria-label={t("request_logs.clear_option_body")}
             />
             <span className="min-w-0">
@@ -506,7 +514,7 @@ export function RequestLogsPage() {
             <Checkbox
               checked={clearOptions.clear_detail_content}
               onCheckedChange={handleClearDetailContentChange}
-              disabled={clearOptions.clear_request_records}
+              disabled={clearingLogs || clearOptions.clear_request_records}
               aria-label={t("request_logs.clear_option_details")}
             />
             <span className="min-w-0">
@@ -523,6 +531,7 @@ export function RequestLogsPage() {
             <Checkbox
               checked={clearOptions.clear_request_records}
               onCheckedChange={handleClearRequestRecordsChange}
+              disabled={clearingLogs}
               aria-label={t("request_logs.clear_option_records")}
             />
             <span className="min-w-0">

--- a/src/modules/monitor/__tests__/RequestLogsPage.test.tsx
+++ b/src/modules/monitor/__tests__/RequestLogsPage.test.tsx
@@ -6,6 +6,35 @@ import { RequestLogsPage } from "@/modules/monitor/RequestLogsPage";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const emptyLogsResponse = {
+  items: [],
+  total: 0,
+  page: 1,
+  size: 50,
+  filters: {
+    api_keys: [],
+    api_key_names: {},
+    models: [],
+    channels: [],
+  },
+  stats: {
+    total: 0,
+    success_rate: 0,
+    total_tokens: 0,
+    total_cost: 0,
+  },
+};
+
 const mocks = vi.hoisted(() => ({
   getUsageLogs: vi.fn(),
   getLogContent: vi.fn(),
@@ -279,5 +308,42 @@ describe("RequestLogsPage", () => {
       clear_request_records: false,
     });
     expect(await screen.findByText("Primary")).toBeInTheDocument();
+  });
+
+  test("keeps the clear dialog open until cleanup and refresh both finish", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+    const cleanup = deferred<{ deleted_logs: number; deleted_contents: number }>();
+    const refresh = deferred<typeof emptyLogsResponse>();
+
+    mocks.getUsageLogs
+      .mockResolvedValueOnce(emptyLogsResponse)
+      .mockImplementationOnce(() => refresh.promise);
+    mocks.clearUsageLogs.mockImplementationOnce(() => cleanup.promise);
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Clear Database Logs" }));
+    await user.click(await screen.findByRole("button", { name: "Clear Selected Data" }));
+
+    cleanup.resolve({ deleted_logs: 0, deleted_contents: 1 });
+    await waitFor(() => expect(mocks.getUsageLogs).toHaveBeenCalledTimes(2));
+
+    await new Promise((resolve) => window.setTimeout(resolve, 220));
+
+    expect(screen.getByRole("dialog", { name: "Clear Database Logs" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear Selected Data" })).toBeDisabled();
+
+    refresh.resolve(emptyLogsResponse);
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Clear Database Logs" })).not.toBeInTheDocument(),
+    );
   });
 });


### PR DESCRIPTION
修复 /manage/monitor/request-logs 清空数据库日志弹窗提前关闭的问题。\n\n变更：\n- 点击确认后不再立即关闭弹窗。\n- 清理 API 和刷新请求日志列表都完成后才关闭弹窗。\n- 清理中确认按钮显示 loading，并禁用取消、关闭和清理选项。\n- 新增回归测试覆盖清理完成但刷新未完成时弹窗仍保持打开。\n\n验证：\n- bun run test\n- bun run test src/modules/monitor/__tests__/RequestLogsPage.test.tsx\n- bun run lint（0 errors，3 个既有 no-unused-vars warning）\n- bunx oxfmt src/modules/monitor/RequestLogsPage.tsx src/modules/monitor/__tests__/RequestLogsPage.test.tsx --check\n- bun run build\n- bun run bundle:diff\n\n备注：全量 bunx oxfmt . --check 因仓库既有 49 个未格式化文件失败，本次只保留相关两个文件的格式检查通过。