### PR TITLE
fix: allow kimi auth file channel aliases

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -270,4 +270,35 @@ describe("AuthFileDetailModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(saveChannelEditor).toHaveBeenCalled();
   });
+
+  test("shows the channel alias editor for Kimi auth files without account_type metadata", () => {
+    renderDetailModal({
+      detailTab: "fields",
+      detailFile: {
+        name: "kimi-1770000000000.json",
+        label: "Kimi Team A",
+        type: "kimi",
+        provider: "kimi",
+        size: 256,
+      },
+      prefixProxyEditor: {
+        ...basePrefixProxyEditor,
+        fileName: "kimi-1770000000000.json",
+        json: { type: "kimi", refresh_token: "kimi-refresh-token" },
+        prefix: "",
+        proxyUrl: "",
+        proxyId: "",
+      },
+      channelEditor: {
+        open: true,
+        fileName: "kimi-1770000000000.json",
+        label: "Kimi Team A",
+        saving: false,
+        error: null,
+      },
+    });
+
+    expect(screen.getByText("Channel name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g. Gemini Primary")).toHaveValue("Kimi Team A");
+  });
 });

--- a/src/modules/auth-files/components/AuthFileDetailModal.tsx
+++ b/src/modules/auth-files/components/AuthFileDetailModal.tsx
@@ -15,8 +15,8 @@ import { EChart } from "@/modules/ui/charts/EChart";
 import { ProxyPoolSelect } from "@/modules/proxies/ProxyPoolSelect";
 import { useProxyPoolChecks } from "@/modules/proxies/useProxyPoolChecks";
 import {
+  canRenameAuthFileChannel,
   downloadTextAsFile,
-  isOauthAuthFile,
   matchesModelPattern,
   normalizeProviderKey,
   parseAdditionalQuotaWindowLabel,
@@ -124,15 +124,15 @@ export function AuthFileDetailModal({
   const detailProviderKey = detailFile ? normalizeProviderKey(resolveFileType(detailFile)) : "";
   const supportsUsageTrend = detailProviderKey === "kimi" || detailProviderKey === "codex";
   const excludedModels = excluded[providerKey] ?? [];
-  const isOauthDetailFile = detailFile ? isOauthAuthFile(detailFile) : false;
+  const canRenameChannel = detailFile ? canRenameAuthFileChannel(detailFile) : false;
   const channelBaseline = detailFile ? readAuthFileChannelName(detailFile) : "";
   const channelEditorMatchesFile = Boolean(
     detailFile && channelEditor.fileName === detailFile.name,
   );
   const channelLabelValue =
-    isOauthDetailFile && channelEditorMatchesFile ? channelEditor.label : channelBaseline;
+    canRenameChannel && channelEditorMatchesFile ? channelEditor.label : channelBaseline;
   const channelDirty =
-    isOauthDetailFile && channelEditorMatchesFile && channelEditor.label.trim() !== channelBaseline;
+    canRenameChannel && channelEditorMatchesFile && channelEditor.label.trim() !== channelBaseline;
   const saveFieldsDisabled =
     prefixProxyEditor.loading ||
     prefixProxyEditor.saving ||
@@ -455,7 +455,7 @@ export function AuthFileDetailModal({
                   </div>
                 ) : (
                   <div className="max-w-3xl space-y-5" data-testid="auth-file-fields-grid">
-                    {isOauthDetailFile ? (
+                    {canRenameChannel ? (
                       <div className="grid gap-2">
                         <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
                           {t("auth_files.channel_name_label")}

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -721,9 +721,12 @@ export const isOauthAuthFile = (file: AuthFileItem): boolean =>
     .trim()
     .toLowerCase() === "oauth";
 
+export const canRenameAuthFileChannel = (file: AuthFileItem): boolean =>
+  isOauthAuthFile(file) || normalizeProviderKey(resolveFileType(file)) === "kimi";
+
 export const resolveAuthFileDisplayName = (file: AuthFileItem): string => {
   const channelName = readAuthFileChannelName(file);
-  if (isOauthAuthFile(file) && channelName) return channelName;
+  if (canRenameAuthFileChannel(file) && channelName) return channelName;
   return String(file.name || "");
 };
 

--- a/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -17,7 +17,7 @@ import {
   dateTimeLocalInputToIso,
   formatFileSize,
   MAX_AUTH_FILE_SIZE,
-  isOauthAuthFile,
+  canRenameAuthFileChannel,
   normalizeAuthIndexValue,
   normalizeProviderKey,
   normalizeAuthFileSubscriptionPeriod,
@@ -410,7 +410,7 @@ export function useAuthFilesDetailEditors(
       if (prefixProxyEditor.fileName !== detailFile.name) {
         void openPrefixProxyEditor(detailFile);
       }
-      if (isOauthAuthFile(detailFile) && channelEditor.fileName !== detailFile.name) {
+      if (canRenameAuthFileChannel(detailFile) && channelEditor.fileName !== detailFile.name) {
         openChannelEditor(detailFile);
       }
       return;


### PR DESCRIPTION
修复 Kimi 认证文件无法像 Codex 一样设置渠道别名的问题。

变更：
- Kimi 认证文件详情弹窗允许编辑渠道名/别名。
- Kimi 旧数据即使缺少 account_type，也会在前端展示别名编辑入口。
- Kimi 别名会作为认证文件展示名，方便在请求日志里区分具体文件。

验证：
- bun run test src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
- bun run lint
- bun run build
- bun run bundle:diff
- bun run check
- bunx oxfmt src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx src/modules/auth-files/components/AuthFileDetailModal.tsx src/modules/auth-files/helpers/authFilesPageUtils.ts src/modules/auth-files/hooks/useAuthFilesDetailEditors.ts --check

说明：全仓 bunx oxfmt . --check 仍有 41 个既有格式问题，本 PR 未引入也未批量格式化这些无关文件。
