### PR TITLE
fix: channel-groups 列表表格无法上下滚动

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1413,10 +1413,11 @@ export function RoutingConfigEditor({
           rowKey={(group) => group.id}
           virtualize={false}
           rowHeight={44}
-          height="h-auto max-h-[68vh]"
+          height="h-[calc(100dvh-200px)]"
           minWidth="min-w-[1360px]"
           caption={t("channel_groups_page.table_group")}
           emptyText={t("channel_groups_page.empty_groups")}
+          allowWheelPropagationAtBoundary
           rowClassName={(group) =>
             group.system
               ? "bg-slate-50/55 dark:bg-neutral-900/45"


### PR DESCRIPTION
修复渠道分组管理页面中 DataTable 列表无法垂直滚动的问题。

**问题原因**：DataTable 的 height 参数使用了 `h-auto max-h-[68vh]`，导致：
1. CSS Grid 容器高度不确定（auto），内部滚动容器的 `h-full` 无法正确解析
2. `handleWheel` 事件处理器在内部无法滚动时阻止了所有滚动事件冒泡

**修改内容**：
- `height` 改为 `h-[calc(100dvh-200px)]`，提供确定高度使 CSS Grid 内部滚动正常
- 添加 `allowWheelPropagationAtBoundary`，当到达滚动边界时允许事件冒泡到页面滚动

**验证**：编译通过