### PR TITLE
docs: define dev to main merge workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@
 - 安装依赖：`bun install`
 - 开发启动：`bun run dev`
 - 构建：`bun run build`
-- 测试：暂无（当前仓库未配置测试脚本/用例）
+- 测试：`bun run test`
+- CI 低并发测试：`bun run test:ci`（优先交给 GitHub Actions，不要在本地默认执行全量测试）
 - Lint：`bun run lint`
 - 格式化：`bun run format`
 - 格式化检查（CI 友好，如有）：`bunx oxfmt . --check`
@@ -120,6 +121,17 @@
 - 所有实现类任务（包含新增需求、bugfix、文档/规范修改、配置调整等）默认都必须以最新 `origin/dev` 为基线创建功能分支；不得从过期分支、`main` 或未同步的本地分支直接开始。若当前工作区已有未提交改动，必须使用隔离 worktree 或其它不污染现有改动的方式从最新 `dev` 开分支。
 - 除非用户明确要求“只开 PR 不合并”“暂不合并”“停在分支上”等相反指令，否则任务完成并验证通过后，必须主动把功能分支通过 PR/merge 合并回 `dev`，并确认 `origin/dev` 已包含本次提交；不能停留在“已推送分支”或“已创建 PR”状态就结束。
 - 未经用户明确要求，不允许合并、推送或以任何方式改动 `main`/`origin/main`。只有当用户清楚说明“合并到 main”“推送到 main”或同等含义时，才可以执行 `main` 相关操作。
+- `dev` 合并到 `main` 的专用流程（仅当用户明确要求时执行）：
+  - 若用户说“把我们的 dev 合并到 main”且没有限定单个仓库，默认需要分别处理 `CliRelay/` 和 `codeProxy/` 两个仓库；若用户明确指定仓库，则只处理指定仓库。
+  - 只做合并发布流程，不做功能开发、重构或顺手修复；若发现冲突或检查失败，先报告阻塞点，不要在 `main` 或 `dev` 上直接改代码。
+  - 开始前先在每个目标仓库执行 `git fetch origin --prune`，确认 `dev == origin/dev`、`main == origin/main`。本地分支落后时只允许 fast-forward；当前工作区脏或在其它任务分支上时，使用临时 worktree/临时目录处理，不要切走或覆盖用户现有改动。
+  - 先用 `git log --oneline origin/main..origin/dev` 或等价命令确认 `dev` 是否确实领先 `main`；如果没有领先提交，直接报告该仓库已同步，不要创建空 PR。
+  - 合并必须通过 GitHub PR：优先复用已有 `base=main`、`head=dev` 的 open PR；没有则创建 `dev -> main` PR。不要本地直接 merge 后推 `main`，不要 force push。
+  - 测试和构建默认交给 GitHub Actions。合并流程中不要在本地跑全量 `go test ./...`、`bun run test`、`bun run build`、`npm`/`npx` 等重负载命令；只做 `git status`、`git diff --check`、PR/check 状态查询这类轻量检查。本仓库如确需本地轻量命令，必须使用 Bun（`bun run ...`），不要使用 npm。
+  - 使用 `gh pr checks --watch` 或等价方式等待 PR 必要检查完成；检查通过后再执行 PR merge。检查失败时读取失败日志，区分是既有测试失败、CI 配置问题还是真实代码问题，并向用户说明，不要盲目本地重跑高负载测试。
+  - 如果 PR 出现冲突，不要在 `main` 或 `dev` 上手工解冲突；从最新 `origin/dev` 新建修复分支解决冲突/兼容问题，走 PR 合回 `dev` 后，再重新发起 `dev -> main`。
+  - PR 合并后再次 `git fetch origin --prune`，fast-forward 本地 `main`/`dev` 到远端，最后报告每个仓库的 `dev`、`origin/dev`、`main`、`origin/main` 短哈希以及 PR 链接和检查结论。
+  - 合并到 `main` 不等于允许手动部署、重启或替换远端服务；除非用户另行明确要求生产操作，否则只完成 GitHub 合并和同步确认。
 - 合并/推送时只包含本次任务相关文件，不要把本地未跟踪目录或无关改动一起提交。
 
 （可选）在此处追加本项目特有的关键路径、命令、约束与注意事项。该区块不会被生成脚本覆盖。


### PR DESCRIPTION
## Summary
- document the dedicated dev to main merge flow
- require PR-based merges and GitHub Actions checks
- avoid local heavy tests/builds during merge-only tasks
- update frontend command notes to use Bun test/test:ci instead of stale no-test wording

## Local verification
- git diff --check

No local tests/builds were run because this is documentation-only and merge verification should run in GitHub Actions.