### PR TITLE
Hide auth file quota recovery badges

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -387,6 +387,55 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText(rawError)).not.toBeInTheDocument();
   });
 
+  test("cards view hides auth-level quota recovery records from badge rows", async () => {
+    const now = Date.now();
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-plus.json",
+          label: "Codex Plus",
+          account_type: "oauth",
+          type: "codex",
+          plan_type: "plus",
+          size: 1024,
+          modified: now,
+          disabled: false,
+          restrictions: [
+            {
+              scope: "auth",
+              http_status: 429,
+              quota_exceeded: true,
+              reason: "quota",
+              status: "error",
+              status_message: '{"error":{"type":"usage_limit_reached","message":"usage limit"}}',
+              unavailable: true,
+              next_retry_after: new Date(now + 5 * 60 * 60 * 1000).toISOString(),
+            },
+          ],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("Codex Plus");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).queryByText("Restricted")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("429 Error")).not.toBeInTheDocument();
+  });
+
   test("supports multi-select delete from the toolbar", async () => {
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -331,6 +331,28 @@ describe("Auth Files helper coverage", () => {
     ).toEqual([]);
   });
 
+  test("ignores auth-level quota recovery records as auth-file restriction badges", () => {
+    const file = {
+      name: "codex.json",
+      restrictions: [
+        {
+          scope: "auth",
+          http_status: 429,
+          quota_exceeded: true,
+          reason: "quota",
+          status: "error",
+          status_message: '{"error":{"type":"usage_limit_reached","message":"usage limit"}}',
+          unavailable: true,
+          next_retry_after: "2026-05-06T13:00:00.000Z",
+        },
+      ],
+    } as AuthFileItem;
+
+    expect(
+      resolveAuthFileRestrictionBadges(file, Date.parse("2026-05-06T08:00:00.000Z")),
+    ).toEqual([]);
+  });
+
   test("does not derive restriction badges from normal auth status", () => {
     expect(
       resolveAuthFileRestrictionBadges({

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -441,7 +441,13 @@ export const resolveAuthFileRestrictionBadges = (
   const rawRestrictions = Array.isArray(file.restrictions) ? file.restrictions : [];
   const displayableRawRestrictions = rawRestrictions.filter((restriction) => {
     const scope = normalizeTagValue(restriction.scope);
-    return scope !== "model";
+    if (scope === "model") return false;
+    const status = Number(restriction.http_status);
+    if (status === 429 || status >= 500) return false;
+    if (restriction.quota_exceeded || restriction.reason === "quota") return false;
+    const message = String(restriction.status_message ?? "").toLowerCase();
+    if (message.includes("usage_limit") || message.includes("usage limit")) return false;
+    return true;
   });
   const restrictions =
     rawRestrictions.length > 0


### PR DESCRIPTION
## Summary
- Hide quota recovery and transient error records from auth-file restriction badges.
- Add coverage for auth-level quota recovery records in card and helper rendering.

## Test Plan
- bun run test src/modules/auth-files/__tests__/auth-files-helpers.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --no-file-parallelism --maxWorkers=1
- bun run lint
- bun run build
- bun run test:ci