### PR TITLE
fix: ECharts monitor 图表首次加载无动画

### DIFF
--- a/src/modules/monitor/MonitorDashboardSections.tsx
+++ b/src/modules/monitor/MonitorDashboardSections.tsx
@@ -171,8 +171,7 @@ export function MonitorDistributionSections({
 
   return (
     <>
-      <Reveal>
-        <section className="grid gap-4 lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)]">
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)]">
           <Card
             title={t("monitor.model_distribution")}
             description={t("monitor.last_days_desc", {
@@ -270,11 +269,9 @@ export function MonitorDistributionSections({
             </div>
           </Card>
         </section>
-      </Reveal>
 
       {apikeyDistributionData.length > 0 ? (
-        <Reveal>
-          <Card
+        <Card
             title={t("monitor.apikey_distribution")}
             description={t("monitor.apikey_distribution_desc", {
               days: timeRange,
@@ -318,8 +315,7 @@ export function MonitorDistributionSections({
               </div>
             </div>
           </Card>
-        </Reveal>
-      ) : null}
+        ) : null}
     </>
   );
 }
@@ -368,8 +364,7 @@ export function MonitorHourlySections({
 }) {
   return (
     <>
-      <Reveal>
-        <Card
+      <Card
           title={t("monitor.hourly_model.title")}
           description={t("monitor.hourly_model_desc")}
           actions={
@@ -389,10 +384,8 @@ export function MonitorHourlySections({
             }))}
           />
         </Card>
-      </Reveal>
 
-      <Reveal>
-        <Card
+      <Card
           title={t("monitor.hourly_token.title")}
           description={t("monitor.hourly_token_desc")}
           actions={
@@ -412,7 +405,6 @@ export function MonitorHourlySections({
             }))}
           />
         </Card>
-      </Reveal>
     </>
   );
 }

--- a/src/modules/monitor/MonitorPage.tsx
+++ b/src/modules/monitor/MonitorPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { usageApi } from "@/lib/http/apis";
 import { useTheme } from "@/modules/ui/ThemeProvider";
 import { CHART_COLOR_CLASSES, HOURLY_MODEL_COLORS } from "@/modules/monitor/monitor-constants";
@@ -90,16 +90,13 @@ export function MonitorPage() {
   >({});
   const [error, setError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(true);
-  const [isPending, startTransition] = useTransition();
 
   const refreshData = useCallback(async () => {
     setIsRefreshing(true);
     setError(null);
     try {
       const chartResp = await usageApi.getChartData(timeRange, apiFilter);
-      startTransition(() => {
-        setChartData(chartResp);
-      });
+      setChartData(chartResp);
     } catch (requestError) {
       const message =
         requestError instanceof Error ? requestError.message : t("monitor.failed_fetch");
@@ -158,7 +155,7 @@ export function MonitorPage() {
   }, []);
 
   const hasData = metrics.totalRequests > 0;
-  const isLoading = isRefreshing || isPending;
+  const isLoading = isRefreshing;
 
   useEffect(() => {
     void refreshData();
@@ -601,51 +598,47 @@ export function MonitorPage() {
         refreshData={refreshData}
       />
 
-      {hasData ? (
-        <>
-          <MonitorDistributionSections
-            t={t}
-            timeRange={timeRange}
-            modelMetric={modelMetric}
-            setModelMetric={setModelMetric}
-            modelDistributionOption={modelDistributionOption}
-            modelDistributionLegend={modelDistributionLegend}
-            toggleModelDistributionLegend={toggleModelDistributionLegend}
-            dailyTrendOption={dailyTrendOption}
-            dailyLegendAvailability={dailyLegendAvailability}
-            dailyLegendSelected={dailyLegendSelected}
-            toggleDailyLegend={toggleDailyLegend}
-            apikeyDistributionData={apikeyDistributionData}
-            apikeyMetric={apikeyMetric}
-            setApikeyMetric={setApikeyMetric}
-            apikeyDistributionOption={apikeyDistributionOption}
-            apikeyDistributionLegend={apikeyDistributionLegend}
-            toggleApikeyDistributionLegend={toggleApikeyDistributionLegend}
-            isRefreshing={isRefreshing}
-          />
+      <MonitorDistributionSections
+        t={t}
+        timeRange={timeRange}
+        modelMetric={modelMetric}
+        setModelMetric={setModelMetric}
+        modelDistributionOption={modelDistributionOption}
+        modelDistributionLegend={modelDistributionLegend}
+        toggleModelDistributionLegend={toggleModelDistributionLegend}
+        dailyTrendOption={dailyTrendOption}
+        dailyLegendAvailability={dailyLegendAvailability}
+        dailyLegendSelected={dailyLegendSelected}
+        toggleDailyLegend={toggleDailyLegend}
+        apikeyDistributionData={apikeyDistributionData}
+        apikeyMetric={apikeyMetric}
+        setApikeyMetric={setApikeyMetric}
+        apikeyDistributionOption={apikeyDistributionOption}
+        apikeyDistributionLegend={apikeyDistributionLegend}
+        toggleApikeyDistributionLegend={toggleApikeyDistributionLegend}
+        isRefreshing={isRefreshing}
+      />
 
-          <MonitorHourlySections
-            t={t}
-            isRefreshing={isRefreshing}
-            modelHourWindow={modelHourWindow}
-            setModelHourWindow={setModelHourWindow}
-            hourlyModelLegendKeys={hourlyModelLegendKeys}
-            hourlyModelOption={hourlyModelOption}
-            hourlySeries={hourlySeries}
-            getHourlyModelSeriesLabel={getHourlyModelSeriesLabel}
-            hourlyModelPalette={hourlyModelPalette}
-            hourlyModelSelected={hourlyModelSelected}
-            toggleHourlyModelLegend={toggleHourlyModelLegend}
-            tokenHourWindow={tokenHourWindow}
-            setTokenHourWindow={setTokenHourWindow}
-            hourlyTokenOption={hourlyTokenOption}
-            hourlyTokenLabels={hourlyTokenLabels}
-            hourlyTokenPalette={hourlyTokenPalette}
-            hourlyTokenSelected={hourlyTokenSelected}
-            toggleHourlyTokenLegend={toggleHourlyTokenLegend}
-          />
-        </>
-      ) : null}
+      <MonitorHourlySections
+        t={t}
+        isRefreshing={isRefreshing}
+        modelHourWindow={modelHourWindow}
+        setModelHourWindow={setModelHourWindow}
+        hourlyModelLegendKeys={hourlyModelLegendKeys}
+        hourlyModelOption={hourlyModelOption}
+        hourlySeries={hourlySeries}
+        getHourlyModelSeriesLabel={getHourlyModelSeriesLabel}
+        hourlyModelPalette={hourlyModelPalette}
+        hourlyModelSelected={hourlyModelSelected}
+        toggleHourlyModelLegend={toggleHourlyModelLegend}
+        tokenHourWindow={tokenHourWindow}
+        setTokenHourWindow={setTokenHourWindow}
+        hourlyTokenOption={hourlyTokenOption}
+        hourlyTokenLabels={hourlyTokenLabels}
+        hourlyTokenPalette={hourlyTokenPalette}
+        hourlyTokenSelected={hourlyTokenSelected}
+        toggleHourlyTokenLegend={toggleHourlyTokenLegend}
+      />
     </div>
   );
 }

--- a/src/modules/ui/charts/EChartRenderer.tsx
+++ b/src/modules/ui/charts/EChartRenderer.tsx
@@ -160,7 +160,6 @@ export function EChartRenderer({
           const width = container.clientWidth;
           const height = container.clientHeight;
           if (width > 0 && height > 0) {
-            requestResize(width, height);
             window.setTimeout(() => {
               requestResize(container.clientWidth, container.clientHeight);
             }, 60);


### PR DESCRIPTION
## Summary
- 修复 monitor 页面首次进入时 ECharts 图表加载没有动画的问题
- 根因：Reveal 的 opacity transition 遮盖了 ECharts 动画、hasData 守卫延迟了 React.lazy import、startTransition 导致状态不同步、onChartReady 中 resize 可能打断动画
- 见 commit message 详细说明

## Test plan
- [ ] 访问 /manage/monitor 页面，观察图表首次加载时是否有入场动画
- [ ] 切换时间范围/API Key 后图表更新动画是否正常