### PR TITLE
fix: move 新增 button to top toolbar and style 全选 with secondary variant

### DIFF
--- a/src/modules/providers/components/ProvidersToolbar.tsx
+++ b/src/modules/providers/components/ProvidersToolbar.tsx
@@ -97,7 +97,7 @@ export function ProvidersToolbar({
             </DropdownMenu.Root>
 
             <Button
-              variant="ghost"
+              variant="secondary"
               size="sm"
               className="relative h-8! px-2 text-xs"
               onClick={() => onSelectAll(!allCurrentSelected)}
@@ -116,6 +116,13 @@ export function ProvidersToolbar({
           </>
         ) : null}
 
+        {onAddCurrent ? (
+          <Button variant="primary" size="sm" className="h-8! px-3 text-xs" onClick={onAddCurrent}>
+            <Plus size={14} />
+            {t("providers.add_new")}
+          </Button>
+        ) : null}
+
         <Button
           variant="secondary"
           size="sm"
@@ -128,7 +135,7 @@ export function ProvidersToolbar({
         </Button>
       </div>
 
-      {/* Right group: grid + add */}
+      {/* Right group: grid */}
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1.5">
           <LayoutGrid size={14} className="text-slate-500 dark:text-white/50" />
@@ -145,12 +152,6 @@ export function ProvidersToolbar({
             aria-label={t("providers.grid_columns_aria")}
           />
         </div>
-        {onAddCurrent ? (
-          <Button variant="primary" size="sm" className="h-8! px-3 text-xs" onClick={onAddCurrent}>
-            <Plus size={14} />
-            {t("providers.add_new")}
-          </Button>
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Move "新增" button from right group to left toolbar button group
- Change "全选" button variant from "ghost" to "secondary" to match "导入 JSON" button style

## Test plan
- [ ] Verify "新增" button appears in left toolbar group alongside import/export/select buttons
- [ ] Verify "全选" button has same background styling as "导入 JSON" button
- [ ] Verify layout still works correctly on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)