### PR TITLE
fix: remove frontend-only fast path that caused infinite update loop

### DIFF
--- a/src/modules/update/__tests__/updateShared.test.ts
+++ b/src/modules/update/__tests__/updateShared.test.ts
@@ -64,7 +64,7 @@ describe("applyUpdateFlow", () => {
     });
   });
 
-  test("treats completed frontend-only updates as successful before the page reload sees the new UI commit", async () => {
+  test("reports timeout when frontend-only update completes but UI commit does not change (backend need not restart)", async () => {
     const notify = vi.fn();
     const onSuccess = vi.fn();
 
@@ -92,11 +92,11 @@ describe("applyUpdateFlow", () => {
       t: ((key: string) => key) as never,
     });
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
     expect(notify).toHaveBeenCalledWith({
-      type: "success",
-      message: "auto_update.success",
+      type: "warning",
+      message: "update completed",
     });
-    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/update/updateShared.ts
+++ b/src/modules/update/updateShared.ts
@@ -94,9 +94,6 @@ const targetNeedsUiChange = (target?: UpdateCheckResponse | null) =>
   Boolean(target?.latest_ui_commit?.trim()) &&
   !sameCommit(target?.current_ui_commit, target?.latest_ui_commit);
 
-const isFrontendOnlyUpdateTarget = (target?: UpdateCheckResponse | null) =>
-  Boolean(target) && !targetNeedsBackendChange(target) && targetNeedsUiChange(target);
-
 export const matchesAppliedTarget = (
   info: UpdateCheckResponse,
   target?: UpdateCheckResponse | null,
@@ -153,9 +150,6 @@ const waitForAppliedTarget = async ({
     const progress = await pollProgress();
     if (progress?.status === "failed") {
       return { ok: false as const, latest: lastCheck, progress, failed: true as const };
-    }
-    if (progress?.status === "completed" && isFrontendOnlyUpdateTarget(target)) {
-      return { ok: true as const, latest: lastCheck, progress };
     }
     try {
       await apiClient.get("/system-stats", {


### PR DESCRIPTION
## Summary
- Removed `isFrontendOnlyUpdateTarget` fast path in `waitForAppliedTarget` that returned success without verifying the frontend panel was actually updated
- When only the frontend panel needs updating (backend already up-to-date), the updater's `docker compose pull + up -d` cannot update the management panel assets. The old code treated the updater reporting "completed" as success and reloaded the page, but the frontend commit never changed → infinite loop
- Now all updates go through `matchesAppliedTarget` verification, ensuring the target commit is actually reached before reporting success
- Updated test to expect timeout behavior instead of fake success for frontend-only scenarios

## Test plan
- [x] Unit tests pass (460/460)
- [x] Build passes

Closes: # (infinite update loop on cliproxy.07230805.xyz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)