### PR TITLE
fix: show DB-backed payload rules in config editor

### DIFF
--- a/src/modules/config/ConfigPage.tsx
+++ b/src/modules/config/ConfigPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronUp, Code2, Eye, Search, Settings } from "lucide-react";
 import { parse as parseYaml } from "yaml";
-import { configFileApi } from "@/lib/http/apis";
+import { configApi, configFileApi } from "@/lib/http/apis";
 import { FloatingSaveBar } from "@/modules/config/FloatingSaveBar";
 import { RuntimeConfigPanel } from "@/modules/config/RuntimeConfigPanel";
 import { VisualConfigEditor } from "@/modules/config/visual/VisualConfigEditor";
@@ -89,13 +89,16 @@ export function ConfigPage() {
     setLoading(true);
     setError("");
     try {
-      const text = await configFileApi.fetchConfigYaml();
+      const [text, runtimeConfig] = await Promise.all([
+        configFileApi.fetchConfigYaml(),
+        configApi.getConfig().catch(() => undefined),
+      ]);
       setYamlText(text);
       setYamlDirty(false);
       setSearchPositions([]);
       setSearchIndex(0);
       setLastSearchedQuery("");
-      loadVisualValuesFromYaml(text);
+      loadVisualValuesFromYaml(text, runtimeConfig);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t("config_page.toast_load_failed");
       setError(message);
@@ -128,10 +131,13 @@ export function ConfigPage() {
       const commercialModeChanged = previousCommercialMode !== nextCommercialMode;
 
       await configFileApi.saveConfigYaml(nextYaml);
-      const latest = await configFileApi.fetchConfigYaml();
+      const [latest, runtimeConfig] = await Promise.all([
+        configFileApi.fetchConfigYaml(),
+        configApi.getConfig().catch(() => undefined),
+      ]);
       setYamlText(latest);
       setYamlDirty(false);
-      loadVisualValuesFromYaml(latest);
+      loadVisualValuesFromYaml(latest, runtimeConfig);
       notify({ type: "success", message: t("config_page.toast_saved") });
       if (commercialModeChanged) {
         notify({ type: "info", message: t("config_page.toast_commercial_changed") });

--- a/src/modules/config/__tests__/ConfigPage.test.tsx
+++ b/src/modules/config/__tests__/ConfigPage.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import i18n from "@/i18n";
+import { ConfigPage } from "@/modules/config/ConfigPage";
+import type { VisualConfigValues } from "@/modules/config/visual/types";
+import { ThemeProvider } from "@/modules/ui/ThemeProvider";
+import { ToastProvider } from "@/modules/ui/ToastProvider";
+
+const mocks = vi.hoisted(() => ({
+  fetchConfigYaml: vi.fn(),
+  saveConfigYaml: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/http/apis", () => ({
+  configApi: {
+    getConfig: mocks.getConfig,
+  },
+  configFileApi: {
+    fetchConfigYaml: mocks.fetchConfigYaml,
+    saveConfigYaml: mocks.saveConfigYaml,
+  },
+}));
+
+vi.mock("@/modules/config/RuntimeConfigPanel", () => ({
+  RuntimeConfigPanel: () => <div data-testid="runtime-config-panel" />,
+}));
+
+vi.mock("@/modules/config/visual/VisualConfigEditor", () => ({
+  VisualConfigEditor: ({ values }: { values: VisualConfigValues }) => (
+    <div data-testid="visual-config-editor">
+      {values.payloadOverrideRules[0]?.models[0]?.name ?? "no payload override"}
+    </div>
+  ),
+}));
+
+function renderPage() {
+  return render(
+    <ThemeProvider>
+      <ToastProvider>
+        <ConfigPage />
+      </ToastProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("ConfigPage", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+    localStorage.clear();
+    mocks.fetchConfigYaml.mockResolvedValue("port: 8318\nlogging-to-file: true\n");
+    mocks.saveConfigYaml.mockResolvedValue({});
+    mocks.getConfig.mockResolvedValue({
+      payload: {
+        override: [
+          {
+            models: [{ name: "gpt-5.4", protocol: "codex" }],
+            params: { service_tier: "priority" },
+          },
+        ],
+      },
+    });
+  });
+
+  test("loads DB-backed payload rules into the visual editor after YAML cleanup", async () => {
+    renderPage();
+
+    expect(await screen.findByTestId("visual-config-editor")).toHaveTextContent("gpt-5.4");
+
+    await waitFor(() => {
+      expect(mocks.fetchConfigYaml).toHaveBeenCalledTimes(1);
+      expect(mocks.getConfig).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/modules/config/visual/__tests__/VisualConfigEditor.test.tsx
+++ b/src/modules/config/visual/__tests__/VisualConfigEditor.test.tsx
@@ -142,4 +142,64 @@ describe("VisualConfigEditor auto update config", () => {
       expect(nextYaml.match(/https:\/\/plugin\.example/g)).toHaveLength(1);
     });
   });
+
+  test("loads payload rules from runtime config when YAML was cleaned after DB migration", async () => {
+    const { result } = renderHook(() => useVisualConfig());
+
+    act(() => {
+      result.current.loadVisualValuesFromYaml("port: 8318\nlogging-to-file: true\n", {
+        payload: {
+          override: [
+            {
+              models: [{ name: "gpt-5.4", protocol: "codex" }],
+              params: { service_tier: "priority" },
+            },
+          ],
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.visualValues.payloadOverrideRules).toHaveLength(1);
+      expect(result.current.visualValues.payloadOverrideRules[0]?.models[0]).toMatchObject({
+        name: "gpt-5.4",
+        protocol: "codex",
+      });
+      expect(result.current.visualValues.payloadOverrideRules[0]?.params[0]).toMatchObject({
+        path: "service_tier",
+        value: "priority",
+      });
+    });
+  });
+
+  test("writes empty payload marker when DB-backed payload rules are cleared visually", async () => {
+    const { result } = renderHook(() => useVisualConfig());
+
+    act(() => {
+      result.current.loadVisualValuesFromYaml("port: 8318\n", {
+        payload: {
+          override: [
+            {
+              models: [{ name: "gpt-5.4", protocol: "codex" }],
+              params: { service_tier: "priority" },
+            },
+          ],
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.visualValues.payloadOverrideRules).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.setVisualValues({ payloadOverrideRules: [] });
+    });
+
+    await waitFor(() => {
+      const nextYaml = result.current.applyVisualChangesToYaml("port: 8318\n");
+      expect(nextYaml).toContain("payload: {}\n");
+      expect(nextYaml).not.toContain("service_tier");
+    });
+  });
 });

--- a/src/modules/config/visual/useVisualConfig.ts
+++ b/src/modules/config/visual/useVisualConfig.ts
@@ -92,6 +92,21 @@ function deleteIfEmpty(parent: Record<string, unknown>, key: string): void {
   if (Object.keys(value).length === 0) delete parent[key];
 }
 
+function hasPayloadRuleSections(payload: Record<string, unknown> | null): payload is Record<string, unknown> {
+  return Boolean(
+    payload &&
+      (hasOwn(payload, "default") || hasOwn(payload, "override") || hasOwn(payload, "filter")),
+  );
+}
+
+function hasVisualPayloadRules(values: VisualConfigValues): boolean {
+  return (
+    values.payloadDefaultRules.length > 0 ||
+    values.payloadOverrideRules.length > 0 ||
+    values.payloadFilterRules.length > 0
+  );
+}
+
 function setBoolean(obj: Record<string, unknown>, key: string, value: boolean): void {
   if (value) {
     obj[key] = true;
@@ -451,7 +466,7 @@ export function useVisualConfig() {
     return JSON.stringify(visualValues) !== JSON.stringify(baselineValues);
   }, [baselineValues, visualValues]);
 
-  const loadVisualValuesFromYaml = useCallback((yamlContent: string) => {
+  const loadVisualValuesFromYaml = useCallback((yamlContent: string, runtimeConfig?: Record<string, unknown>) => {
     try {
       const parsedRaw: unknown = parseYaml(yamlContent) || {};
       const parsed = asRecord(parsedRaw) ?? {};
@@ -459,7 +474,9 @@ export function useVisualConfig() {
       const remoteManagement = asRecord(parsed["remote-management"]);
       const quotaExceeded = asRecord(parsed["quota-exceeded"]);
       const routing = asRecord(parsed.routing);
-      const payload = asRecord(parsed.payload);
+      const yamlPayload = asRecord(parsed.payload);
+      const runtimePayload = asRecord(runtimeConfig?.payload);
+      const payload = hasPayloadRuleSections(runtimePayload) ? runtimePayload : yamlPayload;
       const streaming = asRecord(parsed.streaming);
       const autoUpdate = asRecord(parsed["auto-update"]);
 
@@ -730,12 +747,10 @@ export function useVisualConfig() {
           }
         }
 
-        if (
-          hasOwn(parsed, "payload") ||
-          values.payloadDefaultRules.length > 0 ||
-          values.payloadOverrideRules.length > 0 ||
-          values.payloadFilterRules.length > 0
-        ) {
+        const currentHasPayloadRules = hasVisualPayloadRules(values);
+        const baselineHadPayloadRules = hasVisualPayloadRules(baselineValues);
+
+        if (hasOwn(parsed, "payload") || currentHasPayloadRules || baselineHadPayloadRules) {
           const payload = ensureRecord(parsed, "payload");
           if (values.payloadDefaultRules.length > 0) {
             payload.default = serializePayloadRulesForYaml(values.payloadDefaultRules);
@@ -752,7 +767,13 @@ export function useVisualConfig() {
           } else if (hasOwn(payload, "filter")) {
             delete payload.filter;
           }
-          deleteIfEmpty(parsed, "payload");
+          if (Object.keys(payload).length === 0) {
+            if (baselineHadPayloadRules && !currentHasPayloadRules) {
+              parsed.payload = {};
+            } else {
+              delete parsed.payload;
+            }
+          }
         }
 
         return stringifyYaml(parsed, { indent: 2, lineWidth: 120, minContentWidth: 0 });
@@ -760,7 +781,7 @@ export function useVisualConfig() {
         return currentYaml;
       }
     },
-    [visualValues],
+    [baselineValues, visualValues],
   );
 
   const setVisualValues = useCallback((newValues: Partial<VisualConfigValues>) => {


### PR DESCRIPTION
## Summary
- Load runtime config alongside cleaned YAML so the visual config editor can display DB-backed payload rules.
- Preserve a clear marker when visually removing DB-backed payload rules so stale rules are removed instead of reappearing.
- Add regression coverage for the hook and page loading path.

## Verification
- bun run test src/modules/config/__tests__/ConfigPage.test.tsx src/modules/config/visual/__tests__/VisualConfigEditor.test.tsx
- bun run build
- bun run lint (existing unrelated warning remains)

Refs kittors/CliRelay#208