### PR TITLE
fix: allow non-qwen vision fallback models

### DIFF
--- a/src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -246,7 +246,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
     expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty("models");
   });
 
-  test("offers fetched OpenCode Go models as vision fallback options from string api-call body", async () => {
+  test("offers allowed multimodal OpenCode Go models as vision fallback options from string api-call body", async () => {
     const user = userEvent.setup();
     mocks.apiCallRequest.mockImplementation(async () => ({
       statusCode: 200,
@@ -258,6 +258,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
           { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
           { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
           { id: "qwen3.6-plus", object: "model", owned_by: "opencode" },
+          { id: "mimo-v2-omni", object: "model", owned_by: "opencode" },
           { id: "minimax-m2.5", object: "model", owned_by: "opencode" },
         ],
       }),
@@ -288,8 +289,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
     expect(await screen.findByRole("option", { name: /qwen3\.5-plus/i })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /qwen3\.6-plus/i })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /deepseek-v4-flash/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /mimo-v2-omni/i })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /minimax-m2\.5/i })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("option", { name: /qwen3\.5-plus/i }));
+    await user.click(screen.getByRole("option", { name: /mimo-v2-omni/i }));
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
     await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");
@@ -302,7 +304,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
           name: "OpenCode Go",
           apiKey: "sk-opencode-go",
           excludedModels: ["minimax-m2.5"],
-          visionFallbackModel: "qwen3.5-plus",
+          visionFallbackModel: "mimo-v2-omni",
         }),
       ]);
     });

--- a/src/modules/providers/components/ProviderKeyModal.tsx
+++ b/src/modules/providers/components/ProviderKeyModal.tsx
@@ -34,7 +34,13 @@ import type { ModelEntryDraft } from "@/modules/providers/ModelInputList";
 const OPENCODE_GO_MODELS_URL = "https://opencode.ai/zen/go/v1/models";
 const OPENCODE_GO_CHAT_URL = "https://opencode.ai/zen/go/v1/chat/completions";
 const OPENCODE_GO_MESSAGES_URL = "https://opencode.ai/zen/go/v1/messages";
-const OPENCODE_GO_VISION_MODEL_IDS = new Set(["qwen3.5-plus", "qwen3.6-plus"]);
+const OPENCODE_GO_KNOWN_VISION_MODEL_IDS = new Set([
+  "qwen3.5-plus",
+  "qwen3.6-plus",
+  "mimo-v2-omni",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+]);
 
 type ProviderKeyModalTab = "basic" | "request" | "models";
 
@@ -76,6 +82,22 @@ const SectionCard = ({
     {children}
   </div>
 );
+
+const isOpenCodeGoVisionModel = (modelId: string): boolean => {
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized) return false;
+  if (OPENCODE_GO_KNOWN_VISION_MODEL_IDS.has(normalized)) return true;
+  if (
+    normalized.includes("vision") ||
+    normalized.includes("multimodal") ||
+    normalized.includes("omni")
+  ) {
+    return true;
+  }
+  return normalized
+    .split(/[-_./:]+/)
+    .some((token) => token === "vl");
+};
 
 export function ProviderKeyModal({
   open,
@@ -233,7 +255,7 @@ export function ProviderKeyModal({
   const openCodeVisionFallbackOptions = useMemo(() => {
     const allowedModels = openCodeModels.filter(
       (model) =>
-        OPENCODE_GO_VISION_MODEL_IDS.has(model.id.toLowerCase()) &&
+        isOpenCodeGoVisionModel(model.id) &&
         !disableAllModels &&
         !excludedModelIds.has(model.id.toLowerCase()),
     );
@@ -254,7 +276,7 @@ export function ProviderKeyModal({
       openCodeModels.some(
         (model) =>
           model.id.toLowerCase() === fallbackLower &&
-          OPENCODE_GO_VISION_MODEL_IDS.has(fallbackLower) &&
+          isOpenCodeGoVisionModel(model.id) &&
           !excludedModelIds.has(fallbackLower),
       );
     if (allowed) return;


### PR DESCRIPTION
## Summary
- show all allowed OpenCode Go models recognized as multimodal or vision-capable in the fallback selector
- keep disabled and text-only models out of the image fallback selector
- update provider modal coverage for non-qwen fallback selection

## Verification
- bun run test -- src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx src/modules/providers/__tests__/providers-helpers.test.ts src/modules/providers/__tests__/provider-import-export.test.ts src/lib/http/apis/__tests__/providers-opencode-go.test.ts
- bun run build
- Chrome desktop and narrow-width UI verification