### PR TITLE
Fix scoped auth files usage load

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -199,6 +199,51 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByRole("switch", { name: "Enable/Disable" })).toBeInTheDocument();
   });
 
+  test("loads initial usage stats only for listed auth files", async () => {
+    const now = Date.now();
+    mocks.list.mockImplementationOnce(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+          auth_index: "auth-codex",
+        },
+        {
+          name: "kimi-a.json",
+          type: "kimi",
+          size: 1024,
+          modified: now,
+          disabled: false,
+          auth_index: "auth-kimi",
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-pro.json")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mocks.getEntityStats).toHaveBeenCalledWith(30, "all", {
+        authIndexes: ["auth-codex", "auth-kimi"],
+        sources: ["t:codex-pro.json", "t:codex-pro", "t:kimi-a.json", "t:kimi-a"],
+      });
+    });
+  });
+
   test("shows active restriction badge with reason and recovery tooltip", async () => {
     const now = Date.now();
     mocks.list.mockImplementationOnce(async () => ({

--- a/src/modules/auth-files/hooks/useAuthFilesDataState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesDataState.ts
@@ -88,12 +88,18 @@ export function useAuthFilesDataState() {
     else setLoading(true);
     if (!hasExisting) setUsageLoading(true);
     try {
-      const [filesRes, usageRes] = await Promise.all([
-        authFilesApi.list(),
-        usageApi.getEntityStats(30, "all").catch(() => null),
-      ]);
+      const filesRes = await authFilesApi.list();
       const list = Array.isArray(filesRes?.files) ? filesRes.files : [];
+      filesRef.current = list;
       setFiles(list);
+
+      const scope = buildEntityStatsScopeForFiles(list);
+      const hasUsageScope =
+        (scope.authIndexes?.length ?? 0) > 0 || (scope.sources?.length ?? 0) > 0;
+      const usageRes = hasUsageScope
+        ? await usageApi.getEntityStats(30, "all", scope).catch(() => null)
+        : ({ source: [], auth_index: [] } satisfies EntityStatsResponse);
+
       setUsageData((prev) => usageRes ?? prev);
       return list;
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- scope auth-files initial usage stats to the listed auth files
- avoid broad entity-stats loads when refreshing the files tab
- add regression coverage for scoped initial usage loading

## Tests
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.excluded.test.tsx --no-file-parallelism --maxWorkers=1
- bun run build
- bun run test:ci
- bun run lint (0 errors; existing unrelated warning)