### PR TITLE
fix(apikey-lookup): bring back Quick Import without management key

### DIFF
--- a/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
+++ b/src/modules/apikey-lookup/ApiKeyLookupPage.tsx
@@ -25,6 +25,7 @@ import {
   buildLogColumns,
   PublicLogsSection,
 } from "@/modules/apikey-lookup/components/PublicLogsSection";
+import { QuickImportTabContent } from "@/modules/apikey-lookup/components/QuickImportTabContent";
 import { UsageTabSection } from "@/modules/apikey-lookup/components/UsageTabSection";
 import { useApiKeyLookupCharts } from "@/modules/apikey-lookup/hooks/useApiKeyLookupCharts";
 import type { ChartDataResponse, LogRow, PublicLogItem } from "@/modules/apikey-lookup/types";
@@ -184,6 +185,7 @@ export function ApiKeyLookupPage() {
 
   // ── Tab state ──
   const [activeTab, setActiveTab] = useState<ApiKeyLookupTab>("usage");
+  const [quickImportReloadToken, setQuickImportReloadToken] = useState(0);
 
   // ── Logs state (server-side pagination) ──
   const [rawItems, setRawItems] = useState<PublicLogItem[]>([]);
@@ -457,6 +459,8 @@ export function ApiKeyLookupPage() {
         void fetchChartDataFn(queriedKey, timeRange);
       } else if (activeTab === "models") {
         void fetchModelsFn(queriedKey);
+      } else if (activeTab === "quickImport") {
+        setQuickImportReloadToken((value) => value + 1);
       } else {
         fetchLogs(queriedKey, 1);
       }
@@ -629,6 +633,12 @@ export function ApiKeyLookupPage() {
                   searchFilter={modelsSearchFilter}
                   onSearchChange={setModelsSearchFilter}
                 />
+              </Reveal>
+            ) : null}
+
+            {activeTab === "quickImport" ? (
+              <Reveal>
+                <QuickImportTabContent apiKey={queriedKey} reloadToken={quickImportReloadToken} />
               </Reveal>
             ) : null}
           </>

--- a/src/modules/apikey-lookup/components/LookupResultsToolbar.tsx
+++ b/src/modules/apikey-lookup/components/LookupResultsToolbar.tsx
@@ -3,7 +3,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { TimeRangeSelector } from "@/modules/monitor/MonitorPagePieces";
 import type { TimeRange } from "@/modules/monitor/monitor-constants";
 
-export type ApiKeyLookupTab = "usage" | "logs" | "models";
+export type ApiKeyLookupTab = "usage" | "logs" | "models" | "quickImport";
 
 export function LookupResultsToolbar({
   t,
@@ -34,6 +34,7 @@ export function LookupResultsToolbar({
             <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
             <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
             <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
+            <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
           </TabsList>
         </Tabs>
         {activeTab === "usage" || activeTab === "logs" ? (

--- a/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
+++ b/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
@@ -56,19 +56,44 @@ function readStoredManagementAuth(): { apiBase: string; managementKey: string } 
   }
 }
 
-async function fetchQuickImportConfigs(): Promise<CcSwitchImportConfigListItem[]> {
+async function fetchPublicQuickImportConfigs(apiKey: string): Promise<CcSwitchImportConfigListItem[]> {
+  const key = apiKey.trim();
+  if (!key) return [];
+
+  const base = detectApiBaseFromLocation();
+  const resp = await fetch(`${base}${MANAGEMENT_API_PREFIX}/public/ccswitch-import-configs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ api_key: key }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(text || `Request failed (${resp.status})`);
+  }
+  const data = (await resp.json()) as Record<string, unknown>;
+  return normalizeCcSwitchImportConfigs(data["ccswitch-import-configs"] ?? data.items ?? data);
+}
+
+async function fetchQuickImportConfigs(apiKey: string): Promise<CcSwitchImportConfigListItem[]> {
   const auth = readStoredManagementAuth();
-  const managementBase = auth
-    ? computeManagementApiBase(auth.apiBase)
-    : `${detectApiBaseFromLocation()}${MANAGEMENT_API_PREFIX}`;
+  if (!auth) {
+    try {
+      return await fetchPublicQuickImportConfigs(apiKey);
+    } catch {
+      // Backward compatible fallback for older servers that don't have the public endpoint yet.
+      return ccSwitchImportConfigsApi.list();
+    }
+  }
+
+  const managementBase = computeManagementApiBase(auth.apiBase);
 
   try {
     const response = await fetch(`${managementBase}/ccswitch-import-configs`, {
-      headers: auth
-        ? {
-            Authorization: `Bearer ${auth.managementKey}`,
-          }
-        : undefined,
+      headers: {
+        Authorization: `Bearer ${auth.managementKey}`,
+      },
     });
     if (!response.ok) {
       const text = await response.text().catch(() => "");
@@ -77,8 +102,7 @@ async function fetchQuickImportConfigs(): Promise<CcSwitchImportConfigListItem[]
     const data = (await response.json()) as Record<string, unknown>;
     return normalizeCcSwitchImportConfigs(data["ccswitch-import-configs"] ?? data.items ?? data);
   } catch (err) {
-    if (auth) throw err;
-    return ccSwitchImportConfigsApi.list();
+    throw err;
   }
 }
 
@@ -272,7 +296,7 @@ export function QuickImportTabContent({
     setLoading(true);
     setError(null);
 
-    Promise.all([fetchQuickImportConfigs(), fetchQuickImportApiKeyEntry(apiKey)])
+    Promise.all([fetchQuickImportConfigs(apiKey), fetchQuickImportApiKeyEntry(apiKey)])
       .then(([items, entry]) => {
         if (cancelled) return;
         setConfigs(items.filter((item) => QUICK_IMPORT_CLIENTS.includes(item.clientType)));


### PR DESCRIPTION
Restores the Quick Import tab on the standalone `/manage/apikey-lookup` page, but makes it work without requiring a management key.

- Re-add Quick Import tab.
- When no management auth is present, load presets via `/v0/management/public/ccswitch-import-configs` (POST with `api_key`) instead of management-only endpoints.

Validation:
- bun run test src/modules/apikey-lookup/components/__tests__/QuickImportTabContent.test.tsx
- bun run test src/modules/apikey-lookup/__tests__/ApiKeyLookupPage.test.tsx
