### PR TITLE
fix: keep auth file live models in channel groups

### DIFF
--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -137,6 +137,89 @@ describe("ChannelGroupsPage", () => {
     expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
   });
 
+  test("keeps auth-file live models when an owner-mapped credential has models missing owner metadata", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ kimi: "kimi-code" }),
+    );
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        return Promise.resolve({
+          items: [{ name: "Kimi Pool", channels: ["kimi"] }],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({
+          data: [{ id: "kimi-k2.5" }, { id: "kimi-k2.6" }, { id: "gpt-should-not-leak" }],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "kimi-account.json", type: "kimi", disabled: false }],
+        });
+      }
+      if (path === "/auth-files/models") {
+        return Promise.resolve({
+          models: [
+            { id: "kimi-k2.5", owned_by: "kimi-code" },
+            { id: "kimi-k2.6", display_name: "Kimi K2.6" },
+          ],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "kimi-k2.5",
+              owned_by: "kimi-code",
+              description: "Kimi K2.5",
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+            },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/opencode-go-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "新增分组" }));
+    await user.type(screen.getByPlaceholderText("pro"), "kimi");
+    await user.type(screen.getByPlaceholderText("/pro"), "/kimi");
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(await screen.findByRole("option", { name: "kimi" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    expect(await screen.findByLabelText("kimi-k2.5")).toBeInTheDocument();
+    expect(await screen.findByLabelText("kimi-k2.6")).toBeInTheDocument();
+    expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
+  });
+
   test("shows channel tags in the selector options and selected rows", async () => {
     mockedApiGet.mockImplementation((path: string) => {
       if (path === "/routing-config") {

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -302,7 +302,6 @@ const loadAuthFileModelItems = async (
         for (const model of modelsByOwner.get(owner) ?? []) {
           addModel(map, { ...model, source: model.source || "auth-file-owner" });
         }
-        return;
       }
 
       try {
@@ -311,7 +310,7 @@ const loadAuthFileModelItems = async (
         for (const model of liveModels) {
           addModel(map, {
             id: model.id,
-            owned_by: model.owned_by,
+            owned_by: model.owned_by || owner || undefined,
             description: model.display_name,
             source: "auth-file",
           });


### PR DESCRIPTION
修复渠道分组编辑模型列表在认证文件已映射模型归属分组时只显示部分模型的问题。\n\n变更：\n- owner 映射命中模型库后，继续合并认证文件实时模型列表作为补充来源。\n- 为 Kimi 这类实时模型缺少 owned_by 元数据的场景补回回归测试，确保不会放行其它渠道泄漏模型。\n\n验证：\n- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx\n- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx\n- bun run lint\n- bun run build\n- bun run test