### PR TITLE
fix: tighten configured model availability handling

### DIFF
--- a/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/src/modules/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1139,7 +1139,7 @@ describe("AuthFilesPage files table", () => {
       await router.navigate("/auth-files");
     });
 
-    // Should render immediately from sessionStorage cache (no blank state)
+    // Should render immediately from localStorage cache (no blank state)
     expect(screen.getByText("qwen.json")).toBeInTheDocument();
   });
 
@@ -1162,7 +1162,7 @@ describe("AuthFilesPage files table", () => {
       items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 88 }],
     });
     window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -1582,7 +1582,7 @@ describe("AuthFilesPage files table", () => {
       },
     ] as any[];
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -1642,6 +1642,9 @@ describe("AuthFilesPage files table", () => {
     expect(await within(card as HTMLElement).findByText("1 calls")).toBeInTheDocument();
     expect(await within(otherCard as HTMLElement).findByText("10 calls")).toBeInTheDocument();
 
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(2));
+    mocks.fetchQuota.mockClear();
+
     fireEvent.click(within(card as HTMLElement).getByRole("button", { name: "Refresh" }));
 
     await waitFor(() => {
@@ -1674,7 +1677,7 @@ describe("AuthFilesPage files table", () => {
       resolve: (value: { items: Array<{ label: string; percent: number }> }) => void;
       reject: (reason?: unknown) => void;
     };
-    const deferredQueue = Array.from({ length: files.length }, () =>
+    const deferredQueue = Array.from({ length: files.length * 2 }, () =>
       createDeferred<{ items: Array<{ label: string; percent: number }> }>(),
     );
     const startedDeferreds: QuotaRefreshDeferred[] = [];
@@ -1682,7 +1685,7 @@ describe("AuthFilesPage files table", () => {
     let maxActiveFetches = 0;
 
     window.localStorage.setItem(AUTH_FILES_QUOTA_AUTO_REFRESH_KEY, JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -1726,6 +1729,21 @@ describe("AuthFilesPage files table", () => {
     );
 
     expect(await screen.findByText("codex-1.json")).toBeInTheDocument();
+    for (let index = 0; index < files.length; index += 2) {
+      await waitFor(() =>
+        expect(mocks.fetchQuota).toHaveBeenCalledTimes(Math.min(files.length, index + 2)),
+      );
+      const warmupDeferreds = startedDeferreds.splice(0);
+      await act(async () => {
+        warmupDeferreds.forEach((deferred) =>
+          deferred.resolve({ items: [{ label: "m_quota.code_5h", percent: 60 }] }),
+        );
+      });
+    }
+    await waitFor(() => expect(activeFetches).toBe(0));
+    mocks.fetchQuota.mockClear();
+    maxActiveFetches = 0;
+
     const refreshButton = screen.getAllByRole("button", { name: "Refresh" })[0];
     expect(refreshButton).toBeEnabled();
 
@@ -1780,11 +1798,11 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(10000));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_UI_STATE_KEY,
       JSON.stringify({ tab: "files", filter: "codex", search: "", page: 1 }),
     );
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -1854,11 +1872,11 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_UI_STATE_KEY,
       JSON.stringify({ tab: "files", filter: "qwen", search: "", page: 1 }),
     );
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2486,7 +2504,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2541,7 +2559,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2591,7 +2609,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2656,7 +2674,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2712,7 +2730,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2798,7 +2816,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2863,7 +2881,7 @@ describe("AuthFilesPage files table", () => {
     mocks.list.mockImplementation(async () => ({ files: [file] }));
 
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -2937,7 +2955,7 @@ describe("AuthFilesPage files table", () => {
     mocks.list.mockImplementation(async () => ({ files: [file] }));
 
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3018,7 +3036,7 @@ describe("AuthFilesPage files table", () => {
     mocks.list.mockImplementation(async () => ({ files: [file] }));
 
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3086,7 +3104,7 @@ describe("AuthFilesPage files table", () => {
     mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3182,11 +3200,11 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_UI_STATE_KEY,
       JSON.stringify({ tab: "files", filter: "qwen", search: "", page: 1 }),
     );
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3294,7 +3312,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3348,7 +3366,7 @@ describe("AuthFilesPage files table", () => {
     mocks.fetchQuota.mockImplementation(() => new Promise(() => {}));
 
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3427,7 +3445,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3462,6 +3480,9 @@ describe("AuthFilesPage files table", () => {
     const firstCard = firstTitle.closest("section");
     expect(firstCard).not.toBeNull();
     expect(within(firstCard as HTMLElement).getByText("1 calls")).toBeInTheDocument();
+
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(9));
+    mocks.fetchQuota.mockClear();
 
     const toolbarRefreshButton = screen.getAllByRole("button", { name: "Refresh" })[0];
     await waitFor(() => expect(toolbarRefreshButton).toBeEnabled());
@@ -3509,7 +3530,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3546,6 +3567,9 @@ describe("AuthFilesPage files table", () => {
     const cards = screen.getByTestId("auth-files-cards");
     const firstCard = screen.getByText("codex-a.json").closest("section");
     expect(firstCard).not.toBeNull();
+
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(2));
+    mocks.fetchQuota.mockClear();
 
     fireEvent.click(within(firstCard as HTMLElement).getByRole("button", { name: "Refresh" }));
 
@@ -3585,7 +3609,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3622,6 +3646,9 @@ describe("AuthFilesPage files table", () => {
     const row = screen.getByText("codex-a.json").closest("tr");
     expect(row).not.toBeNull();
 
+    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(2));
+    mocks.fetchQuota.mockClear();
+
     fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "Refresh" }));
 
     await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
@@ -3656,7 +3683,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3725,7 +3752,7 @@ describe("AuthFilesPage files table", () => {
     }));
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3777,7 +3804,7 @@ describe("AuthFilesPage files table", () => {
 
     mocks.list.mockImplementation(async () => ({ files: [file] }));
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3838,7 +3865,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3890,7 +3917,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -3994,7 +4021,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -4034,7 +4061,7 @@ describe("AuthFilesPage files table", () => {
     ).toBeGreaterThan(0);
 
     await waitFor(() => {
-      const raw = window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
+      const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
       expect(raw).toContain('"planType":"plus"');
     });
   });
@@ -4058,7 +4085,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -4112,7 +4139,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -4169,7 +4196,7 @@ describe("AuthFilesPage files table", () => {
     mocks.fetchQuota.mockRejectedValue(new Error("request_failed"));
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,
@@ -4220,7 +4247,7 @@ describe("AuthFilesPage files table", () => {
     );
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
         savedAtMs: now,

--- a/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/src/modules/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -92,7 +92,7 @@ describe("Auth Files helper coverage", () => {
       search: "oauth",
       page: 3,
     });
-    expect(window.sessionStorage.getItem(AUTH_FILES_UI_STATE_KEY)).toContain('"filter":"codex"');
+    expect(window.localStorage.getItem(AUTH_FILES_UI_STATE_KEY)).toContain('"filter":"codex"');
     expect(readAuthFilesUiState()).toEqual({
       tab: "files",
       filter: "codex",
@@ -190,7 +190,7 @@ describe("Auth Files helper coverage", () => {
         },
       },
     });
-    expect(window.sessionStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain('"savedAtMs":123');
+    expect(window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain('"savedAtMs":123');
     expect(readAuthFilesDataCache()).toEqual({
       savedAtMs: 123,
       files: sanitized,

--- a/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesFileActions.ts
@@ -2,6 +2,7 @@ import { useCallback, useState, type Dispatch, type RefObject, type SetStateActi
 import { useTranslation } from "react-i18next";
 import { authFilesApi } from "@/lib/http/apis";
 import type { AuthFileItem } from "@/lib/http/types";
+import { invalidateConfiguredModelAvailability } from "@/modules/models/configuredAvailabilityCache";
 import { useToast } from "@/modules/ui/ToastProvider";
 import {
   formatFileSize,
@@ -109,6 +110,8 @@ export function useAuthFilesFileActions({
           }
         }
 
+        if (success > 0) invalidateConfiguredModelAvailability();
+
         if (failed === 0 && tooLarge.length === 0) {
           notify({ type: "success", message: t("auth_files.upload_success", { count: success }) });
         } else {
@@ -158,6 +161,7 @@ export function useAuthFilesFileActions({
         }
 
         if (deletedNames.length > 0) {
+          invalidateConfiguredModelAvailability();
           setFiles((prev) => prev.filter((file) => !deletedNames.includes(file.name)));
           setSelectedFileNames((prev) => prev.filter((name) => !deletedNames.includes(name)));
           setDetailFile((prev) => (prev && deletedNames.includes(prev.name) ? null : prev));
@@ -202,6 +206,7 @@ export function useAuthFilesFileActions({
 
       try {
         const res = await authFilesApi.setStatus(name, nextDisabled);
+        invalidateConfiguredModelAvailability();
         setFiles((prev) =>
           prev.map((item) => (item.name === name ? { ...item, disabled: res.disabled } : item)),
         );

--- a/src/modules/auth-files/hooks/useAuthFilesOAuthConfig.ts
+++ b/src/modules/auth-files/hooks/useAuthFilesOAuthConfig.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { authFilesApi } from "@/lib/http/apis";
+import { invalidateConfiguredModelAvailability } from "@/modules/models/configuredAvailabilityCache";
 import { useToast } from "@/modules/ui/ToastProvider";
 import type { AuthFileModelItem, AliasRow } from "@/modules/auth-files/helpers/authFilesPageUtils";
 import {
@@ -110,6 +111,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
         .filter(Boolean);
       try {
         await authFilesApi.saveOauthExcludedModels(key, models);
+        invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("auth_files.saved") });
         startTransition(() => void refreshExcluded());
       } catch (err: unknown) {
@@ -135,6 +137,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
       const key = normalizeProviderKey(provider);
       try {
         await authFilesApi.deleteOauthExcludedEntry(key);
+        invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("auth_files.deleted") });
         startTransition(() => void refreshExcluded());
       } catch (err: unknown) {
@@ -189,6 +192,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
 
       try {
         await authFilesApi.saveOauthModelAlias(key, next);
+        invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("auth_files.saved") });
         startTransition(() => void refreshAlias());
       } catch (err: unknown) {
@@ -213,6 +217,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
       const key = normalizeProviderKey(channel);
       try {
         await authFilesApi.deleteOauthModelAlias(key);
+        invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("auth_files.deleted") });
         startTransition(() => void refreshAlias());
       } catch (err: unknown) {

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -603,7 +603,7 @@ describe("CcSwitchImportSettingsPage", () => {
     );
   });
 
-  test("shows a compact model mapping loading state while edited config models load", async () => {
+  test("shows saved model mappings immediately while edited config models refresh", async () => {
     const modelsDeferred = createDeferred<{ id: string }[]>();
     listChannelGroups.mockResolvedValue([
       {
@@ -638,22 +638,27 @@ describe("CcSwitchImportSettingsPage", () => {
     await user.click(screen.getByRole("button", { name: /edit config/i }));
 
     const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
-    const mappingStatus = await within(dialog).findByTestId("ccswitch-model-mapping-loading");
 
-    expect(mappingStatus).toHaveTextContent(/loading model mapping/i);
+    expect(within(dialog).queryByTestId("ccswitch-model-mapping-loading")).toBeNull();
     expect(
       within(dialog).queryByText(/no models are available for this channel group/i),
     ).not.toBeInTheDocument();
     expect(
-      within(dialog).queryByLabelText(/cc switch request model for mapping 1/i),
-    ).not.toBeInTheDocument();
+      within(dialog).getByLabelText(/cc switch request model for mapping 1/i),
+    ).toHaveValue("gpt-5.5");
+    expect(
+      within(dialog).getByRole("combobox", { name: /actual channel model 1/i }),
+    ).toHaveTextContent("moonshot-v1-128k");
+    expect(within(dialog).getByRole("button", { name: /^save$/i })).not.toBeDisabled();
 
     modelsDeferred.resolve([{ id: "kimi-k2.5" }]);
 
-    expect(
-      await within(dialog).findByLabelText(/cc switch request model for mapping 1/i),
-    ).toHaveValue("gpt-5.5");
-    expect(within(dialog).queryByTestId("ccswitch-model-mapping-loading")).toBeNull();
+    await waitFor(() =>
+      expect(within(dialog).queryByTestId("ccswitch-model-mapping-loading")).toBeNull(),
+    );
+    expect(within(dialog).getByLabelText(/cc switch request model for mapping 1/i)).toHaveValue(
+      "gpt-5.5",
+    );
   });
 
   test("previews the full BaseURL request address from the selected channel group path", async () => {

--- a/src/modules/channel-groups/ChannelGroupsPage.tsx
+++ b/src/modules/channel-groups/ChannelGroupsPage.tsx
@@ -60,22 +60,32 @@ const normalizeRoutingTags = (values: unknown): string[] => {
   return tags;
 };
 
+type MappedOwnerSelection = {
+  owners: string[];
+  hasUnmappedChannels: boolean;
+};
+
 const collectMappedOwnersForChannels = (
   channels: string[],
   detailsByName: Record<string, ChannelGroupChannelDetail>,
-): string[] => {
+): MappedOwnerSelection => {
   const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
   const owners = new Set<string>();
+  let hasUnmappedChannels = false;
   for (const channel of channels) {
     const detail = detailsByName[channel.trim().toLowerCase()];
     const candidates = [detail?.source, detail?.name, channel];
+    let matched = false;
     for (const candidate of candidates) {
       const key = normalizeProviderKey(String(candidate ?? ""));
       const owner = normalizeOwnerValue(ownerByAuthGroup[key] ?? "");
-      if (owner) owners.add(owner);
+      if (!owner) continue;
+      owners.add(owner);
+      matched = true;
     }
+    if (!matched) hasUnmappedChannels = true;
   }
-  return Array.from(owners);
+  return { owners: Array.from(owners), hasUnmappedChannels };
 };
 
 function hydrateRoutingValues(payload: RoutingConfigItem | undefined): VisualConfigValues {
@@ -273,17 +283,26 @@ export function ChannelGroupsPage() {
         ? data.data.map((model) => String(model.id ?? "").trim()).filter(Boolean)
         : [];
       const availability = await loadConfiguredModelAvailability();
-      const selectedOwnerKeys = collectMappedOwnersForChannels(
+      const ownerSelection = collectMappedOwnersForChannels(
         normalizedChannels,
         availableChannelDetails,
       );
-      const visibleModels = filterByConfiguredModelAvailability(
+      let visibleModels = filterByConfiguredModelAvailability(
         ids.map((id) => ({ id })),
         availability,
       );
       const metadataById = new Map(
         availability.items.map((model) => [model.id.toLowerCase(), model] as const),
       );
+      if (ownerSelection.owners.length > 0 && !ownerSelection.hasUnmappedChannels) {
+        const selectedOwnerSet = new Set(ownerSelection.owners);
+        visibleModels = visibleModels.filter((model) => {
+          const metadata = metadataById.get(model.id.toLowerCase());
+          const owner = normalizeOwnerValue(metadata?.owned_by ?? "");
+          const source = normalizeOwnerValue(metadata?.source ?? "");
+          return selectedOwnerSet.has(owner) || selectedOwnerSet.has(source);
+        });
+      }
       const optionMap = new Map<string, RoutingModelOption>();
       const addModelOption = (id: string, metadata = metadataById.get(id.toLowerCase())) => {
         const normalized = id.trim();
@@ -300,8 +319,8 @@ export function ChannelGroupsPage() {
 
       for (const model of visibleModels) addModelOption(model.id);
 
-      if (selectedOwnerKeys.length > 0) {
-        const selectedOwnerSet = new Set(selectedOwnerKeys);
+      if (ownerSelection.owners.length > 0) {
+        const selectedOwnerSet = new Set(ownerSelection.owners);
         for (const model of availability.items) {
           const owner = normalizeOwnerValue(model.owned_by ?? "");
           const source = normalizeOwnerValue(model.source ?? "");

--- a/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/src/modules/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
 import { apiClient } from "@/lib/http/client";
 import { ChannelGroupsPage } from "@/modules/channel-groups/ChannelGroupsPage";
+import { invalidateConfiguredModelAvailability } from "@/modules/models/modelAvailability";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
 
@@ -55,7 +56,31 @@ describe("ChannelGroupsPage", () => {
     mockedApiGet.mockReset();
     mockedApiPut.mockReset();
     mockedApiPut.mockResolvedValue({ status: "ok" });
+    invalidateConfiguredModelAvailability();
     mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+              pricing: {
+                mode: "token",
+                input_price_per_million: 3,
+                output_price_per_million: 15,
+                cached_price_per_million: 0.3,
+              },
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+            },
+          ],
+        });
+      }
       if (path === "/routing-config") {
         return Promise.resolve({
           strategy: "round-robin",
@@ -66,7 +91,13 @@ describe("ChannelGroupsPage", () => {
       }
       if (path === "/channel-groups") {
         return Promise.resolve({
-          items: [{ name: "Claude Pool", channels: ["Team A Claude"] }],
+          items: [
+            {
+              name: "Claude Pool",
+              channels: ["Team A Claude"],
+              "channel-details": [{ name: "Team A Claude", source: "claude" }],
+            },
+          ],
         });
       }
       if (path.startsWith("/models?")) {
@@ -146,6 +177,23 @@ describe("ChannelGroupsPage", () => {
       JSON.stringify({ kimi: "kimi-code" }),
     );
     mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "kimi-k2.5",
+              owned_by: "kimi-code",
+              description: "Kimi K2.5",
+            },
+            {
+              id: "kimi-k2.6",
+              owned_by: "kimi-code",
+              description: "Kimi K2.6",
+            },
+          ],
+        });
+      }
       if (path === "/routing-config") {
         return Promise.resolve({
           strategy: "round-robin",
@@ -342,6 +390,12 @@ describe("ChannelGroupsPage", () => {
 
   test("keeps live model owner metadata when no auth-file model owner group is configured", async () => {
     mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [{ id: "kimi-k2", owned_by: "moonshot", description: "Kimi K2" }],
+        });
+      }
       if (path === "/routing-config") {
         return Promise.resolve({
           strategy: "round-robin",

--- a/src/modules/models/ModelsPage.tsx
+++ b/src/modules/models/ModelsPage.tsx
@@ -33,6 +33,7 @@ import {
   filterByConfiguredModelAvailability,
   formatModelPrice,
   hasModelPricing,
+  invalidateConfiguredModelAvailability,
   loadConfiguredModelAvailability,
   loadModelPathAvailability,
   type ConfiguredModelAvailability,
@@ -455,6 +456,7 @@ async function saveModelConfig(form: ModelFormState, scope: ModelScope) {
   } else {
     await apiClient.post(modelConfigCollectionPath(scope), payload);
   }
+  invalidateConfiguredModelAvailability();
 
   return payloadToModel(payload, scope === "library" ? "seed" : "user");
 }
@@ -859,6 +861,7 @@ export function ModelsPage() {
     setDeleting(true);
     try {
       await apiClient.delete(`/model-configs/${encodeURIComponent(deleteTarget.id)}`);
+      invalidateConfiguredModelAvailability();
       setModels((prev) => prev.filter((model) => model.id !== deleteTarget.id));
       setSelectedModelIds((prev) => {
         if (!prev.has(deleteTarget.id)) return prev;
@@ -915,6 +918,7 @@ export function ModelsPage() {
       for (const modelId of ids) {
         await apiClient.delete(`/model-configs/${encodeURIComponent(modelId)}`);
       }
+      invalidateConfiguredModelAvailability();
       const deletedIds = new Set(ids);
       setModels((prev) => prev.filter((model) => !deletedIds.has(model.id)));
       setSelectedModelIds((current) => {

--- a/src/modules/models/__tests__/ModelsPage.test.tsx
+++ b/src/modules/models/__tests__/ModelsPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@/i18n";
+import { invalidateConfiguredModelAvailability } from "@/modules/models/modelAvailability";
 import { ModelsPage } from "@/modules/models/ModelsPage";
 import { ThemeProvider } from "@/modules/ui/ThemeProvider";
 import { ToastProvider } from "@/modules/ui/ToastProvider";
@@ -52,7 +53,71 @@ describe("ModelsPage", () => {
     mocks.apiPost.mockReset();
     mocks.apiPut.mockReset();
     mocks.apiDelete.mockReset();
+    invalidateConfiguredModelAvailability();
     mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "gpt-image-2",
+              owned_by: "openai",
+              description: "Image generation model billed per invocation",
+              enabled: true,
+              input_modalities: ["text"],
+              output_modalities: ["image"],
+              supports_vision: false,
+              pricing: {
+                mode: "call",
+                price_per_call: 0.04,
+              },
+            },
+            {
+              id: "qwen3.5-plus",
+              owned_by: "qwen",
+              description: "Vision capable model",
+              enabled: true,
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
+              supports_vision: true,
+              pricing: {
+                mode: "token",
+                input_price_per_million: 1,
+                output_price_per_million: 3,
+              },
+            },
+          ],
+          active_metadata: [
+            {
+              id: "gpt-image-2",
+              owned_by: "openai",
+              description: "Image generation model billed per invocation",
+              enabled: true,
+              input_modalities: ["text"],
+              output_modalities: ["image"],
+              supports_vision: false,
+              pricing: {
+                mode: "call",
+                price_per_call: 0.04,
+              },
+            },
+            {
+              id: "qwen3.5-plus",
+              owned_by: "qwen",
+              description: "Vision capable model",
+              enabled: true,
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
+              supports_vision: true,
+              pricing: {
+                mode: "token",
+                input_price_per_million: 1,
+                output_price_per_million: 3,
+              },
+            },
+          ],
+        });
+      }
       if (path === "/model-configs?scope=active" || path === "/model-configs") {
         return Promise.resolve({
           data: [
@@ -200,6 +265,9 @@ describe("ModelsPage", () => {
       JSON.stringify({ claude: "anthropic" }),
     );
     mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.reject(new Error("configured availability unavailable"));
+      }
       if (path === "/model-configs?scope=active" || path === "/model-configs") {
         return Promise.resolve({
           data: [
@@ -275,6 +343,9 @@ describe("ModelsPage", () => {
 
   test("adds configured ai-provider models missing from active model configs", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.reject(new Error("configured availability unavailable"));
+      }
       if (path === "/model-configs?scope=active" || path === "/model-configs") {
         return Promise.resolve({
           data: [

--- a/src/modules/models/__tests__/modelAvailability.test.ts
+++ b/src/modules/models/__tests__/modelAvailability.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import {
+  filterByConfiguredModelAvailability,
+  normalizeConfiguredModelAvailability,
+} from "@/modules/models/modelAvailability";
+
+describe("model availability normalization", () => {
+  test("preserves an explicit scoped empty availability response", () => {
+    const availability = normalizeConfiguredModelAvailability({
+      scoped: true,
+      data: [],
+    });
+
+    expect(availability.scoped).toBe(true);
+    expect(availability.items).toEqual([]);
+    expect(filterByConfiguredModelAvailability([{ id: "gpt-5" }], availability)).toEqual([]);
+  });
+
+  test("treats an unscoped empty response as unrestricted for older payload shapes", () => {
+    const availability = normalizeConfiguredModelAvailability({});
+
+    expect(availability.scoped).toBe(false);
+    expect(filterByConfiguredModelAvailability([{ id: "gpt-5" }], availability)).toEqual([
+      { id: "gpt-5" },
+    ]);
+  });
+});

--- a/src/modules/models/configuredAvailabilityCache.ts
+++ b/src/modules/models/configuredAvailabilityCache.ts
@@ -1,0 +1,7 @@
+let configuredAvailabilityCacheVersion = 0;
+
+export const getConfiguredAvailabilityCacheVersion = () => configuredAvailabilityCacheVersion;
+
+export const invalidateConfiguredModelAvailability = () => {
+  configuredAvailabilityCacheVersion += 1;
+};

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -12,6 +12,10 @@ import {
   readAuthFilesModelOwnerGroupMap,
   resolveFileType,
 } from "@/modules/auth-files/helpers/authFilesPageUtils";
+import {
+  getConfiguredAvailabilityCacheVersion,
+  invalidateConfiguredModelAvailability,
+} from "@/modules/models/configuredAvailabilityCache";
 
 export type ModelAvailabilityItem = {
   id: string;
@@ -591,7 +595,7 @@ export const normalizeConfiguredModelAvailability = (payload: unknown): Configur
     .sort((a, b) => a!.id.localeCompare(b!.id));
 
   return {
-    scoped: record.scoped === false ? false : items.length > 0,
+    scoped: typeof record.scoped === "boolean" ? record.scoped : items.length > 0,
     items,
     metadataItems,
     idSet: new Set(items.map((item) => item.id.toLowerCase())),
@@ -602,40 +606,55 @@ export const normalizeConfiguredModelAvailability = (payload: unknown): Configur
 
 const CONFIGURED_AVAILABILITY_TTL_MS = 15_000;
 let configuredAvailabilityCache:
-  | { expiresAt: number; value: ConfiguredModelAvailability }
+  | { expiresAt: number; version: number; value: ConfiguredModelAvailability }
   | null = null;
-let configuredAvailabilityInFlight: Promise<ConfiguredModelAvailability> | null = null;
+let configuredAvailabilityInFlight:
+  | { version: number; promise: Promise<ConfiguredModelAvailability> }
+  | null = null;
 
-export const invalidateConfiguredModelAvailability = () => {
-  configuredAvailabilityCache = null;
-};
+export { invalidateConfiguredModelAvailability };
 
 export const loadConfiguredModelAvailability = async (): Promise<ConfiguredModelAvailability> => {
   const now = Date.now();
-  if (configuredAvailabilityCache && now < configuredAvailabilityCache.expiresAt) {
+  const cacheVersion = getConfiguredAvailabilityCacheVersion();
+  if (
+    configuredAvailabilityCache &&
+    configuredAvailabilityCache.version === cacheVersion &&
+    now < configuredAvailabilityCache.expiresAt
+  ) {
     return configuredAvailabilityCache.value;
   }
-  if (configuredAvailabilityInFlight) {
-    return configuredAvailabilityInFlight;
+  if (
+    configuredAvailabilityInFlight &&
+    configuredAvailabilityInFlight.version === cacheVersion
+  ) {
+    return configuredAvailabilityInFlight.promise;
   }
 
-  configuredAvailabilityInFlight = (async (): Promise<ConfiguredModelAvailability> => {
+  const promise = (async (): Promise<ConfiguredModelAvailability> => {
     try {
       const result = normalizeConfiguredModelAvailability(
         await apiClient.get("/models/configured-availability"),
       );
-      configuredAvailabilityCache = { expiresAt: now + CONFIGURED_AVAILABILITY_TTL_MS, value: result };
+      configuredAvailabilityCache = {
+        expiresAt: now + CONFIGURED_AVAILABILITY_TTL_MS,
+        version: cacheVersion,
+        value: result,
+      };
       return result;
     } catch {
       // Fallback to old multi-API aggregation for backward compatibility.
       return loadConfiguredModelAvailabilityFallback();
     }
   })();
+  configuredAvailabilityInFlight = { version: cacheVersion, promise };
 
   try {
-    return await configuredAvailabilityInFlight;
+    return await promise;
   } finally {
-    configuredAvailabilityInFlight = null;
+    if (configuredAvailabilityInFlight?.promise === promise) {
+      configuredAvailabilityInFlight = null;
+    }
   }
 };
 

--- a/src/modules/monitor/RequestLogsFilters.tsx
+++ b/src/modules/monitor/RequestLogsFilters.tsx
@@ -60,7 +60,7 @@ export function RequestLogsFilters({
               selectFilteredLabel={t("request_logs.select_filtered")}
               deselectFilteredLabel={t("request_logs.deselect_filtered")}
               selectedCountLabel={(count: number) =>
-                t("request_logs.selected_count", { count: String(count) })
+                t("request_logs.selected_count", { count })
               }
               noResultsLabel={t("request_logs.no_filter_results")}
               aria-label={t("request_logs.filter_key")}
@@ -79,7 +79,7 @@ export function RequestLogsFilters({
               selectFilteredLabel={t("request_logs.select_filtered")}
               deselectFilteredLabel={t("request_logs.deselect_filtered")}
               selectedCountLabel={(count: number) =>
-                t("request_logs.selected_count", { count: String(count) })
+                t("request_logs.selected_count", { count })
               }
               noResultsLabel={t("request_logs.no_filter_results")}
               aria-label={t("request_logs.filter_model")}
@@ -98,7 +98,7 @@ export function RequestLogsFilters({
               selectFilteredLabel={t("request_logs.select_filtered")}
               deselectFilteredLabel={t("request_logs.deselect_filtered")}
               selectedCountLabel={(count: number) =>
-                t("request_logs.selected_count", { count: String(count) })
+                t("request_logs.selected_count", { count })
               }
               noResultsLabel={t("request_logs.no_filter_results")}
               aria-label={t("request_logs.filter_channel")}

--- a/src/modules/providers/hooks/useOpenAIProviderEditor.ts
+++ b/src/modules/providers/hooks/useOpenAIProviderEditor.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { apiCallApi, getApiCallErrorMessage, providersApi } from "@/lib/http/apis";
 import type { ApiCallResult, OpenAIProvider } from "@/lib/http/types";
 import { useToast } from "@/modules/ui/ToastProvider";
+import { invalidateConfiguredModelAvailability } from "@/modules/models/configuredAvailabilityCache";
 import { keyValueEntriesToRecord } from "@/modules/providers/KeyValueInputList";
 import { createEmptyModelEntry } from "@/modules/providers/ModelInputList";
 import {
@@ -129,6 +130,7 @@ export function useOpenAIProviderEditor({
 
       setOpenaiProviders(next);
       await providersApi.saveOpenAIProviders(next);
+      invalidateConfiguredModelAvailability();
       notify({ type: "success", message: t("providers.saved") });
       closeOpenAIEditor();
       startRefreshTransition(() => void refreshAll());
@@ -156,6 +158,7 @@ export function useOpenAIProviderEditor({
       if (!entry) return;
       try {
         await providersApi.deleteOpenAIProvider(entry.name);
+        invalidateConfiguredModelAvailability();
         setOpenaiProviders((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
         notify({ type: "success", message: t("providers.deleted") });
       } catch (err: unknown) {
@@ -190,6 +193,7 @@ export function useOpenAIProviderEditor({
       setOpenaiProviders(next);
       try {
         await providersApi.saveOpenAIProviders(next);
+        invalidateConfiguredModelAvailability();
         notify({
           type: "success",
           message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),
@@ -283,6 +287,7 @@ export function useOpenAIProviderEditor({
         await providersApi.patchOpenAIProviderDisabled(providerIndex, !enabled);
         // Re-fetch from server to get authoritative state
         const latest = await providersApi.getOpenAIProviders();
+        invalidateConfiguredModelAvailability();
         setOpenaiProviders(latest);
         notify({
           type: "success",

--- a/src/modules/providers/hooks/useProviderKeyEditor.ts
+++ b/src/modules/providers/hooks/useProviderKeyEditor.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useToast } from "@/modules/ui/ToastProvider";
 import type { BedrockProviderConfig, ProviderSimpleConfig } from "@/lib/http/types";
 import { providersApi } from "@/lib/http/apis";
+import { invalidateConfiguredModelAvailability } from "@/modules/models/configuredAvailabilityCache";
 import { keyValueEntriesToRecord } from "@/modules/providers/KeyValueInputList";
 import {
   buildProviderKeyDraft,
@@ -207,6 +208,7 @@ export function useProviderKeyEditor({
         await providersApi.saveBedrockConfigs(next);
         setBedrockKeys(next);
       }
+      invalidateConfiguredModelAvailability();
       notify({ type: "success", message: t("providers.saved") });
       closeKeyEditor();
       startRefreshTransition(() => void refreshAll());
@@ -265,6 +267,7 @@ export function useProviderKeyEditor({
           await providersApi.deleteBedrockConfig(index);
           setBedrockKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
         }
+        invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("providers.deleted") });
       } catch (err: unknown) {
         notify({


### PR DESCRIPTION
## Summary
- Preserve explicit scoped availability responses, including scoped empty model sets.
- Keep saved CC Switch model mappings visible while model options refresh.
- Invalidate configured availability cache after model/provider/auth-file changes.

## Verification
- bun run test -- src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx src/modules/models/__tests__/ModelsPage.test.tsx src/modules/models/__tests__/modelAvailability.test.ts src/modules/providers/__tests__/ProvidersPage.openai.test.tsx src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx src/modules/providers/__tests__/ProvidersPage.bedrock.test.tsx
- bun run build
- bun run lint