### PR TITLE
fix: restore provider page scrolling and compact card actions

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3034,6 +3034,7 @@
     "batch_deselect_all": "Deselect All",
     "batch_clear": "Clear",
     "select_provider": "Select {{name}}",
+    "more_actions": "More actions",
     "import_preview_title": "Import preview",
     "import_preview_desc": "Review the normalized diff for {{filename}} before replacing the current provider configuration.",
     "confirm_import": "Confirm import",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2369,6 +2369,7 @@
     "batch_deselect_all": "取消全选",
     "batch_clear": "清空",
     "select_provider": "选择 {{name}}",
+    "more_actions": "更多操作",
     "import_preview_title": "导入预览",
     "import_preview_desc": "先查看 {{filename}} 规范化后的 diff，再决定是否替换当前供应商配置。",
     "confirm_import": "确认导入",

--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -1,8 +1,16 @@
-import type { ReactNode } from "react";
-import { Settings2, Trash2 } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { EllipsisVertical, Settings2, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/modules/ui/Button";
+import { buttonClassName } from "@/modules/ui/Button";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
+
+const ACTION_MENU_CONTENT_CLASS =
+  "z-[220] min-w-36 rounded-2xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
+const ACTION_MENU_ITEM_CLASS =
+  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
+const ACTION_MENU_DANGER_ITEM_CLASS =
+  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-600 outline-none transition-colors focus:bg-rose-50 data-[highlighted]:bg-rose-50 dark:text-rose-300 dark:focus:bg-rose-500/10 dark:data-[highlighted]:bg-rose-500/10";
 
 export interface ProviderCardProps {
   /** Card title (provider name) */
@@ -40,11 +48,14 @@ export function ProviderCard({
   children,
 }: ProviderCardProps) {
   const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const hasActionMenu = Boolean(onEdit || onDelete);
 
   return (
     <div
       className={[
-        "group rounded-2xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out",
+        "group relative rounded-2xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out",
+        hasActionMenu ? "pr-11" : "",
         selected
           ? "border-blue-400 bg-blue-50/50 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-950/20 dark:ring-blue-500/20"
           : "border-slate-200 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
@@ -53,6 +64,53 @@ export function ProviderCard({
         .filter(Boolean)
         .join(" ")}
     >
+      {hasActionMenu ? (
+        <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
+          <DropdownMenu.Trigger asChild>
+            <button
+              type="button"
+              className={[
+                buttonClassName({
+                  variant: "ghost",
+                  size: "xs",
+                  iconOnly: true,
+                  className:
+                    "!h-7 !w-7 bg-white/85 text-slate-500 shadow-sm ring-1 ring-slate-200/80 hover:text-slate-950 dark:bg-neutral-950/85 dark:text-white/55 dark:ring-neutral-800 dark:hover:text-white",
+                }),
+                "absolute right-2 top-2 z-10 transition-opacity duration-150 ease-out",
+                menuOpen
+                  ? "pointer-events-auto opacity-100"
+                  : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
+              ].join(" ")}
+              aria-label={t("providers.more_actions")}
+              title={t("providers.more_actions")}
+              data-tooltip-placement="left"
+            >
+              <EllipsisVertical size={14} />
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content align="end" sideOffset={8} className={ACTION_MENU_CONTENT_CLASS}>
+              {onEdit ? (
+                <DropdownMenu.Item className={ACTION_MENU_ITEM_CLASS} onSelect={() => onEdit()}>
+                  <Settings2 size={15} />
+                  <span>{t("providers.edit")}</span>
+                </DropdownMenu.Item>
+              ) : null}
+              {onDelete ? (
+                <DropdownMenu.Item
+                  className={ACTION_MENU_DANGER_ITEM_CLASS}
+                  onSelect={() => onDelete()}
+                >
+                  <Trash2 size={15} />
+                  <span>{t("providers.delete")}</span>
+                </DropdownMenu.Item>
+              ) : null}
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      ) : null}
+
       {/* Header */}
       <div className="flex flex-wrap items-center gap-2">
         {onToggleSelected ? (
@@ -84,18 +142,6 @@ export function ProviderCard({
               ariaLabel={`${t("providers.enable_provider")} ${title}`}
               onCheckedChange={onToggleEnabled}
             />
-          ) : null}
-          {onEdit ? (
-            <Button variant="secondary" size="sm" onClick={onEdit}>
-              <Settings2 size={14} />
-              {t("providers.edit")}
-            </Button>
-          ) : null}
-          {onDelete ? (
-            <Button variant="danger" size="sm" onClick={onDelete}>
-              <Trash2 size={14} />
-              {t("providers.delete")}
-            </Button>
           ) : null}
         </div>
       </div>

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -711,7 +711,7 @@ export function ProvidersPage() {
   return (
     <div
       data-testid="providers-page-shell"
-      className="flex h-[calc(100dvh-112px)] min-h-0 flex-col gap-6 overflow-hidden"
+      className="flex min-h-[calc(100dvh-112px)] flex-col gap-6"
     >
       <div className="flex flex-wrap items-center gap-3">
         <div className="space-y-0.5">

--- a/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -256,7 +256,7 @@ describe("ProvidersPage import/export", () => {
     ).toBeInTheDocument();
   });
 
-  test("locks the page shell height and uses a dedicated scroll area for the active tab content", async () => {
+  test("lets the provider page grow so the app shell can scroll", async () => {
     const user = userEvent.setup();
 
     render(
@@ -274,7 +274,10 @@ describe("ProvidersPage import/export", () => {
     await user.click(await screen.findByRole("tab", { name: /Codex/ }));
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
 
-    expect(screen.getByTestId("providers-page-shell")).toHaveClass("h-[calc(100dvh-112px)]");
+    expect(screen.getByTestId("providers-page-shell")).toHaveClass(
+      "min-h-[calc(100dvh-112px)]",
+    );
+    expect(screen.getByTestId("providers-page-shell")).not.toHaveClass("overflow-hidden");
     expect(screen.getByTestId("providers-tab-scroll")).toHaveClass("overflow-y-auto");
   });
 

--- a/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -178,7 +178,8 @@ describe("ProvidersPage openai tab", () => {
 
     await user.click(await screen.findByRole("tab", { name: /Codex/ }));
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Edit/ }));
+    await user.click(screen.getByRole("button", { name: /More actions/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /Edit/i }));
 
     expect(await screen.findByText("Edit Codex configuration")).toBeInTheDocument();
 
@@ -276,7 +277,8 @@ describe("ProvidersPage openai tab", () => {
     );
 
     expect(await screen.findByText("Keyless OpenAI")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /Edit/ }));
+    await user.click(screen.getByRole("button", { name: /More actions/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /Edit/i }));
     expect(await screen.findByText("Edit OpenAI-compatible provider")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Save/ }));


### PR DESCRIPTION
## Summary
- let the AI providers page grow inside the app shell so lower provider cards remain reachable by scrolling
- replace provider card edit/delete buttons with a compact hover-revealed action menu in the upper-right corner
- update focused provider page tests for the new scrolling and menu behavior

## Validation
- bun run test src/modules/providers/__tests__/ProvidersPage.openai.test.tsx src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
- bun run build
- desktop Chrome UI check against local production preview
- mobile viewport UI check against local production preview