### PR TITLE
Fix auth files group refresh behavior

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -314,7 +314,7 @@ export function AuthFilesPage() {
   } = useAuthFilesQuotaState({
     tab,
     pageItems,
-    visibleScopeKey: `${filter}\n${search}\n${safePage}`,
+    visibleScopeKey: `${filter}\n${search}`,
     loading,
     setFiles,
     setDetailFile,

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -171,6 +171,7 @@ describe("AuthFilesPage files table", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     window.localStorage.clear();
     window.sessionStorage.clear();
   });
@@ -244,7 +245,7 @@ describe("AuthFilesPage files table", () => {
     });
   });
 
-  test("shows active restriction badge with reason and recovery tooltip", async () => {
+  test("shows active auth-level restriction badge with reason and recovery tooltip", async () => {
     const now = Date.now();
     mocks.list.mockImplementationOnce(async () => ({
       files: [
@@ -256,8 +257,7 @@ describe("AuthFilesPage files table", () => {
           disabled: false,
           restrictions: [
             {
-              scope: "model",
-              model: "gpt-5",
+              scope: "auth",
               http_status: 401,
               status_message: "unauthorized",
               next_retry_after: new Date(now + 34 * 60_000 + 50_000).toISOString(),
@@ -284,12 +284,11 @@ describe("AuthFilesPage files table", () => {
     fireEvent.mouseEnter(tooltipTrigger);
 
     const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip).toHaveTextContent("gpt-5");
     expect(tooltip).toHaveTextContent("unauthorized");
     expect(tooltip).toHaveTextContent("Auto recovery in");
   });
 
-  test("keeps verbose restriction errors out of table badges and opens one tooltip", async () => {
+  test("hides model-scoped transport errors from table restriction badges", async () => {
     vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(80);
     vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(640);
 
@@ -334,19 +333,13 @@ describe("AuthFilesPage files table", () => {
     const title = await screen.findByText("A_GptPro");
     const row = title.closest("tr");
     expect(row).not.toBeNull();
-    expect(within(row as HTMLElement).getByText("Restricted")).toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("Restricted")).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("500 Error")).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("429 Error")).not.toBeInTheDocument();
     expect(within(row as HTMLElement).queryByText(rawError)).not.toBeInTheDocument();
-
-    fireEvent.mouseEnter(within(row as HTMLElement).getByText("Restricted"));
-
-    const tooltips = await screen.findAllByRole("tooltip");
-    expect(tooltips).toHaveLength(1);
-    expect(tooltips[0]).toHaveTextContent("gpt-5.4");
-    expect(tooltips[0]).toHaveTextContent(rawError);
-    expect(tooltips[0]).not.toHaveTextContent("A_GptPro");
   });
 
-  test("cards view keeps verbose restriction errors out of badge rows", async () => {
+  test("cards view hides model-scoped transient errors from badge rows", async () => {
     const now = Date.now();
     const rawError = "context canceled";
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
@@ -388,7 +381,9 @@ describe("AuthFilesPage files table", () => {
     const title = await screen.findByText("A_GptPro");
     const card = title.closest("section");
     expect(card).not.toBeNull();
-    expect(within(card as HTMLElement).getByText("Restricted")).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("Restricted")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("500 Error")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("429 Error")).not.toBeInTheDocument();
     expect(within(card as HTMLElement).queryByText(rawError)).not.toBeInTheDocument();
   });
 
@@ -741,6 +736,91 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(9));
     expect(mocks.fetchQuota.mock.calls.map(([, file]) => (file as { name: string }).name)).toEqual(
       codexFiles.slice(0, 9).map((file) => file.name),
+    );
+  });
+
+  test("switching provider after entering from request logs refreshes visible cards with auto-refresh off", async () => {
+    const now = Date.now();
+    const qwenFiles = Array.from({ length: 2 }, (_, index) => ({
+      name: `qwen-${index + 1}.json`,
+      type: "qwen",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: `qwen-${index + 1}`,
+    }));
+    const codexFiles = Array.from({ length: 2 }, (_, index) => ({
+      name: `codex-${index + 1}.json`,
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: `codex-${index + 1}`,
+    }));
+    const files = [...qwenFiles, ...codexFiles] as any[];
+
+    mocks.list.mockImplementation(async () => ({ files }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ label: "m_quota.code_5h", percent: 66, resetAtMs: now + 60_000 }],
+    });
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_UI_STATE_KEY,
+      JSON.stringify({ tab: "files", filter: "qwen", search: "", page: 1 }),
+    );
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files,
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: Object.fromEntries(
+          qwenFiles.map((file) => [
+            file.name,
+            {
+              status: "success",
+              updatedAt: now,
+              items: [{ label: "m_quota.code_5h", percent: 22, resetAtMs: now + 60_000 }],
+            },
+          ]),
+        ),
+      }),
+    );
+
+    const router = createMemoryRouter(
+      [
+        { path: "/monitor/request-logs", element: <div>request logs</div> },
+        {
+          path: "/auth-files",
+          element: (
+            <ThemeProvider>
+              <ToastProvider>
+                <AuthFilesPage />
+              </ToastProvider>
+            </ThemeProvider>
+          ),
+        },
+      ],
+      { initialEntries: ["/monitor/request-logs"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByText("request logs")).toBeInTheDocument();
+    await act(async () => {
+      await router.navigate("/auth-files");
+    });
+
+    expect(await screen.findByText("qwen-1.json")).toBeInTheDocument();
+    mocks.fetchQuota.mockClear();
+
+    fireEvent.click(screen.getByRole("tab", { name: /^codex/i }));
+
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(2));
+    expect(mocks.fetchQuota.mock.calls.map(([, file]) => (file as { name: string }).name)).toEqual(
+      codexFiles.map((file) => file.name),
     );
   });
 
@@ -1350,6 +1430,123 @@ describe("AuthFilesPage files table", () => {
     const quotaLabel = screen.getByText("Code: 5h");
     fireEvent.mouseEnter(quotaLabel);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  test("cards view does not schedule quota countdown ticks when auto-refresh is off", async () => {
+    const now = Date.parse("2026-05-12T08:00:00.000Z");
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const intervalSpy = vi.spyOn(window, "setInterval");
+    const file = {
+      name: "codex.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "1",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ label: "m_quota.code_5h", percent: 22, resetAtMs: now + 10_000 }],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const cards = await screen.findByTestId("auth-files-cards");
+    expect(within(cards).getByText("10秒")).toBeInTheDocument();
+    expect(intervalSpy.mock.calls.some(([, delay]) => delay === 10_000)).toBe(false);
+  });
+
+  test("cards view keeps weekly quota reset separate from five-hour reset and hides file modified time", async () => {
+    const now = Date.parse("2026-05-12T08:00:00.000Z");
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const file = {
+      name: "codex.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "1",
+    } as any;
+    const modifiedText = new Date(now).toLocaleString();
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex.json": {
+            status: "success",
+            updatedAt: now,
+            items: [
+              {
+                key: "code_5h",
+                label: "m_quota.code_5h",
+                percent: 100,
+                resetAtMs: now + 5 * 60 * 60 * 1000,
+              },
+              {
+                key: "code_week",
+                label: "m_quota.code_weekly",
+                percent: 0,
+                resetAtMs: now + 6 * 24 * 60 * 60 * 1000,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("codex.json");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+
+    expect(within(card as HTMLElement).getByText("5小时0秒")).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText("6天0秒")).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText(modifiedText)).not.toBeInTheDocument();
   });
 
   test("cards view shows all antigravity quota items instead of truncating to three", async () => {

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -273,8 +273,7 @@ describe("Auth Files helper coverage", () => {
       name: "codex.json",
       restrictions: [
         {
-          scope: "model",
-          model: "gpt-5",
+          scope: "auth",
           http_status: 401,
           status_message: "unauthorized",
           next_retry_after: "2026-05-06T09:04:52.000Z",
@@ -284,9 +283,8 @@ describe("Auth Files helper coverage", () => {
 
     expect(resolveAuthFileRestrictionBadges(file, nowMs)).toEqual([
       {
-        key: "model:gpt-5:401:2026-05-06T09:04:52.000Z",
+        key: "auth::401:2026-05-06T09:04:52.000Z",
         label: "401 Error",
-        model: "gpt-5",
         reason: "unauthorized",
         recoverAtMs: Date.parse("2026-05-06T09:04:52.000Z"),
         remainingText: "1h 4m 52s",
@@ -295,7 +293,7 @@ describe("Auth Files helper coverage", () => {
     ]);
   });
 
-  test("keeps verbose transport errors out of restriction badge labels", () => {
+  test("ignores model-scoped transport errors as auth-file restriction badges", () => {
     const rawError =
       'Post "https://chatgpt.com/backend-api/codex/responses": read tcp [2607:8700:5500:8131::2]:44434->[2a06:98c1:310b::ac40:9bd1]:443: read: connection reset by peer';
     const file = {
@@ -310,11 +308,27 @@ describe("Auth Files helper coverage", () => {
       ],
     } as AuthFileItem;
 
-    expect(resolveAuthFileRestrictionBadges(file, Date.now())[0]).toMatchObject({
-      label: "Restricted",
-      model: "gpt-5.4",
-      reason: rawError,
-    });
+    expect(resolveAuthFileRestrictionBadges(file, Date.now())).toEqual([]);
+  });
+
+  test("ignores model-scoped 429 usage errors as auth-file restriction badges", () => {
+    const file = {
+      name: "codex.json",
+      restrictions: [
+        {
+          scope: "model",
+          model: "gpt-5.5",
+          http_status: 429,
+          status_message: "usage limit exceeded",
+          quota_exceeded: true,
+          next_retry_after: "2026-05-06T13:00:00.000Z",
+        },
+      ],
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileRestrictionBadges(file, Date.parse("2026-05-06T08:00:00.000Z")),
+    ).toEqual([]);
   });
 
   test("does not derive restriction badges from normal auth status", () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -33,7 +33,6 @@ import type {
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import {
   TYPE_BADGE_CLASSES,
-  formatModified,
   isRuntimeOnlyAuthFile,
   normalizeProviderKey,
   resolveAuthFileDisplayName,
@@ -652,9 +651,6 @@ export function AuthFilesFilesTab({
                             ))}
                           </div>
                         ) : null}
-                        <p className="truncate text-[11px] text-slate-500 dark:text-white/45">
-                          {formatModified(file)}
-                        </p>
                       </div>
 
                       <div

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -439,9 +439,13 @@ export const resolveAuthFileRestrictionBadges = (
   nowMs = Date.now(),
 ): AuthFileRestrictionBadge[] => {
   const rawRestrictions = Array.isArray(file.restrictions) ? file.restrictions : [];
+  const displayableRawRestrictions = rawRestrictions.filter((restriction) => {
+    const scope = normalizeTagValue(restriction.scope);
+    return scope !== "model";
+  });
   const restrictions =
     rawRestrictions.length > 0
-      ? rawRestrictions
+      ? displayableRawRestrictions
       : isLegacyAuthRestrictionActive(file)
         ? [
             {

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -63,7 +63,7 @@ export function useAuthFilesQuotaState({
   const quotaAutoRefreshingRef = useRef<Set<string>>(new Set());
   const quotaByFileNameRef = useRef<Record<string, QuotaState>>(quotaByFileName);
   const quotaWarmupAttemptRef = useRef<Map<string, number>>(new Map());
-  const visiblePageSignatureRef = useRef<string | null>(null);
+  const visibleScopeKeyRef = useRef<string | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   const [quotaPreviewMode, setQuotaPreviewMode] = useLocalStorage<QuotaPreviewMode>(
@@ -87,7 +87,7 @@ export function useAuthFilesQuotaState({
     () => {
       setNowMs(Date.now());
     },
-    tab === "files" ? Math.min(10_000, quotaAutoRefreshMs || 10_000) : null,
+    tab === "files" && quotaAutoRefreshMs > 0 ? Math.min(10_000, quotaAutoRefreshMs) : null,
   );
 
   useEffect(() => {
@@ -174,21 +174,32 @@ export function useAuthFilesQuotaState({
         .filter((item) => !parseAdditionalQuotaWindowLabel(String(item.label ?? "")))
         .map((item) => ({
           item,
-          key: normalize(String(item.label ?? "")),
+          key: normalize(`${String(item.key ?? "")} ${String(item.label ?? "")}`),
         }));
 
       const findExact = (label: string) => items.find((item) => item.label === label) ?? null;
+      const findKey = (...keys: string[]) =>
+        items.find((item) => {
+          const normalizedKey = normalize(String(item.key ?? ""));
+          return keys.some((key) => normalizedKey === normalize(key));
+        }) ?? null;
       const find = (re: RegExp) =>
         candidates.find((candidate) => re.test(candidate.key))?.item ?? null;
 
       const codeFiveHour =
-        findExact("m_quota.code_5h") ?? find(/(mquotacode5h|code5h|5h|5小时|fivehour|5hour)/i);
+        findKey("code_5h", "code5h") ??
+        findExact("m_quota.code_5h") ??
+        find(/(mquotacode5h|code5h|5h|5小时|fivehour|5hour)/i);
       const codeWeek =
-        findExact("m_quota.code_weekly") ?? find(/(mquotacodeweekly|codeweekly|weekly|week|周)/i);
+        findKey("code_week", "code_weekly", "codeweekly") ??
+        findExact("m_quota.code_weekly") ??
+        find(/(mquotacodeweekly|codeweekly|weekly|week|周)/i);
       const reviewFiveHour =
+        findKey("review_5h", "review5h") ??
         findExact("m_quota.review_5h") ??
         find(/(mquotareview5h|review5h|review5hour|reviewfivehour|审查5小时|审查：5小时)/i);
       const reviewWeek =
+        findKey("review_week", "review_weekly", "reviewweekly") ??
         findExact("m_quota.review_weekly") ??
         find(/(mquotareviewweekly|reviewweekly|reviewweek|review_week|审查周|审查：周)/i);
 
@@ -478,20 +489,20 @@ export function useAuthFilesQuotaState({
   useEffect(() => {
     if (tab !== "files") return;
     if (loading) return;
-    if (quotaAutoRefreshMs <= 0) return;
 
-    const visibleSignature = [visibleScopeKey, ...pageItems.map((file) => file.name)].join("\n");
-    const previousVisibleSignature = visiblePageSignatureRef.current;
-    visiblePageSignatureRef.current = visibleSignature;
+    const previousVisibleScopeKey = visibleScopeKeyRef.current;
+    visibleScopeKeyRef.current = visibleScopeKey;
 
-    const switchedVisiblePage =
-      previousVisibleSignature !== null && previousVisibleSignature !== visibleSignature;
-    const toFetch = switchedVisiblePage
+    const switchedVisibleScope =
+      previousVisibleScopeKey !== null && previousVisibleScopeKey !== visibleScopeKey;
+    if (!switchedVisibleScope && quotaAutoRefreshMs <= 0) return;
+
+    const toFetch = switchedVisibleScope
       ? resolveQuotaTargets(pageItems)
       : collectQuotaFetchTargets(pageItems);
     if (!toFetch.length) return;
 
-    if (switchedVisiblePage) {
+    if (switchedVisibleScope) {
       markQuotaTargetsLoading(toFetch);
     }
 
@@ -500,7 +511,7 @@ export function useAuthFilesQuotaState({
       if (!cancelled) {
         await runQuotaRefreshBatch(toFetch, {
           markAsAutoRefreshing: true,
-          showLoading: switchedVisiblePage,
+          showLoading: switchedVisibleScope,
         });
       }
     })();


### PR DESCRIPTION
## Summary
- Refresh visible auth-file quota data immediately when filter/search scope changes, including after route navigation.
- Hide model-scoped transient errors from auth-file restriction badges and remove card modified timestamps.
- Keep auto-refresh off from scheduling quota countdown ticks and prefer stable quota keys for reset windows.

## Test Plan
- bun run test src/modules/auth-files/__tests__/auth-files-helpers.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --no-file-parallelism --maxWorkers=1
- bun run lint
- bun run build
- bun run test:ci