### PR TITLE
fix: update CC Switch usage script planName to 今日已经使用/Used today

### DIFF
--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -125,11 +125,11 @@ describe("ccswitchImport", () => {
     expect(usageScript).toContain("days: 1");
     expect(usageScript).toContain("total_calls");
     expect(usageScript).toContain("quota_cost");
-    expect(usageScript).toContain("今日用量");
+    expect(usageScript).toContain("今日已经使用");
     expect(usageScript).toContain("used: undefined");
     expect(usageScript).toContain("remaining: calls");
     expect(usageScript).toContain('unit: "次"');
-    expect(usageScript).toContain('extra: "今日消耗： " + cost.toFixed(4) + "$"');
+    expect(usageScript).toContain('extra: "今日消耗：" + cost.toFixed(4) + "$"');
     expect(usageScript).not.toContain("额度");
   });
 
@@ -144,10 +144,10 @@ describe("ccswitchImport", () => {
     });
 
     const usageScript = decodeUsageScript(url);
-    expect(usageScript).toContain("Today's usage");
+    expect(usageScript).toContain("Used today");
     expect(usageScript).toContain("API Key not found");
     expect(usageScript).toContain('unit: "times"');
-    expect(usageScript).toContain('extra: "Today\'s cost: " + cost.toFixed(4) + "$"');
+    expect(usageScript).toContain('extra: "Today\'s cost:" + cost.toFixed(4) + "$"');
     expect(usageScript).not.toContain("今日用量");
     expect(usageScript).not.toContain("今日消耗");
   });
@@ -187,7 +187,7 @@ describe("ccswitchImport", () => {
 
     const parsed = new URL(url);
     expect(parsed.searchParams.get("notes")).toBe("Pro pool remark");
-    expect(decodeUsageScript(url)).toContain("Today's usage");
+    expect(decodeUsageScript(url)).toContain("Used today");
   });
 
   test("builds a provider deeplink for a selected channel group route and enabled state", () => {

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -177,16 +177,16 @@ export function buildCcSwitchUsageScript(language?: string): string {
   const labels =
     normalizeUsageScriptLanguage(language) === "en"
       ? {
-          planName: "Today's usage",
+          planName: "Used today",
           invalidMessage: "API Key not found",
           unit: "times",
-          costPrefix: "Today's cost: ",
+          costPrefix: "Today's cost:",
         }
       : {
-          planName: "今日用量",
+          planName: "今日已经使用",
           invalidMessage: "API Key 未找到",
           unit: "次",
-          costPrefix: "今日消耗： ",
+          costPrefix: "今日消耗：",
         };
 
   return `({


### PR DESCRIPTION
## Summary
- Updates CC Switch usage script planName labels to better express business semantics
- Chinese: 今日用量 → 今日已经使用
- English: Today's usage → Used today
- Removes trailing space from costPrefix for cleaner formatting
- All existing tests updated and passing

## Test plan
- [x] All 14 existing CC Switch import tests pass
- [x] Generated script now shows '今日已经使用' instead of '今日用量'