### PR TITLE
fix: allow editing API key values

### DIFF
--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -323,6 +323,10 @@ export function ApiKeysPage() {
     }
     const originalKey = entries[editIndex].key;
     const newKey = form.key.trim();
+    if (!newKey) {
+      notify({ type: "error", message: t("api_keys_page.key_empty") });
+      return;
+    }
     setSaving(true);
     try {
       await apiKeyEntriesApi.update({

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -254,6 +254,72 @@ describe("ApiKeysPage", () => {
     expect(screen.queryByText("Renamed Key")).not.toBeInTheDocument();
   });
 
+  test("allows manually entering an API key when creating an entry", async () => {
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Existing Key")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /create key/i }));
+    await userEvent.type(screen.getAllByPlaceholderText(/team-a/i).at(-1)!, "Manual Key");
+
+    const keyInput = screen.getByPlaceholderText(/enter api key/i);
+    await userEvent.clear(keyInput);
+    await userEvent.type(keyInput, "sk-team-a-manual-key");
+
+    await userEvent.click(screen.getByRole("button", { name: /^Create$/i }));
+
+    await waitFor(() => {
+      expect(mocks.apiKeyEntriesReplace).toHaveBeenCalled();
+    });
+    expect(mocks.apiKeyEntriesReplace).toHaveBeenLastCalledWith([
+      expect.objectContaining({ key: "sk-existing-1234567890" }),
+      expect.objectContaining({ key: "sk-team-a-manual-key", name: "Manual Key" }),
+    ]);
+  });
+
+  test("allows changing an existing API key value", async () => {
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Existing Key")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const keyInput = screen.getByDisplayValue("sk-existing-1234567890");
+    await userEvent.clear(keyInput);
+    await userEvent.type(keyInput, "sk-restored-same-downstream-key");
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mocks.apiKeyEntriesUpdate).toHaveBeenCalled();
+    });
+    expect(mocks.apiKeyEntriesUpdate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        index: 0,
+        value: expect.objectContaining({
+          key: "sk-restored-same-downstream-key",
+          name: "Existing Key",
+        }),
+      }),
+    );
+  });
+
   test("keeps permissions out of the edit modal and preserves them while saving basics", async () => {
     state.entries = [
       {

--- a/src/modules/api-keys/components/ApiKeyFormFields.tsx
+++ b/src/modules/api-keys/components/ApiKeyFormFields.tsx
@@ -44,7 +44,6 @@ export function ApiKeyFormFields({
             onChange={(e) => setForm((prev) => ({ ...prev, key: e.target.value }))}
             placeholder={t("api_keys_page.form_key_placeholder")}
             className="flex-1 font-mono"
-            readOnly
           />
           <Button variant="secondary" size="sm" onClick={regenerateKey}>
             <RefreshCw size={14} />


### PR DESCRIPTION
## Summary
- make the API key field editable in create and edit dialogs
- keep random key generation available via the existing refresh button
- validate blank API keys before saving edits
- add regression tests for manual create and edit key values

## Tests
- bun run vitest run src/modules/api-keys/__tests__/ApiKeysPage.test.tsx src/modules/api-keys/components/__tests__/ApiKeyColumns.test.tsx --no-file-parallelism
- bun run build
- bun run test:ci