### PR TITLE
fix: refresh channel options when editing groups

### DIFF
--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -189,6 +189,12 @@ export function ChannelGroupsPage() {
     };
   }, []);
 
+  const refreshAvailableChannels = useCallback(async () => {
+    const channels = await loadAvailableChannels();
+    setAvailableChannels(channels.names);
+    setAvailableChannelDetails(channels.detailsByName);
+  }, [loadAvailableChannels]);
+
   const loadModelsForChannels = useCallback(async (channels: string[]) => {
     const normalizedChannels = channels
       .map((channel) => String(channel ?? "").trim())
@@ -305,6 +311,7 @@ export function ChannelGroupsPage() {
             disabled={loading || saving}
             availableChannels={availableChannels}
             availableChannelDetails={availableChannelDetails}
+            onRefreshAvailableChannels={refreshAvailableChannels}
             loadModelsForChannels={loadModelsForChannels}
             onChange={handleEditorChange}
           />

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -238,6 +238,7 @@ export function RoutingConfigEditor({
   disabled,
   availableChannels,
   availableChannelDetails = {},
+  onRefreshAvailableChannels,
   loadModelsForChannels,
   onChange,
 }: {
@@ -245,6 +246,7 @@ export function RoutingConfigEditor({
   disabled?: boolean;
   availableChannels: string[];
   availableChannelDetails?: Record<string, ChannelGroupChannelDetail>;
+  onRefreshAvailableChannels?: () => Promise<void> | void;
   loadModelsForChannels?: (channels: string[]) => Promise<RoutingModelLoadResult[]>;
   onChange: (values: Partial<VisualConfigValues>) => void;
 }) {
@@ -396,6 +398,7 @@ export function RoutingConfigEditor({
   ]);
 
   const openCreateGroup = useCallback(() => {
+    void Promise.resolve(onRefreshAvailableChannels?.()).catch(() => undefined);
     setGroupEditorId(null);
     setGroupDraft(createEmptyGroupDraft());
     setGroupEditorTab("basic");
@@ -403,10 +406,11 @@ export function RoutingConfigEditor({
     setModelsError("");
     setModelsSelectionTouched(false);
     setGroupEditorOpen(true);
-  }, []);
+  }, [onRefreshAvailableChannels]);
 
   const openEditGroup = useCallback(
     (group: RoutingChannelGroupEntry) => {
+      void Promise.resolve(onRefreshAvailableChannels?.()).catch(() => undefined);
       const groupName = group.name.trim().toLowerCase();
       const existingRoutes = values.routingPathRoutes
         .filter((route) => route.group.trim().toLowerCase() === groupName)
@@ -431,7 +435,12 @@ export function RoutingConfigEditor({
       notifyStaleChannels(group.name.trim(), staleChannelsByGroup.get(group.id) ?? []);
       setGroupEditorOpen(true);
     },
-    [notifyStaleChannels, staleChannelsByGroup, values.routingPathRoutes],
+    [
+      notifyStaleChannels,
+      onRefreshAvailableChannels,
+      staleChannelsByGroup,
+      values.routingPathRoutes,
+    ],
   );
 
   const closeGroupEditor = useCallback(() => {
@@ -1279,7 +1288,10 @@ export function RoutingConfigEditor({
                   />
                 </TabsContent>
 
-                <TabsContent value="models" className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
+                <TabsContent
+                  value="models"
+                  className="flex h-full min-h-0 flex-col gap-3 overflow-hidden"
+                >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
                       <div className="text-sm font-semibold text-slate-900 dark:text-white">

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -206,4 +206,50 @@ describe("ChannelGroupsPage", () => {
     expect(within(row as HTMLTableRowElement).getByText("pro")).toBeInTheDocument();
     expect(within(row as HTMLTableRowElement).getByText("vip")).toBeInTheDocument();
   });
+
+  test("refreshes channel options when opening the new group editor", async () => {
+    let channelGroupsCalls = 0;
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        channelGroupsCalls += 1;
+        return Promise.resolve({
+          items:
+            channelGroupsCalls === 1 ? [] : [{ name: "Claude Pool", channels: ["Fresh Claude"] }],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({ data: [] });
+      }
+      if (
+        path === "/auth-files" ||
+        path === "/model-configs?scope=library" ||
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/opencode-go-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve({ files: [], data: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "新增分组" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+
+    expect(await screen.findByRole("option", { name: "Fresh Claude" })).toBeInTheDocument();
+    expect(channelGroupsCalls).toBeGreaterThanOrEqual(2);
+  });
 });


### PR DESCRIPTION
修复渠道分组新增/编辑弹窗中的渠道列表在供应商配置刚变更后可能仍使用旧数据的问题。\n\n验证：\n- bun run test -- src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx\n- bun run lint（通过，保留 3 个既有 unused 警告）\n- bun run build\n- bun run check\n\n说明：全仓库 bunx oxfmt . --check 当前会报告 48 个既有格式问题；本次修改的 3 个文件已单独通过 oxfmt check。