### PR TITLE
fix(auth-files): resolve nested Codex ids and dedupe pasted bundles

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -557,6 +557,7 @@ export function AuthFilesPage() {
             setSearch={updateSearch}
             quotaLastUpdatedText={quotaLastUpdatedText}
             loading={loading}
+            files={files}
             filesLength={files.length}
             renderFilesViewModeTabs={renderFilesViewModeTabs}
             quotaAutoRefreshMs={quotaAutoRefreshMs}

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -485,8 +485,8 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(2));
     const uploadCalls = mocks.upload.mock.calls as unknown as [[File], [File]];
     expect(uploadCalls.map(([file]) => file.name)).toEqual([
-      "codex-acct-111.json",
-      "codex-acct-222.json",
+      "codex-alpha@example.test-plus.json",
+      "codex-beta@example.test-plus.json",
     ]);
 
     const uploadedJson = await Promise.all(
@@ -551,6 +551,121 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() =>
       expect(screen.queryByRole("dialog", { name: "Paste Auth JSON" })).not.toBeInTheDocument(),
     );
+  });
+
+  test("skips duplicate codex accounts that are already in the list or repeated in the pasted bundle", async () => {
+    const existingAlpha = {
+      name: "codex-alpha@example.test-plus.json",
+      type: "codex",
+      provider: "codex",
+      account_type: "oauth",
+      email: "alpha@example.test",
+      label: "alpha@example.test",
+      account_id: "acct-111",
+      chatgpt_account_id: "acct-111",
+      auth_index: "auth-alpha",
+      size: 1024,
+      modified: Date.now(),
+      disabled: false,
+    };
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "qwen.json",
+          type: "qwen",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+        },
+        existingAlpha,
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Paste JSON" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Paste Auth JSON" });
+    fireEvent.change(within(dialog).getByLabelText("Auth file JSON"), {
+      target: {
+        value: [
+          "=== 卡密内容 ===",
+          JSON.stringify({
+            exported_at: "2026-05-22T20:11:27.181Z",
+            proxies: [],
+            accounts: [
+              {
+                name: "alpha@example.test",
+                platform: "openai",
+                type: "oauth",
+                credentials: {
+                  access_token: "access-token-one",
+                  chatgpt_account_id: "acct-111",
+                  chatgpt_user_id: "user-111",
+                  email: "alpha@example.test",
+                  expires_at: "2026-06-01T17:08:08.000Z",
+                  plan_type: "plus",
+                },
+                extra: {
+                  email: "alpha@example.test",
+                  last_refresh: "2026-05-22T20:11:27.181Z",
+                },
+              },
+              {
+                name: "beta@example.test",
+                platform: "openai",
+                type: "oauth",
+                credentials: {
+                  access_token: "access-token-two",
+                  chatgpt_account_id: "acct-222",
+                  chatgpt_user_id: "user-222",
+                  email: "beta@example.test",
+                  expires_at: "2026-06-01T17:08:08.000Z",
+                  plan_type: "plus",
+                },
+                extra: {
+                  email: "beta@example.test",
+                  last_refresh: "2026-05-22T20:11:27.181Z",
+                },
+              },
+              {
+                name: "alpha@example.test",
+                platform: "openai",
+                type: "oauth",
+                credentials: {
+                  access_token: "access-token-three",
+                  chatgpt_account_id: "acct-111",
+                  chatgpt_user_id: "user-111",
+                  email: "alpha@example.test",
+                  expires_at: "2026-06-01T17:08:08.000Z",
+                  plan_type: "plus",
+                },
+                extra: {
+                  email: "alpha@example.test",
+                  last_refresh: "2026-05-22T20:11:27.181Z",
+                },
+              },
+            ],
+          }),
+        ].join("\n"),
+      },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Upload JSON" }));
+
+    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(1));
+    const uploadCalls = mocks.upload.mock.calls as unknown as [[File]];
+    expect(uploadCalls.map(([file]) => file.name)).toEqual(["codex-beta@example.test-plus.json"]);
   });
 
   test("refreshes pasted auth files and quotas from the latest uploaded list", async () => {

--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -112,6 +112,9 @@ const toDateTimeLocalInput = (date: Date): string =>
     padDatePart(date.getMinutes()),
   ].join("");
 
+const decodeBase64UrlJson = (part: string): Record<string, unknown> =>
+  JSON.parse(Buffer.from(part, "base64url").toString("utf8")) as Record<string, unknown>;
+
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -402,6 +405,149 @@ describe("AuthFilesPage files table", () => {
       { type: "codex", account_id: "acct-one", access_token: "token-one" },
       { type: "kimi", account_id: "acct-two", refresh_token: "token-two" },
     ]);
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Paste Auth JSON" })).not.toBeInTheDocument(),
+    );
+  });
+
+  test("expands pasted codex export bundles into synthesized auth files", async () => {
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Paste JSON" }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Paste Auth JSON" });
+    fireEvent.change(within(dialog).getByLabelText("Auth file JSON"), {
+      target: {
+        value: [
+          "=== 卡密内容 ===",
+          JSON.stringify({
+            exported_at: "2026-05-22T19:59:51.483Z",
+            proxies: [],
+            accounts: [
+              {
+                name: "alpha@example.test",
+                platform: "openai",
+                type: "oauth",
+                credentials: {
+                  access_token: "access-token-one",
+                  chatgpt_account_id: "acct-111",
+                  chatgpt_user_id: "user-111",
+                  email: "alpha@example.test",
+                  expires_at: "2026-06-01T17:08:08.000Z",
+                  plan_type: "plus",
+                },
+                extra: {
+                  email: "alpha@example.test",
+                  last_refresh: "2026-05-22T19:59:51.483Z",
+                },
+              },
+            ],
+          }),
+          JSON.stringify({
+            exported_at: "2026-05-22T20:02:43.650Z",
+            proxies: [],
+            accounts: [
+              {
+                name: "beta@example.test",
+                platform: "openai",
+                type: "oauth",
+                credentials: {
+                  access_token: "access-token-two",
+                  chatgpt_account_id: "acct-222",
+                  chatgpt_user_id: "user-222",
+                  email: "beta@example.test",
+                  expires_at: "2026-06-01T17:08:08.000Z",
+                  plan_type: "plus",
+                },
+                extra: {
+                  email: "beta@example.test",
+                  last_refresh: "2026-05-22T20:02:43.650Z",
+                },
+              },
+            ],
+          }),
+        ].join("\n"),
+      },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Upload JSON" }));
+
+    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(2));
+    const uploadCalls = mocks.upload.mock.calls as unknown as [[File], [File]];
+    expect(uploadCalls.map(([file]) => file.name)).toEqual([
+      "codex-acct-111.json",
+      "codex-acct-222.json",
+    ]);
+
+    const uploadedJson = await Promise.all(
+      uploadCalls.map(async ([file]) => JSON.parse(await file.text()) as Record<string, unknown>),
+    );
+    const firstLastRefresh = String(uploadedJson[0]?.last_refresh ?? "");
+    const secondLastRefresh = String(uploadedJson[1]?.last_refresh ?? "");
+    expect(firstLastRefresh).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u);
+    expect(secondLastRefresh).toBe(firstLastRefresh);
+
+    expect(uploadedJson).toEqual([
+      expect.objectContaining({
+        type: "codex",
+        account_id: "acct-111",
+        chatgpt_account_id: "acct-111",
+        email: "alpha@example.test",
+        name: "alpha@example.test",
+        plan_type: "plus",
+        chatgpt_plan_type: "plus",
+        id_token_synthetic: true,
+        access_token: "access-token-one",
+        refresh_token: "",
+        last_refresh: firstLastRefresh,
+        expired: "2026-06-01T17:08:08.000Z",
+      }),
+      expect.objectContaining({
+        type: "codex",
+        account_id: "acct-222",
+        chatgpt_account_id: "acct-222",
+        email: "beta@example.test",
+        name: "beta@example.test",
+        plan_type: "plus",
+        chatgpt_plan_type: "plus",
+        id_token_synthetic: true,
+        access_token: "access-token-two",
+        refresh_token: "",
+        last_refresh: firstLastRefresh,
+        expired: "2026-06-01T17:08:08.000Z",
+      }),
+    ]);
+
+    const firstToken = String(uploadedJson[0]?.id_token ?? "");
+    const [firstHeaderPart, firstPayloadPart, firstSignaturePart] = firstToken.split(".");
+    expect(firstSignaturePart).toBe("synthetic");
+    expect(decodeBase64UrlJson(firstHeaderPart)).toMatchObject({
+      alg: "none",
+      typ: "JWT",
+      cpa_synthetic: true,
+    });
+    expect(decodeBase64UrlJson(firstPayloadPart)).toMatchObject({
+      iat: Math.floor(Date.parse(firstLastRefresh) / 1000),
+      exp: Math.floor(Date.parse("2026-06-01T17:08:08.000Z") / 1000),
+      email: "alpha@example.test",
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct-111",
+        chatgpt_plan_type: "plus",
+        chatgpt_user_id: "user-111",
+        user_id: "user-111",
+      },
+    });
+
     await waitFor(() =>
       expect(screen.queryByRole("dialog", { name: "Paste Auth JSON" })).not.toBeInTheDocument(),
     );

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -9,6 +9,7 @@ import {
   pickQuotaPreviewItem,
   readAuthFilesDataCache,
   readAuthFilesUiState,
+  resolveAuthFileDisplayName,
   resolveAuthFileRestrictionBadges,
   resolveAuthFileDisplayTags,
   resolveAuthFilePlanType,
@@ -202,6 +203,18 @@ describe("Auth Files helper coverage", () => {
         },
       },
     });
+  });
+
+  test("shows codex channel emails as the display name without requiring oauth account type", () => {
+    const file = {
+      name: "codex-alpha@example.test-plus.json",
+      type: "codex",
+      provider: "codex",
+      email: "alpha@example.test",
+      label: "",
+    } satisfies AuthFileItem;
+
+    expect(resolveAuthFileDisplayName(file)).toBe("alpha@example.test");
   });
 
   test("treats an explicit empty display tag list as hiding every tag", () => {

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -48,7 +48,11 @@ import {
   resolveFileType,
   shouldShowAuthFileDisplayTag,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
-import type { QuotaItem, QuotaState } from "@/modules/quota/quota-helpers";
+import {
+  parseIdTokenPayload,
+  type QuotaItem,
+  type QuotaState,
+} from "@/modules/quota/quota-helpers";
 import type { QuotaProvider } from "@/modules/quota/quota-fetch";
 
 const MAX_FILENAME_PART_LENGTH = 72;
@@ -68,6 +72,21 @@ const sanitizeFilenamePart = (value: unknown): string => {
     .replace(/^-+|-+$/g, "");
   return text.slice(0, MAX_FILENAME_PART_LENGTH).replace(/^-+|-+$/g, "");
 };
+
+const sanitizeCodexFilenamePart = (value: unknown): string =>
+  Array.from(
+    String(value ?? "")
+      .trim()
+      .toLowerCase(),
+  )
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return code < 32 || char === "/" || char === "\\" ? "-" : char;
+    })
+    .join("")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_FILENAME_PART_LENGTH)
+    .replace(/^-+|-+$/g, "");
 
 const readStringField = (record: Record<string, unknown>, keys: string[]): string => {
   for (const key of keys) {
@@ -89,6 +108,89 @@ const readNestedStringField = (
     if (value) return value;
   }
   return "";
+};
+
+const normalizeDedupKeyPart = (value: unknown): string =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+
+const codexFilenamePlanSuffixes = new Set([
+  "plus",
+  "pro",
+  "free",
+  "team",
+  "premium",
+  "business",
+  "enterprise",
+]);
+
+const parseCodexFilenameIdentity = (fileName: string): { accountId?: string; email?: string } => {
+  const normalized = String(fileName ?? "")
+    .trim()
+    .toLowerCase();
+  const base = normalized.replace(/\.json$/u, "");
+  if (!base.startsWith("codex-")) return {};
+  const rest = base.slice("codex-".length);
+  if (!rest) return {};
+  const parts = rest.split("-").filter(Boolean);
+  if (parts.length === 0) return {};
+
+  const emailIndex = parts.findIndex((part) => part.includes("@"));
+  if (emailIndex >= 0) {
+    const email = parts[emailIndex] ?? "";
+    const accountId = parts.slice(0, emailIndex).join("-");
+    return {
+      ...(accountId ? { accountId } : {}),
+      ...(email ? { email } : {}),
+    };
+  }
+
+  const lastPart = parts.at(-1) ?? "";
+  if (codexFilenamePlanSuffixes.has(lastPart) && parts.length > 1) {
+    return { email: parts.slice(0, -1).join("-") };
+  }
+
+  return { accountId: rest };
+};
+
+const collectAuthIdentityKeys = (record: Record<string, unknown>): string[] => {
+  const credentials = isPlainObject(record.credentials) ? record.credentials : undefined;
+  const metadata = isPlainObject(record.metadata) ? record.metadata : undefined;
+  const attributes = isPlainObject(record.attributes) ? record.attributes : undefined;
+  const provider =
+    normalizeProviderKey(
+      readNestedStringField([credentials, metadata, attributes, record], ["type", "provider"]),
+    ) || "auth";
+  const idTokenCandidate =
+    credentials?.id_token ?? metadata?.id_token ?? attributes?.id_token ?? record.id_token;
+  const parsedIdToken = parseIdTokenPayload(idTokenCandidate);
+  const nestedIdToken = isPlainObject(parsedIdToken?.["https://api.openai.com/auth"])
+    ? (parsedIdToken?.["https://api.openai.com/auth"] as Record<string, unknown>)
+    : undefined;
+
+  const accountId = readNestedStringField(
+    [credentials, metadata, attributes, nestedIdToken, parsedIdToken ?? undefined, record],
+    ["chatgpt_account_id", "chatgptAccountId", "account_id", "accountId"],
+  );
+  const email = readNestedStringField([credentials, metadata, attributes, record], ["email"]);
+  const label = readNestedStringField([credentials, metadata, attributes, record], ["label"]);
+  const fileName = readNestedStringField([record], ["name"]);
+  const filenameIdentity =
+    provider === "codex" && fileName ? parseCodexFilenameIdentity(fileName) : {};
+
+  return [
+    ...(accountId ? [`${provider}:account:${normalizeDedupKeyPart(accountId)}`] : []),
+    ...(email ? [`${provider}:email:${normalizeDedupKeyPart(email)}`] : []),
+    ...(label ? [`${provider}:label:${normalizeDedupKeyPart(label)}`] : []),
+    ...(filenameIdentity.accountId
+      ? [`${provider}:account:${normalizeDedupKeyPart(filenameIdentity.accountId)}`]
+      : []),
+    ...(filenameIdentity.email
+      ? [`${provider}:email:${normalizeDedupKeyPart(filenameIdentity.email)}`]
+      : []),
+    ...(fileName ? [`${provider}:file:${normalizeDedupKeyPart(fileName)}`] : []),
+  ];
 };
 
 const findJsonValueEnd = (input: string, start: number): number => {
@@ -295,17 +397,26 @@ const buildPastedAuthFileName = (
   usedNames: Set<string>,
 ): string => {
   const provider = sanitizeFilenamePart(readStringField(record, ["type", "provider"])) || "auth";
+  const email = readStringField(record, ["email", "name"]);
+  const planType = normalizeCodexPlanType(
+    readStringField(record, ["plan_type", "chatgpt_plan_type"]),
+  );
   const identifier =
-    sanitizeFilenamePart(
-      readStringField(record, [
-        "account_id",
-        "chatgpt_account_id",
-        "auth_index",
-        "authIndex",
-        "id",
-      ]),
-    ) || `import-${index + 1}`;
-  const base = `${provider}-${identifier}`.replace(/^-+|-+$/g, "") || `auth-import-${index + 1}`;
+    provider === "codex" && email
+      ? `codex-${sanitizeCodexFilenamePart(email)}${planType ? `-${planType}` : ""}`
+      : sanitizeFilenamePart(
+          readStringField(record, [
+            "account_id",
+            "chatgpt_account_id",
+            "auth_index",
+            "authIndex",
+            "id",
+          ]),
+        ) || `import-${index + 1}`;
+  const base =
+    provider === "codex" && email
+      ? identifier
+      : `${provider}-${identifier}`.replace(/^-+|-+$/g, "") || `auth-import-${index + 1}`;
   let name = `${base}.json`;
   let suffix = 2;
   while (usedNames.has(name)) {
@@ -316,7 +427,7 @@ const buildPastedAuthFileName = (
   return name;
 };
 
-const buildPastedAuthFiles = (input: string): File[] => {
+const buildPastedAuthFiles = (input: string, existingFiles: AuthFileItem[] = []): File[] => {
   const records = parsePastedAuthJsonRecords(input);
   if (records.length === 0) return [];
   const issuedAt = new Date();
@@ -330,10 +441,23 @@ const buildPastedAuthFiles = (input: string): File[] => {
     normalizedRecords.push(record);
   });
   const usedNames = new Set<string>();
-  return normalizedRecords.map((record, index) => {
-    const name = buildPastedAuthFileName(record, index, usedNames);
-    return new File([JSON.stringify(record, null, 2)], name, { type: "application/json" });
+  const usedIdentityKeys = new Set<string>();
+  existingFiles.forEach((file) => {
+    collectAuthIdentityKeys(file).forEach((key) => usedIdentityKeys.add(key));
   });
+
+  const files: File[] = [];
+  normalizedRecords.forEach((record, index) => {
+    const identityKeys = collectAuthIdentityKeys(record);
+    if (identityKeys.some((key) => usedIdentityKeys.has(key))) {
+      return;
+    }
+    identityKeys.forEach((key) => usedIdentityKeys.add(key));
+    const name = buildPastedAuthFileName(record, index, usedNames);
+    files.push(new File([JSON.stringify(record, null, 2)], name, { type: "application/json" }));
+  });
+
+  return files;
 };
 
 interface AuthFilesFilesTabProps {
@@ -357,6 +481,7 @@ interface AuthFilesFilesTabProps {
   setSearch: (value: string) => void;
   quotaLastUpdatedText: string;
   loading: boolean;
+  files: AuthFileItem[];
   filesLength: number;
   renderFilesViewModeTabs: ReactNode;
   quotaAutoRefreshMs: QuotaAutoRefreshMs;
@@ -436,6 +561,7 @@ export function AuthFilesFilesTab({
   setSearch,
   quotaLastUpdatedText,
   loading,
+  files,
   filesLength,
   renderFilesViewModeTabs,
   quotaAutoRefreshMs,
@@ -575,23 +701,23 @@ export function AuthFilesFilesTab({
 
   const submitJsonImport = useCallback(async () => {
     setJsonImportError("");
-    let files: File[];
+    let uploadFiles: File[];
     try {
-      files = buildPastedAuthFiles(jsonImportText);
+      uploadFiles = buildPastedAuthFiles(jsonImportText, files);
     } catch {
       setJsonImportError(t("auth_files.paste_json_invalid"));
       return;
     }
 
-    if (files.length === 0) {
+    if (uploadFiles.length === 0) {
       setJsonImportError(t("auth_files.paste_json_empty"));
       return;
     }
 
-    await handleUpload(files);
+    await handleUpload(uploadFiles);
     setJsonImportText("");
     setJsonImportOpen(false);
-  }, [handleUpload, jsonImportText, t]);
+  }, [files, handleUpload, jsonImportText, t]);
 
   return (
     <div className="mt-3 space-y-3">

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -79,6 +79,18 @@ const readStringField = (record: Record<string, unknown>, keys: string[]): strin
   return "";
 };
 
+const readNestedStringField = (
+  records: readonly (Record<string, unknown> | undefined)[],
+  keys: string[],
+): string => {
+  for (const record of records) {
+    if (!record) continue;
+    const value = readStringField(record, keys);
+    if (value) return value;
+  }
+  return "";
+};
+
 const findJsonValueEnd = (input: string, start: number): number => {
   let depth = 0;
   let inString = false;
@@ -114,6 +126,16 @@ const findJsonValueEnd = (input: string, start: number): number => {
   throw new Error("incomplete json");
 };
 
+const findNextJsonValueStart = (input: string, start: number): number => {
+  for (let index = start; index < input.length; index += 1) {
+    const char = input[index];
+    if (char === "{" || char === "[") {
+      return index;
+    }
+  }
+  return -1;
+};
+
 const parsePastedJsonValues = (input: string): unknown[] => {
   const values: unknown[] = [];
   let index = 0;
@@ -125,7 +147,10 @@ const parsePastedJsonValues = (input: string): unknown[] => {
     if (index >= input.length) break;
     const startChar = input[index];
     if (startChar !== "{" && startChar !== "[") {
-      throw new Error("invalid json start");
+      const nextIndex = findNextJsonValueStart(input, index + 1);
+      if (nextIndex === -1) break;
+      index = nextIndex;
+      continue;
     }
     const end = findJsonValueEnd(input, index);
     values.push(JSON.parse(input.slice(index, end)) as unknown);
@@ -136,7 +161,7 @@ const parsePastedJsonValues = (input: string): unknown[] => {
 };
 
 const parsePastedAuthJsonRecords = (input: string): Record<string, unknown>[] => {
-  const values = parsePastedJsonValues(input.trim());
+  const values = parsePastedJsonValues(input);
   const records: Record<string, unknown>[] = [];
 
   values.forEach((value) => {
@@ -152,6 +177,116 @@ const parsePastedAuthJsonRecords = (input: string): Record<string, unknown>[] =>
   });
 
   return records;
+};
+
+const normalizeCodexPlanType = (value: unknown): string =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+
+const encodeBase64UrlJson = (value: unknown): string => {
+  const raw = JSON.stringify(value);
+  if (typeof btoa === "function") {
+    return btoa(raw).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+  }
+  const buffer = (globalThis as { Buffer?: { from: (input: string, encoding: string) => unknown } })
+    .Buffer;
+  if (buffer?.from) {
+    const bytes = buffer.from(raw, "utf-8") as { toString: (encoding: string) => string };
+    return bytes.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+  }
+  throw new Error("base64url encoder is unavailable");
+};
+
+const buildSyntheticCodexIdToken = (input: {
+  accountId: string;
+  email: string;
+  expiresAt: Date;
+  issuedAt: Date;
+  planType: string;
+  userId: string;
+}): string => {
+  const header = { alg: "none", typ: "JWT", cpa_synthetic: true };
+  const payload = {
+    iat: Math.floor(input.issuedAt.getTime() / 1000),
+    exp: Math.floor(input.expiresAt.getTime() / 1000),
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: input.accountId,
+      chatgpt_plan_type: input.planType,
+      chatgpt_user_id: input.userId,
+      user_id: input.userId,
+    },
+    email: input.email,
+  };
+  return `${encodeBase64UrlJson(header)}.${encodeBase64UrlJson(payload)}.synthetic`;
+};
+
+const buildSyntheticCodexAuthRecord = (
+  account: Record<string, unknown>,
+  issuedAt: Date,
+): Record<string, unknown> | null => {
+  const credentials = isPlainObject(account.credentials) ? account.credentials : undefined;
+  const email = readNestedStringField([credentials, account], ["email", "name"]);
+  const accountId = readNestedStringField(
+    [credentials, account],
+    ["chatgpt_account_id", "account_id"],
+  );
+  const userId = readNestedStringField([credentials, account], ["chatgpt_user_id", "user_id"]);
+  const planType = normalizeCodexPlanType(
+    readNestedStringField([credentials, account], ["plan_type", "chatgpt_plan_type"]),
+  );
+  const accessToken = readNestedStringField([credentials, account], ["access_token"]);
+  const refreshToken = readNestedStringField([credentials, account], ["refresh_token"]);
+  const expired = readNestedStringField([credentials, account], ["expires_at", "expired"]);
+  if (!email || !accountId || !accessToken || !expired || !userId) {
+    return null;
+  }
+
+  const expiresAt = new Date(expired);
+  if (Number.isNaN(expiresAt.getTime())) return null;
+
+  const normalizedPlanType = planType || "plus";
+  return {
+    type: "codex",
+    account_id: accountId,
+    chatgpt_account_id: accountId,
+    email,
+    name: email,
+    plan_type: normalizedPlanType,
+    chatgpt_plan_type: normalizedPlanType,
+    id_token: buildSyntheticCodexIdToken({
+      accountId,
+      email,
+      expiresAt,
+      issuedAt,
+      planType: normalizedPlanType,
+      userId,
+    }),
+    id_token_synthetic: true,
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    last_refresh: issuedAt.toISOString(),
+    expired,
+  };
+};
+
+const buildPastedAuthBundleRecords = (
+  record: Record<string, unknown>,
+  issuedAt: Date,
+): Record<string, unknown>[] | null => {
+  const accounts = record.accounts;
+  if (!Array.isArray(accounts)) return null;
+
+  return accounts.map((account, accountIndex) => {
+    if (!isPlainObject(account)) {
+      throw new Error(`bundle account ${accountIndex + 1} is not object`);
+    }
+    const synthesized = buildSyntheticCodexAuthRecord(account, issuedAt);
+    if (!synthesized) {
+      throw new Error(`bundle account ${accountIndex + 1} is not a supported Codex export`);
+    }
+    return synthesized;
+  });
 };
 
 const buildPastedAuthFileName = (
@@ -184,8 +319,18 @@ const buildPastedAuthFileName = (
 const buildPastedAuthFiles = (input: string): File[] => {
   const records = parsePastedAuthJsonRecords(input);
   if (records.length === 0) return [];
+  const issuedAt = new Date();
+  const normalizedRecords: Record<string, unknown>[] = [];
+  records.forEach((record) => {
+    const bundledRecords = buildPastedAuthBundleRecords(record, issuedAt);
+    if (bundledRecords) {
+      normalizedRecords.push(...bundledRecords);
+      return;
+    }
+    normalizedRecords.push(record);
+  });
   const usedNames = new Set<string>();
-  return records.map((record, index) => {
+  return normalizedRecords.map((record, index) => {
     const name = buildPastedAuthFileName(record, index, usedNames);
     return new File([JSON.stringify(record, null, 2)], name, { type: "application/json" });
   });

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -849,10 +849,48 @@ export const buildLast7DayAxis = () => {
   return result;
 };
 
+const codexFilenamePlanSuffixes = new Set([
+  "plus",
+  "pro",
+  "free",
+  "team",
+  "premium",
+  "business",
+  "enterprise",
+]);
+
+const readCodexFilenameChannelName = (fileName: string): string => {
+  const normalized = String(fileName ?? "")
+    .trim()
+    .toLowerCase();
+  const base = normalized.replace(/\.json$/u, "");
+  if (!base.startsWith("codex-")) return "";
+  const rest = base.slice("codex-".length);
+  if (!rest) return "";
+  const parts = rest.split("-").filter(Boolean);
+  if (parts.length === 0) return "";
+
+  const emailIndex = parts.findIndex((part) => part.includes("@"));
+  if (emailIndex >= 0) {
+    return parts[emailIndex] ?? "";
+  }
+
+  const lastPart = parts.at(-1) ?? "";
+  if (codexFilenamePlanSuffixes.has(lastPart) && parts.length > 1) {
+    return parts.slice(0, -1).join("-");
+  }
+
+  return "";
+};
+
 export const readAuthFileChannelName = (file: AuthFileItem): string => {
   const candidates = [file.label, file.email];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  if (normalizeProviderKey(resolveFileType(file)) === "codex") {
+    const fromName = readCodexFilenameChannelName(String(file.name || ""));
+    if (fromName) return fromName;
   }
   return "";
 };
@@ -863,7 +901,9 @@ export const isOauthAuthFile = (file: AuthFileItem): boolean =>
     .toLowerCase() === "oauth";
 
 export const canRenameAuthFileChannel = (file: AuthFileItem): boolean =>
-  isOauthAuthFile(file) || normalizeProviderKey(resolveFileType(file)) === "kimi";
+  isOauthAuthFile(file) ||
+  normalizeProviderKey(resolveFileType(file)) === "kimi" ||
+  normalizeProviderKey(resolveFileType(file)) === "codex";
 
 export const resolveAuthFileDisplayName = (file: AuthFileItem): string => {
   const channelName = readAuthFileChannelName(file);

--- a/src/modules/quota/__tests__/quota-fetch.test.ts
+++ b/src/modules/quota/__tests__/quota-fetch.test.ts
@@ -27,6 +27,26 @@ beforeEach(() => {
   mocks.downloadText.mockReset();
 });
 
+const encodeBase64UrlJson = (value: unknown): string =>
+  Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+
+const buildSyntheticCodexIdToken = (accountId: string): string =>
+  [
+    encodeBase64UrlJson({ alg: "none", typ: "JWT", cpa_synthetic: true }),
+    encodeBase64UrlJson({
+      iat: 1779509287,
+      exp: 1780333688,
+      email: "alpha@example.test",
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: accountId,
+        chatgpt_plan_type: "plus",
+        chatgpt_user_id: "user-111",
+        user_id: "user-111",
+      },
+    }),
+    "synthetic",
+  ].join(".");
+
 describe("resolveQuotaProvider", () => {
   test("supports kimi auth files", () => {
     expect(resolveQuotaProvider({ name: "kimi.json", provider: "kimi" } as any)).toBe("kimi");
@@ -51,6 +71,39 @@ describe("resolveQuotaProvider", () => {
         account_type: "api-key",
       } as any),
     ).toBeNull();
+  });
+});
+
+describe("fetchQuota for codex", () => {
+  test("uses the ChatGPT account id from nested synthetic token claims", async () => {
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: JSON.stringify({
+        plan_type: "plus",
+        rate_limit: null,
+        code_review_rate_limit: null,
+      }),
+    });
+
+    await fetchQuota("codex", {
+      name: "codex-alpha@example.test-plus.json",
+      type: "codex",
+      provider: "codex",
+      auth_index: "auth-codex-alpha",
+      id_token: buildSyntheticCodexIdToken("acct-111"),
+    } as any);
+
+    expect(mocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authIndex: "auth-codex-alpha",
+        method: "GET",
+        header: expect.objectContaining({
+          "Chatgpt-Account-Id": "acct-111",
+        }),
+      }),
+    );
   });
 });
 

--- a/src/modules/quota/quota-codex.ts
+++ b/src/modules/quota/quota-codex.ts
@@ -55,13 +55,48 @@ export const resolveCodexChatgptAccountId = (file: AuthFileItem): string | null 
   const attributes = isRecord(file.attributes)
     ? (file.attributes as Record<string, unknown>)
     : null;
+  const directCandidates = [
+    file.chatgpt_account_id,
+    file.chatgptAccountId,
+    file.account_id,
+    file.accountId,
+    metadata?.chatgpt_account_id,
+    metadata?.chatgptAccountId,
+    metadata?.account_id,
+    metadata?.accountId,
+    attributes?.chatgpt_account_id,
+    attributes?.chatgptAccountId,
+    attributes?.account_id,
+    attributes?.accountId,
+  ];
+  for (const candidate of directCandidates) {
+    const id = normalizeStringValue(candidate);
+    if (id) return id;
+  }
+
   const candidates = [file.id_token, metadata?.id_token, attributes?.id_token];
   for (const candidate of candidates) {
     const payload = parseIdTokenPayload(candidate);
-    const id = payload
-      ? normalizeStringValue(payload.chatgpt_account_id ?? payload.chatgptAccountId)
+    if (!payload) continue;
+    const directId = normalizeStringValue(
+      payload.chatgpt_account_id ??
+        payload.chatgptAccountId ??
+        payload.account_id ??
+        payload.accountId,
+    );
+    if (directId) return directId;
+    const nestedAuth = isRecord(payload["https://api.openai.com/auth"])
+      ? (payload["https://api.openai.com/auth"] as Record<string, unknown>)
       : null;
-    if (id) return id;
+    const nestedId = nestedAuth
+      ? normalizeStringValue(
+          nestedAuth.chatgpt_account_id ??
+            nestedAuth.chatgptAccountId ??
+            nestedAuth.account_id ??
+            nestedAuth.accountId,
+        )
+      : null;
+    if (nestedId) return nestedId;
   }
   return null;
 };

--- a/src/utils/quota/resolvers.ts
+++ b/src/utils/quota/resolvers.ts
@@ -8,7 +8,21 @@ import { normalizeStringValue, normalizePlanType, parseIdTokenPayload } from "./
 export function extractCodexChatgptAccountId(value: unknown): string | null {
   const payload = parseIdTokenPayload(value);
   if (!payload) return null;
-  return normalizeStringValue(payload.chatgpt_account_id ?? payload.chatgptAccountId);
+  const directId = normalizeStringValue(
+    payload.chatgpt_account_id ??
+      payload.chatgptAccountId ??
+      payload.account_id ??
+      payload.accountId,
+  );
+  if (directId) return directId;
+  const nested = payload["https://api.openai.com/auth"];
+  if (!nested || typeof nested !== "object" || Array.isArray(nested)) return null;
+  return normalizeStringValue(
+    (nested as Record<string, unknown>).chatgpt_account_id ??
+      (nested as Record<string, unknown>).chatgptAccountId ??
+      (nested as Record<string, unknown>).account_id ??
+      (nested as Record<string, unknown>).accountId,
+  );
 }
 
 export function resolveCodexChatgptAccountId(file: AuthFileItem): string | null {
@@ -21,11 +35,49 @@ export function resolveCodexChatgptAccountId(file: AuthFileItem): string | null 
       ? (file.attributes as Record<string, unknown>)
       : null;
 
+  const directCandidates = [
+    file.chatgpt_account_id,
+    file.chatgptAccountId,
+    file.account_id,
+    file.accountId,
+    metadata?.chatgpt_account_id,
+    metadata?.chatgptAccountId,
+    metadata?.account_id,
+    metadata?.accountId,
+    attributes?.chatgpt_account_id,
+    attributes?.chatgptAccountId,
+    attributes?.account_id,
+    attributes?.accountId,
+  ];
+
+  for (const candidate of directCandidates) {
+    const id = normalizeStringValue(candidate);
+    if (id) return id;
+  }
+
   const candidates = [file.id_token, metadata?.id_token, attributes?.id_token];
 
   for (const candidate of candidates) {
-    const id = extractCodexChatgptAccountId(candidate);
-    if (id) return id;
+    const payload = parseIdTokenPayload(candidate);
+    if (!payload) continue;
+    const directId = normalizeStringValue(
+      payload.chatgpt_account_id ??
+        payload.chatgptAccountId ??
+        payload.account_id ??
+        payload.accountId,
+    );
+    if (directId) return directId;
+    const nested = payload["https://api.openai.com/auth"];
+    const nestedId =
+      nested && typeof nested === "object" && !Array.isArray(nested)
+        ? normalizeStringValue(
+            (nested as Record<string, unknown>).chatgpt_account_id ??
+              (nested as Record<string, unknown>).chatgptAccountId ??
+              (nested as Record<string, unknown>).account_id ??
+              (nested as Record<string, unknown>).accountId,
+          )
+        : null;
+    if (nestedId) return nestedId;
   }
 
   return null;


### PR DESCRIPTION
Adds support for pasted Codex export bundles in auth-file import.

- parses wrapper text, multiple JSON objects, and bundle accounts arrays
- synthesizes per-account Codex auth files with email-based names
- skips duplicate Codex accounts already present or repeated in the paste
- resolves nested Codex account IDs for quota fetches

Verification:
- bun run test -- src/modules/quota/__tests__/quota-fetch.test.ts src/modules/auth-files/__tests__/auth-files-helpers.test.tsx src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- bun run build
- manual Chrome verification on the auth-files page