### PR TITLE
fix: move refresh button to chips row, out of usage data area

### DIFF
--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -39,6 +39,7 @@ export function ProviderKeyListCard({
   naturalHeight = false,
   showConnectionRows = true,
   showModelMetric = true,
+  renderMetricsExtra,
 }: {
   items: ProviderSimpleConfig[];
   loading?: boolean;
@@ -48,6 +49,7 @@ export function ProviderKeyListCard({
   onToggleEnabled?: (index: number, enabled: boolean) => void;
   gridColumns?: number;
   renderExtra?: (item: ProviderSimpleConfig, index: number) => ReactNode;
+  renderMetricsExtra?: (item: ProviderSimpleConfig, index: number, stats: KeyStatBucket) => ReactNode;
   getStats: (item: ProviderSimpleConfig) => KeyStatBucket;
   getStatusBar: (item: ProviderSimpleConfig) => StatusBarData;
   getLatencyEntry?: (key: string) => { latencyMs: number | null; loading: boolean; error: boolean };
@@ -185,7 +187,7 @@ export function ProviderKeyListCard({
                   />
                 ) : null}
 
-                <div className="mt-2 flex flex-wrap gap-1.5">
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
                   {showModelMetric ? (
                     <ProviderMetricChip
                       tone="blue"
@@ -216,6 +218,9 @@ export function ProviderKeyListCard({
                     tone={stats.failure > 0 ? "rose" : "slate"}
                     label={t("providers.failed_stats", { count: stats.failure })}
                   />
+                  {renderMetricsExtra ? (
+                    <div className="ml-auto">{renderMetricsExtra(item, idx, stats)}</div>
+                  ) : null}
                 </div>
 
                 {headerEntries.length ? (

--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -1041,6 +1041,48 @@ export function ProvidersPage() {
                   onRefresh={() => void refreshOpenCodeGoUsage(item, idx)}
                 />
               )}
+              renderMetricsExtra={(item, idx) => {
+                const cacheKey = getOpenCodeGoUsageCacheKey(item, idx);
+                const loading = openCodeGoUsageLoadingState[cacheKey] ?? false;
+                const hasError = Boolean(openCodeGoUsageState[cacheKey]?.error);
+                return (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void refreshOpenCodeGoUsage(item, idx);
+                    }}
+                    disabled={loading}
+                    className={[
+                      "inline-flex h-6 w-6 items-center justify-center rounded-lg transition-all duration-150",
+                      "text-slate-400 hover:bg-slate-200/60 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25",
+                      "dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/60 dark:focus-visible:ring-white/20",
+                      loading || hasError
+                        ? "opacity-100"
+                        : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+                    ].join(" ")}
+                    aria-label="Refresh usage"
+                    title="Refresh usage"
+                  >
+                    <svg
+                      width="13"
+                      height="13"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className={loading ? "animate-spin" : ""}
+                    >
+                      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+                      <path d="M21 3v5h-5" />
+                      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+                      <path d="M3 21v-5h5" />
+                    </svg>
+                  </button>
+                );
+              }}
               gridColumns={gridColumns}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}

--- a/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import { RefreshCw } from "lucide-react";
 import type { OpenCodeGoUsageItem } from "@/lib/http/types";
 
 export interface OpenCodeGoUsageCacheEntry {
@@ -97,11 +96,9 @@ export function OpenCodeGoUsageCardSection({
   );
 
   const hasUsage = Boolean(usageEntry && usageEntry.usage.length > 0);
-  const showError = Boolean(usageEntry?.error);
-  const showRefreshButton = loading || showError;
 
   return (
-    <div className="group/usage relative mt-3">
+    <div className="mt-3">
       {loading && !hasUsage ? (
         <div className="space-y-2">
           {TYPE_LABELS.map((type) => (
@@ -169,27 +166,6 @@ export function OpenCodeGoUsageCardSection({
             : usageEntry.error}
         </p>
       ) : null}
-
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onRefresh();
-        }}
-        disabled={loading}
-        className={[
-          "absolute right-0 top-0 inline-flex items-center justify-center rounded-lg p-1 transition-all duration-150",
-          "text-slate-400 hover:bg-slate-200/60 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25",
-          "dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/60 dark:focus-visible:ring-white/20",
-          showRefreshButton
-            ? "opacity-100 pointer-events-auto"
-            : "opacity-0 pointer-events-none group-hover/usage:opacity-100 group-focus-within/usage:opacity-100 group-hover/usage:pointer-events-auto group-focus-within/usage:pointer-events-auto",
-        ].join(" ")}
-        aria-label={t("providers.opencode_go_usage_refresh")}
-        title={t("providers.opencode_go_usage_refresh")}
-      >
-        <RefreshCw size={13} className={loading ? "animate-spin" : ""} />
-      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Refresh 按钮位置重构：

- **OpenCodeGoUsageCardSection**: 纯数据展示，不再包含任何按钮
- **ProviderKeyListCard**: 新增 `renderMetricsExtra` prop，在 chips 行末尾渲染
- **Refresh 按钮**: 位于 `[成功] [失败] <ml-auto> [🔄]` 行，默认隐藏，hover/loading/error 显示

效果：
- 刷新入口在卡片的成功/失败数据行，不覆盖额度进度条
- 额度区只展示三列数据（标签 | 条 | 剩余%），无按钮干扰
- 按钮使用 group-hover 控制显隐，不额外占用宽度

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>