### PR TITLE
fix: use workspace build in frontend workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "VITE_APP_VERSION=${{ github.ref_name }}-${SHORT_SHA}" >> "$GITHUB_ENV"
 
       - name: Build production bundle
-        run: bunx vite build
+        run: bun run build
 
       - name: Write deployment version marker
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "VITE_APP_VERSION=${{ github.ref_name }}" >> "$GITHUB_ENV"
 
       - name: Build production bundle
-        run: bunx vite build
+        run: bun run build
 
       - name: Package panel-dist.zip
         run: cd dist && zip -r ../panel-dist.zip manage.html assets/


### PR DESCRIPTION
## Summary
- switch frontend deploy and release workflows to the repository build script
- keep CI aligned with the current admin-panel workspace build output

## Verification
- git diff --check
- actionlint unavailable locally
- bun run build was verified on the same dev head before this workflow-only change