### PR TITLE
fix: localize ccswitch usage import

### DIFF
--- a/src/modules/api-keys/ApiKeysPage.tsx
+++ b/src/modules/api-keys/ApiKeysPage.tsx
@@ -42,7 +42,7 @@ import { ErrorDetailModal } from "@/modules/monitor/ErrorDetailModal";
 import type { ApiKeyFormValues } from "@/modules/api-keys/types";
 
 export function ApiKeysPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { notify } = useToast();
   const auth = useOptionalAuth();
 
@@ -443,9 +443,10 @@ export function ApiKeysPage() {
         configs: ccSwitchImportConfigs,
         providerName: ccSwitchImportEntry.name,
         usageBaseUrl: baseApiUrl,
+        usageLanguage: i18n.language,
       });
     },
-    [ccSwitchImportEntry, ccSwitchImportConfigs, channelGroupItems, auth],
+    [ccSwitchImportEntry, ccSwitchImportConfigs, channelGroupItems, auth, i18n.language],
   );
 
   const handleImportWithConfig = useCallback(

--- a/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
+++ b/src/modules/apikey-lookup/components/QuickImportTabContent.tsx
@@ -15,10 +15,7 @@ import {
   normalizeCcSwitchImportConfigs,
 } from "@/lib/http/apis/ccswitch-import-configs";
 import type { ApiKeyEntry } from "@/lib/http/apis/api-keys";
-import {
-  openCcSwitchImportUrl,
-  type CcSwitchClientType,
-} from "@/modules/ccswitch/ccswitchImport";
+import { openCcSwitchImportUrl, type CcSwitchClientType } from "@/modules/ccswitch/ccswitchImport";
 import {
   appendCcSwitchRoutePath,
   buildCcSwitchImportUrlForConfig,
@@ -56,7 +53,9 @@ function readStoredManagementAuth(): { apiBase: string; managementKey: string } 
   }
 }
 
-async function fetchPublicQuickImportConfigs(apiKey: string): Promise<CcSwitchImportConfigListItem[]> {
+async function fetchPublicQuickImportConfigs(
+  apiKey: string,
+): Promise<CcSwitchImportConfigListItem[]> {
   const key = apiKey.trim();
   if (!key) return [];
 
@@ -155,9 +154,7 @@ function QuickImportCard({
   const clientType = config.clientType as "codex" | "claude";
 
   return (
-    <div
-      className="grid min-h-[116px] w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
-    >
+    <div className="grid min-h-[116px] w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700">
       <button
         type="button"
         onClick={() => onSelect(config)}
@@ -196,9 +193,7 @@ function QuickImportCard({
         <Button
           variant="ghost"
           size="xs"
-          title={
-            copied ? t("ccswitch.copy_import_link_copied") : t("ccswitch.copy_import_link")
-          }
+          title={copied ? t("ccswitch.copy_import_link_copied") : t("ccswitch.copy_import_link")}
           onClick={() => onCopyLink(config)}
           className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
         >
@@ -262,7 +257,7 @@ export function QuickImportTabContent({
   apiKey: string;
   reloadToken?: number;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { notify } = useToast();
   const [configs, setConfigs] = useState<CcSwitchImportConfigListItem[]>([]);
   const [apiKeyEntry, setApiKeyEntry] = useState<ApiKeyEntry | null>(null);
@@ -349,9 +344,10 @@ export function QuickImportTabContent({
         config,
         configs,
         usageBaseUrl,
+        usageLanguage: i18n.language,
       });
     },
-    [apiKey, configs],
+    [apiKey, configs, i18n.language],
   );
 
   const handleImport = useCallback(

--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -5,6 +5,7 @@ import {
   pickCcSwitchDefaultModel,
   resolveCcSwitchImportConfig,
 } from "@/modules/ccswitch/ccswitchImport";
+import { buildCcSwitchImportUrlForConfig } from "@/modules/ccswitch/ccswitchImportLinks";
 
 const decodeUsageScript = (url: string) => {
   const encoded = new URL(url).searchParams.get("usageScript");
@@ -125,8 +126,68 @@ describe("ccswitchImport", () => {
     expect(usageScript).toContain("total_calls");
     expect(usageScript).toContain("quota_cost");
     expect(usageScript).toContain("今日用量");
-    expect(usageScript).toContain('extra: "今日消耗 " + cost.toFixed(4) + " $"');
+    expect(usageScript).toContain("used: undefined");
+    expect(usageScript).toContain("remaining: calls");
+    expect(usageScript).toContain('unit: "次"');
+    expect(usageScript).toContain('extra: "今日消耗： " + cost.toFixed(4) + "$"');
     expect(usageScript).not.toContain("额度");
+  });
+
+  test("builds an English usage script when the management UI language is English", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      model: "gpt-5.5",
+      usageLanguage: "en",
+    });
+
+    const usageScript = decodeUsageScript(url);
+    expect(usageScript).toContain("Today's usage");
+    expect(usageScript).toContain("API Key not found");
+    expect(usageScript).toContain('unit: "times"');
+    expect(usageScript).toContain('extra: "Today\'s cost: " + cost.toFixed(4) + "$"');
+    expect(usageScript).not.toContain("今日用量");
+    expect(usageScript).not.toContain("今日消耗");
+  });
+
+  test("passes provider notes in CC Switch deeplinks", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      note: "Pro pool remark",
+      model: "gpt-5.5",
+    });
+
+    expect(new URL(url).searchParams.get("notes")).toBe("Pro pool remark");
+  });
+
+  test("passes CC Switch import config remarks as provider notes", () => {
+    const url = buildCcSwitchImportUrlForConfig({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      config: {
+        id: "codex-pro",
+        clientType: "codex",
+        providerName: "Relay Pro",
+        note: "Pro pool remark",
+        defaultModel: "gpt-5.5",
+        modelMappings: [],
+        allowedChannelGroups: ["pro"],
+        routePath: "/pro/cs_test",
+        endpointPath: "/v1",
+        usageAutoInterval: 30,
+      },
+      configs: [],
+      usageLanguage: "en",
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("notes")).toBe("Pro pool remark");
+    expect(decodeUsageScript(url)).toContain("Today's usage");
   });
 
   test("builds a provider deeplink for a selected channel group route and enabled state", () => {

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -24,6 +24,8 @@ export interface CcSwitchClientConfig {
   fallbackLabel: string;
 }
 
+type CcSwitchUsageScriptLanguage = "zh-CN" | "en";
+
 export const CC_SWITCH_CLIENTS: CcSwitchClientConfig[] = [
   {
     type: "claude",
@@ -163,7 +165,30 @@ const getGenericRequestModel = (
   return (exactMatch ?? genericMappings[0])?.requestModel.trim() ?? "";
 };
 
-export function buildCcSwitchUsageScript(): string {
+const normalizeUsageScriptLanguage = (language: string | undefined): CcSwitchUsageScriptLanguage =>
+  String(language ?? "")
+    .trim()
+    .toLowerCase()
+    .startsWith("en")
+    ? "en"
+    : "zh-CN";
+
+export function buildCcSwitchUsageScript(language?: string): string {
+  const labels =
+    normalizeUsageScriptLanguage(language) === "en"
+      ? {
+          planName: "Today's usage",
+          invalidMessage: "API Key not found",
+          unit: "times",
+          costPrefix: "Today's cost: ",
+        }
+      : {
+          planName: "今日用量",
+          invalidMessage: "API Key 未找到",
+          unit: "次",
+          costPrefix: "今日消耗： ",
+        };
+
   return `({
   request: {
     url: "{{baseUrl}}/v0/management/public/usage/summary",
@@ -176,13 +201,13 @@ export function buildCcSwitchUsageScript(): string {
     var calls = Number(stats.total_calls || 0) || 0;
     var cost = Number(stats.quota_cost || 0) || 0;
     return {
-      planName: "今日用量",
+      planName: "${labels.planName}",
       isValid: response && response.found === false ? false : true,
-      invalidMessage: response && response.found === false ? "API Key 未找到" : null,
-      used: calls,
-      remaining: null,
-      unit: "次",
-      extra: "今日消耗 " + cost.toFixed(4) + " $"
+      invalidMessage: response && response.found === false ? "${labels.invalidMessage}" : null,
+      used: undefined,
+      remaining: calls,
+      unit: "${labels.unit}",
+      extra: "${labels.costPrefix}" + cost.toFixed(4) + "$"
     };
   }
 })`;
@@ -255,12 +280,14 @@ export function buildCcSwitchImportUrl(input: {
   baseUrl: string;
   clientType: CcSwitchClientType;
   enabled?: boolean;
+  note?: string;
   providerName: string;
   model?: string;
   modelMappings?: readonly CcSwitchModelMappingInput[];
   models?: readonly string[];
   settings?: CcSwitchImportSettingsInput;
   usageBaseUrl?: string;
+  usageLanguage?: string;
 }): string {
   const client = getCcSwitchClientConfig(input.clientType);
   const settings = normalizeCcSwitchImportSettings(
@@ -285,9 +312,13 @@ export function buildCcSwitchImportUrl(input: {
     enabled: String(input.enabled ?? true),
     usageEnabled: "true",
     usageBaseUrl: importConfig.usageBaseUrl,
-    usageScript: encodeBase64(buildCcSwitchUsageScript()),
+    usageScript: encodeBase64(buildCcSwitchUsageScript(input.usageLanguage)),
     usageAutoInterval: String(importConfig.usageAutoInterval),
   });
+  const note = String(input.note ?? "").trim();
+  if (note) {
+    params.set("notes", note);
+  }
 
   const modelMappings = normalizeModelMappings(input.modelMappings);
   const genericMappedModel =

--- a/src/modules/ccswitch/ccswitchImportLinks.ts
+++ b/src/modules/ccswitch/ccswitchImportLinks.ts
@@ -1,7 +1,4 @@
-import {
-  buildCcSwitchImportUrl,
-  type CcSwitchClientType,
-} from "@/modules/ccswitch/ccswitchImport";
+import { buildCcSwitchImportUrl, type CcSwitchClientType } from "@/modules/ccswitch/ccswitchImport";
 import {
   normalizeCcSwitchClaudeAuthField,
   normalizeCcSwitchImportSettings,
@@ -66,6 +63,7 @@ export function buildCcSwitchImportUrlForConfig({
   configs,
   providerName,
   usageBaseUrl,
+  usageLanguage,
 }: {
   apiKey: string;
   baseUrl: string;
@@ -73,17 +71,20 @@ export function buildCcSwitchImportUrlForConfig({
   configs: readonly CcSwitchImportConfigListItem[];
   providerName?: string;
   usageBaseUrl?: string;
+  usageLanguage?: string;
 }): string {
   return buildCcSwitchImportUrl({
     apiKey,
     baseUrl,
     clientType: config.clientType,
     enabled: true,
+    note: config.note,
     providerName: config.providerName || providerName || "CliProxy",
     model: config.defaultModel,
     modelMappings: config.modelMappings,
     models: [],
     settings: buildCcSwitchSettingsForConfig(config, configs),
     usageBaseUrl,
+    usageLanguage,
   });
 }


### PR DESCRIPTION
## Summary
- generate CC Switch usage scripts in Chinese or English based on the current management UI language
- use the CC Switch highlighted numeric field for today call count as requested
- pass CC Switch import config remarks through the deeplink notes parameter

## Tests
- bun run test -- src/modules/ccswitch/__tests__/ccswitchImport.test.ts
- bun run lint
- bun run build
- bunx oxfmt src/modules/ccswitch/ccswitchImport.ts src/modules/ccswitch/ccswitchImportLinks.ts src/modules/ccswitch/__tests__/ccswitchImport.test.ts src/modules/apikey-lookup/components/QuickImportTabContent.tsx src/modules/api-keys/ApiKeysPage.tsx --check