### PR TITLE
fix(providers): restore provider card release checks

### DIFF
--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -81,7 +81,7 @@ export function ProviderCard({
           {onToggleEnabled ? (
             <ToggleSwitch
               checked={enabled}
-              ariaLabel={t("providers.enable")}
+              ariaLabel={`${t("providers.enable_provider")} ${title}`}
               onCheckedChange={onToggleEnabled}
             />
           ) : null}

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import type { LucideIcon } from "lucide-react";
 import { Loader2, Plus, Zap } from "lucide-react";
 import type { ProviderSimpleConfig } from "@/lib/http/types";
 import { Button } from "@/modules/ui/Button";
@@ -19,10 +18,6 @@ import type { ProviderAccessSummary } from "@/modules/providers/provider-access"
 import { useTranslation } from "react-i18next";
 
 export function ProviderKeyListCard({
-  icon: Icon,
-  iconSrc,
-  iconDarkSrc,
-  iconAlt = "",
   title,
   description,
   items,
@@ -43,10 +38,6 @@ export function ProviderKeyListCard({
   selectedKeys,
   onToggleSelected,
 }: {
-  icon: LucideIcon;
-  iconSrc?: string;
-  iconDarkSrc?: string;
-  iconAlt?: string;
   title: string;
   description: string;
   items: ProviderSimpleConfig[];
@@ -67,17 +58,6 @@ export function ProviderKeyListCard({
   onToggleSelected?: (key: string, checked: boolean) => void;
 }) {
   const { t } = useTranslation();
-  const renderIcon = () =>
-    iconSrc ? (
-      <>
-        <img src={iconSrc} alt={iconAlt} className={`size-4 ${iconDarkSrc ? "dark:hidden" : ""}`} />
-        {iconDarkSrc ? (
-          <img src={iconDarkSrc} alt={iconAlt} className="hidden size-4 dark:block" />
-        ) : null}
-      </>
-    ) : (
-      <Icon size={16} className="text-slate-900 dark:text-white" />
-    );
 
   return (
     <Card
@@ -99,12 +79,14 @@ export function ProviderKeyListCard({
         <div
           data-testid="providers-tab-scroll"
           className={[
-            "min-h-0 flex-1 pr-1",
-            gridColumns > 1
-              ? "grid gap-3"
-              : "space-y-3",
+            "min-h-0 flex-1 overflow-y-auto pr-1",
+            gridColumns > 1 ? "grid gap-3" : "space-y-3",
           ].join(" ")}
-          style={gridColumns > 1 ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
+          style={
+            gridColumns > 1
+              ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` }
+              : undefined
+          }
         >
           {items.map((item, idx) => {
             const selectionKey = `${item.apiKey.trim().toLowerCase()}:${idx}`;
@@ -138,9 +120,7 @@ export function ProviderKeyListCard({
                     : undefined
                 }
                 onToggleEnabled={
-                  onToggleEnabled
-                    ? (enabled) => onToggleEnabled(idx, enabled)
-                    : undefined
+                  onToggleEnabled ? (enabled) => onToggleEnabled(idx, enabled) : undefined
                 }
                 onEdit={() => onEdit(idx)}
                 onDelete={() => onDelete(idx)}
@@ -172,9 +152,7 @@ export function ProviderKeyListCard({
                             ) : entry.error ? (
                               <span className="text-rose-500">×</span>
                             ) : entry.latencyMs !== null ? (
-                              <span className="font-medium">
-                                {formatLatency(entry.latencyMs)}
-                              </span>
+                              <span className="font-medium">{formatLatency(entry.latencyMs)}</span>
                             ) : (
                               <Zap size={10} />
                             )}
@@ -203,9 +181,7 @@ export function ProviderKeyListCard({
 
                 {accessSummary ? (
                   <div className="mt-2 flex flex-wrap gap-1.5 text-[11px]">
-                    <span
-                      className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}
-                    >
+                    <span className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}>
                       {accessSummary.totalKeys === 0
                         ? t("providers.access_no_keys")
                         : accessSummary.reachableKeys === 0

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Bot, Cloud, Database, Download, FileKey, Globe, LayoutGrid, RefreshCw, Upload } from "lucide-react";
+import { Cloud, Download, LayoutGrid, RefreshCw, Upload } from "lucide-react";
 import iconGemini from "@/assets/icons/gemini.svg";
 import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
@@ -58,7 +58,14 @@ type ProviderTab =
 
 const PROVIDER_TAB_STORAGE_KEY = "providers-page:tab";
 const PROVIDER_TAB_VALUES: ProviderTab[] = [
-  "gemini", "claude", "codex", "opencode-go", "vertex", "bedrock", "openai", "ampcode",
+  "gemini",
+  "claude",
+  "codex",
+  "opencode-go",
+  "vertex",
+  "bedrock",
+  "openai",
+  "ampcode",
 ];
 
 function readSavedProviderTab(): ProviderTab {
@@ -108,8 +115,12 @@ const getProviderSelectionKey = (
   index: number,
 ) =>
   kind === "openai"
-    ? `${String((item as OpenAIProvider).name ?? "").trim().toLowerCase()}:${index}`
-    : `${String((item as ProviderSimpleConfig).apiKey ?? "").trim().toLowerCase()}:${index}`;
+    ? `${String((item as OpenAIProvider).name ?? "")
+        .trim()
+        .toLowerCase()}:${index}`
+    : `${String((item as ProviderSimpleConfig).apiKey ?? "")
+        .trim()
+        .toLowerCase()}:${index}`;
 
 export function ProvidersPage() {
   const { t } = useTranslation();
@@ -700,7 +711,7 @@ export function ProvidersPage() {
   return (
     <div
       data-testid="providers-page-shell"
-      className="flex min-h-0 flex-col gap-6"
+      className="flex h-[calc(100dvh-112px)] min-h-0 flex-col gap-6 overflow-hidden"
     >
       <div className="flex flex-wrap items-center gap-3">
         <div className="space-y-0.5">
@@ -863,7 +874,6 @@ export function ProvidersPage() {
           </div>
           <TabsContent value="gemini" className="flex flex-col">
             <ProviderKeyListCard
-              icon={Globe}
               title={t("providers.gemini_keys")}
               description={t("providers.openai_desc")}
               items={geminiKeys}
@@ -885,7 +895,6 @@ export function ProvidersPage() {
 
           <TabsContent value="claude" className="flex flex-col">
             <ProviderKeyListCard
-              icon={Bot}
               title={t("providers.claude_keys")}
               description={t("providers.codex_desc")}
               items={claudeKeys}
@@ -907,7 +916,6 @@ export function ProvidersPage() {
 
           <TabsContent value="codex" className="flex flex-col">
             <ProviderKeyListCard
-              icon={FileKey}
               title={t("providers.codex_keys")}
               description={t("providers.gemini_desc")}
               items={codexKeys}
@@ -929,9 +937,6 @@ export function ProvidersPage() {
 
           <TabsContent value="opencode-go" className="flex flex-col">
             <ProviderKeyListCard
-              icon={FileKey}
-              iconSrc={iconOpenCodeLight}
-              iconDarkSrc={iconOpenCodeDark}
               title={t("providers.opencode_go_keys")}
               description={t("providers.opencode_go_desc")}
               items={openCodeGoKeys}
@@ -954,7 +959,6 @@ export function ProvidersPage() {
 
           <TabsContent value="vertex" className="flex flex-col">
             <ProviderKeyListCard
-              icon={Database}
               title={t("providers.vertex_keys")}
               description={t("providers.vertex_desc")}
               items={vertexKeys}
@@ -975,7 +979,6 @@ export function ProvidersPage() {
 
           <TabsContent value="bedrock" className="flex flex-col">
             <ProviderKeyListCard
-              icon={Cloud}
               title={t("providers.bedrock_keys")}
               description={t("providers.bedrock_desc")}
               items={bedrockKeys}

--- a/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   getOpenAIProviders: vi.fn(async () => []),
   saveCodexConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveOpenAIProviders: vi.fn(async (_configs: unknown[]) => ({})),
+  patchOpenAIProviderDisabled: vi.fn(async (_index: number, _disabled: boolean) => ({})),
   getEntityStats: vi.fn(async () => ({ source: [] })),
   apiKeyEntriesList: vi.fn(async () => []),
   channelGroupsList: vi.fn(async () => []),
@@ -33,6 +34,7 @@ vi.mock("@/lib/http/apis", async (importOriginal) => {
       getOpenAIProviders: mocks.getOpenAIProviders,
       saveCodexConfigs: mocks.saveCodexConfigs,
       saveOpenAIProviders: mocks.saveOpenAIProviders,
+      patchOpenAIProviderDisabled: mocks.patchOpenAIProviderDisabled,
     },
     usageApi: {
       ...mod.usageApi,
@@ -72,6 +74,7 @@ describe("ProvidersPage openai tab", () => {
     mocks.getOpenAIProviders.mockReset();
     mocks.saveCodexConfigs.mockReset();
     mocks.saveOpenAIProviders.mockReset();
+    mocks.patchOpenAIProviderDisabled.mockReset();
     mocks.getEntityStats.mockReset();
     mocks.apiKeyEntriesList.mockReset();
     mocks.channelGroupsList.mockReset();
@@ -83,6 +86,7 @@ describe("ProvidersPage openai tab", () => {
     mocks.getVertexConfigs.mockImplementation(async () => []);
     mocks.saveCodexConfigs.mockImplementation(async () => ({}));
     mocks.saveOpenAIProviders.mockImplementation(async () => ({}));
+    mocks.patchOpenAIProviderDisabled.mockImplementation(async () => ({}));
     mocks.apiKeyEntriesList.mockImplementation(async () => []);
     mocks.channelGroupsList.mockImplementation(async () => []);
     mocks.proxiesList.mockImplementation(async () => [
@@ -286,9 +290,7 @@ describe("ProvidersPage openai tab", () => {
         }),
       ]);
     });
-    expect(mocks.saveOpenAIProviders.mock.calls[0]?.[0]?.[0]).not.toHaveProperty(
-      "apiKeyEntries",
-    );
+    expect(mocks.saveOpenAIProviders.mock.calls[0]?.[0]?.[0]).not.toHaveProperty("apiKeyEntries");
   });
 
   test("toggles an OpenAI Compatible provider without removing keys", async () => {
@@ -325,21 +327,8 @@ describe("ProvidersPage openai tab", () => {
     await user.click(providerSwitch);
 
     await waitFor(() => {
-      expect(mocks.saveOpenAIProviders).toHaveBeenCalledWith([
-        expect.objectContaining({
-          name: "OpenAI Main",
-          disabled: true,
-          apiKeyEntries: [
-            expect.objectContaining({
-              apiKey: "sk-openai-enabled-1234567890",
-            }),
-            expect.objectContaining({
-              apiKey: "sk-openai-disabled-1234567890",
-              disabled: true,
-            }),
-          ],
-        }),
-      ]);
+      expect(mocks.patchOpenAIProviderDisabled).toHaveBeenCalledWith(0, true);
     });
+    expect(mocks.saveOpenAIProviders).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -72,12 +72,14 @@ export function OpenAIProvidersTab({
         <div
           data-testid="providers-tab-scroll"
           className={[
-            "pr-1",
-            gridColumns > 1
-              ? "grid gap-3"
-              : "space-y-3",
+            "min-h-0 flex-1 overflow-y-auto pr-1",
+            gridColumns > 1 ? "grid gap-3" : "space-y-3",
           ].join(" ")}
-          style={gridColumns > 1 ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` } : undefined}
+          style={
+            gridColumns > 1
+              ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` }
+              : undefined
+          }
         >
           {providers.map((provider, idx) => {
             const selectionKey = `${provider.name.trim().toLowerCase()}:${idx}`;
@@ -161,9 +163,7 @@ export function OpenAIProvidersTab({
                                     : "bg-amber-500/15 text-amber-700 dark:text-amber-200",
                                 ].join(" ")}
                               >
-                                {entryEnabled
-                                  ? t("providers.enabled")
-                                  : t("providers.disabled")}
+                                {entryEnabled ? t("providers.enabled") : t("providers.disabled")}
                               </span>
                               <span className="rounded-full bg-emerald-600/10 px-2 py-0.5 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
                                 {t("providers.success_stats", { count: entryStats.success })}


### PR DESCRIPTION
Restores provider page scroll containment, gives provider enable switches unique accessible labels, and aligns the OpenAI provider toggle test with the patch endpoint. Validation: targeted provider tests, lint, changed-file format check, and diff check.