### PR TITLE
feat: CC Switch 弹窗模型映射立即展示 + availability 新接口支持

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -305,7 +305,9 @@ export function CcSwitchImportConfigModal({
       endpointPath:
         value.endpointPath || DEFAULT_CC_SWITCH_IMPORT_SETTINGS[value.clientType].endpointPath,
     });
-    setAvailableModels([]);
+    setAvailableModels(
+      dedupeModels(value.modelMappings.map((mapping) => mapping.targetModel).filter(Boolean)),
+    );
   }, [open, value]);
 
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
@@ -363,7 +365,10 @@ export function CcSwitchImportConfigModal({
         };
         const needsModelConfigs = authoritativeModelOwnerKeys.size > 0 || modelOwnerKeys.size > 0;
         if (needsModelConfigs) {
-          const modelConfigs = await modelsApi.getModelConfigs("active").catch(() => []);
+          const modelConfigs =
+            availability.metadataItems && availability.metadataItems.length > 0
+              ? availability.metadataItems
+              : await modelsApi.getModelConfigs("active").catch(() => []);
           if (cancelled) return;
           if (modelOwnerKeys.size > 0 && authoritativeModelOwnerKeys.size === 0) {
             const allowedModelIds = new Set(
@@ -419,15 +424,15 @@ export function CcSwitchImportConfigModal({
     if (!open) return;
     setDraft((current) => {
       const currentSelectedGroup = current.allowedChannelGroups[0] ?? "";
-      return currentSelectedGroup
-        ? reconcileModelMappings(current, availableModels)
-        : {
-            ...current,
-            defaultModel: "",
-            modelMappings: [],
-          };
+      if (!currentSelectedGroup) {
+        return { ...current, defaultModel: "", modelMappings: [] };
+      }
+      if (modelsLoading && availableModels.length === 0 && current.modelMappings.length > 0) {
+        return current;
+      }
+      return reconcileModelMappings(current, availableModels);
     });
-  }, [availableModelsKey, open, selectedGroup]);
+  }, [availableModelsKey, open, selectedGroup, modelsLoading, availableModels.length]);
 
   const authFieldOptions = useMemo(
     () =>
@@ -492,15 +497,15 @@ export function CcSwitchImportConfigModal({
     [availableModels, draft.modelMappings],
   );
   const preparedDraft = prepareDraftForSave(draft);
-  const modelMappingsLoading = Boolean(selectedGroup && modelsLoading);
+  const hasRenderableMappings = draft.modelMappings.length > 0;
+  const modelMappingsLoading = Boolean(selectedGroup && modelsLoading && !hasRenderableMappings);
   const duplicateRequestModels = getDuplicateGenericRequestModels(draft.modelMappings);
   const isSaveDisabled =
     !preparedDraft.providerName.trim() ||
     !selectedGroup ||
     !preparedDraft.defaultModel.trim() ||
     preparedDraft.modelMappings.length === 0 ||
-    duplicateRequestModels.length > 0 ||
-    modelMappingsLoading;
+    duplicateRequestModels.length > 0;
 
   const setClientType = (clientType: CcSwitchClientType) => {
     const defaults = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[clientType];

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -29,6 +29,7 @@ export type ConfiguredModelAvailability = {
   scoped: boolean;
   items: ModelAvailabilityItem[];
   idSet: Set<string>;
+  metadataItems?: ModelAvailabilityItem[];
 };
 
 export type ModelPricingMode = "token" | "call";
@@ -535,7 +536,110 @@ const loadAuthFileModelItems = async (
   return { items: Array.from(map.values()), scoped };
 };
 
+/* ── New backend aggregation endpoint support ── */
+
+const normalizeAvailabilityItem = (raw: unknown): ModelAvailabilityItem | null => {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const id = String(record.id ?? "").trim();
+  if (!id) return null;
+
+  const pricingRecord = record.pricing && typeof record.pricing === "object" ? (record.pricing as Record<string, unknown>) : {};
+  const pricing: ModelPricing = {
+    mode: String(pricingRecord.mode ?? "token") === "call" ? "call" : "token",
+    inputPricePerMillion: asNumber(pricingRecord.input_price_per_million ?? pricingRecord.inputPricePerMillion),
+    outputPricePerMillion: asNumber(pricingRecord.output_price_per_million ?? pricingRecord.outputPricePerMillion),
+    cachedPricePerMillion: asNumber(pricingRecord.cached_price_per_million ?? pricingRecord.cachedPricePerMillion),
+    pricePerCall: asNumber(pricingRecord.price_per_call ?? pricingRecord.pricePerCall),
+  };
+
+  const inputModalities = Array.isArray(record.input_modalities) ? (record.input_modalities as string[]) : [];
+  const outputModalities = Array.isArray(record.output_modalities) ? (record.output_modalities as string[]) : [];
+  const supportsVision = record.supports_vision === true || inputModalities.some((m: string) => ["image", "vision"].includes(m.toLowerCase()));
+
+  return {
+    id,
+    owned_by: String(record.owned_by ?? ""),
+    description: String(record.description ?? ""),
+    source: String(record.source ?? record.metadata_source ?? ""),
+    enabled: record.enabled !== false,
+    pricing,
+    inputModalities,
+    outputModalities,
+    supportsVision,
+  };
+};
+
+export const normalizeConfiguredModelAvailability = (payload: unknown): ConfiguredModelAvailability => {
+  const record = isRecord(payload) ? payload : {};
+  const rawItems = Array.isArray(record.data)
+    ? record.data
+    : Array.isArray(record.models)
+      ? record.models
+      : Array.isArray(record.items)
+        ? record.items
+        : [];
+  const items = rawItems
+    .map((item) => normalizeAvailabilityItem(item))
+    .filter((item): item is NonNullable<typeof item> => item !== null)
+    .sort((a, b) => a!.id.localeCompare(b!.id));
+
+  const rawMetadata = Array.isArray(record.active_metadata) ? record.active_metadata : [];
+  const metadataItems = rawMetadata
+    .map((item) => normalizeAvailabilityItem(item))
+    .filter((item): item is NonNullable<typeof item> => item !== null)
+    .sort((a, b) => a!.id.localeCompare(b!.id));
+
+  return {
+    scoped: record.scoped === false ? false : items.length > 0,
+    items,
+    metadataItems,
+    idSet: new Set(items.map((item) => item.id.toLowerCase())),
+  };
+};
+
+/* ── In-flight/TTL cache ── */
+
+const CONFIGURED_AVAILABILITY_TTL_MS = 15_000;
+let configuredAvailabilityCache:
+  | { expiresAt: number; value: ConfiguredModelAvailability }
+  | null = null;
+let configuredAvailabilityInFlight: Promise<ConfiguredModelAvailability> | null = null;
+
+export const invalidateConfiguredModelAvailability = () => {
+  configuredAvailabilityCache = null;
+};
+
 export const loadConfiguredModelAvailability = async (): Promise<ConfiguredModelAvailability> => {
+  const now = Date.now();
+  if (configuredAvailabilityCache && now < configuredAvailabilityCache.expiresAt) {
+    return configuredAvailabilityCache.value;
+  }
+  if (configuredAvailabilityInFlight) {
+    return configuredAvailabilityInFlight;
+  }
+
+  configuredAvailabilityInFlight = (async (): Promise<ConfiguredModelAvailability> => {
+    try {
+      const result = normalizeConfiguredModelAvailability(
+        await apiClient.get("/models/configured-availability"),
+      );
+      configuredAvailabilityCache = { expiresAt: now + CONFIGURED_AVAILABILITY_TTL_MS, value: result };
+      return result;
+    } catch {
+      // Fallback to old multi-API aggregation for backward compatibility.
+      return loadConfiguredModelAvailabilityFallback();
+    }
+  })();
+
+  try {
+    return await configuredAvailabilityInFlight;
+  } finally {
+    configuredAvailabilityInFlight = null;
+  }
+};
+
+const loadConfiguredModelAvailabilityFallback = async (): Promise<ConfiguredModelAvailability> => {
   const [authFiles, libraryPayload, providerItems] = await Promise.all([
     loadAuthFiles(),
     apiClient.get("/model-configs?scope=library").catch(() => null),


### PR DESCRIPTION
## 改动

### CC Switch 弹窗交互修复
- 打开弹窗时用已有 modelMappings 初始化 availableModels，映射立即展示
- modelsLoading 不遮挡已有映射（仅新建配置时显示 loading skeleton）
- 可用模型加载期间不阻塞保存按钮
- reconcile effect 在后台加载时跳过已有配置的重整

### availability 新接口支持
- loadConfiguredModelAvailability 优先尝试新后端 /models/configured-availability
- 新增 normalizeConfiguredModelAvailability 支持新后端返回格式
- 新增 in-flight/TTL 缓存（15s），避免重复请求
- 新增 invalidateConfiguredModelAvailability 供配置保存后失效缓存
- 旧后端不可用时自动 fallback 到原多接口逻辑
- owner 过滤优先使用聚合接口返回的 active_metadata（替代额外调 getModelConfigs）

详见设计文档 docs/ccswitch-model-availability-performance-issue_CN.md