### PR TITLE
fix: refresh auth file usage after quota updates

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -106,8 +106,17 @@ export function AuthFilesPage() {
     applyImport,
   } = useAuthFilesOAuthConfig(tab);
 
-  const { files, setFiles, loading, refreshingAll, usageLoading, usageData, usageIndex, loadAll } =
-    useAuthFilesDataState();
+  const {
+    files,
+    setFiles,
+    loading,
+    refreshingAll,
+    usageLoading,
+    usageData,
+    usageIndex,
+    loadAll,
+    refreshUsageData,
+  } = useAuthFilesDataState();
 
   const [confirm, setConfirm] = useState<null | { type: "deleteSelection"; names: string[] }>(null);
 
@@ -297,6 +306,7 @@ export function AuthFilesPage() {
     loading,
     setFiles,
     setDetailFile,
+    refreshUsageData,
   });
 
   const openDetailWithQuotaRefresh = useCallback(

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -524,6 +524,91 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText(/^pro$/i)).not.toBeInTheDocument();
   });
 
+  test("refreshes usage stats after a single auth-file card quota refresh", async () => {
+    const now = Date.now();
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [
+          {
+            name: "codex-pro.json",
+            label: "A_GptPro",
+            account_type: "oauth",
+            type: "codex",
+            auth_index: "77",
+            size: 1024,
+            modified: now,
+            disabled: false,
+          },
+        ],
+        quotaByFileName: {
+          "codex-pro.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 80 }],
+          },
+        },
+      }),
+    );
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          auth_index: "77",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        },
+      ],
+    }));
+    mocks.getEntityStats
+      .mockResolvedValueOnce({
+        source: [],
+        auth_index: [
+          { entity_name: "77", requests: 1, failed: 0, avg_latency: 0, total_tokens: 0 },
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        source: [],
+        auth_index: [
+          { entity_name: "77", requests: 4, failed: 1, avg_latency: 0, total_tokens: 0 },
+        ],
+      } as any);
+    mocks.fetchQuota.mockImplementation(async () => [
+      { key: "code_5h", label: "m_quota.code_5h", percent: 60 },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("A_GptPro");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(await within(card as HTMLElement).findByText("1 calls")).toBeInTheDocument();
+
+    fireEvent.click(within(card as HTMLElement).getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(mocks.fetchQuota).toHaveBeenCalledTimes(1);
+      expect(mocks.getEntityStats).toHaveBeenCalledTimes(2);
+      expect(within(card as HTMLElement).getByText("4 calls")).toBeInTheDocument();
+    });
+  });
+
   test("cards view hides default auth-file badges when display tags are empty", async () => {
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     mocks.list.mockImplementation(async () => ({

--- a/src/modules/auth-files/hooks/useAuthFilesDataState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDataState.ts
@@ -54,6 +54,16 @@ export function useAuthFilesDataState() {
     }
   }, [notify, t]);
 
+  const refreshUsageData = useCallback(async (): Promise<EntityStatsResponse | null> => {
+    try {
+      const nextUsageData = await usageApi.getEntityStats(30, "all");
+      setUsageData(nextUsageData);
+      return nextUsageData;
+    } catch {
+      return null;
+    }
+  }, []);
+
   useEffect(() => {
     void loadAll();
   }, [loadAll]);
@@ -97,5 +107,6 @@ export function useAuthFilesDataState() {
     usageData,
     usageIndex,
     loadAll,
+    refreshUsageData,
   };
 }

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -37,6 +37,7 @@ interface UseAuthFilesQuotaStateOptions {
   loading: boolean;
   setFiles: Dispatch<SetStateAction<AuthFileItem[]>>;
   setDetailFile: Dispatch<SetStateAction<AuthFileItem | null>>;
+  refreshUsageData?: () => Promise<unknown>;
 }
 
 export function useAuthFilesQuotaState({
@@ -45,6 +46,7 @@ export function useAuthFilesQuotaState({
   loading,
   setFiles,
   setDetailFile,
+  refreshUsageData,
 }: UseAuthFilesQuotaStateOptions) {
   const { t } = useTranslation();
   const initialDataCache = useMemo(() => readAuthFilesDataCache(), []);
@@ -58,6 +60,7 @@ export function useAuthFilesQuotaState({
   const quotaInFlightRef = useRef<Set<string>>(new Set());
   const quotaAutoRefreshingRef = useRef<Set<string>>(new Set());
   const quotaByFileNameRef = useRef<Record<string, QuotaState>>(quotaByFileName);
+  const usageRefreshInFlightRef = useRef<Promise<unknown> | null>(null);
   const quotaWarmupAttemptRef = useRef<Map<string, number>>(new Map());
   const visiblePageSignatureRef = useRef<string | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -111,6 +114,16 @@ export function useAuthFilesQuotaState({
     },
     [setDetailFile, setFiles],
   );
+
+  const refreshUsageDataAfterQuota = useCallback(async () => {
+    if (!refreshUsageData) return;
+    if (!usageRefreshInFlightRef.current) {
+      usageRefreshInFlightRef.current = refreshUsageData().finally(() => {
+        usageRefreshInFlightRef.current = null;
+      });
+    }
+    await usageRefreshInFlightRef.current.catch(() => undefined);
+  }, [refreshUsageData]);
 
   const resolveQuotaCardSlots = useCallback(
     (provider: QuotaProvider, items: QuotaItem[]) => {
@@ -308,6 +321,7 @@ export function useAuthFilesQuotaState({
             updatedAt: Date.now(),
           },
         }));
+        await refreshUsageDataAfterQuota();
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : t("auth_files.unknown_error");
         setQuotaByFileName((prev) => ({
@@ -324,7 +338,7 @@ export function useAuthFilesQuotaState({
         quotaInFlightRef.current.delete(name);
       }
     },
-    [patchAuthFileByName, resolveQuotaCardSlots, t],
+    [patchAuthFileByName, refreshUsageDataAfterQuota, resolveQuotaCardSlots, t],
   );
 
   const checkAuthFileConnectivity = useCallback(

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -39,7 +39,6 @@ import {
   type ModelAvailabilityItem,
   type ModelConfigMetadataItem,
   type ModelPathAvailabilityItem,
-  type ModelPathItem,
   type ModelPricing,
   type ModelPricingMode,
   normalizeModelConfigMetadataRows,
@@ -293,46 +292,6 @@ function mergeConfiguredModelAvailability(
   return visible.sort((a, b) => a.id.localeCompare(b.id));
 }
 
-function compactPathLabel(path: ModelPathItem): string {
-  if (path.scope === "root") {
-    return `root:${path.path}`;
-  }
-  return `group:${path.path}`;
-}
-
-function ModelPathBadges({ paths }: { paths: ModelPathItem[] }) {
-  if (paths.length === 0) {
-    return <span className="text-xs text-slate-400 dark:text-white/35">-</span>;
-  }
-  const visible = paths.slice(0, 3);
-  const hidden = paths.slice(3);
-  return (
-    <div className="flex min-w-0 flex-wrap gap-1.5">
-      {visible.map((path) => (
-        <OverflowTooltip
-          key={`${path.method}-${path.path}-${path.family}`}
-          content={`${path.method} ${path.path}`}
-          className="min-w-0"
-        >
-          <span className="inline-flex max-w-[12rem] items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-[11px] font-medium text-slate-700 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white/75">
-            <span className="truncate">{compactPathLabel(path)}</span>
-          </span>
-        </OverflowTooltip>
-      ))}
-      {hidden.length > 0 ? (
-        <OverflowTooltip
-          content={hidden.map((path) => `${path.method} ${path.path}`).join("\n")}
-          className="min-w-0"
-        >
-          <span className="inline-flex items-center rounded-md border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-500 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/55">
-            +{hidden.length}
-          </span>
-        </OverflowTooltip>
-      ) : null}
-    </div>
-  );
-}
-
 function toFormState(model: ModelItem): ModelFormState {
   return {
     originalId: model.id,
@@ -543,7 +502,6 @@ export function ModelsPage() {
   const { notify } = useToast();
 
   const [models, setModels] = useState<ModelItem[]>([]);
-  const [modelPathItems, setModelPathItems] = useState<ModelPathAvailabilityItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchFilter, setSearchFilter] = useState("");
   const [totalCost, setTotalCost] = useState(0);
@@ -587,7 +545,6 @@ export function ModelsPage() {
       const pathItems = pathAvailability?.items ?? [];
       const visibleData = mergeConfiguredModelAvailability(data, availability, pathItems);
       setModels(visibleData);
-      setModelPathItems(pathItems);
       setOwnerPresets(presets);
       setOwnerFilter((current) => {
         if (!current) return "";
@@ -651,14 +608,6 @@ export function ModelsPage() {
   }, [activeTab, models, ownerFilter, searchFilter]);
 
   const filteredModelIds = useMemo(() => filteredModels.map((model) => model.id), [filteredModels]);
-
-  const modelPathsById = useMemo(() => {
-    const map = new Map<string, ModelPathItem[]>();
-    for (const item of modelPathItems) {
-      map.set(item.id.toLowerCase(), item.paths);
-    }
-    return map;
-  }, [modelPathItems]);
 
   const selectedModels = useMemo(
     () => models.filter((model) => selectedModelIds.has(model.id)),
@@ -1095,13 +1044,6 @@ export function ModelsPage() {
         render: (row) => row.owned_by || "-",
       },
       {
-        key: "paths",
-        label: t("models_page.col_paths"),
-        width: "w-[28rem]",
-        cellClassName: "min-w-0",
-        render: (row) => <ModelPathBadges paths={modelPathsById.get(row.id.toLowerCase()) ?? []} />,
-      },
-      {
         key: "mode",
         label: t("models_page.col_pricing_mode"),
         width: "w-36",
@@ -1176,7 +1118,6 @@ export function ModelsPage() {
       allVisibleModelsSelected,
       canDeleteModels,
       filteredModelIds.length,
-      modelPathsById,
       openEditModel,
       selectedModelIds,
       someVisibleModelsSelected,

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -143,6 +143,13 @@ describe("ModelsPage", () => {
     expect(screen.queryByText("seed-only-model")).not.toBeInTheDocument();
   });
 
+  test("does not render the model request paths column", async () => {
+    renderPage();
+
+    expect(await screen.findByText("gpt-image-2")).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Paths" })).not.toBeInTheDocument();
+  });
+
   test("renders active models as an availability list without deletion selection controls", async () => {
     renderPage();
 


### PR DESCRIPTION
## Summary
- Refresh auth-file usage stats after single-card or single-row quota refreshes so request counts update without a full page reload.
- Coalesce concurrent usage-stat refreshes during quota refresh batches.
- Remove the Models page request paths column.

## Test Plan
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx
- bun run build
- git diff --check
- bun run lint