### PR TITLE
fix: avoid request-log multiselect bulk toggle jump

### DIFF
--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -54,6 +54,7 @@ export interface SearchableCheckboxMultiSelectProps {
   maxSummaryItems?: number;
   mobileBreakpoint?: number;
   emptyValueMeansAllSelected?: boolean;
+  showFilteredToggleWithoutQuery?: boolean;
 }
 
 function optionText(option: SearchableCheckboxMultiSelectOption): string {
@@ -81,6 +82,7 @@ export function SearchableCheckboxMultiSelect({
   maxSummaryItems = 2,
   mobileBreakpoint = 640,
   emptyValueMeansAllSelected = false,
+  showFilteredToggleWithoutQuery = true,
 }: SearchableCheckboxMultiSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -130,7 +132,9 @@ export function SearchableCheckboxMultiSelect({
   const allVisibleSelected =
     visibleValues.length > 0 && visibleValues.every((optionValue) => selectedSet.has(optionValue));
 
-  const showFilteredToggle = !(showAllSelectionSummary && query.trim().length === 0);
+  const hasQuery = query.trim().length > 0;
+  const showFilteredToggle =
+    hasQuery || (showFilteredToggleWithoutQuery && !showAllSelectionSummary);
 
   const updatePosition = useCallback(() => {
     const trigger = triggerRef.current;

--- a/pages/request-logs/RequestLogsFilters.tsx
+++ b/pages/request-logs/RequestLogsFilters.tsx
@@ -66,6 +66,7 @@ export function RequestLogsFilters({
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
+            showFilteredToggleWithoutQuery={false}
           />
         </div>
         <div className="w-full min-[480px]:w-auto sm:w-[200px]">
@@ -84,6 +85,7 @@ export function RequestLogsFilters({
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
+            showFilteredToggleWithoutQuery={false}
           />
         </div>
         <div className="w-full min-[480px]:w-auto sm:w-[180px]">
@@ -102,6 +104,7 @@ export function RequestLogsFilters({
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
+            showFilteredToggleWithoutQuery={false}
           />
         </div>
         <div className="w-full min-[480px]:w-auto sm:w-[150px]">
@@ -120,6 +123,7 @@ export function RequestLogsFilters({
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
+            showFilteredToggleWithoutQuery={false}
           />
         </div>
 

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -277,6 +277,32 @@ describe("RequestLogsPage", () => {
     );
   });
 
+  test("keeps the filtered-results bulk action hidden until the user actually searches", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue(responseWithFilterOptions);
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const [, modelFilter] = await screen.findAllByRole("combobox");
+
+    await user.click(modelFilter);
+    await user.click(await screen.findByRole("option", { name: "gpt-5.4" }));
+
+    expect(screen.queryByRole("button", { name: /Select shown/i })).not.toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox"), "gpt");
+
+    expect(screen.getByRole("button", { name: /Select shown/i })).toBeInTheDocument();
+  });
+
   test("renders request logs table through the shared DataTable wrapper", async () => {
     await i18n.changeLanguage("zh-CN");
 


### PR DESCRIPTION
## Summary
- add an opt-in switch to hide the bulk filtered-results row while no search query is present
- disable that bulk row for request-log multi-select filters so unchecking a model no longer inserts a new row mid-click
- add a request-logs regression test that keeps the bulk action hidden until a real search happens

## Verification
- rtk bun run test -- RequestLogsPage
- rtk bun run build