### PR TITLE
fix: allow keyless OpenAI-compatible providers

### DIFF
--- a/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -250,6 +250,47 @@ describe("ProvidersPage openai tab", () => {
     });
   });
 
+  test("saves an OpenAI Compatible provider without API key entries", async () => {
+    const user = userEvent.setup();
+    const provider = {
+      name: "Keyless OpenAI",
+      baseUrl: "https://keyless.example.com/v1",
+      models: [{ name: "gpt-compatible" }],
+    } as any;
+    mocks.getOpenAIProviders.mockImplementation(async () => [provider] as any);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Keyless OpenAI")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Edit/ }));
+    expect(await screen.findByText("Edit OpenAI-compatible provider")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => {
+      expect(mocks.saveOpenAIProviders).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: "Keyless OpenAI",
+          baseUrl: "https://keyless.example.com/v1",
+          models: [{ name: "gpt-compatible" }],
+        }),
+      ]);
+    });
+    expect(mocks.saveOpenAIProviders.mock.calls[0]?.[0]?.[0]).not.toHaveProperty(
+      "apiKeyEntries",
+    );
+  });
+
   test("toggles an OpenAI Compatible provider without removing keys", async () => {
     const user = userEvent.setup();
     const provider = {

--- a/src/modules/providers/hooks/useOpenAIProviderEditor.ts
+++ b/src/modules/providers/hooks/useOpenAIProviderEditor.ts
@@ -93,11 +93,6 @@ export function useOpenAIProviderEditor({
       })
       .filter(Boolean) as OpenAIProvider["apiKeyEntries"];
 
-    if (!apiKeyEntries || apiKeyEntries.length === 0) {
-      setOpenaiDraftError(t("providers.key_entry_error"));
-      return null;
-    }
-
     const modelCommit = commitModelEntries(openaiDraft.modelEntries);
     if (modelCommit.error) {
       setOpenaiDraftError(modelCommit.error);
@@ -115,7 +110,7 @@ export function useOpenAIProviderEditor({
       ...(priority !== undefined ? { priority } : {}),
       ...(openaiDraft.testModel.trim() ? { testModel: openaiDraft.testModel.trim() } : {}),
       ...(modelCommit.models ? { models: modelCommit.models } : {}),
-      apiKeyEntries,
+      ...(apiKeyEntries?.length ? { apiKeyEntries } : {}),
     };
   }, [openaiDraft, t]);
 


### PR DESCRIPTION
## Summary
- allow OpenAI-compatible provider edits to save when no API key entries are configured
- keep populated API key entries unchanged when present
- add a regression test for saving a provider with only base URL and models

## Verification
- bun run test src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
- bun run test src/modules/providers/__tests__/providers-helpers.test.ts src/lib/http/apis/__tests__/provider-proxy-id.test.ts src/lib/http/apis/__tests__/providers-opencode-go.test.ts
- bun run lint
- bun run build

Fixes kittors/CliRelay#226