### PR TITLE
feat: show auth file current cycle cost

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/usage-auth-file-trend.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/usage-auth-file-trend.test.ts
@@ -24,6 +24,7 @@ describe("usage auth file trend api", () => {
       hours: 5,
       request_total: 3,
       cycle_request_total: 2,
+      cycle_cost_total: 1.2345,
       cycle_start: "2026-04-27T16:01:21Z",
       daily_usage: [{ date: "2026-04-30", requests: 2 }],
       hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1 }],
@@ -41,6 +42,7 @@ describe("usage auth file trend api", () => {
 
     expect(getMock).toHaveBeenCalledWith("/usage/auth-file-trend?auth_index=auth-1&days=7&hours=5");
     expect(result.request_total).toBe(3);
+    expect(result.cycle_cost_total).toBe(1.2345);
     expect(result.daily_usage).toHaveLength(1);
     expect(result.quota_series[0]?.quota_key).toBe("code_week");
   });

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -77,6 +77,7 @@ export interface AuthFileTrendResponse {
   hours: number;
   request_total: number;
   cycle_request_total: number;
+  cycle_cost_total: number;
   cycle_start: string;
   daily_usage: AuthFileTrendUsagePoint[];
   hourly_usage: AuthFileTrendUsagePoint[];
@@ -245,6 +246,7 @@ export const usageApi = {
       hours: resp?.hours ?? hours,
       request_total: resp?.request_total ?? 0,
       cycle_request_total: resp?.cycle_request_total ?? 0,
+      cycle_cost_total: resp?.cycle_cost_total ?? 0,
       cycle_start: resp?.cycle_start ?? "",
       daily_usage: Array.isArray(resp?.daily_usage) ? resp.daily_usage : [],
       hourly_usage: Array.isArray(resp?.hourly_usage) ? resp.hourly_usage : [],

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -691,6 +691,7 @@
     "detail_tab_models_desc": "Query supported models for this credential to troubleshoot permissions and exclusions.",
     "trend_last_7_days_requests": "Last 7 days requests",
     "trend_current_weekly_cycle": "Current weekly cycle",
+    "trend_current_cycle_cost": "Current cycle cost",
     "trend_cycle_start": "Cycle start",
     "trend_window_title": "Quota and request trends",
     "trend_window_5h": "5 hours",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -686,6 +686,7 @@
     "detail_tab_models_desc": "Запросить поддерживаемые модели для этих учётных данных, чтобы проверить права и исключения.",
     "trend_last_7_days_requests": "Запросы за 7 дней",
     "trend_current_weekly_cycle": "Текущий недельный цикл",
+    "trend_current_cycle_cost": "Стоимость текущего цикла",
     "trend_cycle_start": "Начало цикла",
     "trend_window_title": "Тренды квоты и запросов",
     "trend_window_5h": "5 часов",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -705,6 +705,7 @@
     "detail_tab_models_desc": "查询该凭证支持的模型，用于排查权限与排除规则。",
     "trend_last_7_days_requests": "近 7 天请求数",
     "trend_current_weekly_cycle": "当前周周期",
+    "trend_current_cycle_cost": "当前周期费用消耗",
     "trend_cycle_start": "周期开始",
     "trend_window_title": "额度与请求趋势",
     "trend_window_5h": "5 小时",

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -64,6 +64,7 @@ const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
       hours: 5,
       request_total: 3,
       cycle_request_total: 2,
+      cycle_cost_total: 1.2345,
       cycle_start: "2026-04-27T16:01:21Z",
       daily_usage: [
         { date: "2026-04-24", requests: 0 },
@@ -147,6 +148,8 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("Current weekly cycle")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Current cycle cost")).toBeInTheDocument();
+    expect(screen.getByText("$1.2345")).toBeInTheDocument();
     expect(screen.getByRole("dialog", { name: "View: codex.json" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
   });
@@ -178,6 +181,7 @@ describe("AuthFileDetailModal", () => {
         hours: 5,
         request_total: 12,
         cycle_request_total: 12,
+        cycle_cost_total: 0.008,
         cycle_start: "2026-04-28T05:34:34Z",
         daily_usage: [],
         hourly_usage: [

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -45,6 +45,8 @@ const formatLocalHourKey = (timestamp: string) => {
   return `${formatLocalDateKey(timestamp)} ${padTwo(date.getHours())}:00`;
 };
 
+const formatCurrency = (value: number) => `$${(Number.isFinite(value) ? value : 0).toFixed(4)}`;
+
 interface AuthFileDetailModalProps {
   open: boolean;
   detailFile: AuthFileItem | null;
@@ -295,7 +297,7 @@ export function AuthFileDetailModal({
 
     return (
       <div className="space-y-4">
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
             <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
               {t("auth_files.trend_last_7_days_requests")}
@@ -310,6 +312,14 @@ export function AuthFileDetailModal({
             </p>
             <p className="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
               {formatCount(detailTrend.cycle_request_total)}
+            </p>
+          </div>
+          <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
+            <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
+              {t("auth_files.trend_current_cycle_cost")}
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
+              {formatCurrency(detailTrend.cycle_cost_total)}
             </p>
           </div>
           <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">


### PR DESCRIPTION
## Summary
- surface current cycle cost in the auth-file trend client response
- add a usage summary card for current cycle cost in the auth-file detail modal
- cover the new card and trend field in targeted frontend tests