### PR TITLE
fix: CC Switch 模型映射补齐 + 渠道分组列表闪烁修复

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -196,15 +196,6 @@ function resolveGenericDefaultModel(
 }
 
 function reconcileModelMappings(draft: ConfigDraft, models: readonly string[]): ConfigDraft {
-  if (draft.clientType === "codex") {
-    const modelMappings = draft.modelMappings.filter((mapping) => !mapping.role);
-    return {
-      ...draft,
-      modelMappings,
-      defaultModel: resolveGenericDefaultModel(modelMappings, draft.defaultModel),
-    };
-  }
-
   const modelMappings =
     draft.clientType === "claude"
       ? reconcileClaudeMappings(draft.modelMappings, models, draft.defaultModel)
@@ -343,17 +334,18 @@ export function CcSwitchImportConfigModal({
     const modelOwnerKeys = new Set(
       (selectedGroupOption?.modelOwnerKeys ?? []).map(normalizeModelOwnerKey).filter(Boolean),
     );
-    const lookupParams =
-      lookupChannels.length > 0
-        ? { allowedChannels: lookupChannels }
-        : { allowedChannelGroups: [selectedGroup] };
+    const lookupParams = selectedGroup
+      ? { allowedChannelGroups: [selectedGroup] }
+      : { allowedChannels: lookupChannels };
 
     setModelsLoading(true);
     modelsApi
       .listAvailableModels(lookupParams)
       .then(async (models) => {
         if (cancelled) return;
-        const availability = await loadConfiguredModelAvailability();
+        const availability = await loadConfiguredModelAvailability(
+          selectedGroup ? { allowedChannelGroups: [selectedGroup] } : undefined,
+        );
         if (cancelled) return;
         let visibleModels = filterByConfiguredModelAvailability(models, availability);
         const optionMap = new Map<string, string>();

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -490,6 +490,10 @@ export function RoutingConfigEditor({
     () => resolvedDraftChannels.map((channel) => channel.name.trim()).filter(Boolean),
     [resolvedDraftChannels],
   );
+  const resolvedDraftChannelKey = useMemo(
+    () => resolvedDraftChannelValues.join("\n"),
+    [resolvedDraftChannelValues],
+  );
 
   const editingSystemDefaultGroup =
     groupEditorId === SYSTEM_DEFAULT_GROUP_ID ||
@@ -1348,7 +1352,6 @@ export function RoutingConfigEditor({
     let cancelled = false;
     setModelsLoading(true);
     setModelsError("");
-    setModelOptions([]);
     const modelLoader = editingSystemDefaultGroup
       ? loadModelsForChannels(resolvedDraftChannelValues, SYSTEM_DEFAULT_GROUP_NAME)
       : loadModelsForChannels(resolvedDraftChannelValues);
@@ -1365,18 +1368,21 @@ export function RoutingConfigEditor({
         const normalized = Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
         setModelOptions(normalized);
         const allowed = new Set(normalized.map((model) => model.id));
-        setGroupDraft((current) => ({
-          ...current,
-          allowedModels: modelsSelectionTouched
-            ? current.allowedModels.filter((model) => allowed.has(model))
-            : normalized.map((model) => model.id),
-        }));
+        setGroupDraft((current) => {
+          if (!modelsSelectionTouched && current.allowedModels.length === 0) {
+            return current;
+          }
+          const nextAllowedModels = current.allowedModels.filter((model) => allowed.has(model));
+          const currentStr = JSON.stringify(current.allowedModels);
+          const nextStr = JSON.stringify(nextAllowedModels);
+          if (currentStr === nextStr) return current;
+          return { ...current, allowedModels: nextAllowedModels };
+        });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         const message =
           err instanceof Error ? err.message : t("channel_groups_page.models_load_failed");
-        setModelOptions([]);
         setModelsError(message);
       })
       .finally(() => {
@@ -1392,7 +1398,7 @@ export function RoutingConfigEditor({
     editingSystemDefaultGroup,
     loadModelsForChannels,
     modelsSelectionTouched,
-    resolvedDraftChannelValues,
+    resolvedDraftChannelKey,
     t,
   ]);
 

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -612,9 +612,50 @@ let configuredAvailabilityInFlight:
   | { version: number; promise: Promise<ConfiguredModelAvailability> }
   | null = null;
 
+interface GroupAvailabilityCacheEntry {
+  expiresAt: number;
+  promise: Promise<ConfiguredModelAvailability>;
+}
+
+const GROUP_AVAILABILITY_TTL_MS = 15_000;
+const groupAvailabilityCache = new Map<string, GroupAvailabilityCacheEntry>();
+
 export { invalidateConfiguredModelAvailability };
 
-export const loadConfiguredModelAvailability = async (): Promise<ConfiguredModelAvailability> => {
+export const loadConfiguredModelAvailability = async (
+  options?: { allowedChannelGroups?: string[] },
+): Promise<ConfiguredModelAvailability> => {
+  const validGroups = (options?.allowedChannelGroups ?? [])
+    .map((g) => String(g ?? "").trim())
+    .filter(Boolean);
+
+  if (validGroups.length > 0) {
+    const cacheKey = validGroups.join(",");
+    const now = Date.now();
+    const cached = groupAvailabilityCache.get(cacheKey);
+    if (cached && now < cached.expiresAt) {
+      return cached.promise;
+    }
+    const promise = (async (): Promise<ConfiguredModelAvailability> => {
+      try {
+        const result = normalizeConfiguredModelAvailability(
+          await apiClient.get(
+            `/models/configured-availability?allowed_channel_groups=${encodeURIComponent(cacheKey)}`,
+          ),
+        );
+        groupAvailabilityCache.set(cacheKey, {
+          expiresAt: now + GROUP_AVAILABILITY_TTL_MS,
+          promise: Promise.resolve(result),
+        });
+        return result;
+      } catch {
+        return loadConfiguredModelAvailabilityFallback();
+      }
+    })();
+    groupAvailabilityCache.set(cacheKey, { expiresAt: now + GROUP_AVAILABILITY_TTL_MS, promise });
+    return promise;
+  }
+
   const now = Date.now();
   const cacheVersion = getConfiguredAvailabilityCacheVersion();
   if (


### PR DESCRIPTION
## Summary

修复两个问题：

### 1. CC Switch 编辑弹窗模型显示不全
- 移除 Codex 类型在 `reconcileModelMappings` 中的提前 return，让 Codex 也使用 `reconcileGenericMappings` 合并可用模型
- 模型查询优先使用 `allowed_channel_groups` 参数（标签分组权威语义），而非展开后的渠道快照
- configured-availability 查询也加 `allowed_channel_groups` 参数，确保 scope 与分组一致
- `loadConfiguredModelAvailability` 扩展支持 `{ allowedChannelGroups }` 参数

### 2. 渠道分组模型列表刷新闪烁
- 添加 `resolvedDraftChannelKey` 稳定字符串 key 替代数组引用作为 effect 依赖，消除循环触发
- 模型加载开始时不清空 `modelOptions`，保留旧数据避免表格闪烁
- 加载完成时不无条件写 `allowedModels`：空数组保留"不限制模型"语义
- `setGroupDraft` 增加 identity 保护（JSON.stringify 等值判断），避免无意义的重渲染

## Test plan
- [ ] `bun run check` 编译通过
- [ ] 验证 CC Switch 编辑弹窗 Codex 类型显示全部可用模型
- [ ] 验证渠道分组模型列表不再闪烁