### PR TITLE
fix: keep current cycle cost visible for codex auth files

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -812,12 +812,40 @@ export const TYPE_BADGE_CLASSES: Record<string, string> = {
   unknown: "bg-slate-50 text-slate-600 dark:bg-white/10 dark:text-white/70",
 };
 
+const KNOWN_AUTH_FILE_PROVIDER_KEYS = Object.keys(TYPE_BADGE_CLASSES)
+  .filter((key) => key !== "empty" && key !== "unknown")
+  .sort((left, right) => right.length - left.length);
+
+const trimAuthFileExtension = (name: string): string =>
+  String(name ?? "")
+    .trim()
+    .replace(/\.[^.]+$/u, "");
+
+const matchKnownAuthFileProviderKey = (value: string): string => {
+  const normalized = normalizeProviderKey(value);
+  if (!normalized) return "";
+  return (
+    KNOWN_AUTH_FILE_PROVIDER_KEYS.find(
+      (providerKey) => normalized === providerKey || normalized.startsWith(`${providerKey}-`),
+    ) ?? ""
+  );
+};
+
 export const resolveFileType = (file: AuthFileItem): string => {
   const type = typeof file.type === "string" ? file.type : "";
   const provider = typeof file.provider === "string" ? file.provider : "";
-  const fromName = String(file.name || "").split(".")[0] ?? "";
-  const candidate = normalizeProviderKey(type || provider || fromName);
-  return candidate || "unknown";
+  const directMatch =
+    matchKnownAuthFileProviderKey(type) || matchKnownAuthFileProviderKey(provider);
+  if (directMatch) return directMatch;
+
+  const explicitCandidate = normalizeProviderKey(type || provider);
+  if (explicitCandidate) return explicitCandidate;
+
+  const fromName = trimAuthFileExtension(String(file.name || ""));
+  const nameMatch = matchKnownAuthFileProviderKey(fromName);
+  if (nameMatch) return nameMatch;
+
+  return normalizeProviderKey(fromName) || "unknown";
 };
 
 export const resolveProviderLabel = (providerKey: string): string => {
@@ -863,7 +891,7 @@ const readCodexFilenameChannelName = (fileName: string): string => {
   const normalized = String(fileName ?? "")
     .trim()
     .toLowerCase();
-  const base = normalized.replace(/\.json$/u, "");
+  const base = trimAuthFileExtension(normalized);
   if (!base.startsWith("codex-")) return "";
   const rest = base.slice("codex-".length);
   if (!rest) return "";

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -154,6 +154,19 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
   });
 
+  test("keeps the usage cost card visible for codex files inferred from dotted email file names", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "codex-pcamtu927@gmail.com-plus.json",
+        size: 256,
+      },
+    });
+
+    expect(screen.getByRole("tab", { name: "Usage" })).toBeInTheDocument();
+    expect(screen.getByText("Current cycle cost")).toBeInTheDocument();
+    expect(screen.getByText("$1.2345")).toBeInTheDocument();
+  });
+
   test("keeps the rendered trend visible while a background refresh is running", () => {
     renderDetailModal({ detailTrendLoading: true });
 

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -26,6 +26,18 @@ const mocks = vi.hoisted(() => ({
     ],
   })),
   getEntityStats: vi.fn(async () => ({ source: [], auth_index: [] })),
+  getAuthFileTrend: vi.fn(async () => ({
+    auth_index: "auth-1",
+    days: 7,
+    hours: 5,
+    request_total: 3,
+    cycle_request_total: 2,
+    cycle_cost_total: 1.2345,
+    cycle_start: "2026-04-27T16:01:21Z",
+    daily_usage: [{ date: "2026-04-30", requests: 2 }],
+    hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1 }],
+    quota_series: [],
+  })),
   getUsageLogs: vi.fn(async () => ({ items: [], total: 0, page: 1, size: 200 })),
   getAuthFileGroupTrend: vi.fn(async () => ({
     days: 7,
@@ -81,6 +93,7 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
     usageApi: {
       ...mod.usageApi,
       getEntityStats: mocks.getEntityStats,
+      getAuthFileTrend: mocks.getAuthFileTrend,
       getUsageLogs: mocks.getUsageLogs,
       getAuthFileGroupTrend: mocks.getAuthFileGroupTrend,
       recordAuthFileQuotaSnapshot: mocks.recordAuthFileQuotaSnapshot,
@@ -149,6 +162,19 @@ describe("AuthFilesPage files table", () => {
     }));
     mocks.getEntityStats.mockReset();
     mocks.getEntityStats.mockImplementation(async () => ({ source: [], auth_index: [] }));
+    mocks.getAuthFileTrend.mockReset();
+    mocks.getAuthFileTrend.mockImplementation(async () => ({
+      auth_index: "auth-1",
+      days: 7,
+      hours: 5,
+      request_total: 3,
+      cycle_request_total: 2,
+      cycle_cost_total: 1.2345,
+      cycle_start: "2026-04-27T16:01:21Z",
+      daily_usage: [{ date: "2026-04-30", requests: 2 }],
+      hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1 }],
+      quota_series: [],
+    }));
     mocks.getUsageLogs.mockReset();
     mocks.getUsageLogs.mockImplementation(async () => ({
       items: [],
@@ -2411,6 +2437,47 @@ describe("AuthFilesPage files table", () => {
       ).not.toBeInTheDocument(),
     );
     await waitFor(() => expect(screen.getByTestId("auth-files-cards")).toHaveTextContent(/d left/));
+  });
+
+  test("opens usage trend cards for codex files inferred from dotted email file names", async () => {
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pcamtu927@gmail.com-plus.json",
+          type: "codex",
+          auth_index: "auth-1",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+        },
+      ],
+    }));
+    mocks.downloadText.mockImplementation(async () => JSON.stringify({ type: "codex" }, null, 2));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const cards = await screen.findByTestId("auth-files-cards");
+    expect(cards).toHaveTextContent("pcamtu927@gmail.com");
+
+    fireEvent.click(within(cards).getByRole("button", { name: "View" }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "View: codex-pcamtu927@gmail.com-plus.json",
+    });
+    expect(within(dialog).getByRole("tab", { name: "Usage" })).toBeInTheDocument();
+    expect(await within(dialog).findByText("Current cycle cost")).toBeInTheDocument();
+    expect(within(dialog).getByText("$1.2345")).toBeInTheDocument();
+    expect(mocks.getAuthFileTrend).toHaveBeenCalledWith("auth-1", { days: 7, hours: 5 });
   });
 
   test("sets model owner group from an icon modal after confirmation", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -15,6 +15,7 @@ import {
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveAuthFileSubscriptionStatus,
+  resolveFileType,
   resolveAuthFileStats,
   sanitizeAuthFilesForCache,
   shouldShowAuthFileDisplayTag,
@@ -215,6 +216,15 @@ describe("Auth Files helper coverage", () => {
     } satisfies AuthFileItem;
 
     expect(resolveAuthFileDisplayName(file)).toBe("alpha@example.test");
+  });
+
+  test("infers the codex provider from file names that include dotted emails", () => {
+    const file = {
+      name: "codex-pcamtu927@gmail.com-plus.json",
+    } satisfies AuthFileItem;
+
+    expect(resolveFileType(file)).toBe("codex");
+    expect(resolveAuthFileDisplayName(file)).toBe("pcamtu927@gmail.com");
   });
 
   test("treats an explicit empty display tag list as hiding every tag", () => {


### PR DESCRIPTION
## Summary
- fix auth-file provider inference for codex file names that include dotted email addresses
- keep the auth-files detail usage tab resolving correctly for  style names
- add focused regression coverage for helper logic, detail modal rendering, and page-level dialog flow

## Verification
- bun run test -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx
- bun run build
- local browser verification against the dev build with mocked management responses