### PR TITLE
fix: persistColumnOrder=false no longer breaks in-session reorder

### DIFF
--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -282,9 +282,9 @@ function resolveColumnOrderLock<T>(column: DataTableColumn<T>) {
 }
 
 function shouldAllowColumnReorder<T>(column: DataTableColumn<T>) {
+  if (resolveColumnOrderLock(column) !== null) return false;
   if (column.reorderable !== undefined) return column.reorderable;
   if (NON_REORDERABLE_COLUMN_KEYS.has(column.key)) return false;
-  if (resolveColumnOrderLock(column) !== null) return false;
   return true;
 }
 
@@ -394,7 +394,9 @@ export function DataTable<T>({
   const canPersistColumnOrder = canUseColumnOrder && persistColumnOrder;
 
   const [columnOrder, setColumnOrder] = useState<ColumnOrder>(() =>
-    canPersistColumnOrder ? normalizeColumnOrder(columns, readStoredColumnOrder(tableId)) : [],
+    canUseColumnOrder
+      ? normalizeColumnOrder(columns, canPersistColumnOrder ? readStoredColumnOrder(tableId) : [])
+      : [],
   );
   const columnOrderRef = useRef<ColumnOrder>(columnOrder);
   const [reorderPreview, setReorderPreview] = useState<ColumnReorderPreview | null>(null);
@@ -413,10 +415,10 @@ export function DataTable<T>({
 
   useEffect(() => {
     setColumnWidths(readStoredColumnWidths(tableId));
-    if (canPersistColumnOrder) {
-      setColumnOrder(normalizeColumnOrder(columns, readStoredColumnOrder(tableId)));
+    if (canUseColumnOrder) {
+      setColumnOrder(normalizeColumnOrder(columns, canPersistColumnOrder ? readStoredColumnOrder(tableId) : []));
     }
-  }, [tableId, canPersistColumnOrder, columns]);
+  }, [tableId, canUseColumnOrder, canPersistColumnOrder, columns]);
 
   useEffect(() => {
     columnWidthsRef.current = columnWidths;

--- a/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
@@ -1148,7 +1148,8 @@ describe("DataTable column reorder", () => {
     expect(headers[1]).toHaveTextContent("Name");
   });
 
-  test("does NOT read localStorage when persistColumnOrder is false", () => {
+  test("persistColumnOrder=false ignores cache but reorder still works in-session", async () => {
+    window.localStorage.clear();
     window.localStorage.setItem(
       "codeProxy.dataTable.columnOrder.v1.test-persist-off",
       JSON.stringify(["id", "name"]),
@@ -1174,6 +1175,36 @@ describe("DataTable column reorder", () => {
     const headers = container.querySelectorAll("thead th");
     expect(headers[0]).toHaveTextContent("Name");
     expect(headers[1]).toHaveTextContent("ID");
+
+    // Drag Name column past ID to verify in-session reorder still works
+    const nameHeader = screen.getByRole("columnheader", { name: /Name/ });
+    const idHeader = screen.getByRole("columnheader", { name: /ID/ });
+    Object.defineProperty(nameHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () =>
+        ({ left: 0, width: 160, top: 0, height: 40, right: 160 }) as DOMRect,
+    });
+    Object.defineProperty(idHeader, "getBoundingClientRect", {
+      configurable: true,
+      value: () =>
+        ({ left: 160, width: 96, top: 0, height: 40, right: 256 }) as DOMRect,
+    });
+
+    const handle = container.querySelector("[data-vt-column-reorder-handle]") as HTMLButtonElement;
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 10, clientY: 10 });
+    window.dispatchEvent(new PointerEvent("pointermove", { pointerId: 1, clientX: 220, clientY: 10 }));
+    window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1, clientX: 220, clientY: 10 }));
+
+    await waitFor(() => {
+      const updatedHeaders = container.querySelectorAll("thead th");
+      expect(updatedHeaders[0]).toHaveTextContent("ID");
+      expect(updatedHeaders[1]).toHaveTextContent("Name");
+    });
+
+    // Verify localStorage was NOT written (persistColumnOrder=false)
+    expect(
+      window.localStorage.getItem("codeProxy.dataTable.columnOrder.v1.test-persist-off"),
+    ).toBe(JSON.stringify(["id", "name"]));
   });
 
   test("does not render reorder handles for columns with custom lockOrder", () => {


### PR DESCRIPTION
- persistColumnOrder=false now still normalizes columnOrder for in-session drag
- lockOrder check moved before reorderable in shouldAllowColumnReorder
- Test confirms in-session drag works while localStorage is not written