### PR TITLE
fix: CC Switch 配置重复校验应检查请求模型而非渠道模型

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2474,7 +2474,7 @@
     "config_delete_model_mapping": "Delete model mapping {{index}}",
     "config_actual_channel_model": "Actual channel model",
     "config_actual_channel_model_for_mapping": "Actual channel model {{index}}",
-    "config_actual_model_duplicate": "Actual channel model cannot be repeated: {{model}}",
+    "config_request_model_duplicate": "CC Switch request model cannot be repeated: {{model}}",
     "config_request_model_name": "CC Switch request model",
     "config_request_model_for": "CC Switch request model for {{model}}",
     "config_request_model_for_mapping": "CC Switch request model for mapping {{index}}",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2729,7 +2729,7 @@
     "config_delete_model_mapping": "删除第 {{index}} 条模型映射",
     "config_actual_channel_model": "实际渠道模型",
     "config_actual_channel_model_for_mapping": "第 {{index}} 条实际渠道模型",
-    "config_actual_model_duplicate": "实际渠道模型不能重复：{{model}}",
+    "config_request_model_duplicate": "CC Switch 请求模型不能重复：{{model}}",
     "config_request_model_name": "CC Switch 请求模型",
     "config_request_model_for": "{{model}} 对应的 CC Switch 请求模型",
     "config_request_model_for_mapping": "第 {{index}} 条 CC Switch 请求模型",

--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -229,15 +229,15 @@ function modelOptions(models: readonly string[]): SearchableSelectOption[] {
   }));
 }
 
-function getDuplicateGenericTargetModels(modelMappings: readonly CcSwitchModelMapping[]): string[] {
+function getDuplicateGenericRequestModels(modelMappings: readonly CcSwitchModelMapping[]): string[] {
   const counts = new Map<string, { label: string; count: number }>();
   for (const mapping of modelMappings) {
     if (mapping.role) continue;
-    const targetModel = mapping.targetModel.trim();
-    if (!targetModel) continue;
-    const key = targetModel.toLowerCase();
+    const requestModel = mapping.requestModel.trim();
+    if (!requestModel) continue;
+    const key = requestModel.toLowerCase();
     const current = counts.get(key);
-    counts.set(key, { label: current?.label ?? targetModel, count: (current?.count ?? 0) + 1 });
+    counts.set(key, { label: current?.label ?? requestModel, count: (current?.count ?? 0) + 1 });
   }
   return Array.from(counts.values())
     .filter((item) => item.count > 1)
@@ -493,13 +493,13 @@ export function CcSwitchImportConfigModal({
   );
   const preparedDraft = prepareDraftForSave(draft);
   const modelMappingsLoading = Boolean(selectedGroup && modelsLoading);
-  const duplicateActualModels = getDuplicateGenericTargetModels(draft.modelMappings);
+  const duplicateRequestModels = getDuplicateGenericRequestModels(draft.modelMappings);
   const isSaveDisabled =
     !preparedDraft.providerName.trim() ||
     !selectedGroup ||
     !preparedDraft.defaultModel.trim() ||
     preparedDraft.modelMappings.length === 0 ||
-    duplicateActualModels.length > 0 ||
+    duplicateRequestModels.length > 0 ||
     modelMappingsLoading;
 
   const setClientType = (clientType: CcSwitchClientType) => {
@@ -959,10 +959,10 @@ export function CcSwitchImportConfigModal({
                   </tbody>
                 </table>
               )}
-              {duplicateActualModels.length > 0 ? (
+              {duplicateRequestModels.length > 0 ? (
                 <div className="border-t border-rose-100 bg-rose-50 px-4 py-2 text-xs font-medium text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">
-                  {t("ccswitch.config_actual_model_duplicate", {
-                    model: duplicateActualModels.join(", "),
+                  {t("ccswitch.config_request_model_duplicate", {
+                    model: duplicateRequestModels.join(", "),
                   })}
                 </div>
               ) : null}

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -222,7 +222,7 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(within(dialog).queryByRole("tab", { name: /gemini cli/i })).not.toBeInTheDocument();
   });
 
-  test("manually adds and deletes Codex model mappings while validating duplicate actual models", async () => {
+  test("manually adds and deletes Codex model mappings while validating duplicate request models", async () => {
     listChannelGroups.mockResolvedValue([
       {
         name: "pro",
@@ -242,10 +242,11 @@ describe("CcSwitchImportSettingsPage", () => {
 
     expect(await within(dialog).findByText(/add a model mapping/i)).toBeInTheDocument();
     expect(
-      within(dialog).queryByLabelText(/cc switch request model for deepseek-v4-flash/i),
+      within(dialog).queryByLabelText(/cc switch request model for mapping 1/i),
     ).not.toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: /^save$/i })).toBeDisabled();
 
+    // Add mapping 1: targetModel=deepseek-v4-flash, requestModel=gpt-5.5
     await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
     await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 1/i }));
     await user.click(await screen.findByRole("option", { name: "deepseek-v4-flash" }));
@@ -254,22 +255,24 @@ describe("CcSwitchImportSettingsPage", () => {
       "gpt-5.5",
     );
 
+    // Add mapping 2: targetModel=kimi-k2, requestModel=gpt-5.5 (duplicate request model)
     await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
     await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 2/i }));
-    await user.click(await screen.findByRole("option", { name: "deepseek-v4-flash" }));
+    await user.click(await screen.findByRole("option", { name: "kimi-k2" }));
     await user.type(
       within(dialog).getByLabelText(/cc switch request model for mapping 2/i),
-      "gpt-5.4",
+      "gpt-5.5",
     );
 
     expect(
-      await within(dialog).findByText(/actual channel model cannot be repeated/i),
+      await within(dialog).findByText(/cc switch request model cannot be repeated/i),
     ).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: /^save$/i })).toBeDisabled();
 
+    // Delete mapping 2 — error should go away
     await user.click(within(dialog).getByRole("button", { name: /delete model mapping 2/i }));
     expect(
-      within(dialog).queryByText(/actual channel model cannot be repeated/i),
+      within(dialog).queryByText(/cc switch request model cannot be repeated/i),
     ).not.toBeInTheDocument();
 
     await user.type(within(dialog).getByLabelText(/provider name/i), "Relay Codex");


### PR DESCRIPTION
## 修复

CC Switch 配置的模型映射表中，重复校验放在了错误的列上。之前校验的是「实际渠道模型」(targetModel) 不能重复，但实际上应该校验的是「CC Switch 请求模型」(requestModel) 不能重复。

## 修改

-  → ，从检查 targetModel 改为检查 requestModel
- 错误提示 i18n 改为 CC Switch 请求模型不能重复
- 测试用例更新：验证重复 requestModel 报错

## 验证

- [x] 编译通过
- [x] 测试通过 (26 passed)