### PR TITLE
fix: 保序、全选视觉态、group cache 失效

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -128,23 +128,35 @@ function reconcileGenericMappings(
   models: readonly string[],
   fallbackModel: string,
 ): CcSwitchModelMapping[] {
+  const currentNonRole = currentMappings.filter((mapping) => !mapping.role);
   const currentByTarget = new Map(
-    currentMappings
-      .filter((mapping) => !mapping.role)
-      .map((mapping) => [mapping.targetModel.trim().toLowerCase(), mapping]),
+    currentNonRole.map((mapping) => [mapping.targetModel.trim().toLowerCase(), mapping]),
   );
-  const currentTargets = currentMappings
-    .filter((mapping) => !mapping.role)
-    .map((mapping) => mapping.targetModel);
-  const targets = dedupeModels(models.length > 0 ? [...currentTargets, ...models] : currentTargets);
-  const resolvedTargets = targets.length > 0 ? targets : dedupeModels([fallbackModel]);
+  const seen = new Set<string>();
+  const result: CcSwitchModelMapping[] = [];
 
-  return resolvedTargets.map((targetModel) => {
-    const existing = currentByTarget.get(targetModel.toLowerCase());
-    return {
-      requestModel: existing?.requestModel.trim() || targetModel,
-      targetModel,
-    };
+  for (const mapping of currentNonRole) {
+    const key = mapping.targetModel.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(mapping);
+  }
+
+  const sortedNew = [...new Set(models.map((m) => m.trim()).filter(Boolean))]
+    .filter((m) => !seen.has(m.toLowerCase()))
+    .sort((a, b) => a.localeCompare(b));
+  for (const targetModel of sortedNew) {
+    const key = targetModel.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ requestModel: targetModel, targetModel });
+  }
+
+  const resolvedTargets =
+    result.length > 0 ? result : dedupeModels([fallbackModel]).map((targetModel) => ({ requestModel: targetModel, targetModel }));
+  return resolvedTargets.map((mapping) => {
+    const existing = currentByTarget.get(mapping.targetModel.trim().toLowerCase());
+    return existing ?? mapping;
   });
 }
 

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -171,15 +171,13 @@ describe("CcSwitchImportSettingsPage", () => {
       new RegExp(`^${origin.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/pro/cs_[a-z0-9]+/v1$`),
     );
 
-    expect(await within(dialog).findByText(/add a model mapping/i)).toBeInTheDocument();
+    expect(await within(dialog).findByDisplayValue("deepseek-v4-flash")).toBeInTheDocument();
+    expect(await within(dialog).findByDisplayValue("kimi-k2")).toBeInTheDocument();
     expect(listAvailableModels).not.toHaveBeenCalled();
-    await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
-    await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 1/i }));
-    await user.click(await screen.findByRole("option", { name: "deepseek-v4-flash" }));
-    expect(screen.queryByRole("option", { name: "gpt-4o-mini" })).not.toBeInTheDocument();
     const requestModelInput = within(dialog).getByLabelText(
       /cc switch request model for mapping 1/i,
     );
+    await user.clear(requestModelInput);
     await user.type(requestModelInput, "gpt-5.5");
 
     await user.type(within(dialog).getByLabelText(/provider name/i), "Relay Codex");
@@ -240,25 +238,24 @@ describe("CcSwitchImportSettingsPage", () => {
     await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
     await user.click(await screen.findByRole("option", { name: /pro.*\/pro/i }));
 
-    expect(await within(dialog).findByText(/add a model mapping/i)).toBeInTheDocument();
-    expect(
-      within(dialog).queryByLabelText(/cc switch request model for mapping 1/i),
-    ).not.toBeInTheDocument();
+    // Auto-populated: row 1 = deepseek-v4-flash, row 2 = kimi-k2
+    expect(await within(dialog).findByDisplayValue("deepseek-v4-flash")).toBeInTheDocument();
+    expect(await within(dialog).findByDisplayValue("kimi-k2")).toBeInTheDocument();
     expect(within(dialog).getByRole("button", { name: /^save$/i })).toBeDisabled();
 
-    // Add mapping 1: targetModel=deepseek-v4-flash, requestModel=gpt-5.5
-    await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
-    await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 1/i }));
-    await user.click(await screen.findByRole("option", { name: "deepseek-v4-flash" }));
+    // Row 1: change request model to gpt-5.5
+    await user.clear(
+      within(dialog).getByLabelText(/cc switch request model for mapping 1/i),
+    );
     await user.type(
       within(dialog).getByLabelText(/cc switch request model for mapping 1/i),
       "gpt-5.5",
     );
 
-    // Add mapping 2: targetModel=kimi-k2, requestModel=gpt-5.5 (duplicate request model)
-    await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
-    await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 2/i }));
-    await user.click(await screen.findByRole("option", { name: "kimi-k2" }));
+    // Row 2: change request model to gpt-5.5 (duplicate request model)
+    await user.clear(
+      within(dialog).getByLabelText(/cc switch request model for mapping 2/i),
+    );
     await user.type(
       within(dialog).getByLabelText(/cc switch request model for mapping 2/i),
       "gpt-5.5",
@@ -337,10 +334,7 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(groupSelect).toHaveTextContent("/openai/pro");
     expect(within(dialog).queryByText(/path address/i)).not.toBeInTheDocument();
 
-    expect(await within(dialog).findByText(/add a model mapping/i)).toBeInTheDocument();
-    await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
-    await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 1/i }));
-    expect(await screen.findByRole("option", { name: "gpt-5.5" })).toBeInTheDocument();
+    expect(await within(dialog).findByDisplayValue("gpt-5.5")).toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: "unexpected-extra-model" }),
     ).not.toBeInTheDocument();
@@ -406,13 +400,10 @@ describe("CcSwitchImportSettingsPage", () => {
     await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
     await user.click(await screen.findByRole("option", { name: /chatgpt-pro.*\/openai\/pro/i }));
 
-    expect(await within(dialog).findByText(/add a model mapping/i)).toBeInTheDocument();
-    await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
-    await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 1/i }));
-    expect(await screen.findByRole("option", { name: "gpt-5.5" })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: "gpt-5-codex" })).not.toBeInTheDocument();
+    expect(await within(dialog).findByDisplayValue("gpt-5.5")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("gpt-5-codex")).not.toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
-      allowedChannels: ["A_GptPro"],
+      allowedChannelGroups: ["chatgpt-pro"],
     });
     expect(loadConfiguredModelAvailability).toHaveBeenCalledTimes(1);
     expect(getModelConfigs).toHaveBeenCalledWith("active");
@@ -473,14 +464,11 @@ describe("CcSwitchImportSettingsPage", () => {
       await screen.findByRole("option", { name: /opencodego\+gpt.*\/codexdeepseek/i }),
     );
 
-    expect(await within(dialog).findByText(/add a model mapping/i)).toBeInTheDocument();
-    await user.click(within(dialog).getByRole("button", { name: /add model mapping/i }));
-    await user.click(within(dialog).getByRole("combobox", { name: /actual channel model 1/i }));
-    expect(await screen.findByRole("option", { name: "gpt-5.5" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "minimax-m2.7" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "kimi-k2.6" })).toBeInTheDocument();
+    expect(await within(dialog).findByDisplayValue("gpt-5.5")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("minimax-m2.7")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("kimi-k2.6")).toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
-      allowedChannels: ["A_GptPro", "opencode go"],
+      allowedChannelGroups: ["opencodego+gpt"],
     });
   });
 
@@ -538,7 +526,7 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(await screen.findByRole("option", { name: "kimi-k2.6" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "kimi-k2" })).not.toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
-      allowedChannels: ["kimi"],
+      allowedChannelGroups: ["kimicode"],
     });
     expect(getModelConfigs).toHaveBeenCalledWith("active");
   });

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -499,10 +499,13 @@ export function RoutingConfigEditor({
     groupEditorId === SYSTEM_DEFAULT_GROUP_ID ||
     (groupEditorId !== null && groupDraft.name.trim().toLowerCase() === SYSTEM_DEFAULT_GROUP_NAME);
 
-  const selectedModelSet = useMemo(
-    () => new Set(groupDraft.allowedModels.map((model) => model.trim()).filter(Boolean)),
-    [groupDraft.allowedModels],
-  );
+  const selectedModelSet = useMemo(() => {
+    const effectiveSelectAll = !modelsSelectionTouched && groupDraft.allowedModels.length === 0;
+    if (effectiveSelectAll) {
+      return new Set(modelOptions.map((model) => model.id));
+    }
+    return new Set(groupDraft.allowedModels.map((model) => model.trim()).filter(Boolean));
+  }, [groupDraft.allowedModels, modelOptions, modelsSelectionTouched]);
 
   const modelOptionIds = useMemo(() => modelOptions.map((model) => model.id), [modelOptions]);
   const selectedVisibleModelCount = useMemo(
@@ -731,6 +734,13 @@ export function RoutingConfigEditor({
     setModelsSelectionTouched(true);
     setGroupDraft((current) => {
       const currentModels = current.allowedModels.map((model) => model.trim()).filter(Boolean);
+      // First interaction from "no restriction" empty state: initialize with full visible set
+      if (currentModels.length === 0 && modelOptionIds.length > 0) {
+        const initial = new Set(modelOptionIds);
+        if (checked) initial.add(normalized);
+        else initial.delete(normalized);
+        return { ...current, allowedModels: Array.from(initial) };
+      }
       if (checked) {
         return {
           ...current,
@@ -742,7 +752,7 @@ export function RoutingConfigEditor({
         allowedModels: currentModels.filter((model) => model !== normalized),
       };
     });
-  }, []);
+  }, [modelOptionIds]);
 
   const selectAllDraftModels = useCallback(() => {
     setModelsSelectionTouched(true);

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -177,11 +177,14 @@ describe("RoutingConfigEditor", () => {
     expect(await screen.findByLabelText("claude-sonnet-4-5")).toBeInTheDocument();
     expect(loadModelsForChannels).toHaveBeenCalledWith(["Team A Claude"]);
 
+    // All models display as checked (no explicit restriction = all allowed)
+    expect(screen.getByLabelText("claude-opus-4-5")).toBeChecked();
+    expect(screen.getByLabelText("claude-sonnet-4-5")).toBeChecked();
+
     await user.click(screen.getByRole("button", { name: "添加" }));
 
-    expect(screen.getByTestId("allowed-models")).toHaveTextContent(
-      "claude-opus-4-5,claude-sonnet-4-5",
-    );
+    // Empty allowed-models means "no restriction" - no explicit list saved
+    expect(screen.getByTestId("allowed-models")).not.toHaveTextContent(/claude/);
   });
 
   test("renders channel-scoped models as a checkbox table with descriptions and prices", async () => {

--- a/src/modules/models/modelAvailability.ts
+++ b/src/modules/models/modelAvailability.ts
@@ -614,6 +614,7 @@ let configuredAvailabilityInFlight:
 
 interface GroupAvailabilityCacheEntry {
   expiresAt: number;
+  cacheVersion: number;
   promise: Promise<ConfiguredModelAvailability>;
 }
 
@@ -632,8 +633,9 @@ export const loadConfiguredModelAvailability = async (
   if (validGroups.length > 0) {
     const cacheKey = validGroups.join(",");
     const now = Date.now();
+    const cacheVersion = getConfiguredAvailabilityCacheVersion();
     const cached = groupAvailabilityCache.get(cacheKey);
-    if (cached && now < cached.expiresAt) {
+    if (cached && cached.cacheVersion === cacheVersion && now < cached.expiresAt) {
       return cached.promise;
     }
     const promise = (async (): Promise<ConfiguredModelAvailability> => {
@@ -645,6 +647,7 @@ export const loadConfiguredModelAvailability = async (
         );
         groupAvailabilityCache.set(cacheKey, {
           expiresAt: now + GROUP_AVAILABILITY_TTL_MS,
+          cacheVersion,
           promise: Promise.resolve(result),
         });
         return result;
@@ -652,7 +655,7 @@ export const loadConfiguredModelAvailability = async (
         return loadConfiguredModelAvailabilityFallback();
       }
     })();
-    groupAvailabilityCache.set(cacheKey, { expiresAt: now + GROUP_AVAILABILITY_TTL_MS, promise });
+    groupAvailabilityCache.set(cacheKey, { expiresAt: now + GROUP_AVAILABILITY_TTL_MS, cacheVersion, promise });
     return promise;
   }
 


### PR DESCRIPTION
## Summary

Review 指出的三个问题修复：

### P1: reconcileGenericMappings 保序
已有映射保持原顺序（先填入 result），新增可用模型排序后追加末尾。修复了保存映射 `moonshot-v1-128k` 被 `kimi-k2.5` 排序位移的问题。

### P2: 空 allowedModels 全选视觉态
- `selectedModelSet` 对 `!modelsSelectionTouched && allowedModels.length === 0` 视为全选，UI 显示所有行已勾选
- 保存仍保留空数组（"不限制模型"语义）
- `toggleDraftModel` 首次交互时从空 `allowedModels` 初始化全量模型集再执行切换

### P2: group cache 失效
`GroupAvailabilityCacheEntry` 加入 `cacheVersion` 字段，跟随 `getConfiguredAvailabilityCacheVersion()`。调用 `invalidateConfiguredModelAvailability()` 后所有组缓存条目自动失效。

### 测试同步
- CC Switch 测试适配 Codex 自动补齐模型映射（不再有空状态"add a model mapping"）
- CC Switch 测试适配 group-scoped 查询参数（`allowedChannelGroups`）
- RoutingConfigEditor 测试适配空 allowedModels 语义和全选视觉态

## Test plan
- [x] 41 tests pass (3 test suites)
- [x] `bun run check` 通过