### PR TITLE
ci: add Bun frontend PR checks

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -1,0 +1,50 @@
+name: PR Test Build
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-test-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.2
+
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Test
+        run: bun run test:ci
+
+      - name: Build
+        run: bun run build
+
+      - name: Bundle diff
+        run: bun run bundle:diff

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ bun run build
 bun run preview
 ```
 
+### Quality Checks
+
+Pull requests to `dev` and `main` run lint, low-concurrency Vitest, build, and bundle diff in GitHub Actions. The frontend package manager is Bun (`packageManager: bun@1.2.2`); use `bun run ...` commands for local spot checks and leave full CI validation to GitHub Actions when local hardware is constrained.
+
 ## 📁 Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "bun run lint && bun run build && bun run bundle:diff",
     "bundle:diff": "node scripts/bundle-diff.mjs",
     "test": "vitest run",
+    "test:ci": "vitest run --no-file-parallelism --maxWorkers=1 --testTimeout=30000 --reporter=dot",
     "test:watch": "vitest",
     "e2e": "playwright test"
   },

--- a/scripts/bundle-diff.mjs
+++ b/scripts/bundle-diff.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { gzipSync } from "node:zlib";
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 
 const root = resolve(import.meta.dirname, "..");
 const distAssetsDir = join(root, "dist", "assets");
@@ -124,6 +124,7 @@ const markdown = [
   "",
 ].join("\n");
 
+mkdirSync(dirname(outputPath), { recursive: true });
 writeFileSync(outputPath, markdown);
 console.log(`Bundle diff written to ${outputPath}`);
 if (failures.length) {


### PR DESCRIPTION
## Summary
- add a frontend PR workflow that uses Bun for install, lint, low-concurrency Vitest, build, and bundle diff
- add a dedicated bun run test:ci script for CI-safe Vitest settings
- document that PR quality checks run in GitHub Actions and Bun is the canonical frontend package manager

## Local verification
- git diff --check
- package.json JSON parse check
- workflow YAML parse check

Full frontend tests/build are intentionally left to GitHub Actions to avoid local hardware pressure.