### PR TITLE
Simplify auth file action controls

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -535,6 +535,8 @@
     "batch_deselect_filtered": "Clear filtered results",
     "batch_clear": "Clear selection",
     "batch_delete_action": "Delete selected ({{count}})",
+    "selection_actions": "Selection actions",
+    "more_actions": "More actions",
     "batch_deleted_selected": "Deleted {{count}} auth files",
     "batch_delete_partial": "Bulk delete finished: {{success}} succeeded, {{failed}} failed",
     "batch_enable": "Enable",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -622,6 +622,8 @@
     "batch_deselect_filtered": "Снять выбор результатов фильтра",
     "batch_clear": "Очистить выбор",
     "batch_delete_action": "Удалить выбранные ({{count}})",
+    "selection_actions": "Действия выбора",
+    "more_actions": "Ещё действия",
     "batch_deleted_selected": "Удалено файлов авторизации: {{count}}",
     "batch_delete_partial": "Пакетное удаление завершено: успешных {{success}}, ошибок {{failed}}",
     "batch_enable": "Включить",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -543,6 +543,8 @@
     "batch_deselect_filtered": "取消全部筛选结果",
     "batch_clear": "清空选择",
     "batch_delete_action": "删除所选（{{count}}）",
+    "selection_actions": "选择批量操作",
+    "more_actions": "更多操作",
     "batch_deleted_selected": "已删除 {{count}} 个认证文件",
     "batch_delete_partial": "批量删除完成，成功 {{success}} 个，失败 {{failed}} 个",
     "batch_enable": "启用",

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -215,9 +215,35 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByRole("combobox", { name: "Quota" })).toBeInTheDocument();
     expect(screen.getByText("5h")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add OAuth Login" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Select current page" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Selection actions" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Select current page" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Delete All" })).not.toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Enable/Disable" })).toBeInTheDocument();
+  });
+
+  test("keeps bulk selection collapsed until files are selected", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Selection actions" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Select current page" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear selection" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Selection actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Select current page" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Select filtered results" })).toBeInTheDocument();
   });
 
   test("uploads multiple auth files from pasted JSON objects", async () => {
@@ -795,7 +821,10 @@ describe("AuthFilesPage files table", () => {
 
     expect(await screen.findByText("codex-visible.json")).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
-    expect(mocks.fetchQuota).toHaveBeenCalledWith("codex", expect.objectContaining({ name: file.name }));
+    expect(mocks.fetchQuota).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ name: file.name }),
+    );
   });
 
   test("refreshes quota for a newly authorized auth file", async () => {
@@ -843,9 +872,12 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add OAuth Login" }));
 
     const dialog = await screen.findByRole("dialog", { name: "Add OAuth Login" });
-    fireEvent.change(within(dialog).getByPlaceholderText("Paste the full callback URL from browser"), {
-      target: { value: "http://localhost:1455/auth/callback?code=ok" },
-    });
+    fireEvent.change(
+      within(dialog).getByPlaceholderText("Paste the full callback URL from browser"),
+      {
+        target: { value: "http://localhost:1455/auth/callback?code=ok" },
+      },
+    );
     fireEvent.click(within(dialog).getByRole("button", { name: "Submit callback" }));
 
     expect(await screen.findByText("codex-authorized.json")).toBeInTheDocument();
@@ -1405,8 +1437,10 @@ describe("AuthFilesPage files table", () => {
       </MemoryRouter>,
     );
 
+    const user = userEvent.setup();
     expect(await screen.findByText("A_GptPro")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Edit Tags" }));
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    await user.click(screen.getByRole("menuitem", { name: "Edit Tags" }));
 
     const dialog = await screen.findByRole("dialog", { name: "Auth File Tags" });
     fireEvent.change(within(dialog).getByLabelText("Custom tag"), { target: { value: "vip" } });
@@ -3132,6 +3166,57 @@ describe("AuthFilesPage files table", () => {
     const actions = quota.nextElementSibling;
     expect(actions).not.toBeNull();
     expect(actions).toHaveClass("mt-auto");
+  });
+
+  test("cards keep secondary actions inside a more actions menu", async () => {
+    const user = userEvent.setup();
+    const now = Date.now();
+    const file = {
+      name: "codex.json",
+      type: "codex",
+      size: 1024,
+      modified: now,
+      disabled: false,
+      auth_index: "1",
+    } as any;
+
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.sessionStorage.setItem(
+      AUTH_FILES_DATA_CACHE_KEY,
+      JSON.stringify({
+        savedAtMs: now,
+        files: [file],
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const cards = await screen.findByTestId("auth-files-cards");
+    const card = within(cards).getByText("codex.json").closest("section");
+    expect(card).not.toBeNull();
+    const cardView = within(card as HTMLElement);
+
+    expect(cardView.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+    expect(cardView.getByRole("button", { name: "View" })).toBeInTheDocument();
+    expect(cardView.getByRole("button", { name: "More actions" })).toBeInTheDocument();
+    expect(cardView.queryByRole("button", { name: "Edit Tags" })).not.toBeInTheDocument();
+    expect(cardView.queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
+
+    await user.click(cardView.getByRole("button", { name: "More actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Edit Tags" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Download" })).toBeInTheDocument();
   });
 
   test("cards localize codex additional quota window labels in Chinese", async () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useState, type RefObject, type ReactNode } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useTranslation } from "react-i18next";
 import {
   BarChart3,
   CircleHelp,
   ClipboardPaste,
   Download,
+  Ellipsis,
   Eye,
+  ListChecks,
   Plus,
   RefreshCw,
   Search,
@@ -14,7 +17,7 @@ import {
   Upload,
 } from "lucide-react";
 import type { AuthFileItem } from "@/lib/http/types";
-import { Button } from "@/modules/ui/Button";
+import { Button, buttonClassName } from "@/modules/ui/Button";
 import { Card } from "@/modules/ui/Card";
 import { EmptyState } from "@/modules/ui/EmptyState";
 import { TextInput } from "@/modules/ui/Input";
@@ -46,6 +49,10 @@ import type { QuotaItem, QuotaState } from "@/modules/quota/quota-helpers";
 import type { QuotaProvider } from "@/modules/quota/quota-fetch";
 
 const MAX_FILENAME_PART_LENGTH = 72;
+const ACTION_MENU_CONTENT_CLASS =
+  "z-[220] min-w-44 rounded-2xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
+const ACTION_MENU_ITEM_CLASS =
+  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -637,51 +644,82 @@ export function AuthFilesFilesTab({
 
             {selectableFilteredFiles.length > 0 || selectedCount > 0 ? (
               <div className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="!h-8 px-2 text-xs"
-                  onClick={() => selectCurrentPage(!allPageSelected)}
-                  disabled={selectablePageNames.length === 0}
-                >
-                  {allPageSelected
-                    ? t("auth_files.batch_deselect_page")
-                    : t("auth_files.batch_select_page")}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="!h-8 px-2 text-xs"
-                  onClick={() => selectFilteredFiles(!allFilteredSelected)}
-                  disabled={selectableFilteredFiles.length === 0}
-                >
-                  {allFilteredSelected
-                    ? t("auth_files.batch_deselect_filtered")
-                    : t("auth_files.batch_select_filtered")}
-                </Button>
-                <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
-                  {t("auth_files.batch_selected", { count: selectedCount })}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="!h-8 px-2 text-xs"
-                  onClick={() => setSelectedFileNames([])}
-                  disabled={selectedCount === 0}
-                >
-                  {t("auth_files.batch_clear")}
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  className="!h-8 px-2 text-xs"
-                  onClick={() =>
-                    setConfirm({ type: "deleteSelection", names: [...selectedFileNames] })
-                  }
-                  disabled={selectedCount === 0 || deletingAll}
-                >
-                  {t("auth_files.batch_delete_action", { count: selectedCount })}
-                </Button>
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger asChild>
+                    <button
+                      type="button"
+                      className={buttonClassName({
+                        variant: "secondary",
+                        size: "sm",
+                        iconOnly: true,
+                        className: "!h-8 !w-8",
+                      })}
+                      aria-label={t("auth_files.selection_actions")}
+                      title={t("auth_files.selection_actions")}
+                      data-tooltip-placement="top"
+                    >
+                      <ListChecks size={15} />
+                    </button>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content
+                      align="end"
+                      sideOffset={8}
+                      className={ACTION_MENU_CONTENT_CLASS}
+                    >
+                      <DropdownMenu.Item
+                        className={ACTION_MENU_ITEM_CLASS}
+                        disabled={selectablePageNames.length === 0}
+                        onSelect={() => selectCurrentPage(!allPageSelected)}
+                      >
+                        <ListChecks size={15} />
+                        <span>
+                          {allPageSelected
+                            ? t("auth_files.batch_deselect_page")
+                            : t("auth_files.batch_select_page")}
+                        </span>
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        className={ACTION_MENU_ITEM_CLASS}
+                        disabled={selectableFilteredFiles.length === 0}
+                        onSelect={() => selectFilteredFiles(!allFilteredSelected)}
+                      >
+                        <ListChecks size={15} />
+                        <span>
+                          {allFilteredSelected
+                            ? t("auth_files.batch_deselect_filtered")
+                            : t("auth_files.batch_select_filtered")}
+                        </span>
+                      </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
+                {selectedCount > 0 ? (
+                  <>
+                    <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
+                      {t("auth_files.batch_selected", { count: selectedCount })}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="!h-8 px-2 text-xs"
+                      onClick={() => setSelectedFileNames([])}
+                    >
+                      {t("auth_files.batch_clear")}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      className="!h-8 px-2 text-xs"
+                      onClick={() =>
+                        setConfirm({ type: "deleteSelection", names: [...selectedFileNames] })
+                      }
+                      disabled={deletingAll}
+                    >
+                      {t("auth_files.batch_delete_action", { count: selectedCount })}
+                    </Button>
+                  </>
+                ) : null}
               </div>
             ) : null}
           </div>
@@ -926,18 +964,6 @@ export function AuthFilesFilesTab({
                             </HoverTooltip>
                           ) : null}
 
-                          <HoverTooltip content={t("auth_files.edit_tags")}>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => openTagsEditor(file)}
-                              title={t("auth_files.edit_tags")}
-                              aria-label={t("auth_files.edit_tags")}
-                            >
-                              <Tags size={16} />
-                            </Button>
-                          </HoverTooltip>
-
                           <HoverTooltip content={t("auth_files.view")}>
                             <Button
                               variant="ghost"
@@ -950,17 +976,45 @@ export function AuthFilesFilesTab({
                             </Button>
                           </HoverTooltip>
 
-                          <HoverTooltip content={t("auth_files.download")}>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => void downloadAuthFile(file)}
-                              title={t("auth_files.download")}
-                              aria-label={t("auth_files.download")}
-                            >
-                              <Download size={16} />
-                            </Button>
-                          </HoverTooltip>
+                          <DropdownMenu.Root>
+                            <DropdownMenu.Trigger asChild>
+                              <button
+                                type="button"
+                                className={buttonClassName({
+                                  variant: "ghost",
+                                  size: "sm",
+                                  iconOnly: true,
+                                })}
+                                aria-label={t("auth_files.more_actions")}
+                                title={t("auth_files.more_actions")}
+                                data-tooltip-placement="top"
+                              >
+                                <Ellipsis size={16} />
+                              </button>
+                            </DropdownMenu.Trigger>
+                            <DropdownMenu.Portal>
+                              <DropdownMenu.Content
+                                align="end"
+                                sideOffset={8}
+                                className={ACTION_MENU_CONTENT_CLASS}
+                              >
+                                <DropdownMenu.Item
+                                  className={ACTION_MENU_ITEM_CLASS}
+                                  onSelect={() => openTagsEditor(file)}
+                                >
+                                  <Tags size={15} />
+                                  <span>{t("auth_files.edit_tags")}</span>
+                                </DropdownMenu.Item>
+                                <DropdownMenu.Item
+                                  className={ACTION_MENU_ITEM_CLASS}
+                                  onSelect={() => void downloadAuthFile(file)}
+                                >
+                                  <Download size={15} />
+                                  <span>{t("auth_files.download")}</span>
+                                </DropdownMenu.Item>
+                              </DropdownMenu.Content>
+                            </DropdownMenu.Portal>
+                          </DropdownMenu.Root>
                         </div>
                       </div>
                     </Card>


### PR DESCRIPTION
## Summary
- Collapse auth-file bulk selection controls behind a compact selection menu until files are selected.
- Move secondary card actions into a more-actions menu while keeping refresh and view visible.
- Update focused tests and locale labels for the adjusted action controls.

## Verification
- bun run test -- src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bunx oxfmt src/modules/auth-files/components/AuthFilesFilesTab.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/i18n/locales/en.json src/i18n/locales/zh-CN.json src/i18n/locales/ru.json --check
- bun run build
- bun run lint
- git diff --check
- Local browser check with mocked management API