### PR TITLE
Refresh auth files tabs on entry

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -134,6 +134,7 @@ export function AuthFilesPage() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const filesRef = useRef<AuthFileItem[]>(files);
   const oauthBaselineSignatureRef = useRef("");
+  const previousTabRef = useRef<"files" | "excluded" | "alias" | null>(null);
 
   useEffect(() => {
     filesRef.current = files;
@@ -340,6 +341,17 @@ export function AuthFilesPage() {
     const filesRefreshPromise = refreshFilesForItems(currentPageItems);
     await Promise.all([filesRefreshPromise, quotaRefreshPromise]);
   }, [forceRefreshPage, pageItems, refreshFilesForItems]);
+
+  useEffect(() => {
+    const previousTab = previousTabRef.current;
+    previousTabRef.current = tab;
+    if (previousTab === null || previousTab === tab || tab !== "files") return;
+
+    void (async () => {
+      await loadAll();
+      await forceRefreshPage();
+    })();
+  }, [forceRefreshPage, loadAll, tab]);
 
   const {
     groupOverviewOpen,

--- a/src/modules/auth-files/__tests__/AuthFilesPage.excluded.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.excluded.test.tsx
@@ -1,13 +1,16 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { AuthFilesPage } from "@/modules/auth-files/AuthFilesPage";
 
 const mocks = vi.hoisted(() => ({
-  list: vi.fn(async () => ({ files: [] })),
+  list: vi.fn(async (): Promise<{ files: any[] }> => ({ files: [] })),
   getOauthExcludedModels: vi.fn(async () => ({})),
+  getOauthModelAlias: vi.fn(async () => ({})),
+  getModelConfigs: vi.fn(async () => []),
+  getModelOwnerPresets: vi.fn(async () => []),
   getUsage: vi.fn(async () => ({ apis: {} })),
   getEntityStats: vi.fn(async () => ({ source: [], auth_index: [] })),
 }));
@@ -20,6 +23,12 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
       ...mod.authFilesApi,
       list: mocks.list,
       getOauthExcludedModels: mocks.getOauthExcludedModels,
+      getOauthModelAlias: mocks.getOauthModelAlias,
+    },
+    modelsApi: {
+      ...mod.modelsApi,
+      getModelConfigs: mocks.getModelConfigs,
+      getModelOwnerPresets: mocks.getModelOwnerPresets,
     },
     usageApi: { ...mod.usageApi, getUsage: mocks.getUsage, getEntityStats: mocks.getEntityStats },
     oauthApi: {
@@ -34,6 +43,25 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
 });
 
 describe("AuthFilesPage OAuth excluded models", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    mocks.list.mockReset();
+    mocks.list.mockResolvedValue({ files: [] });
+    mocks.getOauthExcludedModels.mockReset();
+    mocks.getOauthExcludedModels.mockResolvedValue({});
+    mocks.getOauthModelAlias.mockReset();
+    mocks.getOauthModelAlias.mockResolvedValue({});
+    mocks.getModelConfigs.mockReset();
+    mocks.getModelConfigs.mockResolvedValue([]);
+    mocks.getModelOwnerPresets.mockReset();
+    mocks.getModelOwnerPresets.mockResolvedValue([]);
+    mocks.getUsage.mockReset();
+    mocks.getUsage.mockResolvedValue({ apis: {} });
+    mocks.getEntityStats.mockReset();
+    mocks.getEntityStats.mockResolvedValue({ source: [], auth_index: [] });
+  });
+
   test("does not refetch endlessly when excluded models map is empty", async () => {
     render(
       <MemoryRouter initialEntries={["/auth-files?tab=excluded"]}>
@@ -55,5 +83,65 @@ describe("AuthFilesPage OAuth excluded models", () => {
 
     await new Promise((r) => setTimeout(r, 30));
     expect(mocks.getOauthExcludedModels).toHaveBeenCalledTimes(1);
+  });
+
+  test("refetches excluded models whenever the excluded tab is entered", async () => {
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("tab", { name: "OAuth Excluded Models" }));
+    await waitFor(() => expect(mocks.getOauthExcludedModels).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    ));
+
+    fireEvent.click(screen.getByRole("tab", { name: "OAuth Excluded Models" }));
+    await waitFor(() => expect(mocks.getOauthExcludedModels).toHaveBeenCalledTimes(2));
+  });
+
+  test("refetches auth files whenever the files tab is re-entered", async () => {
+    mocks.list
+      .mockResolvedValueOnce({
+        files: [{ name: "before.json", type: "codex", size: 1, modified: Date.now() }] as any[],
+      })
+      .mockResolvedValue({
+        files: [{ name: "after.json", type: "codex", size: 1, modified: Date.now() }] as any[],
+      });
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("before.json")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "OAuth Excluded Models" }));
+    await waitFor(() => expect(mocks.getOauthExcludedModels).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("after.json")).toBeInTheDocument();
   });
 });

--- a/src/modules/auth-files/hooks/useAuthFilesOAuthConfig.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesOAuthConfig.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { authFilesApi } from "@/lib/http/apis";
 import { useToast } from "@/modules/ui/ToastProvider";
@@ -7,7 +7,6 @@ import {
   buildAliasRows,
   normalizeProviderKey,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
-import type { OAuthModelAliasEntry } from "@/lib/http/types";
 
 export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   const { t } = useTranslation();
@@ -19,14 +18,11 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   const [excludedDraft, setExcludedDraft] = useState<Record<string, string>>({});
   const [excludedNewProvider, setExcludedNewProvider] = useState("");
   const [excludedUnsupported, setExcludedUnsupported] = useState(false);
-  const [excludedLoadAttempted, setExcludedLoadAttempted] = useState(false);
 
   const [aliasLoading, setAliasLoading] = useState(false);
-  const [aliasMap, setAliasMap] = useState<Record<string, OAuthModelAliasEntry[]>>({});
   const [aliasEditing, setAliasEditing] = useState<Record<string, AliasRow[]>>({});
   const [aliasNewChannel, setAliasNewChannel] = useState("");
   const [aliasUnsupported, setAliasUnsupported] = useState(false);
-  const [aliasLoadAttempted, setAliasLoadAttempted] = useState(false);
 
   const [importOpen, setImportOpen] = useState(false);
   const [importChannel, setImportChannel] = useState("");
@@ -34,9 +30,9 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   const [importModels, setImportModels] = useState<AuthFileModelItem[]>([]);
   const [importSearch, setImportSearch] = useState("");
   const [importSelected, setImportSelected] = useState<Set<string>>(new Set());
+  const previousTabRef = useRef<"files" | "excluded" | "alias" | null>(null);
 
   const refreshExcluded = useCallback(async () => {
-    setExcludedLoadAttempted(true);
     setExcludedLoading(true);
     try {
       const map = await authFilesApi.getOauthExcludedModels();
@@ -65,12 +61,10 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   }, [notify, t]);
 
   const refreshAlias = useCallback(async () => {
-    setAliasLoadAttempted(true);
     setAliasLoading(true);
     try {
       const map = await authFilesApi.getOauthModelAlias();
       setAliasUnsupported(false);
-      setAliasMap(map);
       setAliasEditing(
         Object.fromEntries(Object.entries(map).map(([key, value]) => [key, buildAliasRows(value)])),
       );
@@ -78,7 +72,6 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
       const message = err instanceof Error ? err.message : "";
       if (/404|not found/i.test(message)) {
         setAliasUnsupported(true);
-        setAliasMap({});
         setAliasEditing({});
         return;
       }
@@ -89,37 +82,17 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   }, [notify, t]);
 
   useEffect(() => {
-    if (
-      tab === "excluded" &&
-      !excludedLoadAttempted &&
-      !excludedLoading &&
-      !excludedUnsupported &&
-      Object.keys(excluded).length === 0
-    ) {
+    const previousTab = previousTabRef.current;
+    previousTabRef.current = tab;
+    if (previousTab === tab) return;
+
+    if (tab === "excluded") {
       void refreshExcluded();
     }
-    if (
-      tab === "alias" &&
-      !aliasLoadAttempted &&
-      !aliasLoading &&
-      !aliasUnsupported &&
-      Object.keys(aliasMap).length === 0
-    ) {
+    if (tab === "alias") {
       void refreshAlias();
     }
-  }, [
-    aliasLoading,
-    aliasMap,
-    aliasUnsupported,
-    aliasLoadAttempted,
-    excluded,
-    excludedLoading,
-    excludedUnsupported,
-    excludedLoadAttempted,
-    refreshAlias,
-    refreshExcluded,
-    tab,
-  ]);
+  }, [refreshAlias, refreshExcluded, tab]);
 
   const saveExcludedProvider = useCallback(
     async (provider: string, text: string) => {
@@ -191,7 +164,6 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
       notify({ type: "info", message: t("auth_files.please_enter_channel") });
       return;
     }
-    setAliasMap((prev) => (prev[key] ? prev : { ...prev, [key]: [] }));
     setAliasEditing((prev) => (prev[key] ? prev : { ...prev, [key]: buildAliasRows([]) }));
     setAliasNewChannel("");
   }, [aliasNewChannel, notify, t]);


### PR DESCRIPTION
Summary

- Refresh auth-files data when returning to the Files tab from OAuth tabs.
- Refresh OAuth excluded models and alias data whenever those tabs are entered, without looping while the tab remains active.
- Add regressions for tab re-entry refresh behavior.

Tests

- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.excluded.test.tsx --no-file-parallelism --maxWorkers=1
- bun run test:ci
- bun run build
- bun run lint
- git diff --check
