### PR TITLE
fix: stabilize auth-files filter toolbar

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1157,6 +1157,118 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("Total 1 · Page 1 / 1")).toBeInTheDocument();
   });
 
+  test("keeps custom tag filter options stable while searching", async () => {
+    const user = userEvent.setup();
+    const now = Date.now();
+    window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-tagged.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+          custom_tags: ["vip-team"],
+          display_tags: ["vip-team"],
+        },
+        {
+          name: "codex-plain.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        },
+        {
+          name: "qwen-plain.json",
+          type: "qwen",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-tagged.json")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Custom tag" })).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Filename / provider / type"), "plain");
+
+    expect(screen.queryByText("codex-tagged.json")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Custom tag" })).toBeInTheDocument();
+    await user.click(screen.getByRole("combobox", { name: "Custom tag" }));
+    expect(screen.getByRole("option", { name: "vip-team" })).toBeInTheDocument();
+  });
+
+  test("keeps type filter counts stable while searching", async () => {
+    const user = userEvent.setup();
+    const now = Date.now();
+    window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-alpha.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        },
+        {
+          name: "codex-beta.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        },
+        {
+          name: "qwen-lab.json",
+          type: "qwen",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-alpha.json")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /All3/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /codex2/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /qwen1/i })).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Filename / provider / type"), "alpha");
+
+    expect(screen.getByText("codex-alpha.json")).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("codex-beta.json")).not.toBeInTheDocument());
+    expect(screen.queryByText("qwen-lab.json")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /All3/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /codex2/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /qwen1/i })).toBeInTheDocument();
+  });
+
   test("refreshes only the clicked auth-file card usage stats after quota refresh", async () => {
     const now = Date.now();
     const files = [

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -452,9 +452,9 @@ export function AuthFilesFilesTab({
 
       <Card padding="compact">
         <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-end">
-              <div className="w-fit max-w-full space-y-1.5">
+          <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-start">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+              <div className="min-w-0 space-y-1.5">
                 <div className="flex items-center gap-2">
                   <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
                     {t("auth_files.type_filter")}
@@ -523,9 +523,11 @@ export function AuthFilesFilesTab({
                   </HoverTooltip>
                 </div>
               ) : null}
+            </div>
 
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,220px)_minmax(0,180px)] xl:grid-cols-[minmax(0,220px)_minmax(0,180px)_minmax(0,1fr)] xl:items-end">
               {customTagOptions.length > 0 ? (
-                <div className="w-full max-w-[220px] space-y-1.5">
+                <div className="min-w-0 space-y-1.5">
                   <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
                     {t("auth_files.tag_filter")}
                   </p>
@@ -540,7 +542,7 @@ export function AuthFilesFilesTab({
                 </div>
               ) : null}
 
-              <div className="w-full max-w-[180px] space-y-1.5">
+              <div className="min-w-0 space-y-1.5">
                 <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
                   {t("auth_files.status_filter")}
                 </p>
@@ -555,7 +557,7 @@ export function AuthFilesFilesTab({
                 />
               </div>
 
-              <div className="w-full max-w-[560px] space-y-1.5">
+              <div className="min-w-0 space-y-1.5 xl:min-w-[18rem]">
                 <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
                   {t("auth_files.search")}
                 </p>
@@ -569,7 +571,7 @@ export function AuthFilesFilesTab({
             </div>
           </div>
 
-          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+          <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
             <div className="flex flex-wrap items-center gap-2">
               <div className="inline-flex items-center gap-2 text-xs text-slate-500 dark:text-white/45">
                 <span className="font-medium">{t("auth_files.quota_updated_at")}</span>
@@ -607,86 +609,87 @@ export function AuthFilesFilesTab({
                   />
                 </div>
               </div>
+            </div>
 
-              <div className="flex flex-wrap items-center gap-1.5">
+            <div className="flex flex-wrap items-center gap-1.5 lg:justify-end">
+              <Button
+                variant="secondary"
+                size="sm"
+                className="!h-8 px-2 text-xs"
+                onClick={openGroupOverview}
+                disabled={loading || groupOverviewLoading || filteredFiles.length === 0}
+              >
+                <BarChart3 size={14} className={groupOverviewLoading ? "animate-pulse" : ""} />
+                {t("auth_files.group_overview_button")}
+              </Button>
+              <HoverTooltip content={t("auth_files.refresh")}>
                 <Button
                   variant="secondary"
                   size="sm"
-                  className="!h-8 px-2 text-xs"
-                  onClick={openGroupOverview}
-                  disabled={loading || groupOverviewLoading || filteredFiles.length === 0}
+                  onClick={() => void refreshFilesAndQuota()}
+                  disabled={loading || usageLoading || refreshingAll}
+                  aria-label={t("auth_files.refresh")}
+                  title={t("auth_files.refresh")}
                 >
-                  <BarChart3 size={14} className={groupOverviewLoading ? "animate-pulse" : ""} />
-                  {t("auth_files.group_overview_button")}
+                  <RefreshCw
+                    size={15}
+                    className={loading || usageLoading || refreshingAll ? "animate-spin" : ""}
+                  />
                 </Button>
-                <HoverTooltip content={t("auth_files.refresh")}>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => void refreshFilesAndQuota()}
-                    disabled={loading || usageLoading || refreshingAll}
-                    aria-label={t("auth_files.refresh")}
-                    title={t("auth_files.refresh")}
-                  >
-                    <RefreshCw
-                      size={15}
-                      className={loading || usageLoading || refreshingAll ? "animate-spin" : ""}
-                    />
-                  </Button>
-                </HoverTooltip>
-                <HoverTooltip content={t("auth_files.upload")}>
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={uploading}
-                    aria-label={t("auth_files.upload")}
-                    title={t("auth_files.upload")}
-                  >
-                    <Upload size={15} />
-                  </Button>
-                </HoverTooltip>
-                <HoverTooltip content={t("auth_files.paste_json")}>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      setJsonImportError("");
-                      setJsonImportOpen(true);
-                    }}
-                    disabled={uploading}
-                    aria-label={t("auth_files.paste_json")}
-                    title={t("auth_files.paste_json")}
-                  >
-                    <ClipboardPaste size={15} />
-                  </Button>
-                </HoverTooltip>
-                <HoverTooltip content={t("auth_files_page.add_oauth")}>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      const normalized = normalizeProviderKey(filter);
-                      const oauthTab =
-                        normalized === "codex" ||
-                        normalized === "anthropic" ||
-                        normalized === "antigravity" ||
-                        normalized === "gemini-cli" ||
-                        normalized === "kimi" ||
-                        normalized === "qwen"
-                          ? (normalized as OAuthDialogTab)
-                          : "codex";
-                      setOauthDialogDefaultTab(oauthTab);
-                      setOauthDialogOpen(true);
-                    }}
-                    aria-label={t("auth_files_page.add_oauth")}
-                    title={t("auth_files_page.add_oauth")}
-                  >
-                    <Plus size={15} />
-                  </Button>
-                </HoverTooltip>
-              </div>
+              </HoverTooltip>
+              <HoverTooltip content={t("auth_files.upload")}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploading}
+                  aria-label={t("auth_files.upload")}
+                  title={t("auth_files.upload")}
+                >
+                  <Upload size={15} />
+                </Button>
+              </HoverTooltip>
+              <HoverTooltip content={t("auth_files.paste_json")}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setJsonImportError("");
+                    setJsonImportOpen(true);
+                  }}
+                  disabled={uploading}
+                  aria-label={t("auth_files.paste_json")}
+                  title={t("auth_files.paste_json")}
+                >
+                  <ClipboardPaste size={15} />
+                </Button>
+              </HoverTooltip>
+              <HoverTooltip content={t("auth_files_page.add_oauth")}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    const normalized = normalizeProviderKey(filter);
+                    const oauthTab =
+                      normalized === "codex" ||
+                      normalized === "anthropic" ||
+                      normalized === "antigravity" ||
+                      normalized === "gemini-cli" ||
+                      normalized === "kimi" ||
+                      normalized === "qwen"
+                        ? (normalized as OAuthDialogTab)
+                        : "codex";
+                    setOauthDialogDefaultTab(oauthTab);
+                    setOauthDialogOpen(true);
+                  }}
+                  aria-label={t("auth_files_page.add_oauth")}
+                  title={t("auth_files_page.add_oauth")}
+                >
+                  <Plus size={15} />
+                </Button>
+              </HoverTooltip>
             </div>
+          </div>
 
             {selectableFilteredFiles.length > 0 || selectedCount > 0 ? (
               <div className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
@@ -769,7 +772,6 @@ export function AuthFilesFilesTab({
               </div>
             ) : null}
           </div>
-        </div>
       </Card>
 
       {loading && filesLength === 0 ? (

--- a/src/modules/auth-files/hooks/useAuthFilesListState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesListState.ts
@@ -55,43 +55,43 @@ export function useAuthFilesListState({
     });
   }, [files, search]);
 
+  const typeScopedFiles = useMemo(() => {
+    const normalizedFilter = normalizeProviderKey(filter);
+    return !normalizedFilter || normalizedFilter === "all"
+      ? files
+      : files.filter(
+          (file) => normalizeProviderKey(resolveFileType(file)) === normalizedFilter,
+        );
+  }, [files, filter]);
+
   const filterCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    searchFilteredFiles.forEach((file) => {
+    files.forEach((file) => {
       const typeKey = normalizeProviderKey(resolveFileType(file));
       counts[typeKey] = (counts[typeKey] ?? 0) + 1;
     });
-    return { total: searchFilteredFiles.length, counts };
-  }, [searchFilteredFiles]);
-
-  const typeFilteredFiles = useMemo(() => {
-    const normalizedFilter = normalizeProviderKey(filter);
-    return !normalizedFilter || normalizedFilter === "all"
-      ? searchFilteredFiles
-      : searchFilteredFiles.filter(
-          (file) => normalizeProviderKey(resolveFileType(file)) === normalizedFilter,
-        );
-  }, [filter, searchFilteredFiles]);
+    return { total: files.length, counts };
+  }, [files]);
 
   const customTagOptions = useMemo(() => {
     const set = new Set<string>();
-    typeFilteredFiles.forEach((file) => {
+    typeScopedFiles.forEach((file) => {
       readAuthFileCustomTags(file).forEach((tag) => {
         const normalized = normalizeTagValue(tag);
         if (normalized) set.add(normalized);
       });
     });
     return Array.from(set).sort((a, b) => authFilesSortCollator.compare(a, b));
-  }, [typeFilteredFiles]);
+  }, [typeScopedFiles]);
 
   const tagScopedFiles = useMemo(() => {
     const normalizedTagFilter = normalizeTagValue(tagFilter);
     return normalizedTagFilter
-      ? typeFilteredFiles.filter((file) =>
+      ? typeScopedFiles.filter((file) =>
           readAuthFileCustomTags(file).includes(normalizedTagFilter),
         )
-      : typeFilteredFiles;
-  }, [tagFilter, typeFilteredFiles]);
+      : typeScopedFiles;
+  }, [tagFilter, typeScopedFiles]);
 
   const statusFilterCounts = useMemo(() => {
     const counts: Partial<Record<AuthFileStatusFilter, number>> = {
@@ -109,10 +109,13 @@ export function useAuthFilesListState({
     const statusScoped = tagScopedFiles.filter((file) =>
       authFileMatchesStatusFilter(file, statusFilter),
     );
-    return [...statusScoped].sort((a, b) =>
-      authFilesSortCollator.compare(resolveAuthFileSortKey(a), resolveAuthFileSortKey(b)),
-    );
-  }, [statusFilter, tagScopedFiles]);
+    const searchFilteredNames = new Set(searchFilteredFiles.map((file) => file.name));
+    return statusScoped
+      .filter((file) => searchFilteredNames.has(file.name))
+      .sort((a, b) =>
+        authFilesSortCollator.compare(resolveAuthFileSortKey(a), resolveAuthFileSortKey(b)),
+      );
+  }, [searchFilteredFiles, statusFilter, tagScopedFiles]);
 
   const totalPages = Math.max(1, Math.ceil(filteredFiles.length / AUTH_FILES_PAGE_SIZE));
   const safePage = Math.min(totalPages, Math.max(1, page));


### PR DESCRIPTION
## Summary
- Stabilize auth-files filter controls so search input no longer changes type counts or tag/status option sources.
- Rework the files toolbar into fixed grid bands for steadier filter, search, and action alignment.
- Add regression coverage for search-time filter stability.

## Tests
- bun run test -- src/modules/auth-files/__tests__
- bun run build