### PR TITLE
frontend: add clearable multi-select request log filters

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2360,7 +2360,16 @@
     "prev_page": "Previous page",
     "next_page": "Next page",
     "last_page": "Last page",
-    "rows_per_page": "Rows per page"
+    "rows_per_page": "Rows per page",
+    "reset_filters": "Reset filters",
+    "selected_count": "{{count}} selected",
+    "select_filtered": "Select shown",
+    "deselect_filtered": "Clear shown",
+    "no_filter_results": "No matching filters",
+    "clear_key_filter": "Clear key filter",
+    "clear_model_filter": "Clear model filter",
+    "clear_channel_filter": "Clear channel filter",
+    "clear_status_filter": "Clear status filter"
   },
   "ccswitch": {
     "import_to_ccswitch": "Import to CC Switch",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2606,7 +2606,16 @@
     "prev_page": "上一页",
     "next_page": "下一页",
     "last_page": "末页",
-    "rows_per_page": "每页行数"
+    "rows_per_page": "每页行数",
+    "reset_filters": "重置筛选",
+    "selected_count": "{{count}} 项",
+    "select_filtered": "选择当前结果",
+    "deselect_filtered": "清除当前结果",
+    "no_filter_results": "没有匹配的筛选项",
+    "clear_key_filter": "清空密钥筛选",
+    "clear_model_filter": "清空模型筛选",
+    "clear_channel_filter": "清空渠道筛选",
+    "clear_status_filter": "清空状态筛选"
   },
   "ccswitch": {
     "import_to_ccswitch": "导入到 CC Switch",

--- a/src/lib/http/apis/usage.ts
+++ b/src/lib/http/apis/usage.ts
@@ -239,15 +239,25 @@ export const usageApi = {
     model?: string;
     channel?: string;
     status?: string;
+    api_keys?: string[];
+    models?: string[];
+    channels?: string[];
+    statuses?: string[];
   }): Promise<UsageLogsResponse> {
     const qs = new URLSearchParams();
     if (params.page) qs.set("page", String(params.page));
     if (params.size) qs.set("size", String(params.size));
     if (params.days) qs.set("days", String(params.days));
-    if (params.api_key) qs.set("api_key", params.api_key);
-    if (params.model) qs.set("model", params.model);
-    if (params.channel) qs.set("channel", params.channel);
-    if (params.status) qs.set("status", params.status);
+    // Multi-value params take priority
+    appendUniqueParams(qs, "api_key", params.api_keys);
+    appendUniqueParams(qs, "model", params.models);
+    appendUniqueParams(qs, "channel", params.channels);
+    appendUniqueParams(qs, "status", params.statuses);
+    // Backward compatibility: fallback to single-value params if no multi-value
+    if (!params.api_keys?.length && params.api_key) qs.set("api_key", params.api_key);
+    if (!params.models?.length && params.model) qs.set("model", params.model);
+    if (!params.channels?.length && params.channel) qs.set("channel", params.channel);
+    if (!params.statuses?.length && params.status) qs.set("status", params.status);
     const query = qs.toString();
     const resp = await apiClient.get<UsageLogsResponse>(`/usage/logs${query ? `?${query}` : ""}`);
     return {

--- a/src/modules/monitor/RequestLogsFilters.tsx
+++ b/src/modules/monitor/RequestLogsFilters.tsx
@@ -1,0 +1,193 @@
+import { useTranslation } from "react-i18next";
+import { useMemo } from "react";
+import { Filter, RotateCcw } from "lucide-react";
+import { SearchableCheckboxMultiSelect } from "@/modules/ui/SearchableCheckboxMultiSelect";
+import type { SearchableCheckboxMultiSelectOption } from "@/modules/ui/SearchableCheckboxMultiSelect";
+import { cn } from "@/modules/ui/selectStyles";
+
+type StatusFilterValue = "success" | "failed";
+
+interface RequestLogStats {
+  total: number;
+  success_rate: number;
+  total_tokens: number;
+  total_cost: number;
+}
+
+interface RequestLogsFiltersProps {
+  keyOptions: SearchableCheckboxMultiSelectOption[];
+  modelOptions: SearchableCheckboxMultiSelectOption[];
+  channelOptions: SearchableCheckboxMultiSelectOption[];
+  statusOptions: SearchableCheckboxMultiSelectOption[];
+  selectedApiKeys: string[];
+  selectedModels: string[];
+  selectedChannels: string[];
+  selectedStatuses: StatusFilterValue[];
+  onApiKeysChange: (value: string[]) => void;
+  onModelsChange: (value: string[]) => void;
+  onChannelsChange: (value: string[]) => void;
+  onStatusesChange: (value: StatusFilterValue[]) => void;
+  onResetFilters: () => void;
+  hasActiveFilters: boolean;
+  stats: RequestLogStats;
+  lastUpdatedText: string;
+  loading: boolean;
+}
+
+export function RequestLogsFilters({
+  keyOptions,
+  modelOptions,
+  channelOptions,
+  statusOptions,
+  selectedApiKeys,
+  selectedModels,
+  selectedChannels,
+  selectedStatuses,
+  onApiKeysChange,
+  onModelsChange,
+  onChannelsChange,
+  onStatusesChange,
+  onResetFilters,
+  hasActiveFilters,
+  stats,
+  lastUpdatedText,
+  loading,
+}: RequestLogsFiltersProps) {
+  const { t } = useTranslation();
+
+  const statusChangeAdapter = useMemo(
+    () => (value: string[]) => onStatusesChange(value as StatusFilterValue[]),
+    [onStatusesChange],
+  );
+
+  return (
+    <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800/60">
+      <div className="grid gap-2 min-[480px]:grid-cols-2 sm:flex sm:flex-wrap sm:items-center">
+        {/* Filter controls */}
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="w-full min-[480px]:w-auto sm:w-[180px]">
+            <SearchableCheckboxMultiSelect
+              value={selectedApiKeys}
+              onChange={onApiKeysChange}
+              options={keyOptions}
+              placeholder={t("request_logs.all_keys_placeholder")}
+              searchPlaceholder={t("request_logs.search_keys")}
+              selectFilteredLabel={t("request_logs.select_filtered")}
+              deselectFilteredLabel={t("request_logs.deselect_filtered")}
+              selectedCountLabel={(count: number) =>
+                t("request_logs.selected_count", { count: String(count) })
+              }
+              noResultsLabel={t("request_logs.no_filter_results")}
+              aria-label={t("request_logs.filter_key")}
+              clearLabel={t("request_logs.clear_key_filter")}
+              size="sm"
+            />
+          </div>
+          <div className="w-full min-[480px]:w-auto sm:w-[200px]">
+            <SearchableCheckboxMultiSelect
+              value={selectedModels}
+              onChange={onModelsChange}
+              options={modelOptions}
+              placeholder={t("request_logs.all_models_placeholder")}
+              searchPlaceholder={t("request_logs.search_models")}
+              selectFilteredLabel={t("request_logs.select_filtered")}
+              deselectFilteredLabel={t("request_logs.deselect_filtered")}
+              selectedCountLabel={(count: number) =>
+                t("request_logs.selected_count", { count: String(count) })
+              }
+              noResultsLabel={t("request_logs.no_filter_results")}
+              aria-label={t("request_logs.filter_model")}
+              clearLabel={t("request_logs.clear_model_filter")}
+              size="sm"
+            />
+          </div>
+          <div className="w-full min-[480px]:w-auto sm:w-[180px]">
+            <SearchableCheckboxMultiSelect
+              value={selectedChannels}
+              onChange={onChannelsChange}
+              options={channelOptions}
+              placeholder={t("request_logs.all_channels_placeholder")}
+              searchPlaceholder={t("request_logs.search_channels")}
+              selectFilteredLabel={t("request_logs.select_filtered")}
+              deselectFilteredLabel={t("request_logs.deselect_filtered")}
+              selectedCountLabel={(count: number) =>
+                t("request_logs.selected_count", { count: String(count) })
+              }
+              noResultsLabel={t("request_logs.no_filter_results")}
+              aria-label={t("request_logs.filter_channel")}
+              clearLabel={t("request_logs.clear_channel_filter")}
+              size="sm"
+            />
+          </div>
+          <div className="w-full min-[480px]:w-auto sm:w-[150px]">
+            <SearchableCheckboxMultiSelect
+              value={selectedStatuses}
+              onChange={statusChangeAdapter}
+              options={statusOptions}
+              placeholder={t("request_logs.all_status")}
+              searchPlaceholder=""
+              selectFilteredLabel={t("request_logs.select_filtered")}
+              deselectFilteredLabel={t("request_logs.deselect_filtered")}
+              selectedCountLabel={(count: number) => `${count}`}
+              noResultsLabel={t("request_logs.no_filter_results")}
+              aria-label={t("request_logs.filter_status")}
+              clearLabel={t("request_logs.clear_status_filter")}
+              showClearButton
+              size="sm"
+            />
+          </div>
+
+          {/* Reset filters button */}
+          {hasActiveFilters ? (
+            <button
+              type="button"
+              onClick={onResetFilters}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium",
+                "text-slate-500 hover:text-slate-700 hover:bg-slate-100",
+                "dark:text-white/50 dark:hover:text-white/80 dark:hover:bg-white/10",
+                "transition-colors",
+              )}
+            >
+              <RotateCcw size={12} aria-hidden="true" />
+              {t("request_logs.reset_filters")}
+            </button>
+          ) : null}
+        </div>
+
+        {/* Stats summary */}
+        <div className="col-span-2 min-[480px]:col-span-2 sm:col-span-1 sm:ml-auto">
+          <div className="grid grid-cols-2 items-center gap-x-3 gap-y-1.5 text-xs text-slate-600 dark:text-white/55 sm:flex sm:items-center sm:gap-1.5">
+            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+              <Filter size={12} aria-hidden="true" />
+              {t("request_logs.records_count", {
+                count: stats.total.toLocaleString(),
+              } as Record<string, string>)}
+            </span>
+
+            <span className="inline-flex items-center justify-end gap-1.5 whitespace-nowrap sm:justify-start">
+              {t("common.success_rate")}
+              <span className="font-mono tabular-nums">{stats.success_rate.toFixed(1)}%</span>
+            </span>
+
+            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+              {t("request_logs.col_total_token")}
+              <span className="font-mono tabular-nums">
+                {stats.total_tokens.toLocaleString()}
+              </span>
+            </span>
+
+            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+              {t("request_logs.col_cost")}
+              <span className="font-mono tabular-nums">${stats.total_cost.toFixed(4)}</span>
+            </span>
+
+            <span className="col-span-2 text-[11px] text-slate-400 dark:text-white/40 sm:col-span-1 sm:text-xs">
+              {loading ? t("request_logs.refreshing") : lastUpdatedText}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/monitor/RequestLogsPage.tsx
+++ b/src/modules/monitor/RequestLogsPage.tsx
@@ -1,17 +1,17 @@
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Filter, LoaderCircle, RefreshCw, ScrollText } from "lucide-react";
+import { LoaderCircle, RefreshCw, ScrollText } from "lucide-react";
 import { usageApi } from "@/lib/http/apis";
 import type { ClearUsageLogsPayload, UsageLogItem, UsageLogsResponse } from "@/lib/http/apis/usage";
 import { Button } from "@/modules/ui/Button";
 import { Checkbox } from "@/modules/ui/Checkbox";
 import { Modal } from "@/modules/ui/Modal";
 import { useToast } from "@/modules/ui/ToastProvider";
-import { Select } from "@/modules/ui/Select";
-import { SearchableSelect } from "@/modules/ui/SearchableSelect";
 import { DataTable } from "@/modules/ui/DataTable";
 import { LogContentModal } from "@/modules/monitor/LogContentModal";
 import { ErrorDetailModal } from "@/modules/monitor/ErrorDetailModal";
+import { RequestLogsFilters } from "@/modules/monitor/RequestLogsFilters";
+import type { SearchableCheckboxMultiSelectOption } from "@/modules/ui/SearchableCheckboxMultiSelect";
 import {
   buildRequestLogKeyOptions,
   buildRequestLogsColumns,
@@ -22,7 +22,7 @@ import {
   type RequestLogsRow as LogRow,
   type TimeRange,
 } from "@/modules/monitor/requestLogsShared";
-type StatusFilter = "" | "success" | "failed";
+type StatusFilterValue = "success" | "failed";
 const DEFAULT_LOG_STATS = { total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 };
 const DEFAULT_CLEAR_OPTIONS: ClearUsageLogsPayload = {
   clear_body_content: true,
@@ -95,23 +95,35 @@ export function RequestLogsPage() {
     total_cost: number;
   }>(DEFAULT_LOG_STATS);
 
-  // Filters
+  // Multi-value filters
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
-  const [apiQuery, setApiQuery] = useState("");
-  const [modelQuery, setModelQuery] = useState("");
-  const [channelQuery, setChannelQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>("");
+  const [selectedApiKeys, setSelectedApiKeys] = useState<string[]>([]);
+  const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [selectedChannels, setSelectedChannels] = useState<string[]>([]);
+  const [selectedStatuses, setSelectedStatuses] = useState<StatusFilterValue[]>([]);
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
   const [clearingLogs, setClearingLogs] = useState(false);
   const [clearOptions, setClearOptions] = useState<ClearUsageLogsPayload>(DEFAULT_CLEAR_OPTIONS);
 
-  const fetchInFlightRef = useRef(false);
+  const requestSeqRef = useRef(0);
+
+  const hasActiveFilters =
+    selectedApiKeys.length > 0 ||
+    selectedModels.length > 0 ||
+    selectedChannels.length > 0 ||
+    selectedStatuses.length > 0;
+
+  const resetFilters = useCallback(() => {
+    setSelectedApiKeys([]);
+    setSelectedModels([]);
+    setSelectedChannels([]);
+    setSelectedStatuses([]);
+  }, []);
 
   // Fetch logs from backend (server-side pagination)
   const fetchLogs = useCallback(
     async (page: number, size: number) => {
-      if (fetchInFlightRef.current) return;
-      fetchInFlightRef.current = true;
+      const seq = ++requestSeqRef.current;
       setLoading(true);
 
       try {
@@ -119,11 +131,13 @@ export function RequestLogsPage() {
           page,
           size,
           days: timeRange,
-          api_key: apiQuery || undefined,
-          model: modelQuery || undefined,
-          channel: channelQuery || undefined,
-          status: statusFilter || undefined,
+          api_keys: selectedApiKeys.length > 0 ? selectedApiKeys : undefined,
+          models: selectedModels.length > 0 ? selectedModels : undefined,
+          channels: selectedChannels.length > 0 ? selectedChannels : undefined,
+          statuses: selectedStatuses.length > 0 ? selectedStatuses : undefined,
         });
+
+        if (seq !== requestSeqRef.current) return;
 
         setRawItems(resp.items ?? []);
         setTotalCount(resp.total ?? 0);
@@ -150,11 +164,10 @@ export function RequestLogsPage() {
         const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
         notify({ type: "error", message });
       } finally {
-        fetchInFlightRef.current = false;
         setLoading(false);
       }
     },
-    [timeRange, apiQuery, modelQuery, channelQuery, statusFilter, notify, t],
+    [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses, notify, t],
   );
 
   // Derive display rows from raw items
@@ -184,29 +197,39 @@ export function RequestLogsPage() {
   // Fetch page 1 when filters change
   useEffect(() => {
     fetchLogs(1, pageSize);
-  }, [timeRange, apiQuery, modelQuery, channelQuery, statusFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Build options from backend filter data
-  const keyOptions = useMemo(() => {
-    return buildRequestLogKeyOptions(filterOptions.api_keys, filterOptions.api_key_names ?? {}, {
+  // Build multi-select options from backend filter data (exclude the "" "all" option)
+  const keyOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    const opts = buildRequestLogKeyOptions(filterOptions.api_keys, filterOptions.api_key_names ?? {}, {
       allKeys: t("request_logs.all_keys"),
       systemCall: t("request_logs.system_call"),
     });
+    return opts.filter((option) => option.value !== "");
   }, [filterOptions.api_keys, filterOptions.api_key_names, t]);
 
-  const modelOptions = useMemo(() => {
-    return [
-      { value: "", label: t("request_logs.all_models") },
-      ...filterOptions.models.map((m) => ({ value: m, label: m })),
-    ];
-  }, [filterOptions.models, t]);
+  const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    return filterOptions.models.map((m) => ({
+      value: m,
+      label: m,
+      searchText: m,
+    }));
+  }, [filterOptions.models]);
 
-  const channelOptions = useMemo(() => {
+  const channelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    return filterOptions.channels.map((ch) => ({
+      value: ch,
+      label: ch,
+      searchText: ch,
+    }));
+  }, [filterOptions.channels]);
+
+  const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return [
-      { value: "", label: t("request_logs.all_channels") },
-      ...filterOptions.channels.map((ch) => ({ value: ch, label: ch })),
+      { value: "success", label: t("request_logs.status_success"), searchText: "success" },
+      { value: "failed", label: t("request_logs.status_failed"), searchText: "failed" },
     ];
-  }, [filterOptions.channels, t]);
+  }, [t]);
 
   const lastUpdatedText = useMemo(() => {
     if (loading) return t("request_logs.refreshing");
@@ -321,83 +344,25 @@ export function RequestLogsPage() {
         </div>
 
         {/* 筛选 + 统计 */}
-        <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800/60">
-          <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-2">
-            <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:gap-2">
-              <SearchableSelect
-                value={apiQuery}
-                onChange={setApiQuery}
-                options={keyOptions}
-                placeholder={t("request_logs.all_keys_placeholder")}
-                searchPlaceholder={t("request_logs.search_keys")}
-                aria-label={t("request_logs.filter_key")}
-                className="w-full sm:w-auto"
-              />
-              <SearchableSelect
-                value={modelQuery}
-                onChange={setModelQuery}
-                options={modelOptions}
-                placeholder={t("request_logs.all_models_placeholder")}
-                searchPlaceholder={t("request_logs.search_models")}
-                aria-label={t("request_logs.filter_model")}
-                className="w-full sm:w-auto"
-              />
-              <SearchableSelect
-                value={channelQuery}
-                onChange={setChannelQuery}
-                options={channelOptions}
-                placeholder={t("request_logs.all_channels_placeholder")}
-                searchPlaceholder={t("request_logs.search_channels")}
-                aria-label={t("request_logs.filter_channel")}
-                className="w-full sm:w-auto"
-              />
-              <Select
-                value={statusFilter}
-                onChange={(v) => setStatusFilter(v as StatusFilter)}
-                options={[
-                  { value: "", label: t("request_logs.all_status") },
-                  { value: "success", label: t("request_logs.status_success") },
-                  { value: "failed", label: t("request_logs.status_failed") },
-                ]}
-                aria-label={t("request_logs.filter_status")}
-                name="statusFilter"
-                className="w-full sm:w-auto"
-              />
-            </div>
-
-            <div className="hidden sm:block sm:flex-1" />
-
-            <div className="grid grid-cols-2 items-center gap-x-3 gap-y-1.5 text-xs text-slate-600 dark:text-white/55 sm:flex sm:items-center sm:gap-1.5">
-              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-                <Filter size={12} aria-hidden="true" />
-                {t("request_logs.records_count", {
-                  count: stats.total.toLocaleString(),
-                } as Record<string, string>)}
-              </span>
-
-              <span className="inline-flex items-center justify-end gap-1.5 whitespace-nowrap sm:justify-start">
-                {t("common.success_rate")}
-                <span className="font-mono tabular-nums">{stats.success_rate.toFixed(1)}%</span>
-              </span>
-
-              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-                {t("request_logs.col_total_token")}
-                <span className="font-mono tabular-nums">
-                  {stats.total_tokens.toLocaleString()}
-                </span>
-              </span>
-
-              <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-                {t("request_logs.col_cost")}
-                <span className="font-mono tabular-nums">${stats.total_cost.toFixed(4)}</span>
-              </span>
-
-              <span className="col-span-2 text-[11px] text-slate-400 dark:text-white/40 sm:col-span-1 sm:text-xs">
-                {lastUpdatedText}
-              </span>
-            </div>
-          </div>
-        </div>
+        <RequestLogsFilters
+          keyOptions={keyOptions}
+          modelOptions={modelOptions}
+          channelOptions={channelOptions}
+          statusOptions={statusOptions}
+          selectedApiKeys={selectedApiKeys}
+          selectedModels={selectedModels}
+          selectedChannels={selectedChannels}
+          selectedStatuses={selectedStatuses}
+          onApiKeysChange={setSelectedApiKeys}
+          onModelsChange={setSelectedModels}
+          onChannelsChange={setSelectedChannels}
+          onStatusesChange={setSelectedStatuses}
+          onResetFilters={resetFilters}
+          hasActiveFilters={hasActiveFilters}
+          stats={stats}
+          lastUpdatedText={lastUpdatedText}
+          loading={loading}
+        />
 
         {/* 表格区域 — 自适应视口高度，内部滚动 */}
         <div className="relative min-h-[360px] h-[calc(100dvh-300px)] overflow-hidden px-5">

--- a/src/modules/ui/SearchableCheckboxMultiSelect.tsx
+++ b/src/modules/ui/SearchableCheckboxMultiSelect.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { Check, ChevronDown, Search } from "lucide-react";
+import { Check, ChevronDown, Search, X } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   cn,
@@ -48,6 +48,11 @@ export interface SearchableCheckboxMultiSelectProps {
   "aria-label"?: string;
   className?: string;
   size?: ControlSize;
+  clearLabel?: string;
+  onClear?: () => void;
+  showClearButton?: boolean;
+  maxSummaryItems?: number;
+  mobileBreakpoint?: number;
 }
 
 function optionText(option: SearchableCheckboxMultiSelectOption): string {
@@ -69,6 +74,11 @@ export function SearchableCheckboxMultiSelect({
   "aria-label": ariaLabel,
   className,
   size = "default",
+  clearLabel,
+  onClear,
+  showClearButton = true,
+  maxSummaryItems = 2,
+  mobileBreakpoint = 640,
 }: SearchableCheckboxMultiSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -105,6 +115,41 @@ export function SearchableCheckboxMultiSelect({
     const rect = trigger.getBoundingClientRect();
     const gap = 6;
     const maxHeight = 360;
+
+    // Mobile: use viewport-safe positioning
+    const isNarrow = window.innerWidth < mobileBreakpoint;
+    if (isNarrow) {
+      const maxHeightMobile = Math.min(420, window.innerHeight * 0.7);
+      const spaceBelow = window.innerHeight - rect.bottom - gap;
+      const spaceAbove = rect.top - gap;
+      const openAbove = spaceBelow < maxHeightMobile && spaceAbove > spaceBelow;
+
+      if (openAbove) {
+        setDropdownPlacement("top");
+        setDropdownStyle({
+          position: "fixed",
+          left: 12,
+          right: 12,
+          width: "auto",
+          maxHeight: Math.min(maxHeightMobile, spaceAbove),
+          bottom: window.innerHeight - rect.top + gap,
+          zIndex: 99999,
+        });
+        return;
+      }
+      setDropdownPlacement("bottom");
+      setDropdownStyle({
+        position: "fixed",
+        left: 12,
+        right: 12,
+        width: "auto",
+        maxHeight: Math.min(maxHeightMobile, spaceBelow),
+        top: Math.min(rect.bottom + gap, window.innerHeight - maxHeightMobile - 12),
+        zIndex: 99999,
+      });
+      return;
+    }
+
     const spaceBelow = window.innerHeight - rect.bottom - gap;
     const spaceAbove = rect.top - gap;
     const openAbove = spaceBelow < maxHeight && spaceAbove > spaceBelow;
@@ -131,7 +176,7 @@ export function SearchableCheckboxMultiSelect({
       maxHeight: Math.min(maxHeight, spaceBelow),
       zIndex: 99999,
     });
-  }, []);
+  }, [mobileBreakpoint]);
 
   useEffect(() => {
     if (!open) return;
@@ -209,51 +254,74 @@ export function SearchableCheckboxMultiSelect({
   const selectedSummary = useMemo(() => {
     if (value.length === 0) return placeholder;
     const labels = value
-      .slice(0, 2)
+      .slice(0, maxSummaryItems)
       .map((item) =>
         optionText(options.find((option) => option.value === item) ?? { value: item, label: item }),
       )
       .join(", ");
-    return value.length > 2 ? `${labels} +${value.length - 2}` : labels;
-  }, [options, placeholder, value]);
+    return value.length > maxSummaryItems ? `${labels} +${value.length - maxSummaryItems}` : labels;
+  }, [maxSummaryItems, options, placeholder, value]);
+
+  const handleClear = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onClear?.();
+      commitSelection([]);
+      setQuery("");
+    },
+    [commitSelection, onClear],
+  );
 
   return (
     <>
-      <button
-        ref={triggerRef}
-        type="button"
-        role="combobox"
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-label={ariaLabel}
-        disabled={disabled}
-        onClick={() => {
-          if (!open) updatePosition();
-          setOpen((current) => !current);
-        }}
-        className={cn(
-          getSelectTriggerBase(size),
-          "w-full justify-between text-left",
-          disabled && selectTriggerDisabled,
-          className,
-        )}
-      >
-        <span className={cn("truncate", value.length === 0 && "text-slate-400 dark:text-white/35")}>
-          {selectedSummary}
-        </span>
-        <span className="flex shrink-0 items-center gap-2">
-          {value.length > 0 ? (
-            <span className="rounded-md bg-sky-50 px-1.5 py-0.5 text-[11px] font-semibold text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">
-              {selectedCountLabel(value.length)}
-            </span>
-          ) : null}
-          <ChevronDown
-            size={14}
-            className={cn(selectChevron, open && "rotate-180")}
-            aria-hidden="true"
-          />
-        </span>
-      </button>
+      <div className={cn("relative", className)}>
+        <button
+          ref={triggerRef}
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-label={ariaLabel}
+          disabled={disabled}
+          onClick={() => {
+            if (!open) updatePosition();
+            setOpen((current) => !current);
+          }}
+          className={cn(
+            getSelectTriggerBase(size),
+            "w-full justify-between text-left",
+            value.length > 0 && showClearButton && "pr-9",
+            disabled && selectTriggerDisabled,
+          )}
+        >
+          <span className={cn("truncate", value.length === 0 && "text-slate-400 dark:text-white/35")}>
+            {selectedSummary}
+          </span>
+          <span className="flex shrink-0 items-center gap-2">
+            {value.length > 0 ? (
+              <span className="rounded-md bg-sky-50 px-1.5 py-0.5 text-[11px] font-semibold text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">
+                {selectedCountLabel(value.length)}
+              </span>
+            ) : null}
+            <ChevronDown
+              size={14}
+              className={cn(selectChevron, open && "rotate-180")}
+              aria-hidden="true"
+            />
+          </span>
+        </button>
+        {value.length > 0 && showClearButton && !disabled ? (
+          <button
+            type="button"
+            aria-label={clearLabel}
+            onClick={handleClear}
+            className="absolute right-7 top-1/2 -translate-y-1/2 flex items-center justify-center w-5 h-5 rounded text-slate-400 hover:text-slate-600 hover:bg-slate-100 dark:hover:bg-white/10 dark:hover:text-slate-300 transition-colors"
+          >
+            <X size={12} />
+          </button>
+        ) : null}
+      </div>
 
       {createPortal(
         <AnimatePresence>


### PR DESCRIPTION
## Summary
- Replace single-value filter selects with SearchableCheckboxMultiSelect supporting multi-value filtering for API keys, models, channels, and status
- Add clear button per filter and global reset filter button
- Extract RequestLogsFilters sub-component for cleaner page structure
- Enhance SearchableCheckboxMultiSelect with clear button (sibling element, avoid button nesting), mobile-safe positioning (viewport-width dropdown on narrow screens), and configurable maxSummaryItems
- Update usage API to send array params via appendUniqueParams
- Add i18n keys for reset/clear/select actions

## Test plan
- [x] bun run build passes
- [x] bun run lint passes (0 errors)
- [x] go build passes (backend compatibility verified)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>