### PR TITLE
fix: 修复默认全选态取消单个模型清空全部的问题

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -734,6 +734,20 @@ export function RoutingConfigEditor({
     setModelsSelectionTouched(true);
     setGroupDraft((current) => {
       const currentModels = current.allowedModels.map((model) => model.trim()).filter(Boolean);
+      // Implicit select-all state: empty + untouched = "all models allowed"
+      if (!modelsSelectionTouched && currentModels.length === 0) {
+        if (!checked) {
+          // User unchecks one model from implicit select-all → exclude that one
+          const initial = new Set(modelOptionIds);
+          initial.delete(normalized);
+          return { ...current, allowedModels: Array.from(initial) };
+        }
+        // checked === true: user explicitly adds one model from empty
+        return {
+          ...current,
+          allowedModels: [normalized],
+        };
+      }
       if (checked) {
         return {
           ...current,
@@ -745,7 +759,7 @@ export function RoutingConfigEditor({
         allowedModels: currentModels.filter((model) => model !== normalized),
       };
     });
-  }, []);
+  }, [modelOptionIds, modelsSelectionTouched]);
 
   const selectAllDraftModels = useCallback(() => {
     setModelsSelectionTouched(true);

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -418,8 +418,7 @@ describe("RoutingConfigEditor", () => {
     await user.click(within(row).getByRole("button", { name: "编辑分组" }));
 
     expect(await screen.findByLabelText("gpt-root-allowed")).toBeChecked();
-    await user.click(screen.getByLabelText("gpt-root-allowed"));
-    await user.click(screen.getByLabelText("gpt-root-allowed"));
+    await user.click(screen.getByLabelText("gpt-root-hidden"));
     await user.click(screen.getByRole("button", { name: "保存" }));
 
     expect(loadModelsForChannels).toHaveBeenCalledWith([], "default");


### PR DESCRIPTION
修复模型选择从隐式全选态取消单个选项会清空所有 checkbox 的回归。当 !modelsSelectionTouched && allowedModels 为空时，取消一个模型用全集初始化再删除该模型，而非从空数组过滤。