### PR TITLE
fix: animate header text right on hover to avoid handle overlap

### DIFF
--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -1295,7 +1295,7 @@ export function DataTable<T>({
                         <GripVertical size={13} aria-hidden="true" />
                       </button>
                     ) : null}
-                    <div className={`min-w-0 truncate ${canReorder ? "pl-7" : ""}`}>
+                    <div className={`min-w-0 truncate transition-[padding] duration-150 ${canReorder ? "group-hover/column:pl-7" : ""}`}>
                       {col.headerRender ? col.headerRender() : col.label}
                     </div>
                     {canResize ? (


### PR DESCRIPTION
Replace constant pl-7 with group-hover/column:pl-7 + 150ms transition. Column name shifts right only on hover, keeping centered columns centered when idle.