### PR TITLE
fix: show ccswitch usage cost in dollars

### DIFF
--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -125,7 +125,8 @@ describe("ccswitchImport", () => {
     expect(usageScript).toContain("total_calls");
     expect(usageScript).toContain("quota_cost");
     expect(usageScript).toContain("今日用量");
-    expect(usageScript).toContain("今日消耗");
+    expect(usageScript).toContain('extra: "今日消耗 " + cost.toFixed(4) + " $"');
+    expect(usageScript).not.toContain("额度");
   });
 
   test("builds a provider deeplink for a selected channel group route and enabled state", () => {

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -96,11 +96,14 @@ const encodeBase64 = (value: string): string => {
     const bytes = buffer.from(value, "utf-8") as { toString: (encoding: string) => string };
     return bytes.toString("base64");
   }
-  if (typeof btoa === "function") {
-    const utf8Bytes = new (globalThis as { TextEncoder?: new () => { encode: (input: string) => Uint8Array } }).TextEncoder().encode(value);
+  const TextEncoderCtor = (
+    globalThis as { TextEncoder?: new () => { encode: (input: string) => Uint8Array } }
+  ).TextEncoder;
+  if (typeof btoa === "function" && TextEncoderCtor) {
+    const utf8Bytes = new TextEncoderCtor().encode(value);
     let binary = "";
-    for (let i = 0; i < utf8Bytes.length; i++) {
-      binary += String.fromCharCode(utf8Bytes[i]);
+    for (const byte of utf8Bytes) {
+      binary += String.fromCharCode(byte);
     }
     return btoa(binary);
   }
@@ -179,7 +182,7 @@ export function buildCcSwitchUsageScript(): string {
       used: calls,
       remaining: null,
       unit: "次",
-      extra: "今日消耗 " + cost.toFixed(4) + " 额度"
+      extra: "今日消耗 " + cost.toFixed(4) + " $"
     };
   }
 })`;


### PR DESCRIPTION
## Summary
- change CC Switch usage extra text from quota wording to dollar unit
- keep UTF-8 Base64 encoding type-safe for the generated usage script
- add regression coverage so the generated usage script no longer contains the old unit wording

## Tests
- bun run test -- src/modules/ccswitch/__tests__/ccswitchImport.test.ts
- bun run lint
- bun run build
- bunx oxfmt src/modules/ccswitch/ccswitchImport.ts src/modules/ccswitch/__tests__/ccswitchImport.test.ts --check