### PR TITLE
Generate isolated CC Switch import routes

### DIFF
--- a/src/lib/http/apis/__tests__/ccswitch-import-configs.test.ts
+++ b/src/lib/http/apis/__tests__/ccswitch-import-configs.test.ts
@@ -26,6 +26,7 @@ describe("ccSwitchImportConfigsApi", () => {
         note: "kimicode",
         defaultModel: "kimi-k2.5",
         allowedChannelGroups: ["kimicode"],
+        routePath: "/kimicode/cs_kimi",
         endpointPath: "/v1",
         usageAutoInterval: 30,
         apiKeyField: "ANTHROPIC_API_KEY",
@@ -40,6 +41,7 @@ describe("ccSwitchImportConfigsApi", () => {
       expect.objectContaining({
         id: "kimi-code",
         "client-type": "claude",
+        "route-path": "/kimicode/cs_kimi",
         "model-mappings": [
           { role: "main", "request-model": "kimi-k2.5", "target-model": "kimi-k2.5" },
           {

--- a/src/lib/http/apis/ccswitch-import-configs.ts
+++ b/src/lib/http/apis/ccswitch-import-configs.ts
@@ -42,8 +42,7 @@ const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
       const requestModel =
         normalizeString(
           record["request-model"] ?? record.requestModel ?? record.request ?? record.alias,
-        ) ??
-        (normalizedRole ? normalizedRole : targetModel);
+        ) ?? (normalizedRole ? normalizedRole : targetModel);
       if (!targetModel || !requestModel) return null;
       return {
         ...(normalizedRole ? { role: normalizedRole } : {}),
@@ -76,6 +75,7 @@ export function normalizeCcSwitchImportConfigs(raw: unknown): CcSwitchImportConf
         allowedChannelGroups: normalizeStringList(
           record["allowed-channel-groups"] ?? record.allowedChannelGroups,
         ),
+        routePath: normalizeString(record["route-path"] ?? record.routePath),
         endpointPath: normalizeString(record["endpoint-path"]),
         usageAutoInterval: normalizeNumber(record["usage-auto-interval"]),
         apiKeyField:
@@ -101,6 +101,7 @@ const serializeCcSwitchImportConfig = (config: CcSwitchImportConfigListItem) => 
     "target-model": mapping.targetModel,
   })),
   "allowed-channel-groups": [...config.allowedChannelGroups],
+  "route-path": config.routePath,
   "endpoint-path": config.endpointPath,
   "usage-auto-interval": config.usageAutoInterval,
   ...(config.clientType === "claude" && config.apiKeyField

--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -10,7 +10,6 @@ import {
   type ApiKeyPermissionProfile,
 } from "@/lib/http/apis/api-key-permission-profiles";
 import { ccSwitchImportConfigsApi } from "@/lib/http/apis/ccswitch-import-configs";
-import type { ChannelGroupItem } from "@/lib/http/apis/channel-groups";
 import { detectApiBaseFromLocation } from "@/lib/connection";
 import { useOptionalAuth } from "@/modules/auth/AuthProvider";
 import {
@@ -101,7 +100,7 @@ export function ApiKeysPage() {
   const [saving, setSaving] = useState(false);
   const [permissionProfiles, setPermissionProfiles] = useState<ApiKeyPermissionProfile[]>([]);
   const [form, setForm] = useState<ApiKeyFormValues>(() => makeEmptyApiKeyForm());
-  const { channelGroupItems, channelGroupByName, fetchModelOptions, refreshPermissionOptions } =
+  const { channelGroupItems, channelGroupByName, refreshPermissionOptions } =
     useApiKeyPermissionOptions();
   const {
     usageViewKey,
@@ -455,7 +454,7 @@ export function ApiKeysPage() {
         ? groupItem["path-routes"][0]
         : "";
       const baseApiUrl = auth?.state.apiBase || detectApiBaseFromLocation();
-      const baseUrl = appendRoutePath(baseApiUrl, routePath || "");
+      const baseUrl = appendRoutePath(baseApiUrl, config.routePath || routePath || "");
 
       const settings =
         ccSwitchImportConfigs.length > 0

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -488,6 +488,7 @@ describe("ApiKeysPage", () => {
         note: "Primary route",
         "default-model": "gpt-5.4",
         "allowed-channel-groups": ["pro", "team-a"],
+        "route-path": "/pro/cs_codex",
         "endpoint-path": "/openai/v2",
         "usage-auto-interval": 45,
       },
@@ -521,7 +522,9 @@ describe("ApiKeysPage", () => {
     expect(parsed.searchParams.get("app")).toBe("codex");
     expect(parsed.searchParams.get("apiKey")).toBe("sk-group-1234567890");
     expect(parsed.searchParams.get("name")).toBe("Preset Codex");
-    expect(parsed.searchParams.get("endpoint")).toBe("http://localhost:3000/pro/openai/v2");
+    expect(parsed.searchParams.get("endpoint")).toBe(
+      "http://localhost:3000/pro/cs_codex/openai/v2",
+    );
     expect(parsed.searchParams.get("model")).toBe("gpt-5.4");
     expect(parsed.searchParams.get("usageAutoInterval")).toBe("45");
 
@@ -554,6 +557,7 @@ describe("ApiKeysPage", () => {
         note: "Role defaults",
         "default-model": "claude-sonnet-4-5",
         "allowed-channel-groups": ["team-a"],
+        "route-path": "/team-a/cs_claude",
         "endpoint-path": "",
         "usage-auto-interval": 60,
         "api-key-field": "ANTHROPIC_AUTH_TOKEN",
@@ -594,6 +598,7 @@ describe("ApiKeysPage", () => {
     const parsed = new URL(openedUrl);
     expect(parsed.searchParams.get("app")).toBe("claude");
     expect(parsed.searchParams.get("name")).toBe("Preset Claude");
+    expect(parsed.searchParams.get("endpoint")).toBe("http://localhost:3000/team-a/cs_claude");
     expect(parsed.searchParams.get("model")).toBe("claude-sonnet-4-5");
     expect(parsed.searchParams.get("haikuModel")).toBe("claude-haiku-4-5");
     expect(parsed.searchParams.get("sonnetModel")).toBe("claude-sonnet-4-5");
@@ -634,6 +639,7 @@ describe("ApiKeysPage", () => {
         note: "Team route",
         "default-model": "gpt-5.4",
         "allowed-channel-groups": ["team-a"],
+        "route-path": "/team-a/cs_team",
         "endpoint-path": "/v1",
         "usage-auto-interval": 30,
       },
@@ -679,7 +685,7 @@ describe("ApiKeysPage", () => {
     const openedUrl = String(openSpy.mock.calls.at(-1)?.[0] ?? "");
     const parsed = new URL(openedUrl);
     expect(parsed.searchParams.get("name")).toBe("Team Codex");
-    expect(parsed.searchParams.get("endpoint")).toBe("http://localhost:3000/team-a/v1");
+    expect(parsed.searchParams.get("endpoint")).toBe("http://localhost:3000/team-a/cs_team/v1");
     expect(parsed.searchParams.get("model")).toBe("gpt-5.4");
 
     openSpy.mockRestore();

--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -25,10 +25,11 @@ import {
   normalizeCcSwitchClaudeAuthField,
   type CcSwitchClaudeAuthField,
 } from "@/modules/ccswitch/ccswitchImportSettings";
-import type {
-  CcSwitchClaudeModelRole,
-  CcSwitchImportConfigListItem,
-  CcSwitchModelMapping,
+import {
+  ensureCcSwitchRoutePath,
+  type CcSwitchClaudeModelRole,
+  type CcSwitchImportConfigListItem,
+  type CcSwitchModelMapping,
 } from "@/modules/ccswitch/ccswitchImportConfigList";
 
 export interface CcSwitchChannelGroupOption {
@@ -72,7 +73,9 @@ const normalizeRoutePath = (path: string | undefined): string => {
 };
 
 const appendUrlPath = (baseUrl: string, path: string): string => {
-  const normalizedBase = String(baseUrl ?? "").trim().replace(/\/+$/, "");
+  const normalizedBase = String(baseUrl ?? "")
+    .trim()
+    .replace(/\/+$/, "");
   const normalizedPath = normalizeRoutePath(path);
   if (!normalizedBase) return normalizedPath;
   if (!normalizedPath) return normalizedBase;
@@ -148,9 +151,7 @@ function reconcileClaudeMappings(
   fallbackModel: string,
 ): CcSwitchModelMapping[] {
   const currentByRole = new Map(
-    currentMappings
-      .filter((mapping) => mapping.role)
-      .map((mapping) => [mapping.role, mapping]),
+    currentMappings.filter((mapping) => mapping.role).map((mapping) => [mapping.role, mapping]),
   );
 
   return CLAUDE_ROLE_ORDER.map((role) => {
@@ -184,8 +185,11 @@ function resolveGenericDefaultModel(
   ) {
     return normalizedFallback;
   }
-  return modelMappings.find((mapping) => !mapping.role && mapping.requestModel.trim())
-    ?.requestModel.trim() || "";
+  return (
+    modelMappings
+      .find((mapping) => !mapping.role && mapping.requestModel.trim())
+      ?.requestModel.trim() || ""
+  );
 }
 
 function reconcileModelMappings(draft: ConfigDraft, models: readonly string[]): ConfigDraft {
@@ -216,6 +220,7 @@ function modelOptions(models: readonly string[]): SearchableSelectOption[] {
 function prepareDraftForSave(draft: ConfigDraft): ConfigDraft {
   const endpointPath = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[draft.clientType].endpointPath;
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
+  const routePath = ensureCcSwitchRoutePath(draft.routePath, selectedGroup, draft.id);
   const normalizedMappings = draft.modelMappings
     .map((mapping) => {
       const targetModel = mapping.targetModel.trim();
@@ -235,6 +240,7 @@ function prepareDraftForSave(draft: ConfigDraft): ConfigDraft {
   return {
     ...draft,
     allowedChannelGroups: selectedGroup ? [selectedGroup] : [],
+    routePath,
     endpointPath,
     defaultModel,
     modelMappings: normalizedMappings,
@@ -269,7 +275,8 @@ export function CcSwitchImportConfigModal({
     if (!open) return;
     setDraft({
       ...value,
-      endpointPath: DEFAULT_CC_SWITCH_IMPORT_SETTINGS[value.clientType].endpointPath,
+      endpointPath:
+        value.endpointPath || DEFAULT_CC_SWITCH_IMPORT_SETTINGS[value.clientType].endpointPath,
     });
     setAvailableModels([]);
   }, [open, value]);
@@ -444,8 +451,11 @@ export function CcSwitchImportConfigModal({
       }),
     [channelGroupOptions],
   );
+  const previewRoutePath = selectedGroup
+    ? ensureCcSwitchRoutePath(draft.routePath, selectedGroup, draft.id)
+    : "";
   const fullBaseUrl = appendUrlPath(
-    appendUrlPath(baseUrl, selectedGroupOption?.routePath ?? ""),
+    appendUrlPath(baseUrl, previewRoutePath),
     DEFAULT_CC_SWITCH_IMPORT_SETTINGS[draft.clientType].endpointPath,
   );
   const currentModelOptions = useMemo(() => modelOptions(availableModels), [availableModels]);
@@ -496,7 +506,8 @@ export function CcSwitchImportConfigModal({
         ...current,
         modelMappings,
         defaultModel:
-          modelMappings.find((mapping) => !mapping.role && mapping.requestModel.trim())
+          modelMappings
+            .find((mapping) => !mapping.role && mapping.requestModel.trim())
             ?.requestModel.trim() ?? "",
       };
     });
@@ -557,6 +568,7 @@ export function CcSwitchImportConfigModal({
                 setDraft((current) => ({
                   ...current,
                   allowedChannelGroups: next ? [next] : [],
+                  routePath: next ? ensureCcSwitchRoutePath("", next, current.id) : "",
                   modelMappings: [],
                   defaultModel: "",
                 }))

--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -5,10 +5,7 @@ import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
 import iconGemini from "@/assets/icons/gemini.svg";
 import { detectApiBaseFromLocation } from "@/lib/connection";
-import {
-  channelGroupsApi,
-  type ChannelGroupChannelDetail,
-} from "@/lib/http/apis/channel-groups";
+import { channelGroupsApi, type ChannelGroupChannelDetail } from "@/lib/http/apis/channel-groups";
 import {
   normalizeProviderKey,
   readAuthFilesModelOwnerGroupMap,
@@ -187,7 +184,7 @@ export function CcSwitchImportSettingsPage() {
                   {t(client.labelKey)}
                 </div>
                 <div className="font-mono text-[11px] text-slate-500 dark:text-white/45">
-                  {row.endpointPath || t("ccswitch.import_endpoint_root")}
+                  {row.routePath || row.endpointPath || t("ccswitch.import_endpoint_root")}
                 </div>
               </div>
             </div>

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -85,10 +85,7 @@ describe("CcSwitchImportSettingsPage", () => {
       { name: "pro", description: "Pro route", "path-routes": ["/pro"] },
       { name: "team-a", description: "Team A route", "path-routes": ["/team-a"] },
     ]);
-    listAvailableModels.mockResolvedValue([
-      { id: "deepseek-v4-flash" },
-      { id: "kimi-k2" },
-    ]);
+    listAvailableModels.mockResolvedValue([{ id: "deepseek-v4-flash" }, { id: "kimi-k2" }]);
     getModelConfigs.mockResolvedValue([]);
     listConfigs.mockResolvedValue([]);
     replaceConfigs.mockResolvedValue(undefined);
@@ -148,16 +145,20 @@ describe("CcSwitchImportSettingsPage", () => {
     const origin = window.location.origin;
 
     expect(within(dialog).queryByLabelText(/codex endpoint path/i)).not.toBeInTheDocument();
-    expect(within(dialog).queryByRole("combobox", { name: /default model/i })).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole("combobox", { name: /default model/i }),
+    ).not.toBeInTheDocument();
     expect(within(dialog).queryByText(/for codex cli/i)).not.toBeInTheDocument();
-    expect(within(dialog).getByText(/select a channel group to load available models/i)).toBeInTheDocument();
+    expect(
+      within(dialog).getByText(/select a channel group to load available models/i),
+    ).toBeInTheDocument();
     expect(within(dialog).queryByDisplayValue("gpt-5.5")).not.toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
     await user.click(await screen.findByRole("option", { name: /pro.*\/pro/i }));
 
     expect(within(dialog).getByTestId("ccswitch-config-endpoint-preview")).toHaveTextContent(
-      `${origin}/pro/v1`,
+      new RegExp(`^${origin.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/pro/cs_[a-z0-9]+/v1$`),
     );
 
     const requestModelInput = await within(dialog).findByLabelText(
@@ -183,6 +184,7 @@ describe("CcSwitchImportSettingsPage", () => {
           note: "Pro preset",
           defaultModel: "gpt-5.5",
           allowedChannelGroups: ["pro"],
+          routePath: expect.stringMatching(/^\/pro\/cs_[a-z0-9]+$/),
           endpointPath: "/v1",
           modelMappings: expect.arrayContaining([
             {
@@ -452,7 +454,9 @@ describe("CcSwitchImportSettingsPage", () => {
     await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
     await user.click(await screen.findByRole("option", { name: /team-a.*\/team-a/i }));
 
-    expect(endpointPreview).toHaveTextContent(`${origin}/team-a/v1`);
+    expect(endpointPreview).toHaveTextContent(
+      new RegExp(`^${origin.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/team-a/cs_[a-z0-9]+/v1$`),
+    );
   });
 
   test("creates a Claude Code config with main and family default models", async () => {
@@ -496,6 +500,7 @@ describe("CcSwitchImportSettingsPage", () => {
           providerName: "Relay Claude",
           defaultModel: "claude-sonnet-4-5",
           allowedChannelGroups: ["pro"],
+          routePath: expect.stringMatching(/^\/pro\/cs_[a-z0-9]+$/),
           apiKeyField: "ANTHROPIC_AUTH_TOKEN",
           modelMappings: expect.arrayContaining([
             {

--- a/src/modules/ccswitch/__tests__/ccswitchImportConfigList.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImportConfigList.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { createCcSwitchRoutePath } from "@/modules/ccswitch/ccswitchImportConfigList";
+
+describe("ccswitchImportConfigList", () => {
+  test("creates distinct CC Switch route paths from generated config IDs", () => {
+    const routeA = createCcSwitchRoutePath("kimicode", "ccswitch-1770000000000-alpha123");
+    const routeB = createCcSwitchRoutePath("kimicode", "ccswitch-1770000000000-bravo456");
+
+    expect(routeA).toBe("/kimicode/cs_alpha123");
+    expect(routeB).toBe("/kimicode/cs_bravo456");
+    expect(routeA).not.toBe(routeB);
+  });
+});

--- a/src/modules/ccswitch/ccswitchImportConfigList.ts
+++ b/src/modules/ccswitch/ccswitchImportConfigList.ts
@@ -26,6 +26,7 @@ export interface CcSwitchImportConfigListItem {
   defaultModel: string;
   modelMappings: CcSwitchModelMapping[];
   allowedChannelGroups: string[];
+  routePath: string;
   endpointPath: string;
   usageAutoInterval: number;
   apiKeyField?: CcSwitchClaudeAuthField;
@@ -114,6 +115,47 @@ const createConfigId = () => {
   return `ccswitch-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 };
 
+const normalizeRouteSegment = (value: unknown): string =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\/+|\/+$/g, "")
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const routeTokenFromSeed = (seed: string): string => {
+  const parts = seed
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  const normalized = parts.join("");
+  const suffix = parts.at(-1) ?? "";
+  const tokenSource = suffix.length >= 6 ? suffix : normalized;
+  const token = tokenSource.slice(-12);
+  if (token) return token;
+  return Math.random().toString(36).slice(2, 14) || "route";
+};
+
+export function createCcSwitchRoutePath(group: string, seed: string = createConfigId()): string {
+  const groupSegment = normalizeRouteSegment(group);
+  if (!groupSegment) return "";
+  return `/${groupSegment}/cs_${routeTokenFromSeed(seed)}`;
+}
+
+export function ensureCcSwitchRoutePath(
+  routePath: string | undefined,
+  group: string,
+  seed: string,
+): string {
+  const groupSegment = normalizeRouteSegment(group);
+  if (!groupSegment) return "";
+  const normalizedRoutePath = normalizeCcSwitchEndpointPath(routePath);
+  if (normalizedRoutePath.toLowerCase().startsWith(`/${groupSegment}/`)) {
+    return normalizedRoutePath;
+  }
+  return createCcSwitchRoutePath(groupSegment, seed);
+}
+
 export function deriveCcSwitchImportSettingsFromConfigList(
   configs: readonly CcSwitchImportConfigListItem[],
 ) {
@@ -167,8 +209,10 @@ export function createCcSwitchImportConfig(
       ? modelMappings.find((mapping) => mapping.role === "main")?.targetModel
       : modelMappings.find((mapping) => mapping.requestModel)?.requestModel;
 
+  const id = String(input.id ?? "").trim() || createConfigId();
+
   return {
-    id: String(input.id ?? "").trim() || createConfigId(),
+    id,
     clientType: input.clientType,
     providerName: String(input.providerName ?? "").trim() || defaultProviderName(input.clientType),
     note: String(input.note ?? "").trim(),
@@ -178,6 +222,7 @@ export function createCcSwitchImportConfig(
       String(defaults.defaultModel ?? "").trim(),
     modelMappings,
     allowedChannelGroups: normalizeChannelGroups(input.allowedChannelGroups),
+    routePath: normalizeCcSwitchEndpointPath(input.routePath),
     endpointPath: normalizeCcSwitchEndpointPath(input.endpointPath ?? defaults.endpointPath),
     usageAutoInterval: normalizeUsageAutoInterval(
       input.usageAutoInterval,


### PR DESCRIPTION
## Summary
- persist route-path in CC Switch import configs
- generate unique /group/cs_<id> namespaces for each imported preset
- use saved route paths when building CC Switch import BaseURL values

## Test Plan
- bunx vitest run src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx src/modules/api-keys/__tests__/ApiKeysPage.test.tsx src/lib/http/apis/__tests__/ccswitch-import-configs.test.ts src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/ccswitch/__tests__/ccswitchImportConfigList.test.ts
- bun run lint
- bunx oxfmt <changed files> --check
- bun run build
- bun run check
