### PR TITLE
feat: add ccswitch model mapping loading state

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2413,6 +2413,8 @@
     "config_model_mapping_title": "Model mapping",
     "config_model_mapping_hint": "Expose the request model name CC Switch should send, then route it to the actual model available in this channel group.",
     "config_claude_model_mapping_hint": "Set Claude Code's main, Haiku, Sonnet, and Opus defaults, with editable request names.",
+    "config_model_mapping_loading": "Loading model mapping",
+    "config_model_mapping_loading_hint": "Fetching the channel models before updating the mapping table.",
     "config_model_mapping_empty": "No models are available for this channel group.",
     "config_model_mapping_select_group_first": "Select a channel group to load available models.",
     "config_actual_channel_model": "Actual channel model",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -141,6 +141,8 @@
     "config_model_mapping_title": "Model mapping",
     "config_model_mapping_hint": "Expose the request model name CC Switch should send, then route it to the actual model available in this channel group.",
     "config_claude_model_mapping_hint": "Set Claude Code's main, Haiku, Sonnet, and Opus defaults, with editable request names.",
+    "config_model_mapping_loading": "Loading model mapping",
+    "config_model_mapping_loading_hint": "Fetching the channel models before updating the mapping table.",
     "config_model_mapping_empty": "No models are available for this channel group.",
     "config_model_mapping_select_group_first": "Select a channel group to load available models.",
     "config_actual_channel_model": "Actual channel model",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2648,6 +2648,8 @@
     "config_model_mapping_title": "模型映射",
     "config_model_mapping_hint": "设置 CC Switch 对外请求的模型名，并映射到当前渠道分组实际可用的模型。",
     "config_claude_model_mapping_hint": "设置 Claude Code 的主模型、Haiku、Sonnet、Opus 默认模型，并可分别改写请求名。",
+    "config_model_mapping_loading": "正在加载模型映射",
+    "config_model_mapping_loading_hint": "正在获取当前渠道模型，稍后刷新映射表。",
     "config_model_mapping_empty": "当前渠道分组暂无可用模型。",
     "config_model_mapping_select_group_first": "先选择一个渠道分组以加载可用模型。",
     "config_actual_channel_model": "实际渠道模型",

--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { LoaderCircle } from "lucide-react";
 import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
 import iconGemini from "@/assets/icons/gemini.svg";
@@ -56,6 +57,7 @@ const controlClassName =
 const fieldClassName = "flex flex-col gap-1.5";
 
 const CLAUDE_ROLE_ORDER: CcSwitchClaudeModelRole[] = ["main", "haiku", "sonnet", "opus"];
+const MODEL_MAPPING_LOADING_ROWS = ["short", "medium", "long"];
 
 const rolePriority: Record<CcSwitchClaudeModelRole, string[]> = {
   main: ["sonnet", "opus", "haiku", "claude"],
@@ -456,11 +458,13 @@ export function CcSwitchImportConfigModal({
   );
   const currentModelOptions = useMemo(() => modelOptions(availableModels), [availableModels]);
   const preparedDraft = prepareDraftForSave(draft);
+  const modelMappingsLoading = Boolean(selectedGroup && modelsLoading);
   const isSaveDisabled =
     !preparedDraft.providerName.trim() ||
     !selectedGroup ||
     !preparedDraft.defaultModel.trim() ||
-    preparedDraft.modelMappings.length === 0;
+    preparedDraft.modelMappings.length === 0 ||
+    modelMappingsLoading;
 
   const setClientType = (clientType: CcSwitchClientType) => {
     const defaults = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[clientType];
@@ -698,14 +702,51 @@ export function CcSwitchImportConfigModal({
                   : t("ccswitch.config_model_mapping_hint")}
               </p>
             </div>
-            {modelsLoading ? (
-              <span className="rounded-full bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55">
+            {modelMappingsLoading ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55">
+                <LoaderCircle size={12} className="animate-spin" />
                 {t("ccswitch.import_model_loading")}
               </span>
             ) : null}
           </div>
 
-          {draft.modelMappings.length === 0 ? (
+          {modelMappingsLoading ? (
+            <div
+              role="status"
+              aria-label={t("ccswitch.config_model_mapping_loading")}
+              data-testid="ccswitch-model-mapping-loading"
+              className="px-4 py-5"
+            >
+              <div className="flex items-center gap-3 rounded-2xl border border-slate-200/75 bg-slate-50/85 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900/55">
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white text-slate-500 shadow-sm ring-1 ring-slate-200/80 dark:bg-neutral-950 dark:text-white/60 dark:ring-neutral-800">
+                  <LoaderCircle size={17} className="animate-spin" />
+                </span>
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold text-slate-800 dark:text-white/85">
+                    {t("ccswitch.config_model_mapping_loading")}
+                  </div>
+                  <p className="mt-0.5 text-xs text-slate-500 dark:text-white/50">
+                    {t("ccswitch.config_model_mapping_loading_hint")}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 space-y-2" aria-hidden="true">
+                {MODEL_MAPPING_LOADING_ROWS.map((row) => (
+                  <div
+                    key={row}
+                    className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)] gap-3 rounded-xl border border-slate-200/70 bg-white px-3 py-3 dark:border-neutral-800 dark:bg-neutral-950/70"
+                  >
+                    <span className="h-3 rounded-full bg-slate-200/80 dark:bg-white/10" />
+                    <span
+                      className={`h-3 rounded-full bg-slate-200/80 dark:bg-white/10 ${
+                        row === "short" ? "w-1/2" : row === "medium" ? "w-2/3" : "w-5/6"
+                      }`}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : draft.modelMappings.length === 0 ? (
             <div className="px-4 py-8 text-center text-sm text-slate-500 dark:text-white/50">
               {selectedGroup
                 ? t("ccswitch.config_model_mapping_empty")

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -15,6 +15,16 @@ const replaceConfigs = vi.fn();
 const loadConfiguredModelAvailability = vi.fn();
 const filterByConfiguredModelAvailability = vi.fn();
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 vi.mock("@/lib/http/apis/channel-groups", () => ({
   channelGroupsApi: {
     list: () => listChannelGroups(),
@@ -508,6 +518,59 @@ describe("CcSwitchImportSettingsPage", () => {
         }),
       ]),
     );
+  });
+
+  test("shows a compact model mapping loading state while edited config models load", async () => {
+    const modelsDeferred = createDeferred<{ id: string }[]>();
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "kimicode",
+        description: "Kimi Code route",
+        "path-routes": ["/kimicode"],
+      },
+    ]);
+    listAvailableModels.mockReturnValue(modelsDeferred.promise);
+    listConfigs.mockResolvedValue([
+      {
+        id: "cfg-kimi",
+        clientType: "codex",
+        providerName: "Relay Kimi",
+        note: "saved mapping",
+        defaultModel: "gpt-5.5",
+        allowedChannelGroups: ["kimicode"],
+        endpointPath: "/v1",
+        usageAutoInterval: 30,
+        modelMappings: [
+          {
+            requestModel: "gpt-5.5",
+            targetModel: "moonshot-v1-128k",
+          },
+        ],
+      },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(await screen.findByText("Relay Kimi")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /edit config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
+    const mappingStatus = await within(dialog).findByTestId("ccswitch-model-mapping-loading");
+
+    expect(mappingStatus).toHaveTextContent(/loading model mapping/i);
+    expect(
+      within(dialog).queryByText(/no models are available for this channel group/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByLabelText(/cc switch request model for moonshot-v1-128k/i),
+    ).not.toBeInTheDocument();
+
+    modelsDeferred.resolve([{ id: "kimi-k2.5" }]);
+
+    expect(
+      await within(dialog).findByLabelText(/cc switch request model for kimi-k2\.5/i),
+    ).toBeInTheDocument();
+    expect(within(dialog).queryByTestId("ccswitch-model-mapping-loading")).toBeNull();
   });
 
   test("previews the full BaseURL request address from the selected channel group path", async () => {


### PR DESCRIPTION
## Summary
- Add a compact loading state inside the CC Switch config model mapping section while channel models are loading.
- Keep the mapping table and empty state hidden until model data is ready.
- Add locale strings and a regression test for edited configs with pending model loading.

## Tests
- bun run test src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
- bun run lint
- bun run build