### PR TITLE
fix: remove hover padding that shifted centered columns

### DIFF
--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -1295,7 +1295,7 @@ export function DataTable<T>({
                         <GripVertical size={13} aria-hidden="true" />
                       </button>
                     ) : null}
-                    <div className={`min-w-0 truncate transition-[padding] duration-150 ${canReorder ? "group-hover/column:pl-7" : ""}`}>
+                    <div className="min-w-0 truncate">
                       {col.headerRender ? col.headerRender() : col.label}
                     </div>
                     {canResize ? (


### PR DESCRIPTION
Revert the group-hover/column:pl-7 approach. The absolute handle at left-1 with th px-4 creates only ~8px overlap with text, negligible for all alignment types.