### PR TITLE
fix: ProviderCard header 布局 — 菜单固定在右侧，健康图标紧贴标题

### DIFF
--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -66,8 +66,9 @@ export function ProviderCard({
         .join(" ")}
     >
       {/* Header */}
-      <div className="flex min-w-0 items-center gap-2">
-        {onToggleSelected ? (
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          {onToggleSelected ? (
             <div
               className={[
                 "flex items-center justify-center overflow-hidden transition-[width,opacity] duration-200 ease-out",
@@ -86,7 +87,7 @@ export function ProviderCard({
             </div>
           ) : null}
           <p
-            className="min-w-0 max-w-[180px] flex-1 truncate text-sm font-semibold text-slate-900 dark:text-white"
+            className="min-w-0 max-w-[180px] truncate text-sm font-semibold text-slate-900 dark:text-white"
             title={title}
           >
             {title}
@@ -94,60 +95,61 @@ export function ProviderCard({
           {hasHeaderExtra ? (
             <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">{headerExtra}</div>
           ) : null}
-          {hasActionMenu ? (
-            <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
-              <DropdownMenu.Trigger asChild>
-                <button
-                  type="button"
-                  className={[
-                    "inline-flex h-5 w-5 flex-none items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none outline-none ring-0 transition-[color,opacity] duration-150 ease-out hover:bg-transparent hover:text-slate-950 focus-visible:ring-2 focus-visible:ring-slate-400/35 active:bg-transparent dark:text-white/55 dark:hover:bg-transparent dark:hover:text-white dark:focus-visible:ring-white/15",
-                    menuOpen
-                      ? "pointer-events-auto opacity-100"
-                      : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 max-md:pointer-events-auto max-md:opacity-100",
-                  ].join(" ")}
-                  aria-label={t("providers.more_actions")}
-                  title={t("providers.more_actions")}
-                  data-tooltip-placement="left"
-                >
-                  <EllipsisVertical size={13} />
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  align="end"
-                  sideOffset={8}
-                  className={ACTION_MENU_CONTENT_CLASS}
-                >
-                  {onToggleEnabled ? (
-                    <DropdownMenu.Item
-                      className={ACTION_MENU_ITEM_CLASS}
-                      onSelect={() => onToggleEnabled(!enabled)}
-                    >
-                      <Power size={15} />
-                      <span>
-                        {enabled ? t("providers.disable") : t("providers.enable")}
-                      </span>
-                    </DropdownMenu.Item>
-                  ) : null}
-                  {onEdit ? (
-                    <DropdownMenu.Item className={ACTION_MENU_ITEM_CLASS} onSelect={() => onEdit()}>
-                      <Settings2 size={15} />
-                      <span>{t("providers.edit")}</span>
-                    </DropdownMenu.Item>
-                  ) : null}
-                  {onDelete ? (
-                    <DropdownMenu.Item
-                      className={ACTION_MENU_DANGER_ITEM_CLASS}
-                      onSelect={() => onDelete()}
-                    >
-                      <Trash2 size={15} />
-                      <span>{t("providers.delete")}</span>
-                    </DropdownMenu.Item>
-                  ) : null}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-          ) : null}
+        </div>
+        {hasActionMenu ? (
+          <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenu.Trigger asChild>
+              <button
+                type="button"
+                className={[
+                  "inline-flex h-5 w-5 flex-none items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none outline-none ring-0 transition-[color,opacity] duration-150 ease-out hover:bg-transparent hover:text-slate-950 focus-visible:ring-2 focus-visible:ring-slate-400/35 active:bg-transparent dark:text-white/55 dark:hover:bg-transparent dark:hover:text-white dark:focus-visible:ring-white/15",
+                  menuOpen
+                    ? "pointer-events-auto opacity-100"
+                    : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 max-md:pointer-events-auto max-md:opacity-100",
+                ].join(" ")}
+                aria-label={t("providers.more_actions")}
+                title={t("providers.more_actions")}
+                data-tooltip-placement="left"
+              >
+                <EllipsisVertical size={13} />
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content
+                align="end"
+                sideOffset={8}
+                className={ACTION_MENU_CONTENT_CLASS}
+              >
+                {onToggleEnabled ? (
+                  <DropdownMenu.Item
+                    className={ACTION_MENU_ITEM_CLASS}
+                    onSelect={() => onToggleEnabled(!enabled)}
+                  >
+                    <Power size={15} />
+                    <span>
+                      {enabled ? t("providers.disable") : t("providers.enable")}
+                    </span>
+                  </DropdownMenu.Item>
+                ) : null}
+                {onEdit ? (
+                  <DropdownMenu.Item className={ACTION_MENU_ITEM_CLASS} onSelect={() => onEdit()}>
+                    <Settings2 size={15} />
+                    <span>{t("providers.edit")}</span>
+                  </DropdownMenu.Item>
+                ) : null}
+                {onDelete ? (
+                  <DropdownMenu.Item
+                    className={ACTION_MENU_DANGER_ITEM_CLASS}
+                    onSelect={() => onDelete()}
+                  >
+                    <Trash2 size={15} />
+                    <span>{t("providers.delete")}</span>
+                  </DropdownMenu.Item>
+                ) : null}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+        ) : null}
         </div>
 
       {/* Content */}


### PR DESCRIPTION
修复 ProviderCard header 布局问题：

1. ⋮ 菜单按钮现固定在卡片最右端（之前标题的 flex-1 会撑满中间空间）
2. 健康探测图标（延迟值）紧贴卡片名称右侧（之前因 flex-1 撑开分离）
3. 标题保留 max-w-[180px] truncate 处理超长名称截断

**修改**：外层 flex 改用 justify-between，标题/checkbox/headerExtra 包裹在左侧容器