### PR TITLE
fix: target auth file refresh usage updates

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -115,7 +115,8 @@ export function AuthFilesPage() {
     usageData,
     usageIndex,
     loadAll,
-    refreshUsageData,
+    refreshFilesForItems,
+    refreshUsageDataForFiles,
   } = useAuthFilesDataState();
 
   const [confirm, setConfirm] = useState<null | { type: "deleteSelection"; names: string[] }>(null);
@@ -306,7 +307,7 @@ export function AuthFilesPage() {
     loading,
     setFiles,
     setDetailFile,
-    refreshUsageData,
+    refreshUsageDataForFiles,
   });
 
   const openDetailWithQuotaRefresh = useCallback(
@@ -324,10 +325,11 @@ export function AuthFilesPage() {
   );
 
   const refreshFilesAndQuota = useCallback(async () => {
+    const currentPageItems = pageItems;
     const quotaRefreshPromise = forceRefreshPage();
-    const filesRefreshPromise = loadAll();
+    const filesRefreshPromise = refreshFilesForItems(currentPageItems);
     await Promise.all([filesRefreshPromise, quotaRefreshPromise]);
-  }, [forceRefreshPage, loadAll]);
+  }, [forceRefreshPage, pageItems, refreshFilesForItems]);
 
   const {
     groupOverviewOpen,

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -524,27 +524,43 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText(/^pro$/i)).not.toBeInTheDocument();
   });
 
-  test("refreshes usage stats after a single auth-file card quota refresh", async () => {
+  test("refreshes only the clicked auth-file card usage stats after quota refresh", async () => {
     const now = Date.now();
+    const files = [
+      {
+        name: "codex-pro-a.json",
+        label: "A_GptPro",
+        account_type: "oauth",
+        type: "codex",
+        auth_index: "77",
+        size: 1024,
+        modified: now,
+        disabled: false,
+      },
+      {
+        name: "codex-pro-b.json",
+        label: "B_GptPro",
+        account_type: "oauth",
+        type: "codex",
+        auth_index: "88",
+        size: 1024,
+        modified: now,
+        disabled: false,
+      },
+    ] as any[];
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.sessionStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
-        files: [
-          {
-            name: "codex-pro.json",
-            label: "A_GptPro",
-            account_type: "oauth",
-            type: "codex",
-            auth_index: "77",
-            size: 1024,
-            modified: now,
-            disabled: false,
-          },
-        ],
+        files,
         quotaByFileName: {
-          "codex-pro.json": {
+          "codex-pro-a.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 80 }],
+          },
+          "codex-pro-b.json": {
             status: "success",
             updatedAt: now,
             items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 80 }],
@@ -552,31 +568,20 @@ describe("AuthFilesPage files table", () => {
         },
       }),
     );
-    mocks.list.mockImplementation(async () => ({
-      files: [
-        {
-          name: "codex-pro.json",
-          label: "A_GptPro",
-          account_type: "oauth",
-          type: "codex",
-          auth_index: "77",
-          size: 1024,
-          modified: now,
-          disabled: false,
-        },
-      ],
-    }));
+    mocks.list.mockImplementation(async () => ({ files }));
     mocks.getEntityStats
       .mockResolvedValueOnce({
         source: [],
         auth_index: [
           { entity_name: "77", requests: 1, failed: 0, avg_latency: 0, total_tokens: 0 },
+          { entity_name: "88", requests: 10, failed: 0, avg_latency: 0, total_tokens: 0 },
         ],
       } as any)
       .mockResolvedValueOnce({
         source: [],
         auth_index: [
           { entity_name: "77", requests: 4, failed: 1, avg_latency: 0, total_tokens: 0 },
+          { entity_name: "88", requests: 99, failed: 0, avg_latency: 0, total_tokens: 0 },
         ],
       } as any);
     mocks.fetchQuota.mockImplementation(async () => [
@@ -598,7 +603,11 @@ describe("AuthFilesPage files table", () => {
     const title = await screen.findByText("A_GptPro");
     const card = title.closest("section");
     expect(card).not.toBeNull();
+    const otherTitle = await screen.findByText("B_GptPro");
+    const otherCard = otherTitle.closest("section");
+    expect(otherCard).not.toBeNull();
     expect(await within(card as HTMLElement).findByText("1 calls")).toBeInTheDocument();
+    expect(await within(otherCard as HTMLElement).findByText("10 calls")).toBeInTheDocument();
 
     fireEvent.click(within(card as HTMLElement).getByRole("button", { name: "Refresh" }));
 
@@ -606,6 +615,8 @@ describe("AuthFilesPage files table", () => {
       expect(mocks.fetchQuota).toHaveBeenCalledTimes(1);
       expect(mocks.getEntityStats).toHaveBeenCalledTimes(2);
       expect(within(card as HTMLElement).getByText("4 calls")).toBeInTheDocument();
+      expect(within(otherCard as HTMLElement).getByText("10 calls")).toBeInTheDocument();
+      expect(within(otherCard as HTMLElement).queryByText("99 calls")).not.toBeInTheDocument();
     });
   });
 
@@ -1957,6 +1968,99 @@ describe("AuthFilesPage files table", () => {
     expect(row).not.toBeNull();
     const rowRefreshButton = within(row as HTMLElement).getByRole("button", { name: "Refresh" });
     await waitFor(() => expect(rowRefreshButton.querySelector("svg")).toHaveClass("animate-spin"));
+  });
+
+  test("toolbar refresh updates usage stats only for the current card page", async () => {
+    const now = Date.now();
+    const files = Array.from({ length: 10 }, (_, index) => {
+      const number = index + 1;
+      return {
+        name: `auth-${number}.json`,
+        type: "codex",
+        size: 1024,
+        modified: now,
+        disabled: false,
+        auth_index: String(number),
+      };
+    }) as any[];
+    const oldStats = files.map((file, index) => ({
+      entity_name: file.auth_index,
+      requests: index + 1,
+      failed: 0,
+      avg_latency: 0,
+      total_tokens: 0,
+    }));
+    const nextStats = files.map((file, index) => ({
+      entity_name: file.auth_index,
+      requests: 101 + index,
+      failed: 0,
+      avg_latency: 0,
+      total_tokens: 0,
+    }));
+
+    mocks.list.mockImplementation(async () => ({ files }));
+    mocks.getEntityStats
+      .mockResolvedValue({ source: [], auth_index: nextStats } as any)
+      .mockResolvedValueOnce({ source: [], auth_index: oldStats } as any)
+      .mockResolvedValueOnce({ source: [], auth_index: nextStats } as any);
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ label: "m_quota.code_5h", percent: 55, resetAtMs: now + 60_000 }],
+    });
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files,
+        usageData: { source: [], auth_index: oldStats },
+        quotaByFileName: Object.fromEntries(
+          files.map((file) => [
+            file.name,
+            {
+              status: "success",
+              updatedAt: now,
+              items: [{ label: "m_quota.code_5h", percent: 22, resetAtMs: now + 30_000 }],
+            },
+          ]),
+        ),
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const firstTitle = await screen.findByText("auth-1.json");
+    const firstCard = firstTitle.closest("section");
+    expect(firstCard).not.toBeNull();
+    expect(within(firstCard as HTMLElement).getByText("1 calls")).toBeInTheDocument();
+
+    const toolbarRefreshButton = screen.getAllByRole("button", { name: "Refresh" })[0];
+    await waitFor(() => expect(toolbarRefreshButton).toBeEnabled());
+    fireEvent.click(toolbarRefreshButton);
+
+    await waitFor(() => {
+      expect(mocks.fetchQuota).toHaveBeenCalledTimes(9);
+      expect(within(firstCard as HTMLElement).getByText("101 calls")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    const tenthTitle = await screen.findByText("auth-10.json");
+    const tenthCard = tenthTitle.closest("section");
+    expect(tenthCard).not.toBeNull();
+    expect(within(tenthCard as HTMLElement).getByText("10 calls")).toBeInTheDocument();
+    expect(within(tenthCard as HTMLElement).queryByText("110 calls")).not.toBeInTheDocument();
   });
 
   test("cards view refresh action only refreshes the clicked auth file", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesDataState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDataState.ts
@@ -4,11 +4,51 @@ import { authFilesApi, usageApi } from "@/lib/http/apis";
 import type { AuthFileItem, EntityStatsResponse } from "@/lib/http/types";
 import { useToast } from "@/modules/ui/ToastProvider";
 import {
+  buildAuthFileSourceCandidates,
   buildUsageIndex,
+  normalizeAuthIndexValue,
   readAuthFilesDataCache,
   sanitizeAuthFilesForCache,
   writeAuthFilesDataCache,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
+import { normalizeUsageSourceId } from "@/modules/providers/provider-usage";
+
+const mergeTargetUsageData = (
+  previous: EntityStatsResponse | null,
+  next: EntityStatsResponse,
+  targetFiles: AuthFileItem[],
+): EntityStatsResponse => {
+  const targetAuthIndices = new Set(
+    targetFiles
+      .map((file) => normalizeAuthIndexValue(file.auth_index ?? file.authIndex))
+      .filter(Boolean) as string[],
+  );
+  const targetSources = new Set(targetFiles.flatMap((file) => buildAuthFileSourceCandidates(file)));
+
+  const isTargetAuthIndex = (value: unknown) => {
+    const normalized = normalizeAuthIndexValue(value);
+    return Boolean(normalized && targetAuthIndices.has(normalized));
+  };
+  const isTargetSource = (value: unknown) => {
+    const normalized = normalizeUsageSourceId(value, (v) => v);
+    return Boolean(normalized && targetSources.has(normalized));
+  };
+  const previousAuthIndex = Array.isArray(previous?.auth_index) ? previous.auth_index : [];
+  const previousSource = Array.isArray(previous?.source) ? previous.source : [];
+  const nextAuthIndex = Array.isArray(next.auth_index) ? next.auth_index : [];
+  const nextSource = Array.isArray(next.source) ? next.source : [];
+
+  return {
+    auth_index: [
+      ...previousAuthIndex.filter((point) => !isTargetAuthIndex(point.entity_name)),
+      ...nextAuthIndex.filter((point) => isTargetAuthIndex(point.entity_name)),
+    ],
+    source: [
+      ...previousSource.filter((point) => !isTargetSource(point.entity_name)),
+      ...nextSource.filter((point) => isTargetSource(point.entity_name)),
+    ],
+  };
+};
 
 export function useAuthFilesDataState() {
   const { t } = useTranslation();
@@ -54,15 +94,61 @@ export function useAuthFilesDataState() {
     }
   }, [notify, t]);
 
-  const refreshUsageData = useCallback(async (): Promise<EntityStatsResponse | null> => {
-    try {
-      const nextUsageData = await usageApi.getEntityStats(30, "all");
-      setUsageData(nextUsageData);
-      return nextUsageData;
-    } catch {
-      return null;
-    }
-  }, []);
+  const refreshFilesForItems = useCallback(
+    async (targetFiles: AuthFileItem[]): Promise<AuthFileItem[]> => {
+      if (targetFiles.length === 0) return filesRef.current;
+
+      const targetNames = new Set(targetFiles.map((file) => file.name).filter(Boolean));
+      if (targetNames.size === 0) return filesRef.current;
+
+      try {
+        const filesRes = await authFilesApi.list();
+        const list = Array.isArray(filesRes?.files) ? filesRes.files : [];
+        const filesByName = new Map(list.map((file) => [file.name, file]));
+        let updatedFiles = filesRef.current;
+
+        setFiles((prev) => {
+          const next = prev.map((item) => {
+            if (!targetNames.has(item.name)) return item;
+            return filesByName.get(item.name) ?? item;
+          });
+          updatedFiles = next;
+          filesRef.current = next;
+          return next;
+        });
+
+        return updatedFiles;
+      } catch (err: unknown) {
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("auth_files.load_failed"),
+        });
+        return filesRef.current;
+      }
+    },
+    [notify, t],
+  );
+
+  const refreshUsageDataForFiles = useCallback(
+    async (targetFiles: AuthFileItem[]): Promise<EntityStatsResponse | null> => {
+      if (targetFiles.length === 0) return usageDataRef.current;
+
+      try {
+        const nextUsageData = await usageApi.getEntityStats(30, "all");
+        const mergedUsageData = mergeTargetUsageData(
+          usageDataRef.current,
+          nextUsageData,
+          targetFiles,
+        );
+        usageDataRef.current = mergedUsageData;
+        setUsageData(mergedUsageData);
+        return mergedUsageData;
+      } catch {
+        return null;
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     void loadAll();
@@ -107,6 +193,7 @@ export function useAuthFilesDataState() {
     usageData,
     usageIndex,
     loadAll,
-    refreshUsageData,
+    refreshFilesForItems,
+    refreshUsageDataForFiles,
   };
 }

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -37,7 +37,7 @@ interface UseAuthFilesQuotaStateOptions {
   loading: boolean;
   setFiles: Dispatch<SetStateAction<AuthFileItem[]>>;
   setDetailFile: Dispatch<SetStateAction<AuthFileItem | null>>;
-  refreshUsageData?: () => Promise<unknown>;
+  refreshUsageDataForFiles?: (files: AuthFileItem[]) => Promise<unknown>;
 }
 
 export function useAuthFilesQuotaState({
@@ -46,7 +46,7 @@ export function useAuthFilesQuotaState({
   loading,
   setFiles,
   setDetailFile,
-  refreshUsageData,
+  refreshUsageDataForFiles,
 }: UseAuthFilesQuotaStateOptions) {
   const { t } = useTranslation();
   const initialDataCache = useMemo(() => readAuthFilesDataCache(), []);
@@ -60,7 +60,6 @@ export function useAuthFilesQuotaState({
   const quotaInFlightRef = useRef<Set<string>>(new Set());
   const quotaAutoRefreshingRef = useRef<Set<string>>(new Set());
   const quotaByFileNameRef = useRef<Record<string, QuotaState>>(quotaByFileName);
-  const usageRefreshInFlightRef = useRef<Promise<unknown> | null>(null);
   const quotaWarmupAttemptRef = useRef<Map<string, number>>(new Map());
   const visiblePageSignatureRef = useRef<string | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -115,15 +114,13 @@ export function useAuthFilesQuotaState({
     [setDetailFile, setFiles],
   );
 
-  const refreshUsageDataAfterQuota = useCallback(async () => {
-    if (!refreshUsageData) return;
-    if (!usageRefreshInFlightRef.current) {
-      usageRefreshInFlightRef.current = refreshUsageData().finally(() => {
-        usageRefreshInFlightRef.current = null;
-      });
-    }
-    await usageRefreshInFlightRef.current.catch(() => undefined);
-  }, [refreshUsageData]);
+  const refreshUsageDataAfterQuota = useCallback(
+    async (targetFiles: AuthFileItem[]) => {
+      if (!refreshUsageDataForFiles || targetFiles.length === 0) return;
+      await refreshUsageDataForFiles(targetFiles).catch(() => undefined);
+    },
+    [refreshUsageDataForFiles],
+  );
 
   const resolveQuotaCardSlots = useCallback(
     (provider: QuotaProvider, items: QuotaItem[]) => {
@@ -245,7 +242,11 @@ export function useAuthFilesQuotaState({
   );
 
   const refreshQuota = useCallback(
-    async (file: AuthFileItem, provider: QuotaProvider, options?: { showLoading?: boolean }) => {
+    async (
+      file: AuthFileItem,
+      provider: QuotaProvider,
+      options?: { showLoading?: boolean; refreshUsage?: boolean },
+    ) => {
       const name = file.name;
       if (quotaInFlightRef.current.has(name)) return;
       quotaInFlightRef.current.add(name);
@@ -321,7 +322,9 @@ export function useAuthFilesQuotaState({
             updatedAt: Date.now(),
           },
         }));
-        await refreshUsageDataAfterQuota();
+        if (options?.refreshUsage !== false) {
+          await refreshUsageDataAfterQuota([file]);
+        }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : t("auth_files.unknown_error");
         setQuotaByFileName((prev) => ({
@@ -453,6 +456,7 @@ export function useAuthFilesQuotaState({
             try {
               await refreshQuota(current.file, current.provider, {
                 showLoading: options?.showLoading,
+                refreshUsage: false,
               });
             } finally {
               if (markAsAutoRefreshing) {
@@ -464,13 +468,15 @@ export function useAuthFilesQuotaState({
       );
 
       await Promise.allSettled(workers);
+      await refreshUsageDataAfterQuota(targets.map((target) => target.file));
     },
-    [refreshQuota],
+    [refreshQuota, refreshUsageDataAfterQuota],
   );
 
   useEffect(() => {
     if (tab !== "files") return;
     if (loading) return;
+    if (quotaAutoRefreshMs <= 0) return;
 
     const visibleSignature = pageItems.map((file) => file.name).join("\n");
     const previousVisibleSignature = visiblePageSignatureRef.current;
@@ -505,6 +511,7 @@ export function useAuthFilesQuotaState({
     loading,
     markQuotaTargetsLoading,
     pageItems,
+    quotaAutoRefreshMs,
     resolveQuotaTargets,
     runQuotaRefreshBatch,
     tab,


### PR DESCRIPTION
## Summary
- Target auth-file usage stat refreshes to only the clicked file or current page items.
- Refresh current-page auth-file file/quota data without replacing full usage state.
- Respect disabled quota auto-refresh when switching visible pages.

## Tests
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run test src/modules/models/__tests__/ModelsPage.test.tsx
- git diff --check
- bun run lint
- bun run build