### PR TITLE
Refresh auth files after pasted JSON upload

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -15,7 +15,10 @@ import { ImportModelsModal } from "@/modules/auth-files/components/ImportModelsM
 import { GroupOverviewModal } from "@/modules/auth-files/components/GroupOverviewModal";
 import { useAuthFilesDataState } from "@/modules/auth-files/hooks/useAuthFilesDataState";
 import { useAuthFilesDetailEditors } from "@/modules/auth-files/hooks/useAuthFilesDetailEditors";
-import { useAuthFilesFileActions } from "@/modules/auth-files/hooks/useAuthFilesFileActions";
+import {
+  useAuthFilesFileActions,
+  type AuthFilesUploadResult,
+} from "@/modules/auth-files/hooks/useAuthFilesFileActions";
 import { useAuthFilesFilesPresentation } from "@/modules/auth-files/hooks/useAuthFilesFilesPresentation";
 import { useAuthFilesListState } from "@/modules/auth-files/hooks/useAuthFilesListState";
 import { useAuthFilesModelOwnerGroups } from "@/modules/auth-files/hooks/useAuthFilesModelOwnerGroups";
@@ -330,6 +333,30 @@ export function AuthFilesPage() {
     refreshUsageDataForFiles,
   });
 
+  const refreshQuotaForUploadedFiles = useCallback(
+    async (result: AuthFilesUploadResult | null, previousNames: Set<string>) => {
+      if (!result || tab !== "files") return;
+      const uploadedNames = new Set(result.uploadedNames);
+      const targets = result.files.flatMap((file) => {
+        if (!uploadedNames.has(file.name) && previousNames.has(file.name)) return [];
+        const provider = resolveQuotaProvider(file);
+        return provider ? [{ file, provider }] : [];
+      });
+      if (!targets.length) return;
+      await runQuotaRefreshBatch(targets, { markAsAutoRefreshing: true, showLoading: true });
+    },
+    [runQuotaRefreshBatch, tab],
+  );
+
+  const handleUploadAndRefreshQuota = useCallback(
+    async (input: FileList | File[] | null) => {
+      const previousNames = new Set(filesRef.current.map((file) => file.name));
+      const result = await handleUpload(input);
+      void refreshQuotaForUploadedFiles(result, previousNames);
+    },
+    [handleUpload, refreshQuotaForUploadedFiles],
+  );
+
   const openDetailWithQuotaRefresh = useCallback(
     (file: Parameters<typeof openDetail>[0]) => {
       const openPromise = openDetail(file);
@@ -450,7 +477,7 @@ export function AuthFilesPage() {
         <TabsContent value="files">
           <AuthFilesFilesTab
             fileInputRef={fileInputRef}
-            handleUpload={handleUpload}
+            handleUpload={handleUploadAndRefreshQuota}
             filterChips={filterChips}
             filter={filter}
             setFilter={updateFilter}

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { AuthFilesPage } from "@/modules/auth-files/AuthFilesPage";
 import {
   AUTH_FILES_DATA_CACHE_KEY,
+  AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
   AUTH_FILES_UI_STATE_KEY,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import i18n from "@/i18n";
@@ -243,6 +244,72 @@ describe("AuthFilesPage files table", () => {
     ]);
     await waitFor(() =>
       expect(screen.queryByRole("dialog", { name: "Paste Auth JSON" })).not.toBeInTheDocument(),
+    );
+  });
+
+  test("refreshes pasted auth files and quotas from the latest uploaded list", async () => {
+    window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
+    const now = Date.now();
+    const initialFile = {
+      name: "qwen.json",
+      type: "qwen",
+      size: 1024,
+      modified: now,
+      disabled: false,
+    };
+    const uploadedFile = {
+      name: "auth-server-renamed.json",
+      type: "codex",
+      provider: "codex",
+      account_type: "oauth",
+      auth_index: "auth-codex",
+      chatgpt_account_id: "acct-123",
+      size: 2048,
+      modified: now + 1,
+      disabled: false,
+    };
+    mocks.list
+      .mockImplementationOnce(async () => ({ files: [initialFile] }))
+      .mockImplementationOnce(async () => ({ files: [initialFile, uploadedFile] }));
+    mocks.fetchQuota.mockImplementation(async () => ({ items: [] }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Paste JSON" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Paste Auth JSON" });
+    fireEvent.change(within(dialog).getByLabelText("Auth file JSON"), {
+      target: {
+        value: JSON.stringify({
+          chatgpt_account_id: "acct-123",
+          client_id: "app_test",
+          access_token: "token",
+          id_token: "id-token",
+        }),
+      },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Upload JSON" }));
+
+    expect(await screen.findByText("auth-server-renamed.json")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.fetchQuota).toHaveBeenCalledWith(
+        "codex",
+        expect.objectContaining({
+          name: "auth-server-renamed.json",
+          chatgpt_account_id: "acct-123",
+        }),
+      ),
     );
   });
 

--- a/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
@@ -19,6 +19,11 @@ interface UseAuthFilesFileActionsOptions {
   setSelectedFileNames: Dispatch<SetStateAction<string[]>>;
 }
 
+export type AuthFilesUploadResult = {
+  files: AuthFileItem[];
+  uploadedNames: string[];
+};
+
 export function useAuthFilesFileActions({
   loadAll,
   fileInputRef,
@@ -59,10 +64,10 @@ export function useAuthFilesFileActions({
   );
 
   const handleUpload = useCallback(
-    async (input: FileList | File[] | null) => {
+    async (input: FileList | File[] | null): Promise<AuthFilesUploadResult | null> => {
       const list = Array.isArray(input) ? input : input ? Array.from(input) : [];
       const files = list.filter(Boolean);
-      if (files.length === 0) return;
+      if (files.length === 0) return null;
 
       const tooLarge: File[] = [];
       const valid: File[] = [];
@@ -85,18 +90,20 @@ export function useAuthFilesFileActions({
             maxSize: formatFileSize(MAX_AUTH_FILE_SIZE),
           }),
         });
-        return;
+        return null;
       }
 
       setUploading(true);
       try {
         let success = 0;
         let failed = 0;
+        const uploadedNames: string[] = [];
 
         for (const file of valid) {
           try {
             await authFilesApi.upload(file);
             success += 1;
+            uploadedNames.push(file.name);
           } catch {
             failed += 1;
           }
@@ -111,12 +118,14 @@ export function useAuthFilesFileActions({
           });
         }
 
-        await loadAll();
+        const nextFiles = await loadAll();
+        return success > 0 ? { files: nextFiles, uploadedNames } : null;
       } catch (err: unknown) {
         notify({
           type: "error",
           message: err instanceof Error ? err.message : t("auth_files.upload_failed"),
         });
+        return null;
       } finally {
         setUploading(false);
         if (fileInputRef.current) {


### PR DESCRIPTION
## Summary
- return refreshed auth-file data after upload actions
- trigger quota refresh for newly uploaded supported auth files from the latest list
- cover pasted JSON upload refresh behavior with a regression test

## Verification
- bun run test src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run lint
- bun run build
- bun run bundle:diff
- git diff --check