### PR TITLE
fix: restrict auth-owned channel group models

### DIFF
--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -13,6 +13,10 @@ import {
   type RoutingModelOption,
 } from "@/modules/channel-groups/RoutingConfigEditor";
 import {
+  normalizeProviderKey,
+  readAuthFilesModelOwnerGroupMap,
+} from "@/modules/auth-files/helpers/authFilesPageUtils";
+import {
   DEFAULT_VISUAL_VALUES,
   makeClientId,
   type VisualConfigValues,
@@ -38,6 +42,27 @@ function parsePriorityText(value: string): number | null {
   const priority = Number(trimmed);
   return Number.isSafeInteger(priority) ? priority : null;
 }
+
+const normalizeOwnerValue = (value: string): string =>
+  value.trim().replace(/\s+/g, "-").toLowerCase();
+
+const collectMappedOwnersForChannels = (
+  channels: string[],
+  detailsByName: Record<string, ChannelGroupChannelDetail>,
+): string[] => {
+  const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
+  const owners = new Set<string>();
+  for (const channel of channels) {
+    const detail = detailsByName[channel.trim().toLowerCase()];
+    const candidates = [detail?.source, detail?.name, channel];
+    for (const candidate of candidates) {
+      const key = normalizeProviderKey(String(candidate ?? ""));
+      const owner = normalizeOwnerValue(ownerByAuthGroup[key] ?? "");
+      if (owner) owners.add(owner);
+    }
+  }
+  return Array.from(owners);
+};
 
 function hydrateRoutingValues(payload: RoutingConfigItem | undefined): VisualConfigValues {
   const next = createEmptyRoutingValues();
@@ -209,6 +234,27 @@ export function ChannelGroupsPage() {
       ? data.data.map((model) => String(model.id ?? "").trim()).filter(Boolean)
       : [];
     const availability = await loadConfiguredModelAvailability();
+    const selectedOwnerKeys = collectMappedOwnersForChannels(
+      normalizedChannels,
+      availableChannelDetails,
+    );
+    if (selectedOwnerKeys.length > 0) {
+      const selectedOwnerSet = new Set(selectedOwnerKeys);
+      const optionMap = new Map<string, RoutingModelOption>();
+      for (const model of availability.items) {
+        if (!selectedOwnerSet.has(normalizeOwnerValue(model.owned_by ?? ""))) continue;
+        const key = model.id.toLowerCase();
+        if (!optionMap.has(key)) {
+          optionMap.set(key, {
+            id: model.id,
+            owned_by: model.owned_by,
+            description: model.description,
+            pricing: model.pricing,
+          });
+        }
+      }
+      return Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
+    }
     const visibleModels = filterByConfiguredModelAvailability(
       ids.map((id) => ({ id })),
       availability,
@@ -227,7 +273,7 @@ export function ChannelGroupsPage() {
           pricing: metadata?.pricing,
         };
       });
-  }, []);
+  }, [availableChannelDetails]);
 
   const loadPage = useCallback(async () => {
     setLoading(true);

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -153,12 +153,23 @@ describe("ChannelGroupsPage", () => {
       }
       if (path === "/channel-groups") {
         return Promise.resolve({
-          items: [{ name: "Kimi Pool", channels: ["kimi"] }],
+          items: [
+            {
+              name: "Kimi Pool",
+              channels: ["kimi"],
+              "channel-details": [{ name: "kimi", source: "kimi", display_tags: ["kimi"] }],
+            },
+          ],
         });
       }
       if (path.startsWith("/models?")) {
         return Promise.resolve({
-          data: [{ id: "kimi-k2.5" }, { id: "kimi-k2.6" }, { id: "gpt-should-not-leak" }],
+          data: [
+            { id: "kimi-k2" },
+            { id: "kimi-k2-thinking" },
+            { id: "kimi-k2.5" },
+            { id: "gpt-should-not-leak" },
+          ],
         });
       }
       if (path === "/auth-files") {
@@ -181,6 +192,16 @@ describe("ChannelGroupsPage", () => {
               id: "kimi-k2.5",
               owned_by: "kimi-code",
               description: "Kimi K2.5",
+            },
+            {
+              id: "kimi-k2",
+              owned_by: "moonshot",
+              description: "Kimi K2",
+            },
+            {
+              id: "kimi-k2-thinking",
+              owned_by: "moonshot",
+              description: "Kimi K2 Thinking",
             },
             {
               id: "gpt-should-not-leak",
@@ -217,6 +238,8 @@ describe("ChannelGroupsPage", () => {
 
     expect(await screen.findByLabelText("kimi-k2.5")).toBeInTheDocument();
     expect(await screen.findByLabelText("kimi-k2.6")).toBeInTheDocument();
+    expect(screen.queryByLabelText("kimi-k2")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("kimi-k2-thinking")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
修正渠道分组模型列表在认证文件渠道已绑定模型归属时仍混入其它 owned_by 模型的问题。\n\n变更：\n- 选中渠道能通过 channel-details/source 映射到认证文件模型归属时，模型列表直接以该 owner 的可用模型为准。\n- 不再让 /models?allowed_channels 返回的其它 owned_by（例如 moonshot）污染 Kimi Code 这类认证文件归属模型列表。\n- 回归测试覆盖：/models 返回 moonshot 的 kimi-k2/kimi-k2-thinking、认证文件归属为 kimi-code 且实时模型补出 kimi-k2.6 时，最终只显示 kimi-code 模型。\n\n验证：\n- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx --testNamePattern "keeps auth-file live models"\n- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx\n- bun run lint\n- bun run build\n- bun run test src/modules/api-keys/__tests__/ApiKeysPage.test.tsx --testNamePattern "creates, edits, and deletes API key entries"\n- bun run test