### PR TITLE
fix: column reorder review findings (persistColumnOrder, lockOrder, preview line, handle layout, tests)

### DIFF
--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -284,6 +284,7 @@ function resolveColumnOrderLock<T>(column: DataTableColumn<T>) {
 function shouldAllowColumnReorder<T>(column: DataTableColumn<T>) {
   if (column.reorderable !== undefined) return column.reorderable;
   if (NON_REORDERABLE_COLUMN_KEYS.has(column.key)) return false;
+  if (resolveColumnOrderLock(column) !== null) return false;
   return true;
 }
 
@@ -390,9 +391,10 @@ export function DataTable<T>({
   }, [columns]);
 
   const canUseColumnOrder = Boolean(tableId && columnReorderable);
+  const canPersistColumnOrder = canUseColumnOrder && persistColumnOrder;
 
   const [columnOrder, setColumnOrder] = useState<ColumnOrder>(() =>
-    canUseColumnOrder ? normalizeColumnOrder(columns, readStoredColumnOrder(tableId)) : [],
+    canPersistColumnOrder ? normalizeColumnOrder(columns, readStoredColumnOrder(tableId)) : [],
   );
   const columnOrderRef = useRef<ColumnOrder>(columnOrder);
   const [reorderPreview, setReorderPreview] = useState<ColumnReorderPreview | null>(null);
@@ -411,10 +413,10 @@ export function DataTable<T>({
 
   useEffect(() => {
     setColumnWidths(readStoredColumnWidths(tableId));
-    if (canUseColumnOrder) {
+    if (canPersistColumnOrder) {
       setColumnOrder(normalizeColumnOrder(columns, readStoredColumnOrder(tableId)));
     }
-  }, [tableId, canUseColumnOrder, columns]);
+  }, [tableId, canPersistColumnOrder, columns]);
 
   useEffect(() => {
     columnWidthsRef.current = columnWidths;
@@ -840,13 +842,21 @@ export function DataTable<T>({
       const currentColumns = orderedColumnsRef.current;
       if (!rootRect || !containerRect) return null;
 
-      const targetKey = currentColumns[Math.min(toIndex, currentColumns.length - 1)]?.key;
+      // When dragging right (fromIndex < toIndex), the dragged item is inserted
+      // before column toIndex after the removal shift, so the preview line sits
+      // at the RIGHT edge of the column at toIndex - 1.
+      // When dragging left (fromIndex >= toIndex), the line sits at the LEFT
+      // edge of the column at toIndex.
+      const usePrev = toIndex > fromIndex;
+      const elemIdx = usePrev
+        ? Math.min(toIndex - 1, currentColumns.length - 1)
+        : Math.min(toIndex, currentColumns.length - 1);
+      const targetKey = currentColumns[elemIdx]?.key;
       const headerCell = targetKey ? headerCellsRef.current[targetKey] : null;
       if (!headerCell) return null;
 
       const cellRect = headerCell.getBoundingClientRect();
-      const startOfColumn = toIndex <= fromIndex;
-      const left = startOfColumn ? cellRect.left : cellRect.right;
+      const left = usePrev ? cellRect.right : cellRect.left;
 
       return {
         fromIndex,
@@ -901,13 +911,13 @@ export function DataTable<T>({
       const fromIndex = normalizedPrev.indexOf(active.columnKey);
       if (fromIndex < 0) return prev;
       const next = moveColumnKey(normalizedPrev, fromIndex, preview.toIndex);
-      if (next.join(" ") === normalizedPrev.join(" ")) return prev;
-      if (canUseColumnOrder && persistColumnOrder) {
+      if (next.length === normalizedPrev.length && next.every((v, i) => v === normalizedPrev[i])) return prev;
+      if (canPersistColumnOrder) {
         writeStoredColumnOrder(tableId, next);
       }
       return next;
     });
-  }, [canUseColumnOrder, persistColumnOrder, tableId]);
+  }, [canPersistColumnOrder, tableId]);
 
   const handleColumnReorderPointerDown = useCallback(
     (column: DataTableColumn<T>, e: ReactPointerEvent<HTMLButtonElement>) => {
@@ -1262,22 +1272,20 @@ export function DataTable<T>({
                     style={resolveColumnStyle(col)}
                     className={`group/column relative whitespace-nowrap px-4 py-3 ${col.width ?? ""} ${col.headerClassName ?? ""}`}
                   >
-                    <div className="flex min-w-0 items-center gap-1">
-                      {canReorder ? (
-                        <button
-                          type="button"
-                          data-vt-column-reorder-handle
-                          aria-label={t("common.reorder_column", { column: col.label })}
-                          title={t("common.reorder_column", { column: col.label })}
-                          className="inline-flex h-5 w-5 shrink-0 cursor-grab touch-none items-center justify-center rounded-md text-slate-400/55 opacity-0 transition-opacity hover:bg-slate-200/60 hover:text-slate-600 group-hover/column:opacity-100 focus-visible:opacity-100 active:cursor-grabbing dark:text-white/30 dark:hover:bg-white/10 dark:hover:text-white/65"
-                          onPointerDown={(event) => handleColumnReorderPointerDown(col, event)}
-                        >
-                          <GripVertical size={13} aria-hidden="true" />
-                        </button>
-                      ) : null}
-                      <div className="min-w-0 flex-1 truncate">
-                        {col.headerRender ? col.headerRender() : col.label}
-                      </div>
+                    {canReorder ? (
+                      <button
+                        type="button"
+                        data-vt-column-reorder-handle
+                        aria-label={t("common.reorder_column", { column: col.label })}
+                        title={t("common.reorder_column", { column: col.label })}
+                        className="absolute left-1 top-1/2 z-10 -translate-y-1/2 inline-flex h-5 w-5 items-center justify-center rounded-md cursor-grab touch-none text-slate-400/55 opacity-0 transition-opacity hover:bg-slate-200/60 hover:text-slate-600 group-hover/column:opacity-100 focus-visible:opacity-100 active:cursor-grabbing dark:text-white/30 dark:hover:bg-white/10 dark:hover:text-white/65"
+                        onPointerDown={(event) => handleColumnReorderPointerDown(col, event)}
+                      >
+                        <GripVertical size={13} aria-hidden="true" />
+                      </button>
+                    ) : null}
+                    <div className="min-w-0 truncate">
+                      {col.headerRender ? col.headerRender() : col.label}
                     </div>
                     {canResize ? (
                       <button

--- a/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
@@ -980,7 +980,7 @@ describe("DataTable column reorder", () => {
     expect(container.querySelectorAll("[data-vt-column-reorder-handle]")).toHaveLength(0);
   });
 
-  test("reorders header and body cells after dragging a column handle", async () => {
+  test("reorders header, body cells, and colgroup after dragging a column handle", async () => {
     window.localStorage.clear();
     const columns: DataTableColumn<DemoRow>[] = [
       { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
@@ -1021,6 +1021,16 @@ describe("DataTable column reorder", () => {
       const headers = screen.getAllByRole("columnheader").map((node) => node.textContent);
       expect(headers.join("|")).toContain("ID|Name");
     });
+
+    // Verify body cells are also reordered (now id before name)
+    const cells = container.querySelectorAll("tbody td");
+    expect(cells).toHaveLength(2);
+    expect(cells[0].textContent).toBe("1");
+    expect(cells[1].textContent).toContain("Row 1");
+
+    // Verify colgroup has the correct number of elements (order verified by col+header+body consistency)
+    const cols = container.querySelectorAll("colgroup col");
+    expect(cols).toHaveLength(2);
 
     expect(
       window.localStorage.getItem("codeProxy.dataTable.columnOrder.v1.test-column-reorder"),
@@ -1136,5 +1146,164 @@ describe("DataTable column reorder", () => {
     expect(headers).toHaveLength(2);
     expect(headers[0]).toHaveTextContent("ID");
     expect(headers[1]).toHaveTextContent("Name");
+  });
+
+  test("does NOT read localStorage when persistColumnOrder is false", () => {
+    window.localStorage.setItem(
+      "codeProxy.dataTable.columnOrder.v1.test-persist-off",
+      JSON.stringify(["id", "name"]),
+    );
+
+    const { container } = render(
+      <DataTable
+        tableId="test-persist-off"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={[
+          { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
+          { key: "id", label: "ID", width: "w-24", render: (row) => row.id },
+        ]}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+        persistColumnOrder={false}
+      />,
+    );
+
+    // Should ignore cache and use default (name, id) order
+    const headers = container.querySelectorAll("thead th");
+    expect(headers[0]).toHaveTextContent("Name");
+    expect(headers[1]).toHaveTextContent("ID");
+  });
+
+  test("does not render reorder handles for columns with custom lockOrder", () => {
+    const threeColumns: DataTableColumn<DemoRow>[] = [
+      { key: "name", label: "Name", width: "w-40", lockOrder: "start", render: (row) => row.name },
+      { key: "email", label: "Email", width: "w-40", render: () => "a@b.com" },
+      { key: "actions", label: "Actions", width: "w-24", lockOrder: "end", render: () => "..." },
+    ];
+
+    const { container } = render(
+      <DataTable
+        tableId="test-lock-order"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={threeColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const handles = container.querySelectorAll("[data-vt-column-reorder-handle]");
+    expect(handles).toHaveLength(1);
+    expect(handles[0]).toHaveAttribute("data-vt-column-reorder-handle");
+  });
+
+  test("reorders columns correctly when dragging three columns rightward", async () => {
+    window.localStorage.clear();
+    const threeColumns: DataTableColumn<DemoRow>[] = [
+      { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
+      { key: "email", label: "Email", width: "w-40", render: () => "a@b.com" },
+      { key: "id", label: "ID", width: "w-24", render: (row) => row.id },
+    ];
+
+    const { container } = render(
+      <DataTable
+        tableId="test-three-col-drag"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={threeColumns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const nameHeader = screen.getByRole("columnheader", { name: /Name/ });
+    const emailHeader = screen.getByRole("columnheader", { name: /Email/ });
+    const idHeader = screen.getByRole("columnheader", { name: /ID/ });
+    Object.defineProperty(nameHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 0, width: 160, top: 0, height: 40, right: 160 }) as DOMRect,
+    });
+    Object.defineProperty(emailHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 160, width: 160, top: 0, height: 40, right: 320 }) as DOMRect,
+    });
+    Object.defineProperty(idHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 320, width: 96, top: 0, height: 40, right: 416 }) as DOMRect,
+    });
+
+    // Drag the first column (Name) rightward past Email to position 2
+    const handle = container.querySelector("[data-vt-column-reorder-handle]") as HTMLButtonElement;
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+    window.dispatchEvent(new PointerEvent("pointermove", { pointerId: 1, clientX: 300, clientY: 10 }));
+    window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1, clientX: 300, clientY: 10 }));
+
+    await waitFor(() => {
+      const headers = screen.getAllByRole("columnheader");
+      expect(headers[0]).toHaveTextContent("Email");
+      expect(headers[1]).toHaveTextContent("Name");
+      expect(headers[2]).toHaveTextContent("ID");
+    });
+
+    // Verify localStorage
+    expect(
+      window.localStorage.getItem("codeProxy.dataTable.columnOrder.v1.test-three-col-drag"),
+    ).toBe(JSON.stringify(["email", "name", "id"]));
+  });
+
+  test("respects end-locked boundary when dragging near actions column", async () => {
+    window.localStorage.clear();
+    const columns: DataTableColumn<DemoRow>[] = [
+      { key: "name", label: "Name", width: "w-40", render: (row) => row.name },
+      { key: "email", label: "Email", width: "w-40", render: () => "a@b.com" },
+      { key: "actions", label: "Actions", width: "w-24", render: () => "..." },
+    ];
+
+    const { container } = render(
+      <DataTable
+        tableId="test-end-locked-boundary"
+        rows={[{ id: "1", name: "Row 1" }]}
+        columns={columns}
+        rowKey={(row) => row.id}
+        height="h-[160px]"
+        minHeight="min-h-0"
+        virtualize={false}
+      />,
+    );
+
+    const actionHeader = screen.getByRole("columnheader", { name: /Actions/ });
+    const emailHeader = screen.getByRole("columnheader", { name: /Email/ });
+    Object.defineProperty(actionHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 320, width: 96, top: 0, height: 40, right: 416 }) as DOMRect,
+    });
+    Object.defineProperty(emailHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 160, width: 160, top: 0, height: 40, right: 320 }) as DOMRect,
+    });
+
+    const nameHeader = screen.getByRole("columnheader", { name: /Name/ });
+    Object.defineProperty(nameHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 0, width: 160, top: 0, height: 40, right: 160 }) as DOMRect,
+    });
+
+    // Drag Name column past the movable boundary (toward actions, should stop before actions)
+    const handle = container.querySelector("[data-vt-column-reorder-handle]") as HTMLButtonElement;
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+    window.dispatchEvent(new PointerEvent("pointermove", { pointerId: 1, clientX: 400, clientY: 10 }));
+    window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1, clientX: 400, clientY: 10 }));
+
+    await waitFor(() => {
+      const headers = screen.getAllByRole("columnheader");
+      // Name should swap with Email but not cross past actions
+      expect(headers[0]).toHaveTextContent("Email");
+      expect(headers[1]).toHaveTextContent("Name");
+      expect(headers[2]).toHaveTextContent("Actions");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Address all P2 and P3 findings from code review:

- **P2 persistColumnOrder**: now guards localStorage reads, not just writes
- **P2 lockOrder**: columns with lockOrder no longer show drag handles
- **P2 preview line**: rightward drag now uses correct column edge (toIndex-1)
- **P3 NUL byte**: replaced with safe array element-wise comparison
- **P3 handle layout**: absolute positioned, no layout space when hidden
- **P3 tests**: body cell order, persistColumnOrder=false, custom lockOrder, 
  three-column rightward drag, end-locked boundary
- **Lint**: fixed unused row param warnings in new tests

All 33 tests pass, TypeScript clean, lint clean (1 pre-existing warning in QuickImportTabContent.tsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)