### PR TITLE
fix: spin proxy row refresh icon

### DIFF
--- a/src/modules/proxies/ProxiesPage.tsx
+++ b/src/modules/proxies/ProxiesPage.tsx
@@ -297,7 +297,11 @@ export function ProxiesPage() {
                 disabled={result?.checking}
                 size="xs"
               >
-                {result?.checking ? <RefreshCw size={14} /> : <CheckCircle2 size={14} />}
+                {result?.checking ? (
+                  <RefreshCw size={14} className="animate-spin" />
+                ) : (
+                  <CheckCircle2 size={14} />
+                )}
               </Button>
               <Button
                 aria-label={t("proxies.edit_label", { name: entry.name })}

--- a/src/modules/proxies/__tests__/ProxiesPage.test.tsx
+++ b/src/modules/proxies/__tests__/ProxiesPage.test.tsx
@@ -134,6 +134,33 @@ describe("ProxiesPage", () => {
     expect(await screen.findByText(/44 ms/i)).toBeInTheDocument();
   });
 
+  test("spins the row refresh icon while a proxy check is in progress", async () => {
+    let resolveNextCheck: ((value: unknown) => void) | undefined;
+    mocks.apiPost
+      .mockResolvedValueOnce({ ok: true, status_code: 204, latency_ms: 31 })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNextCheck = resolve;
+          }),
+      );
+
+    renderPage();
+
+    expect(await screen.findByText(/31 ms/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /^refresh$/i }));
+
+    await waitFor(() => {
+      const button = screen.getByRole("button", { name: /check hk proxy/i });
+      expect(button.querySelector("svg")).toHaveClass("animate-spin");
+    });
+
+    resolveNextCheck?.({ ok: true, status_code: 204, latency_ms: 44 });
+
+    expect(await screen.findByText(/44 ms/i)).toBeInTheDocument();
+  });
+
   test("renders cached check results on page entry while refreshing them in the background", async () => {
     let resolveNextCheck: ((value: unknown) => void) | undefined;
     window.sessionStorage.setItem(


### PR DESCRIPTION
## Summary\n- add a spin animation to the proxy row refresh icon while a check is running\n- add a regression test for the loading icon state\n\n## Verification\n- bun run test src/modules/proxies/__tests__/ProxiesPage.test.tsx