### PR TITLE
Fix API key lookup CC Switch permission filtering

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2749,7 +2749,6 @@
     "quick_import_setup_title": "Install CC Switch first",
     "quick_import_setup_desc": "Go to the CC Switch repository and download the latest CC Switch release. After the app is installed, choose one of the cards below to import this API key into the matching CC Switch provider preset.",
     "quick_import_download_latest": "Download the latest CC Switch",
-    "quick_import_cards_title": "CC Switch card presets",
     "quick_import_codex": "Codex",
     "quick_import_claude": "Claude",
     "quick_import_load_failed": "Failed to load CC Switch import presets",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2985,7 +2985,6 @@
     "quick_import_setup_title": "请先安装 CC Switch",
     "quick_import_setup_desc": "请前往 CC Switch 仓库下载并安装最新版本的 CC Switch。安装完成后，点击下方配置卡片，即可把当前 API Key 导入到对应的 CC Switch 供应商预设。",
     "quick_import_download_latest": "下载最新 CC Switch",
-    "quick_import_cards_title": "CC Switch 卡片配置",
     "quick_import_codex": "Codex",
     "quick_import_claude": "Claude",
     "quick_import_load_failed": "加载 CC Switch 导入预设失败",

--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -38,6 +38,7 @@ import {
   deriveCcSwitchImportSettingsFromConfigList,
   type CcSwitchImportConfigListItem,
 } from "@/modules/ccswitch/ccswitchImportConfigList";
+import { ccSwitchConfigMatchesApiKeyPermissions } from "@/modules/ccswitch/ccswitchImportCompatibility";
 import { LogContentModal } from "@/modules/monitor/LogContentModal";
 import { ErrorDetailModal } from "@/modules/monitor/ErrorDetailModal";
 import type { ApiKeyFormValues } from "@/modules/api-keys/types";
@@ -56,40 +57,6 @@ function appendRoutePath(baseUrl: string, path: string): string {
     return normalizedBase;
   }
   return `${normalizedBase}${normalizedPath}`;
-}
-
-function normalizeModelList(models: readonly unknown[] | undefined): string[] {
-  if (!Array.isArray(models)) return [];
-  const seen = new Set<string>();
-  const normalized: string[] = [];
-
-  models.forEach((model) => {
-    const value = String(model ?? "").trim();
-    if (!value || seen.has(value)) return;
-    seen.add(value);
-    normalized.push(value);
-  });
-
-  return normalized;
-}
-
-function getCcSwitchImportTargetModels(config: CcSwitchImportConfigListItem): string[] {
-  const mappedTargets = normalizeModelList(
-    config.modelMappings.map((mapping) => mapping.targetModel),
-  );
-  if (mappedTargets.length > 0) return mappedTargets;
-  return normalizeModelList([config.defaultModel]);
-}
-
-function ccSwitchConfigMatchesAllowedModels(
-  config: CcSwitchImportConfigListItem,
-  allowedModels: readonly string[],
-): boolean {
-  if (allowedModels.length === 0) return true;
-  const allowed = new Set(allowedModels);
-  const targetModels = getCcSwitchImportTargetModels(config);
-  if (targetModels.length === 0) return true;
-  return targetModels.every((model) => allowed.has(model));
 }
 
 async function copyTextToClipboard(text: string): Promise<boolean> {
@@ -450,20 +417,9 @@ export function ApiKeysPage() {
 
   const compatibleConfigs = useMemo(() => {
     if (!ccSwitchImportEntry) return [];
-    const entryGroups = (ccSwitchImportEntry["allowed-channel-groups"] ?? [])
-      .map((g) =>
-        String(g ?? "")
-          .trim()
-          .toLowerCase(),
-      )
-      .filter(Boolean);
-    const entryModels = normalizeModelList(ccSwitchImportEntry["allowed-models"]);
-    return ccSwitchImportConfigs.filter((config) => {
-      const matchesGroups =
-        entryGroups.length === 0 ||
-        config.allowedChannelGroups.some((g) => entryGroups.includes(g));
-      return matchesGroups && ccSwitchConfigMatchesAllowedModels(config, entryModels);
-    });
+    return ccSwitchImportConfigs.filter((config) =>
+      ccSwitchConfigMatchesApiKeyPermissions(config, ccSwitchImportEntry),
+    );
   }, [ccSwitchImportEntry, ccSwitchImportConfigs]);
 
   const handleOpenCcSwitchImport = useCallback((entry: ApiKeyEntry) => {

--- a/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
+++ b/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
@@ -13,6 +13,7 @@ import {
   ccSwitchImportConfigsApi,
   normalizeCcSwitchImportConfigs,
 } from "@/lib/http/apis/ccswitch-import-configs";
+import type { ApiKeyEntry } from "@/lib/http/apis/api-keys";
 import {
   buildCcSwitchImportUrl,
   openCcSwitchImportUrl,
@@ -22,6 +23,7 @@ import {
   deriveCcSwitchImportSettingsFromConfigList,
   type CcSwitchImportConfigListItem,
 } from "@/modules/ccswitch/ccswitchImportConfigList";
+import { ccSwitchConfigMatchesApiKeyPermissions } from "@/modules/ccswitch/ccswitchImportCompatibility";
 import { normalizeCcSwitchClaudeAuthField } from "@/modules/ccswitch/ccswitchImportSettings";
 import { Card } from "@/modules/ui/Card";
 import { useToast } from "@/modules/ui/ToastProvider";
@@ -76,6 +78,40 @@ async function fetchQuickImportConfigs(): Promise<CcSwitchImportConfigListItem[]
   } catch (err) {
     if (auth) throw err;
     return ccSwitchImportConfigsApi.list();
+  }
+}
+
+function normalizeApiKeyEntries(raw: unknown): ApiKeyEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry): entry is ApiKeyEntry =>
+      entry !== null &&
+      typeof entry === "object" &&
+      !Array.isArray(entry) &&
+      typeof (entry as { key?: unknown }).key === "string",
+  );
+}
+
+async function fetchQuickImportApiKeyEntry(apiKey: string): Promise<ApiKeyEntry | null> {
+  const auth = readStoredManagementAuth();
+  if (!auth) return null;
+
+  const key = apiKey.trim();
+  if (!key) return null;
+
+  const managementBase = computeManagementApiBase(auth.apiBase);
+  try {
+    const response = await fetch(`${managementBase}/api-key-entries`, {
+      headers: {
+        Authorization: `Bearer ${auth.managementKey}`,
+      },
+    });
+    if (!response.ok) return null;
+    const data = (await response.json()) as Record<string, unknown>;
+    const entries = normalizeApiKeyEntries(data["api-key-entries"] ?? data.items ?? data);
+    return entries.find((entry) => entry.key === key) ?? null;
+  } catch {
+    return null;
   }
 }
 
@@ -181,6 +217,7 @@ export function QuickImportTabContent({
   const { t } = useTranslation();
   const { notify } = useToast();
   const [configs, setConfigs] = useState<CcSwitchImportConfigListItem[]>([]);
+  const [apiKeyEntry, setApiKeyEntry] = useState<ApiKeyEntry | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -189,14 +226,16 @@ export function QuickImportTabContent({
     setLoading(true);
     setError(null);
 
-    fetchQuickImportConfigs()
-      .then((items) => {
+    Promise.all([fetchQuickImportConfigs(), fetchQuickImportApiKeyEntry(apiKey)])
+      .then(([items, entry]) => {
         if (cancelled) return;
         setConfigs(items.filter((item) => QUICK_IMPORT_CLIENTS.includes(item.clientType)));
+        setApiKeyEntry(entry);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         setConfigs([]);
+        setApiKeyEntry(null);
         setError(err instanceof Error ? err.message : t("apikey_lookup.quick_import_load_failed"));
       })
       .finally(() => {
@@ -207,14 +246,22 @@ export function QuickImportTabContent({
     return () => {
       cancelled = true;
     };
-  }, [reloadToken, t]);
+  }, [apiKey, reloadToken, t]);
 
   const groupedConfigs = useMemo(
     () => ({
-      codex: configs.filter((config) => config.clientType === "codex"),
-      claude: configs.filter((config) => config.clientType === "claude"),
+      codex: configs.filter(
+        (config) =>
+          config.clientType === "codex" &&
+          ccSwitchConfigMatchesApiKeyPermissions(config, apiKeyEntry),
+      ),
+      claude: configs.filter(
+        (config) =>
+          config.clientType === "claude" &&
+          ccSwitchConfigMatchesApiKeyPermissions(config, apiKeyEntry),
+      ),
     }),
-    [configs],
+    [apiKeyEntry, configs],
   );
 
   const handleImport = useCallback(
@@ -276,7 +323,6 @@ export function QuickImportTabContent({
         padding="none"
         className="overflow-hidden"
         loading={loading}
-        title={t("apikey_lookup.quick_import_cards_title")}
       >
         {error ? (
           <div className="border-b border-rose-100 bg-rose-50 px-5 py-2.5 text-sm text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">

--- a/src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -60,6 +60,7 @@ const quickImportConfigs = [
 describe("QuickImportTabContent", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
+    window.localStorage.clear();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ "ccswitch-import-configs": quickImportConfigs }), {
         headers: { "Content-Type": "application/json" },
@@ -90,7 +91,7 @@ describe("QuickImportTabContent", () => {
     const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
     const claudeSection = await screen.findByRole("region", { name: /claude quick imports/i });
 
-    expect(screen.getByRole("heading", { name: /cc switch card presets/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /cc switch card presets/i })).toBeNull();
     expect(
       screen.queryByText(/only codex and claude presets are shown here for now/i),
     ).not.toBeInTheDocument();
@@ -135,5 +136,67 @@ describe("QuickImportTabContent", () => {
     expect(within(codexSection).getByRole("button", { name: /team codex/i })).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: /claude quick imports/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/no claude presets yet/i)).not.toBeInTheDocument();
+  });
+
+  test("filters quick import cards by the looked up API key permissions", async () => {
+    window.localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({ apiBase: "http://localhost:3000", managementKey: "mgmt-test" }),
+    );
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/ccswitch-import-configs")) {
+        return new Response(
+          JSON.stringify({
+            "ccswitch-import-configs": [
+              quickImportConfigs[0],
+              {
+                ...quickImportConfigs[0],
+                id: "codex-blocked-model",
+                "provider-name": "Blocked Codex",
+                "default-model": "gpt-5.5",
+                "model-mappings": [
+                  {
+                    "request-model": "gpt-5.5",
+                    "target-model": "gpt-5.5",
+                  },
+                ],
+              },
+              quickImportConfigs[1],
+            ],
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/api-key-entries")) {
+        return new Response(
+          JSON.stringify({
+            "api-key-entries": [
+              {
+                key: "sk-lookup-key",
+                "allowed-channel-groups": ["pro"],
+                "allowed-models": ["gpt-5.3-codex"],
+              },
+            ],
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <QuickImportTabContent apiKey="sk-lookup-key" />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
+
+    expect(within(codexSection).getByRole("button", { name: /team codex/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /blocked codex/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: /claude quick imports/i })).not.toBeInTheDocument();
   });
 });

--- a/src/modules/ccswitch/ccswitchImportCompatibility.ts
+++ b/src/modules/ccswitch/ccswitchImportCompatibility.ts
@@ -1,0 +1,53 @@
+import type { ApiKeyEntry } from "@/lib/http/apis/api-keys";
+import type { CcSwitchImportConfigListItem } from "@/modules/ccswitch/ccswitchImportConfigList";
+
+export function normalizeCcSwitchPermissionList(values: readonly unknown[] | undefined): string[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  values.forEach((value) => {
+    const text = String(value ?? "").trim();
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    normalized.push(text);
+  });
+
+  return normalized;
+}
+
+export function getCcSwitchImportTargetModels(config: CcSwitchImportConfigListItem): string[] {
+  const mappedTargets = normalizeCcSwitchPermissionList(
+    config.modelMappings.map((mapping) => mapping.targetModel),
+  );
+  if (mappedTargets.length > 0) return mappedTargets;
+  return normalizeCcSwitchPermissionList([config.defaultModel]);
+}
+
+export function ccSwitchConfigMatchesAllowedModels(
+  config: CcSwitchImportConfigListItem,
+  allowedModels: readonly string[],
+): boolean {
+  if (allowedModels.length === 0) return true;
+  const allowed = new Set(allowedModels);
+  const targetModels = getCcSwitchImportTargetModels(config);
+  if (targetModels.length === 0) return true;
+  return targetModels.every((model) => allowed.has(model));
+}
+
+export function ccSwitchConfigMatchesApiKeyPermissions(
+  config: CcSwitchImportConfigListItem,
+  entry: Pick<ApiKeyEntry, "allowed-channel-groups" | "allowed-models"> | null | undefined,
+): boolean {
+  if (!entry) return true;
+
+  const entryGroups = normalizeCcSwitchPermissionList(entry["allowed-channel-groups"]).map((group) =>
+    group.toLowerCase(),
+  );
+  const entryModels = normalizeCcSwitchPermissionList(entry["allowed-models"]);
+  const matchesGroups =
+    entryGroups.length === 0 ||
+    config.allowedChannelGroups.some((group) => entryGroups.includes(group.toLowerCase()));
+
+  return matchesGroups && ccSwitchConfigMatchesAllowedModels(config, entryModels);
+}


### PR DESCRIPTION
## Summary

- Apply API key permission filtering to API key lookup CC Switch quick import cards when management session data is available.
- Share the CC Switch compatibility filter with the API Keys import modal.
- Remove the quick import card-list title copy.

## Verification

- bun run test src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
- bun run test src/modules/api-keys/__tests__/ApiKeysPage.test.tsx src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
- bun run lint
- bun run build
- bun run test:ci
