### PR TITLE
fix: rewrite CC Switch usage script and separate usageBaseUrl

### DIFF
--- a/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
+++ b/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
@@ -340,11 +340,15 @@ export function QuickImportTabContent({
       if (!key) return "";
 
       const baseUrl = appendCcSwitchRoutePath(detectApiBaseFromLocation(), config.routePath);
+      // Use root base URL for usage queries so that usage/summary is not
+      // routed through the CC Switch routePath (which the server does not rewrite for /v0/management/* paths).
+      const usageBaseUrl = detectApiBaseFromLocation();
       return buildCcSwitchImportUrlForConfig({
         apiKey: key,
         baseUrl,
         config,
         configs,
+        usageBaseUrl,
       });
     },
     [apiKey, configs],

--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -9,7 +9,12 @@ import {
 const decodeUsageScript = (url: string) => {
   const encoded = new URL(url).searchParams.get("usageScript");
   expect(encoded).toBeTruthy();
-  return atob(encoded!);
+  const binary = atob(encoded!);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
 };
 
 describe("ccswitchImport", () => {
@@ -113,9 +118,14 @@ describe("ccswitchImport", () => {
     expect(parsed.searchParams.get("enabled")).toBe("true");
 
     const usageScript = decodeUsageScript(url);
-    expect(usageScript).toContain("{{baseUrl}}/v0/management/public/usage");
+    expect(usageScript).toContain("{{baseUrl}}/v0/management/public/usage/summary");
     expect(usageScript).toContain('method: "POST"');
     expect(usageScript).toContain('api_key: "{{apiKey}}"');
+    expect(usageScript).toContain("days: 1");
+    expect(usageScript).toContain("total_calls");
+    expect(usageScript).toContain("quota_cost");
+    expect(usageScript).toContain("今日用量");
+    expect(usageScript).toContain("今日消耗");
   });
 
   test("builds a provider deeplink for a selected channel group route and enabled state", () => {
@@ -134,6 +144,25 @@ describe("ccswitchImport", () => {
     expect(parsed.searchParams.get("name")).toBe("Team A Codex");
     expect(parsed.searchParams.get("model")).toBe("gpt-5.4");
     expect(parsed.searchParams.get("enabled")).toBe("false");
+  });
+
+  test("uses separate usageBaseUrl when explicitly provided with a routePath baseUrl", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/team-a",
+      usageBaseUrl: "https://relay.example.com",
+      clientType: "codex",
+      providerName: "Separated Usage",
+      model: "gpt-5.4",
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("homepage")).toBe("https://relay.example.com/team-a");
+    expect(parsed.searchParams.get("endpoint")).toBe("https://relay.example.com/team-a/v1");
+    expect(parsed.searchParams.get("usageBaseUrl")).toBe("https://relay.example.com");
+
+    const usageScript = decodeUsageScript(url);
+    expect(usageScript).toContain("{{baseUrl}}/v0/management/public/usage/summary");
   });
 
   test("uses the request model name from generic model mappings as the provider default", () => {

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -90,12 +90,19 @@ function joinCcSwitchEndpoint(baseUrl: string, endpointPath: string): string {
 }
 
 const encodeBase64 = (value: string): string => {
-  if (typeof btoa === "function") return btoa(value);
   const buffer = (globalThis as { Buffer?: { from: (input: string, encoding: string) => unknown } })
     .Buffer;
   if (buffer?.from) {
     const bytes = buffer.from(value, "utf-8") as { toString: (encoding: string) => string };
     return bytes.toString("base64");
+  }
+  if (typeof btoa === "function") {
+    const utf8Bytes = new (globalThis as { TextEncoder?: new () => { encode: (input: string) => Uint8Array } }).TextEncoder().encode(value);
+    let binary = "";
+    for (let i = 0; i < utf8Bytes.length; i++) {
+      binary += String.fromCharCode(utf8Bytes[i]);
+    }
+    return btoa(binary);
   }
   throw new Error("Base64 encoder is unavailable");
 };
@@ -156,25 +163,23 @@ const getGenericRequestModel = (
 export function buildCcSwitchUsageScript(): string {
   return `({
   request: {
-    url: "{{baseUrl}}/v0/management/public/usage",
+    url: "{{baseUrl}}/v0/management/public/usage/summary",
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ api_key: "{{apiKey}}" })
+    body: JSON.stringify({ api_key: "{{apiKey}}", days: 1 })
   },
   extractor: function(response) {
-    var usage = response && response.usage ? response.usage : {};
-    var apis = usage.apis || {};
-    var keys = Object.keys(apis);
-    var item = keys.length > 0 ? apis[keys[0]] || {} : {};
-    var requests = Number(item.total_requests || usage.total_requests || 0) || 0;
-    var tokens = Number(item.total_tokens || usage.total_tokens || 0) || 0;
+    var stats = response && response.stats ? response.stats : {};
+    var calls = Number(stats.total_calls || 0) || 0;
+    var cost = Number(stats.quota_cost || 0) || 0;
     return {
-      planName: "CliProxy",
+      planName: "今日用量",
       isValid: response && response.found === false ? false : true,
-      used: requests,
+      invalidMessage: response && response.found === false ? "API Key 未找到" : null,
+      used: calls,
       remaining: null,
-      unit: "requests",
-      extra: String(tokens) + " tokens"
+      unit: "次",
+      extra: "今日消耗 " + cost.toFixed(4) + " 额度"
     };
   }
 })`;
@@ -207,6 +212,7 @@ export function resolveCcSwitchImportConfig(input: {
   clientType: CcSwitchClientType;
   models?: readonly string[];
   settings?: CcSwitchImportSettingsInput;
+  usageBaseUrl?: string;
 }): {
   homepage: string;
   endpoint: string;
@@ -224,7 +230,7 @@ export function resolveCcSwitchImportConfig(input: {
   return {
     homepage,
     endpoint,
-    usageBaseUrl: homepage,
+    usageBaseUrl: input.usageBaseUrl ? normalizeCcSwitchBaseUrl(input.usageBaseUrl) : homepage,
     usageAutoInterval: clientSettings.usageAutoInterval,
     model: pickCcSwitchDefaultModel(input.clientType, input.models ?? [], settings),
   };
@@ -251,6 +257,7 @@ export function buildCcSwitchImportUrl(input: {
   modelMappings?: readonly CcSwitchModelMappingInput[];
   models?: readonly string[];
   settings?: CcSwitchImportSettingsInput;
+  usageBaseUrl?: string;
 }): string {
   const client = getCcSwitchClientConfig(input.clientType);
   const settings = normalizeCcSwitchImportSettings(
@@ -261,6 +268,7 @@ export function buildCcSwitchImportUrl(input: {
     clientType: input.clientType,
     models: input.models,
     settings,
+    usageBaseUrl: input.usageBaseUrl,
   });
   const params = new URLSearchParams({
     resource: "provider",

--- a/src/modules/ccswitch/ccswitchImportLinks.ts
+++ b/src/modules/ccswitch/ccswitchImportLinks.ts
@@ -65,12 +65,14 @@ export function buildCcSwitchImportUrlForConfig({
   config,
   configs,
   providerName,
+  usageBaseUrl,
 }: {
   apiKey: string;
   baseUrl: string;
   config: CcSwitchImportConfigListItem;
   configs: readonly CcSwitchImportConfigListItem[];
   providerName?: string;
+  usageBaseUrl?: string;
 }): string {
   return buildCcSwitchImportUrl({
     apiKey,
@@ -82,5 +84,6 @@ export function buildCcSwitchImportUrlForConfig({
     modelMappings: config.modelMappings,
     models: [],
     settings: buildCcSwitchSettingsForConfig(config, configs),
+    usageBaseUrl,
   });
 }


### PR DESCRIPTION
## Summary
- Rewrite usageScript to query /v0/management/public/usage/summary
  returning 今日用量 (today calls + quota cost) instead of requests/tokens
- Add optional usageBaseUrl parameter to buildCcSwitchImportUrl so
  routePath-based imports use the root management URL for usage queries
- QuickImportTabContent now passes usageBaseUrl separately
- Fix encodeBase64 to handle UTF-8 strings
- Update tests for new usage script format and routePath separation