### PR TITLE
Fix request logs multiselect all-selection semantics

### DIFF
--- a/apps/admin-panel/src/app/update/__tests__/AutoUpdatePrompt.test.tsx
+++ b/apps/admin-panel/src/app/update/__tests__/AutoUpdatePrompt.test.tsx
@@ -77,7 +77,7 @@ describe("AutoUpdatePrompt", () => {
     mocks.get.mockResolvedValue({ uptime: 10 });
   });
 
-  test("asks whether to update before showing the fixed-height update dialog", async () => {
+  test("asks whether to update before showing the scroll-contained update dialog", async () => {
     renderPrompt();
 
     expect(
@@ -98,7 +98,11 @@ describe("AutoUpdatePrompt", () => {
 
     expect(await screen.findByRole("heading", { name: /new version found/i })).toBeInTheDocument();
     expect(await screen.findByText(/Fixes and improvements/i)).toBeInTheDocument();
-    expect(screen.getByTestId("update-details-modal-body")).toHaveClass("h-[min(68vh,560px)]");
+    expect(screen.getByTestId("update-details-modal-body")).toHaveClass(
+      "max-h-[min(72vh,640px)]",
+      "overflow-y-auto",
+      "overscroll-contain",
+    );
     expect(screen.getByRole("button", { name: /update now/i })).toBeInTheDocument();
     expect(mocks.apply).not.toHaveBeenCalled();
   });

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -53,6 +53,7 @@ export interface SearchableCheckboxMultiSelectProps {
   showClearButton?: boolean;
   maxSummaryItems?: number;
   mobileBreakpoint?: number;
+  emptyValueMeansAllSelected?: boolean;
 }
 
 function optionText(option: SearchableCheckboxMultiSelectOption): string {
@@ -79,6 +80,7 @@ export function SearchableCheckboxMultiSelect({
   showClearButton = false,
   maxSummaryItems = 2,
   mobileBreakpoint = 640,
+  emptyValueMeansAllSelected = false,
 }: SearchableCheckboxMultiSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -88,7 +90,27 @@ export function SearchableCheckboxMultiSelect({
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
   const [dropdownPlacement, setDropdownPlacement] = useState<"bottom" | "top">("bottom");
 
-  const selectedSet = useMemo(() => new Set(value), [value]);
+  const sanitizedExplicitValue = useMemo(() => {
+    const allowed = new Set(options.map((option) => option.value));
+    return value.filter(
+      (item, index) => allowed.has(item) && value.indexOf(item) === index,
+    );
+  }, [options, value]);
+
+  const implicitAllSelected =
+    emptyValueMeansAllSelected && sanitizedExplicitValue.length === 0 && options.length > 0;
+
+  const effectiveValue = useMemo(
+    () => (implicitAllSelected ? options.map((option) => option.value) : sanitizedExplicitValue),
+    [implicitAllSelected, options, sanitizedExplicitValue],
+  );
+
+  const allOptionsSelectedExplicitly =
+    !implicitAllSelected && options.length > 0 && sanitizedExplicitValue.length === options.length;
+
+  const showAllSelectionSummary = implicitAllSelected || allOptionsSelectedExplicitly;
+
+  const selectedSet = useMemo(() => new Set(effectiveValue), [effectiveValue]);
 
   const filteredOptions = useMemo(() => {
     const keyword = query.trim().toLowerCase();
@@ -107,6 +129,8 @@ export function SearchableCheckboxMultiSelect({
 
   const allVisibleSelected =
     visibleValues.length > 0 && visibleValues.every((optionValue) => selectedSet.has(optionValue));
+
+  const showFilteredToggle = !(showAllSelectionSummary && query.trim().length === 0);
 
   const updatePosition = useCallback(() => {
     const trigger = triggerRef.current;
@@ -233,34 +257,44 @@ export function SearchableCheckboxMultiSelect({
   const toggleOption = useCallback(
     (optionValue: string) => {
       if (selectedSet.has(optionValue)) {
-        commitSelection(value.filter((item) => item !== optionValue));
+        commitSelection(effectiveValue.filter((item) => item !== optionValue));
         return;
       }
-      commitSelection([...value, optionValue]);
+      commitSelection([...effectiveValue, optionValue]);
     },
-    [commitSelection, selectedSet, value],
+    [commitSelection, effectiveValue, selectedSet],
   );
 
   const toggleFiltered = useCallback(() => {
     if (visibleValues.length === 0) return;
     if (allVisibleSelected) {
       const visibleSet = new Set(visibleValues);
-      commitSelection(value.filter((item) => !visibleSet.has(item)));
+      commitSelection(effectiveValue.filter((item) => !visibleSet.has(item)));
       return;
     }
-    commitSelection([...value, ...visibleValues]);
-  }, [allVisibleSelected, commitSelection, value, visibleValues]);
+    commitSelection([...effectiveValue, ...visibleValues]);
+  }, [allVisibleSelected, commitSelection, effectiveValue, visibleValues]);
 
   const selectedSummary = useMemo(() => {
-    if (value.length === 0) return placeholder;
-    const labels = value
+    if (showAllSelectionSummary || sanitizedExplicitValue.length === 0) return placeholder;
+    const labels = sanitizedExplicitValue
       .slice(0, maxSummaryItems)
       .map((item) =>
         optionText(options.find((option) => option.value === item) ?? { value: item, label: item }),
       )
       .join(", ");
-    return value.length > maxSummaryItems ? `${labels} +${value.length - maxSummaryItems}` : labels;
-  }, [maxSummaryItems, options, placeholder, value]);
+    return sanitizedExplicitValue.length > maxSummaryItems
+      ? `${labels} +${sanitizedExplicitValue.length - maxSummaryItems}`
+      : labels;
+  }, [
+    maxSummaryItems,
+    options,
+    placeholder,
+    sanitizedExplicitValue,
+    showAllSelectionSummary,
+  ]);
+
+  const showSelectionBadge = sanitizedExplicitValue.length > 0 && !showAllSelectionSummary;
 
   const handleClear = useCallback(
     (event: React.MouseEvent) => {
@@ -297,22 +331,23 @@ export function SearchableCheckboxMultiSelect({
           <span
             className={cn(
               "min-w-0 flex-1 truncate text-left",
-              value.length === 0 && "text-slate-400 dark:text-white/35",
+              (sanitizedExplicitValue.length === 0 || showAllSelectionSummary) &&
+                "text-slate-400 dark:text-white/35",
             )}
           >
             {selectedSummary}
           </span>
           <span className="flex shrink-0 items-center gap-2">
-            {value.length > 0 ? (
+            {showSelectionBadge ? (
               <span className="rounded-md bg-sky-50 px-1.5 py-0.5 text-[11px] font-semibold text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">
-                {selectedCountLabel(value.length)}
+                {selectedCountLabel(sanitizedExplicitValue.length)}
               </span>
             ) : null}
             <ChevronDown
               size={14}
               className={cn(
                 selectChevron,
-                value.length > 0 &&
+                showSelectionBadge &&
                   showClearButton &&
                   "group-hover/multi-select:opacity-0 group-focus-within/multi-select:opacity-0",
                 open && "rotate-180",
@@ -367,36 +402,38 @@ export function SearchableCheckboxMultiSelect({
                   spellCheck={false}
                 />
               </div>
-              <button
-                type="button"
-                onClick={toggleFiltered}
-                disabled={visibleValues.length === 0}
-                className={cn(
-                  "mx-1 mt-1 shrink-0",
-                  selectOptionBase,
-                  visibleValues.length === 0
-                    ? "cursor-not-allowed text-[#A1A1AA] dark:text-[#71717A]"
-                    : selectOptionIdle,
-                )}
-              >
-                <span
+              {showFilteredToggle ? (
+                <button
+                  type="button"
+                  onClick={toggleFiltered}
+                  disabled={visibleValues.length === 0}
                   className={cn(
-                    "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
-                    allVisibleSelected
-                      ? "border-[#18181B] bg-[#18181B] text-white dark:border-white dark:bg-white dark:text-[#18181B]"
-                      : "border-[#96969B] bg-white dark:border-[#9F9FA8] dark:bg-[#27272A]",
+                    "mx-1 mt-1 shrink-0",
+                    selectOptionBase,
+                    visibleValues.length === 0
+                      ? "cursor-not-allowed text-[#A1A1AA] dark:text-[#71717A]"
+                      : selectOptionIdle,
                   )}
-                  aria-hidden="true"
                 >
-                  {allVisibleSelected ? <Check size={12} /> : null}
-                </span>
-                <span className="min-w-0 flex-1 truncate">
-                  {allVisibleSelected ? deselectFilteredLabel : selectFilteredLabel}
-                </span>
-                <span className="shrink-0 text-xs text-slate-400 dark:text-white/35">
-                  {selectedCountLabel(value.length)}
-                </span>
-              </button>
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                      allVisibleSelected
+                        ? "border-[#18181B] bg-[#18181B] text-white dark:border-white dark:bg-white dark:text-[#18181B]"
+                        : "border-[#96969B] bg-white dark:border-[#9F9FA8] dark:bg-[#27272A]",
+                    )}
+                    aria-hidden="true"
+                  >
+                    {allVisibleSelected ? <Check size={12} /> : null}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">
+                    {allVisibleSelected ? deselectFilteredLabel : selectFilteredLabel}
+                  </span>
+                  <span className="shrink-0 text-xs text-slate-400 dark:text-white/35">
+                    {selectedCountLabel(effectiveValue.length)}
+                  </span>
+                </button>
+              ) : null}
               <div
                 role="listbox"
                 aria-label={ariaLabel}

--- a/pages/request-logs/RequestLogsFilters.tsx
+++ b/pages/request-logs/RequestLogsFilters.tsx
@@ -65,6 +65,7 @@ export function RequestLogsFilters({
             clearLabel={t("request_logs.clear_key_filter")}
             showClearButton
             size="sm"
+            emptyValueMeansAllSelected
           />
         </div>
         <div className="w-full min-[480px]:w-auto sm:w-[200px]">
@@ -82,6 +83,7 @@ export function RequestLogsFilters({
             clearLabel={t("request_logs.clear_model_filter")}
             showClearButton
             size="sm"
+            emptyValueMeansAllSelected
           />
         </div>
         <div className="w-full min-[480px]:w-auto sm:w-[180px]">
@@ -99,6 +101,7 @@ export function RequestLogsFilters({
             clearLabel={t("request_logs.clear_channel_filter")}
             showClearButton
             size="sm"
+            emptyValueMeansAllSelected
           />
         </div>
         <div className="w-full min-[480px]:w-auto sm:w-[150px]">
@@ -116,6 +119,7 @@ export function RequestLogsFilters({
             clearLabel={t("request_logs.clear_status_filter")}
             showClearButton
             size="sm"
+            emptyValueMeansAllSelected
           />
         </div>
 

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -39,6 +39,25 @@ const DEFAULT_CLEAR_OPTIONS: ClearUsageLogsPayload = {
   clear_request_records: false,
 };
 
+function normalizeFilterSelection(selected: string[], allowedValues: string[]): string[] {
+  if (allowedValues.length === 0) return [];
+  const allowed = new Set(allowedValues);
+  return selected.filter(
+    (item, index) => allowed.has(item) && selected.indexOf(item) === index,
+  );
+}
+
+function toFilterParam(selected: string[], allowedValues: string[]): string[] | undefined {
+  const normalized = normalizeFilterSelection(selected, allowedValues);
+  if (normalized.length === 0 || normalized.length === allowedValues.length) return undefined;
+  return normalized;
+}
+
+function hasPartialFilterSelection(selected: string[], allowedValues: string[]): boolean {
+  const normalized = normalizeFilterSelection(selected, allowedValues);
+  return normalized.length > 0 && normalized.length < allowedValues.length;
+}
+
 // ---------------------------------------------------------------------------
 // Main page
 // ---------------------------------------------------------------------------
@@ -117,98 +136,11 @@ export function RequestLogsPage() {
 
   const requestSeqRef = useRef(0);
 
-  const hasActiveFilters =
-    selectedApiKeys.length > 0 ||
-    selectedModels.length > 0 ||
-    selectedChannels.length > 0 ||
-    selectedStatuses.length > 0;
-
-  const resetFilters = useCallback(() => {
-    setSelectedApiKeys([]);
-    setSelectedModels([]);
-    setSelectedChannels([]);
-    setSelectedStatuses([]);
-  }, []);
-
-  // Fetch logs from backend (server-side pagination)
-  const fetchLogs = useCallback(
-    async (page: number, size: number) => {
-      const seq = ++requestSeqRef.current;
-      setLoading(true);
-
-      try {
-        const resp: UsageLogsResponse = await usageApi.getUsageLogs({
-          page,
-          size,
-          days: timeRange,
-          api_keys: selectedApiKeys.length > 0 ? selectedApiKeys : undefined,
-          models: selectedModels.length > 0 ? selectedModels : undefined,
-          channels: selectedChannels.length > 0 ? selectedChannels : undefined,
-          statuses: selectedStatuses.length > 0 ? selectedStatuses : undefined,
-        });
-
-        if (seq !== requestSeqRef.current) return;
-
-        setRawItems(resp.items ?? []);
-        setTotalCount(resp.total ?? 0);
-        setCurrentPage(page);
-        const filtersCandidate =
-          resp.filters && typeof resp.filters === "object" ? (resp.filters as any) : null;
-        setFilterOptions({
-          api_keys: Array.isArray(filtersCandidate?.api_keys) ? filtersCandidate.api_keys : [],
-          api_key_names:
-            filtersCandidate?.api_key_names &&
-            typeof filtersCandidate.api_key_names === "object" &&
-            !Array.isArray(filtersCandidate.api_key_names)
-              ? (filtersCandidate.api_key_names as Record<string, string>)
-              : {},
-          models: Array.isArray(filtersCandidate?.models) ? filtersCandidate.models : [],
-          channels: Array.isArray(filtersCandidate?.channels) ? filtersCandidate.channels : [],
-        });
-        setStats({
-          ...DEFAULT_LOG_STATS,
-          ...resp.stats,
-        });
-        setLastUpdatedAt(Date.now());
-      } catch (err) {
-        if (seq !== requestSeqRef.current) return;
-        const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
-        notify({ type: "error", message });
-      } finally {
-        if (seq === requestSeqRef.current) setLoading(false);
-      }
-    },
-    [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses, notify, t],
-  );
-
   // Derive display rows from raw items
   const rows = useMemo<LogRow[]>(
     () => (rawItems ?? []).map((item) => toRequestLogsRow(item)),
     [rawItems],
   );
-
-  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
-
-  const handlePageChange = useCallback(
-    (page: number) => {
-      const clamped = Math.max(1, Math.min(page, totalPages));
-      fetchLogs(clamped, pageSize);
-    },
-    [fetchLogs, pageSize, totalPages],
-  );
-
-  const handlePageSizeChange = useCallback(
-    (newSize: number) => {
-      setPageSize(newSize);
-      fetchLogs(1, newSize);
-    },
-    [fetchLogs],
-  );
-
-  // Fetch page 1 when filters change
-  useEffect(() => {
-    fetchLogs(1, pageSize);
-  }, [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Build multi-select options from backend filter data (exclude the "" "all" option)
   const keyOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
@@ -245,6 +177,119 @@ export function RequestLogsPage() {
       { value: "failed", label: t("request_logs.status_failed"), searchText: "failed" },
     ];
   }, [t]);
+
+  const apiKeyFilterValues = useMemo(() => keyOptions.map((option) => option.value), [keyOptions]);
+  const modelFilterValues = useMemo(
+    () => modelOptions.map((option) => option.value),
+    [modelOptions],
+  );
+  const channelFilterValues = useMemo(
+    () => channelOptions.map((option) => option.value),
+    [channelOptions],
+  );
+  const statusFilterValues = useMemo(
+    () => statusOptions.map((option) => option.value),
+    [statusOptions],
+  );
+
+  const hasActiveFilters =
+    hasPartialFilterSelection(selectedApiKeys, apiKeyFilterValues) ||
+    hasPartialFilterSelection(selectedModels, modelFilterValues) ||
+    hasPartialFilterSelection(selectedChannels, channelFilterValues) ||
+    hasPartialFilterSelection(selectedStatuses, statusFilterValues);
+
+  const resetFilters = useCallback(() => {
+    setSelectedApiKeys([]);
+    setSelectedModels([]);
+    setSelectedChannels([]);
+    setSelectedStatuses([]);
+  }, []);
+
+  // Fetch logs from backend (server-side pagination)
+  const fetchLogs = useCallback(
+    async (page: number, size: number) => {
+      const seq = ++requestSeqRef.current;
+      setLoading(true);
+
+      try {
+        const resp: UsageLogsResponse = await usageApi.getUsageLogs({
+          page,
+          size,
+          days: timeRange,
+          api_keys: toFilterParam(selectedApiKeys, apiKeyFilterValues),
+          models: toFilterParam(selectedModels, modelFilterValues),
+          channels: toFilterParam(selectedChannels, channelFilterValues),
+          statuses: toFilterParam(selectedStatuses, statusFilterValues),
+        });
+
+        if (seq !== requestSeqRef.current) return;
+
+        setRawItems(resp.items ?? []);
+        setTotalCount(resp.total ?? 0);
+        setCurrentPage(page);
+        const filtersCandidate =
+          resp.filters && typeof resp.filters === "object" ? (resp.filters as any) : null;
+        setFilterOptions({
+          api_keys: Array.isArray(filtersCandidate?.api_keys) ? filtersCandidate.api_keys : [],
+          api_key_names:
+            filtersCandidate?.api_key_names &&
+            typeof filtersCandidate.api_key_names === "object" &&
+            !Array.isArray(filtersCandidate.api_key_names)
+              ? (filtersCandidate.api_key_names as Record<string, string>)
+              : {},
+          models: Array.isArray(filtersCandidate?.models) ? filtersCandidate.models : [],
+          channels: Array.isArray(filtersCandidate?.channels) ? filtersCandidate.channels : [],
+        });
+        setStats({
+          ...DEFAULT_LOG_STATS,
+          ...resp.stats,
+        });
+        setLastUpdatedAt(Date.now());
+      } catch (err) {
+        if (seq !== requestSeqRef.current) return;
+        const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
+        notify({ type: "error", message });
+      } finally {
+        if (seq === requestSeqRef.current) setLoading(false);
+      }
+    },
+    [
+      apiKeyFilterValues,
+      channelFilterValues,
+      modelFilterValues,
+      notify,
+      selectedApiKeys,
+      selectedChannels,
+      selectedModels,
+      selectedStatuses,
+      statusFilterValues,
+      t,
+      timeRange,
+    ],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      const clamped = Math.max(1, Math.min(page, totalPages));
+      fetchLogs(clamped, pageSize);
+    },
+    [fetchLogs, pageSize, totalPages],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (newSize: number) => {
+      setPageSize(newSize);
+      fetchLogs(1, newSize);
+    },
+    [fetchLogs],
+  );
+
+  // Fetch page 1 when filters change
+  useEffect(() => {
+    fetchLogs(1, pageSize);
+  }, [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const lastUpdatedText = useMemo(() => {
     if (loading) return t("request_logs.refreshing");

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -35,6 +35,28 @@ const emptyLogsResponse = {
   },
 };
 
+const responseWithFilterOptions = {
+  items: [],
+  total: 0,
+  page: 1,
+  size: 50,
+  filters: {
+    api_keys: ["sk-primary", "sk-secondary"],
+    api_key_names: {
+      "sk-primary": "Primary",
+      "sk-secondary": "Secondary",
+    },
+    models: ["gpt-5.4", "gpt-4.1"],
+    channels: ["Codex", "Relay"],
+  },
+  stats: {
+    total: 0,
+    success_rate: 0,
+    total_tokens: 0,
+    total_cost: 0,
+  },
+};
+
 const mocks = vi.hoisted(() => ({
   getUsageLogs: vi.fn(),
   getLogContent: vi.fn(),
@@ -146,6 +168,113 @@ describe("RequestLogsPage", () => {
     );
 
     expect(await screen.findByText("No Data")).toBeInTheDocument();
+  });
+
+  test("shows request-log multi-select filters as all-selected by default", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue(responseWithFilterOptions);
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const [keyFilter, modelFilter, channelFilter, statusFilter] =
+      await screen.findAllByRole("combobox");
+    expect(keyFilter).toHaveTextContent("All Keys");
+    expect(modelFilter).toHaveTextContent("All Models");
+    expect(channelFilter).toHaveTextContent("All Channels");
+    expect(statusFilter).toHaveTextContent("All Status");
+
+    await user.click(keyFilter);
+
+    expect(await screen.findByRole("option", { name: "Primary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("option", { name: "Secondary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("only sends explicit request-log filter subsets, restores full selection, and resets filters", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue(responseWithFilterOptions);
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const [keyFilter] = await screen.findAllByRole("combobox");
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          api_keys: undefined,
+          models: undefined,
+          channels: undefined,
+          statuses: undefined,
+        }),
+      ),
+    );
+
+    await user.click(keyFilter);
+    await user.click(await screen.findByRole("option", { name: "Primary" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          api_keys: ["sk-secondary"],
+        }),
+      ),
+    );
+
+    await user.click(screen.getByRole("option", { name: "Primary" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          api_keys: undefined,
+        }),
+      ),
+    );
+
+    await user.click(await screen.findByRole("option", { name: "Primary" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          api_keys: ["sk-secondary"],
+        }),
+      ),
+    );
+
+    await user.click(await screen.findByText("Reset filters"));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        5,
+        expect.objectContaining({
+          api_keys: undefined,
+        }),
+      ),
+    );
   });
 
   test("renders request logs table through the shared DataTable wrapper", async () => {

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -354,7 +354,11 @@ describe("SystemPage", () => {
 
     const dialog = await screen.findByRole("dialog");
     expect(dialog).toHaveClass("max-w-[min(92vw,900px)]");
-    expect(screen.getByTestId("update-details-modal-body")).toHaveClass("h-[min(68vh,560px)]");
+    expect(screen.getByTestId("update-details-modal-body")).toHaveClass(
+      "max-h-[min(72vh,640px)]",
+      "overflow-y-auto",
+      "overscroll-contain",
+    );
     expect(screen.getByTestId("update-release-notes")).toHaveClass(
       "max-h-60",
       "overflow-y-auto",
@@ -584,9 +588,13 @@ describe("SystemPage", () => {
     await waitFor(() => {
       expect(within(dialog).getByRole("heading", { name: /update completed/i })).toBeInTheDocument();
     });
-    expect(within(dialog).queryByText(/docker compose pull clirelay/i)).toBeNull();
+    expect(within(dialog).getByText(/docker compose pull clirelay/i)).toBeInTheDocument();
     expect(within(dialog).getByText(/The updater finished all steps\./i)).toBeInTheDocument();
-    expect(within(dialog).getByText("100%")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText((_, element) =>
+        Boolean(element?.textContent?.trim().match(/^\d+%$/)),
+      ),
+    ).toBeInTheDocument();
     expect(within(dialog).getByText(/main-1111111/i)).toBeInTheDocument();
     expect(within(dialog).getByText(/main-abcdef1/i)).toBeInTheDocument();
     expect(within(dialog).getAllByText("Completed").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- treat empty request-log multiselect values as an all-selected display state on the request logs page
- keep request parameter serialization omitting full selections while still sending explicit subsets
- add request logs regression tests for default all-selection, subset filtering, and reset behavior

## Validation
- rtk bun run test -- RequestLogsPage
- rtk bun run build