### PR TITLE
fix: OpenCode Go 无查询配置时卡片高度与有查询配置一致

### DIFF
--- a/src/modules/providers/ProvidersPage.tsx
+++ b/src/modules/providers/ProvidersPage.tsx
@@ -95,6 +95,9 @@ const getProviderSelectionKey = (
 const getOpenCodeGoUsageCacheKey = (item: ProviderSimpleConfig, index: number) =>
   [item.workspaceId?.trim() || "no-workspace", item.name?.trim() || `item-${index}`, index].join(":");
 
+const hasOpenCodeGoUsageQuery = (item: ProviderSimpleConfig) =>
+  Boolean(item.workspaceId?.trim() && item.authCookie?.trim());
+
 type OpenCodeGoUsageState = Record<string, OpenCodeGoUsageCacheEntry>;
 type OpenCodeGoUsageLoadingState = Record<string, boolean>;
 
@@ -1005,15 +1008,17 @@ export function ProvidersPage() {
               showConnectionRows={false}
               showModelMetric={false}
               showExcludedModels={false}
-              renderExtra={(item, idx) =>
-                item.workspaceId?.trim() && item.authCookie?.trim() ? (
+              renderExtra={(item, idx) => {
+                const queryReady = hasOpenCodeGoUsageQuery(item);
+                const cacheKey = getOpenCodeGoUsageCacheKey(item, idx);
+                return (
                   <OpenCodeGoUsageCardSection
-                    usageEntry={openCodeGoUsageState[getOpenCodeGoUsageCacheKey(item, idx)]}
-                    loading={openCodeGoUsageLoadingState[getOpenCodeGoUsageCacheKey(item, idx)] ?? false}
-                    onRefresh={() => void refreshOpenCodeGoUsage(item, idx)}
+                    queryReady={queryReady}
+                    usageEntry={queryReady ? openCodeGoUsageState[cacheKey] : undefined}
+                    loading={queryReady ? (openCodeGoUsageLoadingState[cacheKey] ?? false) : false}
                   />
-                ) : null
-              }
+                );
+              }}
               renderMetricsExtra={(item, idx) => {
                 if (!(item.workspaceId?.trim() && item.authCookie?.trim())) return null;
                 const cacheKey = getOpenCodeGoUsageCacheKey(item, idx);

--- a/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/src/modules/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -83,11 +83,11 @@ const TYPE_COMPACT_LABELS: Record<string, string> = {
 export function OpenCodeGoUsageCardSection({
   usageEntry,
   loading,
-  onRefresh,
+  queryReady,
 }: {
   usageEntry?: OpenCodeGoUsageCacheEntry;
   loading: boolean;
-  onRefresh: () => void;
+  queryReady: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -96,6 +96,31 @@ export function OpenCodeGoUsageCardSection({
   );
 
   const hasUsage = Boolean(usageEntry && usageEntry.usage.length > 0);
+
+  if (!queryReady) {
+    return (
+      <div
+        className="mt-3 min-h-[3.375rem]"
+        data-testid="opencode-go-usage-footprint"
+        aria-hidden="true"
+      >
+        <div className="invisible mx-auto w-full max-w-[20rem] space-y-1.5">
+          {TYPE_LABELS.map((type) => (
+            <div
+              key={type}
+              className="grid grid-cols-[2rem_minmax(0,1fr)_5.25rem] items-center gap-2"
+            >
+              <span className="truncate text-[11px] font-semibold">
+                {TYPE_COMPACT_LABELS[type]}
+              </span>
+              <div className="h-1.5 rounded-full bg-slate-200/70 dark:bg-white/8" />
+              <span className="text-right text-[11px] tabular-nums">剩余 --</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mt-3">


### PR DESCRIPTION
## 问题

OpenCode Go 未配置 workspaceId/authCookie 时，卡片因 usage 区块条件渲染为 null 而变矮（只剩标题、统计 chip 和成功率条），与配置了查询参数的卡片高度不一致。

## 根因

展示门控（无查询参数时不展示查询内容）被实现为整个 usage 区块不渲染。结合 `naturalHeight`，缺失的三行用量区域导致卡片外框塌缩。

## 修复

1. `OpenCodeGoUsageCardSection` 新增 `queryReady` prop，替换 `onRefresh`
2. `queryReady=false` 时渲染不可见等高占位结构（`aria-hidden`），保留与三行用量区一致的 `min-h-[3.375rem]`
3. `ProvidersPage` 提取 `hasOpenCodeGoUsageQuery` 统一判断，始终挂载 `OpenCodeGoUsageCardSection`，只通过 `queryReady` 控制内容
4. `renderMetricsExtra` 和自动刷新逻辑不变，仍只在查询参数完整时显示刷新入口和发起请求

## 验证

- [x] 编译通过
- [x] 460 单元测试全部通过