### PR TITLE
feat: compact OpenCode Go card — no scroll, remaining %, no key/title

### DIFF
--- a/src/modules/providers/ProviderCard.tsx
+++ b/src/modules/providers/ProviderCard.tsx
@@ -19,6 +19,8 @@ export interface ProviderCardProps {
   enabled?: boolean;
   /** Whether the card should appear dimmed (disabled state) */
   dimmed?: boolean;
+  /** Whether to use natural height (no max-h, no internal scroll). For cards that need full content visible. */
+  naturalHeight?: boolean;
   /** Callback when selection checkbox changes */
   onToggleSelected?: (checked: boolean) => void;
   /** Callback when enabled toggle changes */
@@ -40,6 +42,7 @@ export function ProviderCard({
   selected = false,
   enabled = true,
   dimmed = false,
+  naturalHeight = false,
   onToggleSelected,
   onToggleEnabled,
   onEdit,
@@ -56,7 +59,8 @@ export function ProviderCard({
   return (
     <div
       className={[
-        "group relative flex flex-col rounded-xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out min-h-[220px] max-h-[260px]",
+        "group relative flex flex-col rounded-xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out",
+        naturalHeight ? "min-h-0" : "min-h-[220px] max-h-[260px]",
         selected
           ? "border-blue-400 bg-blue-50/50 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-950/20 dark:ring-blue-500/20"
           : "border-slate-200 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
@@ -153,7 +157,11 @@ export function ProviderCard({
         </div>
 
       {/* Content */}
-      {children ? <div className="mt-2 min-w-0 flex-1 overflow-y-auto">{children}</div> : null}
+      {children ? (
+        <div className={["mt-2 min-w-0 flex-1", naturalHeight ? "" : "overflow-y-auto"].join(" ")}>
+          {children}
+        </div>
+      ) : null}
       {footer ? <div className="mt-auto pt-3">{footer}</div> : null}
     </div>
   );

--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -36,6 +36,9 @@ export function ProviderKeyListCard({
   showBaseUrl = true,
   selectedKeys,
   onToggleSelected,
+  naturalHeight = false,
+  showConnectionRows = true,
+  showModelMetric = true,
 }: {
   items: ProviderSimpleConfig[];
   loading?: boolean;
@@ -52,6 +55,9 @@ export function ProviderKeyListCard({
   showBaseUrl?: boolean;
   selectedKeys?: Set<string>;
   onToggleSelected?: (key: string, checked: boolean) => void;
+  naturalHeight?: boolean;
+  showConnectionRows?: boolean;
+  showModelMetric?: boolean;
 }) {
   const { t } = useTranslation();
   const gridColumnsClass =
@@ -104,6 +110,7 @@ export function ProviderKeyListCard({
                 selected={selected}
                 enabled={!disabled}
                 dimmed={disabled}
+                naturalHeight={naturalHeight}
                 onToggleSelected={
                   onToggleSelected
                     ? (checked) => onToggleSelected(selectionKey, checked)
@@ -168,20 +175,24 @@ export function ProviderKeyListCard({
                 }
                 footer={<ProviderStatusBar data={statusData} />}
               >
-                <ProviderConnectionRows
-                  apiKey={item.apiKey}
-                  baseUrl={item.baseUrl}
-                  proxyUrl={item.proxyUrl}
-                  maskApiKey={maskApiKey}
-                  showBaseUrl={showBaseUrl}
-                />
+                {showConnectionRows ? (
+                  <ProviderConnectionRows
+                    apiKey={item.apiKey}
+                    baseUrl={item.baseUrl}
+                    proxyUrl={item.proxyUrl}
+                    maskApiKey={maskApiKey}
+                    showBaseUrl={showBaseUrl}
+                  />
+                ) : null}
 
                 <div className="mt-2 flex flex-wrap gap-1.5">
-                  <ProviderMetricChip
-                    tone="blue"
-                    label={t("providers.models_label")}
-                    value={models.length}
-                  />
+                  {showModelMetric ? (
+                    <ProviderMetricChip
+                      tone="blue"
+                      label={t("providers.models_label")}
+                      value={models.length}
+                    />
+                  ) : null}
                   {excludedModels.length ? (
                     <ProviderMetricChip
                       tone="rose"

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -995,6 +995,9 @@ export function ProvidersPage() {
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               showBaseUrl={false}
+              naturalHeight
+              showConnectionRows={false}
+              showModelMetric={false}
               renderExtra={(item, idx) => (
                 <OpenCodeGoUsageCardSection
                   usageEntry={openCodeGoUsageState[getOpenCodeGoUsageCacheKey(item, idx)]}

--- a/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -38,19 +38,29 @@ export function mergeOpenCodeGoUsage(
   return result;
 }
 
-const resolveUsageTone = (
-  value: number,
-): { fillClass: string; percentClass: string } => {
-  const normalized = clampPercent(value);
+const resolveRemainingPercent = (usagePercentage: number | undefined): number | null => {
+  if (typeof usagePercentage !== "number" || !Number.isFinite(usagePercentage)) return null;
+  return clampPercent(100 - clampPercent(usagePercentage));
+};
 
-  if (normalized >= 60) {
+const resolveRemainingTone = (
+  remaining: number | null,
+): { fillClass: string; percentClass: string } => {
+  if (remaining === null) {
+    return {
+      fillClass: "bg-slate-300/50 dark:bg-white/10",
+      percentClass: "text-slate-600 dark:text-white/65",
+    };
+  }
+
+  if (remaining >= 60) {
     return {
       fillClass: "bg-emerald-500",
       percentClass: "text-emerald-700 dark:text-emerald-200",
     };
   }
 
-  if (normalized >= 20) {
+  if (remaining >= 20) {
     return {
       fillClass: "bg-amber-500",
       percentClass: "text-amber-700 dark:text-amber-200",
@@ -62,6 +72,8 @@ const resolveUsageTone = (
     percentClass: "text-rose-700 dark:text-rose-200",
   };
 };
+
+const TYPE_LABELS = ["rolling", "weekly", "monthly"] as const;
 
 export function OpenCodeGoUsageCardSection({
   usageEntry,
@@ -78,77 +90,72 @@ export function OpenCodeGoUsageCardSection({
     (usageEntry?.usage ?? []).map((item) => [item.type.toLowerCase(), item]),
   );
 
-  return (
-    <div className="mt-3 rounded-2xl bg-slate-50/85 px-3 py-3 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[11px] font-semibold text-slate-700 dark:text-white/80">
-          {t("providers.opencode_go_usage_title")}
-        </span>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRefresh();
-          }}
-          disabled={loading}
-          className="inline-flex items-center gap-1 rounded-lg px-1.5 py-0.5 text-[11px] font-medium text-slate-500 transition-colors hover:bg-slate-200/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 disabled:opacity-50 dark:text-white/55 dark:hover:bg-white/10 dark:focus-visible:ring-white/20"
-          aria-label={t("providers.opencode_go_usage_refresh")}
-          title={t("providers.opencode_go_usage_refresh")}
-        >
-          <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
-        </button>
-      </div>
+  const hasUsage = Boolean(usageEntry && usageEntry.usage.length > 0);
 
-      {usageEntry ? (
-        <>
-          <div className="mt-2 space-y-2.5">
-            {(["rolling", "weekly", "monthly"] as const).map((type) => {
+  return (
+    <div className="mt-3 flex items-start justify-between gap-2">
+      <div className="min-w-0 flex-1">
+        {hasUsage ? (
+          <div className="space-y-1.5">
+            {TYPE_LABELS.map((type) => {
               const item = usageByType.get(type);
-              const value = item?.percentage ?? 0;
-              const tone = resolveUsageTone(value);
+              const remaining = resolveRemainingPercent(item?.percentage);
+              const tone = resolveRemainingTone(remaining);
+              const remainingText = remaining === null ? "--" : `${remaining}%`;
 
               return (
-                <div key={type} className="space-y-1">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="min-w-0 truncate text-[11px] font-semibold text-slate-700 dark:text-white/80">
-                      {t(`providers.opencode_go_usage_${type}`)}
-                    </span>
-                    <span
-                      className={[
-                        "shrink-0 text-[11px] font-semibold tabular-nums",
-                        tone.percentClass,
-                      ].join(" ")}
-                    >
-                      {value}%
-                    </span>
-                  </div>
+                <div
+                  key={type}
+                  className="grid grid-cols-[2.5rem_minmax(0,1fr)_4.5rem] items-center gap-2"
+                >
+                  <span className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
+                    {t(`providers.opencode_go_usage_${type}`)}
+                  </span>
                   <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
                     <div
                       className={["h-full rounded-full", tone.fillClass].join(" ")}
-                      style={{ width: `${clampPercent(value)}%` }}
+                      style={{ width: `${remaining ?? 0}%` }}
                       aria-hidden="true"
                     />
                   </div>
-                  <div className="truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
-                    {item && item.resets_in
-                      ? t("providers.opencode_go_usage_resets_in", { time: item.resets_in })
-                      : t("providers.opencode_go_usage_no_data")}
-                  </div>
+                  <span
+                    className={[
+                      "truncate text-right text-[11px] font-semibold tabular-nums",
+                      tone.percentClass,
+                    ].join(" ")}
+                  >
+                    {remainingText}
+                  </span>
                 </div>
               );
             })}
           </div>
-          {usageEntry.error ? (
-            <p className="mt-2 text-[11px] font-semibold text-rose-700 dark:text-rose-200">
-              {usageEntry.error}
-            </p>
-          ) : null}
-        </>
-      ) : !loading ? (
-        <p className="mt-2 text-xs text-slate-400 dark:text-white/45">
-          {t("providers.opencode_go_usage_not_queried")}
-        </p>
-      ) : null}
+        ) : !loading ? (
+          <p className="text-xs text-slate-400 dark:text-white/45">
+            {t("providers.opencode_go_usage_not_queried")}
+          </p>
+        ) : null}
+
+        {usageEntry?.error ? (
+          <p className="mt-1 text-[11px] font-semibold text-rose-700 dark:text-rose-200">
+            {usageEntry.error}
+          </p>
+        ) : null}
+      </div>
+
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRefresh();
+        }}
+        disabled={loading}
+        className="mt-0.5 inline-flex shrink-0 items-center justify-center rounded-lg p-1 text-slate-400 transition-colors hover:bg-slate-200/60 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 disabled:opacity-50 dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/60 dark:focus-visible:ring-white/20"
+        aria-label={t("providers.opencode_go_usage_refresh")}
+        title={t("providers.opencode_go_usage_refresh")}
+      >
+        <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

OpenCode Go 卡片改为紧凑剩余额度布局：
- **ProviderCard**: 新增 `naturalHeight` prop，去除 max-h 和内部滚动
- **ProviderKeyListCard**: 新增 `showConnectionRows`/`showModelMetric` props
- **OpenCodeGoUsageCardSection**: 移除标题，改用 `剩余 = 100 - percentage`，单行三列紧凑布局
- **ProvidersPage**: OpenCode Go tab 使用自然高度、不展示 key 和模型数

## Files

| File | Change |
|------|--------|
| `ProviderCard.tsx` | naturalHeight prop, conditional max-h & overflow-y-auto |
| `ProviderKeyListCard.tsx` | showConnectionRows, showModelMetric props |
| `OpenCodeGoUsageCardSection.tsx` | Removed title, single-row 3-col remaining % layout |
| `ProvidersPage.tsx` | OpenCode Go tab passes compact props |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>