### PR TITLE
Polish auth filters and provider card layout

### DIFF
--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -633,6 +633,11 @@ export function AuthFilesFilesTab({
     draftModelOwner === ""
       ? null
       : (modelOwnerGroups.find((group) => group.value === draftModelOwner) ?? null);
+  const selectedModelOwnerGroup =
+    selectedModelOwner === ""
+      ? null
+      : (modelOwnerGroups.find((group) => group.value === selectedModelOwner) ?? null);
+  const showSelectionActions = selectableFilteredFiles.length > 0 || selectedCount > 0;
   const modelOwnerOptions = useMemo<SearchableSelectOption[]>(
     () => [
       {
@@ -719,6 +724,54 @@ export function AuthFilesFilesTab({
     setJsonImportOpen(false);
   }, [files, handleUpload, jsonImportText, t]);
 
+  const selectionActionsMenu = showSelectionActions ? (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          className={buttonClassName({
+            variant: "secondary",
+            size: "sm",
+            iconOnly: true,
+          })}
+          aria-label={t("auth_files.selection_actions")}
+          title={t("auth_files.selection_actions")}
+          data-tooltip-placement="top"
+        >
+          <ListChecks size={15} />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content align="end" sideOffset={8} className={ACTION_MENU_CONTENT_CLASS}>
+          <DropdownMenu.Item
+            className={ACTION_MENU_ITEM_CLASS}
+            disabled={selectablePageNames.length === 0}
+            onSelect={() => selectCurrentPage(!allPageSelected)}
+          >
+            <ListChecks size={15} />
+            <span>
+              {allPageSelected
+                ? t("auth_files.batch_deselect_page")
+                : t("auth_files.batch_select_page")}
+            </span>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            className={ACTION_MENU_ITEM_CLASS}
+            disabled={selectableFilteredFiles.length === 0}
+            onSelect={() => selectFilteredFiles(!allFilteredSelected)}
+          >
+            <ListChecks size={15} />
+            <span>
+              {allFilteredSelected
+                ? t("auth_files.batch_deselect_filtered")
+                : t("auth_files.batch_select_filtered")}
+            </span>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  ) : null;
+
   return (
     <div className="mt-3 space-y-3">
       <input
@@ -759,13 +812,13 @@ export function AuthFilesFilesTab({
             data-testid="auth-files-mobile-filter-panel"
             className={[
               mobileFiltersOpen ? "grid" : "hidden",
-              "gap-3 md:grid xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] xl:items-start",
+              "gap-3 md:grid xl:grid-cols-[minmax(360px,1fr)_minmax(420px,auto)] xl:items-stretch",
             ].join(" ")}
           >
-            <div className="grid min-w-0 gap-2 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-              <div className="min-w-0 space-y-1.5">
-                <div className="flex items-center gap-2">
-                  <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
+            <div className="min-w-0 rounded-2xl bg-slate-50/80 px-3 py-2.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
+              <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                  <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
                     {t("auth_files.type_filter")}
                   </p>
                   <HoverTooltip content={t("auth_files.count_hint")} placement="top">
@@ -777,75 +830,97 @@ export function AuthFilesFilesTab({
                     </span>
                   </HoverTooltip>
                 </div>
-                <Tabs value={filter} onValueChange={setFilter}>
-                  <TabsList>
-                    {filterChips.map((key) => {
-                      const active = filter === key;
-                      const normalizedKey = normalizeProviderKey(key);
-                      const count =
-                        key === "all"
-                          ? filterCounts.total
-                          : (filterCounts.counts[normalizedKey] ?? 0);
-                      const label = key === "all" ? t("auth_files.all") : key;
-                      const countClass = active
-                        ? "bg-black/[0.06] text-[#18181B] dark:bg-white/12 dark:text-white"
-                        : "bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-white/70";
-                      return (
-                        <TabsTrigger key={key} value={key}>
-                          {label}
-                          <span
-                            className={[
-                              "ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums",
-                              countClass,
-                            ].join(" ")}
-                          >
-                            {count}
-                          </span>
-                        </TabsTrigger>
-                      );
-                    })}
-                  </TabsList>
-                </Tabs>
+                {activeFilterCount > 0 ? (
+                  <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-slate-900 px-1.5 text-[10px] font-semibold tabular-nums text-white dark:bg-white dark:text-neutral-950">
+                    {activeFilterCount}
+                  </span>
+                ) : null}
               </div>
 
+              <Tabs value={filter} onValueChange={setFilter} size="sm">
+                <TabsList className="max-w-full">
+                  {filterChips.map((key) => {
+                    const active = filter === key;
+                    const normalizedKey = normalizeProviderKey(key);
+                    const count =
+                      key === "all"
+                        ? filterCounts.total
+                        : (filterCounts.counts[normalizedKey] ?? 0);
+                    const label = key === "all" ? t("auth_files.all") : key;
+                    const countClass = active
+                      ? "bg-black/[0.06] text-[#18181B] dark:bg-white/12 dark:text-white"
+                      : "bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-white/70";
+                    return (
+                      <TabsTrigger key={key} value={key}>
+                        {label}
+                        <span
+                          className={[
+                            "ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums",
+                            countClass,
+                          ].join(" ")}
+                        >
+                          {count}
+                        </span>
+                      </TabsTrigger>
+                    );
+                  })}
+                </TabsList>
+              </Tabs>
+            </div>
+
+            <div
+              className={[
+                "grid min-w-0 gap-2 sm:grid-cols-2",
+                canSetModelOwnerGroup && customTagOptions.length > 0
+                  ? "xl:grid-cols-[minmax(0,150px)_minmax(0,160px)_minmax(0,170px)_minmax(240px,280px)]"
+                  : canSetModelOwnerGroup
+                    ? "xl:grid-cols-[minmax(0,150px)_minmax(0,170px)_minmax(260px,320px)]"
+                    : customTagOptions.length > 0
+                      ? "xl:grid-cols-[minmax(0,170px)_minmax(0,180px)_minmax(260px,320px)]"
+                      : "xl:grid-cols-[minmax(0,180px)_minmax(280px,340px)]",
+                "xl:items-end",
+              ].join(" ")}
+            >
               {canSetModelOwnerGroup ? (
-                <div className="flex items-end">
+                <div className="min-w-0 space-y-1.5">
+                  <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
+                    {t("auth_files.model_owner_group")}
+                  </p>
                   <HoverTooltip content={t("auth_files.model_owner_group")} placement="top">
                     <Button
                       variant="secondary"
                       size="sm"
-                      className="relative !h-9 !w-9 px-0"
+                      className={[
+                        "relative !h-9 w-full justify-start px-3 text-xs",
+                        selectedModelOwner
+                          ? "bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-400/10 dark:text-emerald-100 dark:hover:bg-emerald-400/15"
+                          : "bg-[#EBEBEC] text-[#3F3F46] hover:bg-[#E4E4E7] dark:bg-[#27272A] dark:text-white/75 dark:hover:bg-[#303036]",
+                      ].join(" ")}
                       onClick={() => {
                         setDraftModelOwner(selectedModelOwner);
                         setModelOwnerDialogOpen(true);
                       }}
                       aria-label={t("auth_files.model_owner_group")}
                     >
-                      <Settings2 size={15} />
+                      <Settings2 size={15} className="shrink-0" />
+                      <span className="min-w-0 flex-1 truncate text-left">
+                        {selectedModelOwnerGroup?.label ??
+                          (selectedModelOwner || t("auth_files.auth_file_models_option"))}
+                      </span>
                       {selectedModelOwner ? (
                         <span
                           aria-hidden="true"
-                          className="absolute top-1.5 right-1.5 h-1.5 w-1.5 rounded-full bg-emerald-500 ring-2 ring-white dark:ring-neutral-900"
+                          className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
                         />
                       ) : null}
                     </Button>
                   </HoverTooltip>
                 </div>
               ) : null}
-            </div>
 
-            <div
-              className={[
-                "grid min-w-0 gap-3",
-                customTagOptions.length > 0
-                  ? "sm:grid-cols-2 xl:grid-cols-[minmax(0,180px)_minmax(0,170px)_minmax(0,1fr)]"
-                  : "sm:grid-cols-[minmax(0,180px)_minmax(0,1fr)]",
-                "xl:items-end",
-              ].join(" ")}
-            >
               {customTagOptions.length > 0 ? (
                 <div className="min-w-0 space-y-1.5">
-                  <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
+                  <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
                     {t("auth_files.tag_filter")}
                   </p>
                   <SearchableSelect
@@ -860,7 +935,7 @@ export function AuthFilesFilesTab({
               ) : null}
 
               <div className="min-w-0 space-y-1.5">
-                <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
+                <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
                   {t("auth_files.status_filter")}
                 </p>
                 <Select
@@ -875,13 +950,14 @@ export function AuthFilesFilesTab({
               </div>
 
               <div className="min-w-0 space-y-1.5">
-                <p className="text-[11px] font-semibold text-slate-600 dark:text-white/65">
+                <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
                   {t("auth_files.search")}
                 </p>
                 <TextInput
                   value={search}
                   onChange={(e) => setSearch(e.currentTarget.value)}
                   placeholder={t("auth_files_page.filename_hint")}
+                  aria-label={t("auth_files.search")}
                   endAdornment={<Search size={16} className="text-slate-400" />}
                 />
               </div>
@@ -929,6 +1005,7 @@ export function AuthFilesFilesTab({
             </div>
 
             <div className="flex flex-wrap items-center gap-1.5 lg:justify-end">
+              {selectedCount === 0 ? selectionActionsMenu : null}
               <Button
                 variant="secondary"
                 size="sm"
@@ -1008,84 +1085,31 @@ export function AuthFilesFilesTab({
             </div>
           </div>
 
-          {selectableFilteredFiles.length > 0 || selectedCount > 0 ? (
+          {selectedCount > 0 ? (
             <div className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
-              <DropdownMenu.Root>
-                <DropdownMenu.Trigger asChild>
-                  <button
-                    type="button"
-                    className={buttonClassName({
-                      variant: "secondary",
-                      size: "sm",
-                      iconOnly: true,
-                      className: "!h-8 !w-8",
-                    })}
-                    aria-label={t("auth_files.selection_actions")}
-                    title={t("auth_files.selection_actions")}
-                    data-tooltip-placement="top"
-                  >
-                    <ListChecks size={15} />
-                  </button>
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    align="end"
-                    sideOffset={8}
-                    className={ACTION_MENU_CONTENT_CLASS}
-                  >
-                    <DropdownMenu.Item
-                      className={ACTION_MENU_ITEM_CLASS}
-                      disabled={selectablePageNames.length === 0}
-                      onSelect={() => selectCurrentPage(!allPageSelected)}
-                    >
-                      <ListChecks size={15} />
-                      <span>
-                        {allPageSelected
-                          ? t("auth_files.batch_deselect_page")
-                          : t("auth_files.batch_select_page")}
-                      </span>
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className={ACTION_MENU_ITEM_CLASS}
-                      disabled={selectableFilteredFiles.length === 0}
-                      onSelect={() => selectFilteredFiles(!allFilteredSelected)}
-                    >
-                      <ListChecks size={15} />
-                      <span>
-                        {allFilteredSelected
-                          ? t("auth_files.batch_deselect_filtered")
-                          : t("auth_files.batch_select_filtered")}
-                      </span>
-                    </DropdownMenu.Item>
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu.Root>
-              {selectedCount > 0 ? (
-                <>
-                  <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
-                    {t("auth_files.batch_selected", { count: selectedCount })}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="!h-8 px-2 text-xs"
-                    onClick={() => setSelectedFileNames([])}
-                  >
-                    {t("auth_files.batch_clear")}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    size="sm"
-                    className="!h-8 px-2 text-xs"
-                    onClick={() =>
-                      setConfirm({ type: "deleteSelection", names: [...selectedFileNames] })
-                    }
-                    disabled={deletingAll}
-                  >
-                    {t("auth_files.batch_delete_action", { count: selectedCount })}
-                  </Button>
-                </>
-              ) : null}
+              {selectionActionsMenu}
+              <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
+                {t("auth_files.batch_selected", { count: selectedCount })}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="!h-8 px-2 text-xs"
+                onClick={() => setSelectedFileNames([])}
+              >
+                {t("auth_files.batch_clear")}
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                className="!h-8 px-2 text-xs"
+                onClick={() =>
+                  setConfirm({ type: "deleteSelection", names: [...selectedFileNames] })
+                }
+                disabled={deletingAll}
+              >
+                {t("auth_files.batch_delete_action", { count: selectedCount })}
+              </Button>
             </div>
           ) : null}
         </div>

--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -29,7 +29,7 @@ export interface ProviderCardProps {
   onEdit?: () => void;
   /** Callback when delete button is clicked */
   onDelete?: () => void;
-  /** Extra elements rendered in the header actions area (between toggle and edit) */
+  /** Extra elements rendered below the title row */
   headerExtra?: ReactNode;
   /** Card body content */
   children?: ReactNode;
@@ -50,6 +50,7 @@ export function ProviderCard({
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const hasActionMenu = Boolean(onEdit || onDelete);
+  const hasHeaderExtra = Boolean(headerExtra);
 
   return (
     <div
@@ -112,38 +113,42 @@ export function ProviderCard({
       ) : null}
 
       {/* Header */}
-      <div className="flex flex-wrap items-center gap-2">
-        {onToggleSelected ? (
-          <div
-            className={[
-              "flex items-center justify-center overflow-hidden transition-all duration-200 ease-out",
-              selected
-                ? "w-8 opacity-100"
-                : "w-0 opacity-0 group-hover:w-8 group-hover:opacity-100",
-            ].join(" ")}
-          >
-            <input
-              type="checkbox"
-              aria-label={t("providers.select_provider", { name: title })}
-              checked={selected}
-              onChange={(e) => onToggleSelected(e.currentTarget.checked)}
-              className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-            />
-          </div>
-        ) : null}
-        <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
-          {title}
-        </p>
-        <div className="ml-auto flex items-center gap-2">
-          {headerExtra}
+      <div className="grid gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          {onToggleSelected ? (
+            <div
+              className={[
+                "flex items-center justify-center overflow-hidden transition-[width,opacity] duration-200 ease-out",
+                selected
+                  ? "w-7 opacity-100"
+                  : "w-0 opacity-0 group-hover:w-7 group-hover:opacity-100",
+              ].join(" ")}
+            >
+              <input
+                type="checkbox"
+                aria-label={t("providers.select_provider", { name: title })}
+                checked={selected}
+                onChange={(e) => onToggleSelected(e.currentTarget.checked)}
+                className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
+              />
+            </div>
+          ) : null}
+          <p className="min-w-0 flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white">
+            {title}
+          </p>
           {onToggleEnabled ? (
-            <ToggleSwitch
-              checked={enabled}
-              ariaLabel={`${t("providers.enable_provider")} ${title}`}
-              onCheckedChange={onToggleEnabled}
-            />
+            <div className="shrink-0">
+              <ToggleSwitch
+                checked={enabled}
+                ariaLabel={`${t("providers.enable_provider")} ${title}`}
+                onCheckedChange={onToggleEnabled}
+              />
+            </div>
           ) : null}
         </div>
+        {hasHeaderExtra ? (
+          <div className="flex flex-wrap items-center justify-end gap-2">{headerExtra}</div>
+        ) : null}
       </div>
 
       {/* Content */}

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -58,6 +58,14 @@ export function ProviderKeyListCard({
   onToggleSelected?: (key: string, checked: boolean) => void;
 }) {
   const { t } = useTranslation();
+  const gridStyle =
+    gridColumns > 1
+      ? {
+          gridTemplateColumns: `repeat(auto-fit, minmax(min(100%, max(20rem, calc((100% - ${
+            (gridColumns - 1) * 0.75
+          }rem) / ${gridColumns}))), 1fr))`,
+        }
+      : undefined;
 
   return (
     <Card
@@ -82,11 +90,7 @@ export function ProviderKeyListCard({
             "min-h-0 flex-1 overflow-y-auto pr-1",
             gridColumns > 1 ? "grid gap-3" : "space-y-3",
           ].join(" ")}
-          style={
-            gridColumns > 1
-              ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` }
-              : undefined
-          }
+          style={gridStyle}
         >
           {items.map((item, idx) => {
             const selectionKey = `${item.apiKey.trim().toLowerCase()}:${idx}`;
@@ -135,12 +139,18 @@ export function ProviderKeyListCard({
                         };
                         const providerBaseUrl = item.baseUrl || "";
                         return (
-                          <span
-                            className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
+                          <button
+                            type="button"
+                            className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/25 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300 dark:focus-visible:ring-blue-300/20"
                             onClick={(e) => {
                               e.stopPropagation();
                               if (providerBaseUrl) checkLatency(latencyKey, providerBaseUrl);
                             }}
+                            aria-label={
+                              providerBaseUrl
+                                ? `Check latency: ${providerBaseUrl}`
+                                : "No base URL configured"
+                            }
                             title={
                               providerBaseUrl
                                 ? `Check latency: ${providerBaseUrl}`
@@ -156,7 +166,7 @@ export function ProviderKeyListCard({
                             ) : (
                               <Zap size={10} />
                             )}
-                          </span>
+                          </button>
                         );
                       })()
                     : undefined
@@ -208,9 +218,11 @@ export function ProviderKeyListCard({
                     {headerEntries.map(([k, v]) => (
                       <span
                         key={k}
-                        className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        title={`${k}: ${String(v)}`}
                       >
-                        <span className="font-semibold">{k}:</span> {String(v)}
+                        <span className="shrink-0 font-semibold">{k}:</span>
+                        <span className="min-w-0 truncate">{String(v)}</span>
                       </span>
                     ))}
                   </div>
@@ -218,21 +230,25 @@ export function ProviderKeyListCard({
 
                 {models.length ? (
                   <div className="mt-2 flex flex-wrap gap-1">
-                    {models.map((model) => (
-                      <span
-                        key={model.name}
-                        className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-                        title={
-                          model.alias && model.alias !== model.name
-                            ? `${model.name} => ${model.alias}`
-                            : model.name
-                        }
-                      >
-                        {model.alias && model.alias !== model.name
+                    {models.map((model) => {
+                      const modelLabel =
+                        model.alias && model.alias !== model.name
                           ? `${model.name} → ${model.alias}`
-                          : model.name}
-                      </span>
-                    ))}
+                          : model.name;
+                      return (
+                        <span
+                          key={model.name}
+                          className="inline-flex max-w-full min-w-0 rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                          title={
+                            model.alias && model.alias !== model.name
+                              ? `${model.name} => ${model.alias}`
+                              : model.name
+                          }
+                        >
+                          <span className="min-w-0 truncate">{modelLabel}</span>
+                        </span>
+                      );
+                    })}
                   </div>
                 ) : null}
 
@@ -241,9 +257,10 @@ export function ProviderKeyListCard({
                     {excludedModels.map((model) => (
                       <span
                         key={model}
-                        className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+                        className="inline-flex max-w-full min-w-0 rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+                        title={model}
                       >
-                        {model}
+                        <span className="min-w-0 truncate">{model}</span>
                       </span>
                     ))}
                   </div>

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -48,6 +48,14 @@ export function OpenAIProvidersTab({
   onToggleSelected,
 }: OpenAIProvidersTabProps) {
   const { t } = useTranslation();
+  const gridStyle =
+    gridColumns > 1
+      ? {
+          gridTemplateColumns: `repeat(auto-fit, minmax(min(100%, max(20rem, calc((100% - ${
+            (gridColumns - 1) * 0.75
+          }rem) / ${gridColumns}))), 1fr))`,
+        }
+      : undefined;
 
   return (
     <Card
@@ -75,11 +83,7 @@ export function OpenAIProvidersTab({
             "min-h-0 flex-1 overflow-y-auto pr-1",
             gridColumns > 1 ? "grid gap-3" : "space-y-3",
           ].join(" ")}
-          style={
-            gridColumns > 1
-              ? { gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))` }
-              : undefined
-          }
+          style={gridStyle}
         >
           {providers.map((provider, idx) => {
             const selectionKey = `${provider.name.trim().toLowerCase()}:${idx}`;
@@ -122,9 +126,11 @@ export function OpenAIProvidersTab({
                     {headerEntries.map(([key, value]) => (
                       <span
                         key={key}
-                        className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        title={`${key}: ${String(value)}`}
                       >
-                        <span className="font-semibold">{key}:</span> {String(value)}
+                        <span className="shrink-0 font-semibold">{key}:</span>
+                        <span className="min-w-0 truncate">{String(value)}</span>
                       </span>
                     ))}
                   </div>
@@ -142,7 +148,7 @@ export function OpenAIProvidersTab({
                         return (
                           <div
                             key={`${entry.apiKey}:${entryIndex}`}
-                            className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60"
+                            className="grid gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
                           >
                             <div className="min-w-0">
                               <p className="truncate font-mono text-slate-900 dark:text-white">
@@ -154,7 +160,7 @@ export function OpenAIProvidersTab({
                                 </p>
                               ) : null}
                             </div>
-                            <div className="flex flex-wrap items-center gap-2 tabular-nums">
+                            <div className="flex flex-wrap items-center gap-2 tabular-nums sm:justify-end">
                               <span
                                 className={[
                                   "rounded-full px-2 py-0.5 font-semibold",
@@ -206,21 +212,25 @@ export function OpenAIProvidersTab({
 
                 {provider.models?.length ? (
                   <div className="mt-2 flex flex-wrap gap-1">
-                    {provider.models.map((model) => (
-                      <span
-                        key={model.name}
-                        className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-                        title={
-                          model.alias && model.alias !== model.name
-                            ? `${model.name} => ${model.alias}`
-                            : model.name
-                        }
-                      >
-                        {model.alias && model.alias !== model.name
+                    {provider.models.map((model) => {
+                      const modelLabel =
+                        model.alias && model.alias !== model.name
                           ? `${model.name} → ${model.alias}`
-                          : model.name}
-                      </span>
-                    ))}
+                          : model.name;
+                      return (
+                        <span
+                          key={model.name}
+                          className="inline-flex max-w-full min-w-0 rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
+                          title={
+                            model.alias && model.alias !== model.name
+                              ? `${model.name} => ${model.alias}`
+                              : model.name
+                          }
+                        >
+                          <span className="min-w-0 truncate">{modelLabel}</span>
+                        </span>
+                      );
+                    })}
                   </div>
                 ) : null}
 


### PR DESCRIPTION
## Summary
- Refined the auth files filter area so type chips, tag/status/search controls, model-owner selection, and batch actions align cleanly across desktop and mobile.
- Hardened provider cards against long titles, headers, model badges, OpenAI key rows, and high column counts without squeezing card titles.
- Kept provider edit/delete actions in the compact action menu while separating latency controls from the title row.

## Validation
- bun run lint
- bunx oxfmt src/modules/auth-files/components/AuthFilesFilesTab.tsx src/modules/providers/ProviderCard.tsx src/modules/providers/ProviderKeyListCard.tsx src/modules/providers/components/OpenAIProvidersTab.tsx --check
- bun run test:ci src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx src/modules/providers/__tests__/ProvidersPage.openai.test.tsx src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- bun run build
- Local Chrome UI verification on desktop and narrow mobile widths for all /ai-providers tabs plus /auth-files filters and cards