### PR TITLE
fix: preserve CC Switch edit mappings

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -125,13 +125,12 @@ function reconcileGenericMappings(
   const currentByTarget = new Map(
     currentMappings
       .filter((mapping) => !mapping.role)
-      .map((mapping) => [mapping.targetModel.toLowerCase(), mapping]),
+      .map((mapping) => [mapping.targetModel.trim().toLowerCase(), mapping]),
   );
-  const targets = dedupeModels(
-    models.length > 0
-      ? models
-      : currentMappings.map((mapping) => mapping.targetModel).filter(Boolean),
-  );
+  const currentTargets = currentMappings
+    .filter((mapping) => !mapping.role)
+    .map((mapping) => mapping.targetModel);
+  const targets = dedupeModels(models.length > 0 ? [...currentTargets, ...models] : currentTargets);
   const resolvedTargets = targets.length > 0 ? targets : dedupeModels([fallbackModel]);
 
   return resolvedTargets.map((targetModel) => {
@@ -170,6 +169,25 @@ function reconcileClaudeMappings(
   });
 }
 
+function resolveGenericDefaultModel(
+  modelMappings: readonly CcSwitchModelMapping[],
+  fallbackModel: string,
+): string {
+  const normalizedFallback = fallbackModel.trim();
+  if (
+    normalizedFallback &&
+    modelMappings.some(
+      (mapping) =>
+        !mapping.role &&
+        mapping.requestModel.trim().toLowerCase() === normalizedFallback.toLowerCase(),
+    )
+  ) {
+    return normalizedFallback;
+  }
+  return modelMappings.find((mapping) => !mapping.role && mapping.requestModel.trim())
+    ?.requestModel.trim() || "";
+}
+
 function reconcileModelMappings(draft: ConfigDraft, models: readonly string[]): ConfigDraft {
   const modelMappings =
     draft.clientType === "claude"
@@ -178,7 +196,7 @@ function reconcileModelMappings(draft: ConfigDraft, models: readonly string[]): 
   const defaultModel =
     draft.clientType === "claude"
       ? modelMappings.find((mapping) => mapping.role === "main")?.targetModel || ""
-      : modelMappings.find((mapping) => mapping.requestModel.trim())?.requestModel.trim() || "";
+      : resolveGenericDefaultModel(modelMappings, draft.defaultModel);
 
   return {
     ...draft,
@@ -212,7 +230,7 @@ function prepareDraftForSave(draft: ConfigDraft): ConfigDraft {
   const defaultModel =
     draft.clientType === "claude"
       ? normalizedMappings.find((mapping) => mapping.role === "main")?.targetModel || ""
-      : normalizedMappings.find((mapping) => mapping.requestModel)?.requestModel || "";
+      : resolveGenericDefaultModel(normalizedMappings, draft.defaultModel);
 
   return {
     ...draft,
@@ -369,15 +387,16 @@ export function CcSwitchImportConfigModal({
   const availableModelsKey = availableModels.join("\n");
   useEffect(() => {
     if (!open) return;
-    setDraft((current) =>
-      selectedGroup
+    setDraft((current) => {
+      const currentSelectedGroup = current.allowedChannelGroups[0] ?? "";
+      return currentSelectedGroup
         ? reconcileModelMappings(current, availableModels)
         : {
             ...current,
             defaultModel: "",
             modelMappings: [],
-          },
-    );
+          };
+    });
   }, [availableModelsKey, open, selectedGroup]);
 
   const authFieldOptions = useMemo(

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -377,6 +377,66 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(getModelConfigs).toHaveBeenCalledWith("active");
   });
 
+  test("preserves saved generic model mappings when reopening an edited config", async () => {
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "kimicode",
+        description: "Kimi Code route",
+        "path-routes": ["/kimicode"],
+        "allowed-models": ["kimi-k2.5"],
+      },
+    ]);
+    listConfigs.mockResolvedValue([
+      {
+        id: "cfg-kimi",
+        clientType: "codex",
+        providerName: "Relay Kimi",
+        note: "saved mapping",
+        defaultModel: "gpt-5.5",
+        allowedChannelGroups: ["kimicode"],
+        endpointPath: "/v1",
+        usageAutoInterval: 30,
+        modelMappings: [
+          {
+            requestModel: "gpt-5.5",
+            targetModel: "moonshot-v1-128k",
+          },
+        ],
+      },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(await screen.findByText("Relay Kimi")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /edit config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
+    expect(
+      await within(dialog).findByLabelText(/cc switch request model for kimi-k2\.5/i),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText(/cc switch request model for moonshot-v1-128k/i),
+    ).toHaveValue("gpt-5.5");
+
+    await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(replaceConfigs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: "cfg-kimi",
+          defaultModel: "gpt-5.5",
+          allowedChannelGroups: ["kimicode"],
+          modelMappings: expect.arrayContaining([
+            {
+              requestModel: "gpt-5.5",
+              targetModel: "moonshot-v1-128k",
+            },
+          ]),
+        }),
+      ]),
+    );
+  });
+
   test("previews the full BaseURL request address from the selected channel group path", async () => {
     renderPage();
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- preserve saved CC Switch generic model mappings when the edit modal reloads available channel models
- keep the saved request default model during reconcile and save preparation
- add a regression test for reopening an edited config after refresh-like API reload

## Tests
- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx src/lib/http/apis/__tests__/ccswitch-import-configs.test.ts
- bun run build
- bun run lint (passes with existing unused-variable warnings in unrelated files)