### PR TITLE
Remove CC Switch quick import helper copy

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2750,7 +2750,6 @@
     "quick_import_setup_desc": "Go to the CC Switch repository and download the latest CC Switch release. After the app is installed, choose one of the cards below to import this API key into the matching CC Switch provider preset.",
     "quick_import_download_latest": "Download the latest CC Switch",
     "quick_import_cards_title": "CC Switch card presets",
-    "quick_import_cards_desc": "Only Codex and Claude presets are shown here for now. Click a card to import it.",
     "quick_import_codex": "Codex",
     "quick_import_claude": "Claude",
     "quick_import_load_failed": "Failed to load CC Switch import presets",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2754,7 +2754,6 @@
     "quick_import_claude": "Claude",
     "quick_import_load_failed": "Failed to load CC Switch import presets",
     "quick_import_group_aria": "{{client}} quick imports",
-    "quick_import_empty_group": "No {{client}} presets yet. Create one in CC Switch import settings first.",
     "empty_title": "Query your API key usage",
     "empty_desc": "Enter your API key above to view detailed usage statistics and request logs."
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2986,7 +2986,6 @@
     "quick_import_setup_desc": "请前往 CC Switch 仓库下载并安装最新版本的 CC Switch。安装完成后，点击下方配置卡片，即可把当前 API Key 导入到对应的 CC Switch 供应商预设。",
     "quick_import_download_latest": "下载最新 CC Switch",
     "quick_import_cards_title": "CC Switch 卡片配置",
-    "quick_import_cards_desc": "暂时只聚合展示 Codex 和 Claude 两类配置；点击卡片即可导入。",
     "quick_import_codex": "Codex",
     "quick_import_claude": "Claude",
     "quick_import_load_failed": "加载 CC Switch 导入预设失败",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2990,7 +2990,6 @@
     "quick_import_claude": "Claude",
     "quick_import_load_failed": "加载 CC Switch 导入预设失败",
     "quick_import_group_aria": "{{client}} 快捷导入",
-    "quick_import_empty_group": "暂无 {{client}} 预设，请先在 CC Switch 导入设置中创建。",
     "empty_title": "查询 API 密钥用量",
     "empty_desc": "输入上方 API 密钥后，可查看详细用量统计和请求日志。"
   },

--- a/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
+++ b/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
@@ -277,7 +277,6 @@ export function QuickImportTabContent({
         className="overflow-hidden"
         loading={loading}
         title={t("apikey_lookup.quick_import_cards_title")}
-        description={t("apikey_lookup.quick_import_cards_desc")}
       >
         {error ? (
           <div className="border-b border-rose-100 bg-rose-50 px-5 py-2.5 text-sm text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">

--- a/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
+++ b/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Download, ExternalLink, Zap } from "lucide-react";
+import { Download, ExternalLink } from "lucide-react";
 import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
 import { AUTH_STORAGE_KEY, MANAGEMENT_API_PREFIX } from "@/lib/constants";
@@ -289,6 +289,8 @@ export function QuickImportTabContent({
             const items = groupedConfigs[typedClient];
             const label = t(clientLabelKey[typedClient]);
 
+            if (items.length === 0) return null;
+
             return (
               <section
                 key={typedClient}
@@ -302,18 +304,11 @@ export function QuickImportTabContent({
                     {items.length}
                   </span>
                 </div>
-                {items.length > 0 ? (
-                  <div className="grid gap-3 md:grid-cols-2">
-                    {items.map((config) => (
-                      <QuickImportCard key={config.id} config={config} onSelect={handleImport} />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-2 rounded-2xl border border-dashed border-slate-200 bg-slate-50/70 px-4 py-5 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/40 dark:text-white/45">
-                    <Zap size={15} />
-                    {t("apikey_lookup.quick_import_empty_group", { client: label })}
-                  </div>
-                )}
+                <div className="grid gap-3 md:grid-cols-2">
+                  {items.map((config) => (
+                    <QuickImportCard key={config.id} config={config} onSelect={handleImport} />
+                  ))}
+                </div>
               </section>
             );
           })}

--- a/src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -90,6 +90,10 @@ describe("QuickImportTabContent", () => {
     const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
     const claudeSection = await screen.findByRole("region", { name: /claude quick imports/i });
 
+    expect(screen.getByRole("heading", { name: /cc switch card presets/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/only codex and claude presets are shown here for now/i),
+    ).not.toBeInTheDocument();
     expect(within(codexSection).getByRole("button", { name: /team codex/i })).toBeInTheDocument();
     expect(within(claudeSection).getByRole("button", { name: /team claude/i })).toBeInTheDocument();
     expect(screen.queryByText("Team Gemini")).not.toBeInTheDocument();

--- a/src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -114,4 +114,26 @@ describe("QuickImportTabContent", () => {
     expect(parsed.searchParams.get("apiKey")).toBe("sk-lookup-key");
     expect(parsed.searchParams.get("endpoint")).toMatch(/\/pro\/cs_codex\/v1$/);
   });
+
+  test("hides quick import groups that do not have presets", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ "ccswitch-import-configs": [quickImportConfigs[0]] }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <QuickImportTabContent apiKey="sk-lookup-key" />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
+
+    expect(within(codexSection).getByRole("button", { name: /team codex/i })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: /claude quick imports/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/no claude presets yet/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- remove the helper description under the CC Switch card presets heading
- hide quick import client groups that do not have presets, instead of showing empty placeholders
- remove the now-unused i18n entries
- cover the absent helper copy and hidden empty groups in the quick import component test

## Verification
- bunx vitest run src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx --reporter=verbose
- bun run lint
- bun run build
- bun run test:ci