### PR TITLE
Refine updater completed modal layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ playwright-report/
 .sisyphus/
 .agentflow/
 .helloagents/
+output/playwright/

--- a/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
+++ b/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
@@ -423,6 +423,7 @@ function UpdateProgressConsole({
   const isCompleted = progressStatus === "completed";
   const isFailed = progressStatus === "failed";
   const isRunning = progressStatus === "running";
+  const showLiveLogs = !isCompleted;
   const progressTarget = useVisualProgressTarget(progress);
   const animatedPercent = useAnimatedProgressValue(progressTarget, isFailed);
   const sourceLogs = progress?.logs ?? [];
@@ -463,12 +464,16 @@ function UpdateProgressConsole({
           : "bg-slate-400";
 
   useEffect(() => {
+    if (!showLiveLogs) return;
     if (!logContainerRef.current) return;
     logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight;
-  }, [visibleLogs]);
+  }, [showLiveLogs, visibleLogs]);
 
   return (
-    <div data-testid="update-progress-console" className="min-w-0 space-y-4">
+    <div
+      data-testid="update-progress-console"
+      className={`min-w-0 ${isCompleted ? "space-y-3" : "space-y-4"}`}
+    >
       <section className="min-w-0 overflow-hidden rounded-2xl border border-slate-200 bg-[radial-gradient(circle_at_top_left,_rgba(14,165,233,0.08),_transparent_45%),linear-gradient(180deg,_rgba(255,255,255,1)_0%,_rgba(248,250,252,1)_100%)] p-4 shadow-sm dark:border-neutral-800 dark:bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.14),_transparent_42%),linear-gradient(180deg,_rgba(10,15,27,1)_0%,_rgba(8,12,22,1)_100%)]">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-3">
@@ -538,59 +543,61 @@ function UpdateProgressConsole({
         </dl>
       </section>
 
-      <section
-        data-testid="update-log-stream"
-        className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
-      >
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-          <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
-            {t("auto_update.progress_logs")}
-          </h4>
-          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-white/8 dark:text-white/60">
-            {t("auto_update.progress_log_count", { count: sourceLogs.length })}
-          </span>
-        </div>
+      {showLiveLogs ? (
+        <section
+          data-testid="update-log-stream"
+          className="min-w-0 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
+        >
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <h4 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("auto_update.progress_logs")}
+            </h4>
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-white/8 dark:text-white/60">
+              {t("auto_update.progress_log_count", { count: sourceLogs.length })}
+            </span>
+          </div>
 
-        {visibleLogs.length ? (
-          <div
-            ref={logContainerRef}
-            className="max-h-72 overflow-y-auto rounded-2xl bg-slate-950 px-3 py-3 font-mono text-[12px] leading-6 text-slate-100 shadow-inner dark:bg-black"
-          >
-            {visibleLogs.map((entry, index) => {
-              const stream = entry.stream?.trim().toLowerCase() || "stdout";
-              const streamClass =
-                stream === "stderr"
-                  ? "bg-rose-500/15 text-rose-200 ring-rose-400/20"
-                  : "bg-sky-500/15 text-sky-100 ring-sky-400/20";
-              return (
-                <div
-                  key={`${entry.timestamp ?? "unknown"}-${stream}-${index}-${entry.message}`}
-                  className="flex min-w-0 items-start gap-3 border-b border-white/6 py-1.5 last:border-b-0"
-                >
-                  <span className="shrink-0 text-[11px] text-slate-500">
-                    {formatLogTimestamp(entry.timestamp) || "--:--:--"}
-                  </span>
-                  <span
-                    className={[
-                      "mt-0.5 inline-flex shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ring-1",
-                      streamClass,
-                    ].join(" ")}
+          {visibleLogs.length ? (
+            <div
+              ref={logContainerRef}
+              className="max-h-72 overflow-y-auto rounded-2xl bg-slate-950 px-3 py-3 font-mono text-[12px] leading-6 text-slate-100 shadow-inner dark:bg-black"
+            >
+              {visibleLogs.map((entry, index) => {
+                const stream = entry.stream?.trim().toLowerCase() || "stdout";
+                const streamClass =
+                  stream === "stderr"
+                    ? "bg-rose-500/15 text-rose-200 ring-rose-400/20"
+                    : "bg-sky-500/15 text-sky-100 ring-sky-400/20";
+                return (
+                  <div
+                    key={`${entry.timestamp ?? "unknown"}-${stream}-${index}-${entry.message}`}
+                    className="flex min-w-0 items-start gap-3 border-b border-white/6 py-1.5 last:border-b-0"
                   >
-                    {stream}
-                  </span>
-                  <span className="min-w-0 flex-1 whitespace-pre-wrap break-words text-slate-100">
-                    {entry.message}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/40 dark:text-white/50">
-            {t("auto_update.progress_logs_empty")}
-          </div>
-        )}
-      </section>
+                    <span className="shrink-0 text-[11px] text-slate-500">
+                      {formatLogTimestamp(entry.timestamp) || "--:--:--"}
+                    </span>
+                    <span
+                      className={[
+                        "mt-0.5 inline-flex shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ring-1",
+                        streamClass,
+                      ].join(" ")}
+                    >
+                      {stream}
+                    </span>
+                    <span className="min-w-0 flex-1 whitespace-pre-wrap break-words text-slate-100">
+                      {entry.message}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/40 dark:text-white/50">
+              {t("auto_update.progress_logs_empty")}
+            </div>
+          )}
+        </section>
+      ) : null}
     </div>
   );
 }
@@ -722,7 +729,9 @@ export function UpdateDetailsModal({
       title={modalTitle}
       description={modalDescription}
       maxWidth="max-w-[min(92vw,900px)]"
-      bodyHeightClassName="max-h-[min(72vh,640px)]"
+      bodyHeightClassName={
+        progressCompleted ? "max-h-[min(62vh,520px)]" : "max-h-[min(72vh,640px)]"
+      }
       bodyTestId="update-details-modal-body"
       onClose={() => {
         if (!activeUpdate) onClose();

--- a/apps/admin-panel/src/app/update/__tests__/UpdateDetailsModal.test.tsx
+++ b/apps/admin-panel/src/app/update/__tests__/UpdateDetailsModal.test.tsx
@@ -112,5 +112,7 @@ describe("UpdateDetailsModal", () => {
     expect(screen.queryByRole("button", { name: /updating/i })).toBeNull();
     expect(screen.queryByText("Close")).toBeNull();
     expect(screen.getByRole("button", { name: /refresh page/i })).toBeEnabled();
+    expect(screen.queryByTestId("update-log-stream")).toBeNull();
+    expect(screen.getByTestId("update-details-modal-body")).toHaveClass("max-h-[min(62vh,520px)]");
   });
 });


### PR DESCRIPTION
## Summary
- remove live Docker logs from the completed updater modal state
- tighten completed-state modal height to avoid empty vertical space
- ignore Playwright output artifacts used for browser verification

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- src/app/update/__tests__/UpdateDetailsModal.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- Playwright browser verification against local preview