### PR TITLE
fix: filter CC Switch presets by target models

### DIFF
--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -73,25 +73,12 @@ function normalizeModelList(models: readonly unknown[] | undefined): string[] {
   return normalized;
 }
 
-function getCcSwitchImportRequestModels(config: CcSwitchImportConfigListItem): string[] {
-  const models: string[] = [];
-  const addModel = (model: unknown) => {
-    const value = String(model ?? "").trim();
-    if (value) models.push(value);
-  };
-
-  addModel(config.defaultModel);
-
-  if (config.clientType === "claude") {
-    config.modelMappings.forEach((mapping) => {
-      if (!mapping.role) return;
-      const requestModel = mapping.requestModel.trim();
-      const targetModel = mapping.targetModel.trim();
-      addModel(!requestModel || requestModel === mapping.role ? targetModel : requestModel);
-    });
-  }
-
-  return normalizeModelList(models);
+function getCcSwitchImportTargetModels(config: CcSwitchImportConfigListItem): string[] {
+  const mappedTargets = normalizeModelList(
+    config.modelMappings.map((mapping) => mapping.targetModel),
+  );
+  if (mappedTargets.length > 0) return mappedTargets;
+  return normalizeModelList([config.defaultModel]);
 }
 
 function ccSwitchConfigMatchesAllowedModels(
@@ -100,9 +87,9 @@ function ccSwitchConfigMatchesAllowedModels(
 ): boolean {
   if (allowedModels.length === 0) return true;
   const allowed = new Set(allowedModels);
-  const requestModels = getCcSwitchImportRequestModels(config);
-  if (requestModels.length === 0) return true;
-  return requestModels.every((model) => allowed.has(model));
+  const targetModels = getCcSwitchImportTargetModels(config);
+  if (targetModels.length === 0) return true;
+  return targetModels.every((model) => allowed.has(model));
 }
 
 async function copyTextToClipboard(text: string): Promise<boolean> {

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -757,13 +757,12 @@ describe("ApiKeysPage", () => {
     openSpy.mockRestore();
   });
 
-  test("filters CC Switch presets by the API key allowed models", async () => {
+  test("filters CC Switch presets by the API key target models", async () => {
     state.entries = [
       {
         key: "sk-limited-models-1234567890",
         name: "KimiCode+DeepSeek",
-        "allowed-channel-groups": ["team-a"],
-        "allowed-models": ["kimi-k2.6", "deepseek-v4"],
+        "allowed-models": ["deepseek-v4-flash", "deepseek-v4-pro", "kimi-k2.5", "kimi-k2.6"],
         "created-at": "2026-04-14T00:00:00.000Z",
       },
     ];
@@ -783,8 +782,12 @@ describe("ApiKeysPage", () => {
         "default-model": "gpt-5.5",
         "allowed-channel-groups": ["team-a"],
         "model-mappings": [
-          { role: "main", "request-model": "gpt-5.5", "target-model": "gpt-5.5" },
-          { role: "haiku", "request-model": "deepseek-v4", "target-model": "deepseek-v4" },
+          { role: "main", "request-model": "claude-opus-4-7", "target-model": "gpt-5.5" },
+          {
+            role: "haiku",
+            "request-model": "claude-haiku-4-5",
+            "target-model": "deepseek-v4-flash",
+          },
         ],
       },
       {
@@ -803,8 +806,18 @@ describe("ApiKeysPage", () => {
         "default-model": "kimi-k2.6",
         "allowed-channel-groups": ["team-a"],
         "model-mappings": [
-          { role: "main", "request-model": "kimi-k2.6", "target-model": "kimi-k2.6" },
-          { role: "haiku", "request-model": "deepseek-v4", "target-model": "deepseek-v4" },
+          { role: "main", "request-model": "claude-opus-4-7", "target-model": "kimi-k2.6" },
+          {
+            role: "haiku",
+            "request-model": "claude-haiku-4-5",
+            "target-model": "deepseek-v4-flash",
+          },
+          {
+            role: "sonnet",
+            "request-model": "claude-sonnet-4-6",
+            "target-model": "deepseek-v4-flash",
+          },
+          { role: "opus", "request-model": "claude-opus-4-7", "target-model": "kimi-k2.6" },
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- Replace the CC Switch import filter so API key model permissions are matched against actual target channel models, not request aliases.
- Update the API key regression test to cover Claude request aliases mapped to Kimi and DeepSeek target models.

## Test Plan
- bun run test src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
- bun run lint
- bun run build