### PR TITLE
fix(quota): make Codex account header optional

### DIFF
--- a/src/modules/quota/__tests__/quota-fetch.test.ts
+++ b/src/modules/quota/__tests__/quota-fetch.test.ts
@@ -161,6 +161,68 @@ describe("fetchQuota for antigravity", () => {
   });
 });
 
+describe("fetchQuota for codex", () => {
+  test("requests Codex usage without Chatgpt-Account-Id when the auth file does not include one", async () => {
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: {
+        plan_type: "plus",
+        rate_limit: {
+          primary_window: {
+            used_percent: 25,
+            limit_window_seconds: 18000,
+            reset_after_seconds: 60,
+          },
+          secondary_window: {
+            used_percent: 50,
+            limit_window_seconds: 604800,
+            reset_after_seconds: 120,
+          },
+        },
+      },
+    });
+
+    const result = await fetchQuota("codex", {
+      name: "codex.json",
+      provider: "codex",
+      auth_index: "codex-1",
+      id_token: "",
+    } as any);
+
+    expect(mocks.request).toHaveBeenCalledTimes(1);
+    const requestArgs = mocks.request.mock.calls[0]?.[0];
+    expect(requestArgs).toEqual(
+      expect.objectContaining({
+        authIndex: "codex-1",
+        method: "GET",
+        url: "https://chatgpt.com/backend-api/wham/usage",
+      }),
+    );
+    expect(requestArgs?.header).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer $TOKEN$",
+        "Content-Type": "application/json",
+      }),
+    );
+    expect(requestArgs?.header?.["Chatgpt-Account-Id"]).toBeUndefined();
+    expect(result.planType).toBe("plus");
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        key: "code_5h",
+        percent: 75,
+        windowSeconds: 18000,
+      }),
+      expect.objectContaining({
+        key: "code_week",
+        percent: 50,
+        windowSeconds: 604800,
+      }),
+    ]);
+  });
+});
+
 describe("fetchQuota for claude", () => {
   test("requests Anthropic OAuth usage endpoint and maps remaining percentages", async () => {
     mocks.request.mockResolvedValueOnce({

--- a/src/modules/quota/quota-fetch.ts
+++ b/src/modules/quota/quota-fetch.ts
@@ -130,12 +130,17 @@ export const fetchQuota = async (
 
   if (type === "codex") {
     const accountId = resolveCodexChatgptAccountId(file);
-    if (!accountId) throw new Error("missing_account_id");
+    const requestHeader: Record<string, string> = {
+      ...CODEX_REQUEST_HEADERS,
+    };
+    if (accountId) {
+      requestHeader["Chatgpt-Account-Id"] = accountId;
+    }
     const result = await apiCallApi.request({
       authIndex,
       method: "GET",
       url: CODEX_USAGE_URL,
-      header: { ...CODEX_REQUEST_HEADERS, "Chatgpt-Account-Id": accountId },
+      header: requestHeader,
     });
     if (result.statusCode < 200 || result.statusCode >= 300)
       throw new Error(getApiCallErrorMessage(result));


### PR DESCRIPTION
## Summary
- stop failing Codex quota refresh locally when an auth file does not include `Chatgpt-Account-Id`
- send the quota request with the standard Codex headers and only attach `Chatgpt-Account-Id` when it is present
- add regression coverage for the missing-account-id case

## Why
Some Codex auth files do not contain `Chatgpt-Account-Id`. In the current UI, clicking refresh throws `missing_account_id` on the client before any request is sent, so quota refresh never reaches the backend.

## Verification
- `npm run test -- src/modules/quota/__tests__/quota-fetch.test.ts`
- `npm run build`
- manually verified in a deployed panel that refreshing the affected auth file now sends quota requests successfully