### PR TITLE
fix: auth-files 页面缓存改用 localStorage，首次加载自动拉取 quota

### DIFF
--- a/src/modules/auth-files/AuthFilesPage.tsx
+++ b/src/modules/auth-files/AuthFilesPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigationType, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import type { AuthFileItem } from "@/lib/http/types";
@@ -72,7 +72,6 @@ const buildAuthFilesSignature = (items: AuthFileItem[]): string =>
 export function AuthFilesPage() {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
-  const navigationType = useNavigationType();
 
   const [tab, setTab] = useState<"files" | "excluded" | "alias">("files");
   const {
@@ -362,7 +361,6 @@ export function AuthFilesPage() {
       safePage,
       ...pageItems.map((file) => file.name),
     ].join("\n"),
-    navigationType,
     loading,
     setFiles,
     setDetailFile,

--- a/src/modules/auth-files/helpers/authFilesPageUtils.ts
+++ b/src/modules/auth-files/helpers/authFilesPageUtils.ts
@@ -139,7 +139,7 @@ const sanitizeAuthFileRestrictionsForCache = (
 export const readAuthFilesUiState = (): AuthFilesUiState | null => {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.sessionStorage.getItem(AUTH_FILES_UI_STATE_KEY);
+    const raw = window.localStorage.getItem(AUTH_FILES_UI_STATE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as AuthFilesUiState;
     return parsed && typeof parsed === "object" ? parsed : null;
@@ -151,7 +151,7 @@ export const readAuthFilesUiState = (): AuthFilesUiState | null => {
 export const writeAuthFilesUiState = (state: AuthFilesUiState) => {
   if (typeof window === "undefined") return;
   try {
-    window.sessionStorage.setItem(AUTH_FILES_UI_STATE_KEY, JSON.stringify(state));
+    window.localStorage.setItem(AUTH_FILES_UI_STATE_KEY, JSON.stringify(state));
   } catch {
     // ignore
   }
@@ -308,7 +308,7 @@ const sanitizeQuotaByFileNameForCache = (
 export const readAuthFilesDataCache = (): AuthFilesDataCache | null => {
   if (typeof window === "undefined") return null;
   try {
-    const raw = window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
+    const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<AuthFilesDataCache>;
     const files = Array.isArray(parsed?.files) ? (parsed.files as AuthFileItem[]) : null;
@@ -335,14 +335,14 @@ export const readAuthFilesDataCache = (): AuthFilesDataCache | null => {
 export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
   if (typeof window === "undefined") return;
   try {
-    const raw = window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
+    const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
     const previous = raw ? (JSON.parse(raw) as Partial<AuthFilesDataCache>) : null;
     const fileNames = new Set(cache.files.map((file) => file.name).filter(Boolean));
     const quotaByFileName = sanitizeQuotaByFileNameForCache(
       cache.quotaByFileName ?? previous?.quotaByFileName,
       fileNames,
     );
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: cache.savedAtMs,

--- a/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -35,7 +35,6 @@ interface UseAuthFilesQuotaStateOptions {
   tab: "files" | "excluded" | "alias";
   pageItems: AuthFileItem[];
   visibleScopeKey: string;
-  navigationType: "POP" | "PUSH" | "REPLACE";
   loading: boolean;
   setFiles: Dispatch<SetStateAction<AuthFileItem[]>>;
   setDetailFile: Dispatch<SetStateAction<AuthFileItem | null>>;
@@ -46,7 +45,6 @@ export function useAuthFilesQuotaState({
   tab,
   pageItems,
   visibleScopeKey,
-  navigationType,
   loading,
   setFiles,
   setDetailFile,
@@ -493,7 +491,7 @@ export function useAuthFilesQuotaState({
     visibleScopeKeyRef.current = visibleScopeKey;
 
     const firstVisibleScope = previousVisibleScopeKey === null;
-    const initialVisibleScope = firstVisibleScope && navigationType !== "POP";
+    const initialVisibleScope = firstVisibleScope;
     const switchedVisibleScope = !firstVisibleScope && previousVisibleScopeKey !== visibleScopeKey;
     if (!initialVisibleScope && !switchedVisibleScope && quotaAutoRefreshMs <= 0) return;
 
@@ -526,7 +524,6 @@ export function useAuthFilesQuotaState({
     loading,
     markQuotaTargetsLoading,
     pageItems,
-    navigationType,
     quotaAutoRefreshMs,
     resolveQuotaTargets,
     runQuotaRefreshBatch,


### PR DESCRIPTION
## Summary
- 将 auth-files 页面的 dataCache 和 uiState 从 sessionStorage 改为 localStorage，关闭页面后重新打开时自动恢复卡信息和筛选状态（类型选择、搜索、页码等）
- 移除 quota 初始加载对 navigationType 的判断，确保首次加载时自动拉取 quota，不再需手动刷新

## Test plan
- [ ] 打开 auth-files 页，确认卡片正常加载 quota 数据
- [ ] 切换类型筛选 (all / gemini / codex 等)，确认显示正常
- [ ] 关闭页面重新打开，确认卡片信息、类型筛选、搜索状态恢复
- [ ] 首次加载（直接输入 URL 或刷新），确认 quota 自动拉取无需手动点击刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)