### PR TITLE
feat: 请求日志页样式调整 - 列居中对齐、统计面板右移、清空按钮改为图标

### DIFF
--- a/src/modules/monitor/RequestLogsFilters.tsx
+++ b/src/modules/monitor/RequestLogsFilters.tsx
@@ -1,18 +1,11 @@
 import { useTranslation } from "react-i18next";
 import { useMemo } from "react";
-import { Filter, RotateCcw } from "lucide-react";
+import { RotateCcw } from "lucide-react";
 import { SearchableCheckboxMultiSelect } from "@/modules/ui/SearchableCheckboxMultiSelect";
 import type { SearchableCheckboxMultiSelectOption } from "@/modules/ui/SearchableCheckboxMultiSelect";
 import { cn } from "@/modules/ui/selectStyles";
 
 type StatusFilterValue = "success" | "failed";
-
-interface RequestLogStats {
-  total: number;
-  success_rate: number;
-  total_tokens: number;
-  total_cost: number;
-}
 
 interface RequestLogsFiltersProps {
   keyOptions: SearchableCheckboxMultiSelectOption[];
@@ -29,9 +22,6 @@ interface RequestLogsFiltersProps {
   onStatusesChange: (value: StatusFilterValue[]) => void;
   onResetFilters: () => void;
   hasActiveFilters: boolean;
-  stats: RequestLogStats;
-  lastUpdatedText: string;
-  loading: boolean;
 }
 
 export function RequestLogsFilters({
@@ -49,9 +39,6 @@ export function RequestLogsFilters({
   onStatusesChange,
   onResetFilters,
   hasActiveFilters,
-  stats,
-  lastUpdatedText,
-  loading,
 }: RequestLogsFiltersProps) {
   const { t } = useTranslation();
 
@@ -62,9 +49,7 @@ export function RequestLogsFilters({
 
   return (
     <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800/60">
-      <div className="grid gap-2 min-[480px]:grid-cols-2 sm:flex sm:flex-wrap sm:items-center">
-        {/* Filter controls */}
-        <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
           <div className="w-full min-[480px]:w-auto sm:w-[180px]">
             <SearchableCheckboxMultiSelect
               value={selectedApiKeys}
@@ -157,40 +142,6 @@ export function RequestLogsFilters({
             </button>
           ) : null}
         </div>
-
-        {/* Stats summary */}
-        <div className="col-span-2 min-[480px]:col-span-2 sm:col-span-1 sm:ml-auto">
-          <div className="grid grid-cols-2 items-center gap-x-3 gap-y-1.5 text-xs text-slate-600 dark:text-white/55 sm:flex sm:items-center sm:gap-1.5">
-            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-              <Filter size={12} aria-hidden="true" />
-              {t("request_logs.records_count", {
-                count: stats.total.toLocaleString(),
-              } as Record<string, string>)}
-            </span>
-
-            <span className="inline-flex items-center justify-end gap-1.5 whitespace-nowrap sm:justify-start">
-              {t("common.success_rate")}
-              <span className="font-mono tabular-nums">{stats.success_rate.toFixed(1)}%</span>
-            </span>
-
-            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-              {t("request_logs.col_total_token")}
-              <span className="font-mono tabular-nums">
-                {stats.total_tokens.toLocaleString()}
-              </span>
-            </span>
-
-            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
-              {t("request_logs.col_cost")}
-              <span className="font-mono tabular-nums">${stats.total_cost.toFixed(4)}</span>
-            </span>
-
-            <span className="col-span-2 text-[11px] text-slate-400 dark:text-white/40 sm:col-span-1 sm:text-xs">
-              {loading ? t("request_logs.refreshing") : lastUpdatedText}
-            </span>
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/modules/monitor/RequestLogsPage.tsx
+++ b/src/modules/monitor/RequestLogsPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { LoaderCircle, RefreshCw, ScrollText } from "lucide-react";
+import { LoaderCircle, RefreshCw, ScrollText, Trash2 } from "lucide-react";
 import { usageApi } from "@/lib/http/apis";
 import type { ClearUsageLogsPayload, UsageLogItem, UsageLogsResponse } from "@/lib/http/apis/usage";
 import { Button } from "@/modules/ui/Button";
@@ -318,14 +318,16 @@ export function RequestLogsPage() {
           </h2>
           <div className="flex flex-wrap items-center gap-2">
             <RequestLogsTimeRangeSelector value={timeRange} onChange={setTimeRange} />
-            <Button
-              variant="danger"
-              size="sm"
+            <button
+              type="button"
               onClick={handleOpenClearDialog}
               disabled={loading || clearingLogs}
+              aria-label={t("request_logs.clear_database_logs")}
+              title={t("request_logs.clear_database_logs")}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-rose-50 text-rose-600 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-rose-500/15 dark:text-rose-300 dark:hover:bg-rose-500/25"
             >
-              {t("request_logs.clear_database_logs")}
-            </Button>
+              <Trash2 size={14} aria-hidden="true" />
+            </button>
             <button
               type="button"
               onClick={() => fetchLogs(1, pageSize)}
@@ -344,7 +346,7 @@ export function RequestLogsPage() {
           </div>
         </div>
 
-        {/* 筛选 + 统计 */}
+        {/* 筛选 */}
         <RequestLogsFilters
           keyOptions={keyOptions}
           modelOptions={modelOptions}
@@ -360,40 +362,76 @@ export function RequestLogsPage() {
           onStatusesChange={setSelectedStatuses}
           onResetFilters={resetFilters}
           hasActiveFilters={hasActiveFilters}
-          stats={stats}
-          lastUpdatedText={lastUpdatedText}
-          loading={loading}
         />
 
-        {/* 表格区域 — 自适应视口高度，内部滚动 */}
-        <div className="relative min-h-[360px] h-[calc(100dvh-300px)] overflow-hidden px-5">
-          <DataTable
-            tableId="request-logs"
-            rows={rows}
-            columns={logColumns}
-            rowKey={(row) => row.id}
-            loading={loading}
-            virtualize={false}
-            minWidth="min-w-[1240px]"
-            height="h-full"
-            minHeight="min-h-full"
-            caption={t("request_logs.table_caption")}
-            emptyText={t("request_logs.no_data")}
-            showAllLoadedMessage={false}
-          />
+        {/* 表格区域 + 统计面板 */}
+        <div className="flex min-h-[360px] h-[calc(100dvh-300px)] px-5 overflow-hidden">
+          {/* 表格 */}
+          <div className="relative flex-1 overflow-hidden">
+            <DataTable
+              tableId="request-logs"
+              rows={rows}
+              columns={logColumns}
+              rowKey={(row) => row.id}
+              loading={loading}
+              virtualize={false}
+              minWidth="min-w-[1240px]"
+              height="h-full"
+              minHeight="min-h-full"
+              caption={t("request_logs.table_caption")}
+              emptyText={t("request_logs.no_data")}
+              showAllLoadedMessage={false}
+            />
 
-          {/* Loading overlay */}
-          {loading ? (
-            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
-              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">
-                <span
-                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
-                  aria-hidden="true"
-                />
-                <span role="status">{t("common.loading_ellipsis")}</span>
+            {/* Loading overlay */}
+            {loading ? (
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
+                <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">
+                  <span
+                    className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
+                    aria-hidden="true"
+                  />
+                  <span role="status">{t("common.loading_ellipsis")}</span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          {/* 统计面板 */}
+          <div className="ml-4 w-44 flex-shrink-0 border-l border-slate-100 pl-4 flex flex-col justify-center gap-3 dark:border-neutral-800/60">
+            <div className="text-xs text-slate-500 dark:text-white/50">
+              {t("request_logs.records_count", {
+                count: stats.total.toLocaleString(),
+              } as Record<string, string>)}
+            </div>
+            <div>
+              <div className="text-xs text-slate-500 dark:text-white/50">
+                {t("common.success_rate")}
+              </div>
+              <div className="font-mono tabular-nums text-sm text-slate-900 dark:text-white">
+                {stats.success_rate.toFixed(1)}%
               </div>
             </div>
-          ) : null}
+            <div>
+              <div className="text-xs text-slate-500 dark:text-white/50">
+                {t("request_logs.col_total_token")}
+              </div>
+              <div className="font-mono tabular-nums text-sm text-slate-900 dark:text-white">
+                {stats.total_tokens.toLocaleString()}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-slate-500 dark:text-white/50">
+                {t("request_logs.col_cost")}
+              </div>
+              <div className="font-mono tabular-nums text-sm text-emerald-700 dark:text-emerald-400">
+                ${stats.total_cost.toFixed(4)}
+              </div>
+            </div>
+            <div className="text-[11px] text-slate-400 dark:text-white/40 border-t border-slate-100 pt-3 dark:border-neutral-800/60">
+              {loading ? t("request_logs.refreshing") : lastUpdatedText}
+            </div>
+          </div>
         </div>
 
         {/* 分页控件 — flex-shrink-0 固定在底部 */}

--- a/src/modules/monitor/requestLogsShared.tsx
+++ b/src/modules/monitor/requestLogsShared.tsx
@@ -250,7 +250,8 @@ export function buildRequestLogsColumns(
       key: "id",
       label: t("request_logs.col_id"),
       width: "w-20",
-      cellClassName: "font-mono text-xs tabular-nums text-slate-500 dark:text-white/50",
+      headerClassName: "text-left",
+      cellClassName: "text-left font-mono text-xs tabular-nums text-slate-500 dark:text-white/50",
       render: (row) => (
         <OverflowTooltip content={`#${row.id}`} className="block min-w-0">
           <span className="block min-w-0 truncate">#{row.id}</span>
@@ -261,7 +262,8 @@ export function buildRequestLogsColumns(
       key: "timestamp",
       label: t("request_logs.col_time"),
       width: "w-52",
-      cellClassName: "font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
+      headerClassName: "text-center",
+      cellClassName: "text-center font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) => (
         <OverflowTooltip
           content={formatRequestLogTimestamp(row.timestamp)}
@@ -275,6 +277,8 @@ export function buildRequestLogsColumns(
       key: "channelName",
       label: t("request_logs.col_channel"),
       width: "w-32",
+      headerClassName: "text-center",
+      cellClassName: "text-center",
       render: (row) => (
         <OverflowTooltip content={row.channelName || "--"} className="block min-w-0">
           <span
@@ -350,9 +354,9 @@ export function buildRequestLogsColumns(
       key: "inputTokens",
       label: t("request_logs.col_input"),
       width: "w-32",
-      headerClassName: "text-right",
+      headerClassName: "text-center",
       cellClassName:
-        "text-right font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200 pl-6",
+        "text-center font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200 pl-6",
       render: (row) =>
         row.hasContent && onContentClick ? (
           <button
@@ -375,8 +379,8 @@ export function buildRequestLogsColumns(
       key: "cachedTokens",
       label: t("request_logs.col_cache_read"),
       width: "w-24",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums",
+      headerClassName: "text-center",
+      cellClassName: "text-center font-mono text-xs tabular-nums",
       render: (row) => (
         <OverflowTooltip content={row.cachedTokens.toLocaleString()} className="block min-w-0">
           <span
@@ -391,8 +395,8 @@ export function buildRequestLogsColumns(
       key: "outputTokens",
       label: t("request_logs.col_output"),
       width: "w-24",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
+      headerClassName: "text-center",
+      cellClassName: "text-center font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) =>
         row.hasContent && onContentClick ? (
           <button
@@ -415,8 +419,8 @@ export function buildRequestLogsColumns(
       key: "totalTokens",
       label: t("request_logs.col_total_token"),
       width: "w-28",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums text-slate-900 dark:text-white",
+      headerClassName: "text-center",
+      cellClassName: "text-center font-mono text-xs tabular-nums text-slate-900 dark:text-white",
       render: (row) => (
         <OverflowTooltip content={row.totalTokens.toLocaleString()} className="block min-w-0">
           <span className="block min-w-0 truncate">{row.totalTokens.toLocaleString()}</span>
@@ -427,9 +431,9 @@ export function buildRequestLogsColumns(
       key: "cost",
       label: t("request_logs.col_cost"),
       width: "w-24",
-      headerClassName: "text-right",
+      headerClassName: "text-center",
       cellClassName:
-        "text-right font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-400",
+        "text-center font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-400",
       render: (row) => (
         <OverflowTooltip content={`$${row.cost.toFixed(6)}`} className="block min-w-0">
           <span className="block min-w-0 truncate">${row.cost.toFixed(4)}</span>
@@ -440,6 +444,8 @@ export function buildRequestLogsColumns(
       key: "apiKeyName",
       label: t("request_logs.col_key_name"),
       width: "w-28",
+      headerClassName: "text-center",
+      cellClassName: "text-center",
       render: (row) => (
         <OverflowTooltip
           content={row.isSystemCall ? t("request_logs.system_call") : row.apiKeyName || "--"}
@@ -457,6 +463,8 @@ export function buildRequestLogsColumns(
       key: "model",
       label: t("request_logs.col_model"),
       width: "w-36",
+      headerClassName: "text-center",
+      cellClassName: "text-center",
       render: (row) => (
         <OverflowTooltip content={row.model} className="block min-w-0">
           <span className="block min-w-0 truncate">{row.model}</span>


### PR DESCRIPTION
## Summary
- 请求日志表格除 ID 列外所有列改为水平居中对齐
- 统计信息（记录数、成功率、总 Token、费用、更新时间）从筛选栏移到表格右侧独立面板
- 清空数据库日志文字按钮改为 Trash2 图标按钮，hover 时显示 tooltip

## Test plan
- [x] 编译通过
- [ ] 确认 ID 列左对齐，其他列居中对齐
- [ ] 确认统计面板在表格右侧显示
- [ ] 确认删除图标按钮的 tooltip 正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)