### PR TITLE
fix: 移除清空日志弹窗描述文案 & 修复关闭按钮背景椭圆

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2340,7 +2340,6 @@
     "refreshing": "Refreshing…",
     "not_refreshed": "Not yet refreshed",
     "clear_database_logs": "Clear Database Logs",
-    "clear_database_logs_modal_desc": "Choose which request-log data to remove. You can clear large stored content while keeping request rows and statistics.",
     "clear_database_logs_keep_records_hint": "Recommended default: clear stored bodies and request details while keeping request records, Token totals, cost stats, and the request log table itself.",
     "clear_database_logs_confirm_button": "Clear Selected Data",
     "clear_database_logs_success_content": "Cleared stored request-log content while keeping request records",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2593,7 +2593,6 @@
     "refreshing": "刷新中…",
     "not_refreshed": "尚未刷新",
     "clear_database_logs": "清空数据库日志",
-    "clear_database_logs_modal_desc": "选择要清理的请求日志数据。你可以只清理占空间最大的正文内容，同时保留请求记录与统计。",
     "clear_database_logs_keep_records_hint": "推荐默认项：清理正文和请求详情，但保留请求记录、Token/费用统计，以及请求日志列表本身。",
     "clear_database_logs_confirm_button": "清理所选数据",
     "clear_database_logs_success_content": "已清理请求日志正文内容，并保留请求记录",

--- a/src/modules/monitor/RequestLogsPage.tsx
+++ b/src/modules/monitor/RequestLogsPage.tsx
@@ -451,7 +451,6 @@ export function RequestLogsPage() {
       <Modal
         open={confirmClearOpen}
         title={t("request_logs.clear_database_logs")}
-        description={t("request_logs.clear_database_logs_modal_desc")}
         maxWidth="max-w-xl"
         onClose={() => {
           if (!clearingLogs) setConfirmClearOpen(false);

--- a/src/modules/ui/Modal.tsx
+++ b/src/modules/ui/Modal.tsx
@@ -133,7 +133,7 @@ export function Modal({
               type="button"
               onClick={onClose}
               disabled={!open}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
               aria-label="close"
             >
               <X size={16} />


### PR DESCRIPTION
## Summary
1. 移除"清空数据库日志"弹窗中的描述文案
2. 在 Modal 关闭按钮上添加 `shrink-0`，修复因 flex 压缩导致的圆形 hover 背景变为纵向椭圆的问题

## Test plan
- [ ] 打开清空数据库日志弹窗，确认不再显示旧描述文案
- [ ] 悬停关闭按钮，确认圆形背景正常（正圆，非椭圆）
- [ ] 构建通过

🤖 Generated with Claude Code