### PR TITLE
fix: add OpenAI provider enable toggle

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3063,6 +3063,7 @@
     "priority_label": "Priority (optional)",
     "test_model_label": "Test model (optional)",
     "api_key_entries": "API key entries",
+    "enable_provider": "Enable provider",
     "enable_key_entry": "Enable key entry",
     "key_number": "Key #{{num}}",
     "proxy_url_optional": "Proxy URL (optional)",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2441,6 +2441,7 @@
     "priority_label": "优先级（可选）",
     "test_model_label": "测试模型（可选）",
     "api_key_entries": "API 密钥条目",
+    "enable_provider": "启用提供商",
     "enable_key_entry": "启用密钥条目",
     "key_number": "密钥 #{{num}}",
     "proxy_url_optional": "代理 URL（可选）",

--- a/src/lib/http/apis/__tests__/provider-proxy-id.test.ts
+++ b/src/lib/http/apis/__tests__/provider-proxy-id.test.ts
@@ -37,6 +37,7 @@ describe("provider proxy id serialization", () => {
     expect(
       serializeOpenAIProvider({
         name: "OpenAI",
+        disabled: true,
         baseUrl: "https://api.example.com/v1",
         apiKeyEntries: [
           {
@@ -49,6 +50,7 @@ describe("provider proxy id serialization", () => {
       }),
     ).toEqual(
       expect.objectContaining({
+        disabled: true,
         "api-key-entries": [
           expect.objectContaining({
             disabled: true,

--- a/src/lib/http/apis/__tests__/providers-opencode-go.test.ts
+++ b/src/lib/http/apis/__tests__/providers-opencode-go.test.ts
@@ -168,6 +168,7 @@ describe("providersApi OpenCode Go", () => {
           "openai-compatibility": [
             {
               name: "OpenAI compatible API",
+              disabled: true,
               "base-url": "https://example.com/v1",
               "api-key-entries": [{ "api-key": "sk-openai" }],
             },
@@ -196,6 +197,7 @@ describe("providersApi OpenCode Go", () => {
     await expect(providersApi.getOpenAIProviders()).resolves.toEqual([
       {
         name: "OpenAI compatible API",
+        disabled: true,
         baseUrl: "https://example.com/v1",
         apiKeyEntries: [{ apiKey: "sk-openai" }],
       },

--- a/src/lib/http/apis/helpers.ts
+++ b/src/lib/http/apis/helpers.ts
@@ -207,6 +207,7 @@ export const serializeBedrockKey = (config: BedrockProviderConfig) => {
 
 export const serializeOpenAIProvider = (provider: OpenAIProvider) => {
   const payload: Record<string, unknown> = { name: provider.name };
+  if (provider.disabled === true) payload.disabled = true;
   const baseUrl = normalizeString(provider.baseUrl);
   if (baseUrl) payload["base-url"] = baseUrl;
   const prefix = normalizeString(provider.prefix);

--- a/src/lib/http/apis/providers.ts
+++ b/src/lib/http/apis/providers.ts
@@ -311,6 +311,7 @@ export const providersApi = {
         if (isOauthBackedProviderRow(item)) return null;
         const name = normalizeString(item.name) ?? "";
         if (!name) return null;
+        const disabled = item.disabled === true;
         const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
         const headers = normalizeHeaders(item.headers);
@@ -322,6 +323,7 @@ export const providersApi = {
         const testModel = normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
         return {
           name,
+          ...(disabled ? { disabled } : {}),
           ...(baseUrl ? { baseUrl } : {}),
           ...(prefix ? { prefix } : {}),
           ...(headers ? { headers } : {}),

--- a/src/lib/http/types.ts
+++ b/src/lib/http/types.ts
@@ -182,6 +182,7 @@ export interface ProviderApiKeyEntry {
 
 export interface OpenAIProvider {
   name: string;
+  disabled?: boolean;
   baseUrl?: string;
   prefix?: string;
   headers?: Record<string, string>;

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -321,6 +321,7 @@ export function ProvidersPage() {
     openOpenAIEditor,
     saveOpenAIDraft,
     deleteOpenAIProvider,
+    toggleOpenAIProviderEnabled,
     toggleOpenAIKeyEntryEnabled,
     discoverModels,
     applyDiscoveredModels,
@@ -927,6 +928,9 @@ export function ProvidersPage() {
               getKeyEntryStats={getOpenAIKeyEntryStats}
               getProviderStats={getOpenAIProviderStats}
               getProviderStatusBar={getOpenAIProviderStatusBar}
+              onToggleProviderEnabled={(providerIndex, enabled) =>
+                void toggleOpenAIProviderEnabled(providerIndex, enabled)
+              }
               onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
                 void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
               }

--- a/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -220,8 +220,12 @@ describe("ProvidersPage openai tab", () => {
     );
 
     expect(await screen.findByText("OpenAI Main")).toBeInTheDocument();
-    const enabledSwitch = (await screen.findAllByRole("switch", { name: /Enable key entry 1/i }))[0];
-    const disabledSwitch = (await screen.findAllByRole("switch", { name: /Enable key entry 2/i }))[0];
+    const enabledSwitch = (
+      await screen.findAllByRole("switch", { name: /Enable key entry 1/i })
+    )[0];
+    const disabledSwitch = (
+      await screen.findAllByRole("switch", { name: /Enable key entry 2/i })
+    )[0];
     expect(enabledSwitch).toHaveAttribute("aria-checked", "true");
     expect(disabledSwitch).toHaveAttribute("aria-checked", "false");
 
@@ -235,6 +239,58 @@ describe("ProvidersPage openai tab", () => {
             expect.objectContaining({
               apiKey: "sk-openai-enabled-1234567890",
               disabled: true,
+            }),
+            expect.objectContaining({
+              apiKey: "sk-openai-disabled-1234567890",
+              disabled: true,
+            }),
+          ],
+        }),
+      ]);
+    });
+  });
+
+  test("toggles an OpenAI Compatible provider without removing keys", async () => {
+    const user = userEvent.setup();
+    const provider = {
+      name: "OpenAI Main",
+      baseUrl: "https://example.com/v1",
+      apiKeyEntries: [
+        { apiKey: "sk-openai-enabled-1234567890" },
+        { apiKey: "sk-openai-disabled-1234567890", disabled: true },
+      ],
+      models: [{ name: "gpt-4.1" }],
+    } as any;
+    mocks.getOpenAIProviders.mockImplementation(async () => [provider] as any);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("OpenAI Main")).toBeInTheDocument();
+    const providerSwitch = await screen.findByRole("switch", {
+      name: /Enable provider OpenAI Main/i,
+    });
+    expect(providerSwitch).toHaveAttribute("aria-checked", "true");
+
+    await user.click(providerSwitch);
+
+    await waitFor(() => {
+      expect(mocks.saveOpenAIProviders).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: "OpenAI Main",
+          disabled: true,
+          apiKeyEntries: [
+            expect.objectContaining({
+              apiKey: "sk-openai-enabled-1234567890",
             }),
             expect.objectContaining({
               apiKey: "sk-openai-disabled-1234567890",

--- a/src/modules/providers/__tests__/provider-import-export.test.ts
+++ b/src/modules/providers/__tests__/provider-import-export.test.ts
@@ -76,6 +76,7 @@ describe("provider import/export helpers", () => {
           },
           {
             name: "Fresh",
+            disabled: true,
             "base-url": "https://fresh.example/v1",
             "api-key-entries": [{ "api-key": "sk-fresh" }],
           },
@@ -95,6 +96,7 @@ describe("provider import/export helpers", () => {
     expect(preview.nextItems).toEqual([
       {
         name: "Fresh",
+        disabled: true,
         baseUrl: "https://fresh.example/v1",
         apiKeyEntries: [{ apiKey: "sk-fresh" }],
       },

--- a/src/modules/providers/__tests__/providers-helpers.test.ts
+++ b/src/modules/providers/__tests__/providers-helpers.test.ts
@@ -5,7 +5,10 @@ import {
   maskApiKey,
   normalizeDiscoveredModels,
 } from "@/modules/providers/providers-helpers";
-import { buildCandidateUsageSourceIds, normalizeUsageSourceId } from "@/modules/providers/provider-usage";
+import {
+  buildCandidateUsageSourceIds,
+  normalizeUsageSourceId,
+} from "@/modules/providers/provider-usage";
 
 describe("providers helpers", () => {
   test("masks api keys consistently for provider cards", () => {
@@ -48,6 +51,7 @@ describe("providers helpers", () => {
   test("builds openai draft and preserves api key entries for editing", () => {
     const draft = buildOpenAIDraft({
       name: "OpenAI Main",
+      disabled: true,
       baseUrl: "https://example.com/v1",
       prefix: "oa",
       priority: 5,
@@ -65,6 +69,7 @@ describe("providers helpers", () => {
     });
 
     expect(draft.name).toBe("OpenAI Main");
+    expect(draft.disabled).toBe(true);
     expect(draft.baseUrl).toBe("https://example.com/v1");
     expect(draft.priorityText).toBe("5");
     expect(draft.headersEntries).toEqual([
@@ -93,10 +98,7 @@ describe("providers helpers", () => {
           null,
         ],
       }),
-    ).toEqual([
-      { id: "gpt-4.1", owned_by: "openai" },
-      { id: "gpt-4o-mini" },
-    ]);
+    ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
   });
 
   test("normalizes usage sources and matches raw plus masked api key candidates", () => {

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -24,6 +24,7 @@ interface OpenAIProvidersTabProps {
     totalSuccess: number;
     totalFailure: number;
   };
+  onToggleProviderEnabled?: (providerIndex: number, enabled: boolean) => void;
   onToggleKeyEntryEnabled?: (providerIndex: number, entryIndex: number, enabled: boolean) => void;
   selectedKeys?: Set<string>;
   onToggleSelected?: (key: string, checked: boolean) => void;
@@ -38,6 +39,7 @@ export function OpenAIProvidersTab({
   getKeyEntryStats,
   getProviderStats,
   getProviderStatusBar,
+  onToggleProviderEnabled,
   onToggleKeyEntryEnabled,
   selectedKeys,
   onToggleSelected,
@@ -74,6 +76,7 @@ export function OpenAIProvidersTab({
             const headerEntries = Object.entries(provider.headers || {});
             const stats = getProviderStats(provider);
             const statusData = getProviderStatusBar(provider);
+            const providerEnabled = provider.disabled !== true;
 
             return (
               <div
@@ -83,15 +86,28 @@ export function OpenAIProvidersTab({
                   selected
                     ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                     : "",
+                  providerEnabled ? "" : "opacity-70",
                 ]
                   .filter(Boolean)
                   .join(" ")}
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
-                      {provider.name}
-                    </p>
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
+                        {provider.name}
+                      </p>
+                      <span
+                        className={[
+                          "rounded-full px-2 py-0.5 text-[11px] font-semibold",
+                          providerEnabled
+                            ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
+                            : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
+                        ].join(" ")}
+                      >
+                        {providerEnabled ? t("providers.enabled") : t("providers.disabled")}
+                      </span>
+                    </div>
                     {provider.prefix ? (
                       <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
                         prefix: {provider.prefix}
@@ -213,6 +229,13 @@ export function OpenAIProvidersTab({
                     <ProviderStatusBar data={statusData} />
                   </div>
                   <div className="flex items-center gap-2">
+                    {onToggleProviderEnabled ? (
+                      <ToggleSwitch
+                        checked={providerEnabled}
+                        ariaLabel={`${t("providers.enable_provider")} ${provider.name}`}
+                        onCheckedChange={(enabled) => onToggleProviderEnabled(idx, enabled)}
+                      />
+                    ) : null}
                     {onToggleSelected ? (
                       <div
                         className={[

--- a/src/modules/providers/hooks/useOpenAIProviderEditor.ts
+++ b/src/modules/providers/hooks/useOpenAIProviderEditor.ts
@@ -108,6 +108,7 @@ export function useOpenAIProviderEditor({
 
     return {
       name,
+      ...(openaiDraft.disabled ? { disabled: true } : {}),
       baseUrl,
       ...(openaiDraft.prefix.trim() ? { prefix: openaiDraft.prefix.trim() } : {}),
       ...(headers ? { headers } : {}),
@@ -207,14 +208,38 @@ export function useOpenAIProviderEditor({
         });
       }
     },
-    [
-      notify,
-      openaiProviders,
-      refreshAll,
-      setOpenaiProviders,
-      startRefreshTransition,
-      t,
-    ],
+    [notify, openaiProviders, refreshAll, setOpenaiProviders, startRefreshTransition, t],
+  );
+
+  const toggleOpenAIProviderEnabled = useCallback(
+    async (providerIndex: number, enabled: boolean) => {
+      const provider = openaiProviders[providerIndex];
+      if (!provider) return;
+
+      const prev = openaiProviders;
+      const next = prev.map((item, itemIndex) =>
+        itemIndex === providerIndex
+          ? { ...item, ...(enabled ? { disabled: undefined } : { disabled: true }) }
+          : item,
+      );
+
+      setOpenaiProviders(next);
+      try {
+        await providersApi.saveOpenAIProviders(next);
+        notify({
+          type: "success",
+          message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),
+        });
+        startRefreshTransition(() => void refreshAll());
+      } catch (err: unknown) {
+        setOpenaiProviders(prev);
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("providers.update_failed"),
+        });
+      }
+    },
+    [notify, openaiProviders, refreshAll, setOpenaiProviders, startRefreshTransition, t],
   );
 
   const discoverModels = useCallback(async () => {
@@ -299,6 +324,7 @@ export function useOpenAIProviderEditor({
     openOpenAIEditor,
     saveOpenAIDraft,
     deleteOpenAIProvider,
+    toggleOpenAIProviderEnabled,
     toggleOpenAIKeyEntryEnabled,
     discoverModels,
     applyDiscoveredModels,

--- a/src/modules/providers/provider-import-export.ts
+++ b/src/modules/providers/provider-import-export.ts
@@ -250,6 +250,7 @@ const normalizeOpenAIItem = (
   return {
     item: {
       name,
+      ...(value.disabled === true ? { disabled: true } : {}),
       ...(normalizeString(value["base-url"] ?? value.baseUrl)
         ? { baseUrl: normalizeOpenAIBaseUrl(normalizeString(value["base-url"] ?? value.baseUrl)!) }
         : {}),

--- a/src/modules/providers/providers-helpers.ts
+++ b/src/modules/providers/providers-helpers.ts
@@ -186,6 +186,7 @@ export const buildProviderKeyDraft = (
 
 export type OpenAIDraft = {
   name: string;
+  disabled: boolean;
   baseUrl: string;
   prefix: string;
   headersEntries: KeyValueEntry[];
@@ -204,6 +205,7 @@ export type OpenAIDraft = {
 
 export const buildOpenAIDraft = (input?: OpenAIProvider | null): OpenAIDraft => ({
   name: input?.name ?? "",
+  disabled: input?.disabled === true,
   baseUrl: input?.baseUrl ?? "",
   prefix: input?.prefix ?? "",
   headersEntries: recordToKeyValueEntries(input?.headers),


### PR DESCRIPTION
## Summary
- add an OpenAI-compatible provider enable switch in the providers panel
- preserve per-key enabled states when the whole provider is toggled
- keep disabled state through API normalization, export/import, and editing

## Tests
- bun run test:ci
- bun run build
- bun run lint