### PR TITLE
fix: mark disabled group channels

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2608,6 +2608,7 @@
     "status_invalid": "Issue",
     "deleted_channels_count": "{{count}} deleted channel",
     "deleted_badge": "Deleted",
+    "disabled_badge": "Disabled",
     "round_robin_mode": "Round robin",
     "manage_routes": "Manage path routes",
     "routes_modal_title": "Path routes",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1711,6 +1711,7 @@
     "status_invalid": "Issue",
     "deleted_channels_count": "{{count}} deleted channel",
     "deleted_badge": "Deleted",
+    "disabled_badge": "Disabled",
     "round_robin_mode": "Round robin",
     "manage_routes": "Manage path routes",
     "routes_modal_title": "Path routes",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2843,6 +2843,7 @@
     "status_invalid": "异常",
     "deleted_channels_count": "{{count}} 个已删除渠道",
     "deleted_badge": "已删除",
+    "disabled_badge": "已禁用",
     "round_robin_mode": "轮询",
     "manage_routes": "管理路径路由",
     "routes_modal_title": "路径路由",

--- a/src/lib/http/apis/channel-groups.ts
+++ b/src/lib/http/apis/channel-groups.ts
@@ -4,6 +4,7 @@ import type { TagDisplayFields } from "@/lib/http/types";
 export interface ChannelGroupChannelDetail extends TagDisplayFields {
   name: string;
   source?: string;
+  disabled?: boolean;
 }
 
 export interface ChannelGroupItem {
@@ -40,6 +41,7 @@ const normalizeChannelDetail = (value: unknown): ChannelGroupChannelDetail | nul
   return {
     name,
     source: typeof detail.source === "string" ? detail.source.trim() : undefined,
+    disabled: detail.disabled === true,
     default_tags: normalizeStringList(detail.default_tags),
     custom_tags: normalizeStringList(detail.custom_tags),
     hidden_default_tags: normalizeStringList(detail.hidden_default_tags),

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -217,6 +217,10 @@ function readChannelDisplayTags(detail?: ChannelGroupChannelDetail | null): stri
     .filter((tag, index, list) => Boolean(tag) && list.indexOf(tag) === index);
 }
 
+function isDisabledChannel(detail?: ChannelGroupChannelDetail | null): boolean {
+  return detail?.disabled === true;
+}
+
 function renderChannelTags(tags: string[]) {
   if (tags.length === 0) return null;
   return (
@@ -839,41 +843,51 @@ export function RoutingConfigEditor({
         key: "channel",
         label: t("channel_groups_page.table_channels"),
         cellClassName: "min-w-0 whitespace-nowrap",
-        render: (channel) => (
-          <OverflowTooltip content={channel.name} className="block min-w-0">
-            <span className="block min-w-0">
-              <span
-                className={`flex min-w-0 items-center gap-2 truncate text-sm ${
-                  draftStaleChannelIds.has(channel.id)
-                    ? "text-rose-700 dark:text-rose-200"
-                    : "text-slate-900 dark:text-white"
-                }`}
-              >
-                <span className="truncate">{channel.name}</span>
-                {draftStaleChannelIds.has(channel.id) ? (
-                  <span className="inline-flex shrink-0 items-center rounded-full bg-rose-50 px-2 py-0.5 text-[10px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
-                    {t("channel_groups_page.deleted_badge")}
+        render: (channel) => {
+          const detail = availableChannelDetails[normalizeChannelName(channel.name)];
+          const displayTags = readChannelDisplayTags(detail);
+          const isStale = draftStaleChannelIds.has(channel.id);
+          const isDisabled = isDisabledChannel(detail);
+          return (
+            <OverflowTooltip content={channel.name} className="block min-w-0">
+              <span className="block min-w-0">
+                <span
+                  className={`flex min-w-0 items-center gap-2 truncate text-sm ${
+                    isStale
+                      ? "text-rose-700 dark:text-rose-200"
+                      : isDisabled
+                        ? "text-slate-500 dark:text-white/45"
+                        : "text-slate-900 dark:text-white"
+                  }`}
+                >
+                  <span className="truncate">{channel.name}</span>
+                  {isStale ? (
+                    <span className="inline-flex shrink-0 items-center rounded-full bg-rose-50 px-2 py-0.5 text-[10px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                      {t("channel_groups_page.deleted_badge")}
+                    </span>
+                  ) : null}
+                  {!isStale && isDisabled ? (
+                    <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/55">
+                      {t("channel_groups_page.disabled_badge")}
+                    </span>
+                  ) : null}
+                </span>
+                {displayTags.length > 0 ? (
+                  <span className="mt-1 flex flex-wrap gap-1">
+                    {displayTags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                      >
+                        {tag}
+                      </span>
+                    ))}
                   </span>
                 ) : null}
               </span>
-              {readChannelDisplayTags(availableChannelDetails[normalizeChannelName(channel.name)])
-                .length > 0 ? (
-                <span className="mt-1 flex flex-wrap gap-1">
-                  {readChannelDisplayTags(
-                    availableChannelDetails[normalizeChannelName(channel.name)],
-                  ).map((tag) => (
-                    <span
-                      key={tag}
-                      className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </span>
-              ) : null}
-            </span>
-          </OverflowTooltip>
-        ),
+            </OverflowTooltip>
+          );
+        },
       },
       {
         key: "priority",

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
+import type { ChannelGroupChannelDetail } from "@/lib/http/apis/channel-groups";
 import { DEFAULT_VISUAL_VALUES, type VisualConfigValues } from "@/modules/config/visual/types";
 import {
   RoutingConfigEditor,
@@ -31,9 +32,13 @@ vi.mock("goey-toast", () => ({
 function Harness({
   initialValues,
   loadModelsForChannels,
+  availableChannels = ["Team A Claude", "Main Codex", "Backup Claude"],
+  availableChannelDetails,
 }: {
   initialValues?: VisualConfigValues;
   loadModelsForChannels?: (channels: string[]) => Promise<Array<string | RoutingModelOption>>;
+  availableChannels?: string[];
+  availableChannelDetails?: Record<string, ChannelGroupChannelDetail>;
 }) {
   const [values, setValues] = useState<VisualConfigValues>({
     ...DEFAULT_VISUAL_VALUES,
@@ -47,7 +52,8 @@ function Harness({
       <ToastProvider>
         <RoutingConfigEditor
           values={values}
-          availableChannels={["Team A Claude", "Main Codex", "Backup Claude"]}
+          availableChannels={availableChannels}
+          availableChannelDetails={availableChannelDetails}
           loadModelsForChannels={loadModelsForChannels}
           onChange={(patch) => setValues((prev) => ({ ...prev, ...patch }))}
         />
@@ -483,5 +489,61 @@ describe("RoutingConfigEditor", () => {
         description: expect.stringContaining("Legacy Claude"),
       }),
     );
+  });
+
+  test("shows disabled auth-file channels as disabled instead of deleted", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+
+    render(
+      <Harness
+        availableChannels={["Main Codex", "GptPlus8"]}
+        availableChannelDetails={{
+          "main codex": {
+            name: "Main Codex",
+            source: "codex",
+            default_tags: [],
+            custom_tags: [],
+            hidden_default_tags: [],
+            display_tags: ["codex"],
+          },
+          gptplus8: {
+            name: "GptPlus8",
+            source: "codex",
+            disabled: true,
+            default_tags: [],
+            custom_tags: [],
+            hidden_default_tags: [],
+            display_tags: ["codex"],
+          },
+        }}
+        initialValues={{
+          ...DEFAULT_VISUAL_VALUES,
+          routingChannelGroups: [
+            {
+              id: "group-mixed",
+              name: "chatgpt-mix",
+              description: "pro 和 plus 账号池的混合池",
+              strategy: "round-robin",
+              allowedModels: [],
+              channels: [
+                { id: "channel-deleted", name: "GptPlus6", priority: "20" },
+                { id: "channel-disabled", name: "GptPlus8", priority: "" },
+                { id: "channel-valid", name: "Main Codex", priority: "" },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /异常/ }));
+
+    expect(screen.getByText("1 个已删除渠道")).toBeInTheDocument();
+    expect(screen.getAllByText("GptPlus6").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("GptPlus8").length).toBeGreaterThan(0);
+    const disabledRow = screen.getByRole("row", { name: /GptPlus8/ });
+    expect(within(disabledRow).getByText("已禁用")).toBeInTheDocument();
+    expect(within(disabledRow).queryByText("已删除")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- parse channel-group channel detail disabled state from the management API
- render disabled channels in the group editor as grey with a disabled badge
- keep deleted/stale channel warnings scoped to truly missing channels

## Tests
- npm test -- src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx -t "shows disabled auth-file channels as disabled instead of deleted"
- npm test -- src/modules/channel-groups
- npm run lint
- npm run build