### PR TITLE
fix: prefer auth file source for model owner

### DIFF
--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -243,6 +243,81 @@ describe("ChannelGroupsPage", () => {
     expect(screen.queryByLabelText("gpt-should-not-leak")).not.toBeInTheDocument();
   });
 
+  test("uses the auth-file channel source as model owner when live Kimi models report moonshot", async () => {
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        return Promise.resolve({
+          items: [
+            {
+              name: "Kimi Pool",
+              channels: ["kimi"],
+              "channel-details": [{ name: "kimi", source: "kimi", display_tags: ["kimi"] }],
+            },
+          ],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({
+          data: [{ id: "kimi-k2" }, { id: "kimi-k2-thinking" }, { id: "kimi-k2.5" }],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "kimi-account.json", type: "kimi", disabled: false }],
+        });
+      }
+      if (path === "/auth-files/models") {
+        return Promise.resolve({
+          models: [
+            { id: "kimi-k2", display_name: "Kimi K2", owned_by: "moonshot" },
+            { id: "kimi-k2-thinking", display_name: "Kimi K2 Thinking", owned_by: "moonshot" },
+            { id: "kimi-k2.5", display_name: "Kimi K2.5", owned_by: "moonshot" },
+          ],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({ data: [] });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/opencode-go-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "新增分组" }));
+    await user.type(screen.getByPlaceholderText("pro"), "kimi");
+    await user.type(screen.getByPlaceholderText("/pro"), "/kimi");
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(await screen.findByRole("option", { name: "kimi" }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    const table = await screen.findByRole("table", { name: "允许模型" });
+    expect(await within(table).findByLabelText("kimi-k2")).toBeInTheDocument();
+    expect(within(table).getByLabelText("kimi-k2-thinking")).toBeInTheDocument();
+    expect(within(table).getByLabelText("kimi-k2.5")).toBeInTheDocument();
+    expect(within(table).getAllByText("kimi")).toHaveLength(3);
+    expect(within(table).queryByText("moonshot")).not.toBeInTheDocument();
+  });
+
   test("shows channel tags in the selector options and selected rows", async () => {
     mockedApiGet.mockImplementation((path: string) => {
       if (path === "/routing-config") {

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -310,7 +310,7 @@ const loadAuthFileModelItems = async (
         for (const model of liveModels) {
           addModel(map, {
             id: model.id,
-            owned_by: model.owned_by || owner || undefined,
+            owned_by: owner || group || model.owned_by || undefined,
             description: model.display_name,
             source: "auth-file",
           });


### PR DESCRIPTION
修正 Kimi 认证文件模型列表显示 moonshot 归属的问题。\n\n变更：\n- 认证文件实时模型的展示归属优先使用模型归属映射；没有映射时使用认证文件渠道来源（例如 kimi），最后才回退模型 API 返回的 owned_by。\n- 新增回归测试：Kimi 实时模型返回 owned_by=moonshot 时，渠道分组模型列表显示 kimi，且不出现 moonshot。\n\n验证：\n- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx --testNamePattern "uses the auth-file channel source|keeps auth-file live models"\n- bun run test src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx\n- bun run lint\n- bun run build\n- bun run test