### PR TITLE
fix: keep auth file actions on one row

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -201,6 +201,43 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByRole("switch", { name: "Enable/Disable" })).toBeInTheDocument();
   });
 
+  test("keeps table action buttons on a single row", async () => {
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          type: "codex",
+          account_type: "oauth",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const row = await screen.findByRole("row", { name: /codex-pro\.json/ });
+    const actionGroup = within(row).getByRole("button", { name: "Refresh" }).closest("div");
+    const actionHeader = screen.getByRole("columnheader", { name: "Action" });
+
+    expect(actionGroup).not.toBeNull();
+    expect(actionGroup).toHaveClass("inline-flex");
+    expect(actionGroup).toHaveClass("whitespace-nowrap");
+    expect(actionGroup).not.toHaveClass("flex-wrap");
+    expect(actionHeader).toHaveClass("w-48");
+  });
+
   test("loads initial usage stats only for listed auth files", async () => {
     const now = Date.now();
     mocks.list.mockImplementationOnce(async () => ({

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -538,7 +538,7 @@ export function AuthFilesFilesTab({
                 rowHeight={84}
                 caption={t("auth_files.table_caption")}
                 emptyText={t("auth_files_page.no_files_desc")}
-                minWidth="min-w-[1720px]"
+                minWidth="min-w-[1840px]"
                 height="h-[calc(100dvh-452px)]"
                 rowClassName={(row) => {
                   const runtimeOnly = isRuntimeOnlyAuthFile(row);

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -807,7 +807,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "actions",
         label: t("common.action"),
-        width: "w-40",
+        width: "w-48",
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (file) => {
@@ -825,7 +825,7 @@ export function useAuthFilesFilesPresentation({
             : false;
 
           return (
-            <div className="inline-flex flex-wrap items-center justify-center gap-1">
+            <div className="inline-flex min-w-max items-center justify-center gap-1 whitespace-nowrap">
               {quotaProvider ? (
                 <HoverTooltip content={t("common.refresh")}>
                   <Button


### PR DESCRIPTION
## Summary
- keep the auth-files table action button group on a single row
- widen the action column and table minimum width to prevent compression
- add a regression test for the auth-files action column layout

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
- git diff --check
- bun run lint
- bun run build