### PR TITLE
refactor: ProviderCard component + grid view + UX improvements

### DIFF
--- a/src/lib/http/apis/helpers.ts
+++ b/src/lib/http/apis/helpers.ts
@@ -212,6 +212,7 @@ export const serializeOpenAIProvider = (provider: OpenAIProvider) => {
   if (baseUrl) payload["base-url"] = baseUrl;
   const prefix = normalizeString(provider.prefix);
   if (prefix) payload.prefix = prefix;
+  if (provider.disabled === true) payload.disabled = true;
   const headers = serializeHeaders(provider.headers);
   if (headers) payload.headers = headers;
   const models = serializeModels(provider.models);

--- a/src/lib/http/apis/providers.ts
+++ b/src/lib/http/apis/providers.ts
@@ -321,11 +321,13 @@ export const providersApi = {
         const priority =
           typeof priorityRaw === "number" && Number.isFinite(priorityRaw) ? priorityRaw : undefined;
         const testModel = normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
+        const disabled = item.disabled === true ? true : undefined;
         return {
           name,
           ...(disabled ? { disabled } : {}),
           ...(baseUrl ? { baseUrl } : {}),
           ...(prefix ? { prefix } : {}),
+          ...(disabled !== undefined ? { disabled } : {}),
           ...(headers ? { headers } : {}),
           ...(models ? { models } : {}),
           ...(apiKeyEntries ? { apiKeyEntries } : {}),
@@ -344,4 +346,7 @@ export const providersApi = {
 
   deleteOpenAIProvider: (name: string) =>
     apiClient.delete("/openai-compatibility", undefined, { params: { name } }),
+
+  patchOpenAIProviderDisabled: (index: number, disabled: boolean) =>
+    apiClient.patch("/openai-compatibility", { index, value: { disabled } }),
 };

--- a/src/lib/http/apis/providers.ts
+++ b/src/lib/http/apis/providers.ts
@@ -321,13 +321,11 @@ export const providersApi = {
         const priority =
           typeof priorityRaw === "number" && Number.isFinite(priorityRaw) ? priorityRaw : undefined;
         const testModel = normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
-        const disabled = item.disabled === true ? true : undefined;
         return {
           name,
           ...(disabled ? { disabled } : {}),
           ...(baseUrl ? { baseUrl } : {}),
           ...(prefix ? { prefix } : {}),
-          ...(disabled !== undefined ? { disabled } : {}),
           ...(headers ? { headers } : {}),
           ...(models ? { models } : {}),
           ...(apiKeyEntries ? { apiKeyEntries } : {}),

--- a/src/lib/http/types.ts
+++ b/src/lib/http/types.ts
@@ -185,7 +185,6 @@ export interface OpenAIProvider {
   disabled?: boolean;
   baseUrl?: string;
   prefix?: string;
-  disabled?: boolean;
   headers?: Record<string, string>;
   models?: ProviderModel[];
   apiKeyEntries?: ProviderApiKeyEntry[];

--- a/src/lib/http/types.ts
+++ b/src/lib/http/types.ts
@@ -185,6 +185,7 @@ export interface OpenAIProvider {
   disabled?: boolean;
   baseUrl?: string;
   prefix?: string;
+  disabled?: boolean;
   headers?: Record<string, string>;
   models?: ProviderModel[];
   apiKeyEntries?: ProviderApiKeyEntry[];

--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react";
+import { Settings2, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/modules/ui/Button";
+import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
+
+export interface ProviderCardProps {
+  /** Card title (provider name) */
+  title: string;
+  /** Whether the card is selected for batch operations */
+  selected?: boolean;
+  /** Whether the provider is enabled */
+  enabled?: boolean;
+  /** Whether the card should appear dimmed (disabled state) */
+  dimmed?: boolean;
+  /** Callback when selection checkbox changes */
+  onToggleSelected?: (checked: boolean) => void;
+  /** Callback when enabled toggle changes */
+  onToggleEnabled?: (enabled: boolean) => void;
+  /** Callback when edit button is clicked */
+  onEdit?: () => void;
+  /** Callback when delete button is clicked */
+  onDelete?: () => void;
+  /** Extra elements rendered in the header actions area (between toggle and edit) */
+  headerExtra?: ReactNode;
+  /** Card body content */
+  children?: ReactNode;
+}
+
+export function ProviderCard({
+  title,
+  selected = false,
+  enabled = true,
+  dimmed = false,
+  onToggleSelected,
+  onToggleEnabled,
+  onEdit,
+  onDelete,
+  headerExtra,
+  children,
+}: ProviderCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={[
+        "group rounded-2xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out",
+        selected
+          ? "border-blue-400 bg-blue-50/50 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-950/20 dark:ring-blue-500/20"
+          : "border-slate-200 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
+        dimmed ? "opacity-50" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-2">
+        {onToggleSelected ? (
+          <div
+            className={[
+              "flex items-center justify-center overflow-hidden transition-all duration-200 ease-out",
+              selected
+                ? "w-8 opacity-100"
+                : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
+            ].join(" ")}
+          >
+            <input
+              type="checkbox"
+              aria-label={t("providers.select_provider", { name: title })}
+              checked={selected}
+              onChange={(e) => onToggleSelected(e.currentTarget.checked)}
+              className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
+            />
+          </div>
+        ) : null}
+        <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
+          {title}
+        </p>
+        <div className="ml-auto flex items-center gap-2">
+          {headerExtra}
+          {onToggleEnabled ? (
+            <ToggleSwitch
+              checked={enabled}
+              ariaLabel={t("providers.enable")}
+              onCheckedChange={onToggleEnabled}
+            />
+          ) : null}
+          {onEdit ? (
+            <Button variant="secondary" size="sm" onClick={onEdit}>
+              <Settings2 size={14} />
+              {t("providers.edit")}
+            </Button>
+          ) : null}
+          {onDelete ? (
+            <Button variant="danger" size="sm" onClick={onDelete}>
+              <Trash2 size={14} />
+              {t("providers.delete")}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Content */}
+      {children ? <div className="mt-2 min-w-0">{children}</div> : null}
+    </div>
+  );
+}

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
-import { Loader2, Plus, Settings2, Trash2, Zap } from "lucide-react";
+import { Loader2, Plus, Zap } from "lucide-react";
 import type { ProviderSimpleConfig } from "@/lib/http/types";
 import { Button } from "@/modules/ui/Button";
 import { Card } from "@/modules/ui/Card";
+import { ProviderCard } from "@/modules/providers/ProviderCard";
 import { EmptyState } from "@/modules/ui/EmptyState";
-import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 import { ProviderStatusBar } from "@/modules/providers/ProviderStatusBar";
 import type { KeyStatBucket, StatusBarData } from "@/modules/providers/provider-usage";
 import {
@@ -107,7 +107,7 @@ export function ProviderKeyListCard({
           style={gridColumns > 1 ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
         >
           {items.map((item, idx) => {
-            const selectionKey = item.apiKey.trim().toLowerCase();
+            const selectionKey = `${item.apiKey.trim().toLowerCase()}:${idx}`;
             const selected = selectedKeys?.has(selectionKey) ?? false;
             const disabled = hasDisableAllModelsRule(item.excludedModels);
             const headerEntries = Object.entries(item.headers || {});
@@ -126,48 +126,27 @@ export function ProviderKeyListCard({
                     : "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100";
 
             return (
-              <div
+              <ProviderCard
                 key={`${item.apiKey}:${idx}`}
-                className={[
-                  "group rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
-                  selected
-                    ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
-                    : "",
-                  disabled ? "opacity-50" : "",
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  {onToggleSelected ? (
-                    <div
-                      className={[
-                        "flex h-8 items-center justify-center px-1 transition-opacity",
-                        selected
-                          ? "pointer-events-auto opacity-100"
-                          : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
-                      ].join(" ")}
-                    >
-                      <input
-                        type="checkbox"
-                        aria-label={t("providers.select_provider", {
-                          name: item.name || maskApiKey(item.apiKey),
-                        })}
-                        checked={selected}
-                        onChange={(event) =>
-                          onToggleSelected(selectionKey, event.currentTarget.checked)
-                        }
-                        className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-                      />
-                    </div>
-                  ) : null}
-                  <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
-                    {renderIcon()}
-                    <span className="ml-2">{item.name || maskApiKey(item.apiKey)}</span>
-                  </p>
-                  <div className="ml-auto flex items-center gap-2">
-                    {checkLatency &&
-                      (() => {
+                title={item.name || maskApiKey(item.apiKey)}
+                selected={selected}
+                enabled={!disabled}
+                dimmed={disabled}
+                onToggleSelected={
+                  onToggleSelected
+                    ? (checked) => onToggleSelected(selectionKey, checked)
+                    : undefined
+                }
+                onToggleEnabled={
+                  onToggleEnabled
+                    ? (enabled) => onToggleEnabled(idx, enabled)
+                    : undefined
+                }
+                onEdit={() => onEdit(idx)}
+                onDelete={() => onDelete(idx)}
+                headerExtra={
+                  checkLatency
+                    ? (() => {
                         const latencyKey = item.apiKey;
                         const entry = getLatencyEntry?.(latencyKey) ?? {
                           latencyMs: null,
@@ -201,120 +180,103 @@ export function ProviderKeyListCard({
                             )}
                           </span>
                         );
-                      })()}
-                    {onToggleEnabled ? (
-                      <ToggleSwitch
-                        checked={!disabled}
-                        ariaLabel={t("providers.enable")}
-                        onCheckedChange={(enabled) => onToggleEnabled(idx, enabled)}
-                      />
-                    ) : null}
-                    <Button variant="secondary" size="sm" onClick={() => onEdit(idx)}>
-                      <Settings2 size={14} />
-                      {t("providers.edit")}
-                    </Button>
-                    <Button variant="danger" size="sm" onClick={() => onDelete(idx)}>
-                      <Trash2 size={14} />
-                      {t("providers.delete")}
-                    </Button>
-                  </div>
+                      })()
+                    : undefined
+                }
+              >
+                <div className="space-y-1 text-xs text-slate-600 dark:text-white/65">
+                  <p className="truncate font-mono">apiKey：{maskApiKey(item.apiKey)}</p>
+                  {showBaseUrl ? (
+                    <p className="truncate font-mono">baseUrl：{item.baseUrl || "--"}</p>
+                  ) : null}
+                  {item.proxyUrl ? (
+                    <p className="truncate font-mono">proxyUrl：{item.proxyUrl}</p>
+                  ) : null}
+                  <p className="tabular-nums">
+                    {t("providers.models_label")}: {models.length} ·{" "}
+                    {t("providers.excluded_models_label")}: {excludedModels.length} ·{" "}
+                    {t("providers.headers_optional")}: {headerEntries.length} ·{" "}
+                    {t("providers.success_stats", { count: stats.success })} ·{" "}
+                    {t("providers.failed_stats", { count: stats.failure })}
+                  </p>
                 </div>
 
-                <div className="mt-2 min-w-0">
-                  <div className="space-y-1 text-xs text-slate-600 dark:text-white/65">
-                    <p className="truncate font-mono">apiKey：{maskApiKey(item.apiKey)}</p>
-                    {showBaseUrl ? (
-                      <p className="truncate font-mono">baseUrl：{item.baseUrl || "--"}</p>
-                    ) : null}
-                    {item.proxyUrl ? (
-                      <p className="truncate font-mono">proxyUrl：{item.proxyUrl}</p>
-                    ) : null}
-                    <p className="tabular-nums">
-                      {t("providers.models_label")}: {models.length} ·{" "}
-                      {t("providers.excluded_models_label")}: {excludedModels.length} ·{" "}
-                      {t("providers.headers_optional")}: {headerEntries.length} ·{" "}
-                      {t("providers.success_stats", { count: stats.success })} ·{" "}
-                      {t("providers.failed_stats", { count: stats.failure })}
-                    </p>
-                  </div>
-
-                  {accessSummary ? (
-                    <div className="mt-2 flex flex-wrap gap-1.5 text-[11px]">
-                      <span
-                        className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}
-                      >
-                        {accessSummary.totalKeys === 0
-                          ? t("providers.access_no_keys")
-                          : accessSummary.reachableKeys === 0
-                            ? t("providers.access_none")
-                            : accessSummary.reachableKeys < accessSummary.totalKeys
-                              ? t("providers.access_limited", {
-                                  reachable: accessSummary.reachableKeys,
-                                  total: accessSummary.totalKeys,
-                                })
-                              : t("providers.access_all", { total: accessSummary.totalKeys })}
+                {accessSummary ? (
+                  <div className="mt-2 flex flex-wrap gap-1.5 text-[11px]">
+                    <span
+                      className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}
+                    >
+                      {accessSummary.totalKeys === 0
+                        ? t("providers.access_no_keys")
+                        : accessSummary.reachableKeys === 0
+                          ? t("providers.access_none")
+                          : accessSummary.reachableKeys < accessSummary.totalKeys
+                            ? t("providers.access_limited", {
+                                reachable: accessSummary.reachableKeys,
+                                total: accessSummary.totalKeys,
+                              })
+                            : t("providers.access_all", { total: accessSummary.totalKeys })}
+                    </span>
+                    {accessSummary.exactOverrideKeys > 0 ? (
+                      <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+                        {t("providers.access_exact_overrides", {
+                          count: accessSummary.exactOverrideKeys,
+                        })}
                       </span>
-                      {accessSummary.exactOverrideKeys > 0 ? (
-                        <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
-                          {t("providers.access_exact_overrides", {
-                            count: accessSummary.exactOverrideKeys,
-                          })}
-                        </span>
-                      ) : null}
-                    </div>
-                  ) : null}
+                    ) : null}
+                  </div>
+                ) : null}
 
-                  {headerEntries.length ? (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {headerEntries.map(([k, v]) => (
-                        <span
-                          key={k}
-                          className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
-                        >
-                          <span className="font-semibold">{k}:</span> {String(v)}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
+                {headerEntries.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {headerEntries.map(([k, v]) => (
+                      <span
+                        key={k}
+                        className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                      >
+                        <span className="font-semibold">{k}:</span> {String(v)}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
 
-                  {models.length ? (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {models.map((model) => (
-                        <span
-                          key={model.name}
-                          className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-                          title={
-                            model.alias && model.alias !== model.name
-                              ? `${model.name} => ${model.alias}`
-                              : model.name
-                          }
-                        >
-                          {model.alias && model.alias !== model.name
-                            ? `${model.name} → ${model.alias}`
-                            : model.name}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
+                {models.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {models.map((model) => (
+                      <span
+                        key={model.name}
+                        className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                        title={
+                          model.alias && model.alias !== model.name
+                            ? `${model.name} => ${model.alias}`
+                            : model.name
+                        }
+                      >
+                        {model.alias && model.alias !== model.name
+                          ? `${model.name} → ${model.alias}`
+                          : model.name}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
 
-                  {excludedModels.length ? (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {excludedModels.map((model) => (
-                        <span
-                          key={model}
-                          className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
-                        >
-                          {model}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
+                {excludedModels.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {excludedModels.map((model) => (
+                      <span
+                        key={model}
+                        className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+                      >
+                        {model}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
 
-                  {renderExtra ? renderExtra(item, idx) : null}
+                {renderExtra ? renderExtra(item, idx) : null}
 
-                  <ProviderStatusBar data={statusData} />
-                </div>
-              </div>
+                <ProviderStatusBar data={statusData} />
+              </ProviderCard>
             );
           })}
         </div>

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Loader2, Plus, Settings2, Trash2, Zap } from "lucide-react";
 import type { ProviderSimpleConfig } from "@/lib/http/types";
@@ -30,6 +31,8 @@ export function ProviderKeyListCard({
   onEdit,
   onDelete,
   onToggleEnabled,
+  gridColumns = 2,
+  renderExtra,
 
   getStats,
   getStatusBar,
@@ -52,6 +55,8 @@ export function ProviderKeyListCard({
   onEdit: (index: number) => void;
   onDelete: (index: number) => void;
   onToggleEnabled?: (index: number, enabled: boolean) => void;
+  gridColumns?: number;
+  renderExtra?: (item: ProviderSimpleConfig, index: number) => ReactNode;
   getStats: (item: ProviderSimpleConfig) => KeyStatBucket;
   getStatusBar: (item: ProviderSimpleConfig) => StatusBarData;
   getAccessSummary?: (item: ProviderSimpleConfig) => ProviderAccessSummary | null;
@@ -93,7 +98,13 @@ export function ProviderKeyListCard({
       ) : (
         <div
           data-testid="providers-tab-scroll"
-          className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+          className={[
+            "min-h-0 flex-1 pr-1",
+            gridColumns > 1
+              ? "grid gap-3"
+              : "space-y-3",
+          ].join(" ")}
+          style={gridColumns > 1 ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
         >
           {items.map((item, idx) => {
             const selectionKey = item.apiKey.trim().toLowerCase();
@@ -122,188 +133,81 @@ export function ProviderKeyListCard({
                   selected
                     ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                     : "",
+                  disabled ? "opacity-50" : "",
                 ]
                   .filter(Boolean)
                   .join(" ")}
               >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
-                      {renderIcon()}
-                      <span className="truncate">{item.name || maskApiKey(item.apiKey)}</span>
-                      {disabled ? (
-                        <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[11px] font-semibold text-amber-700 dark:text-amber-200">
-                          {t("providers.disabled")}
-                        </span>
-                      ) : (
-                        <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:text-emerald-200">
-                          {t("providers.enabled")}
-                        </span>
-                      )}
-                      {checkLatency &&
-                        (() => {
-                          const latencyKey = item.apiKey;
-                          const entry = getLatencyEntry?.(latencyKey) ?? {
-                            latencyMs: null,
-                            loading: false,
-                            error: false,
-                          };
-                          const providerBaseUrl = item.baseUrl || "";
-                          return (
-                            <span
-                              className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (providerBaseUrl) checkLatency(latencyKey, providerBaseUrl);
-                              }}
-                              title={
-                                providerBaseUrl
-                                  ? `Check latency: ${providerBaseUrl}`
-                                  : "No base URL configured"
-                              }
-                            >
-                              {entry.loading ? (
-                                <Loader2 size={10} className="animate-spin" />
-                              ) : entry.error ? (
-                                <span className="text-rose-500">×</span>
-                              ) : entry.latencyMs !== null ? (
-                                <span className="font-medium">
-                                  {formatLatency(entry.latencyMs)}
-                                </span>
-                              ) : (
-                                <Zap size={10} />
-                              )}
-                            </span>
-                          );
-                        })()}
-                    </p>
-
-                    <div className="mt-1 space-y-1 text-xs text-slate-600 dark:text-white/65">
-                      <p className="truncate font-mono">apiKey：{maskApiKey(item.apiKey)}</p>
-                      {showBaseUrl ? (
-                        <p className="truncate font-mono">baseUrl：{item.baseUrl || "--"}</p>
-                      ) : null}
-                      {item.proxyUrl ? (
-                        <p className="truncate font-mono">proxyUrl：{item.proxyUrl}</p>
-                      ) : null}
-                      <p className="tabular-nums">
-                        {t("providers.models_label")}: {models.length} ·{" "}
-                        {t("providers.excluded_models_label")}: {excludedModels.length} ·{" "}
-                        {t("providers.headers_optional")}: {headerEntries.length} ·{" "}
-                        {t("providers.success_stats", { count: stats.success })} ·{" "}
-                        {t("providers.failed_stats", { count: stats.failure })}
-                      </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  {onToggleSelected ? (
+                    <div
+                      className={[
+                        "flex h-8 items-center justify-center px-1 transition-opacity",
+                        selected
+                          ? "pointer-events-auto opacity-100"
+                          : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
+                      ].join(" ")}
+                    >
+                      <input
+                        type="checkbox"
+                        aria-label={t("providers.select_provider", {
+                          name: item.name || maskApiKey(item.apiKey),
+                        })}
+                        checked={selected}
+                        onChange={(event) =>
+                          onToggleSelected(selectionKey, event.currentTarget.checked)
+                        }
+                        className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
+                      />
                     </div>
-
-                    {accessSummary ? (
-                      <div className="mt-2 flex flex-wrap gap-1.5 text-[11px]">
-                        <span
-                          className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}
-                        >
-                          {accessSummary.totalKeys === 0
-                            ? t("providers.access_no_keys")
-                            : accessSummary.reachableKeys === 0
-                              ? t("providers.access_none")
-                              : accessSummary.reachableKeys < accessSummary.totalKeys
-                                ? t("providers.access_limited", {
-                                    reachable: accessSummary.reachableKeys,
-                                    total: accessSummary.totalKeys,
-                                  })
-                                : t("providers.access_all", { total: accessSummary.totalKeys })}
-                        </span>
-                        {accessSummary.exactOverrideKeys > 0 ? (
-                          <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
-                            {t("providers.access_exact_overrides", {
-                              count: accessSummary.exactOverrideKeys,
-                            })}
-                          </span>
-                        ) : null}
-                      </div>
-                    ) : null}
-
-                    {headerEntries.length ? (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {headerEntries.map(([k, v]) => (
+                  ) : null}
+                  <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
+                    {renderIcon()}
+                    <span className="ml-2">{item.name || maskApiKey(item.apiKey)}</span>
+                  </p>
+                  <div className="ml-auto flex items-center gap-2">
+                    {checkLatency &&
+                      (() => {
+                        const latencyKey = item.apiKey;
+                        const entry = getLatencyEntry?.(latencyKey) ?? {
+                          latencyMs: null,
+                          loading: false,
+                          error: false,
+                        };
+                        const providerBaseUrl = item.baseUrl || "";
+                        return (
                           <span
-                            key={k}
-                            className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
-                          >
-                            <span className="font-semibold">{k}:</span> {String(v)}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    {models.length ? (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {models.map((model) => (
-                          <span
-                            key={model.name}
-                            className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                            className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (providerBaseUrl) checkLatency(latencyKey, providerBaseUrl);
+                            }}
                             title={
-                              model.alias && model.alias !== model.name
-                                ? `${model.name} => ${model.alias}`
-                                : model.name
+                              providerBaseUrl
+                                ? `Check latency: ${providerBaseUrl}`
+                                : "No base URL configured"
                             }
                           >
-                            {model.alias && model.alias !== model.name
-                              ? `${model.name} → ${model.alias}`
-                              : model.name}
+                            {entry.loading ? (
+                              <Loader2 size={10} className="animate-spin" />
+                            ) : entry.error ? (
+                              <span className="text-rose-500">×</span>
+                            ) : entry.latencyMs !== null ? (
+                              <span className="font-medium">
+                                {formatLatency(entry.latencyMs)}
+                              </span>
+                            ) : (
+                              <Zap size={10} />
+                            )}
                           </span>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    {excludedModels.length ? (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {excludedModels.map((model) => (
-                          <span
-                            key={model}
-                            className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
-                          >
-                            {model}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    <ProviderStatusBar data={statusData} />
-                  </div>
-
-                  <div className="flex flex-wrap items-center gap-2">
-                    {onToggleSelected ? (
-                      <div
-                        className={[
-                          "flex h-8 items-center justify-center px-1 transition-opacity",
-                          selected
-                            ? "pointer-events-auto opacity-100"
-                            : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
-                        ].join(" ")}
-                      >
-                        <input
-                          type="checkbox"
-                          aria-label={t("providers.select_provider", {
-                            name: item.name || maskApiKey(item.apiKey),
-                          })}
-                          checked={selected}
-                          onChange={(event) =>
-                            onToggleSelected(selectionKey, event.currentTarget.checked)
-                          }
-                          className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-                        />
-                      </div>
-                    ) : null}
+                        );
+                      })()}
                     {onToggleEnabled ? (
-                      <div className="inline-flex items-center gap-2">
-                        <span className="text-sm font-semibold leading-none text-slate-900 dark:text-white">
-                          {t("providers.enable")}
-                        </span>
-                        <ToggleSwitch
-                          checked={!disabled}
-                          ariaLabel={t("providers.enable")}
-                          onCheckedChange={(enabled) => onToggleEnabled(idx, enabled)}
-                        />
-                      </div>
+                      <ToggleSwitch
+                        checked={!disabled}
+                        ariaLabel={t("providers.enable")}
+                        onCheckedChange={(enabled) => onToggleEnabled(idx, enabled)}
+                      />
                     ) : null}
                     <Button variant="secondary" size="sm" onClick={() => onEdit(idx)}>
                       <Settings2 size={14} />
@@ -314,6 +218,101 @@ export function ProviderKeyListCard({
                       {t("providers.delete")}
                     </Button>
                   </div>
+                </div>
+
+                <div className="mt-2 min-w-0">
+                  <div className="space-y-1 text-xs text-slate-600 dark:text-white/65">
+                    <p className="truncate font-mono">apiKey：{maskApiKey(item.apiKey)}</p>
+                    {showBaseUrl ? (
+                      <p className="truncate font-mono">baseUrl：{item.baseUrl || "--"}</p>
+                    ) : null}
+                    {item.proxyUrl ? (
+                      <p className="truncate font-mono">proxyUrl：{item.proxyUrl}</p>
+                    ) : null}
+                    <p className="tabular-nums">
+                      {t("providers.models_label")}: {models.length} ·{" "}
+                      {t("providers.excluded_models_label")}: {excludedModels.length} ·{" "}
+                      {t("providers.headers_optional")}: {headerEntries.length} ·{" "}
+                      {t("providers.success_stats", { count: stats.success })} ·{" "}
+                      {t("providers.failed_stats", { count: stats.failure })}
+                    </p>
+                  </div>
+
+                  {accessSummary ? (
+                    <div className="mt-2 flex flex-wrap gap-1.5 text-[11px]">
+                      <span
+                        className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}
+                      >
+                        {accessSummary.totalKeys === 0
+                          ? t("providers.access_no_keys")
+                          : accessSummary.reachableKeys === 0
+                            ? t("providers.access_none")
+                            : accessSummary.reachableKeys < accessSummary.totalKeys
+                              ? t("providers.access_limited", {
+                                  reachable: accessSummary.reachableKeys,
+                                  total: accessSummary.totalKeys,
+                                })
+                              : t("providers.access_all", { total: accessSummary.totalKeys })}
+                      </span>
+                      {accessSummary.exactOverrideKeys > 0 ? (
+                        <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+                          {t("providers.access_exact_overrides", {
+                            count: accessSummary.exactOverrideKeys,
+                          })}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {headerEntries.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {headerEntries.map(([k, v]) => (
+                        <span
+                          key={k}
+                          className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        >
+                          <span className="font-semibold">{k}:</span> {String(v)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {models.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {models.map((model) => (
+                        <span
+                          key={model.name}
+                          className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                          title={
+                            model.alias && model.alias !== model.name
+                              ? `${model.name} => ${model.alias}`
+                              : model.name
+                          }
+                        >
+                          {model.alias && model.alias !== model.name
+                            ? `${model.name} → ${model.alias}`
+                            : model.name}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {excludedModels.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {excludedModels.map((model) => (
+                        <span
+                          key={model}
+                          className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+                        >
+                          {model}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {renderExtra ? renderExtra(item, idx) : null}
+
+                  <ProviderStatusBar data={statusData} />
                 </div>
               </div>
             );

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -105,14 +105,11 @@ function saveGridColumns(cols: number): void {
 const getProviderSelectionKey = (
   kind: ProviderImportKind,
   item: ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
+  index: number,
 ) =>
   kind === "openai"
-    ? String((item as OpenAIProvider).name ?? "")
-        .trim()
-        .toLowerCase()
-    : String((item as ProviderSimpleConfig).apiKey ?? "")
-        .trim()
-        .toLowerCase();
+    ? `${String((item as OpenAIProvider).name ?? "").trim().toLowerCase()}:${index}`
+    : `${String((item as ProviderSimpleConfig).apiKey ?? "").trim().toLowerCase()}:${index}`;
 
 export function ProvidersPage() {
   const { t } = useTranslation();
@@ -380,7 +377,6 @@ export function ProvidersPage() {
     deleteOpenAIProvider,
     toggleOpenAIProviderEnabled,
     toggleOpenAIKeyEntryEnabled,
-    toggleOpenAIProviderEnabled,
     discoverModels,
     applyDiscoveredModels,
   } = useOpenAIProviderEditor({
@@ -542,10 +538,11 @@ export function ProvidersPage() {
   const currentSelectableKeys = useMemo(
     () =>
       currentImportKind
-        ? currentTabItems.map((item) =>
+        ? currentTabItems.map((item, index) =>
             getProviderSelectionKey(
               currentImportKind,
               item as ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
+              index,
             ),
           )
         : [],
@@ -630,11 +627,12 @@ export function ProvidersPage() {
   const handleExportSelected = useCallback(() => {
     const kind = currentImportKind;
     if (!kind || selectedExportCount === 0) return;
-    const selectedItems = currentTabItems.filter((item) =>
+    const selectedItems = currentTabItems.filter((item, index) =>
       selectedExportKeySet.has(
         getProviderSelectionKey(
           kind,
           item as ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
+          index,
         ),
       ),
     );

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Bot, Cloud, Database, Download, FileKey, Globe, RefreshCw, Upload } from "lucide-react";
+import { Bot, Cloud, Database, Download, FileKey, Globe, LayoutGrid, RefreshCw, Upload } from "lucide-react";
 import iconGemini from "@/assets/icons/gemini.svg";
 import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
@@ -18,6 +18,7 @@ import type { BedrockProviderConfig, OpenAIProvider, ProviderSimpleConfig } from
 import { Button } from "@/modules/ui/Button";
 import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { Modal } from "@/modules/ui/Modal";
+import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { downloadTextAsFile } from "@/modules/auth-files/helpers/authFilesPageUtils";
@@ -55,6 +56,52 @@ type ProviderTab =
   | "openai"
   | "ampcode";
 
+const PROVIDER_TAB_STORAGE_KEY = "providers-page:tab";
+const PROVIDER_TAB_VALUES: ProviderTab[] = [
+  "gemini", "claude", "codex", "opencode-go", "vertex", "bedrock", "openai", "ampcode",
+];
+
+function readSavedProviderTab(): ProviderTab {
+  try {
+    const saved = localStorage.getItem(PROVIDER_TAB_STORAGE_KEY);
+    if (saved && PROVIDER_TAB_VALUES.includes(saved as ProviderTab)) return saved as ProviderTab;
+  } catch {
+    // ignore
+  }
+  return "gemini";
+}
+
+function saveProviderTab(tab: ProviderTab): void {
+  try {
+    localStorage.setItem(PROVIDER_TAB_STORAGE_KEY, tab);
+  } catch {
+    // ignore
+  }
+}
+
+const GRID_COLUMNS_STORAGE_KEY = "providers-page:gridColumns";
+
+function readSavedGridColumns(): number {
+  try {
+    const saved = localStorage.getItem(GRID_COLUMNS_STORAGE_KEY);
+    if (saved) {
+      const num = Number(saved);
+      if (num >= 1 && num <= 4) return num;
+    }
+  } catch {
+    // ignore
+  }
+  return 2;
+}
+
+function saveGridColumns(cols: number): void {
+  try {
+    localStorage.setItem(GRID_COLUMNS_STORAGE_KEY, String(cols));
+  } catch {
+    // ignore
+  }
+}
+
 const getProviderSelectionKey = (
   kind: ProviderImportKind,
   item: ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
@@ -75,8 +122,18 @@ export function ProvidersPage() {
   const navigate = useNavigate();
   const { getEntry: getLatencyEntry, checkLatency } = useProviderLatency();
 
-  const [tab, setTab] = useState<ProviderTab>("gemini");
+  const [tab, setTabState] = useState<ProviderTab>(readSavedProviderTab);
+  const setTab = useCallback((next: ProviderTab) => {
+    setTabState(next);
+    saveProviderTab(next);
+  }, []);
   const [loading, setLoading] = useState(true);
+
+  const [gridColumns, setGridColumnsState] = useState(readSavedGridColumns);
+  const setGridColumns = useCallback((cols: number) => {
+    setGridColumnsState(cols);
+    saveGridColumns(cols);
+  }, []);
 
   const [geminiKeys, setGeminiKeys] = useState<ProviderSimpleConfig[]>([]);
   const [claudeKeys, setClaudeKeys] = useState<ProviderSimpleConfig[]>([]);
@@ -323,6 +380,7 @@ export function ProvidersPage() {
     deleteOpenAIProvider,
     toggleOpenAIProviderEnabled,
     toggleOpenAIKeyEntryEnabled,
+    toggleOpenAIProviderEnabled,
     discoverModels,
     applyDiscoveredModels,
   } = useOpenAIProviderEditor({
@@ -644,7 +702,7 @@ export function ProvidersPage() {
   return (
     <div
       data-testid="providers-page-shell"
-      className="flex h-[calc(100dvh-112px)] min-h-0 flex-col gap-6 overflow-hidden"
+      className="flex min-h-0 flex-col gap-6"
     >
       <div className="flex flex-wrap items-center gap-3">
         <div className="space-y-0.5">
@@ -738,6 +796,21 @@ export function ProvidersPage() {
           <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
           {t("providers.refresh")}
         </Button>
+        <div className="ml-auto flex items-center gap-1.5">
+          <LayoutGrid size={14} className="text-slate-500 dark:text-white/50" />
+          <Select
+            value={String(gridColumns)}
+            onChange={(v) => setGridColumns(Number(v))}
+            options={[
+              { value: "1", label: "1 col" },
+              { value: "2", label: "2 cols" },
+              { value: "3", label: "3 cols" },
+              { value: "4", label: "4 cols" },
+            ]}
+            size="sm"
+            aria-label="Grid columns"
+          />
+        </div>
       </div>
 
       <Tabs
@@ -750,7 +823,7 @@ export function ProvidersPage() {
           void refreshTab(nextTab);
         }}
       >
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
+        <div className="flex flex-col gap-4">
           <div className="flex shrink-0">
             <TabsList>
               <TabsTrigger value="gemini">
@@ -790,7 +863,7 @@ export function ProvidersPage() {
               </TabsTrigger>
             </TabsList>
           </div>
-          <TabsContent value="gemini" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="gemini" className="flex flex-col">
             <ProviderKeyListCard
               icon={Globe}
               title={t("providers.gemini_keys")}
@@ -806,12 +879,13 @@ export function ProvidersPage() {
               getAccessSummary={getProviderAccessSummary}
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="claude" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="claude" className="flex flex-col">
             <ProviderKeyListCard
               icon={Bot}
               title={t("providers.claude_keys")}
@@ -827,12 +901,13 @@ export function ProvidersPage() {
               getAccessSummary={getProviderAccessSummary}
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="codex" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="codex" className="flex flex-col">
             <ProviderKeyListCard
               icon={FileKey}
               title={t("providers.codex_keys")}
@@ -848,12 +923,13 @@ export function ProvidersPage() {
               getAccessSummary={getProviderAccessSummary}
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="opencode-go" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="opencode-go" className="flex flex-col">
             <ProviderKeyListCard
               icon={FileKey}
               iconSrc={iconOpenCodeLight}
@@ -872,12 +948,13 @@ export function ProvidersPage() {
               getStatusBar={getSimpleStatusBar}
               getAccessSummary={getProviderAccessSummary}
               showBaseUrl={false}
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="vertex" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="vertex" className="flex flex-col">
             <ProviderKeyListCard
               icon={Database}
               title={t("providers.vertex_keys")}
@@ -892,12 +969,13 @@ export function ProvidersPage() {
               getAccessSummary={getProviderAccessSummary}
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="bedrock" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="bedrock" className="flex flex-col">
             <ProviderKeyListCard
               icon={Cloud}
               title={t("providers.bedrock_keys")}
@@ -913,12 +991,13 @@ export function ProvidersPage() {
               getAccessSummary={getProviderAccessSummary}
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="openai" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="openai" className="flex flex-col">
             <OpenAIProvidersTab
               providers={openaiProviders}
               loading={isActiveTabListLoading("openai")}
@@ -934,12 +1013,13 @@ export function ProvidersPage() {
               onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
                 void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
               }
+              gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
           </TabsContent>
 
-          <TabsContent value="ampcode" className="flex min-h-0 flex-1 flex-col">
+          <TabsContent value="ampcode" className="flex flex-col">
             <AmpcodePanel
               loading={loading}
               isPending={isPending}

--- a/src/modules/providers/components/OpenAIProviderModal.tsx
+++ b/src/modules/providers/components/OpenAIProviderModal.tsx
@@ -53,6 +53,13 @@ export function OpenAIProviderModal({
   const { t } = useTranslation();
   const [discoverQuery, setDiscoverQuery] = useState("");
   const discoveredListRef = useRef<HTMLDivElement | null>(null);
+  const discoveredSectionRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (discoveredModels.length > 0 && discoveredSectionRef.current) {
+      discoveredSectionRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [discoveredModels.length]);
 
   useEffect(() => {
     if (!open) {
@@ -367,27 +374,6 @@ export function OpenAIProviderModal({
         </section>
 
         <section className="space-y-3 border-t border-slate-200/60 pt-5 dark:border-neutral-800/60">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("providers.models_label")}
-            </p>
-            <div className="flex items-center gap-2">
-              <Button variant="secondary" size="sm" onClick={() => void discoverModels()} disabled={discovering}>
-                <RefreshCw size={14} className={discovering ? "animate-spin" : ""} />
-                {t("providers.fetch_models")}
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={applyDiscoveredModels}
-                disabled={discoveredModels.length === 0}
-              >
-                <Check size={14} />
-                {t("providers.merge_selected")}
-              </Button>
-            </div>
-          </div>
-
           <ModelInputList
             title={t("providers.models_optional")}
             entries={openaiDraft.modelEntries}
@@ -396,8 +382,21 @@ export function OpenAIProviderModal({
             showTestModel
           />
 
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("providers.fetch_models")}
+            </p>
+            <Button variant="secondary" size="sm" onClick={() => void discoverModels()} disabled={discovering}>
+              <RefreshCw size={14} className={discovering ? "animate-spin" : ""} />
+              {t("providers.fetch_models")}
+            </Button>
+          </div>
+
           {discoveredModels.length ? (
-            <div className="rounded-2xl border border-slate-200 bg-slate-50/50 p-4 dark:border-neutral-800 dark:bg-neutral-900/40">
+            <div
+              ref={discoveredSectionRef}
+              className="rounded-2xl border border-slate-200 bg-slate-50/50 p-4 dark:border-neutral-800 dark:bg-neutral-900/40"
+            >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <p className="text-xs font-medium text-slate-700 dark:text-white/70">
                   {t("providers.found_models", { count: discoveredModels.length })}
@@ -419,6 +418,15 @@ export function OpenAIProviderModal({
                 </Button>
                 <Button variant="secondary" size="sm" onClick={deselectAllDiscovered}>
                   {t("providers.models_select_none")}
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={applyDiscoveredModels}
+                  disabled={discoverSelected.size === 0}
+                >
+                  <Check size={14} />
+                  {t("providers.merge_selected")}
                 </Button>
                 {discoverQuery.trim() ? (
                   <span className="text-xs text-slate-500 dark:text-white/55">

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from "react-i18next";
-import { Plus, Settings2, Trash2 } from "lucide-react";
+import { Plus } from "lucide-react";
 import type { OpenAIProvider } from "@/lib/http/types";
 import { Button } from "@/modules/ui/Button";
 import { Card } from "@/modules/ui/Card";
 import { EmptyState } from "@/modules/ui/EmptyState";
+import { ProviderCard } from "@/modules/providers/ProviderCard";
 import { ProviderStatusBar } from "@/modules/providers/ProviderStatusBar";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 
@@ -79,190 +80,152 @@ export function OpenAIProvidersTab({
           style={gridColumns > 1 ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
         >
           {providers.map((provider, idx) => {
-            const selectionKey = provider.name.trim().toLowerCase();
+            const selectionKey = `${provider.name.trim().toLowerCase()}:${idx}`;
             const selected = selectedKeys?.has(selectionKey) ?? false;
             const headerEntries = Object.entries(provider.headers || {});
             const stats = getProviderStats(provider);
             const statusData = getProviderStatusBar(provider);
 
             return (
-              <div
+              <ProviderCard
                 key={`${provider.name}:${idx}`}
-                className={[
-                  "group rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
-                  selected
-                    ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
-                    : "",
-                  provider.disabled ? "opacity-50" : "",
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
+                title={provider.name}
+                selected={selected}
+                enabled={provider.disabled !== true}
+                dimmed={provider.disabled === true}
+                onToggleSelected={
+                  onToggleSelected
+                    ? (checked) => onToggleSelected(selectionKey, checked)
+                    : undefined
+                }
+                onToggleEnabled={
+                  onToggleProviderEnabled
+                    ? (enabled) => onToggleProviderEnabled(idx, enabled)
+                    : undefined
+                }
+                onEdit={() => openOpenAIEditor(idx)}
+                onDelete={() => confirmDelete(idx)}
               >
-                <div className="flex flex-wrap items-center gap-2">
-                  {onToggleSelected ? (
-                    <div
-                      className={[
-                        "flex h-8 items-center justify-center px-1 transition-opacity",
-                        selected
-                          ? "pointer-events-auto opacity-100"
-                          : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
-                      ].join(" ")}
-                    >
-                      <input
-                        type="checkbox"
-                        aria-label={t("providers.select_provider", { name: provider.name })}
-                        checked={selected}
-                        onChange={(event) =>
-                          onToggleSelected(selectionKey, event.currentTarget.checked)
-                        }
-                        className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-                      />
-                    </div>
-                  ) : null}
-                  <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
-                    {provider.name}
-                  </p>
-                  <div className="ml-auto flex items-center gap-2">
-                    {onToggleProviderEnabled ? (
-                      <ToggleSwitch
-                        checked={provider.disabled !== true}
-                        ariaLabel={`${t("providers.enable")} ${provider.name}`}
-                        onCheckedChange={(enabled) => onToggleProviderEnabled(idx, enabled)}
-                      />
-                    ) : null}
-                    <Button variant="secondary" size="sm" onClick={() => openOpenAIEditor(idx)}>
-                      <Settings2 size={14} />
-                      {t("providers.edit")}
-                    </Button>
-                    <Button variant="danger" size="sm" onClick={() => confirmDelete(idx)}>
-                      <Trash2 size={14} />
-                      {t("providers.delete")}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="mt-2 min-w-0">
-                  {provider.prefix ? (
-                    <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
-                      prefix: {provider.prefix}
-                    </p>
-                  ) : null}
+                {provider.prefix ? (
                   <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
-                    baseUrl: {provider.baseUrl || "--"}
+                    prefix: {provider.prefix}
                   </p>
+                ) : null}
+                <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
+                  baseUrl: {provider.baseUrl || "--"}
+                </p>
 
-                  {headerEntries.length ? (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {headerEntries.map(([key, value]) => (
-                        <span
-                          key={key}
-                          className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
-                        >
-                          <span className="font-semibold">{key}:</span> {String(value)}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
-
-                  {provider.apiKeyEntries?.length ? (
-                    <div className="mt-2 space-y-1">
-                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                        Keys: {provider.apiKeyEntries.length}
-                      </p>
-                      <div className="space-y-1">
-                        {provider.apiKeyEntries.map((entry, entryIndex) => {
-                          const entryStats = getKeyEntryStats(entry);
-                          const entryEnabled = entry.disabled !== true;
-                          return (
-                            <div
-                              key={`${entry.apiKey}:${entryIndex}`}
-                              className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60"
-                            >
-                              <div className="min-w-0">
-                                <p className="truncate font-mono text-slate-900 dark:text-white">
-                                  {entryIndex + 1}. {maskApiKey(entry.apiKey)}
-                                </p>
-                                {entry.proxyUrl ? (
-                                  <p className="mt-0.5 truncate font-mono text-slate-600 dark:text-white/55">
-                                    proxy: {entry.proxyUrl}
-                                  </p>
-                                ) : null}
-                              </div>
-                              <div className="flex flex-wrap items-center gap-2 tabular-nums">
-                                <span
-                                  className={[
-                                    "rounded-full px-2 py-0.5 font-semibold",
-                                    entryEnabled
-                                      ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
-                                      : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
-                                  ].join(" ")}
-                                >
-                                  {entryEnabled
-                                    ? t("providers.enabled")
-                                    : t("providers.disabled")}
-                                </span>
-                                <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
-                                  {t("providers.success_stats", { count: entryStats.success })}
-                                </span>
-                                <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
-                                  {t("providers.failed_stats", { count: entryStats.failure })}
-                                </span>
-                                {onToggleKeyEntryEnabled ? (
-                                  <ToggleSwitch
-                                    checked={entryEnabled}
-                                    ariaLabel={`${t("providers.enable_key_entry")} ${entryIndex + 1}`}
-                                    onCheckedChange={(enabled) =>
-                                      onToggleKeyEntryEnabled(idx, entryIndex, enabled)
-                                    }
-                                  />
-                                ) : null}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  ) : null}
-
-                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-white/65 tabular-nums">
-                    <span>
-                      {t("providers.models_label")}: {provider.models?.length ?? 0}
-                    </span>
-                    <span>·</span>
-                    <span>{t("providers.success_stats", { count: stats.success })}</span>
-                    <span>·</span>
-                    <span>{t("providers.failed_stats", { count: stats.failure })}</span>
-                    {provider.testModel ? (
-                      <>
-                        <span>·</span>
-                        <span className="truncate">testModel: {provider.testModel}</span>
-                      </>
-                    ) : null}
+                {headerEntries.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {headerEntries.map(([key, value]) => (
+                      <span
+                        key={key}
+                        className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                      >
+                        <span className="font-semibold">{key}:</span> {String(value)}
+                      </span>
+                    ))}
                   </div>
+                ) : null}
 
-                  {provider.models?.length ? (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {provider.models.map((model) => (
-                        <span
-                          key={model.name}
-                          className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-                          title={
-                            model.alias && model.alias !== model.name
-                              ? `${model.name} => ${model.alias}`
-                              : model.name
-                          }
-                        >
-                          {model.alias && model.alias !== model.name
-                            ? `${model.name} → ${model.alias}`
-                            : model.name}
-                        </span>
-                      ))}
+                {provider.apiKeyEntries?.length ? (
+                  <div className="mt-2 space-y-1">
+                    <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                      Keys: {provider.apiKeyEntries.length}
+                    </p>
+                    <div className="space-y-1">
+                      {provider.apiKeyEntries.map((entry, entryIndex) => {
+                        const entryStats = getKeyEntryStats(entry);
+                        const entryEnabled = entry.disabled !== true;
+                        return (
+                          <div
+                            key={`${entry.apiKey}:${entryIndex}`}
+                            className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60"
+                          >
+                            <div className="min-w-0">
+                              <p className="truncate font-mono text-slate-900 dark:text-white">
+                                {entryIndex + 1}. {maskApiKey(entry.apiKey)}
+                              </p>
+                              {entry.proxyUrl ? (
+                                <p className="mt-0.5 truncate font-mono text-slate-600 dark:text-white/55">
+                                  proxy: {entry.proxyUrl}
+                                </p>
+                              ) : null}
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2 tabular-nums">
+                              <span
+                                className={[
+                                  "rounded-full px-2 py-0.5 font-semibold",
+                                  entryEnabled
+                                    ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
+                                    : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
+                                ].join(" ")}
+                              >
+                                {entryEnabled
+                                  ? t("providers.enabled")
+                                  : t("providers.disabled")}
+                              </span>
+                              <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
+                                {t("providers.success_stats", { count: entryStats.success })}
+                              </span>
+                              <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                                {t("providers.failed_stats", { count: entryStats.failure })}
+                              </span>
+                              {onToggleKeyEntryEnabled ? (
+                                <ToggleSwitch
+                                  checked={entryEnabled}
+                                  ariaLabel={`${t("providers.enable_key_entry")} ${entryIndex + 1}`}
+                                  onCheckedChange={(enabled) =>
+                                    onToggleKeyEntryEnabled(idx, entryIndex, enabled)
+                                  }
+                                />
+                              ) : null}
+                            </div>
+                          </div>
+                        );
+                      })}
                     </div>
-                  ) : null}
+                  </div>
+                ) : null}
 
-                  <ProviderStatusBar data={statusData} />
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-white/65 tabular-nums">
+                  <span>
+                    {t("providers.models_label")}: {provider.models?.length ?? 0}
+                  </span>
+                  <span>·</span>
+                  <span>{t("providers.success_stats", { count: stats.success })}</span>
+                  <span>·</span>
+                  <span>{t("providers.failed_stats", { count: stats.failure })}</span>
+                  {provider.testModel ? (
+                    <>
+                      <span>·</span>
+                      <span className="truncate">testModel: {provider.testModel}</span>
+                    </>
+                  ) : null}
                 </div>
-              </div>
+
+                {provider.models?.length ? (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {provider.models.map((model) => (
+                      <span
+                        key={model.name}
+                        className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                        title={
+                          model.alias && model.alias !== model.name
+                            ? `${model.name} => ${model.alias}`
+                            : model.name
+                        }
+                      >
+                        {model.alias && model.alias !== model.name
+                          ? `${model.name} → ${model.alias}`
+                          : model.name}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+
+                <ProviderStatusBar data={statusData} />
+              </ProviderCard>
             );
           })}
         </div>

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -26,6 +26,7 @@ interface OpenAIProvidersTabProps {
   };
   onToggleProviderEnabled?: (providerIndex: number, enabled: boolean) => void;
   onToggleKeyEntryEnabled?: (providerIndex: number, entryIndex: number, enabled: boolean) => void;
+  gridColumns?: number;
   selectedKeys?: Set<string>;
   onToggleSelected?: (key: string, checked: boolean) => void;
 }
@@ -41,6 +42,7 @@ export function OpenAIProvidersTab({
   getProviderStatusBar,
   onToggleProviderEnabled,
   onToggleKeyEntryEnabled,
+  gridColumns = 2,
   selectedKeys,
   onToggleSelected,
 }: OpenAIProvidersTabProps) {
@@ -68,7 +70,13 @@ export function OpenAIProvidersTab({
       ) : (
         <div
           data-testid="providers-tab-scroll"
-          className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+          className={[
+            "pr-1",
+            gridColumns > 1
+              ? "grid gap-3"
+              : "space-y-3",
+          ].join(" ")}
+          style={gridColumns > 1 ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
         >
           {providers.map((provider, idx) => {
             const selectionKey = provider.name.trim().toLowerCase();
@@ -76,7 +84,6 @@ export function OpenAIProvidersTab({
             const headerEntries = Object.entries(provider.headers || {});
             const stats = getProviderStats(provider);
             const statusData = getProviderStatusBar(provider);
-            const providerEnabled = provider.disabled !== true;
 
             return (
               <div
@@ -86,175 +93,42 @@ export function OpenAIProvidersTab({
                   selected
                     ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                     : "",
-                  providerEnabled ? "" : "opacity-70",
+                  provider.disabled ? "opacity-50" : "",
                 ]
                   .filter(Boolean)
                   .join(" ")}
               >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                      <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">
-                        {provider.name}
-                      </p>
-                      <span
-                        className={[
-                          "rounded-full px-2 py-0.5 text-[11px] font-semibold",
-                          providerEnabled
-                            ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
-                            : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
-                        ].join(" ")}
-                      >
-                        {providerEnabled ? t("providers.enabled") : t("providers.disabled")}
-                      </span>
+                <div className="flex flex-wrap items-center gap-2">
+                  {onToggleSelected ? (
+                    <div
+                      className={[
+                        "flex h-8 items-center justify-center px-1 transition-opacity",
+                        selected
+                          ? "pointer-events-auto opacity-100"
+                          : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
+                      ].join(" ")}
+                    >
+                      <input
+                        type="checkbox"
+                        aria-label={t("providers.select_provider", { name: provider.name })}
+                        checked={selected}
+                        onChange={(event) =>
+                          onToggleSelected(selectionKey, event.currentTarget.checked)
+                        }
+                        className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
+                      />
                     </div>
-                    {provider.prefix ? (
-                      <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
-                        prefix: {provider.prefix}
-                      </p>
-                    ) : null}
-                    <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
-                      baseUrl: {provider.baseUrl || "--"}
-                    </p>
-
-                    {headerEntries.length ? (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {headerEntries.map(([key, value]) => (
-                          <span
-                            key={key}
-                            className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
-                          >
-                            <span className="font-semibold">{key}:</span> {String(value)}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    {provider.apiKeyEntries?.length ? (
-                      <div className="mt-2 space-y-1">
-                        <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                          Keys: {provider.apiKeyEntries.length}
-                        </p>
-                        <div className="space-y-1">
-                          {provider.apiKeyEntries.map((entry, entryIndex) => {
-                            const entryStats = getKeyEntryStats(entry);
-                            const entryEnabled = entry.disabled !== true;
-                            return (
-                              <div
-                                key={`${entry.apiKey}:${entryIndex}`}
-                                className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60"
-                              >
-                                <div className="min-w-0">
-                                  <p className="truncate font-mono text-slate-900 dark:text-white">
-                                    {entryIndex + 1}. {maskApiKey(entry.apiKey)}
-                                  </p>
-                                  {entry.proxyUrl ? (
-                                    <p className="mt-0.5 truncate font-mono text-slate-600 dark:text-white/55">
-                                      proxy: {entry.proxyUrl}
-                                    </p>
-                                  ) : null}
-                                </div>
-                                <div className="flex flex-wrap items-center gap-2 tabular-nums">
-                                  <span
-                                    className={[
-                                      "rounded-full px-2 py-0.5 font-semibold",
-                                      entryEnabled
-                                        ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
-                                        : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
-                                    ].join(" ")}
-                                  >
-                                    {entryEnabled
-                                      ? t("providers.enabled")
-                                      : t("providers.disabled")}
-                                  </span>
-                                  <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
-                                    {t("providers.success_stats", { count: entryStats.success })}
-                                  </span>
-                                  <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
-                                    {t("providers.failed_stats", { count: entryStats.failure })}
-                                  </span>
-                                  {onToggleKeyEntryEnabled ? (
-                                    <ToggleSwitch
-                                      checked={entryEnabled}
-                                      ariaLabel={`${t("providers.enable_key_entry")} ${entryIndex + 1}`}
-                                      onCheckedChange={(enabled) =>
-                                        onToggleKeyEntryEnabled(idx, entryIndex, enabled)
-                                      }
-                                    />
-                                  ) : null}
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    ) : null}
-
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-white/65 tabular-nums">
-                      <span>
-                        {t("providers.models_label")}: {provider.models?.length ?? 0}
-                      </span>
-                      <span>·</span>
-                      <span>{t("providers.success_stats", { count: stats.success })}</span>
-                      <span>·</span>
-                      <span>{t("providers.failed_stats", { count: stats.failure })}</span>
-                      {provider.testModel ? (
-                        <>
-                          <span>·</span>
-                          <span className="truncate">testModel: {provider.testModel}</span>
-                        </>
-                      ) : null}
-                    </div>
-
-                    {provider.models?.length ? (
-                      <div className="mt-2 flex flex-wrap gap-1">
-                        {provider.models.map((model) => (
-                          <span
-                            key={model.name}
-                            className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-                            title={
-                              model.alias && model.alias !== model.name
-                                ? `${model.name} => ${model.alias}`
-                                : model.name
-                            }
-                          >
-                            {model.alias && model.alias !== model.name
-                              ? `${model.name} → ${model.alias}`
-                              : model.name}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    <ProviderStatusBar data={statusData} />
-                  </div>
-                  <div className="flex items-center gap-2">
+                  ) : null}
+                  <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
+                    {provider.name}
+                  </p>
+                  <div className="ml-auto flex items-center gap-2">
                     {onToggleProviderEnabled ? (
                       <ToggleSwitch
-                        checked={providerEnabled}
-                        ariaLabel={`${t("providers.enable_provider")} ${provider.name}`}
+                        checked={provider.disabled !== true}
+                        ariaLabel={`${t("providers.enable")} ${provider.name}`}
                         onCheckedChange={(enabled) => onToggleProviderEnabled(idx, enabled)}
                       />
-                    ) : null}
-                    {onToggleSelected ? (
-                      <div
-                        className={[
-                          "flex h-8 items-center justify-center px-1 transition-opacity",
-                          selected
-                            ? "pointer-events-auto opacity-100"
-                            : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100",
-                        ].join(" ")}
-                      >
-                        <input
-                          type="checkbox"
-                          aria-label={t("providers.select_provider", { name: provider.name })}
-                          checked={selected}
-                          onChange={(event) =>
-                            onToggleSelected(selectionKey, event.currentTarget.checked)
-                          }
-                          className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-                        />
-                      </div>
                     ) : null}
                     <Button variant="secondary" size="sm" onClick={() => openOpenAIEditor(idx)}>
                       <Settings2 size={14} />
@@ -265,6 +139,128 @@ export function OpenAIProvidersTab({
                       {t("providers.delete")}
                     </Button>
                   </div>
+                </div>
+
+                <div className="mt-2 min-w-0">
+                  {provider.prefix ? (
+                    <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
+                      prefix: {provider.prefix}
+                    </p>
+                  ) : null}
+                  <p className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">
+                    baseUrl: {provider.baseUrl || "--"}
+                  </p>
+
+                  {headerEntries.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {headerEntries.map(([key, value]) => (
+                        <span
+                          key={key}
+                          className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        >
+                          <span className="font-semibold">{key}:</span> {String(value)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {provider.apiKeyEntries?.length ? (
+                    <div className="mt-2 space-y-1">
+                      <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                        Keys: {provider.apiKeyEntries.length}
+                      </p>
+                      <div className="space-y-1">
+                        {provider.apiKeyEntries.map((entry, entryIndex) => {
+                          const entryStats = getKeyEntryStats(entry);
+                          const entryEnabled = entry.disabled !== true;
+                          return (
+                            <div
+                              key={`${entry.apiKey}:${entryIndex}`}
+                              className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60"
+                            >
+                              <div className="min-w-0">
+                                <p className="truncate font-mono text-slate-900 dark:text-white">
+                                  {entryIndex + 1}. {maskApiKey(entry.apiKey)}
+                                </p>
+                                {entry.proxyUrl ? (
+                                  <p className="mt-0.5 truncate font-mono text-slate-600 dark:text-white/55">
+                                    proxy: {entry.proxyUrl}
+                                  </p>
+                                ) : null}
+                              </div>
+                              <div className="flex flex-wrap items-center gap-2 tabular-nums">
+                                <span
+                                  className={[
+                                    "rounded-full px-2 py-0.5 font-semibold",
+                                    entryEnabled
+                                      ? "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200"
+                                      : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
+                                  ].join(" ")}
+                                >
+                                  {entryEnabled
+                                    ? t("providers.enabled")
+                                    : t("providers.disabled")}
+                                </span>
+                                <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
+                                  {t("providers.success_stats", { count: entryStats.success })}
+                                </span>
+                                <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                                  {t("providers.failed_stats", { count: entryStats.failure })}
+                                </span>
+                                {onToggleKeyEntryEnabled ? (
+                                  <ToggleSwitch
+                                    checked={entryEnabled}
+                                    ariaLabel={`${t("providers.enable_key_entry")} ${entryIndex + 1}`}
+                                    onCheckedChange={(enabled) =>
+                                      onToggleKeyEntryEnabled(idx, entryIndex, enabled)
+                                    }
+                                  />
+                                ) : null}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-white/65 tabular-nums">
+                    <span>
+                      {t("providers.models_label")}: {provider.models?.length ?? 0}
+                    </span>
+                    <span>·</span>
+                    <span>{t("providers.success_stats", { count: stats.success })}</span>
+                    <span>·</span>
+                    <span>{t("providers.failed_stats", { count: stats.failure })}</span>
+                    {provider.testModel ? (
+                      <>
+                        <span>·</span>
+                        <span className="truncate">testModel: {provider.testModel}</span>
+                      </>
+                    ) : null}
+                  </div>
+
+                  {provider.models?.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {provider.models.map((model) => (
+                        <span
+                          key={model.name}
+                          className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                          title={
+                            model.alias && model.alias !== model.name
+                              ? `${model.name} => ${model.alias}`
+                              : model.name
+                          }
+                        >
+                          {model.alias && model.alias !== model.name
+                            ? `${model.name} → ${model.alias}`
+                            : model.name}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  <ProviderStatusBar data={statusData} />
                 </div>
               </div>
             );

--- a/src/modules/providers/hooks/useOpenAIProviderEditor.ts
+++ b/src/modules/providers/hooks/useOpenAIProviderEditor.ts
@@ -310,6 +310,30 @@ export function useOpenAIProviderEditor({
     notify({ type: "success", message: t("providers.models_merged") });
   }, [discoverSelected, discoveredModels, notify, openaiDraft.modelEntries, t]);
 
+  const toggleOpenAIProviderEnabled = useCallback(
+    async (providerIndex: number, enabled: boolean) => {
+      const provider = openaiProviders[providerIndex];
+      if (!provider) return;
+
+      try {
+        await providersApi.patchOpenAIProviderDisabled(providerIndex, !enabled);
+        // Re-fetch from server to get authoritative state
+        const latest = await providersApi.getOpenAIProviders();
+        setOpenaiProviders(latest);
+        notify({
+          type: "success",
+          message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),
+        });
+      } catch (err: unknown) {
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("providers.update_failed"),
+        });
+      }
+    },
+    [notify, openaiProviders, setOpenaiProviders, t],
+  );
+
   return {
     editOpenAIOpen,
     editOpenAIIndex,
@@ -326,6 +350,7 @@ export function useOpenAIProviderEditor({
     deleteOpenAIProvider,
     toggleOpenAIProviderEnabled,
     toggleOpenAIKeyEntryEnabled,
+    toggleOpenAIProviderEnabled,
     discoverModels,
     applyDiscoveredModels,
   };

--- a/src/modules/providers/hooks/useOpenAIProviderEditor.ts
+++ b/src/modules/providers/hooks/useOpenAIProviderEditor.ts
@@ -211,37 +211,6 @@ export function useOpenAIProviderEditor({
     [notify, openaiProviders, refreshAll, setOpenaiProviders, startRefreshTransition, t],
   );
 
-  const toggleOpenAIProviderEnabled = useCallback(
-    async (providerIndex: number, enabled: boolean) => {
-      const provider = openaiProviders[providerIndex];
-      if (!provider) return;
-
-      const prev = openaiProviders;
-      const next = prev.map((item, itemIndex) =>
-        itemIndex === providerIndex
-          ? { ...item, ...(enabled ? { disabled: undefined } : { disabled: true }) }
-          : item,
-      );
-
-      setOpenaiProviders(next);
-      try {
-        await providersApi.saveOpenAIProviders(next);
-        notify({
-          type: "success",
-          message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),
-        });
-        startRefreshTransition(() => void refreshAll());
-      } catch (err: unknown) {
-        setOpenaiProviders(prev);
-        notify({
-          type: "error",
-          message: err instanceof Error ? err.message : t("providers.update_failed"),
-        });
-      }
-    },
-    [notify, openaiProviders, refreshAll, setOpenaiProviders, startRefreshTransition, t],
-  );
-
   const discoverModels = useCallback(async () => {
     const baseUrl = openaiDraft.baseUrl.trim();
     if (!baseUrl) {
@@ -350,7 +319,6 @@ export function useOpenAIProviderEditor({
     deleteOpenAIProvider,
     toggleOpenAIProviderEnabled,
     toggleOpenAIKeyEntryEnabled,
-    toggleOpenAIProviderEnabled,
     discoverModels,
     applyDiscoveredModels,
   };

--- a/src/modules/providers/hooks/useProviderUsageSummary.ts
+++ b/src/modules/providers/hooks/useProviderUsageSummary.ts
@@ -13,7 +13,7 @@ type StatusBlockDetail = import("@/utils/usage").StatusBlockDetail;
 function buildStatusBarData(stats: KeyStatBucket): StatusBarData {
   if (stats.success === 0 && stats.failure === 0) {
     return {
-      blocks: [],
+      blocks: Array.from({ length: 20 }, () => "idle" as const),
       blockDetails: [],
       successRate: 100,
       totalSuccess: 0,


### PR DESCRIPTION
## Changes

1. **ProviderCard component** - Extract reusable card component for consistent provider card layout
2. **Grid view** - Configurable grid columns for provider cards (persisted to localStorage)
3. **Tab persistence** - Active provider tab saved to localStorage
4. **Model discovery UX** - Improvements to the model discovery flow
5. **Fix status bar layout**
6. **Set Codex default baseUrl**
7. **Fix duplicate declarations** after upstream rebase (disabled field dedup)

## Testing

- `bun run build` passes (tsc --noEmit + vite build)
- Tested toggle, grid view, tab persistence in browser
