### PR TITLE
fix: add right margin to model list in channel group editor

### DIFF
--- a/src/modules/channel-groups/RoutingConfigEditor.tsx
+++ b/src/modules/channel-groups/RoutingConfigEditor.tsx
@@ -1868,6 +1868,7 @@ export function RoutingConfigEditor({
                           caption={t("channel_groups_page.allowed_models_label")}
                           emptyText={t("channel_groups_page.no_channel_models")}
                           showAllLoadedMessage={false}
+                          scrollContentClassName="pr-5"
                         />
                       </div>
                     </div>

--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -92,6 +92,8 @@ export interface DataTableProps<T> {
   allowWheelPropagationAtBoundary?: boolean;
   /** Render the table in normal document flow without any internal table scrollbars. */
   naturalFlow?: boolean;
+  /** Extra class for the content wrapper inside the scroll viewport (e.g. "pr-5" for right padding). */
+  scrollContentClassName?: string;
   /** Whether column reorder by dragging the header handle is allowed (default true when tableId is set). */
   columnReorderable?: boolean;
   /** Whether column order is persisted to localStorage (default true). */
@@ -349,6 +351,7 @@ export function DataTable<T>({
   rowClassName,
   allowWheelPropagationAtBoundary = false,
   naturalFlow = false,
+  scrollContentClassName,
   columnReorderable = true,
   persistColumnOrder = true,
 }: DataTableProps<T>) {
@@ -1250,6 +1253,10 @@ export function DataTable<T>({
             : "relative z-10 col-start-1 row-start-1 h-full min-h-0 table-scrollbar overflow-auto overscroll-x-none overscroll-y-none rounded-tl-xl"
         }
       >
+        <div
+          data-vt-scroll-content
+          className={scrollContentClassName ?? ""}
+        >
         {naturalFlow ? null : (
           <div
             data-vt-header-overlay
@@ -1436,6 +1443,7 @@ export function DataTable<T>({
             {t("common.all_records_loaded", { count: rows.length })}
           </div>
         )}
+        </div>
       </div>
 
       {!naturalFlow && vThumb ? (


### PR DESCRIPTION
## Summary

- Added `scrollContentClassName` prop to DataTable to allow right padding (pr-5) for table content inside the scroll viewport
- This keeps the custom scrollbar gutter at the right edge while giving visual breathing room to table content
- Applied `scrollContentClassName="pr-5"` to the model list table in the channel group editor
- Fixes the asymmetric layout where the model list had left padding but no right padding

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] All 74 UI component tests pass
- [x] All 20 RoutingConfigEditor tests pass
- [x] All 34 DataTable scrollbar tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)