### PR TITLE
fix: show group fill-first scheduling mode

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -746,11 +746,14 @@ export function RoutingConfigEditor({
         width: "w-[190px] min-w-[190px]",
         cellClassName: "min-w-0 whitespace-nowrap text-slate-700 dark:text-white/75",
         render: (group) => {
-          const summary = summarizePriorityMode(
-            group.channels,
-            t("channel_groups_page.round_robin_mode"),
-            t("channel_groups_page.priority_short"),
-          );
+          const summary =
+            group.strategy === "fill-first"
+              ? t("channel_groups_page.routing_strategy_fill_first")
+              : summarizePriorityMode(
+                  group.channels,
+                  t("channel_groups_page.round_robin_mode"),
+                  t("channel_groups_page.priority_short"),
+                );
           return (
             <OverflowTooltip content={summary} className="block min-w-0">
               <span className="block truncate">{summary}</span>

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -120,6 +120,34 @@ describe("RoutingConfigEditor", () => {
     expect(screen.getByTestId("group-strategy")).toHaveTextContent("fill-first");
   });
 
+  test("shows fill-first as the table scheduling mode for that group", async () => {
+    await i18n.changeLanguage("zh-CN");
+
+    render(
+      <Harness
+        initialValues={{
+          ...DEFAULT_VISUAL_VALUES,
+          routingChannelGroups: [
+            {
+              id: "group-kimicode",
+              name: "kimicode",
+              description: "",
+              strategy: "fill-first",
+              channels: [
+                { id: "channel-main", name: "Main Codex", priority: "" },
+                { id: "channel-backup", name: "Backup Claude", priority: "" },
+              ],
+              allowedModels: [],
+            },
+          ],
+        }}
+      />,
+    );
+
+    const row = screen.getByRole("row", { name: /kimicode/i });
+    expect(row).toHaveTextContent("优先首个可用渠道");
+  });
+
   test("defaults model tab selections to every channel-scoped model", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();


### PR DESCRIPTION
Fixes the channel groups table scheduling-mode summary so a group configured with `fill-first` displays the group-scoped scheduling strategy instead of falling back to the priority summary.\n\nValidation:\n- `npm test -- src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx`\n- `npm test -- src/modules/channel-groups`\n- `npm run lint` (existing unrelated warning in `ProviderKeyModal.tsx`)\n- `npm run build`\n- Full `npm test` currently has one unrelated baseline failure in `AuthFilesPage.files-table.test.tsx`, reproduced on current `dev`.