### PR TITLE
Fix auth files visible quota refresh

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSearchParams } from "react-router-dom";
+import { useNavigationType, useSearchParams } from "react-router-dom";
 import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import type { AuthFileItem } from "@/lib/http/types";
@@ -70,6 +70,7 @@ const buildAuthFilesSignature = (items: AuthFileItem[]): string =>
 export function AuthFilesPage() {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
+  const navigationType = useNavigationType();
 
   const [tab, setTab] = useState<"files" | "excluded" | "alias">("files");
   const {
@@ -151,21 +152,24 @@ export function AuthFilesPage() {
     setOauthDialogOpen(open);
   }, []);
 
-  const refreshAfterOAuthAuthorized = useCallback(async () => {
+  const waitForAuthFilesChanged = useCallback(async (): Promise<{
+    files: AuthFileItem[];
+    changed: boolean;
+  }> => {
     const previousSignature =
       oauthBaselineSignatureRef.current || buildAuthFilesSignature(filesRef.current);
     const deadline = Date.now() + OAUTH_AUTH_FILES_REFRESH_TIMEOUT_MS;
 
     while (true) {
       if (buildAuthFilesSignature(filesRef.current) !== previousSignature) {
-        return;
+        return { files: filesRef.current, changed: true };
       }
       const nextFiles = await loadAll();
       if (buildAuthFilesSignature(nextFiles) !== previousSignature) {
-        return;
+        return { files: nextFiles, changed: true };
       }
       if (Date.now() >= deadline) {
-        return;
+        return { files: nextFiles, changed: false };
       }
       await wait(OAUTH_AUTH_FILES_REFRESH_INTERVAL_MS);
     }
@@ -326,19 +330,20 @@ export function AuthFilesPage() {
   } = useAuthFilesQuotaState({
     tab,
     pageItems,
-    visibleScopeKey: `${filter}\n${search}`,
+    visibleScopeKey: [filter, tagFilter, search, safePage, ...pageItems.map((file) => file.name)].join(
+      "\n",
+    ),
+    navigationType,
     loading,
     setFiles,
     setDetailFile,
     refreshUsageDataForFiles,
   });
 
-  const refreshQuotaForUploadedFiles = useCallback(
-    async (result: AuthFilesUploadResult | null, previousNames: Set<string>) => {
-      if (!result || tab !== "files") return;
-      const uploadedNames = new Set(result.uploadedNames);
-      const targets = result.files.flatMap((file) => {
-        if (!uploadedNames.has(file.name) && previousNames.has(file.name)) return [];
+  const refreshQuotaForFiles = useCallback(
+    async (targetFiles: AuthFileItem[]) => {
+      if (tab !== "files") return;
+      const targets = targetFiles.flatMap((file) => {
         const provider = resolveQuotaProvider(file);
         return provider ? [{ file, provider }] : [];
       });
@@ -347,6 +352,22 @@ export function AuthFilesPage() {
     },
     [runQuotaRefreshBatch, tab],
   );
+
+  const refreshQuotaForUploadedFiles = useCallback(
+    async (result: AuthFilesUploadResult | null, previousNames: Set<string>) => {
+      if (!result || tab !== "files") return;
+      const uploadedNames = new Set(result.uploadedNames);
+      const targetFiles = result.files.filter(
+        (file) => uploadedNames.has(file.name) || !previousNames.has(file.name),
+      );
+      await refreshQuotaForFiles(targetFiles);
+    },
+    [refreshQuotaForFiles, tab],
+  );
+
+  const refreshAfterOAuthAuthorized = useCallback(async () => {
+    await waitForAuthFilesChanged();
+  }, [waitForAuthFilesChanged]);
 
   const handleUploadAndRefreshQuota = useCallback(
     async (input: FileList | File[] | null) => {

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -46,6 +46,9 @@ const mocks = vi.hoisted(() => ({
     { value: "anthropic", label: "Anthropic", description: "Anthropic models", enabled: true },
   ]),
   upload: vi.fn(async () => ({})),
+  submitCallback: vi.fn(async () => ({})),
+  getAuthStatus: vi.fn(async () => ({ status: "pending" })),
+  startAuth: vi.fn(async () => ({ url: "https://example.test/oauth", state: "state-1" })),
   reconcile: vi.fn(async () => ({})),
 }));
 
@@ -61,6 +64,12 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
       patchFields: mocks.patchFields,
       getModelsForAuthFile: mocks.getModelsForAuthFile,
       upload: mocks.upload,
+    },
+    oauthApi: {
+      ...mod.oauthApi,
+      submitCallback: mocks.submitCallback,
+      getAuthStatus: mocks.getAuthStatus,
+      startAuth: mocks.startAuth,
     },
     modelsApi: {
       ...mod.modelsApi,
@@ -167,6 +176,15 @@ describe("AuthFilesPage files table", () => {
     ]);
     mocks.upload.mockReset();
     mocks.upload.mockImplementation(async () => ({}));
+    mocks.submitCallback.mockReset();
+    mocks.submitCallback.mockImplementation(async () => ({}));
+    mocks.getAuthStatus.mockReset();
+    mocks.getAuthStatus.mockImplementation(async () => ({ status: "pending" }));
+    mocks.startAuth.mockReset();
+    mocks.startAuth.mockImplementation(async () => ({
+      url: "https://example.test/oauth",
+      state: "state-1",
+    }));
     mocks.reconcile.mockReset();
     mocks.reconcile.mockImplementation(async () => ({}));
   });
@@ -718,6 +736,124 @@ describe("AuthFilesPage files table", () => {
 
     // Should render immediately from sessionStorage cache (no blank state)
     expect(screen.getByText("qwen.json")).toBeInTheDocument();
+  });
+
+  test("refreshes visible quota when entering auth files from another route with auto-refresh off", async () => {
+    const now = Date.now();
+    const file = {
+      name: "codex-visible.json",
+      type: "codex",
+      provider: "codex",
+      account_type: "oauth",
+      auth_index: "auth-codex-visible",
+      chatgpt_account_id: "acct-visible",
+      size: 1024,
+      modified: now,
+      disabled: false,
+    };
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 88 }],
+    });
+    window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+        usageData: { source: [], auth_index: [] },
+        quotaByFileName: {
+          "codex-visible.json": {
+            status: "success",
+            updatedAt: now,
+            items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 22 }],
+          },
+        },
+      }),
+    );
+
+    const wrap = (node: ReactNode) => (
+      <ThemeProvider>
+        <ToastProvider>{node}</ToastProvider>
+      </ThemeProvider>
+    );
+    const router = createMemoryRouter(
+      [
+        { path: "/auth-files", element: wrap(<AuthFilesPage />) },
+        { path: "/api-keys", element: wrap(<div>api keys</div>) },
+      ],
+      { initialEntries: ["/api-keys"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByText("api keys")).toBeInTheDocument();
+    await act(async () => {
+      await router.navigate("/auth-files");
+    });
+
+    expect(await screen.findByText("codex-visible.json")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
+    expect(mocks.fetchQuota).toHaveBeenCalledWith("codex", expect.objectContaining({ name: file.name }));
+  });
+
+  test("refreshes quota for a newly authorized auth file", async () => {
+    const now = Date.now();
+    const initialFile = {
+      name: "qwen.json",
+      type: "qwen",
+      size: 1024,
+      modified: now,
+      disabled: false,
+    };
+    const authorizedFile = {
+      name: "codex-authorized.json",
+      type: "codex",
+      provider: "codex",
+      account_type: "oauth",
+      auth_index: "auth-codex-authorized",
+      chatgpt_account_id: "acct-authorized",
+      size: 2048,
+      modified: now + 1,
+      disabled: false,
+    };
+
+    window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
+    mocks.list
+      .mockImplementationOnce(async () => ({ files: [initialFile] }))
+      .mockImplementation(async () => ({ files: [initialFile, authorizedFile] }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 91 }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add OAuth Login" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Add OAuth Login" });
+    fireEvent.change(within(dialog).getByPlaceholderText("Paste the full callback URL from browser"), {
+      target: { value: "http://localhost:1455/auth/callback?code=ok" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Submit callback" }));
+
+    expect(await screen.findByText("codex-authorized.json")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
+    expect(mocks.fetchQuota).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ name: "codex-authorized.json" }),
+    );
   });
 
   test("reads quota preview setting from localStorage", async () => {

--- a/src/modules/auth-files/hooks/useAuthFilesGroupOverview.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesGroupOverview.ts
@@ -24,7 +24,7 @@ interface UseAuthFilesGroupOverviewArgs {
   tab: "files" | "excluded" | "alias";
   runQuotaRefreshBatch: (
     targets: { file: AuthFileItem; provider: QuotaProvider }[],
-    options?: { markAsAutoRefreshing?: boolean; showLoading?: boolean },
+    options?: { markAsAutoRefreshing?: boolean; showLoading?: boolean; refreshUsage?: boolean },
   ) => Promise<void>;
   resolveQuotaProvider: (file: AuthFileItem) => QuotaProvider | null;
   resolveQuotaCardSlots: (

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -35,6 +35,7 @@ interface UseAuthFilesQuotaStateOptions {
   tab: "files" | "excluded" | "alias";
   pageItems: AuthFileItem[];
   visibleScopeKey: string;
+  navigationType: "POP" | "PUSH" | "REPLACE";
   loading: boolean;
   setFiles: Dispatch<SetStateAction<AuthFileItem[]>>;
   setDetailFile: Dispatch<SetStateAction<AuthFileItem | null>>;
@@ -45,6 +46,7 @@ export function useAuthFilesQuotaState({
   tab,
   pageItems,
   visibleScopeKey,
+  navigationType,
   loading,
   setFiles,
   setDetailFile,
@@ -448,7 +450,7 @@ export function useAuthFilesQuotaState({
   const runQuotaRefreshBatch = useCallback(
     async (
       targets: { file: AuthFileItem; provider: QuotaProvider }[],
-      options?: { markAsAutoRefreshing?: boolean; showLoading?: boolean },
+      options?: { markAsAutoRefreshing?: boolean; showLoading?: boolean; refreshUsage?: boolean },
     ) => {
       if (!targets.length) return;
 
@@ -481,7 +483,9 @@ export function useAuthFilesQuotaState({
       );
 
       await Promise.allSettled(workers);
-      await refreshUsageDataAfterQuota(targets.map((target) => target.file));
+      if (options?.refreshUsage !== false) {
+        await refreshUsageDataAfterQuota(targets.map((target) => target.file));
+      }
     },
     [refreshQuota, refreshUsageDataAfterQuota],
   );
@@ -493,16 +497,18 @@ export function useAuthFilesQuotaState({
     const previousVisibleScopeKey = visibleScopeKeyRef.current;
     visibleScopeKeyRef.current = visibleScopeKey;
 
-    const switchedVisibleScope =
-      previousVisibleScopeKey !== null && previousVisibleScopeKey !== visibleScopeKey;
-    if (!switchedVisibleScope && quotaAutoRefreshMs <= 0) return;
+    const firstVisibleScope = previousVisibleScopeKey === null;
+    const initialVisibleScope = firstVisibleScope && navigationType !== "POP";
+    const switchedVisibleScope = !firstVisibleScope && previousVisibleScopeKey !== visibleScopeKey;
+    if (!initialVisibleScope && !switchedVisibleScope && quotaAutoRefreshMs <= 0) return;
 
-    const toFetch = switchedVisibleScope
+    const toFetch =
+      initialVisibleScope || switchedVisibleScope
       ? resolveQuotaTargets(pageItems)
       : collectQuotaFetchTargets(pageItems);
     if (!toFetch.length) return;
 
-    if (switchedVisibleScope) {
+    if (initialVisibleScope || switchedVisibleScope) {
       markQuotaTargetsLoading(toFetch);
     }
 
@@ -511,7 +517,8 @@ export function useAuthFilesQuotaState({
       if (!cancelled) {
         await runQuotaRefreshBatch(toFetch, {
           markAsAutoRefreshing: true,
-          showLoading: switchedVisibleScope,
+          showLoading: initialVisibleScope || switchedVisibleScope,
+          refreshUsage: false,
         });
       }
     })();
@@ -524,6 +531,7 @@ export function useAuthFilesQuotaState({
     loading,
     markQuotaTargetsLoading,
     pageItems,
+    navigationType,
     quotaAutoRefreshMs,
     resolveQuotaTargets,
     runQuotaRefreshBatch,


### PR DESCRIPTION
## Summary
- refresh visible auth-file quotas when entering the auth-files route from another route, even when auto-refresh is disabled
- include visible page identity in quota refresh scope so newly authorized files refresh when they appear
- avoid refreshing usage stats during automatic quota warm-up while keeping explicit refresh actions unchanged

## Verification
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
- bun run lint
- bun run build