### PR TITLE
fix: use auth owner models for cc switch

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -39,6 +39,7 @@ export interface CcSwitchChannelGroupOption {
   allowedModels?: string[];
   channels?: string[];
   modelOwnerKeys?: string[];
+  authoritativeModelOwnerKeys?: string[];
 }
 
 const iconByType: Record<CcSwitchClientType, string> = {
@@ -258,6 +259,10 @@ export function CcSwitchImportConfigModal({
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
   const selectedGroupOption = channelGroupOptions.find((option) => option.value === selectedGroup);
   const selectedGroupAllowedModelsKey = (selectedGroupOption?.allowedModels ?? []).join("\n");
+  const selectedGroupAuthoritativeOwnerKey = (
+    selectedGroupOption?.authoritativeModelOwnerKeys ?? []
+  ).join("\n");
+  const selectedGroupOwnerKey = (selectedGroupOption?.modelOwnerKeys ?? []).join("\n");
 
   useEffect(() => {
     if (!open || !selectedGroup) {
@@ -272,6 +277,37 @@ export function CcSwitchImportConfigModal({
       setAvailableModels(groupAllowedModels);
       setModelsLoading(false);
       return;
+    }
+
+    const authoritativeModelOwnerKeys = new Set(
+      (selectedGroupOption?.authoritativeModelOwnerKeys ?? [])
+        .map(normalizeModelOwnerKey)
+        .filter(Boolean),
+    );
+    if (authoritativeModelOwnerKeys.size > 0) {
+      setModelsLoading(true);
+      modelsApi
+        .getModelConfigs("active")
+        .then((modelConfigs) => {
+          if (cancelled) return;
+          const modelIds = modelConfigs
+            .filter(
+              (model) =>
+                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
+                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.source)),
+            )
+            .map((model) => model.id);
+          setAvailableModels(dedupeModels(modelIds));
+        })
+        .catch(() => {
+          if (!cancelled) setAvailableModels([]);
+        })
+        .finally(() => {
+          if (!cancelled) setModelsLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
     }
 
     const lookupChannels = dedupeModels(selectedGroupOption?.channels ?? []);
@@ -322,7 +358,13 @@ export function CcSwitchImportConfigModal({
     return () => {
       cancelled = true;
     };
-  }, [open, selectedGroup, selectedGroupAllowedModelsKey]);
+  }, [
+    open,
+    selectedGroup,
+    selectedGroupAllowedModelsKey,
+    selectedGroupAuthoritativeOwnerKey,
+    selectedGroupOwnerKey,
+  ]);
 
   const availableModelsKey = availableModels.join("\n");
   useEffect(() => {

--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -9,6 +9,10 @@ import {
   channelGroupsApi,
   type ChannelGroupChannelDetail,
 } from "@/lib/http/apis/channel-groups";
+import {
+  normalizeProviderKey,
+  readAuthFilesModelOwnerGroupMap,
+} from "@/modules/auth-files/helpers/authFilesPageUtils";
 import { useOptionalAuth } from "@/modules/auth/AuthProvider";
 import { ccSwitchImportConfigsApi } from "@/lib/http/apis/ccswitch-import-configs";
 import { Button } from "@/modules/ui/Button";
@@ -65,6 +69,28 @@ const getChannelGroupModelOwnerKeys = (
   return Array.from(keys);
 };
 
+const getChannelGroupMappedModelOwnerKeys = (
+  details: readonly ChannelGroupChannelDetail[] | undefined,
+): string[] => {
+  const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
+  const keys = new Set<string>();
+  for (const detail of details ?? []) {
+    const values = [
+      detail.source,
+      detail.name,
+      ...(detail.default_tags ?? []),
+      ...(detail.custom_tags ?? []),
+      ...(detail.display_tags ?? []),
+    ];
+    for (const value of values) {
+      const authGroup = normalizeProviderKey(String(value ?? ""));
+      const owner = normalizeModelOwnerKey(ownerByAuthGroup[authGroup] ?? "");
+      if (owner) keys.add(owner);
+    }
+  }
+  return Array.from(keys);
+};
+
 export function CcSwitchImportSettingsPage() {
   const { t } = useTranslation();
   const auth = useOptionalAuth();
@@ -101,6 +127,7 @@ export function CcSwitchImportSettingsPage() {
               allowedModels: Array.isArray(item["allowed-models"]) ? item["allowed-models"] : [],
               channels: Array.isArray(item.channels) ? item.channels : [],
               modelOwnerKeys: getChannelGroupModelOwnerKeys(item.channelDetails),
+              authoritativeModelOwnerKeys: getChannelGroupMappedModelOwnerKeys(item.channelDetails),
             }))
             .filter((item) => item.value)
             .sort((left, right) => left.label.localeCompare(right.label)),

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -320,6 +320,63 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(getModelConfigs).toHaveBeenCalledWith("active");
   });
 
+  test("uses the auth-file owner model group as the CC Switch actual model source", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ kimi: "kimi-code" }),
+    );
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "kimicode",
+        description: "Kimi Code route",
+        channels: ["kimi"],
+        channelDetails: [
+          {
+            name: "kimi",
+            source: "kimi",
+            default_tags: ["kimi"],
+            custom_tags: [],
+            hidden_default_tags: [],
+            display_tags: ["kimi"],
+          },
+        ],
+        "path-routes": ["/kimicode"],
+      },
+    ]);
+    listAvailableModels.mockResolvedValue([
+      { id: "kimi-k2" },
+      { id: "kimi-k2-thinking" },
+      { id: "kimi-k2.5" },
+    ]);
+    loadConfiguredModelAvailability.mockResolvedValue({
+      scoped: true,
+      items: [],
+      idSet: new Set(["kimi-k2.5", "kimi-k2.6"]),
+    });
+    getModelConfigs.mockResolvedValue([
+      { id: "kimi-k2.5", owned_by: "kimi-code" },
+      { id: "kimi-k2.6", owned_by: "kimi-code" },
+      { id: "kimi-k2", owned_by: "moonshot" },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /new config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /new cc switch config/i });
+    await user.click(within(dialog).getByRole("tab", { name: /claude code/i }));
+    await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
+    await user.click(await screen.findByRole("option", { name: /kimicode.*\/kimicode/i }));
+
+    expect(await within(dialog).findAllByDisplayValue("kimi-k2.5")).toHaveLength(4);
+    await user.click(within(dialog).getByRole("combobox", { name: /^main model$/i }));
+
+    expect(await screen.findByRole("option", { name: "kimi-k2.6" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "kimi-k2" })).not.toBeInTheDocument();
+    expect(listAvailableModels).not.toHaveBeenCalled();
+    expect(getModelConfigs).toHaveBeenCalledWith("active");
+  });
+
   test("previews the full BaseURL request address from the selected channel group path", async () => {
     renderPage();
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary\n- Carry auth-file model owner group mappings into CC Switch channel group options\n- Use mapped auth owner models as the authoritative actual model source when channel groups have no explicit allowed-models\n- Keep explicit channel group allowed-models and ordinary fallback behavior unchanged\n\n## Tests\n- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx --testNamePattern "auth-file owner model group"\n- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx\n- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/api-keys/__tests__/ApiKeysPage.test.tsx\n- bun run test -- --testTimeout=20000\n- bun run lint\n- bun run build