### PR TITLE
fix: filter CC Switch presets by API key models

### DIFF
--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -58,6 +58,53 @@ function appendRoutePath(baseUrl: string, path: string): string {
   return `${normalizedBase}${normalizedPath}`;
 }
 
+function normalizeModelList(models: readonly unknown[] | undefined): string[] {
+  if (!Array.isArray(models)) return [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  models.forEach((model) => {
+    const value = String(model ?? "").trim();
+    if (!value || seen.has(value)) return;
+    seen.add(value);
+    normalized.push(value);
+  });
+
+  return normalized;
+}
+
+function getCcSwitchImportRequestModels(config: CcSwitchImportConfigListItem): string[] {
+  const models: string[] = [];
+  const addModel = (model: unknown) => {
+    const value = String(model ?? "").trim();
+    if (value) models.push(value);
+  };
+
+  addModel(config.defaultModel);
+
+  if (config.clientType === "claude") {
+    config.modelMappings.forEach((mapping) => {
+      if (!mapping.role) return;
+      const requestModel = mapping.requestModel.trim();
+      const targetModel = mapping.targetModel.trim();
+      addModel(!requestModel || requestModel === mapping.role ? targetModel : requestModel);
+    });
+  }
+
+  return normalizeModelList(models);
+}
+
+function ccSwitchConfigMatchesAllowedModels(
+  config: CcSwitchImportConfigListItem,
+  allowedModels: readonly string[],
+): boolean {
+  if (allowedModels.length === 0) return true;
+  const allowed = new Set(allowedModels);
+  const requestModels = getCcSwitchImportRequestModels(config);
+  if (requestModels.length === 0) return true;
+  return requestModels.every((model) => allowed.has(model));
+}
+
 async function copyTextToClipboard(text: string): Promise<boolean> {
   try {
     await navigator.clipboard.writeText(text);
@@ -423,9 +470,12 @@ export function ApiKeysPage() {
           .toLowerCase(),
       )
       .filter(Boolean);
+    const entryModels = normalizeModelList(ccSwitchImportEntry["allowed-models"]);
     return ccSwitchImportConfigs.filter((config) => {
-      if (entryGroups.length === 0) return true;
-      return config.allowedChannelGroups.some((g) => entryGroups.includes(g));
+      const matchesGroups =
+        entryGroups.length === 0 ||
+        config.allowedChannelGroups.some((g) => entryGroups.includes(g));
+      return matchesGroups && ccSwitchConfigMatchesAllowedModels(config, entryModels);
     });
   }, [ccSwitchImportEntry, ccSwitchImportConfigs]);
 

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -756,4 +756,76 @@ describe("ApiKeysPage", () => {
 
     openSpy.mockRestore();
   });
+
+  test("filters CC Switch presets by the API key allowed models", async () => {
+    state.entries = [
+      {
+        key: "sk-limited-models-1234567890",
+        name: "KimiCode+DeepSeek",
+        "allowed-channel-groups": ["team-a"],
+        "allowed-models": ["kimi-k2.6", "deepseek-v4"],
+        "created-at": "2026-04-14T00:00:00.000Z",
+      },
+    ];
+    state.channelGroups = [
+      {
+        name: "team-a",
+        description: "Team A route",
+        "path-routes": ["/team-a"],
+      },
+    ];
+    state.ccSwitchImportConfigs = [
+      {
+        id: "preset-deepseek-gpt",
+        "client-type": "claude",
+        "provider-name": "deepseek+gpt",
+        note: "Uses a blocked main model",
+        "default-model": "gpt-5.5",
+        "allowed-channel-groups": ["team-a"],
+        "model-mappings": [
+          { role: "main", "request-model": "gpt-5.5", "target-model": "gpt-5.5" },
+          { role: "haiku", "request-model": "deepseek-v4", "target-model": "deepseek-v4" },
+        ],
+      },
+      {
+        id: "preset-chatgpt-pro",
+        "client-type": "claude",
+        "provider-name": "chatgpt-pro",
+        note: "Uses another blocked model",
+        "default-model": "gpt-5.2",
+        "allowed-channel-groups": ["team-a"],
+      },
+      {
+        id: "preset-kimi-deepseek",
+        "client-type": "claude",
+        "provider-name": "Kimi+DeepSeek",
+        note: "Allowed preset",
+        "default-model": "kimi-k2.6",
+        "allowed-channel-groups": ["team-a"],
+        "model-mappings": [
+          { role: "main", "request-model": "kimi-k2.6", "target-model": "kimi-k2.6" },
+          { role: "haiku", "request-model": "deepseek-v4", "target-model": "deepseek-v4" },
+        ],
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeysPage />
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("KimiCode+DeepSeek")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /import to cc switch/i }));
+    await screen.findByRole("dialog", { name: /import to cc switch/i });
+
+    expect(screen.queryByRole("button", { name: /deepseek\+gpt/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /chatgpt-pro/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /kimi\+deepseek/i })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Filter API key CC Switch import presets by the API key allowed model list as well as channel groups.
- Add a regression test covering mixed allowed and blocked preset models.

## Test Plan
- bun run test src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
- bun run lint
- bun run build