### PR TITLE
fix: keep kimi auth display fallback

### DIFF
--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -709,7 +709,7 @@ export const buildLast7DayAxis = () => {
 };
 
 export const readAuthFileChannelName = (file: AuthFileItem): string => {
-  const candidates = [file.label, file.email, file.provider, file.type];
+  const candidates = [file.label, file.email];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
   }


### PR DESCRIPTION
## Summary

Fix Kimi auth-file display fallback so files without a custom channel label keep showing their filename instead of the provider/type value.

## Test Plan

- npx vitest run src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --testNamePattern "cards view shows only kimi coding quotas and marks depleted weekly quota red"
- npx vitest run src/modules/auth-files/__tests__/AuthFileDetailModal.test.tsx
- npm run build