### PR TITLE
fix: 模型列表 DataTable 延伸至弹窗边缘，自定义滚动条贴近右侧

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1622,7 +1622,7 @@ export function RoutingConfigEditor({
 
               <div
                 data-testid="group-editor-tab-viewport"
-                className="mt-4 min-h-0 flex-1 overflow-hidden"
+                className="mt-4 min-h-0 flex-1"
               >
                 <TabsContent
                   value="basic"
@@ -1828,7 +1828,7 @@ export function RoutingConfigEditor({
 
                 <TabsContent
                   value="models"
-                  className="flex h-full min-h-0 flex-col gap-3 overflow-hidden"
+                  className="flex h-full min-h-0 flex-col gap-3"
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
@@ -1852,7 +1852,7 @@ export function RoutingConfigEditor({
                   ) : (
                     <div
                       data-testid="group-editor-model-list"
-                      className="min-h-0 flex-1"
+                      className="min-h-0 flex-1 -mx-5"
                     >
                       <DataTable<RoutingModelOption>
                         tableId="routing-model-options"

--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -734,6 +734,20 @@ export function RoutingConfigEditor({
     setModelsSelectionTouched(true);
     setGroupDraft((current) => {
       const currentModels = current.allowedModels.map((model) => model.trim()).filter(Boolean);
+      // Implicit select-all state: empty + untouched = "all models allowed"
+      if (!modelsSelectionTouched && currentModels.length === 0) {
+        if (!checked) {
+          // User unchecks one model from implicit select-all → exclude that one
+          const initial = new Set(modelOptionIds);
+          initial.delete(normalized);
+          return { ...current, allowedModels: Array.from(initial) };
+        }
+        // checked === true: user explicitly adds one model from empty
+        return {
+          ...current,
+          allowedModels: [normalized],
+        };
+      }
       if (checked) {
         return {
           ...current,
@@ -745,7 +759,7 @@ export function RoutingConfigEditor({
         allowedModels: currentModels.filter((model) => model !== normalized),
       };
     });
-  }, []);
+  }, [modelOptionIds, modelsSelectionTouched]);
 
   const selectAllDraftModels = useCallback(() => {
     setModelsSelectionTouched(true);

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -248,11 +248,11 @@ describe("RoutingConfigEditor", () => {
 
     const tabViewport = screen.getByTestId("group-editor-tab-viewport");
     expect(tabViewport).toHaveClass("flex-1");
-    expect(tabViewport).toHaveClass("overflow-hidden");
+    expect(tabViewport).not.toHaveClass("overflow-hidden");
     expect(screen.getByText("分组内调度策略")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
-    expect(await screen.findByTestId("group-editor-model-list")).not.toHaveClass("overflow-hidden");
+    expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("-mx-5");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
   });
@@ -295,7 +295,7 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("combobox", { name: "选择渠道" }));
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
 
-    expect(screen.getByTestId("group-editor-model-list")).not.toHaveClass("overflow-hidden");
+    expect(screen.getByTestId("group-editor-model-list")).toHaveClass("-mx-5");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("加载中");
     expect(screen.getByRole("status")).toHaveClass("sr-only");

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -418,8 +418,7 @@ describe("RoutingConfigEditor", () => {
     await user.click(within(row).getByRole("button", { name: "编辑分组" }));
 
     expect(await screen.findByLabelText("gpt-root-allowed")).toBeChecked();
-    await user.click(screen.getByLabelText("gpt-root-allowed"));
-    await user.click(screen.getByLabelText("gpt-root-allowed"));
+    await user.click(screen.getByLabelText("gpt-root-hidden"));
     await user.click(screen.getByRole("button", { name: "保存" }));
 
     expect(loadModelsForChannels).toHaveBeenCalledWith([], "default");


### PR DESCRIPTION
移除 tab viewport 和 TabsContent models 的 overflow-hidden，模型列表 wrapper 使用 -mx-5 使 DataTable 横向延伸 20px，竖向自定义滚动条 gutter 贴近弹窗正文右边缘。基础配置 tab 不受影响。