### PR TITLE
fix(ccswitch): filter out implicit channel groups from dropdown

### DIFF
--- a/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
+++ b/src/modules/ccswitch/CcSwitchImportSettingsPage.tsx
@@ -109,6 +109,7 @@ export function CcSwitchImportSettingsPage() {
         if (cancelled) return;
         setChannelGroupOptions(
           items
+            .filter((item) => item.implicit !== true || item.name === "default")
             .map((item) => ({
               value: String(item.name ?? "")
                 .trim()

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -764,4 +764,26 @@ describe("CcSwitchImportSettingsPage", () => {
 
     await waitFor(() => expect(replaceConfigs).toHaveBeenCalledWith([]));
   });
+
+  test("filters out implicit channel groups except default from the CC Switch dropdown", async () => {
+    listChannelGroups.mockResolvedValue([
+      { name: "pro", description: "Pro route", "path-routes": ["/pro"] },
+      { name: "default", implicit: true },
+      { name: "nvidia", implicit: true },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /new config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /new cc switch config/i });
+    await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
+
+    const options = await screen.findAllByRole("option");
+    const optionLabels = options.map((el) => el.textContent ?? "");
+
+    expect(optionLabels.some((text) => text.includes("pro"))).toBe(true);
+    expect(optionLabels.some((text) => text.includes("default"))).toBe(true);
+    expect(optionLabels.some((text) => text.includes("nvidia"))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- CC Switch 新建配置弹窗的渠道分组下拉现在会过滤掉隐式分组（如供应商 prefix 自动合成的 `nvidia`）
- 保留 `default` 隐式分组（它对路由系统有意义且可能被用户选用）
- 修复了渠道分组管理页显示 5 条、CC Switch 下拉却多出 `nvidia` 的不一致问题

## Cause

后端 `/v0/management/channel-groups` 同时返回显式分组和隐式分组（由供应商 prefix 自动合成）。CC Switch 下拉直接消费该 API 结果而未过滤 `implicit`，导致用户能看到渠道分组管理页不存在的选项。

## Test plan

- 新增回归测试：mock 返回一个显式分组 + `default`（隐式）+ `nvidia`（隐式）
- 断言下拉包含 `pro` 和 `default`，不包含 `nvidia`
- 全部 449 个测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)