### PR TITLE
fix: handle noop update apply responses

### DIFF
--- a/apps/admin-panel/src/app/update/updateShared.ts
+++ b/apps/admin-panel/src/app/update/updateShared.ts
@@ -14,6 +14,8 @@ const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve
 const normalizedProgressStatus = (progress?: UpdateProgressResponse | null) =>
   progress?.status?.trim().toLowerCase() ?? "";
 
+const normalizedApplyStatus = (status?: string | null) => status?.trim().toLowerCase() ?? "";
+
 export const shortCommit = (commit?: string) => {
   const trimmed = commit?.trim() ?? "";
   return trimmed.length > 7 ? trimmed.slice(0, 7) : trimmed;
@@ -211,6 +213,19 @@ export const applyUpdateFlow = async ({
   t: TFunction;
 }) => {
   const response = await updateApi.apply();
+  if (normalizedApplyStatus(response.status) === "noop") {
+    const message = response.message?.trim() || t("auto_update.no_update");
+    const nextCandidate = candidate ? { ...candidate, message, update_available: false } : null;
+    if (nextCandidate) onCheck?.(nextCandidate);
+    onProgress?.({ status: "idle", stage: "idle", message, logs: [] });
+    notify({
+      type: isAlreadyUpToDateMessage(message) ? "success" : "warning",
+      message: isAlreadyUpToDateMessage(message)
+        ? t("auto_update.no_update")
+        : formatUpdateStatusMessage(message),
+    });
+    return false;
+  }
   const target = response.target ?? candidate;
   const result = await waitForAppliedTarget({
     target,

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -139,6 +139,47 @@ describe("SystemPage", () => {
     expect(mocks.check).toHaveBeenCalledTimes(1);
   });
 
+  test("does not wait in the update console when apply returns noop", async () => {
+    mocks.check.mockResolvedValueOnce({
+      enabled: true,
+      update_available: true,
+      current_version: "dev-1111111",
+      current_commit: "111111111111",
+      current_ui_version: "panel-dev-1111111",
+      current_ui_commit: "111111111111",
+      latest_version: "dev-abcdef1",
+      latest_commit: "abcdef123456",
+      latest_ui_version: "panel-dev-fedcba9",
+      latest_ui_commit: "fedcba987654",
+      target_channel: "dev",
+      docker_image: "ghcr.io/kittors/clirelay",
+      docker_tag: "dev",
+      release_notes: "Fixes and improvements",
+      updater_available: true,
+    });
+    mocks.apply.mockResolvedValueOnce({
+      status: "noop",
+      message:
+        "docker image for dev is not ready; latest successful publish is 1111111 but branch head is abcdef1",
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /check docker update/i }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /update now/i }));
+
+    await waitFor(() => {
+      expect(mocks.apply).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(within(dialog).queryByTestId("update-progress-console")).toBeNull();
+    });
+    expect(mocks.progress).not.toHaveBeenCalled();
+    expect(within(dialog).getByText(/docker image for dev is not ready/i)).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: /update now/i })).toBeDisabled();
+  });
+
   test("shows only default root v1 model discovery results", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/model-path-availability") {


### PR DESCRIPTION
## Summary
- handle noop update apply responses without entering the live update console
- mark stale update candidates unavailable and show the backend readiness message
- add a regression test for the update apply race path

## Validation
- bun run --filter @code-proxy/admin-panel test:ci -- pages/system/__tests__/SystemPage.test.tsx
- bun run build
- bun run lint
- git diff --check