### PR TITLE
Fix AI providers card scrolling and action menu

### DIFF
--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -2,7 +2,6 @@ import { useState, type ReactNode } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { EllipsisVertical, Settings2, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { buttonClassName } from "@/modules/ui/Button";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 
 const ACTION_MENU_CONTENT_CLASS =
@@ -56,7 +55,6 @@ export function ProviderCard({
     <div
       className={[
         "group relative rounded-2xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out",
-        hasActionMenu ? "pr-11" : "",
         selected
           ? "border-blue-400 bg-blue-50/50 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-950/20 dark:ring-blue-500/20"
           : "border-slate-200 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
@@ -65,53 +63,6 @@ export function ProviderCard({
         .filter(Boolean)
         .join(" ")}
     >
-      {hasActionMenu ? (
-        <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
-          <DropdownMenu.Trigger asChild>
-            <button
-              type="button"
-              className={[
-                buttonClassName({
-                  variant: "ghost",
-                  size: "xs",
-                  iconOnly: true,
-                  className:
-                    "!h-7 !w-7 bg-white/85 text-slate-500 shadow-sm ring-1 ring-slate-200/80 hover:text-slate-950 dark:bg-neutral-950/85 dark:text-white/55 dark:ring-neutral-800 dark:hover:text-white",
-                }),
-                "absolute right-2 top-2 z-10 transition-opacity duration-150 ease-out",
-                menuOpen
-                  ? "pointer-events-auto opacity-100"
-                  : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
-              ].join(" ")}
-              aria-label={t("providers.more_actions")}
-              title={t("providers.more_actions")}
-              data-tooltip-placement="left"
-            >
-              <EllipsisVertical size={14} />
-            </button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content align="end" sideOffset={8} className={ACTION_MENU_CONTENT_CLASS}>
-              {onEdit ? (
-                <DropdownMenu.Item className={ACTION_MENU_ITEM_CLASS} onSelect={() => onEdit()}>
-                  <Settings2 size={15} />
-                  <span>{t("providers.edit")}</span>
-                </DropdownMenu.Item>
-              ) : null}
-              {onDelete ? (
-                <DropdownMenu.Item
-                  className={ACTION_MENU_DANGER_ITEM_CLASS}
-                  onSelect={() => onDelete()}
-                >
-                  <Trash2 size={15} />
-                  <span>{t("providers.delete")}</span>
-                </DropdownMenu.Item>
-              ) : null}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-      ) : null}
-
       {/* Header */}
       <div className="grid gap-2">
         <div className="flex min-w-0 items-center gap-2">
@@ -144,6 +95,49 @@ export function ProviderCard({
                 onCheckedChange={onToggleEnabled}
               />
             </div>
+          ) : null}
+          {hasActionMenu ? (
+            <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
+              <DropdownMenu.Trigger asChild>
+                <button
+                  type="button"
+                  className={[
+                    "inline-flex h-5 w-5 flex-none items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none outline-none ring-0 transition-[color,opacity] duration-150 ease-out hover:bg-transparent hover:text-slate-950 focus-visible:ring-2 focus-visible:ring-slate-400/35 active:bg-transparent dark:text-white/55 dark:hover:bg-transparent dark:hover:text-white dark:focus-visible:ring-white/15",
+                    menuOpen
+                      ? "pointer-events-auto opacity-100"
+                      : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+                  ].join(" ")}
+                  aria-label={t("providers.more_actions")}
+                  title={t("providers.more_actions")}
+                  data-tooltip-placement="left"
+                >
+                  <EllipsisVertical size={13} />
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  align="end"
+                  sideOffset={8}
+                  className={ACTION_MENU_CONTENT_CLASS}
+                >
+                  {onEdit ? (
+                    <DropdownMenu.Item className={ACTION_MENU_ITEM_CLASS} onSelect={() => onEdit()}>
+                      <Settings2 size={15} />
+                      <span>{t("providers.edit")}</span>
+                    </DropdownMenu.Item>
+                  ) : null}
+                  {onDelete ? (
+                    <DropdownMenu.Item
+                      className={ACTION_MENU_DANGER_ITEM_CLASS}
+                      onSelect={() => onDelete()}
+                    >
+                      <Trash2 size={15} />
+                      <span>{t("providers.delete")}</span>
+                    </DropdownMenu.Item>
+                  ) : null}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           ) : null}
         </div>
         {hasHeaderExtra ? (

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -711,7 +711,7 @@ export function ProvidersPage() {
   return (
     <div
       data-testid="providers-page-shell"
-      className="flex min-h-[calc(100dvh-112px)] flex-col gap-6"
+      className="flex h-[calc(100dvh-97px)] min-h-0 flex-col gap-6 overflow-hidden sm:h-[calc(100dvh-113px)]"
     >
       <div className="flex flex-wrap items-center gap-3">
         <div className="space-y-0.5">
@@ -832,7 +832,7 @@ export function ProvidersPage() {
           void refreshTab(nextTab);
         }}
       >
-        <div className="flex flex-col gap-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
           <div className="flex shrink-0">
             <TabsList>
               <TabsTrigger value="gemini">
@@ -872,7 +872,7 @@ export function ProvidersPage() {
               </TabsTrigger>
             </TabsList>
           </div>
-          <TabsContent value="gemini" className="flex flex-col">
+          <TabsContent value="gemini" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               title={t("providers.gemini_keys")}
               description={t("providers.openai_desc")}
@@ -893,7 +893,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="claude" className="flex flex-col">
+          <TabsContent value="claude" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               title={t("providers.claude_keys")}
               description={t("providers.codex_desc")}
@@ -914,7 +914,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="codex" className="flex flex-col">
+          <TabsContent value="codex" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               title={t("providers.codex_keys")}
               description={t("providers.gemini_desc")}
@@ -935,7 +935,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="opencode-go" className="flex flex-col">
+          <TabsContent value="opencode-go" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               title={t("providers.opencode_go_keys")}
               description={t("providers.opencode_go_desc")}
@@ -957,7 +957,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="vertex" className="flex flex-col">
+          <TabsContent value="vertex" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               title={t("providers.vertex_keys")}
               description={t("providers.vertex_desc")}
@@ -977,7 +977,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="bedrock" className="flex flex-col">
+          <TabsContent value="bedrock" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               title={t("providers.bedrock_keys")}
               description={t("providers.bedrock_desc")}
@@ -998,7 +998,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="openai" className="flex flex-col">
+          <TabsContent value="openai" className="min-h-0 flex flex-1 flex-col">
             <OpenAIProvidersTab
               providers={openaiProviders}
               loading={isActiveTabListLoading("openai")}
@@ -1020,7 +1020,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="ampcode" className="flex flex-col">
+          <TabsContent value="ampcode" className="min-h-0 flex flex-1 flex-col">
             <AmpcodePanel
               loading={loading}
               isPending={isPending}

--- a/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -256,7 +256,7 @@ describe("ProvidersPage import/export", () => {
     ).toBeInTheDocument();
   });
 
-  test("lets the provider page grow so the app shell can scroll", async () => {
+  test("keeps provider scrolling inside the card list area", async () => {
     const user = userEvent.setup();
 
     render(
@@ -275,9 +275,10 @@ describe("ProvidersPage import/export", () => {
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
 
     expect(screen.getByTestId("providers-page-shell")).toHaveClass(
-      "min-h-[calc(100dvh-112px)]",
+      "h-[calc(100dvh-97px)]",
+      "sm:h-[calc(100dvh-113px)]",
+      "overflow-hidden",
     );
-    expect(screen.getByTestId("providers-page-shell")).not.toHaveClass("overflow-hidden");
     expect(screen.getByTestId("providers-tab-scroll")).toHaveClass("overflow-y-auto");
   });
 


### PR DESCRIPTION
## Summary
- keep the AI providers page shell fixed-height so scrolling stays inside the provider card list
- move provider card edit/delete actions into a compact hover-only overflow menu aligned with the enable switch
- update provider page coverage for the internal scroll container

## Validation
- bun run test src/modules/providers/__tests__/ProvidersPage.openai.test.tsx src/modules/providers/__tests__/ProvidersPage.import-export.test.tsx
- bun run build
- verified desktop and mobile provider-list scrolling and hover menu behavior in local browser checks