### PR TITLE
fix: 修复 Provider 标签页切换与刷新加载状态

### DIFF
--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -30,10 +30,7 @@ import { ApiKeyUsageModal } from "@/modules/api-keys/components/ApiKeyUsageModal
 import { useApiKeyPermissionOptions } from "@/modules/api-keys/hooks/useApiKeyPermissionOptions";
 import { useApiKeyUsageView } from "@/modules/api-keys/hooks/useApiKeyUsageView";
 import { CcSwitchImportCardList } from "@/modules/api-keys/components/CcSwitchImportCardList";
-import {
-  buildCcSwitchImportUrl,
-  openCcSwitchImportUrl,
-} from "@/modules/ccswitch/ccswitchImport";
+import { buildCcSwitchImportUrl, openCcSwitchImportUrl } from "@/modules/ccswitch/ccswitchImport";
 import {
   normalizeCcSwitchClaudeAuthField,
   normalizeCcSwitchImportSettings,

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -25,6 +25,7 @@ export function ProviderKeyListCard({
   title,
   description,
   items,
+  loading = false,
   onAdd,
   onEdit,
   onDelete,
@@ -46,6 +47,7 @@ export function ProviderKeyListCard({
   title: string;
   description: string;
   items: ProviderSimpleConfig[];
+  loading?: boolean;
   onAdd: () => void;
   onEdit: (index: number) => void;
   onDelete: (index: number) => void;
@@ -78,6 +80,7 @@ export function ProviderKeyListCard({
       description={description}
       className="flex h-full min-h-0 flex-col"
       bodyClassName="min-h-0 flex flex-1 flex-col"
+      loading={loading}
       actions={
         <Button variant="primary" size="sm" onClick={onAdd}>
           <Plus size={14} />
@@ -88,7 +91,10 @@ export function ProviderKeyListCard({
       {items.length === 0 ? (
         <EmptyState title={t("providers.no_config")} description={t("providers.no_config_desc")} />
       ) : (
-        <div data-testid="providers-tab-scroll" className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+        <div
+          data-testid="providers-tab-scroll"
+          className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+        >
           {items.map((item, idx) => {
             const selectionKey = item.apiKey.trim().toLowerCase();
             const selected = selectedKeys?.has(selectionKey) ?? false;

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -116,7 +116,6 @@ export function ProvidersPage() {
   } | null>(null);
   const [importing, setImporting] = useState(false);
   const [selectedExportKeys, setSelectedExportKeys] = useState<string[]>([]);
-
   const refreshTab = useCallback(
     async (tabId: typeof tab) => {
       setLoading(true);
@@ -356,6 +355,7 @@ export function ProvidersPage() {
         provider === "vertex" ||
         provider === "bedrock"
       ) {
+        setSelectedExportKeys([]);
         setTab(provider);
         await refreshTab(provider);
         if (action === "new") {
@@ -370,6 +370,7 @@ export function ProvidersPage() {
       }
 
       if (provider === "openai") {
+        setSelectedExportKeys([]);
         setTab("openai");
         await refreshTab("openai");
         if (action === "new") {
@@ -384,6 +385,7 @@ export function ProvidersPage() {
       }
 
       if (provider === "ampcode") {
+        setSelectedExportKeys([]);
         setTab("ampcode");
         await refreshTab("ampcode");
       }
@@ -466,18 +468,14 @@ export function ProvidersPage() {
           return openaiProviders;
       }
     },
-    [
-      bedrockKeys,
-      claudeKeys,
-      codexKeys,
-      geminiKeys,
-      openCodeGoKeys,
-      openaiProviders,
-      vertexKeys,
-    ],
+    [bedrockKeys, claudeKeys, codexKeys, geminiKeys, openCodeGoKeys, openaiProviders, vertexKeys],
   );
 
   const currentImportKind = getImportKind();
+  const isActiveTabListLoading = useCallback(
+    (tabId: ProviderTab) => tab === tabId && loading,
+    [loading, tab],
+  );
   const currentTabItems = useMemo(
     () => (currentImportKind ? getCurrentItems(currentImportKind) : []),
     [currentImportKind, getCurrentItems],
@@ -533,13 +531,13 @@ export function ProvidersPage() {
   );
 
   useEffect(() => {
-    setSelectedExportKeys([]);
-  }, [tab]);
-
-  useEffect(() => {
+    if (selectedExportKeys.length === 0) return;
     const selectableKeySet = new Set(currentSelectableKeys);
-    setSelectedExportKeys((prev) => prev.filter((key) => selectableKeySet.has(key)));
-  }, [currentSelectableKeys]);
+    const next = selectedExportKeys.filter((key) => selectableKeySet.has(key));
+    if (next.length !== selectedExportKeys.length) {
+      setSelectedExportKeys(next);
+    }
+  }, [currentSelectableKeys, selectedExportKeys]);
 
   const toggleExportSelection = useCallback((key: string, checked: boolean) => {
     setSelectedExportKeys((prev) => {
@@ -597,7 +595,11 @@ export function ProvidersPage() {
       }
 
       try {
-        const preview = prepareProviderImport(kind, await file.text(), getCurrentItems(kind) as never);
+        const preview = prepareProviderImport(
+          kind,
+          await file.text(),
+          getCurrentItems(kind) as never,
+        );
         setImportPreview({
           kind,
           nextItems: preview.nextItems,
@@ -656,7 +658,7 @@ export function ProvidersPage() {
 
       <div
         data-testid="providers-batch-actions"
-        className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]"
+        className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/3"
       >
         {currentImportKind ? (
           <>
@@ -675,9 +677,8 @@ export function ProvidersPage() {
             <Button
               variant="secondary"
               size="sm"
-              className="!h-8 px-2 text-xs"
+              className="h-8! px-2 text-xs"
               onClick={() => importInputRef.current?.click()}
-              disabled={loading}
             >
               <Upload size={14} />
               {t("providers.import_json")}
@@ -685,7 +686,7 @@ export function ProvidersPage() {
             <Button
               variant="secondary"
               size="sm"
-              className="!h-8 px-2 text-xs"
+              className="h-8! px-2 text-xs"
               onClick={handleExport}
               disabled={currentTabItems.length === 0}
             >
@@ -695,7 +696,7 @@ export function ProvidersPage() {
             <Button
               variant="secondary"
               size="sm"
-              className="!h-8 px-2 text-xs"
+              className="h-8! px-2 text-xs"
               onClick={() => selectAllCurrentItems(!allCurrentSelected)}
               disabled={currentSelectableKeys.length === 0}
             >
@@ -709,7 +710,7 @@ export function ProvidersPage() {
             <Button
               variant="ghost"
               size="sm"
-              className="!h-8 px-2 text-xs"
+              className="h-8! px-2 text-xs"
               onClick={() => setSelectedExportKeys([])}
               disabled={selectedExportCount === 0}
             >
@@ -718,7 +719,7 @@ export function ProvidersPage() {
             <Button
               variant="secondary"
               size="sm"
-              className="!h-8 px-2 text-xs"
+              className="h-8! px-2 text-xs"
               onClick={handleExportSelected}
               disabled={selectedExportCount === 0}
             >
@@ -729,7 +730,7 @@ export function ProvidersPage() {
         <Button
           variant="secondary"
           size="sm"
-          className="!h-8 px-2 text-xs"
+          className="h-8! px-2 text-xs"
           onClick={() => void refreshTab(tab)}
           disabled={loading}
         >
@@ -742,6 +743,8 @@ export function ProvidersPage() {
         value={tab}
         onValueChange={(next) => {
           const nextTab = next as typeof tab;
+          if (nextTab === tab) return;
+          setSelectedExportKeys([]);
           setTab(nextTab);
           void refreshTab(nextTab);
         }}
@@ -787,160 +790,167 @@ export function ProvidersPage() {
             </TabsList>
           </div>
           <TabsContent value="gemini" className="flex min-h-0 flex-1 flex-col">
-          <ProviderKeyListCard
-            icon={Globe}
-            title={t("providers.gemini_keys")}
-            description={t("providers.openai_desc")}
-            items={geminiKeys}
-            onAdd={() => openKeyEditor("gemini", null)}
-            onEdit={(idx) => openKeyEditor("gemini", idx)}
-            onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "gemini", index: idx })}
-            onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("gemini", idx, enabled)}
-            getStats={getSimpleStats}
-            getStatusBar={getSimpleStatusBar}
-            getAccessSummary={getProviderAccessSummary}
-            getLatencyEntry={getLatencyEntry}
-            checkLatency={checkLatency}
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <ProviderKeyListCard
+              icon={Globe}
+              title={t("providers.gemini_keys")}
+              description={t("providers.openai_desc")}
+              items={geminiKeys}
+              loading={isActiveTabListLoading("gemini")}
+              onAdd={() => openKeyEditor("gemini", null)}
+              onEdit={(idx) => openKeyEditor("gemini", idx)}
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "gemini", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("gemini", idx, enabled)}
+              getStats={getSimpleStats}
+              getStatusBar={getSimpleStatusBar}
+              getAccessSummary={getProviderAccessSummary}
+              getLatencyEntry={getLatencyEntry}
+              checkLatency={checkLatency}
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="claude" className="flex min-h-0 flex-1 flex-col">
-          <ProviderKeyListCard
-            icon={Bot}
-            title={t("providers.claude_keys")}
-            description={t("providers.codex_desc")}
-            items={claudeKeys}
-            onAdd={() => openKeyEditor("claude", null)}
-            onEdit={(idx) => openKeyEditor("claude", idx)}
-            onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "claude", index: idx })}
-            onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("claude", idx, enabled)}
-            getStats={getSimpleStats}
-            getStatusBar={getSimpleStatusBar}
-            getAccessSummary={getProviderAccessSummary}
-            getLatencyEntry={getLatencyEntry}
-            checkLatency={checkLatency}
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <ProviderKeyListCard
+              icon={Bot}
+              title={t("providers.claude_keys")}
+              description={t("providers.codex_desc")}
+              items={claudeKeys}
+              loading={isActiveTabListLoading("claude")}
+              onAdd={() => openKeyEditor("claude", null)}
+              onEdit={(idx) => openKeyEditor("claude", idx)}
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "claude", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("claude", idx, enabled)}
+              getStats={getSimpleStats}
+              getStatusBar={getSimpleStatusBar}
+              getAccessSummary={getProviderAccessSummary}
+              getLatencyEntry={getLatencyEntry}
+              checkLatency={checkLatency}
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="codex" className="flex min-h-0 flex-1 flex-col">
-          <ProviderKeyListCard
-            icon={FileKey}
-            title={t("providers.codex_keys")}
-            description={t("providers.gemini_desc")}
-            items={codexKeys}
-            onAdd={() => openKeyEditor("codex", null)}
-            onEdit={(idx) => openKeyEditor("codex", idx)}
-            onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "codex", index: idx })}
-            onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("codex", idx, enabled)}
-            getStats={getSimpleStats}
-            getStatusBar={getSimpleStatusBar}
-            getAccessSummary={getProviderAccessSummary}
-            getLatencyEntry={getLatencyEntry}
-            checkLatency={checkLatency}
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <ProviderKeyListCard
+              icon={FileKey}
+              title={t("providers.codex_keys")}
+              description={t("providers.gemini_desc")}
+              items={codexKeys}
+              loading={isActiveTabListLoading("codex")}
+              onAdd={() => openKeyEditor("codex", null)}
+              onEdit={(idx) => openKeyEditor("codex", idx)}
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "codex", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("codex", idx, enabled)}
+              getStats={getSimpleStats}
+              getStatusBar={getSimpleStatusBar}
+              getAccessSummary={getProviderAccessSummary}
+              getLatencyEntry={getLatencyEntry}
+              checkLatency={checkLatency}
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="opencode-go" className="flex min-h-0 flex-1 flex-col">
-          <ProviderKeyListCard
-            icon={FileKey}
-            iconSrc={iconOpenCodeLight}
-            iconDarkSrc={iconOpenCodeDark}
-            title={t("providers.opencode_go_keys")}
-            description={t("providers.opencode_go_desc")}
-            items={openCodeGoKeys}
-            onAdd={() => openKeyEditor("opencode-go", null)}
-            onEdit={(idx) => openKeyEditor("opencode-go", idx)}
-            onDelete={(idx) =>
-              setConfirm({ type: "deleteKey", keyType: "opencode-go", index: idx })
-            }
-            onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("opencode-go", idx, enabled)}
-            getStats={getSimpleStats}
-            getStatusBar={getSimpleStatusBar}
-            getAccessSummary={getProviderAccessSummary}
-            showBaseUrl={false}
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <ProviderKeyListCard
+              icon={FileKey}
+              iconSrc={iconOpenCodeLight}
+              iconDarkSrc={iconOpenCodeDark}
+              title={t("providers.opencode_go_keys")}
+              description={t("providers.opencode_go_desc")}
+              items={openCodeGoKeys}
+              loading={isActiveTabListLoading("opencode-go")}
+              onAdd={() => openKeyEditor("opencode-go", null)}
+              onEdit={(idx) => openKeyEditor("opencode-go", idx)}
+              onDelete={(idx) =>
+                setConfirm({ type: "deleteKey", keyType: "opencode-go", index: idx })
+              }
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("opencode-go", idx, enabled)}
+              getStats={getSimpleStats}
+              getStatusBar={getSimpleStatusBar}
+              getAccessSummary={getProviderAccessSummary}
+              showBaseUrl={false}
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="vertex" className="flex min-h-0 flex-1 flex-col">
-          <ProviderKeyListCard
-            icon={Database}
-            title={t("providers.vertex_keys")}
-            description={t("providers.vertex_desc")}
-            items={vertexKeys}
-            onAdd={() => openKeyEditor("vertex", null)}
-            onEdit={(idx) => openKeyEditor("vertex", idx)}
-            onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "vertex", index: idx })}
-            getStats={getSimpleStats}
-            getStatusBar={getSimpleStatusBar}
-            getAccessSummary={getProviderAccessSummary}
-            getLatencyEntry={getLatencyEntry}
-            checkLatency={checkLatency}
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <ProviderKeyListCard
+              icon={Database}
+              title={t("providers.vertex_keys")}
+              description={t("providers.vertex_desc")}
+              items={vertexKeys}
+              loading={isActiveTabListLoading("vertex")}
+              onAdd={() => openKeyEditor("vertex", null)}
+              onEdit={(idx) => openKeyEditor("vertex", idx)}
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "vertex", index: idx })}
+              getStats={getSimpleStats}
+              getStatusBar={getSimpleStatusBar}
+              getAccessSummary={getProviderAccessSummary}
+              getLatencyEntry={getLatencyEntry}
+              checkLatency={checkLatency}
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="bedrock" className="flex min-h-0 flex-1 flex-col">
-          <ProviderKeyListCard
-            icon={Cloud}
-            title={t("providers.bedrock_keys")}
-            description={t("providers.bedrock_desc")}
-            items={bedrockKeys}
-            onAdd={() => openKeyEditor("bedrock", null)}
-            onEdit={(idx) => openKeyEditor("bedrock", idx)}
-            onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "bedrock", index: idx })}
-            onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("bedrock", idx, enabled)}
-            getStats={getSimpleStats}
-            getStatusBar={getSimpleStatusBar}
-            getAccessSummary={getProviderAccessSummary}
-            getLatencyEntry={getLatencyEntry}
-            checkLatency={checkLatency}
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <ProviderKeyListCard
+              icon={Cloud}
+              title={t("providers.bedrock_keys")}
+              description={t("providers.bedrock_desc")}
+              items={bedrockKeys}
+              loading={isActiveTabListLoading("bedrock")}
+              onAdd={() => openKeyEditor("bedrock", null)}
+              onEdit={(idx) => openKeyEditor("bedrock", idx)}
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "bedrock", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("bedrock", idx, enabled)}
+              getStats={getSimpleStats}
+              getStatusBar={getSimpleStatusBar}
+              getAccessSummary={getProviderAccessSummary}
+              getLatencyEntry={getLatencyEntry}
+              checkLatency={checkLatency}
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="openai" className="flex min-h-0 flex-1 flex-col">
-          <OpenAIProvidersTab
-            providers={openaiProviders}
-            openOpenAIEditor={openOpenAIEditor}
-            confirmDelete={(index) => setConfirm({ type: "deleteOpenAI", index })}
-            maskApiKey={maskApiKey}
-            getKeyEntryStats={getOpenAIKeyEntryStats}
-            getProviderStats={getOpenAIProviderStats}
-            getProviderStatusBar={getOpenAIProviderStatusBar}
-            onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
-              void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
-            }
-            selectedKeys={selectedExportKeySet}
-            onToggleSelected={toggleExportSelection}
-          />
-        </TabsContent>
+            <OpenAIProvidersTab
+              providers={openaiProviders}
+              loading={isActiveTabListLoading("openai")}
+              openOpenAIEditor={openOpenAIEditor}
+              confirmDelete={(index) => setConfirm({ type: "deleteOpenAI", index })}
+              maskApiKey={maskApiKey}
+              getKeyEntryStats={getOpenAIKeyEntryStats}
+              getProviderStats={getOpenAIProviderStats}
+              getProviderStatusBar={getOpenAIProviderStatusBar}
+              onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
+                void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
+              }
+              selectedKeys={selectedExportKeySet}
+              onToggleSelected={toggleExportSelection}
+            />
+          </TabsContent>
 
           <TabsContent value="ampcode" className="flex min-h-0 flex-1 flex-col">
-          <AmpcodePanel
-            loading={loading}
-            isPending={isPending}
-            saveAmpcode={saveAmpcode}
-            ampcode={ampcode}
-            ampMappings={ampMappings}
-            ampUpstreamUrl={ampUpstreamUrl}
-            setAmpUpstreamUrl={setAmpUpstreamUrl}
-            ampUpstreamApiKey={ampUpstreamApiKey}
-            setAmpUpstreamApiKey={setAmpUpstreamApiKey}
-            ampForceMappings={ampForceMappings}
-            setAmpForceMappings={setAmpForceMappings}
-            setAmpMappings={setAmpMappings}
-          />
-        </TabsContent>
+            <AmpcodePanel
+              loading={loading}
+              isPending={isPending}
+              saveAmpcode={saveAmpcode}
+              ampcode={ampcode}
+              ampMappings={ampMappings}
+              ampUpstreamUrl={ampUpstreamUrl}
+              setAmpUpstreamUrl={setAmpUpstreamUrl}
+              ampUpstreamApiKey={ampUpstreamApiKey}
+              setAmpUpstreamApiKey={setAmpUpstreamApiKey}
+              ampForceMappings={ampForceMappings}
+              setAmpForceMappings={setAmpForceMappings}
+              setAmpMappings={setAmpMappings}
+            />
+          </TabsContent>
         </div>
       </Tabs>
 
@@ -1024,11 +1034,7 @@ export function ProvidersPage() {
         }}
         footer={
           <>
-            <Button
-              variant="secondary"
-              onClick={() => setImportPreview(null)}
-              disabled={importing}
-            >
+            <Button variant="secondary" onClick={() => setImportPreview(null)} disabled={importing}>
               {t("common.cancel")}
             </Button>
             <Button

--- a/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -9,7 +9,7 @@ import { ToastProvider } from "@/modules/ui/ToastProvider";
 const mocks = vi.hoisted(() => ({
   getGeminiKeys: vi.fn(async () => []),
   getClaudeConfigs: vi.fn(async () => []),
-  getCodexConfigs: vi.fn(async () => []),
+  getCodexConfigs: vi.fn(async (): Promise<any[]> => []),
   getOpenCodeGoConfigs: vi.fn(async () => []),
   getVertexConfigs: vi.fn(async () => []),
   getBedrockConfigs: vi.fn(async () => []),
@@ -127,6 +127,109 @@ describe("ProvidersPage import/export", () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
+  test("keeps import enabled while switching and refreshing provider tabs", async () => {
+    const user = userEvent.setup();
+    let resolveRefresh: ((configs: any[]) => void) | undefined;
+    mocks.getCodexConfigs
+      .mockResolvedValueOnce([
+        {
+          name: "Codex Main",
+          apiKey: "sk-old",
+        },
+      ] as any)
+      .mockImplementationOnce(() => new Promise<any[]>((resolve) => (resolveRefresh = resolve)));
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const importButton = await screen.findByRole("button", { name: /Import JSON/i });
+    expect(importButton).toBeEnabled();
+
+    await user.click(screen.getByRole("tab", { name: /Codex/ }));
+    expect(importButton).toBeEnabled();
+    expect(await screen.findByText("Codex Main")).toBeInTheDocument();
+
+    const refreshButton = screen.getByRole("button", { name: /Refresh/i });
+    await user.click(refreshButton);
+    expect(importButton).toBeEnabled();
+    await waitFor(() => expect(refreshButton).toBeDisabled());
+    expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+
+    resolveRefresh?.([]);
+    await waitFor(() => expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument());
+  });
+
+  test("shows page loading when switching to an unloaded provider tab", async () => {
+    const user = userEvent.setup();
+    let resolveSwitch: ((configs: any[]) => void) | undefined;
+    mocks.getCodexConfigs.mockImplementationOnce(
+      () => new Promise<any[]>((resolve) => (resolveSwitch = resolve)),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const refreshButton = await screen.findByRole("button", { name: /Refresh/i });
+    await user.click(screen.getByRole("tab", { name: /Codex/ }));
+
+    await waitFor(() => expect(refreshButton).toBeDisabled());
+    expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+
+    resolveSwitch?.([
+      {
+        name: "Codex Main",
+        apiKey: "sk-old",
+      },
+    ]);
+    expect(await screen.findByText("Codex Main")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument());
+  });
+
+  test("does not refresh when clicking the active provider tab again", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const codexTab = await screen.findByRole("tab", { name: /Codex/ });
+    await user.click(codexTab);
+    expect(await screen.findByText("Codex Main")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(1));
+
+    await user.click(codexTab);
+    expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(1);
+  });
+
   test("keeps provider import, refresh, and export actions together in the batch toolbar", async () => {
     const user = userEvent.setup();
 
@@ -148,7 +251,9 @@ describe("ProvidersPage import/export", () => {
     const batchActions = screen.getByTestId("providers-batch-actions");
     expect(within(batchActions).getByRole("button", { name: /Import JSON/i })).toBeInTheDocument();
     expect(within(batchActions).getByRole("button", { name: /Refresh/i })).toBeInTheDocument();
-    expect(within(batchActions).getByRole("button", { name: /^Export JSON$/i })).toBeInTheDocument();
+    expect(
+      within(batchActions).getByRole("button", { name: /^Export JSON$/i }),
+    ).toBeInTheDocument();
   });
 
   test("locks the page shell height and uses a dedicated scroll area for the active tab content", async () => {

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -9,6 +9,7 @@ import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 
 interface OpenAIProvidersTabProps {
   providers: OpenAIProvider[];
+  loading?: boolean;
   openOpenAIEditor: (index: number | null) => void;
   confirmDelete: (index: number) => void;
   maskApiKey: (value: string) => string;
@@ -30,6 +31,7 @@ interface OpenAIProvidersTabProps {
 
 export function OpenAIProvidersTab({
   providers,
+  loading = false,
   openOpenAIEditor,
   confirmDelete,
   maskApiKey,
@@ -48,6 +50,7 @@ export function OpenAIProvidersTab({
       description={t("providers.claude_desc")}
       className="flex h-full min-h-0 flex-col"
       bodyClassName="min-h-0 flex flex-1 flex-col"
+      loading={loading}
       actions={
         <Button variant="primary" size="sm" onClick={() => openOpenAIEditor(null)}>
           <Plus size={14} />
@@ -61,7 +64,10 @@ export function OpenAIProvidersTab({
           description={t("providers.no_openai_desc")}
         />
       ) : (
-        <div data-testid="providers-tab-scroll" className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+        <div
+          data-testid="providers-tab-scroll"
+          className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+        >
           {providers.map((provider, idx) => {
             const selectionKey = provider.name.trim().toLowerCase();
             const selected = selectedKeys?.has(selectionKey) ?? false;
@@ -141,7 +147,9 @@ export function OpenAIProvidersTab({
                                         : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
                                     ].join(" ")}
                                   >
-                                    {entryEnabled ? t("providers.enabled") : t("providers.disabled")}
+                                    {entryEnabled
+                                      ? t("providers.enabled")
+                                      : t("providers.disabled")}
                                   </span>
                                   <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
                                     {t("providers.success_stats", { count: entryStats.success })}

--- a/src/modules/ui/Tabs.tsx
+++ b/src/modules/ui/Tabs.tsx
@@ -119,7 +119,7 @@ export function TabsList({
       {indicator ? (
         <motion.div
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-0.5 left-0 top-0.5 z-0 rounded-full bg-white shadow-sm shadow-black/[0.04] dark:bg-[#46464C] dark:shadow-none"
+          className="pointer-events-none absolute bottom-0.5 left-0 top-0.5 z-0 rounded-full bg-white shadow-sm shadow-black/4 dark:bg-[#46464C] dark:shadow-none"
           initial={false}
           animate={{ x: indicator.x, width: indicator.width }}
           transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}

--- a/src/modules/ui/Tooltip.tsx
+++ b/src/modules/ui/Tooltip.tsx
@@ -263,13 +263,13 @@ export function TooltipBubble({
       role="tooltip"
       className={[
         interactive ? "pointer-events-auto select-text" : "pointer-events-none",
-        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-[28rem] dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
+        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-md dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
       ].join(" ")}
       style={style}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <span className="block break-words text-slate-900 dark:text-white">{content}</span>
+      <span className="block wrap-break-word text-slate-900 dark:text-white">{content}</span>
     </span>,
     document.body,
   );


### PR DESCRIPTION
修复 Provider 管理页在标签页切换和刷新时的加载状态问题。

本次改动让 Provider 列表的 loading 状态只作用于当前激活的标签页内容，避免刷新时误禁用导入操作；切换标签页时会清空导出选择，并在可选项变化后同步清理无效选择。同时避免重复点击当前标签页触发不必要的刷新请求。

新增测试覆盖了导入按钮在切换/刷新期间保持可用、未加载标签页显示 loading、重复点击当前
标签页不重复刷新，以及导入/刷新/导出操作保持在批量工具栏内。