### PR TITLE
fix: use CC Switch usage script `used` field for correct "已使用" semantics

### DIFF
--- a/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
+++ b/src/modules/ccswitch/__tests__/ccswitchImport.test.ts
@@ -125,9 +125,9 @@ describe("ccswitchImport", () => {
     expect(usageScript).toContain("days: 1");
     expect(usageScript).toContain("total_calls");
     expect(usageScript).toContain("quota_cost");
-    expect(usageScript).toContain("今日已经使用");
-    expect(usageScript).toContain("used: undefined");
-    expect(usageScript).toContain("remaining: calls");
+    expect(usageScript).toContain("今日用量");
+    expect(usageScript).toContain("used: calls");
+    expect(usageScript).toContain("remaining: null");
     expect(usageScript).toContain('unit: "次"');
     expect(usageScript).toContain('extra: "今日消耗：" + cost.toFixed(4) + "$"');
     expect(usageScript).not.toContain("额度");
@@ -144,7 +144,7 @@ describe("ccswitchImport", () => {
     });
 
     const usageScript = decodeUsageScript(url);
-    expect(usageScript).toContain("Used today");
+    expect(usageScript).toContain("Today's usage");
     expect(usageScript).toContain("API Key not found");
     expect(usageScript).toContain('unit: "times"');
     expect(usageScript).toContain('extra: "Today\'s cost:" + cost.toFixed(4) + "$"');
@@ -187,7 +187,7 @@ describe("ccswitchImport", () => {
 
     const parsed = new URL(url);
     expect(parsed.searchParams.get("notes")).toBe("Pro pool remark");
-    expect(decodeUsageScript(url)).toContain("Used today");
+    expect(decodeUsageScript(url)).toContain("Today's usage");
   });
 
   test("builds a provider deeplink for a selected channel group route and enabled state", () => {

--- a/src/modules/ccswitch/ccswitchImport.ts
+++ b/src/modules/ccswitch/ccswitchImport.ts
@@ -177,13 +177,13 @@ export function buildCcSwitchUsageScript(language?: string): string {
   const labels =
     normalizeUsageScriptLanguage(language) === "en"
       ? {
-          planName: "Used today",
+          planName: "Today's usage",
           invalidMessage: "API Key not found",
           unit: "times",
           costPrefix: "Today's cost:",
         }
       : {
-          planName: "今日已经使用",
+          planName: "今日用量",
           invalidMessage: "API Key 未找到",
           unit: "次",
           costPrefix: "今日消耗：",
@@ -204,8 +204,8 @@ export function buildCcSwitchUsageScript(language?: string): string {
       planName: "${labels.planName}",
       isValid: response && response.found === false ? false : true,
       invalidMessage: response && response.found === false ? "${labels.invalidMessage}" : null,
-      used: undefined,
-      remaining: calls,
+      used: calls,
+      remaining: null,
       unit: "${labels.unit}",
       extra: "${labels.costPrefix}" + cost.toFixed(4) + "$"
     };


### PR DESCRIPTION
## Summary
- Switch from `remaining: calls` to `used: calls` + `remaining: null` so CC Switch renders "已使用：" instead of "剩余："
- Updated planName text: "今日已经使用" → "今日用量" (zh-CN), "Used today" → "Today's usage" (en)
- No behavior change for CliRelay backend

## Test plan
- [x] Unit tests pass (13/14 pass, 1 pre-existing jsdom window failure)
- [x] Script output verified: `used: calls`, `remaining: null`, `planName: "今日用量"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)