### PR TITLE
fix: normalize management panel API base

### DIFF
--- a/packages/api-client/src/client/__tests__/client.test.ts
+++ b/packages/api-client/src/client/__tests__/client.test.ts
@@ -1,5 +1,29 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiClient } from "@code-proxy/api-client";
+import { computeManagementApiBase, normalizeApiBase } from "../constants";
+
+describe("API base normalization", () => {
+  test("normalizes full management panel URLs back to the service root", () => {
+    expect(normalizeApiBase("https://relay.example.com/manage/ccswitch-import-settings")).toBe(
+      "https://relay.example.com",
+    );
+    expect(normalizeApiBase("https://relay.example.com/manage/login?next=/config#section")).toBe(
+      "https://relay.example.com",
+    );
+    expect(computeManagementApiBase("https://relay.example.com/manage")).toBe(
+      "https://relay.example.com/v0/management",
+    );
+  });
+
+  test("preserves deployment prefixes before the management panel path", () => {
+    expect(normalizeApiBase("https://example.com/relay/manage/ccswitch-import-settings")).toBe(
+      "https://example.com/relay",
+    );
+    expect(computeManagementApiBase("https://example.com/relay/v0/management/config")).toBe(
+      "https://example.com/relay/v0/management",
+    );
+  });
+});
 
 describe("ApiClient authentication failure handling", () => {
   const originalFetch = globalThis.fetch;
@@ -87,5 +111,23 @@ describe("ApiClient authentication failure handling", () => {
 
     await expect(client.get("/config")).resolves.toEqual({ ok: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects management panel HTML returned from a misconfigured API base", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("<!doctype html><html><body>panel</body></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({
+      apiBase: "http://localhost:8317",
+      managementKey: "test-key",
+    });
+
+    await expect(client.get("/config")).rejects.toThrow("web panel HTML instead of JSON");
   });
 });

--- a/packages/api-client/src/client/client.ts
+++ b/packages/api-client/src/client/client.ts
@@ -261,6 +261,16 @@ export class ApiClient {
         return undefined as T;
       }
 
+      const contentType = response.headers.get("Content-Type") ?? "";
+      if (
+        contentType.toLowerCase().includes("text/html") &&
+        /^<!doctype html|^<html[\s>]/i.test(trimmed)
+      ) {
+        throw new Error(
+          "Management API returned the web panel HTML instead of JSON. Check the API base URL.",
+        );
+      }
+
       try {
         return JSON.parse(trimmed) as T;
       } catch {

--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -9,14 +9,30 @@ export const normalizeApiBase = (input: string): string => {
   let base = input.trim();
   if (!base) return "";
 
-  base = base.replace(/\/?v0\/management\/?$/i, "");
-  base = base.replace(/\/+$/, "");
-
   if (!/^https?:\/\//i.test(base)) {
     base = `http://${base}`;
   }
 
-  return base;
+  try {
+    const url = new URL(base);
+    url.hash = "";
+    url.search = "";
+
+    const normalizedPath = url.pathname.replace(/\/+$/, "");
+    const lowerPath = normalizedPath.toLowerCase();
+    const managementIndex = lowerPath.search(/\/v0\/management(?:\/|$)/);
+    const manageIndex = lowerPath.search(/\/manage(?:\/|$)/);
+
+    if (managementIndex >= 0) {
+      url.pathname = normalizedPath.slice(0, managementIndex) || "/";
+    } else if (manageIndex >= 0) {
+      url.pathname = normalizedPath.slice(0, manageIndex) || "/";
+    }
+
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return base.replace(/\/?v0\/management\/?$/i, "").replace(/\/+$/, "");
+  }
 };
 
 export const computeManagementApiBase = (base: string): string => {


### PR DESCRIPTION
## Summary
- normalize full management panel URLs back to the service API root before building management requests
- reject HTML panel responses for JSON API requests so misconfigured connections fail loudly instead of appearing to save
- add regression coverage for panel URL normalization and HTML fallback responses

## Verification
- bun run --filter @code-proxy/admin-panel test -- packages/api-client/src/client/__tests__/client.test.ts packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- bun run lint packages/api-client/src/client/constants.ts packages/api-client/src/client/client.ts packages/api-client/src/client/__tests__/client.test.ts
- bun run build
- local browser check on the management login page