### PR TITLE
Fix API key permission profile display and sync

### DIFF
--- a/src/lib/http/apis/__tests__/api-key-permission-profiles.test.ts
+++ b/src/lib/http/apis/__tests__/api-key-permission-profiles.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { apiKeyPermissionProfilesApi } from "@/lib/http/apis/api-key-permission-profiles";
+import {
+  apiKeyPermissionProfilesApi,
+  resolveEntryPermissionProfileId,
+} from "@/lib/http/apis/api-key-permission-profiles";
 
 const mocks = vi.hoisted(() => ({
   get: vi.fn(),
@@ -78,5 +81,42 @@ describe("apiKeyPermissionProfilesApi", () => {
       }),
     ]);
     expect(mocks.putRawText).not.toHaveBeenCalled();
+  });
+
+  test("uses explicit profile binding and does not infer unrestricted entries as bound", () => {
+    const profiles = [
+      {
+        id: "unrestricted",
+        name: "Unrestricted",
+        "daily-limit": 0,
+        "total-quota": 0,
+        "concurrency-limit": 0,
+        "rpm-limit": 0,
+        "tpm-limit": 0,
+        "allowed-channel-groups": [],
+        "allowed-channels": [],
+        "allowed-models": [],
+        "system-prompt": "",
+      },
+    ];
+
+    expect(
+      resolveEntryPermissionProfileId(
+        {
+          key: "sk-explicit",
+          "permission-profile-id": "unrestricted",
+        },
+        profiles,
+      ),
+    ).toBe("unrestricted");
+
+    expect(
+      resolveEntryPermissionProfileId(
+        {
+          key: "sk-plain",
+        },
+        profiles,
+      ),
+    ).toBe("");
   });
 });

--- a/src/lib/http/apis/api-key-permission-profiles.ts
+++ b/src/lib/http/apis/api-key-permission-profiles.ts
@@ -186,9 +186,10 @@ export function resolveEntryPermissionProfileId(
 ): string {
   const explicit = normalizeString(entry["permission-profile-id"]);
   if (explicit && profiles.some((profile) => profile.id === explicit)) return explicit;
+  if (!hasApiKeyPermissionSettings(entry)) return "";
   const match = findMatchingPermissionProfile(entry, profiles);
   if (match) return match.id;
-  return hasApiKeyPermissionSettings(entry) ? CUSTOM_PERMISSION_PROFILE_ID : "";
+  return CUSTOM_PERMISSION_PROFILE_ID;
 }
 
 export const apiKeyPermissionProfilesApi = {

--- a/src/modules/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/src/modules/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -6,6 +6,7 @@ import {
   applyApiKeyPermissionProfile,
   apiKeyPermissionProfilesApi,
   makePermissionProfileId,
+  resolveEntryPermissionProfileId,
   type ApiKeyPermissionProfile,
 } from "@/lib/http/apis/api-key-permission-profiles";
 import { RestrictionMultiSelect } from "@/modules/api-keys/RestrictionMultiSelect";
@@ -89,8 +90,12 @@ const draftToProfile = (draft: ProfileDraft): ApiKeyPermissionProfile => ({
 const formatLimit = (value: number, unlimited: string) =>
   value > 0 ? value.toLocaleString() : unlimited;
 
+const formatRestrictionCount = (count: number, unlimited: string) =>
+  count > 0 ? count.toLocaleString() : unlimited;
+
 const boundProfileCount = (profile: ApiKeyPermissionProfile, entries: ApiKeyEntry[]) =>
-  entries.filter((entry) => entry["permission-profile-id"] === profile.id).length;
+  entries.filter((entry) => resolveEntryPermissionProfileId(entry, [profile]) === profile.id)
+    .length;
 
 export function ApiKeyPermissionsPage() {
   const { t } = useTranslation();
@@ -201,6 +206,7 @@ export function ApiKeyPermissionsPage() {
     setSaving(true);
     try {
       const isEdit = profiles.some((item) => item.id === profile.id);
+      const previousProfile = profiles.find((item) => item.id === profile.id) ?? null;
       const nextProfiles = isEdit
         ? profiles.map((item) => (item.id === profile.id ? profile : item))
         : [...profiles, profile];
@@ -208,11 +214,13 @@ export function ApiKeyPermissionsPage() {
 
       let nextEntries = entries;
       if (isEdit) {
-        nextEntries = entries.map((entry) =>
-          entry["permission-profile-id"] === profile.id
-            ? applyApiKeyPermissionProfile(entry, profile)
-            : entry,
-        );
+        nextEntries = entries.map((entry) => {
+          const wasBound =
+            entry["permission-profile-id"] === profile.id ||
+            (previousProfile !== null &&
+              resolveEntryPermissionProfileId(entry, [previousProfile]) === previousProfile.id);
+          return wasBound ? applyApiKeyPermissionProfile(entry, profile) : entry;
+        });
         if (JSON.stringify(nextEntries) !== JSON.stringify(entries)) {
           await apiKeyEntriesApi.replace(nextEntries);
         }
@@ -300,9 +308,18 @@ export function ApiKeyPermissionsPage() {
         width: "w-[220px] min-w-[220px]",
         render: (profile) =>
           t("api_key_permissions_page.permission_summary", {
-            groups: profile["allowed-channel-groups"].length,
-            channels: profile["allowed-channels"].length,
-            models: profile["allowed-models"].length,
+            groups: formatRestrictionCount(
+              profile["allowed-channel-groups"].length,
+              t("api_keys_page.unlimited"),
+            ),
+            channels: formatRestrictionCount(
+              profile["allowed-channels"].length,
+              t("api_keys_page.unlimited"),
+            ),
+            models: formatRestrictionCount(
+              profile["allowed-models"].length,
+              t("api_keys_page.unlimited"),
+            ),
           }),
       },
       {

--- a/src/modules/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
+++ b/src/modules/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
@@ -125,6 +125,14 @@ describe("ApiKeyPermissionsPage", () => {
         "allowed-models": ["old-model"],
         "created-at": "2026-05-02T00:00:00.000Z",
       },
+      {
+        key: "sk-team-c-1234567890",
+        name: "Team C",
+        "daily-limit": 15000,
+        "allowed-channel-groups": ["legacy"],
+        "system-prompt": "标准系统提示词",
+        "created-at": "2026-05-03T00:00:00.000Z",
+      },
     ];
     state.configYaml = "";
     state.permissionProfiles = [
@@ -177,6 +185,8 @@ describe("ApiKeyPermissionsPage", () => {
     expect(await screen.findByText("标准配置")).toBeInTheDocument();
     expect(screen.queryByText("Team A")).not.toBeInTheDocument();
     expect(screen.getByText("每日 15,000")).toBeInTheDocument();
+    expect(screen.getByText("分组 1 · 渠道 无限制 · 模型 无限制")).toBeInTheDocument();
+    expect(screen.getByText("已绑定 2 个")).toBeInTheDocument();
     expect(screen.getByText("标准系统提示词")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "新增配置" }));
@@ -215,5 +225,35 @@ describe("ApiKeyPermissionsPage", () => {
     });
     expect(mocks.fetchConfigYaml).not.toHaveBeenCalled();
     expect(mocks.saveConfigYaml).not.toHaveBeenCalled();
+  });
+
+  test("updates API keys that are explicitly or historically bound to an edited profile", async () => {
+    renderPage();
+
+    expect(await screen.findByText("标准配置")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "编辑" }));
+    const dialog = await screen.findByRole("dialog", { name: "编辑权限配置" });
+    const dailyLimit = within(dialog).getByRole("spinbutton", { name: "每日请求限额" });
+    await userEvent.clear(dailyLimit);
+    await userEvent.type(dailyLimit, "16000");
+    await userEvent.click(within(dialog).getByRole("button", { name: "保存配置" }));
+
+    await waitFor(() => {
+      expect(mocks.apiKeyEntriesReplace).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "Team A",
+            "permission-profile-id": "standard",
+            "daily-limit": 16000,
+          }),
+          expect.objectContaining({
+            name: "Team C",
+            "permission-profile-id": "standard",
+            "daily-limit": 16000,
+          }),
+        ]),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Show unrestricted group/channel/model counts as unlimited on the API key permission profiles page.
- Count explicitly bound API keys and safe historical copied-profile matches.
- Keep matching API keys synchronized when an existing permission profile changes.

## Test Plan
- `bun run test:ci`
- `bun run build`
- `git diff --check`
