### PR TITLE
fix: restore group modal scroll spacing

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -17,6 +17,7 @@ import { ConfirmModal } from "@/modules/ui/ConfirmModal";
 import { TextInput } from "@/modules/ui/Input";
 import { Modal } from "@/modules/ui/Modal";
 import { SearchableCheckboxMultiSelect } from "@/modules/ui/SearchableCheckboxMultiSelect";
+import { ScrollArea } from "@/modules/ui/ScrollArea";
 import { Select } from "@/modules/ui/Select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/modules/ui/Tabs";
 import { useToast } from "@/modules/ui/ToastProvider";
@@ -1620,216 +1621,214 @@ export function RoutingConfigEditor({
                 </TabsList>
               </div>
 
-              <div
-                data-testid="group-editor-tab-viewport"
-                className="mt-4 min-h-0 flex-1"
-              >
-                <TabsContent
-                  value="basic"
-                  className="h-full min-h-0 overflow-y-auto space-y-5 pr-1"
-                >
-                  <Field
-                    label={t("channel_groups_page.routing_strategy_label")}
-                    tooltip={t("channel_groups_page.routing_strategy_tooltip")}
+              <div data-testid="group-editor-tab-viewport" className="mt-4 min-h-0 flex-1">
+                <TabsContent value="basic" className="h-full min-h-0">
+                  <ScrollArea
+                    data-testid="group-editor-basic-scroll-area"
+                    className="h-full min-h-0 -mr-5"
+                    contentClassName="space-y-5 pr-5"
+                    scrollbarVisibility="always"
                   >
-                    <Select
-                      aria-label={t("channel_groups_page.routing_strategy_label")}
-                      value={groupDraft.strategy}
-                      disabled={disabled}
-                      className="w-full"
-                      options={[
-                        {
-                          value: "round-robin",
-                          label: t("channel_groups_page.routing_strategy_round_robin"),
-                        },
-                        {
-                          value: "fill-first",
-                          label: t("channel_groups_page.routing_strategy_fill_first"),
-                        },
-                      ]}
-                      onChange={(value) => {
-                        setGroupDraft((current) => ({
-                          ...current,
-                          strategy: value === "fill-first" ? "fill-first" : "round-robin",
-                        }));
-                      }}
-                    />
-                  </Field>
-
-                  <label className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 text-sm dark:border-neutral-800 dark:bg-neutral-900/60">
-                    <Checkbox
-                      checked={groupDraft.excludeFromDefault}
-                      onCheckedChange={(checked) =>
-                        setGroupDraft((current) => ({
-                          ...current,
-                          excludeFromDefault: checked,
-                        }))
-                      }
-                      disabled={disabled}
-                      aria-label={t("channel_groups_page.exclude_from_default_label")}
-                      className="mt-0.5"
-                    />
-                    <span className="min-w-0">
-                      <span className="block font-semibold text-slate-900 dark:text-white">
-                        {t("channel_groups_page.exclude_from_default_label")}
-                      </span>
-                      <span className="mt-1 block text-xs leading-5 text-slate-500 dark:text-white/55">
-                        {t("channel_groups_page.exclude_from_default_hint")}
-                      </span>
-                    </span>
-                  </label>
-
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <Field label={t("channel_groups_page.group_name_label")}>
-                      <TextInput
-                        value={groupDraft.name}
-                        onChange={(event) => {
-                          const value = event.currentTarget.value;
-                          setGroupDraft((current) => ({ ...current, name: value }));
-                        }}
-                        placeholder="pro"
-                        disabled={disabled}
-                      />
-                    </Field>
-                    <Field label={t("channel_groups_page.description_label")}>
-                      <TextInput
-                        value={groupDraft.description}
-                        onChange={(event) => {
-                          const value = event.currentTarget.value;
-                          setGroupDraft((current) => ({ ...current, description: value }));
-                        }}
-                        placeholder={t("channel_groups_page.description_placeholder")}
-                        disabled={disabled}
-                      />
-                    </Field>
-                  </div>
-
-                  <div className="grid gap-4 md:grid-cols-1">
                     <Field
-                      label={t("channel_groups_page.route_path_label")}
-                      hint={t("channel_groups_page.route_path_hint")}
+                      label={t("channel_groups_page.routing_strategy_label")}
+                      tooltip={t("channel_groups_page.routing_strategy_tooltip")}
                     >
-                      <TextInput
-                        value={primaryRoute.path}
-                        onChange={(event) =>
-                          updatePrimaryRoute({ path: event.currentTarget.value })
-                        }
-                        placeholder="/pro"
+                      <Select
+                        aria-label={t("channel_groups_page.routing_strategy_label")}
+                        value={groupDraft.strategy}
                         disabled={disabled}
+                        className="w-full"
+                        options={[
+                          {
+                            value: "round-robin",
+                            label: t("channel_groups_page.routing_strategy_round_robin"),
+                          },
+                          {
+                            value: "fill-first",
+                            label: t("channel_groups_page.routing_strategy_fill_first"),
+                          },
+                        ]}
+                        onChange={(value) => {
+                          setGroupDraft((current) => ({
+                            ...current,
+                            strategy: value === "fill-first" ? "fill-first" : "round-robin",
+                          }));
+                        }}
                       />
                     </Field>
-                  </div>
 
-                  <Field
-                    label={t("channel_groups_page.match_strategy_label")}
-                    hint={t("channel_groups_page.match_strategy_hint")}
-                  >
-                    <Select
-                      aria-label={t("channel_groups_page.match_strategy_label")}
-                      value={groupDraft.matchMode}
-                      disabled={disabled}
-                      className="w-full"
-                      options={[
-                        {
-                          value: "channels",
-                          label: t("channel_groups_page.match_strategy_channels"),
-                        },
-                        {
-                          value: "tags",
-                          label: t("channel_groups_page.match_strategy_tags"),
-                        },
-                      ]}
-                      onChange={(value) => {
-                        setGroupDraft((current) => ({
-                          ...current,
-                          matchMode: value === "tags" ? "tags" : "channels",
-                        }));
-                        setModelsSelectionTouched(false);
-                      }}
+                    <label className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 text-sm dark:border-neutral-800 dark:bg-neutral-900/60">
+                      <Checkbox
+                        checked={groupDraft.excludeFromDefault}
+                        onCheckedChange={(checked) =>
+                          setGroupDraft((current) => ({
+                            ...current,
+                            excludeFromDefault: checked,
+                          }))
+                        }
+                        disabled={disabled}
+                        aria-label={t("channel_groups_page.exclude_from_default_label")}
+                        className="mt-0.5"
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-semibold text-slate-900 dark:text-white">
+                          {t("channel_groups_page.exclude_from_default_label")}
+                        </span>
+                        <span className="mt-1 block text-xs leading-5 text-slate-500 dark:text-white/55">
+                          {t("channel_groups_page.exclude_from_default_hint")}
+                        </span>
+                      </span>
+                    </label>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <Field label={t("channel_groups_page.group_name_label")}>
+                        <TextInput
+                          value={groupDraft.name}
+                          onChange={(event) => {
+                            const value = event.currentTarget.value;
+                            setGroupDraft((current) => ({ ...current, name: value }));
+                          }}
+                          placeholder="pro"
+                          disabled={disabled}
+                        />
+                      </Field>
+                      <Field label={t("channel_groups_page.description_label")}>
+                        <TextInput
+                          value={groupDraft.description}
+                          onChange={(event) => {
+                            const value = event.currentTarget.value;
+                            setGroupDraft((current) => ({ ...current, description: value }));
+                          }}
+                          placeholder={t("channel_groups_page.description_placeholder")}
+                          disabled={disabled}
+                        />
+                      </Field>
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-1">
+                      <Field
+                        label={t("channel_groups_page.route_path_label")}
+                        hint={t("channel_groups_page.route_path_hint")}
+                      >
+                        <TextInput
+                          value={primaryRoute.path}
+                          onChange={(event) =>
+                            updatePrimaryRoute({ path: event.currentTarget.value })
+                          }
+                          placeholder="/pro"
+                          disabled={disabled}
+                        />
+                      </Field>
+                    </div>
+
+                    <Field
+                      label={t("channel_groups_page.match_strategy_label")}
+                      hint={t("channel_groups_page.match_strategy_hint")}
+                    >
+                      <Select
+                        aria-label={t("channel_groups_page.match_strategy_label")}
+                        value={groupDraft.matchMode}
+                        disabled={disabled}
+                        className="w-full"
+                        options={[
+                          {
+                            value: "channels",
+                            label: t("channel_groups_page.match_strategy_channels"),
+                          },
+                          {
+                            value: "tags",
+                            label: t("channel_groups_page.match_strategy_tags"),
+                          },
+                        ]}
+                        onChange={(value) => {
+                          setGroupDraft((current) => ({
+                            ...current,
+                            matchMode: value === "tags" ? "tags" : "channels",
+                          }));
+                          setModelsSelectionTouched(false);
+                        }}
+                      />
+                    </Field>
+
+                    <div className="space-y-3">
+                      {groupDraft.matchMode === "tags" ? (
+                        <Field
+                          label={t("channel_groups_page.select_tag_label")}
+                          hint={t("channel_groups_page.select_tag_hint")}
+                        >
+                          <SearchableCheckboxMultiSelect
+                            value={selectedTagValues}
+                            onChange={updateDraftTags}
+                            options={tagOptions}
+                            placeholder={t("channel_groups_page.select_tag_placeholder")}
+                            searchPlaceholder={t("channel_groups_page.search_tag_placeholder")}
+                            selectFilteredLabel={t("channel_groups_page.select_filtered_tags")}
+                            deselectFilteredLabel={t("channel_groups_page.deselect_filtered_tags")}
+                            selectedCountLabel={(count) =>
+                              t("channel_groups_page.selected_tags_count", { count })
+                            }
+                            noResultsLabel={t("channel_groups_page.no_search_results")}
+                            aria-label={t("channel_groups_page.select_tag_label")}
+                            disabled={disabled}
+                          />
+                        </Field>
+                      ) : (
+                        <Field
+                          label={t("channel_groups_page.select_channel_label")}
+                          hint={t("channel_groups_page.select_channel_hint")}
+                        >
+                          <SearchableCheckboxMultiSelect
+                            value={selectedChannelValues}
+                            onChange={updateDraftChannels}
+                            options={channelOptions}
+                            placeholder={t("channel_groups_page.select_channel_placeholder")}
+                            searchPlaceholder={t("channel_groups_page.search_channel_placeholder")}
+                            selectFilteredLabel={t("channel_groups_page.select_filtered_channels")}
+                            deselectFilteredLabel={t(
+                              "channel_groups_page.deselect_filtered_channels",
+                            )}
+                            selectedCountLabel={(count) =>
+                              t("channel_groups_page.selected_channels_count", { count })
+                            }
+                            noResultsLabel={t("channel_groups_page.no_search_results")}
+                            aria-label={t("channel_groups_page.select_channel_label")}
+                            disabled={disabled}
+                          />
+                        </Field>
+                      )}
+                    </div>
+
+                    <DataTable<RoutingChannelGroupMemberEntry>
+                      tableId="routing-channel-group-members"
+                      rows={resolvedDraftChannels}
+                      columns={groupMemberColumns}
+                      rowKey={(channel) => channel.id}
+                      virtualize={false}
+                      rowHeight={52}
+                      height="h-auto"
+                      minHeight="min-h-0"
+                      minWidth="min-w-[640px]"
+                      caption={
+                        groupDraft.matchMode === "tags"
+                          ? t("channel_groups_page.matched_channel_label")
+                          : t("channel_groups_page.select_channel_label")
+                      }
+                      emptyText={
+                        groupDraft.matchMode === "tags"
+                          ? t("channel_groups_page.empty_matched_channels")
+                          : t("channel_groups_page.empty_group_channels")
+                      }
+                      rowClassName={(channel) =>
+                        draftStaleChannelIds.has(channel.id)
+                          ? "bg-rose-50/70 dark:bg-rose-500/10"
+                          : ""
+                      }
+                      naturalFlow
                     />
-                  </Field>
-
-                  <div className="space-y-3">
-                    {groupDraft.matchMode === "tags" ? (
-                      <Field
-                        label={t("channel_groups_page.select_tag_label")}
-                        hint={t("channel_groups_page.select_tag_hint")}
-                      >
-                        <SearchableCheckboxMultiSelect
-                          value={selectedTagValues}
-                          onChange={updateDraftTags}
-                          options={tagOptions}
-                          placeholder={t("channel_groups_page.select_tag_placeholder")}
-                          searchPlaceholder={t("channel_groups_page.search_tag_placeholder")}
-                          selectFilteredLabel={t("channel_groups_page.select_filtered_tags")}
-                          deselectFilteredLabel={t("channel_groups_page.deselect_filtered_tags")}
-                          selectedCountLabel={(count) =>
-                            t("channel_groups_page.selected_tags_count", { count })
-                          }
-                          noResultsLabel={t("channel_groups_page.no_search_results")}
-                          aria-label={t("channel_groups_page.select_tag_label")}
-                          disabled={disabled}
-                        />
-                      </Field>
-                    ) : (
-                      <Field
-                        label={t("channel_groups_page.select_channel_label")}
-                        hint={t("channel_groups_page.select_channel_hint")}
-                      >
-                        <SearchableCheckboxMultiSelect
-                          value={selectedChannelValues}
-                          onChange={updateDraftChannels}
-                          options={channelOptions}
-                          placeholder={t("channel_groups_page.select_channel_placeholder")}
-                          searchPlaceholder={t("channel_groups_page.search_channel_placeholder")}
-                          selectFilteredLabel={t("channel_groups_page.select_filtered_channels")}
-                          deselectFilteredLabel={t(
-                            "channel_groups_page.deselect_filtered_channels",
-                          )}
-                          selectedCountLabel={(count) =>
-                            t("channel_groups_page.selected_channels_count", { count })
-                          }
-                          noResultsLabel={t("channel_groups_page.no_search_results")}
-                          aria-label={t("channel_groups_page.select_channel_label")}
-                          disabled={disabled}
-                        />
-                      </Field>
-                    )}
-                  </div>
-
-                  <DataTable<RoutingChannelGroupMemberEntry>
-                    tableId="routing-channel-group-members"
-                    rows={resolvedDraftChannels}
-                    columns={groupMemberColumns}
-                    rowKey={(channel) => channel.id}
-                    virtualize={false}
-                    rowHeight={52}
-                    height="h-auto"
-                    minHeight="min-h-0"
-                    minWidth="min-w-[640px]"
-                    caption={
-                      groupDraft.matchMode === "tags"
-                        ? t("channel_groups_page.matched_channel_label")
-                        : t("channel_groups_page.select_channel_label")
-                    }
-                    emptyText={
-                      groupDraft.matchMode === "tags"
-                        ? t("channel_groups_page.empty_matched_channels")
-                        : t("channel_groups_page.empty_group_channels")
-                    }
-                    rowClassName={(channel) =>
-                      draftStaleChannelIds.has(channel.id)
-                        ? "bg-rose-50/70 dark:bg-rose-500/10"
-                        : ""
-                    }
-                    naturalFlow
-                  />
+                  </ScrollArea>
                 </TabsContent>
 
-                <TabsContent
-                  value="models"
-                  className="flex h-full min-h-0 flex-col gap-3"
-                >
+                <TabsContent value="models" className="flex h-full min-h-0 flex-col gap-3">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-1">
                       <div className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -1850,25 +1849,27 @@ export function RoutingConfigEditor({
                       {modelsError}
                     </div>
                   ) : (
-                    <div
-                      data-testid="group-editor-model-list"
-                      className="min-h-0 flex-1 -mx-5"
-                    >
-                      <DataTable<RoutingModelOption>
-                        tableId="routing-model-options"
-                        rows={modelOptions}
-                        columns={modelColumns}
-                        rowKey={(model) => model.id}
-                        loading={modelsLoading}
-                        virtualize={false}
-                        rowHeight={58}
-                        height="h-full"
-                        minHeight="min-h-[360px]"
-                        minWidth="min-w-[760px]"
-                        caption={t("channel_groups_page.allowed_models_label")}
-                        emptyText={t("channel_groups_page.no_channel_models")}
-                        showAllLoadedMessage={false}
-                      />
+                    <div data-testid="group-editor-model-list" className="min-h-0 flex-1 -mx-5">
+                      <div
+                        data-testid="group-editor-model-list-content"
+                        className="h-full min-h-0 pl-5"
+                      >
+                        <DataTable<RoutingModelOption>
+                          tableId="routing-model-options"
+                          rows={modelOptions}
+                          columns={modelColumns}
+                          rowKey={(model) => model.id}
+                          loading={modelsLoading}
+                          virtualize={false}
+                          rowHeight={58}
+                          height="h-full"
+                          minHeight="min-h-[360px]"
+                          minWidth="min-w-[760px]"
+                          caption={t("channel_groups_page.allowed_models_label")}
+                          emptyText={t("channel_groups_page.no_channel_models")}
+                          showAllLoadedMessage={false}
+                        />
+                      </div>
                     </div>
                   )}
                 </TabsContent>

--- a/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -251,8 +251,19 @@ describe("RoutingConfigEditor", () => {
     expect(tabViewport).not.toHaveClass("overflow-hidden");
     expect(screen.getByText("分组内调度策略")).toBeInTheDocument();
 
+    const basicScrollArea = screen.getByTestId("group-editor-basic-scroll-area");
+    const basicScrollViewport = basicScrollArea.querySelector("[data-scroll-area-viewport]");
+    const basicScrollContent = basicScrollArea.querySelector("[data-scroll-area-content]");
+    expect(basicScrollArea).toHaveClass("-mr-5");
+    expect(basicScrollViewport).not.toBeNull();
+    expect(basicScrollContent).not.toBeNull();
+    expect(basicScrollViewport!).toHaveClass("table-scrollbar");
+    expect(basicScrollViewport!).toHaveAttribute("data-scrollbar-visibility", "always");
+    expect(basicScrollContent!).toHaveClass("space-y-5", "pr-5");
+
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
     expect(await screen.findByTestId("group-editor-model-list")).toHaveClass("-mx-5");
+    expect(screen.getByTestId("group-editor-model-list-content")).toHaveClass("pl-5");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("tablist")).toBeInTheDocument();
   });
@@ -276,7 +287,7 @@ describe("RoutingConfigEditor", () => {
     expect(tableShell).toHaveClass("h-auto");
     expect(tableShell).toHaveClass("min-h-0");
     expect(tableShell).not.toHaveClass("h-[248px]");
-    expect(channelTable.closest(".table-scrollbar")).toBeNull();
+    expect(tableShell!.querySelector(".table-scrollbar")).toBeNull();
     expect(tableShell!.querySelector("[data-vt-scrollbar]")).toBeNull();
   });
 
@@ -296,6 +307,7 @@ describe("RoutingConfigEditor", () => {
     await user.click(screen.getByRole("tab", { name: "模型列表" }));
 
     expect(screen.getByTestId("group-editor-model-list")).toHaveClass("-mx-5");
+    expect(screen.getByTestId("group-editor-model-list-content")).toHaveClass("pl-5");
     expect(screen.getByRole("table", { name: "允许模型" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("加载中");
     expect(screen.getByRole("status")).toHaveClass("sr-only");

--- a/src/modules/ui/ScrollArea.tsx
+++ b/src/modules/ui/ScrollArea.tsx
@@ -1,0 +1,205 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type PointerEvent as ReactPointerEvent,
+  type PropsWithChildren,
+} from "react";
+
+type ScrollbarVisibility = "hover" | "always";
+
+type ScrollMetrics = {
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+type DragState = {
+  pointerId: number;
+  startY: number;
+  startScrollTop: number;
+  trackLength: number;
+  thumbHeight: number;
+  scrollRange: number;
+};
+
+const cn = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");
+
+export function ScrollArea({
+  children,
+  className,
+  viewportClassName,
+  contentClassName,
+  scrollbarVisibility = "hover",
+  ...divProps
+}: PropsWithChildren<
+  {
+    viewportClassName?: string;
+    contentClassName?: string;
+    scrollbarVisibility?: ScrollbarVisibility;
+  } & HTMLAttributes<HTMLDivElement>
+>) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const [metrics, setMetrics] = useState<ScrollMetrics>({
+    clientHeight: 0,
+    scrollHeight: 0,
+    scrollTop: 0,
+  });
+
+  const measure = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    setMetrics({
+      clientHeight: viewport.clientHeight,
+      scrollHeight: viewport.scrollHeight,
+      scrollTop: viewport.scrollTop,
+    });
+  }, []);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(viewport);
+    if (contentRef.current) {
+      observer.observe(contentRef.current);
+    }
+
+    const raf = window.requestAnimationFrame(measure);
+    window.addEventListener("resize", measure);
+    return () => {
+      window.cancelAnimationFrame(raf);
+      window.removeEventListener("resize", measure);
+      observer.disconnect();
+    };
+  }, [measure]);
+
+  useEffect(() => {
+    measure();
+  }, [children, measure]);
+
+  const thumb = useMemo(() => {
+    const trackInset = 8;
+    const hasVerticalOverflow = metrics.scrollHeight > metrics.clientHeight + 1;
+    if (!hasVerticalOverflow) return null;
+
+    const trackLength = Math.max(0, metrics.clientHeight - trackInset * 2);
+    const viewport = Math.max(1, metrics.clientHeight);
+    const content = Math.max(viewport, metrics.scrollHeight);
+    const height = Math.max(28, Math.round((viewport / content) * trackLength));
+    const maxThumbOffset = Math.max(0, trackLength - height);
+    const scrollRange = Math.max(1, metrics.scrollHeight - metrics.clientHeight);
+    const top = Math.min(
+      maxThumbOffset,
+      Math.max(0, Math.round((metrics.scrollTop / scrollRange) * maxThumbOffset)),
+    );
+
+    return {
+      top,
+      height,
+      trackLength,
+      scrollRange,
+    };
+  }, [metrics]);
+
+  const handleScroll = useCallback(() => {
+    measure();
+  }, [measure]);
+
+  const handleThumbPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!thumb) return;
+      const viewport = viewportRef.current;
+      if (!viewport) return;
+
+      event.preventDefault();
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      dragStateRef.current = {
+        pointerId: event.pointerId,
+        startY: event.clientY,
+        startScrollTop: viewport.scrollTop,
+        trackLength: thumb.trackLength,
+        thumbHeight: thumb.height,
+        scrollRange: thumb.scrollRange,
+      };
+    },
+    [thumb],
+  );
+
+  const handleThumbPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current;
+      const viewport = viewportRef.current;
+      if (!state || !viewport || state.pointerId !== event.pointerId) return;
+
+      const maxThumbOffset = Math.max(1, state.trackLength - state.thumbHeight);
+      const delta = event.clientY - state.startY;
+      viewport.scrollTop = state.startScrollTop + (delta / maxThumbOffset) * state.scrollRange;
+      measure();
+    },
+    [measure],
+  );
+
+  const handleThumbPointerUp = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragStateRef.current?.pointerId !== event.pointerId) return;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    dragStateRef.current = null;
+  }, []);
+
+  const visibilityClasses =
+    scrollbarVisibility === "always"
+      ? "opacity-100"
+      : "opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100";
+
+  return (
+    <div
+      {...divProps}
+      data-scroll-area-root
+      className={cn("group relative isolate min-h-0 min-w-0", className)}
+    >
+      <div
+        ref={viewportRef}
+        tabIndex={0}
+        data-scroll-area-viewport
+        data-scrollbar-visibility={scrollbarVisibility}
+        onScroll={handleScroll}
+        className={cn(
+          "h-full min-h-0 table-scrollbar overflow-auto overscroll-contain",
+          viewportClassName,
+        )}
+      >
+        <div ref={contentRef} data-scroll-area-content className={contentClassName}>
+          {children}
+        </div>
+      </div>
+
+      {thumb ? (
+        <div
+          data-scroll-area-scrollbar="y"
+          className={cn(
+            "pointer-events-auto absolute bottom-0 right-0 top-0 z-30 w-2",
+            visibilityClasses,
+          )}
+        >
+          <div className="absolute inset-y-2 left-0 right-0 rounded-full bg-slate-200/40 dark:bg-white/10" />
+          <div
+            role="presentation"
+            className="pointer-events-auto absolute left-0 right-0 cursor-pointer rounded-full bg-slate-500/40 transition-colors hover:bg-slate-500/70 dark:bg-white/25 dark:hover:bg-white/50"
+            style={{ top: thumb.top + 8, height: thumb.height }}
+            onPointerDown={handleThumbPointerDown}
+            onPointerMove={handleThumbPointerMove}
+            onPointerUp={handleThumbPointerUp}
+            onPointerCancel={handleThumbPointerUp}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/ui/__tests__/ScrollArea.test.tsx
+++ b/src/modules/ui/__tests__/ScrollArea.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { ScrollArea } from "@/modules/ui/ScrollArea";
+
+function setScrollMetrics(
+  element: HTMLDivElement,
+  metrics: {
+    clientHeight: number;
+    scrollHeight: number;
+    scrollTop?: number;
+  },
+) {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: metrics.clientHeight },
+    scrollHeight: { configurable: true, value: metrics.scrollHeight },
+    scrollTop: { configurable: true, writable: true, value: metrics.scrollTop ?? 0 },
+  });
+}
+
+describe("ScrollArea", () => {
+  test("uses the hidden-native-scrollbar viewport", () => {
+    const { container } = render(
+      <ScrollArea data-testid="demo-scroll-area" scrollbarVisibility="always">
+        <div>Content</div>
+      </ScrollArea>,
+    );
+
+    const viewport = container.querySelector("[data-scroll-area-viewport]");
+    expect(viewport).not.toBeNull();
+    expect(viewport).toHaveClass("table-scrollbar");
+    expect(viewport).toHaveAttribute("data-scrollbar-visibility", "always");
+  });
+
+  test("renders a visible vertical scrollbar only when content overflows", async () => {
+    const { container } = render(
+      <ScrollArea className="h-[120px]" scrollbarVisibility="always">
+        <div style={{ height: 420 }}>Tall content</div>
+      </ScrollArea>,
+    );
+
+    const viewport = container.querySelector(
+      "[data-scroll-area-viewport]",
+    ) as HTMLDivElement | null;
+    expect(viewport).not.toBeNull();
+
+    setScrollMetrics(viewport!, {
+      clientHeight: 120,
+      scrollHeight: 420,
+      scrollTop: 24,
+    });
+    window.dispatchEvent(new Event("resize"));
+    fireEvent.scroll(viewport!);
+
+    await waitFor(() => {
+      const scrollbar = container.querySelector('[data-scroll-area-scrollbar="y"]');
+      const thumb = scrollbar?.querySelector('[role="presentation"]') as HTMLDivElement | null;
+
+      expect(scrollbar).not.toBeNull();
+      expect(scrollbar).toHaveClass("opacity-100", "right-0");
+      expect(thumb).not.toBeNull();
+      expect(thumb!.style.height).not.toBe("");
+      expect(thumb!.style.top).not.toBe("");
+    });
+  });
+
+  test("does not render a custom scrollbar without overflow", async () => {
+    const { container } = render(
+      <ScrollArea className="h-[120px]" scrollbarVisibility="always">
+        <div>Short content</div>
+      </ScrollArea>,
+    );
+
+    const viewport = container.querySelector(
+      "[data-scroll-area-viewport]",
+    ) as HTMLDivElement | null;
+    expect(viewport).not.toBeNull();
+
+    setScrollMetrics(viewport!, {
+      clientHeight: 120,
+      scrollHeight: 120,
+    });
+    window.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-scroll-area-scrollbar="y"]')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a reusable ScrollArea with hidden native scrollbars and DOM-rendered vertical scrollbar
- Use the wrapped scroll area in the channel group basic tab with overflow-only, always-visible scrollbar behavior
- Restore model table horizontal breathing room while keeping the table scrollbar close to the modal edge

## Verification
- bun run test -- src/modules/channel-groups/__tests__/RoutingConfigEditor.test.tsx src/modules/ui/__tests__/ScrollArea.test.tsx src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
- bun run build
- Browser QA covered desktop Chrome for the group modal and mobile viewport with the same local UI data set
- git diff --check