### PR TITLE
feat: manage card usage UI — ToggleSwitch hover, OpenCodeGo visual & cache merge

### DIFF
--- a/src/modules/auth-files/components/AuthFilesFilesTab.tsx
+++ b/src/modules/auth-files/components/AuthFilesFilesTab.tsx
@@ -1203,7 +1203,7 @@ export function AuthFilesFilesTab({
                                   "flex h-8 items-center justify-center px-1 transition-opacity",
                                   showSelectionControl
                                     ? "opacity-100 pointer-events-auto"
-                                    : "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto",
+                                    : "opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto",
                                 ].join(" ")}
                               >
                                 <input
@@ -1222,12 +1222,19 @@ export function AuthFilesFilesTab({
                             {runtimeOnly ? (
                               <span className="text-xs text-slate-400 dark:text-white/40">--</span>
                             ) : (
-                              <ToggleSwitch
-                                ariaLabel={t("auth_files.enable_disable")}
-                                checked={!fileDisabled}
-                                onCheckedChange={(enabled) => void setFileEnabled(file, enabled)}
-                                disabled={Boolean(statusUpdating[file.name])}
-                              />
+                              <div
+                                className={[
+                                  "flex h-8 items-center justify-center transition-opacity",
+                                  "opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto",
+                                ].join(" ")}
+                              >
+                                <ToggleSwitch
+                                  ariaLabel={t("auth_files.enable_disable")}
+                                  checked={!fileDisabled}
+                                  onCheckedChange={(enabled) => void setFileEnabled(file, enabled)}
+                                  disabled={Boolean(statusUpdating[file.name])}
+                                />
+                              </div>
                             )}
                           </div>
                         </div>

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -20,6 +20,7 @@ import { useOpenAIProviderEditor } from "@/modules/providers/hooks/useOpenAIProv
 import { ProviderKeyListCard } from "@/modules/providers/ProviderKeyListCard";
 import {
   OpenCodeGoUsageCardSection,
+  mergeOpenCodeGoUsage,
   type OpenCodeGoUsageCacheEntry,
 } from "@/modules/providers/components/OpenCodeGoUsageCardSection";
 import { useProviderKeyEditor } from "@/modules/providers/hooks/useProviderKeyEditor";
@@ -168,7 +169,12 @@ export function ProvidersPage() {
           updatedAt: Date.now(),
         };
         setOpenCodeGoUsageState((prev) => {
-          const next = { ...prev, [cacheKey]: entry };
+          const existing = prev[cacheKey];
+          const merged = mergeOpenCodeGoUsage(existing?.usage ?? [], entry.usage);
+          const next = {
+            ...prev,
+            [cacheKey]: { ...entry, usage: merged, workspaceId: entry.workspaceId ?? existing?.workspaceId },
+          };
           setCachedData("opencode-go-usage", next);
           return next;
         });

--- a/src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/src/modules/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -310,3 +310,76 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
   });
 });
+
+describe("mergeOpenCodeGoUsage", () => {
+  test("returns incoming when existing is empty", async () => {
+    const { mergeOpenCodeGoUsage } = await import(
+      "@/modules/providers/components/OpenCodeGoUsageCardSection"
+    );
+    const incoming = [{ type: "rolling", label: "Rolling", percentage: 50, resets_in: "30m" }];
+    expect(mergeOpenCodeGoUsage([], incoming)).toEqual(incoming);
+  });
+
+  test("returns existing when incoming is empty", async () => {
+    const { mergeOpenCodeGoUsage } = await import(
+      "@/modules/providers/components/OpenCodeGoUsageCardSection"
+    );
+    const existing = [{ type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" }];
+    expect(mergeOpenCodeGoUsage(existing, [])).toEqual(existing);
+  });
+
+  test("overwrites matching types and preserves non-matching types", async () => {
+    const { mergeOpenCodeGoUsage } = await import(
+      "@/modules/providers/components/OpenCodeGoUsageCardSection"
+    );
+    const existing = [
+      { type: "rolling", label: "Rolling", percentage: 50, resets_in: "30m" },
+      { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
+      { type: "monthly", label: "Monthly", percentage: 10, resets_in: "20d" },
+    ];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" },
+    ];
+    const result = mergeOpenCodeGoUsage(existing, incoming);
+
+    expect(result).toHaveLength(3);
+    expect(result.find((i) => i.type === "rolling")?.percentage).toBe(80);
+    expect(result.find((i) => i.type === "weekly")?.percentage).toBe(30);
+    expect(result.find((i) => i.type === "monthly")?.percentage).toBe(10);
+  });
+
+  test("handles case-insensitive type matching", async () => {
+    const { mergeOpenCodeGoUsage } = await import(
+      "@/modules/providers/components/OpenCodeGoUsageCardSection"
+    );
+    const existing = [
+      { type: "Rolling", label: "Rolling", percentage: 50, resets_in: "30m" },
+    ];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 75, resets_in: "25m" },
+    ];
+    const result = mergeOpenCodeGoUsage(existing, incoming);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].percentage).toBe(75);
+  });
+
+  test("preserves incoming order with appended preserved items", async () => {
+    const { mergeOpenCodeGoUsage } = await import(
+      "@/modules/providers/components/OpenCodeGoUsageCardSection"
+    );
+    const existing = [
+      { type: "monthly", label: "Monthly", percentage: 10, resets_in: "20d" },
+      { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
+    ];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" },
+    ];
+    const result = mergeOpenCodeGoUsage(existing, incoming);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].type).toBe("rolling");
+    expect(result[1].type).toBe("monthly");
+    expect(result[2].type).toBe("weekly");
+  });
+});

--- a/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -9,6 +9,60 @@ export interface OpenCodeGoUsageCacheEntry {
   error?: string;
 }
 
+const clampPercent = (value: number): number => Math.max(0, Math.min(100, value));
+
+export function mergeOpenCodeGoUsage(
+  existing: OpenCodeGoUsageItem[],
+  incoming: OpenCodeGoUsageItem[],
+): OpenCodeGoUsageItem[] {
+  if (!existing.length) return incoming;
+  if (!incoming.length) return existing;
+
+  const seen = new Set<string>();
+  const result: OpenCodeGoUsageItem[] = [];
+
+  for (const item of incoming) {
+    const key = item.type.toLowerCase();
+    seen.add(key);
+    result.push(item);
+  }
+
+  for (const item of existing) {
+    const key = item.type.toLowerCase();
+    if (!seen.has(key)) {
+      result.push(item);
+      seen.add(key);
+    }
+  }
+
+  return result;
+}
+
+const resolveUsageTone = (
+  value: number,
+): { fillClass: string; percentClass: string } => {
+  const normalized = clampPercent(value);
+
+  if (normalized >= 60) {
+    return {
+      fillClass: "bg-emerald-500",
+      percentClass: "text-emerald-700 dark:text-emerald-200",
+    };
+  }
+
+  if (normalized >= 20) {
+    return {
+      fillClass: "bg-amber-500",
+      percentClass: "text-amber-700 dark:text-amber-200",
+    };
+  }
+
+  return {
+    fillClass: "bg-rose-500",
+    percentClass: "text-rose-700 dark:text-rose-200",
+  };
+};
+
 export function OpenCodeGoUsageCardSection({
   usageEntry,
   loading,
@@ -25,9 +79,9 @@ export function OpenCodeGoUsageCardSection({
   );
 
   return (
-    <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50/60 p-3 dark:border-neutral-800 dark:bg-neutral-900/40">
+    <div className="mt-3 rounded-2xl bg-slate-50/85 px-3 py-3 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-slate-700 dark:text-white/75">
+        <span className="text-[11px] font-semibold text-slate-700 dark:text-white/80">
           {t("providers.opencode_go_usage_title")}
         </span>
         <button
@@ -37,7 +91,7 @@ export function OpenCodeGoUsageCardSection({
             onRefresh();
           }}
           disabled={loading}
-          className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-200/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 disabled:opacity-50 dark:text-white/55 dark:hover:bg-white/10 dark:focus-visible:ring-white/20"
+          className="inline-flex items-center gap-1 rounded-lg px-1.5 py-0.5 text-[11px] font-medium text-slate-500 transition-colors hover:bg-slate-200/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 disabled:opacity-50 dark:text-white/55 dark:hover:bg-white/10 dark:focus-visible:ring-white/20"
           aria-label={t("providers.opencode_go_usage_refresh")}
           title={t("providers.opencode_go_usage_refresh")}
         >
@@ -47,37 +101,45 @@ export function OpenCodeGoUsageCardSection({
 
       {usageEntry ? (
         <>
-          <div className="mt-2 grid gap-2">
+          <div className="mt-2 space-y-2.5">
             {(["rolling", "weekly", "monthly"] as const).map((type) => {
               const item = usageByType.get(type);
               const value = item?.percentage ?? 0;
+              const tone = resolveUsageTone(value);
+
               return (
-                <div key={type}>
+                <div key={type} className="space-y-1">
                   <div className="flex items-center justify-between gap-2">
-                    <span className="text-xs text-slate-600 dark:text-white/65">
+                    <span className="min-w-0 truncate text-[11px] font-semibold text-slate-700 dark:text-white/80">
                       {t(`providers.opencode_go_usage_${type}`)}
                     </span>
-                    <span className="text-xs font-semibold tabular-nums text-slate-700 dark:text-white/80">
+                    <span
+                      className={[
+                        "shrink-0 text-[11px] font-semibold tabular-nums",
+                        tone.percentClass,
+                      ].join(" ")}
+                    >
                       {value}%
                     </span>
                   </div>
-                  <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-neutral-800">
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
                     <div
-                      className="h-full rounded-full bg-sky-500"
-                      style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+                      className={["h-full rounded-full", tone.fillClass].join(" ")}
+                      style={{ width: `${clampPercent(value)}%` }}
+                      aria-hidden="true"
                     />
                   </div>
-                  <p className="mt-0.5 text-[11px] text-slate-400 dark:text-white/45">
+                  <div className="truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
                     {item && item.resets_in
                       ? t("providers.opencode_go_usage_resets_in", { time: item.resets_in })
                       : t("providers.opencode_go_usage_no_data")}
-                  </p>
+                  </div>
                 </div>
               );
             })}
           </div>
           {usageEntry.error ? (
-            <p className="mt-2 text-[11px] text-rose-600 dark:text-rose-400">
+            <p className="mt-2 text-[11px] font-semibold text-rose-700 dark:text-rose-200">
               {usageEntry.error}
             </p>
           ) : null}


### PR DESCRIPTION
## Summary

- **Auth Files 卡片**: ToggleSwitch 从头部常驻改为 hover/focus 可见
- **OpenCodeGo 用量视觉**: 统一为 auth-files quota 区的轻量条形样式，使用 emerald/amber/rose 颜色编码
- **OpenCodeGo 缓存合并**: 刷新时按 type 局部合并，保留未返回窗口的旧值

## Files

| File | Change |
|------|--------|
| `AuthFilesFilesTab.tsx` | ToggleSwitch wrapped in hover/focus div; checkbox also gets focus-within |
| `OpenCodeGoUsageCardSection.tsx` | Visual redesign + `mergeOpenCodeGoUsage` utility |
| `ProvidersPage.tsx` | Use merge logic in refresh handler |
| `ProvidersPage.opencode-go.test.tsx` | 5 test cases for merge function |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>