### PR TITLE
fix: avoid passive wheel preventDefault warning

### DIFF
--- a/src/modules/ui/VirtualTable.tsx
+++ b/src/modules/ui/VirtualTable.tsx
@@ -7,7 +7,6 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
-  type WheelEvent as ReactWheelEvent,
 } from "react";
 import { useTranslation } from "react-i18next";
 import { TableCellOverflowTooltip } from "@/modules/ui/TableCellOverflowTooltip";
@@ -257,38 +256,54 @@ export function VirtualTable<T>({
     }
   }, [updateScrollMetrics]);
 
-  const onWheelCapture = useCallback((e: ReactWheelEvent<HTMLDivElement>) => {
+  const handleWheel = useCallback(
+    (e: WheelEvent) => {
+      const el = containerRef.current;
+      if (!el) return;
+
+      const canScrollY = el.scrollHeight > el.clientHeight + 1;
+      const canScrollX = el.scrollWidth > el.clientWidth + 1;
+      const wantsY = e.deltaY !== 0;
+      const wantsX = e.deltaX !== 0;
+
+      const maxTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      const maxLeft = Math.max(0, el.scrollWidth - el.clientWidth);
+      const atTop = el.scrollTop <= 0;
+      const atBottom = el.scrollTop >= maxTop - 1;
+      const atLeft = el.scrollLeft <= 0;
+      const atRight = el.scrollLeft >= maxLeft - 1;
+
+      const canMoveY =
+        wantsY && canScrollY && ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom));
+      const canMoveX =
+        wantsX && canScrollX && ((e.deltaX < 0 && !atLeft) || (e.deltaX > 0 && !atRight));
+
+      if (canMoveY || canMoveX) {
+        e.stopPropagation();
+        return;
+      }
+
+      if (wantsY || wantsX) {
+        if (allowWheelPropagationAtBoundary) return;
+        if (e.cancelable) e.preventDefault();
+        e.stopPropagation();
+      }
+    },
+    [allowWheelPropagationAtBoundary],
+  );
+
+  useEffect(() => {
+    if (naturalFlow) return;
+
     const el = containerRef.current;
     if (!el) return;
 
-    const canScrollY = el.scrollHeight > el.clientHeight + 1;
-    const canScrollX = el.scrollWidth > el.clientWidth + 1;
-    const wantsY = e.deltaY !== 0;
-    const wantsX = e.deltaX !== 0;
+    el.addEventListener("wheel", handleWheel, { capture: true, passive: false });
 
-    const maxTop = Math.max(0, el.scrollHeight - el.clientHeight);
-    const maxLeft = Math.max(0, el.scrollWidth - el.clientWidth);
-    const atTop = el.scrollTop <= 0;
-    const atBottom = el.scrollTop >= maxTop - 1;
-    const atLeft = el.scrollLeft <= 0;
-    const atRight = el.scrollLeft >= maxLeft - 1;
-
-    const canMoveY =
-      wantsY && canScrollY && ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom));
-    const canMoveX =
-      wantsX && canScrollX && ((e.deltaX < 0 && !atLeft) || (e.deltaX > 0 && !atRight));
-
-    if (canMoveY || canMoveX) {
-      e.stopPropagation();
-      return;
-    }
-
-    if (wantsY || wantsX) {
-      if (allowWheelPropagationAtBoundary) return;
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  }, [allowWheelPropagationAtBoundary]);
+    return () => {
+      el.removeEventListener("wheel", handleWheel, { capture: true });
+    };
+  }, [handleWheel, naturalFlow]);
 
   const dragRef = useRef<null | {
     axis: "x" | "y";
@@ -567,7 +582,6 @@ export function VirtualTable<T>({
       <div
         ref={containerRef}
         onScroll={naturalFlow ? undefined : onScroll}
-        onWheelCapture={naturalFlow ? undefined : onWheelCapture}
         tabIndex={naturalFlow ? undefined : 0}
         data-scrollbar-visibility={naturalFlow ? undefined : "hover"}
         className={

--- a/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx
@@ -461,6 +461,28 @@ describe("VirtualTable scrollbar wrapper", () => {
     expect(preventDefault).toHaveBeenCalled();
   });
 
+  test("registers wheel interception as a non-passive native listener", () => {
+    const addEventListener = vi.spyOn(HTMLDivElement.prototype, "addEventListener");
+
+    render(
+      <VirtualTable
+        rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
+        columns={columns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    expect(addEventListener).toHaveBeenCalledWith("wheel", expect.any(Function), {
+      capture: true,
+      passive: false,
+    });
+
+    addEventListener.mockRestore();
+  });
+
   test("shows vertical scrollbar after data change without requiring a user scroll", async () => {
     const { container, rerender } = render(
       <VirtualTable


### PR DESCRIPTION
## Summary

- Move `VirtualTable` wheel boundary interception from React `onWheelCapture` to a native `wheel` listener with `passive: false`.
- Keep the existing scroll-boundary behavior while avoiding browser console warnings from passive listener `preventDefault()` calls.
- Add a regression test that verifies the non-passive listener registration.

## Validation

- `bun run test src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx`
- `bun run lint` (passes with existing warning in `src/modules/providers/components/ProviderKeyModal.tsx`)
- `bunx oxfmt src/modules/ui/VirtualTable.tsx src/modules/ui/__tests__/VirtualTable.scrollbar.test.tsx --check`
- `bun run build`
- `bun run check`
- `git diff --check`

## Notes

- Full-repo `bunx oxfmt . --check` currently fails on existing unrelated files, so this PR keeps formatting scoped to the touched files.
- The same fix has already been merged into `zuohuadong/codeProxy:dev` via https://github.com/zuohuadong/codeProxy/pull/1.
