### PR TITLE
fix: 恢复基础配置 tab 原生滚动条

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1814,7 +1814,7 @@ export function RoutingConfigEditor({
 
                 <TabsContent
                   value="models"
-                  className="flex h-full min-h-0 flex-col gap-3"
+                  className="flex h-full min-h-0 flex-col gap-3 overflow-hidden"
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
@@ -1838,7 +1838,7 @@ export function RoutingConfigEditor({
                   ) : (
                     <div
                       data-testid="group-editor-model-list"
-                      className="min-h-0 flex-1 -mx-5"
+                      className="min-h-0 flex-1 overflow-hidden"
                     >
                       <DataTable<RoutingModelOption>
                         tableId="routing-model-options"

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1612,7 +1612,7 @@ export function RoutingConfigEditor({
               >
                 <TabsContent
                   value="basic"
-                  className="h-full min-h-0 overflow-y-auto space-y-5 scrollbar-hidden"
+                  className="h-full min-h-0 overflow-y-auto space-y-5 pr-1"
                 >
                   <Field
                     label={t("channel_groups_page.routing_strategy_label")}

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1838,7 +1838,7 @@ export function RoutingConfigEditor({
                   ) : (
                     <div
                       data-testid="group-editor-model-list"
-                      className="min-h-0 flex-1 overflow-hidden"
+                      className="min-h-0 flex-1"
                     >
                       <DataTable<RoutingModelOption>
                         tableId="routing-model-options"

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -252,7 +252,7 @@ describe("RoutingConfigEditor", () => {
     expect(screen.getByText("分组内调度策略")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
-    expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
+    expect(await screen.findByTestId("group-editor-model-list")).not.toHaveClass("overflow-hidden");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
   });
@@ -295,7 +295,7 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
 
-    expect(screen.getByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
+    expect(screen.getByTestId("group-editor-model-list")).not.toHaveClass("overflow-hidden");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("加载中");
     expect(screen.getByRole("status")).toHaveClass("sr-only");

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -252,7 +252,7 @@ describe("RoutingConfigEditor", () => {
     expect(screen.getByText("分组内调度策略")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
-    expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("-mx-5");
+    expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
   });
@@ -295,7 +295,7 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
 
-    expect(screen.getByTestId("group-editor-model-list")).toHaveClass("-mx-5");
+    expect(screen.getByTestId("group-editor-model-list")).toHaveClass("overflow-hidden");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("加载中");
     expect(screen.getByRole("status")).toHaveClass("sr-only");


### PR DESCRIPTION
修复之前错误隐藏基础配置 tab 原生滚动条的问题。基础配置是表单内容，不适用 DataTable 自定义滚动条，应保留可见的原生滚动条（项目已有全局滚动条样式，显示正常）。