### PR TITLE
fix: stop management polling after auth ban

### DIFF
--- a/src/lib/http/__tests__/client.test.ts
+++ b/src/lib/http/__tests__/client.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiClient } from "@/lib/http/client";
+
+describe("ApiClient authentication failure handling", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("dispatches unauthorized and suppresses later fetches after management IP ban", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "IP banned due to too many failed attempts. Try again in 30m0s",
+        }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({
+      apiBase: "http://localhost:8317",
+      managementKey: "stale-key",
+    });
+
+    let unauthorizedEvents = 0;
+    const onUnauthorized = () => {
+      unauthorizedEvents += 1;
+    };
+    window.addEventListener("unauthorized", onUnauthorized);
+
+    try {
+      await expect(client.get("/api-keys")).rejects.toThrow("IP banned due to too many failed attempts");
+      expect(unauthorizedEvents).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await expect(client.get("/auth-files")).rejects.toThrow("Management session is no longer valid");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("unauthorized", onUnauthorized);
+    }
+  });
+
+  test("setConfig resumes requests after an authentication suspension", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "missing management key" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({
+      apiBase: "http://localhost:8317",
+      managementKey: "old-key",
+    });
+
+    await expect(client.get("/config")).rejects.toThrow("missing management key");
+    await expect(client.get("/config")).rejects.toThrow("Management session is no longer valid");
+
+    client.setConfig({
+      apiBase: "http://localhost:8317",
+      managementKey: "new-key",
+    });
+
+    await expect(client.get("/config")).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/http/client.ts
+++ b/src/lib/http/client.ts
@@ -34,9 +34,12 @@ export class ApiClient {
 
   private managementKey = "";
 
+  private authSuspended = false;
+
   setConfig(config: ApiClientConfig): void {
     this.apiBase = computeManagementApiBase(config.apiBase);
     this.managementKey = config.managementKey.trim();
+    this.authSuspended = false;
   }
 
   private buildUrl(path: string, params?: RequestOptions["params"]): string {
@@ -153,6 +156,23 @@ export class ApiClient {
     return message;
   }
 
+  private shouldSuspendAuth(status: number, message: string): boolean {
+    if (status === 401) return true;
+    return status === 403 && /IP banned due to too many failed attempts/i.test(message);
+  }
+
+  private suspendAuth(): void {
+    if (this.authSuspended) return;
+    this.authSuspended = true;
+    window.dispatchEvent(new Event("unauthorized"));
+  }
+
+  private assertAuthActive(): void {
+    if (this.authSuspended) {
+      throw new Error("Management session is no longer valid. Please sign in again.");
+    }
+  }
+
   private applyVersionHeaders(response: Response): void {
     const version = this.readHeader(response.headers, VERSION_HEADER_KEYS);
     const buildDate = this.readHeader(response.headers, BUILD_DATE_HEADER_KEYS);
@@ -198,6 +218,7 @@ export class ApiClient {
       responseType?: ResponseType;
     } = {},
   ): Promise<T> {
+    this.assertAuthActive();
     const { controller, cleanup } = this.createAbortController(options);
 
     try {
@@ -210,14 +231,14 @@ export class ApiClient {
         headers,
       });
 
-      if (response.status === 401) {
-        window.dispatchEvent(new Event("unauthorized"));
-      }
-
       this.applyVersionHeaders(response);
 
       if (!response.ok) {
-        throw new Error(await this.buildErrorMessage(response));
+        const message = await this.buildErrorMessage(response);
+        if (this.shouldSuspendAuth(response.status, message)) {
+          this.suspendAuth();
+        }
+        throw new Error(message);
       }
 
       if (response.status === 204) {
@@ -322,6 +343,7 @@ export class ApiClient {
   }
 
   async downloadToFile(path: string, preferredFilename: string, options?: RequestOptions): Promise<void> {
+    this.assertAuthActive();
     const { controller, cleanup } = this.createAbortController(options);
 
     try {
@@ -333,13 +355,14 @@ export class ApiClient {
         signal: controller.signal,
       });
 
-      if (response.status === 401) {
-        window.dispatchEvent(new Event("unauthorized"));
-      }
       this.applyVersionHeaders(response);
 
       if (!response.ok) {
-        throw new Error(await this.buildErrorMessage(response));
+        const message = await this.buildErrorMessage(response);
+        if (this.shouldSuspendAuth(response.status, message)) {
+          this.suspendAuth();
+        }
+        throw new Error(message);
       }
 
       const filename = this.extractDownloadFilename(response.headers, preferredFilename);


### PR DESCRIPTION
## Summary

Complements the CliRelay issue #183 backend fix from the management UI side.

- Treats management IP-ban 403 responses like an auth failure.
- Suspends the shared API client after 401 or management-ban 403 so background panels stop polling with stale credentials.
- Resumes requests only after `setConfig`, which happens during a fresh sign-in.

## Tests

- `bun run test src/lib/http/__tests__/client.test.ts`
- `bun run check` (passes with the existing 3 unused-code warnings in unrelated files)
