### PR TITLE
fix(ccswitch): show hidden implicit channel group label when editing saved config

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2450,6 +2450,7 @@
     "config_channel_groups_loading": "Loading channel groups...",
     "config_channel_groups_search_placeholder": "Search channel groups...",
     "config_channel_groups_empty": "No matching channel groups",
+    "config_channel_group_hidden": "(hidden group)",
     "config_select_filtered_groups": "Select shown groups",
     "config_deselect_filtered_groups": "Clear shown groups",
     "config_selected_groups_count": "{{count}} selected",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -2705,6 +2705,7 @@
     "config_channel_groups_loading": "正在加载渠道分组...",
     "config_channel_groups_search_placeholder": "搜索渠道分组...",
     "config_channel_groups_empty": "没有匹配的渠道分组",
+    "config_channel_group_hidden": "已隐藏组",
     "config_select_filtered_groups": "选择当前结果",
     "config_deselect_filtered_groups": "清空当前结果",
     "config_selected_groups_count": "已选 {{count}} 项",

--- a/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
+++ b/src/modules/ccswitch/CcSwitchImportConfigModal.tsx
@@ -454,8 +454,8 @@ export function CcSwitchImportConfigModal({
   const client = getCcSwitchClientConfig(draft.clientType);
   const clientLabel = t(client.labelKey);
   const groupSelectOptions = useMemo<SearchableSelectOption[]>(
-    () =>
-      channelGroupOptions.map((option) => {
+    () => {
+      const options = channelGroupOptions.map((option) => {
         const path = routeLabel(option.routePath);
         return {
           value: option.value,
@@ -480,8 +480,22 @@ export function CcSwitchImportConfigModal({
             </span>
           ),
         };
-      }),
-    [channelGroupOptions],
+      });
+
+      const currentGroup = draft.allowedChannelGroups[0] ?? "";
+      if (currentGroup && !channelGroupOptions.some((o) => o.value === currentGroup)) {
+        const hiddenLabel = `${currentGroup} ${t("ccswitch.config_channel_group_hidden")}`;
+        options.push({
+          value: currentGroup,
+          triggerLabel: <span>{hiddenLabel}</span>,
+          searchText: hiddenLabel,
+          label: <span>{hiddenLabel}</span>,
+        });
+      }
+
+      return options;
+    },
+    [channelGroupOptions, draft.allowedChannelGroups, t],
   );
   const previewRoutePath = selectedGroup
     ? ensureCcSwitchRoutePath(draft.routePath, selectedGroup, draft.id)

--- a/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/src/modules/ccswitch/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -786,4 +786,47 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(optionLabels.some((text) => text.includes("default"))).toBe(true);
     expect(optionLabels.some((text) => text.includes("nvidia"))).toBe(false);
   });
+
+  test("shows hidden channel group label when editing a config with an implicit filtered-out group", async () => {
+    listChannelGroups.mockResolvedValue([
+      { name: "pro", description: "Pro route", "path-routes": ["/pro"] },
+      { name: "default", implicit: true },
+      { name: "nvidia", implicit: true },
+    ]);
+    listAvailableModels.mockResolvedValue([]);
+    listConfigs.mockResolvedValue([
+      {
+        id: "cfg-nvidia",
+        clientType: "codex",
+        providerName: "Relay NVIDIA",
+        note: "old config",
+        defaultModel: "gpt-5.5",
+        allowedChannelGroups: ["nvidia"],
+        endpointPath: "/v1",
+        usageAutoInterval: 30,
+        modelMappings: [{ requestModel: "gpt-5.5", targetModel: "mistral-7b" }],
+      },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(await screen.findByText("Relay NVIDIA")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /edit config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
+    expect(
+      await within(dialog).findByRole("combobox", { name: /select channel group/i }),
+    ).toHaveTextContent(/nvidia/i);
+
+    await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(replaceConfigs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: "cfg-nvidia",
+          allowedChannelGroups: ["nvidia"],
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes P2 issue where editing a saved CC Switch config referencing an implicit channel group (e.g. "nvidia") shows a placeholder instead of the group name
- Appends the hidden group as a read-only option marked with "(hidden group)" label
- Preserves existing behavior for create mode (implicit groups remain filtered out)

## Test plan

- [x] Existing 14 tests pass (including the regression test for filtering out implicit groups in create mode)
- [x] New test verifies: editing a config with `allowedChannelGroups: ["nvidia"]` (implicit) shows the group label correctly and saves without data loss
- [x] Build passes (tsc --noEmit && vite build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)