### PR TITLE
Fix mixed channel group model lists

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -284,6 +284,7 @@ export function CcSwitchImportConfigModal({
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
   const selectedGroupOption = channelGroupOptions.find((option) => option.value === selectedGroup);
   const selectedGroupAllowedModelsKey = (selectedGroupOption?.allowedModels ?? []).join("\n");
+  const selectedGroupChannelsKey = (selectedGroupOption?.channels ?? []).join("\n");
   const selectedGroupAuthoritativeOwnerKey = (
     selectedGroupOption?.authoritativeModelOwnerKeys ?? []
   ).join("\n");
@@ -309,32 +310,6 @@ export function CcSwitchImportConfigModal({
         .map(normalizeModelOwnerKey)
         .filter(Boolean),
     );
-    if (authoritativeModelOwnerKeys.size > 0) {
-      setModelsLoading(true);
-      modelsApi
-        .getModelConfigs("active")
-        .then((modelConfigs) => {
-          if (cancelled) return;
-          const modelIds = modelConfigs
-            .filter(
-              (model) =>
-                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
-                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.source)),
-            )
-            .map((model) => model.id);
-          setAvailableModels(dedupeModels(modelIds));
-        })
-        .catch(() => {
-          if (!cancelled) setAvailableModels([]);
-        })
-        .finally(() => {
-          if (!cancelled) setModelsLoading(false);
-        });
-      return () => {
-        cancelled = true;
-      };
-    }
-
     const lookupChannels = dedupeModels(selectedGroupOption?.channels ?? []);
     const modelOwnerKeys = new Set(
       (selectedGroupOption?.modelOwnerKeys ?? []).map(normalizeModelOwnerKey).filter(Boolean),
@@ -352,26 +327,46 @@ export function CcSwitchImportConfigModal({
         const availability = await loadConfiguredModelAvailability();
         if (cancelled) return;
         let visibleModels = filterByConfiguredModelAvailability(models, availability);
-        if (modelOwnerKeys.size > 0) {
+        const optionMap = new Map<string, string>();
+        const addModelId = (id: string) => {
+          const normalized = String(id ?? "").trim();
+          if (!normalized) return;
+          const key = normalized.toLowerCase();
+          if (!optionMap.has(key)) optionMap.set(key, normalized);
+        };
+        const needsModelConfigs = authoritativeModelOwnerKeys.size > 0 || modelOwnerKeys.size > 0;
+        if (needsModelConfigs) {
           const modelConfigs = await modelsApi.getModelConfigs("active").catch(() => []);
           if (cancelled) return;
-          const allowedModelIds = new Set(
-            modelConfigs
-              .filter(
-                (model) =>
-                  modelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
-                  modelOwnerKeys.has(normalizeModelOwnerKey(model.source)),
-              )
-              .map((model) => model.id.toLowerCase()),
-          );
-          if (allowedModelIds.size > 0) {
-            visibleModels = visibleModels.filter((model) =>
-              allowedModelIds.has(model.id.toLowerCase()),
+          if (modelOwnerKeys.size > 0 && authoritativeModelOwnerKeys.size === 0) {
+            const allowedModelIds = new Set(
+              modelConfigs
+                .filter(
+                  (model) =>
+                    modelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
+                    modelOwnerKeys.has(normalizeModelOwnerKey(model.source)),
+                )
+                .map((model) => model.id.toLowerCase()),
             );
+            if (allowedModelIds.size > 0) {
+              visibleModels = visibleModels.filter((model) =>
+                allowedModelIds.has(model.id.toLowerCase()),
+              );
+            }
+          }
+          if (authoritativeModelOwnerKeys.size > 0) {
+            for (const model of modelConfigs) {
+              if (
+                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
+                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.source))
+              ) {
+                addModelId(model.id);
+              }
+            }
           }
         }
-        const modelIds = visibleModels.map((model) => model.id);
-        setAvailableModels(dedupeModels(modelIds));
+        for (const model of visibleModels) addModelId(model.id);
+        setAvailableModels(dedupeModels(Array.from(optionMap.values())));
       })
       .catch(() => {
         if (!cancelled) setAvailableModels([]);
@@ -387,6 +382,7 @@ export function CcSwitchImportConfigModal({
     open,
     selectedGroup,
     selectedGroupAllowedModelsKey,
+    selectedGroupChannelsKey,
     selectedGroupAuthoritativeOwnerKey,
     selectedGroupOwnerKey,
   ]);

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -322,6 +322,75 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(getModelConfigs).toHaveBeenCalledWith("active");
   });
 
+  test("merges mapped Codex owner models with OpenCode Go channel models in CC Switch presets", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ codex: "codex" }),
+    );
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "opencodego+gpt",
+        description: "OpenCode Go and GPT route",
+        channels: ["A_GptPro", "opencode go"],
+        channelDetails: [
+          {
+            name: "A_GptPro",
+            source: "codex",
+            default_tags: ["codex", "pro"],
+            custom_tags: ["20x"],
+            display_tags: ["codex", "pro", "20x"],
+          },
+          {
+            name: "opencode go",
+            source: "opencode-go",
+            default_tags: ["opencode-go"],
+            custom_tags: [],
+            display_tags: ["opencode-go"],
+          },
+        ],
+        "path-routes": ["/codexdeepseek"],
+      },
+    ]);
+    listAvailableModels.mockResolvedValue([
+      { id: "gpt-5.5" },
+      { id: "gpt-5.3-codex" },
+      { id: "minimax-m2.7" },
+      { id: "kimi-k2.6" },
+    ]);
+    loadConfiguredModelAvailability.mockResolvedValue({
+      scoped: true,
+      items: [],
+      idSet: new Set(["gpt-5.5", "gpt-5.3-codex", "minimax-m2.7", "kimi-k2.6"]),
+    });
+    getModelConfigs.mockResolvedValue([
+      { id: "gpt-5.5", owned_by: "codex" },
+      { id: "gpt-5.3-codex", owned_by: "codex" },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /new config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /new cc switch config/i });
+    await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
+    await user.click(
+      await screen.findByRole("option", { name: /opencodego\+gpt.*\/codexdeepseek/i }),
+    );
+
+    expect(
+      await within(dialog).findByLabelText(/cc switch request model for gpt-5\.5/i),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText(/cc switch request model for minimax-m2\.7/i),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText(/cc switch request model for kimi-k2\.6/i),
+    ).toBeInTheDocument();
+    expect(listAvailableModels).toHaveBeenCalledWith({
+      allowedChannels: ["A_GptPro", "opencode go"],
+    });
+  });
+
   test("uses the auth-file owner model group as the CC Switch actual model source", async () => {
     window.localStorage.setItem(
       "authFilesPage.modelOwnerGroupMap.v1",
@@ -375,7 +444,9 @@ describe("CcSwitchImportSettingsPage", () => {
 
     expect(await screen.findByRole("option", { name: "kimi-k2.6" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "kimi-k2" })).not.toBeInTheDocument();
-    expect(listAvailableModels).not.toHaveBeenCalled();
+    expect(listAvailableModels).toHaveBeenCalledWith({
+      allowedChannels: ["kimi"],
+    });
     expect(getModelConfigs).toHaveBeenCalledWith("active");
   });
 

--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -238,23 +238,6 @@ export function ChannelGroupsPage() {
       normalizedChannels,
       availableChannelDetails,
     );
-    if (selectedOwnerKeys.length > 0) {
-      const selectedOwnerSet = new Set(selectedOwnerKeys);
-      const optionMap = new Map<string, RoutingModelOption>();
-      for (const model of availability.items) {
-        if (!selectedOwnerSet.has(normalizeOwnerValue(model.owned_by ?? ""))) continue;
-        const key = model.id.toLowerCase();
-        if (!optionMap.has(key)) {
-          optionMap.set(key, {
-            id: model.id,
-            owned_by: model.owned_by,
-            description: model.description,
-            pricing: model.pricing,
-          });
-        }
-      }
-      return Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
-    }
     const visibleModels = filterByConfiguredModelAvailability(
       ids.map((id) => ({ id })),
       availability,
@@ -262,17 +245,33 @@ export function ChannelGroupsPage() {
     const metadataById = new Map(
       availability.items.map((model) => [model.id.toLowerCase(), model] as const),
     );
-    return Array.from(new Set(visibleModels.map((model) => model.id)))
-      .sort((a, b) => a.localeCompare(b))
-      .map((id): RoutingModelOption => {
-        const metadata = metadataById.get(id.toLowerCase());
-        return {
-          id,
-          owned_by: metadata?.owned_by,
-          description: metadata?.description,
-          pricing: metadata?.pricing,
-        };
+    const optionMap = new Map<string, RoutingModelOption>();
+    const addModelOption = (id: string, metadata = metadataById.get(id.toLowerCase())) => {
+      const normalized = id.trim();
+      if (!normalized) return;
+      const key = normalized.toLowerCase();
+      if (optionMap.has(key)) return;
+      optionMap.set(key, {
+        id: normalized,
+        owned_by: metadata?.owned_by,
+        description: metadata?.description,
+        pricing: metadata?.pricing,
       });
+    };
+
+    for (const model of visibleModels) addModelOption(model.id);
+
+    if (selectedOwnerKeys.length > 0) {
+      const selectedOwnerSet = new Set(selectedOwnerKeys);
+      for (const model of availability.items) {
+        const owner = normalizeOwnerValue(model.owned_by ?? "");
+        const source = normalizeOwnerValue(model.source ?? "");
+        if (!selectedOwnerSet.has(owner) && !selectedOwnerSet.has(source)) continue;
+        addModelOption(model.id, model);
+      }
+    }
+
+    return Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
   }, [availableChannelDetails]);
 
   const loadPage = useCallback(async () => {

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -234,6 +234,109 @@ describe("ChannelGroupsPage", () => {
     expect(within(table).queryByLabelText("kimi-k2-thinking")).not.toBeInTheDocument();
   });
 
+  test("merges mapped owner models with OpenCode Go live models for mixed channel groups", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.modelOwnerGroupMap.v1",
+      JSON.stringify({ codex: "codex" }),
+    );
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        return Promise.resolve({
+          items: [
+            {
+              name: "opencodego+gpt",
+              channels: ["A_GptPro", "opencode go"],
+              "channel-details": [
+                {
+                  name: "A_GptPro",
+                  source: "codex",
+                  display_tags: ["codex", "pro", "20x"],
+                },
+                {
+                  name: "opencode go",
+                  source: "opencode-go",
+                  display_tags: ["opencode-go"],
+                },
+              ],
+            },
+          ],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({
+          data: [
+            { id: "gpt-5.5" },
+            { id: "gpt-5.3-codex" },
+            { id: "minimax-m2.7" },
+            { id: "kimi-k2.6" },
+          ],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "codex.json", type: "codex", disabled: false }],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            { id: "gpt-5.5", owned_by: "codex", description: "GPT Pro" },
+            { id: "gpt-5.3-codex", owned_by: "codex", description: "Codex" },
+          ],
+        });
+      }
+      if (path === "/opencode-go-api-key") {
+        return Promise.resolve({
+          "opencode-go-api-key": [{ name: "opencode go", "api-key": "sk-opencode-go" }],
+        });
+      }
+      if (path === "/model-definitions/opencode-go") {
+        return Promise.resolve({
+          models: [
+            { id: "minimax-m2.7", display_name: "MiniMax M2.7", owned_by: "opencode" },
+            { id: "kimi-k2.6", display_name: "Kimi K2.6", owned_by: "opencode" },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "新增分组" }));
+    await user.type(screen.getByPlaceholderText("pro"), "opencodego+gpt");
+    await user.type(screen.getByPlaceholderText("/pro"), "/codexdeepseek");
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(await screen.findByRole("option", { name: /A_GptPro/ }));
+    await user.click(await screen.findByRole("option", { name: /opencode go/ }));
+    await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    const table = await screen.findByRole("table", { name: "允许模型" });
+    expect(await within(table).findByLabelText("gpt-5.5")).toBeInTheDocument();
+    expect(within(table).getByLabelText("gpt-5.3-codex")).toBeInTheDocument();
+    expect(within(table).getByLabelText("minimax-m2.7")).toBeInTheDocument();
+    expect(within(table).getByLabelText("kimi-k2.6")).toBeInTheDocument();
+  });
+
   test("keeps live model owner metadata when no auth-file model owner group is configured", async () => {
     mockedApiGet.mockImplementation((path: string) => {
       if (path === "/routing-config") {

--- a/src/modules/ui/SearchableSelect.tsx
+++ b/src/modules/ui/SearchableSelect.tsx
@@ -79,14 +79,39 @@ export function SearchableSelect({
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+  const [pos, setPos] = useState({
+    top: 0,
+    left: 0,
+    width: 0,
+    placement: "bottom" as "bottom" | "top",
+    maxHeight: 320,
+  });
 
   const reposition = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    setPos({ top: rect.bottom + 6, left: rect.left, width: Math.max(rect.width, 200) });
-  }, []);
+    const gap = 6;
+    const maxPanelHeight = 320;
+    const minPanelHeight = 160;
+    const estimatedHeight = Math.min(options.length * 36 + 48, maxPanelHeight);
+    const spaceBelow = window.innerHeight - rect.bottom - gap;
+    const spaceAbove = rect.top - gap;
+    const openAbove = spaceBelow < estimatedHeight && spaceAbove > spaceBelow;
+    const availableSpace = Math.max(openAbove ? spaceAbove : spaceBelow, 0);
+    const maxHeight = Math.min(
+      maxPanelHeight,
+      Math.max(Math.min(minPanelHeight, maxPanelHeight), availableSpace),
+    );
+    const panelHeight = Math.min(estimatedHeight, maxHeight);
+    setPos({
+      top: openAbove ? Math.max(gap, rect.top - gap - panelHeight) : rect.bottom + gap,
+      left: rect.left,
+      width: Math.max(rect.width, 200),
+      placement: openAbove ? "top" : "bottom",
+      maxHeight,
+    });
+  }, [options.length]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -204,14 +229,14 @@ export function SearchableSelect({
               role="listbox"
               aria-label={ariaLabel}
               className={searchableSelectPanel}
-              {...getSelectDropdownMotion()}
+              {...getSelectDropdownMotion(pos.placement)}
               transition={selectDropdownTransition}
               style={{
                 top: pos.top,
                 left: pos.left,
                 minWidth: pos.width,
                 maxWidth: "min(500px, 90vw)",
-                maxHeight: 320,
+                maxHeight: pos.maxHeight,
               }}
             >
               {/* Search input */}

--- a/src/modules/ui/__tests__/SearchableSelect.test.tsx
+++ b/src/modules/ui/__tests__/SearchableSelect.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { SearchableSelect } from "@/modules/ui/SearchableSelect";
+
+describe("SearchableSelect", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("positions the dropdown above the trigger when the viewport has no room below", async () => {
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: 600,
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+      this: HTMLElement,
+    ) {
+      if (this.getAttribute("role") === "combobox") {
+        return {
+          x: 120,
+          y: 550,
+          top: 550,
+          bottom: 590,
+          left: 120,
+          right: 340,
+          width: 220,
+          height: 40,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+
+    render(
+      <SearchableSelect
+        value=""
+        onChange={vi.fn()}
+        aria-label="Select model"
+        placeholder="Select model"
+        searchPlaceholder="Search models"
+        options={Array.from({ length: 12 }, (_, index) => ({
+          value: `model-${index}`,
+          label: `model-${index}`,
+        }))}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Select model" }));
+
+    const listbox = await screen.findByRole("listbox", { name: "Select model" });
+    expect(Number.parseFloat(listbox.style.top)).toBeLessThan(550);
+    expect(Number.parseFloat(listbox.style.top)).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Merge live channel-scoped models with mapped owner models in channel group model loading so mixed groups like opencodego+gpt include OpenCode Go models.
- Apply the same union logic in CC Switch import presets.
- Keep searchable select dropdowns within the viewport by opening upward near the bottom edge.

## Tests
- bun run test:ci
- bun run build
- bun run lint (passes with existing warning in ProviderKeyModal.tsx)
- git diff --check

## Read-only production checks
- /channel-groups confirms opencodego+gpt currently stores only 5 allowed models.
- /models?allowed_channels=A_GptPro,opencode go returns 30 live models.
- /model-definitions/opencode-go returns 14 OpenCode Go definitions.