### PR TITLE
fix: 用绝对定位 overlay 替代行级 hover 背景，消除列宽拖拽时的行闪烁

### DIFF
--- a/src/modules/ui/DataTable.tsx
+++ b/src/modules/ui/DataTable.tsx
@@ -423,8 +423,15 @@ export function DataTable<T>({
   );
   const columnOrderRef = useRef<ColumnOrder>(columnOrder);
   const [reorderPreview, setReorderPreview] = useState<ColumnReorderPreview | null>(null);
+  const [rowHoverOverlay, setRowHoverOverlay] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
   const columnReorderRef = useRef<ColumnReorderState | null>(null);
   const reorderPreviewRef = useRef<ColumnReorderPreview | null>(null);
+  const hoveredRowRef = useRef<HTMLTableRowElement | null>(null);
 
   const orderedColumns = useMemo(() => {
     if (!canUseColumnOrder) return columns;
@@ -555,6 +562,16 @@ export function DataTable<T>({
     if (!el) return;
     const next = el.scrollTop;
     updateScrollMetrics();
+    if (hoveredRowRef.current) {
+      const rowRect = hoveredRowRef.current.getBoundingClientRect();
+      const containerRect = el.getBoundingClientRect();
+      setRowHoverOverlay({
+        left: el.scrollLeft,
+        top: rowRect.top - containerRect.top + el.scrollTop,
+        width: el.clientWidth,
+        height: rowRect.height,
+      });
+    }
 
     const scrollBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     const {
@@ -597,6 +614,23 @@ export function DataTable<T>({
       });
     }
   }, [updateScrollMetrics]);
+
+  const updateRowHoverOverlay = useCallback((row: HTMLTableRowElement | null) => {
+    hoveredRowRef.current = row;
+    const el = containerRef.current;
+    if (!row || !el) {
+      setRowHoverOverlay(null);
+      return;
+    }
+    const rowRect = row.getBoundingClientRect();
+    const containerRect = el.getBoundingClientRect();
+    setRowHoverOverlay({
+      left: el.scrollLeft,
+      top: rowRect.top - containerRect.top + el.scrollTop,
+      width: el.clientWidth,
+      height: rowRect.height,
+    });
+  }, []);
 
   const handleWheel = useCallback(
     (e: WheelEvent) => {
@@ -1431,17 +1465,33 @@ export function DataTable<T>({
       >
         <div
           data-vt-scroll-content
-          className={scrollContentClassName ?? ""}
+          className={`relative ${scrollContentClassName ?? ""}`}
         >
+        {!naturalFlow && rowHoverOverlay ? (
+          <div
+            data-vt-row-hover-overlay
+            aria-hidden="true"
+            className="pointer-events-none absolute z-0 rounded-lg bg-slate-50 dark:bg-white/[0.04]"
+            style={{
+              transform: `translate(${rowHoverOverlay.left}px, ${rowHoverOverlay.top}px)`,
+              width: rowHoverOverlay.width,
+              height: rowHoverOverlay.height,
+            }}
+          />
+        ) : null}
         {naturalFlow ? null : (
           <div
             data-vt-header-overlay
-            className={`pointer-events-none sticky left-0 top-0 z-10 w-full ${vThumb ? "rounded-l-xl" : "rounded-xl"} bg-slate-100 dark:bg-neutral-800`}
-            style={{ height: headerHeight, marginBottom: -headerHeight }}
+            className="pointer-events-none sticky left-0 top-0 z-40 rounded-xl bg-slate-100 dark:bg-neutral-800"
+            style={{
+              height: headerHeight,
+              marginBottom: -headerHeight,
+              width: scrollMetrics.clientWidth || "100%",
+            }}
           />
         )}
         <table
-          className={`w-full ${minWidth} table-fixed border-separate border-spacing-0 text-sm`}
+          className={`relative w-full ${minWidth} table-fixed border-separate border-spacing-0 text-sm`}
         >
           <caption className="sr-only">{caption}</caption>
           <colgroup>
@@ -1462,7 +1512,7 @@ export function DataTable<T>({
             className={
               naturalFlow
                 ? "bg-slate-100 dark:bg-neutral-800"
-                : "sticky top-0 z-40 bg-slate-100 dark:bg-neutral-800"
+                : "sticky top-0 z-50"
             }
           >
             <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-white/55">
@@ -1470,6 +1520,13 @@ export function DataTable<T>({
                 const canResize = shouldAllowColumnResize(col, colIndex, orderedColumns);
                 const canReorder = canUseColumnOrder && shouldAllowColumnReorder(col);
                 const isResizingColumns = activeResizeColumnKey !== null;
+                const headerChromeClass = naturalFlow ? "bg-slate-100 dark:bg-neutral-800" : "";
+                const headerCornerClass = [
+                  naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
+                  naturalFlow && colIndex === orderedColumns.length - 1 ? "rounded-r-xl" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ");
                 return (
                   <th
                     key={col.key}
@@ -1478,7 +1535,7 @@ export function DataTable<T>({
                       headerCellsRef.current[col.key] = node;
                     }}
                     style={resolveColumnStyle(col)}
-                    className={`group/column relative bg-slate-100 px-4 py-3 whitespace-nowrap dark:bg-neutral-800 ${col.width ?? ""} ${col.headerClassName ?? ""}`}
+                    className={`group/column relative z-50 px-4 py-3 whitespace-nowrap ${headerChromeClass} ${headerCornerClass} ${col.width ?? ""} ${col.headerClassName ?? ""}`}
                   >
                     {canReorder ? (
                       <button
@@ -1581,8 +1638,14 @@ export function DataTable<T>({
                   return (
                     <tr
                       key={key}
-                      className={`text-sm transition-colors hover:bg-slate-50 dark:hover:bg-white/[0.04] ${extraCls}`}
+                      className={`text-sm transition-colors ${
+                        naturalFlow ? "hover:bg-slate-50 dark:hover:bg-white/[0.04]" : ""
+                      } ${extraCls}`}
                       style={virtualize ? { height: rowHeight } : undefined}
+                      onMouseEnter={
+                        naturalFlow ? undefined : (event) => updateRowHoverOverlay(event.currentTarget)
+                      }
+                      onMouseLeave={naturalFlow ? undefined : () => updateRowHoverOverlay(null)}
                     >
                       {orderedColumns.map((col, colIdx) => {
                         const isFirst = colIdx === 0;

--- a/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
+++ b/src/modules/ui/__tests__/DataTable.scrollbar.test.tsx
@@ -855,8 +855,8 @@ describe("DataTable scrollbar wrapper", () => {
         "sticky",
         "left-0",
         "top-0",
-        "z-10",
-        "rounded-l-xl",
+        "z-40",
+        "rounded-xl",
         "bg-slate-100",
       );
       expect(gutter).toContainElement(y);
@@ -887,16 +887,28 @@ describe("DataTable scrollbar wrapper", () => {
 
     const header = container.querySelector("thead") as HTMLTableSectionElement | null;
     const firstHeader = container.querySelector("th") as HTMLTableCellElement | null;
+    const lastHeader = container.querySelectorAll("th").item(1) as HTMLTableCellElement | null;
     const headerOverlay = container.querySelector(
       "[data-vt-header-overlay]",
     ) as HTMLDivElement | null;
     expect(header).not.toBeNull();
     expect(firstHeader).not.toBeNull();
+    expect(lastHeader).not.toBeNull();
     expect(headerOverlay).not.toBeNull();
-    expect(header).toHaveClass("sticky", "top-0", "z-40", "bg-slate-100", "dark:bg-neutral-800");
-    expect(firstHeader!.className).not.toContain("rounded-l-xl");
-    expect(firstHeader).toHaveClass("bg-slate-100", "dark:bg-neutral-800");
-    expect(headerOverlay).toHaveClass("bg-slate-100", "dark:bg-neutral-800");
+    expect(header).toHaveClass("sticky", "top-0", "z-50");
+    expect(header).not.toHaveClass("bg-slate-100");
+    expect(firstHeader).not.toHaveClass("rounded-l-xl");
+    expect(lastHeader).not.toHaveClass("rounded-r-xl");
+    expect(firstHeader).not.toHaveClass("bg-slate-100");
+    expect(headerOverlay).toHaveClass(
+      "sticky",
+      "left-0",
+      "top-0",
+      "z-40",
+      "rounded-xl",
+      "bg-slate-100",
+      "dark:bg-neutral-800",
+    );
   });
 
   test("prevents vertical wheel bounce when already at a scroll boundary", () => {


### PR DESCRIPTION
## Summary
- 使用 translate 定位的 overlay div 替代 tr 上的 hover:bg-slate-50
- 添加 rowHoverOverlay 状态，在滚动时自动修正位置
- z-index 从 header 移除 bg 背景，交由 header-chrome 独立处理
- header overlay 使用 scrollMetrics.clientWidth 确保宽度精确
- thead z-50，每列 th z-50，body tbody z-0 确保层叠正确

## Test plan
- [x] 编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)