### PR TITLE
feat: add resizable data table columns

### DIFF
--- a/.helloagents/plan/2026-05-28-resizable-table-columns/tasks.md
+++ b/.helloagents/plan/2026-05-28-resizable-table-columns/tasks.md
@@ -1,0 +1,19 @@
+# 表格列宽拖拽任务
+
+<!-- LIVE_STATUS_BEGIN -->
+- 状态：验证完成
+- 进度：已完成实现、测试、构建和 Chrome 桌面/移动真实界面验收
+- 更新时间：2026-05-28 21:25
+- 当前：准备提交并合并回 dev
+<!-- LIVE_STATUS_END -->
+
+## 清单
+
+- [x] 同步 `dev` / `main` 基线并从 `origin/dev` 创建功能分支
+- [x] 检查并恢复 `main` / `dev` 分支保护
+- [x] 定位管理端公共表格组件
+- [x] 实现列宽拖拽、视觉提示、边界与 localStorage 缓存
+- [x] 补充组件测试
+- [x] 运行 lint、format、格式化检查和 build
+- [x] 使用 Chrome DevTools MCP 覆盖桌面和移动真实界面验收
+- [ ] 推送功能分支并合并回 `dev`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@
 - OAuth 登录弹窗：`src/modules/oauth/OAuthLoginDialog.tsx`
 - CC Switch 导入：`src/modules/ccswitch/`（deeplink 协议生成与复用入口组件）
 - 自动更新提示：`src/modules/update/AutoUpdatePrompt.tsx`
+- 通用数据表格：`src/modules/ui/DataTable.tsx`（有限行表格壳，支持列宽拖拽与按 `tableId` 的 localStorage 缓存）
 - 模型配置管理：`src/modules/models/ModelsPage.tsx`（`/manage/models`，数据库模型配置与计价规则）
 - 代理池管理：`src/modules/proxies/ProxiesPage.tsx`（`/proxies`，集中维护可复用出站代理）
 - API Key 权限配置：`src/modules/api-key-permissions/ApiKeyPermissionsPage.tsx`（`/api-key-permissions`，维护可复用权限配置，供 API Key 弹窗选择）

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -73,7 +73,9 @@
     "zoom_out": "Zoom out",
     "rotate_left": "Rotate left",
     "rotate_right": "Rotate right",
-    "reset_image": "Reset image"
+    "reset_image": "Reset image",
+    "resize_column": "Drag to resize {{column}} column",
+    "column_width_px": "Width: {{width}} px"
   },
   "title": {
     "main": "Code Proxy Admin Dashboard",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -55,7 +55,9 @@
     "zoom_out": "Уменьшить",
     "rotate_left": "Повернуть влево",
     "rotate_right": "Повернуть вправо",
-    "reset_image": "Сбросить изображение"
+    "reset_image": "Сбросить изображение",
+    "resize_column": "Перетащите, чтобы изменить ширину столбца {{column}}",
+    "column_width_px": "Ширина: {{width}} px"
   },
   "ccswitch": {
     "import_to_ccswitch": "Импорт в CC Switch",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -75,7 +75,9 @@
     "zoom_out": "缩小",
     "rotate_left": "向左旋转",
     "rotate_right": "向右旋转",
-    "reset_image": "还原图片"
+    "reset_image": "还原图片",
+    "resize_column": "拖拽调整 {{column}} 列宽",
+    "column_width_px": "宽：{{width}} 像素"
   },
   "title": {
     "main": "Code Proxy 管理后台",

--- a/src/modules/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/src/modules/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -19,7 +19,7 @@ import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 import { useToast } from "@/modules/ui/ToastProvider";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 
 type ProfileDraft = {
   id: string;
@@ -269,7 +269,7 @@ export function ApiKeyPermissionsPage() {
     }
   };
 
-  const columns = useMemo<VirtualTableColumn<ApiKeyPermissionProfile>[]>(
+  const columns = useMemo<DataTableColumn<ApiKeyPermissionProfile>[]>(
     () => [
       {
         key: "name",
@@ -406,7 +406,8 @@ export function ApiKeyPermissionsPage() {
             icon={<ShieldCheck size={32} />}
           />
         ) : (
-          <VirtualTable<ApiKeyPermissionProfile>
+          <DataTable<ApiKeyPermissionProfile>
+            tableId="api-key-permission-profiles"
             rows={profiles}
             columns={columns}
             rowKey={(profile) => profile.id}

--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -24,7 +24,7 @@ import { Card } from "@/modules/ui/Card";
 import { Button } from "@/modules/ui/Button";
 import { EmptyState } from "@/modules/ui/EmptyState";
 import { useToast } from "@/modules/ui/ToastProvider";
-import { VirtualTable } from "@/modules/ui/VirtualTable";
+import { DataTable } from "@/modules/ui/DataTable";
 import { ApiKeyFormModal } from "@/modules/api-keys/components/ApiKeyFormModal";
 import { ApiKeyUsageModal } from "@/modules/api-keys/components/ApiKeyUsageModal";
 import { useApiKeyPermissionOptions } from "@/modules/api-keys/hooks/useApiKeyPermissionOptions";
@@ -533,7 +533,8 @@ export function ApiKeysPage() {
             icon={<KeyRound size={32} className="text-slate-400" />}
           />
         ) : (
-          <VirtualTable<ApiKeyEntry>
+          <DataTable<ApiKeyEntry>
+            tableId="api-keys"
             rows={entries}
             columns={apiKeyColumns}
             rowKey={(row) => row.key}

--- a/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/src/modules/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -165,8 +165,8 @@ vi.mock("@/modules/monitor/ErrorDetailModal", () => ({
   ErrorDetailModal: () => null,
 }));
 
-vi.mock("@/modules/ui/VirtualTable", () => ({
-  VirtualTable: ({ rows, columns }: { rows: any[]; columns: any[] }) => (
+vi.mock("@/modules/ui/DataTable", () => ({
+  DataTable: ({ rows, columns }: { rows: any[]; columns: any[] }) => (
     <div>
       {rows.map((row, rowIndex) => (
         <div key={row.key}>
@@ -655,9 +655,7 @@ describe("ApiKeysPage", () => {
       await waitFor(() => {
         expect(writeText).toHaveBeenCalledWith(expect.stringContaining("ccswitch://v1/import?"));
       });
-      expect(
-        screen.getByRole("button", { name: /import link copied/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /import link copied/i })).toBeInTheDocument();
       expect(openSpy).not.toHaveBeenCalled();
 
       const copiedUrl = String(writeText.mock.calls.at(-1)?.[0] ?? "");

--- a/src/modules/api-keys/components/ApiKeyColumns.tsx
+++ b/src/modules/api-keys/components/ApiKeyColumns.tsx
@@ -19,7 +19,7 @@ import {
   VendorIcon,
 } from "@/modules/api-keys/apiKeyPageUtils";
 import { HoverTooltip, OverflowTooltip } from "@/modules/ui/Tooltip";
-import type { VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import type { DataTableColumn } from "@/modules/ui/DataTable";
 
 type CreateApiKeyColumnsOptions = {
   t: TFunction;
@@ -39,7 +39,7 @@ export const createApiKeyColumns = ({
   onImportToCcSwitch,
   onEdit,
   onDelete,
-}: CreateApiKeyColumnsOptions): VirtualTableColumn<ApiKeyEntry>[] => [
+}: CreateApiKeyColumnsOptions): DataTableColumn<ApiKeyEntry>[] => [
   {
     key: "status",
     label: t("api_keys_page.col_status"),

--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -27,7 +27,7 @@ import { HoverTooltip } from "@/modules/ui/Tooltip";
 import { Select } from "@/modules/ui/Select";
 import { SearchableSelect, type SearchableSelectOption } from "@/modules/ui/SearchableSelect";
 import { Tabs, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 import type {
   AuthFileModelOwnerGroup,
@@ -508,7 +508,7 @@ interface AuthFilesFilesTabProps {
   selectedFileNames: string[];
   deletingAll: boolean;
   pageItems: AuthFileItem[];
-  fileColumns: VirtualTableColumn<AuthFileItem>[];
+  fileColumns: DataTableColumn<AuthFileItem>[];
   filesViewMode: FilesViewMode;
   selectedFileNameSet: Set<string>;
   quotaByFileName: Record<string, QuotaState>;
@@ -1137,7 +1137,8 @@ export function AuthFilesFilesTab({
         <Card padding="none" className="relative overflow-hidden">
           <div className="p-4 sm:p-5">
             {filesViewMode === "table" ? (
-              <VirtualTable<AuthFileItem>
+              <DataTable<AuthFileItem>
+                tableId="auth-files"
                 rows={pageItems}
                 columns={fileColumns}
                 rowKey={(row) => row.name}

--- a/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/src/modules/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -18,7 +18,7 @@ import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { HoverTooltip } from "@/modules/ui/Tooltip";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
-import type { VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import type { DataTableColumn } from "@/modules/ui/DataTable";
 import {
   pickQuotaPreviewItem,
   type FilesViewMode,
@@ -493,7 +493,7 @@ export function useAuthFilesFilesPresentation({
     [formatQuotaResetTextCompact, translateQuotaText],
   );
 
-  const fileColumns = useMemo<VirtualTableColumn<AuthFileItem>[]>(() => {
+  const fileColumns = useMemo<DataTableColumn<AuthFileItem>[]>(() => {
     return [
       {
         key: "select",

--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/modules/ui/Button";
 import { Card } from "@/modules/ui/Card";
 import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { useToast } from "@/modules/ui/ToastProvider";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 import {
   CcSwitchImportConfigModal,
   type CcSwitchChannelGroupOption,
@@ -166,7 +166,7 @@ export function CcSwitchImportSettingsPage() {
     };
   }, [notify, t]);
 
-  const columns = useMemo<VirtualTableColumn<CcSwitchImportConfigListItem>[]>(
+  const columns = useMemo<DataTableColumn<CcSwitchImportConfigListItem>[]>(
     () => [
       {
         key: "client",
@@ -316,7 +316,8 @@ export function CcSwitchImportSettingsPage() {
         padding="compact"
         className="rounded-2xl"
       >
-        <VirtualTable<CcSwitchImportConfigListItem>
+        <DataTable<CcSwitchImportConfigListItem>
+          tableId="ccswitch-import-configs"
           rows={configs}
           columns={columns}
           rowKey={(row) => row.id}

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -21,7 +21,7 @@ import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { HoverTooltip, OverflowTooltip } from "@/modules/ui/Tooltip";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 import { VendorIcon } from "@/modules/api-keys/apiKeyPageUtils";
 import {
   emptyModelPricing,
@@ -894,7 +894,7 @@ export function RoutingConfigEditor({
     setDeleteGroupTarget(null);
   }, [deleteGroupTarget, removeRoutingGroup]);
 
-  const groupColumns = useMemo<VirtualTableColumn<RoutingChannelGroupEntry>[]>(
+  const groupColumns = useMemo<DataTableColumn<RoutingChannelGroupEntry>[]>(
     () => [
       {
         key: "name",
@@ -1143,7 +1143,7 @@ export function RoutingConfigEditor({
     [disabled, openEditGroup, resolveGroupChannels, routesByGroup, staleChannelsByGroup, t],
   );
 
-  const groupMemberColumns = useMemo<VirtualTableColumn<RoutingChannelGroupMemberEntry>[]>(
+  const groupMemberColumns = useMemo<DataTableColumn<RoutingChannelGroupMemberEntry>[]>(
     () => [
       {
         key: "channel",
@@ -1237,7 +1237,7 @@ export function RoutingConfigEditor({
                   </Button>
                 </div>
               ),
-            } satisfies VirtualTableColumn<RoutingChannelGroupMemberEntry>,
+            } satisfies DataTableColumn<RoutingChannelGroupMemberEntry>,
           ]),
     ],
     [
@@ -1251,7 +1251,7 @@ export function RoutingConfigEditor({
     ],
   );
 
-  const modelColumns = useMemo<VirtualTableColumn<RoutingModelOption>[]>(
+  const modelColumns = useMemo<DataTableColumn<RoutingModelOption>[]>(
     () => [
       {
         key: "select",
@@ -1406,7 +1406,8 @@ export function RoutingConfigEditor({
           </Button>
         </div>
 
-        <VirtualTable<RoutingChannelGroupEntry>
+        <DataTable<RoutingChannelGroupEntry>
+          tableId="routing-channel-groups"
           rows={displayGroups}
           columns={groupColumns}
           rowKey={(group) => group.id}
@@ -1772,7 +1773,8 @@ export function RoutingConfigEditor({
                     )}
                   </div>
 
-                  <VirtualTable<RoutingChannelGroupMemberEntry>
+                  <DataTable<RoutingChannelGroupMemberEntry>
+                    tableId="routing-channel-group-members"
                     rows={resolvedDraftChannels}
                     columns={groupMemberColumns}
                     rowKey={(channel) => channel.id}
@@ -1848,7 +1850,8 @@ export function RoutingConfigEditor({
                       data-testid="group-editor-model-list"
                       className="min-h-0 flex-1 overflow-hidden"
                     >
-                      <VirtualTable<RoutingModelOption>
+                      <DataTable<RoutingModelOption>
+                        tableId="routing-model-options"
                         rows={modelOptions}
                         columns={modelColumns}
                         rowKey={(model) => model.id}

--- a/src/modules/image-generation/ImageGenerationPage.tsx
+++ b/src/modules/image-generation/ImageGenerationPage.tsx
@@ -9,7 +9,7 @@ import { ImagePreviewOverlay } from "@/modules/ui/ImagePreviewOverlay";
 import { Modal } from "@/modules/ui/Modal";
 import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 
 const GPT_IMAGE_MODEL = "gpt-image-2";
 const GENERATION_STATUS_KEYS = [
@@ -324,10 +324,12 @@ export function ImageGenerationPage() {
 
               <div className="grid gap-4 xl:grid-cols-2">
                 <SpecTable
+                  tableId="image-generation-request-params"
                   title={t("image_generation.request_params_title")}
                   rows={activeDoc.requestRows}
                 />
                 <SpecTable
+                  tableId="image-generation-response-schema"
                   title={t("image_generation.response_schema_title")}
                   rows={activeDoc.responseRows}
                 />
@@ -386,9 +388,9 @@ function EndpointCallDoc({ doc }: { doc: EndpointDoc }) {
   );
 }
 
-function SpecTable({ title, rows }: { title: string; rows: SpecRow[] }) {
+function SpecTable({ tableId, title, rows }: { tableId: string; title: string; rows: SpecRow[] }) {
   const { t } = useTranslation();
-  const columns = useMemo<VirtualTableColumn<SpecRow>[]>(
+  const columns = useMemo<DataTableColumn<SpecRow>[]>(
     () => [
       {
         key: "name",
@@ -428,7 +430,8 @@ function SpecTable({ title, rows }: { title: string; rows: SpecRow[] }) {
     >
       <h4 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h4>
       <div className="mt-4">
-        <VirtualTable<SpecRow>
+        <DataTable<SpecRow>
+          tableId={tableId}
           rows={rows}
           columns={columns}
           rowKey={(row) => row.name}

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { OverflowTooltip } from "@/modules/ui/Tooltip";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 import { apiClient } from "@/lib/http/client";
 import iconClaude from "@/assets/icons/claude.svg";
 import iconCodex from "@/assets/icons/codex.svg";
@@ -1062,7 +1062,7 @@ export function ModelsPage() {
 
   const canDeleteModels = activeTab === "library";
 
-  const modelColumns = useMemo<VirtualTableColumn<ModelItem>[]>(
+  const modelColumns = useMemo<DataTableColumn<ModelItem>[]>(
     () => [
       ...(canDeleteModels
         ? [
@@ -1088,7 +1088,7 @@ export function ModelsPage() {
                   onCheckedChange={(checked) => toggleModelSelection(row.id, checked)}
                 />
               ),
-            } satisfies VirtualTableColumn<ModelItem>,
+            } satisfies DataTableColumn<ModelItem>,
           ]
         : []),
       {
@@ -1551,7 +1551,8 @@ export function ModelsPage() {
                 </div>
               </div>
 
-              <VirtualTable<ModelItem>
+              <DataTable<ModelItem>
+                tableId="models-library"
                 rows={filteredModels}
                 columns={modelColumns}
                 rowKey={(row) => row.id}
@@ -1606,7 +1607,8 @@ export function ModelsPage() {
             </div>
           }
         >
-          <VirtualTable<ModelItem>
+          <DataTable<ModelItem>
+            tableId="model-configs"
             rows={filteredModels}
             columns={modelColumns}
             rowKey={(row) => row.id}

--- a/src/modules/monitor/RequestLogsPage.tsx
+++ b/src/modules/monitor/RequestLogsPage.tsx
@@ -9,7 +9,7 @@ import { Modal } from "@/modules/ui/Modal";
 import { useToast } from "@/modules/ui/ToastProvider";
 import { Select } from "@/modules/ui/Select";
 import { SearchableSelect } from "@/modules/ui/SearchableSelect";
-import { VirtualTable } from "@/modules/ui/VirtualTable";
+import { DataTable } from "@/modules/ui/DataTable";
 import { LogContentModal } from "@/modules/monitor/LogContentModal";
 import { ErrorDetailModal } from "@/modules/monitor/ErrorDetailModal";
 import {
@@ -401,7 +401,8 @@ export function RequestLogsPage() {
 
         {/* 表格区域 — 自适应视口高度，内部滚动 */}
         <div className="relative min-h-[360px] h-[calc(100dvh-300px)] overflow-hidden px-5">
-          <VirtualTable
+          <DataTable
+            tableId="request-logs"
             rows={rows}
             columns={logColumns}
             rowKey={(row) => row.id}

--- a/src/modules/monitor/__tests__/RequestLogsPage.test.tsx
+++ b/src/modules/monitor/__tests__/RequestLogsPage.test.tsx
@@ -148,7 +148,7 @@ describe("RequestLogsPage", () => {
     expect(await screen.findByText("No Data")).toBeInTheDocument();
   });
 
-  test("renders request logs table through the shared VirtualTable wrapper", async () => {
+  test("renders request logs table through the shared DataTable wrapper", async () => {
     await i18n.changeLanguage("zh-CN");
 
     mocks.getUsageLogs.mockResolvedValue({

--- a/src/modules/monitor/requestLogsShared.tsx
+++ b/src/modules/monitor/requestLogsShared.tsx
@@ -104,6 +104,9 @@ export interface RequestLogsTableColumn<T> {
   key: string;
   label: string;
   width?: string;
+  resizable?: boolean;
+  minWidthPx?: number;
+  maxWidthPx?: number;
   headerClassName?: string;
   cellClassName?: string;
   render: (row: T, index: number) => React.ReactNode;

--- a/src/modules/proxies/ProxiesPage.tsx
+++ b/src/modules/proxies/ProxiesPage.tsx
@@ -9,7 +9,7 @@ import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import { ToggleSwitch } from "@/modules/ui/ToggleSwitch";
 import { useToast } from "@/modules/ui/ToastProvider";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 import {
   emptyProxyDraft,
   proxyEndpoint,
@@ -198,7 +198,7 @@ export function ProxiesPage() {
     [refreshCheckResults],
   );
 
-  const columns = useMemo<VirtualTableColumn<ProxyPoolEntry>[]>(
+  const columns = useMemo<DataTableColumn<ProxyPoolEntry>[]>(
     () => [
       {
         key: "name",
@@ -354,7 +354,8 @@ export function ProxiesPage() {
       </div>
 
       <Card className="overflow-hidden" loading={loading && entries.length === 0}>
-        <VirtualTable<ProxyPoolEntry>
+        <DataTable<ProxyPoolEntry>
+          tableId="proxy-pool"
           rows={sortedEntries}
           columns={columns}
           rowKey={(entry) => entry.id}

--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from "react";
@@ -15,14 +16,20 @@ import { TableCellOverflowTooltip } from "@/modules/ui/TableCellOverflowTooltip"
 // Types
 // ---------------------------------------------------------------------------
 
-/** Column definition for VirtualTable */
-export interface VirtualTableColumn<T> {
+/** Column definition for DataTable */
+export interface DataTableColumn<T> {
   /** Unique key for this column */
   key: string;
   /** Header label */
   label: string;
   /** Fixed width class (Tailwind), e.g. "w-52" */
   width?: string;
+  /** Whether users can drag this column's right edge to resize it. */
+  resizable?: boolean;
+  /** Minimum drag-resize width in px. */
+  minWidthPx?: number;
+  /** Maximum drag-resize width in px. */
+  maxWidthPx?: number;
   /** Extra header class (e.g. "text-right") */
   headerClassName?: string;
   /** Extra cell class */
@@ -35,11 +42,13 @@ export interface VirtualTableColumn<T> {
   render: (row: T, index: number) => ReactNode;
 }
 
-export interface VirtualTableProps<T> {
+export interface DataTableProps<T> {
+  /** Stable id used to keep each table's column widths isolated in localStorage. */
+  tableId?: string;
   /** Row data array */
   rows: readonly T[];
   /** Column definitions */
-  columns: VirtualTableColumn<T>[];
+  columns: DataTableColumn<T>[];
   /** Unique key extractor for each row */
   rowKey: (row: T, index: number) => string;
   /** Whether the initial data is loading */
@@ -50,7 +59,7 @@ export interface VirtualTableProps<T> {
   loadingMore?: boolean;
   /** Callback when scrolled near bottom (triggers next page load) */
   onScrollBottom?: () => void;
-  /** Enable row virtualization (default true). Disable to allow natural row height. */
+  /** Legacy row windowing mode. Most management tables keep this disabled for finite row sets. */
   virtualize?: boolean;
   /** Row height in px (default 44) */
   rowHeight?: number;
@@ -87,8 +96,69 @@ const DEFAULT_ROW_HEIGHT = 44;
 const DEFAULT_OVERSCAN = 12;
 const DEFAULT_SCROLL_THRESHOLD = 100;
 const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
+const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v1";
+const DEFAULT_MIN_COLUMN_WIDTH = 72;
+const DEFAULT_MAX_COLUMN_WIDTH = 640;
+const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
 
-function resolveCellOverflowTooltip<T>(column: VirtualTableColumn<T>, row: T, index: number) {
+type ColumnWidthMap = Record<string, number>;
+
+function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
+  const minWidth = column.minWidthPx ?? DEFAULT_MIN_COLUMN_WIDTH;
+  const maxWidth = column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH;
+  return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
+}
+
+function getColumnWidthStorageKey(tableId?: string) {
+  const trimmed = tableId?.trim();
+  return trimmed ? `${COLUMN_WIDTH_STORAGE_PREFIX}.${trimmed}` : null;
+}
+
+function readStoredColumnWidths(tableId?: string): ColumnWidthMap {
+  const key = getColumnWidthStorageKey(tableId);
+  if (!key || typeof window === "undefined") return {};
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>)
+        .filter(([, value]) => typeof value === "number" && Number.isFinite(value))
+        .map(([columnKey, value]) => [columnKey, Math.round(value as number)]),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredColumnWidths(tableId: string | undefined, widths: ColumnWidthMap) {
+  const key = getColumnWidthStorageKey(tableId);
+  if (!key || typeof window === "undefined") return;
+
+  try {
+    const normalized = Object.fromEntries(
+      Object.entries(widths).filter(([, value]) => Number.isFinite(value) && value > 0),
+    );
+    window.localStorage.setItem(key, JSON.stringify(normalized));
+  } catch {
+    // localStorage can be unavailable in private browsing or embedded contexts.
+  }
+}
+
+function shouldAllowColumnResize<T>(
+  column: DataTableColumn<T>,
+  columnIndex: number,
+  columns: DataTableColumn<T>[],
+) {
+  if (columnIndex >= columns.length - 1) return false;
+  if (column.resizable !== undefined) return column.resizable;
+  return !NON_RESIZABLE_COLUMN_KEYS.has(column.key);
+}
+
+function resolveCellOverflowTooltip<T>(column: DataTableColumn<T>, row: T, index: number) {
   if (column.overflowTooltip === false) return false;
 
   if (typeof column.overflowTooltip === "function") {
@@ -103,7 +173,8 @@ function resolveCellOverflowTooltip<T>(column: VirtualTableColumn<T>, row: T, in
 // Component
 // ---------------------------------------------------------------------------
 
-export function VirtualTable<T>({
+export function DataTable<T>({
+  tableId,
   rows,
   columns,
   rowKey,
@@ -111,7 +182,7 @@ export function VirtualTable<T>({
   hasMore = false,
   loadingMore = false,
   onScrollBottom,
-  virtualize = true,
+  virtualize = false,
   rowHeight = DEFAULT_ROW_HEIGHT,
   overscan = DEFAULT_OVERSCAN,
   scrollThreshold = DEFAULT_SCROLL_THRESHOLD,
@@ -125,11 +196,23 @@ export function VirtualTable<T>({
   rowClassName,
   allowWheelPropagationAtBoundary = false,
   naturalFlow = false,
-}: VirtualTableProps<T>) {
+}: DataTableProps<T>) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const headerRef = useRef<HTMLTableSectionElement | null>(null);
+  const headerCellsRef = useRef<Record<string, HTMLTableCellElement | null>>({});
   const headerHeightRef = useRef(0);
+  const [columnWidths, setColumnWidths] = useState<ColumnWidthMap>(() =>
+    readStoredColumnWidths(tableId),
+  );
+  const columnWidthsRef = useRef<ColumnWidthMap>(columnWidths);
+  const [resizePreview, setResizePreview] = useState<null | {
+    width: number;
+    clientX: number;
+    rootTop: number;
+    rootBottom: number;
+  }>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(480);
@@ -154,6 +237,33 @@ export function VirtualTable<T>({
   });
 
   const colCount = columns.length;
+
+  useEffect(() => {
+    setColumnWidths(readStoredColumnWidths(tableId));
+  }, [tableId]);
+
+  useEffect(() => {
+    columnWidthsRef.current = columnWidths;
+  }, [columnWidths]);
+
+  useEffect(() => {
+    const validKeys = new Set(columns.map((column) => column.key));
+    setColumnWidths((prev) => {
+      let changed = false;
+      const next: ColumnWidthMap = {};
+      columns.forEach((column) => {
+        const width = prev[column.key];
+        if (width !== undefined) next[column.key] = clampColumnWidth(column, width);
+      });
+      Object.keys(prev).forEach((key) => {
+        if (!validKeys.has(key)) changed = true;
+      });
+      columns.forEach((column) => {
+        if (next[column.key] !== prev[column.key]) changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [columns]);
 
   const updateScrollMetrics = useCallback(() => {
     const el = containerRef.current;
@@ -324,7 +434,7 @@ export function VirtualTable<T>({
       if (!el) return;
 
       const pointerId = e.pointerId;
-      e.currentTarget.setPointerCapture(pointerId);
+      e.currentTarget.setPointerCapture?.(pointerId);
 
       if (axis === "y") {
         const headerH = headerHeightRef.current;
@@ -407,6 +517,115 @@ export function VirtualTable<T>({
     if (!drag) return;
     if (drag.pointerId !== e.pointerId) return;
     dragRef.current = null;
+  }, []);
+
+  const columnResizeRef = useRef<null | {
+    pointerId: number;
+    columnKey: string;
+    startClientX: number;
+    startWidth: number;
+    minWidth: number;
+    maxWidth: number;
+  }>(null);
+
+  const finishColumnResize = useCallback(() => {
+    const active = columnResizeRef.current;
+    if (!active) return;
+
+    columnResizeRef.current = null;
+    setResizePreview(null);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    const latestWidths = columnWidthsRef.current;
+    writeStoredColumnWidths(tableId, {
+      ...latestWidths,
+      [active.columnKey]: latestWidths[active.columnKey] ?? active.startWidth,
+    });
+  }, [tableId]);
+
+  const handleColumnResizePointerDown = useCallback(
+    (column: DataTableColumn<T>, e: ReactPointerEvent<HTMLButtonElement>) => {
+      if (e.button !== 0) return;
+
+      const headerCell = headerCellsRef.current[column.key];
+      if (!headerCell) return;
+
+      const rect = headerCell.getBoundingClientRect();
+      const rootRect = rootRef.current?.getBoundingClientRect();
+      const startWidth = columnWidths[column.key] ?? rect.width;
+      const minWidth = column.minWidthPx ?? DEFAULT_MIN_COLUMN_WIDTH;
+      const maxWidth = column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH;
+      const nextStartWidth = Math.max(minWidth, Math.min(maxWidth, startWidth));
+
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+
+      columnResizeRef.current = {
+        pointerId: e.pointerId,
+        columnKey: column.key,
+        startClientX: e.clientX,
+        startWidth: nextStartWidth,
+        minWidth,
+        maxWidth,
+      };
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      setColumnWidths((prev) => ({ ...prev, [column.key]: nextStartWidth }));
+      setResizePreview({
+        width: nextStartWidth,
+        clientX: e.clientX,
+        rootTop: rootRect?.top ?? 0,
+        rootBottom: rootRect?.bottom ?? window.innerHeight,
+      });
+    },
+    [columnWidths],
+  );
+
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent) => {
+      const active = columnResizeRef.current;
+      if (!active) return;
+
+      event.preventDefault();
+      const rootRect = rootRef.current?.getBoundingClientRect();
+      const nextWidth = Math.max(
+        active.minWidth,
+        Math.min(active.maxWidth, active.startWidth + event.clientX - active.startClientX),
+      );
+      const roundedWidth = Math.round(nextWidth);
+
+      columnWidthsRef.current = { ...columnWidthsRef.current, [active.columnKey]: roundedWidth };
+      setColumnWidths((prev) => ({ ...prev, [active.columnKey]: roundedWidth }));
+      setResizePreview({
+        width: roundedWidth,
+        clientX: event.clientX,
+        rootTop: rootRect?.top ?? 0,
+        rootBottom: rootRect?.bottom ?? window.innerHeight,
+      });
+    };
+
+    const handlePointerUp = () => finishColumnResize();
+    const handleWindowBlur = () => finishColumnResize();
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    window.addEventListener("blur", handleWindowBlur);
+
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [finishColumnResize]);
+
+  useEffect(() => {
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
   }, []);
 
   const measureHeaderHeight = useCallback(() => {
@@ -562,8 +781,18 @@ export function VirtualTable<T>({
     return { vThumb: v, hThumb: h };
   }, [headerHeight, scrollMetrics]);
 
+  const resolveColumnStyle = useCallback(
+    (column: DataTableColumn<T>): CSSProperties | undefined => {
+      const width = columnWidths[column.key];
+      if (!width) return undefined;
+      return { width, minWidth: width, maxWidth: width };
+    },
+    [columnWidths],
+  );
+
   return (
     <div
+      ref={rootRef}
       aria-busy={loading || loadingMore ? true : undefined}
       data-vt-natural-flow={naturalFlow ? true : undefined}
       className={
@@ -601,17 +830,43 @@ export function VirtualTable<T>({
           className={`w-full ${minWidth} table-fixed border-separate border-spacing-0 text-sm`}
         >
           <caption className="sr-only">{caption}</caption>
+          <colgroup>
+            {columns.map((col) => (
+              <col key={col.key} style={resolveColumnStyle(col)} />
+            ))}
+          </colgroup>
 
           {/* ── HeroUI-styled header ── */}
           <thead ref={headerRef} className={naturalFlow ? undefined : "sticky top-0 z-20"}>
             <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-white/55">
-              {columns.map((col) => {
+              {columns.map((col, colIndex) => {
+                const canResize = shouldAllowColumnResize(col, colIndex, columns);
                 return (
                   <th
                     key={col.key}
-                    className={`whitespace-nowrap px-4 py-3 ${col.width ?? ""} ${col.headerClassName ?? ""}`}
+                    aria-label={col.label}
+                    ref={(node) => {
+                      headerCellsRef.current[col.key] = node;
+                    }}
+                    style={resolveColumnStyle(col)}
+                    className={`group/column relative whitespace-nowrap px-4 py-3 ${col.width ?? ""} ${col.headerClassName ?? ""}`}
                   >
                     {col.headerRender ? col.headerRender() : col.label}
+                    {canResize ? (
+                      <button
+                        type="button"
+                        data-vt-column-resizer
+                        aria-label={t("common.resize_column", { column: col.label })}
+                        title={t("common.resize_column", { column: col.label })}
+                        className="absolute -right-1 top-1/2 z-30 h-6 w-2.5 -translate-y-1/2 cursor-col-resize touch-none rounded-full outline-none transition-colors hover:bg-blue-500/10 focus-visible:bg-blue-500/15"
+                        onPointerDown={(event) => handleColumnResizePointerDown(col, event)}
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="mx-auto block h-full w-px rounded-full bg-slate-300 opacity-45 transition-all group-hover/column:bg-blue-500 group-hover/column:opacity-80 dark:bg-white/25 dark:group-hover/column:bg-blue-400"
+                        />
+                      </button>
+                    ) : null}
                   </th>
                 );
               })}
@@ -690,6 +945,7 @@ export function VirtualTable<T>({
                         return (
                           <td
                             key={col.key}
+                            style={resolveColumnStyle(col)}
                             className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${roundCls}`}
                           >
                             <TableCellOverflowTooltip
@@ -780,6 +1036,30 @@ export function VirtualTable<T>({
             onPointerCancel={handleThumbPointerUp}
           />
         </div>
+      ) : null}
+
+      {resizePreview ? (
+        <>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none fixed z-50 w-px bg-blue-500/80 shadow-[0_0_0_1px_rgba(59,130,246,0.18)]"
+            style={{
+              left: resizePreview.clientX,
+              top: resizePreview.rootTop,
+              height: Math.max(0, resizePreview.rootBottom - resizePreview.rootTop),
+            }}
+          />
+          <div
+            role="status"
+            className="pointer-events-none fixed z-50 rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white shadow-lg"
+            style={{
+              left: resizePreview.clientX + 10,
+              top: Math.max(8, resizePreview.rootTop + 16),
+            }}
+          >
+            {t("common.column_width_px", { width: resizePreview.width })}
+          </div>
+        </>
       ) : null}
     </div>
   );

--- a/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
@@ -1,13 +1,13 @@
 import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
-import { VirtualTable, type VirtualTableColumn } from "@/modules/ui/VirtualTable";
+import { DataTable, type DataTableColumn } from "@/modules/ui/DataTable";
 
 interface DemoRow {
   id: string;
   name: string;
 }
 
-const columns: VirtualTableColumn<DemoRow>[] = [
+const columns: DataTableColumn<DemoRow>[] = [
   { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
 ];
 
@@ -45,12 +45,162 @@ function setElementOverflow(
   });
 }
 
-describe("VirtualTable scrollbar wrapper", () => {
+describe("DataTable scrollbar wrapper", () => {
+  test("renders subtle resizers between columns but not after the last column", () => {
+    const twoColumns: DataTableColumn<DemoRow>[] = [
+      { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
+      { key: "id", label: "ID", width: "w-24", render: (row) => row.id },
+    ];
+
+    const { container } = render(
+      <DataTable
+        tableId="test-resizer-render"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={twoColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const resizers = container.querySelectorAll("[data-vt-column-resizer]");
+    expect(resizers).toHaveLength(1);
+    expect(resizers[0]).toHaveAttribute("title", "Drag to resize Name column");
+    expect(resizers[0]).toHaveClass("cursor-col-resize");
+  });
+
+  test("does not render a resizer for selection columns", () => {
+    const selectionColumns: DataTableColumn<DemoRow>[] = [
+      { key: "select", label: "Select", width: "w-12", render: () => "x" },
+      { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
+      { key: "id", label: "ID", width: "w-24", render: (row) => row.id },
+    ];
+
+    const { container } = render(
+      <DataTable
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={selectionColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    expect(container.querySelectorAll("[data-vt-column-resizer]")).toHaveLength(1);
+    expect(container.querySelector("[title='Drag to resize Select column']")).toBeNull();
+  });
+
+  test("persists resized column widths by table id", async () => {
+    window.localStorage.clear();
+    const twoColumns: DataTableColumn<DemoRow>[] = [
+      { key: "name", label: "Name", width: "w-40", minWidthPx: 90, render: (row) => row.name },
+      { key: "id", label: "ID", width: "w-24", render: (row) => row.id },
+    ];
+
+    const { container, unmount } = render(
+      <DataTable
+        tableId="test-column-widths"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={twoColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const nameHeader = screen.getByRole("columnheader", { name: /Name/ });
+    Object.defineProperty(nameHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () =>
+        ({
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: 160,
+          bottom: 40,
+          width: 160,
+          height: 40,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    });
+
+    const resizer = container.querySelector("[data-vt-column-resizer]") as HTMLButtonElement | null;
+    expect(resizer).not.toBeNull();
+
+    fireEvent.pointerDown(resizer!, { button: 0, pointerId: 1, clientX: 160 });
+    window.dispatchEvent(new PointerEvent("pointermove", { pointerId: 1, clientX: 212 }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("Width: 212 px");
+    });
+
+    window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1, clientX: 212 }));
+
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem("codeProxy.dataTable.columnWidths.v1.test-column-widths"),
+      ).toBe(JSON.stringify({ name: 212 }));
+    });
+
+    unmount();
+
+    const { container: secondContainer } = render(
+      <DataTable
+        tableId="test-column-widths"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={twoColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const storedCol = secondContainer.querySelector("col") as HTMLTableColElement | null;
+    expect(storedCol).not.toBeNull();
+    expect(storedCol!.style.width).toBe("212px");
+  });
+
+  test("keeps column width caches isolated between table ids", () => {
+    window.localStorage.clear();
+    window.localStorage.setItem(
+      "codeProxy.dataTable.columnWidths.v1.first-table",
+      JSON.stringify({ name: 240 }),
+    );
+    window.localStorage.setItem(
+      "codeProxy.dataTable.columnWidths.v1.second-table",
+      JSON.stringify({ name: 120 }),
+    );
+
+    const { container } = render(
+      <DataTable
+        tableId="second-table"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={[
+          { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
+          { key: "id", label: "ID", width: "w-24", render: (row) => row.id },
+        ]}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const firstCol = container.querySelector("col") as HTMLTableColElement | null;
+    expect(firstCol).not.toBeNull();
+    expect(firstCol!.style.width).toBe("120px");
+  });
+
   test("truncates primitive cell content and shows the full value on overflow hover", () => {
     const longName = "Very long table cell value that should be visible in the tooltip";
 
     render(
-      <VirtualTable
+      <DataTable
         rows={[{ id: "1", name: longName }]}
         columns={columns}
         rowKey={(row) => row.id}
@@ -74,7 +224,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("does not show a primitive cell tooltip when the content fits", () => {
     render(
-      <VirtualTable
+      <DataTable
         rows={[{ id: "1", name: "Short" }]}
         columns={columns}
         rowKey={(row) => row.id}
@@ -97,7 +247,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("uses column-provided overflow tooltip text for complex cell content", () => {
     const fullValue = "Complex rendered value with supporting markup";
-    const complexColumns: VirtualTableColumn<DemoRow>[] = [
+    const complexColumns: DataTableColumn<DemoRow>[] = [
       {
         key: "name",
         label: "Name",
@@ -112,7 +262,7 @@ describe("VirtualTable scrollbar wrapper", () => {
     ];
 
     render(
-      <VirtualTable
+      <DataTable
         rows={[{ id: "1", name: fullValue }]}
         columns={complexColumns}
         rowKey={(row) => row.id}
@@ -135,7 +285,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("infers overflow tooltip text from JSX cell content", () => {
     const fullValue = "JSX-rendered table cell value";
-    const jsxColumns: VirtualTableColumn<DemoRow>[] = [
+    const jsxColumns: DataTableColumn<DemoRow>[] = [
       {
         key: "name",
         label: "Name",
@@ -149,7 +299,7 @@ describe("VirtualTable scrollbar wrapper", () => {
     ];
 
     render(
-      <VirtualTable
+      <DataTable
         rows={[{ id: "1", name: fullValue }]}
         columns={jsxColumns}
         rowKey={(row) => row.id}
@@ -175,7 +325,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("uses a focusable scroll container with hover-reveal metadata", () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={[
           { id: "1", name: "Row 1" },
           { id: "2", name: "Row 2" },
@@ -204,7 +354,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("renders an in-table initial loading state", () => {
     render(
-      <VirtualTable
+      <DataTable
         rows={[]}
         columns={columns}
         rowKey={(row) => row.id}
@@ -222,7 +372,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("renders DOM scrollbars only when overflow exists", async () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -258,7 +408,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("reveals scrollbars from their hover zones and marks thumbs as draggable", async () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -297,7 +447,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("keeps custom scrollbar layers above row content badges", async () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -335,7 +485,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("keeps the vertical scrollbar in a gutter outside the table viewport", async () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -396,13 +546,13 @@ describe("VirtualTable scrollbar wrapper", () => {
   });
 
   test("keeps the header corner fixed to the viewport instead of scrolling cells", () => {
-    const wideColumns: VirtualTableColumn<DemoRow>[] = [
+    const wideColumns: DataTableColumn<DemoRow>[] = [
       { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
       { key: "id", label: "ID", width: "w-40", render: (row) => row.id },
     ];
 
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={[{ id: "1", name: "Row 1" }]}
         columns={wideColumns}
         rowKey={(row) => row.id}
@@ -427,7 +577,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("prevents vertical wheel bounce when already at a scroll boundary", () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -465,7 +615,7 @@ describe("VirtualTable scrollbar wrapper", () => {
     const addEventListener = vi.spyOn(HTMLDivElement.prototype, "addEventListener");
 
     render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -485,7 +635,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("shows vertical scrollbar after data change without requiring a user scroll", async () => {
     const { container, rerender } = render(
-      <VirtualTable
+      <DataTable
         rows={[{ id: "1", name: "Row 1" }]}
         columns={columns}
         rowKey={(row) => row.id}
@@ -514,7 +664,7 @@ describe("VirtualTable scrollbar wrapper", () => {
     });
 
     rerender(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -540,7 +690,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("thumb aligns to track edges at scroll start/end", async () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}
@@ -598,7 +748,7 @@ describe("VirtualTable scrollbar wrapper", () => {
 
   test("vertical track starts below sticky header", async () => {
     const { container } = render(
-      <VirtualTable
+      <DataTable
         rows={Array.from({ length: 60 }, (_, i) => ({ id: String(i), name: `Row ${i}` }))}
         columns={columns}
         rowKey={(row) => row.id}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -49,7 +49,7 @@
   height: 0;
 }
 
-/* VirtualTable：隐藏原生滚动条，改用 DOM 自定义滚动条 */
+/* DataTable：隐藏原生滚动条，改用 DOM 自定义滚动条 */
 .table-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- Rename the shared finite-row table component from `VirtualTable` to `DataTable`.
- Add resizable column handles with per-table localStorage persistence.
- Add stable table identifiers for management pages that use the shared table component.

## Validation
- `bun run lint`
- targeted Bun tests for DataTable, API keys, and request logs
- `bun run build`
- `bunx oxfmt <changed files> --check`
- `git diff --check`
- Chrome UI validation on desktop and mobile viewports

## Notes
- Full-repository formatting check still reports pre-existing unrelated formatting differences outside this change.