### PR TITLE
fix: align data table resize preview center

### DIFF
--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -99,6 +99,7 @@ const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
 const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v1";
 const DEFAULT_MIN_COLUMN_WIDTH = 72;
 const DEFAULT_MAX_COLUMN_WIDTH = 640;
+const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
 const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
 
 type ColumnWidthMap = Record<string, number>;
@@ -107,7 +108,7 @@ interface ColumnResizeState {
   pointerId: number;
   columnKey: string;
   startClientX: number;
-  startEdgeClientX: number;
+  startLineCenterClientX: number;
   startWidth: number;
   minWidth: number;
   maxWidth: number;
@@ -558,7 +559,7 @@ export function DataTable<T>({
       const hasHorizontalOverflow = scroller
         ? scroller.scrollWidth > scroller.clientWidth + 1
         : false;
-      const edgeClientX = active.startEdgeClientX + width - active.startWidth;
+      const lineCenterClientX = active.startLineCenterClientX + width - active.startWidth;
       const top = Math.max(0, containerRect.top - rootRect.top);
       const bottomInset = hasHorizontalOverflow ? 14 : 0;
       const bottom = Math.min(rootRect.height, containerRect.bottom - rootRect.top - bottomInset);
@@ -570,7 +571,7 @@ export function DataTable<T>({
 
       return {
         width,
-        left: edgeClientX - rootRect.left,
+        left: lineCenterClientX - rootRect.left - COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2,
         top,
         height,
         tooltipTop,
@@ -616,7 +617,8 @@ export function DataTable<T>({
         pointerId: e.pointerId,
         columnKey: column.key,
         startClientX: e.clientX,
-        startEdgeClientX: rect.right,
+        startLineCenterClientX:
+          e.currentTarget.getBoundingClientRect().left + e.currentTarget.offsetWidth / 2,
         startWidth: nextStartWidth,
         minWidth,
         maxWidth,

--- a/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
@@ -188,7 +188,9 @@ describe("DataTable scrollbar wrapper", () => {
     const root = container.firstElementChild as HTMLDivElement;
     const scrollContainer = container.querySelector(".table-scrollbar") as HTMLDivElement | null;
     const nameHeader = screen.getByRole("columnheader", { name: /Name/ });
+    const resizer = container.querySelector("[data-vt-column-resizer]") as HTMLButtonElement | null;
     expect(scrollContainer).not.toBeNull();
+    expect(resizer).not.toBeNull();
 
     Object.defineProperty(root, "getBoundingClientRect", {
       configurable: true,
@@ -235,15 +237,30 @@ describe("DataTable scrollbar wrapper", () => {
           toJSON: () => ({}),
         }) as DOMRect,
     });
+    Object.defineProperties(resizer!, {
+      getBoundingClientRect: {
+        configurable: true,
+        value: () =>
+          ({
+            x: 196,
+            y: 100,
+            top: 100,
+            left: 196,
+            right: 212,
+            bottom: 140,
+            width: 16,
+            height: 40,
+            toJSON: () => ({}),
+          }) as DOMRect,
+      },
+      offsetWidth: { configurable: true, value: 16 },
+    });
     setScrollMetrics(scrollContainer!, {
       clientHeight: 220,
       scrollHeight: 560,
       clientWidth: 580,
       scrollWidth: 900,
     });
-
-    const resizer = container.querySelector("[data-vt-column-resizer]") as HTMLButtonElement | null;
-    expect(resizer).not.toBeNull();
 
     fireEvent.pointerDown(resizer!, { button: 0, pointerId: 2, clientX: 200, clientY: 120 });
     window.dispatchEvent(
@@ -253,7 +270,7 @@ describe("DataTable scrollbar wrapper", () => {
     const status = await screen.findByRole("status");
     const previewLine = status.previousElementSibling as HTMLDivElement | null;
     expect(previewLine).not.toBeNull();
-    expect(previewLine!.style.left).toBe("220px");
+    expect(previewLine!.style.left).toBe("223px");
     expect(previewLine!.style.top).toBe("20px");
     expect(previewLine!.style.height).toBe("206px");
     expect(status).toHaveTextContent("Width: 200 px");


### PR DESCRIPTION
## Summary
- Align the body resize preview line to the visual center of the active header resize handle.
- Account for the preview line width so its center, not its left edge, matches the dragged handle.
- Update the table resize regression test to cover handle-center alignment.

## Validation
- `bun run test src/modules/ui/__tests__/DataTable.scrollbar.test.tsx src/modules/monitor/__tests__/RequestLogsPage.test.tsx`
- `bun run lint`
- `bun run build`
- `bunx oxfmt src/modules/ui/DataTable.tsx src/modules/ui/__tests__/DataTable.scrollbar.test.tsx --check`
- `git diff --check`
- Chrome UI geometry validation on the request logs table

## Notes
- Lint still reports one existing unrelated warning outside this change.