### PR TITLE
fix: clear button hover behavior and layout for multi-select filters

### DIFF
--- a/src/modules/monitor/RequestLogsFilters.tsx
+++ b/src/modules/monitor/RequestLogsFilters.tsx
@@ -80,6 +80,7 @@ export function RequestLogsFilters({
               noResultsLabel={t("request_logs.no_filter_results")}
               aria-label={t("request_logs.filter_key")}
               clearLabel={t("request_logs.clear_key_filter")}
+              showClearButton
               size="sm"
             />
           </div>
@@ -98,6 +99,7 @@ export function RequestLogsFilters({
               noResultsLabel={t("request_logs.no_filter_results")}
               aria-label={t("request_logs.filter_model")}
               clearLabel={t("request_logs.clear_model_filter")}
+              showClearButton
               size="sm"
             />
           </div>
@@ -116,6 +118,7 @@ export function RequestLogsFilters({
               noResultsLabel={t("request_logs.no_filter_results")}
               aria-label={t("request_logs.filter_channel")}
               clearLabel={t("request_logs.clear_channel_filter")}
+              showClearButton
               size="sm"
             />
           </div>

--- a/src/modules/monitor/RequestLogsPage.tsx
+++ b/src/modules/monitor/RequestLogsPage.tsx
@@ -161,10 +161,11 @@ export function RequestLogsPage() {
         });
         setLastUpdatedAt(Date.now());
       } catch (err) {
+        if (seq !== requestSeqRef.current) return;
         const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
         notify({ type: "error", message });
       } finally {
-        setLoading(false);
+        if (seq === requestSeqRef.current) setLoading(false);
       }
     },
     [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses, notify, t],

--- a/src/modules/ui/SearchableCheckboxMultiSelect.tsx
+++ b/src/modules/ui/SearchableCheckboxMultiSelect.tsx
@@ -76,7 +76,7 @@ export function SearchableCheckboxMultiSelect({
   size = "default",
   clearLabel,
   onClear,
-  showClearButton = true,
+  showClearButton = false,
   maxSummaryItems = 2,
   mobileBreakpoint = 640,
 }: SearchableCheckboxMultiSelectProps) {
@@ -275,7 +275,7 @@ export function SearchableCheckboxMultiSelect({
 
   return (
     <>
-      <div className={cn("relative", className)}>
+      <div className={cn("group/multi-select relative", className)}>
         <button
           ref={triggerRef}
           type="button"
@@ -291,11 +291,10 @@ export function SearchableCheckboxMultiSelect({
           className={cn(
             getSelectTriggerBase(size),
             "w-full justify-between text-left",
-            value.length > 0 && showClearButton && "pr-9",
             disabled && selectTriggerDisabled,
           )}
         >
-          <span className={cn("truncate", value.length === 0 && "text-slate-400 dark:text-white/35")}>
+          <span className={cn("min-w-0 flex-1 truncate text-left", value.length === 0 && "text-slate-400 dark:text-white/35")}>
             {selectedSummary}
           </span>
           <span className="flex shrink-0 items-center gap-2">
@@ -306,7 +305,11 @@ export function SearchableCheckboxMultiSelect({
             ) : null}
             <ChevronDown
               size={14}
-              className={cn(selectChevron, open && "rotate-180")}
+              className={cn(
+                selectChevron,
+                value.length > 0 && showClearButton && "group-hover/multi-select:opacity-0 group-focus-within/multi-select:opacity-0",
+                open && "rotate-180",
+              )}
               aria-hidden="true"
             />
           </span>
@@ -316,7 +319,14 @@ export function SearchableCheckboxMultiSelect({
             type="button"
             aria-label={clearLabel}
             onClick={handleClear}
-            className="absolute right-7 top-1/2 -translate-y-1/2 flex items-center justify-center w-5 h-5 rounded text-slate-400 hover:text-slate-600 hover:bg-slate-100 dark:hover:bg-white/10 dark:hover:text-slate-300 transition-colors"
+            className={cn(
+              "absolute right-3 top-1/2 z-10 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded",
+              "text-slate-400 opacity-0 pointer-events-none transition-colors",
+              "group-hover/multi-select:pointer-events-auto group-hover/multi-select:opacity-100",
+              "group-focus-within/multi-select:pointer-events-auto group-focus-within/multi-select:opacity-100",
+              "hover:bg-slate-100 hover:text-slate-600",
+              "dark:hover:bg-white/10 dark:hover:text-slate-300",
+            )}
           >
             <X size={12} />
           </button>


### PR DESCRIPTION
## Summary
- Show clear button on hover/focus instead of always visible
- Position clear button over chevron (same right-3 spot), not next to it
- Chevron fades out when clear button appears on group hover/focus
- Remove pr-9 padding hack; add min-w-0 flex-1 to summary text for proper shrinking
- Add showClearButton to all 4 request log filters
- Fix fetchLogs seq check in catch/finally for request log page

## Test plan
- [x] bun run build passes
- [x] bun run test -- RequestLogs passes (9 tests)