### PR TITLE
fix: 将卡片网格改为 auto-fill + 固定最大宽度，防止单卡片横向拉满

### DIFF
--- a/src/modules/providers/ProviderKeyListCard.tsx
+++ b/src/modules/providers/ProviderKeyListCard.tsx
@@ -78,8 +78,8 @@ export function ProviderKeyListCard({
       ) : (
         <div
           data-testid="providers-tab-scroll"
-          className="min-h-0 flex-1 overflow-y-auto pr-1 grid gap-3 items-start content-start"
-          style={{ gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))" }}
+          className="min-h-0 flex-1 overflow-y-auto pr-1 grid gap-3 items-start content-start justify-start"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))" }}
         >
           {items.map((item, idx) => {
             const selectionKey = `${item.apiKey.trim().toLowerCase()}:${idx}`;

--- a/src/modules/providers/components/OpenAIProvidersTab.tsx
+++ b/src/modules/providers/components/OpenAIProvidersTab.tsx
@@ -71,8 +71,8 @@ export function OpenAIProvidersTab({
       ) : (
         <div
           data-testid="providers-tab-scroll"
-          className="min-h-0 flex-1 overflow-y-auto pr-1 grid gap-3 items-start content-start"
-          style={{ gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))" }}
+          className="min-h-0 flex-1 overflow-y-auto pr-1 grid gap-3 items-start content-start justify-start"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))" }}
         >
           {providers.map((provider, idx) => {
             const selectionKey = `${provider.name.trim().toLowerCase()}:${idx}`;


### PR DESCRIPTION
修复上一个 PR 中自动适配网格遗留的问题： 在单卡片时仍会拉满整行。

### 改动
两个文件中各 2 行变更：
-  → ：保留空轨道，空间不足时自动保留空白区
-  → ：硬性上限 22rem（~352px），阻止单卡片拉伸
- 增加 ：卡片列从左侧自然排列


### 视觉效果
- 大窗口、1 张 OpenCode Go 卡片：卡片宽 ~352px，左对齐，不再横跨整行
- 大窗口、多张卡片：同行排列，超出宽度自动换行
- 中等窗口：自动减少列数，卡片 ~320-352px 稳定
- 窄屏： 保证单列满宽

### 验证状态
- [x] 编译通过
- [x] 测试通过（72 test files, 456 tests passed）