### PR TITLE
refactor: standardize API client requests

### DIFF
--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -7,17 +7,16 @@ import {
   useMemo,
   useState,
 } from "react";
-import { AUTH_STORAGE_KEY } from "@code-proxy/api-client";
 import {
   computeManagementApiBase,
+  readPersistedAuthSnapshot,
   detectApiBaseFromLocation,
+  clearPersistedAuthSnapshot,
   normalizeApiBase,
+  writePersistedAuthSnapshot,
 } from "@code-proxy/api-client";
 import { apiClient } from "@code-proxy/api-client";
 import { configApi } from "@code-proxy/api-client";
-import type { AuthSnapshot } from "@code-proxy/api-client";
-
-const AUTH_PERSIST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 interface AuthContextState {
   state: {
@@ -45,46 +44,6 @@ interface AuthContextState {
 
 const AuthContext = createContext<AuthContextState | null>(null);
 
-interface PersistedAuthSnapshot extends AuthSnapshot {
-  expiresAt: number;
-}
-
-const readAuthSnapshot = (): AuthSnapshot | null => {
-  try {
-    const raw = window.localStorage.getItem(AUTH_STORAGE_KEY);
-    if (!raw) {
-      return null;
-    }
-    const parsed = JSON.parse(raw) as Partial<PersistedAuthSnapshot>;
-    if (typeof parsed.expiresAt !== "number" || parsed.expiresAt <= Date.now()) {
-      window.localStorage.removeItem(AUTH_STORAGE_KEY);
-      return null;
-    }
-    if (!parsed.apiBase || !parsed.managementKey) {
-      return null;
-    }
-    return {
-      apiBase: normalizeApiBase(parsed.apiBase),
-      managementKey: parsed.managementKey,
-      rememberPassword: Boolean(parsed.rememberPassword),
-    };
-  } catch {
-    return null;
-  }
-};
-
-const writeAuthSnapshot = (snapshot: AuthSnapshot): void => {
-  const payload: PersistedAuthSnapshot = {
-    ...snapshot,
-    expiresAt: Date.now() + AUTH_PERSIST_TTL_MS,
-  };
-  window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(payload));
-};
-
-const clearAuthSnapshot = (): void => {
-  window.localStorage.removeItem(AUTH_STORAGE_KEY);
-};
-
 export function AuthProvider({ children }: PropsWithChildren) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);
@@ -96,7 +55,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
   const bootstrap = useCallback(async () => {
     const fallbackBase = detectApiBaseFromLocation();
-    const snapshot = readAuthSnapshot();
+    const snapshot = readPersistedAuthSnapshot();
 
     const resolvedBase = snapshot?.apiBase ?? fallbackBase;
     const resolvedKey = snapshot?.managementKey ?? "";
@@ -122,7 +81,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setIsAuthenticated(true);
     } catch {
       setIsAuthenticated(false);
-      clearAuthSnapshot();
+      clearPersistedAuthSnapshot();
     } finally {
       setIsRestoring(false);
     }
@@ -135,7 +94,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     const handleUnauthorized = () => {
       setIsAuthenticated(false);
-      clearAuthSnapshot();
+      clearPersistedAuthSnapshot();
     };
 
     const handleVersion = (event: Event) => {
@@ -174,13 +133,13 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setIsAuthenticated(true);
 
       if (input.rememberPassword) {
-        writeAuthSnapshot({
+        writePersistedAuthSnapshot({
           apiBase: normalizedBase,
           managementKey: trimmedKey,
           rememberPassword: true,
         });
       } else {
-        clearAuthSnapshot();
+        clearPersistedAuthSnapshot();
       }
     },
     [],
@@ -189,7 +148,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const logout = useCallback(() => {
     setIsAuthenticated(false);
     setManagementKey("");
-    clearAuthSnapshot();
+    clearPersistedAuthSnapshot();
   }, []);
 
   const restore = useCallback(async () => {

--- a/packages/api-client/src/client/__tests__/client.test.ts
+++ b/packages/api-client/src/client/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { ApiClient } from "@code-proxy/api-client";
+import { ApiClient, ApiError, unwrapApiEnvelope } from "@code-proxy/api-client";
 import { computeManagementApiBase, normalizeApiBase } from "../constants";
 
 describe("API base normalization", () => {
@@ -22,6 +22,88 @@ describe("API base normalization", () => {
     expect(computeManagementApiBase("https://example.com/relay/v0/management/config")).toBe(
       "https://example.com/relay/v0/management",
     );
+  });
+});
+
+describe("ApiClient request standardization", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("unwraps standardized API envelopes when data helpers are used", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: 0, data: { enabled: true } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({ apiBase: "http://localhost:8317", managementKey: "test-key" });
+
+    await expect(client.getData("/config")).resolves.toEqual({ enabled: true });
+    expect(unwrapApiEnvelope<{ ok: boolean }>({ result: { ok: true } })).toEqual({ ok: true });
+  });
+
+  test("keeps management Authorization controlled by the configured key", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({ apiBase: "http://localhost:8317", managementKey: "expected-key" });
+    await client.get("/config", {
+      headers: {
+        Authorization: "Bearer stale-key",
+        "X-Request-Source": "unit-test",
+      },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer expected-key");
+    expect(headers.get("X-Request-Source")).toBe("unit-test");
+  });
+
+  test("rejects absolute request paths before they can be fetched", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({ apiBase: "http://localhost:8317", managementKey: "test-key" });
+
+    await expect(client.get("https://evil.example/config")).rejects.toThrow(
+      "Management API paths must be relative",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("surfaces HTTP metadata through ApiError", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "bad request" }), {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({ apiBase: "http://localhost:8317", managementKey: "test-key" });
+
+    await expect(client.get("/config")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 400,
+      statusText: "Bad Request",
+      isAuthError: false,
+    } satisfies Partial<ApiError>);
   });
 });
 

--- a/packages/api-client/src/client/auth-storage.ts
+++ b/packages/api-client/src/client/auth-storage.ts
@@ -1,0 +1,58 @@
+import type { AuthSnapshot } from "../dto/types";
+import { AUTH_PERSIST_TTL_MS, AUTH_STORAGE_KEY, normalizeApiBase } from "./constants";
+
+interface PersistedAuthSnapshot extends AuthSnapshot {
+  expiresAt: number;
+}
+
+const getStorage = (): Storage | null => {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+};
+
+export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(AUTH_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<PersistedAuthSnapshot>;
+    if (typeof parsed.expiresAt !== "number" || parsed.expiresAt <= Date.now()) {
+      storage.removeItem(AUTH_STORAGE_KEY);
+      return null;
+    }
+    if (!parsed.apiBase || !parsed.managementKey) {
+      storage.removeItem(AUTH_STORAGE_KEY);
+      return null;
+    }
+
+    return {
+      apiBase: normalizeApiBase(parsed.apiBase),
+      managementKey: parsed.managementKey,
+      rememberPassword: Boolean(parsed.rememberPassword),
+    };
+  } catch {
+    storage.removeItem(AUTH_STORAGE_KEY);
+    return null;
+  }
+};
+
+export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
+  const storage = getStorage();
+  if (!storage) return;
+
+  const payload: PersistedAuthSnapshot = {
+    ...snapshot,
+    expiresAt: Date.now() + AUTH_PERSIST_TTL_MS,
+  };
+  storage.setItem(AUTH_STORAGE_KEY, JSON.stringify(payload));
+};
+
+export const clearPersistedAuthSnapshot = (): void => {
+  getStorage()?.removeItem(AUTH_STORAGE_KEY);
+};

--- a/packages/api-client/src/client/client.ts
+++ b/packages/api-client/src/client/client.ts
@@ -4,21 +4,14 @@ import {
   BUILD_DATE_HEADER_KEYS,
   computeManagementApiBase,
 } from "./constants";
+import { extractDownloadFilename, type BrowserFilePickerWindow } from "./download";
+import { ApiError, extractApiErrorMessage, isAbortError, truncateErrorText } from "./errors";
+import { unwrapApiEnvelope, type ApiSuccessEnvelope } from "./response";
 
 interface ApiClientConfig {
   apiBase: string;
   managementKey: string;
 }
-
-type BrowserFilePickerWindow = Window &
-  typeof globalThis & {
-    showSaveFilePicker?: (options?: { suggestedName?: string }) => Promise<{
-      createWritable: () => Promise<{
-        write: (data: BufferSource | Blob | string) => Promise<void>;
-        close: () => Promise<void>;
-      }>;
-    }>;
-  };
 
 type Primitive = string | number | boolean;
 
@@ -27,9 +20,35 @@ export interface RequestOptions {
   headers?: HeadersInit;
   timeoutMs?: number;
   signal?: AbortSignal;
+  unwrapEnvelope?: boolean;
 }
 
 type ResponseType = "json" | "text" | "blob";
+
+const RESERVED_MANAGEMENT_HEADERS = new Set(["authorization"]);
+
+const getWindowOrigin = () => {
+  try {
+    return window.location.origin;
+  } catch {
+    return "http://localhost";
+  }
+};
+
+const dispatchWindowEvent = (event: Event): void => {
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    window.dispatchEvent(event);
+  }
+};
+
+const normalizeRequestPath = (path: string): string => {
+  const trimmed = path.trim();
+  if (!trimmed) return "/";
+  if (/^(?:https?:)?\/\//i.test(trimmed)) {
+    throw new ApiError({ message: "Management API paths must be relative." });
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+};
 
 export class ApiClient {
   private apiBase = "";
@@ -45,7 +64,8 @@ export class ApiClient {
   }
 
   private buildUrl(path: string, params?: RequestOptions["params"]): string {
-    const baseUrl = `${this.apiBase}${path}`;
+    const requestPath = normalizeRequestPath(path);
+    const baseUrl = `${this.apiBase}${requestPath}`;
     if (!params) return baseUrl;
 
     const pairs = Object.entries(params).filter(
@@ -53,11 +73,12 @@ export class ApiClient {
     );
     if (pairs.length === 0) return baseUrl;
 
-    const url = new URL(baseUrl, window.location.origin);
+    const origin = getWindowOrigin();
+    const url = new URL(baseUrl, origin);
     for (const [key, value] of pairs) {
       url.searchParams.set(key, String(value));
     }
-    return url.toString().replace(window.location.origin, "");
+    return url.toString().replace(origin, "");
   }
 
   private readHeader(headers: Headers, keys: string[]): string | null {
@@ -70,6 +91,13 @@ export class ApiClient {
     return null;
   }
 
+  private mergeAllowedHeaders(target: Headers, source: Headers): void {
+    source.forEach((value, key) => {
+      if (RESERVED_MANAGEMENT_HEADERS.has(key.toLowerCase())) return;
+      target.set(key, value);
+    });
+  }
+
   private buildHeaders(init?: RequestInit, options?: RequestOptions): Headers {
     const headersFromOptions = new Headers(options?.headers);
     const headersFromInit = new Headers(init?.headers);
@@ -80,24 +108,25 @@ export class ApiClient {
     if (typeof init?.body === "string" && !hasContentType) {
       headers.set("Content-Type", "application/json");
     }
+
+    this.mergeAllowedHeaders(headers, headersFromOptions);
+    this.mergeAllowedHeaders(headers, headersFromInit);
+
     if (this.managementKey) {
       headers.set("Authorization", `Bearer ${this.managementKey}`);
     }
-
-    headersFromOptions.forEach((value, key) => {
-      headers.set(key, value);
-    });
-    headersFromInit.forEach((value, key) => {
-      headers.set(key, value);
-    });
 
     return headers;
   }
 
   private createAbortController(options?: RequestOptions) {
     const controller = new AbortController();
-    const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS;
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const timeoutMs = Math.max(1, options?.timeoutMs ?? REQUEST_TIMEOUT_MS);
+    let timedOut = false;
+    const timer = globalThis.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
     const externalSignal = options?.signal;
     const onExternalAbort = () => controller.abort();
 
@@ -111,8 +140,9 @@ export class ApiClient {
 
     return {
       controller,
+      didTimeout: () => timedOut,
       cleanup: () => {
-        clearTimeout(timer);
+        globalThis.clearTimeout(timer);
         if (externalSignal) {
           externalSignal.removeEventListener("abort", onExternalAbort);
         }
@@ -120,42 +150,61 @@ export class ApiClient {
     };
   }
 
-  private async buildErrorMessage(response: Response): Promise<string> {
+  private async parseResponseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+
+    const contentType = response.headers.get("Content-Type") ?? "";
+    if (
+      contentType.toLowerCase().includes("text/html") &&
+      /^<!doctype html|^<html[\s>]/i.test(trimmed)
+    ) {
+      throw new ApiError({
+        message:
+          "Management API returned the web panel HTML instead of JSON. Check the API base URL.",
+        status: response.status,
+        statusText: response.statusText,
+        url: response.url,
+        payload: truncateErrorText(trimmed),
+      });
+    }
+
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return text;
+    }
+  }
+
+  private async buildApiError(response: Response): Promise<ApiError> {
+    let payload: unknown = null;
     let message = `Request failed (${response.status})`;
+
     try {
       const text = await response.text();
       const trimmed = text.trim();
-
       if (trimmed) {
         try {
-          const errorPayload = JSON.parse(trimmed) as Record<string, unknown>;
-          const nestedError =
-            errorPayload.error &&
-            typeof errorPayload.error === "object" &&
-            !Array.isArray(errorPayload.error)
-              ? (errorPayload.error as Record<string, unknown>)
-              : null;
-          const errorText =
-            typeof errorPayload.error === "string"
-              ? errorPayload.error
-              : typeof nestedError?.message === "string"
-                ? nestedError.message
-                : typeof errorPayload.message === "string"
-                  ? errorPayload.message
-                  : null;
-          if (errorText) {
-            message = errorText;
-          } else {
-            message = trimmed;
-          }
+          payload = JSON.parse(trimmed) as unknown;
+          message = extractApiErrorMessage(payload, truncateErrorText(trimmed));
         } catch {
-          message = trimmed;
+          payload = truncateErrorText(trimmed);
+          message = truncateErrorText(trimmed);
         }
       }
     } catch {
-      // 忽略错误体解析失败
+      // Keep the status-based fallback when error body cannot be read.
     }
-    return message;
+
+    return new ApiError({
+      message,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url,
+      payload,
+      isAuthError: this.shouldSuspendAuth(response.status, message),
+    });
   }
 
   private shouldSuspendAuth(status: number, message: string): boolean {
@@ -166,12 +215,16 @@ export class ApiClient {
   private suspendAuth(): void {
     if (this.authSuspended) return;
     this.authSuspended = true;
-    window.dispatchEvent(new Event("unauthorized"));
+    dispatchWindowEvent(new Event("unauthorized"));
   }
 
   private assertAuthActive(): void {
     if (this.authSuspended) {
-      throw new Error("Management session is no longer valid. Please sign in again.");
+      throw new ApiError({
+        message: "Management session is no longer valid. Please sign in again.",
+        status: 401,
+        isAuthError: true,
+      });
     }
   }
 
@@ -180,32 +233,12 @@ export class ApiClient {
     const buildDate = this.readHeader(response.headers, BUILD_DATE_HEADER_KEYS);
 
     if (version || buildDate) {
-      window.dispatchEvent(
+      dispatchWindowEvent(
         new CustomEvent("server-version-update", {
           detail: { version, buildDate },
         }),
       );
     }
-  }
-
-  private extractDownloadFilename(headers: Headers, fallback: string): string {
-    const header = headers.get("Content-Disposition")?.trim();
-    if (!header) return fallback;
-
-    const utf8Match = header.match(/filename\*=UTF-8''([^;]+)/i);
-    if (utf8Match?.[1]) {
-      try {
-        return decodeURIComponent(utf8Match[1]);
-      } catch {
-        return utf8Match[1];
-      }
-    }
-
-    const quotedMatch = header.match(/filename="([^"]+)"/i);
-    if (quotedMatch?.[1]) return quotedMatch[1];
-
-    const plainMatch = header.match(/filename=([^;]+)/i);
-    return plainMatch?.[1]?.trim() || fallback;
   }
 
   private async request<T>(
@@ -221,7 +254,7 @@ export class ApiClient {
     } = {},
   ): Promise<T> {
     this.assertAuthActive();
-    const { controller, cleanup } = this.createAbortController(options);
+    const { controller, cleanup, didTimeout } = this.createAbortController(options);
 
     try {
       const url = this.buildUrl(path, options?.params);
@@ -236,11 +269,11 @@ export class ApiClient {
       this.applyVersionHeaders(response);
 
       if (!response.ok) {
-        const message = await this.buildErrorMessage(response);
-        if (this.shouldSuspendAuth(response.status, message)) {
+        const error = await this.buildApiError(response);
+        if (error.isAuthError) {
           this.suspendAuth();
         }
-        throw new Error(message);
+        throw error;
       }
 
       if (response.status === 204) {
@@ -251,31 +284,26 @@ export class ApiClient {
         return (await response.blob()) as T;
       }
 
-      const text = await response.text();
       if (responseType === "text") {
-        return text as T;
+        return (await response.text()) as T;
       }
 
-      const trimmed = text.trim();
-      if (!trimmed) {
-        return undefined as T;
+      const payload = await this.parseResponseBody(response);
+      return (options?.unwrapEnvelope ? unwrapApiEnvelope<T>(payload) : payload) as T;
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
       }
-
-      const contentType = response.headers.get("Content-Type") ?? "";
-      if (
-        contentType.toLowerCase().includes("text/html") &&
-        /^<!doctype html|^<html[\s>]/i.test(trimmed)
-      ) {
-        throw new Error(
-          "Management API returned the web panel HTML instead of JSON. Check the API base URL.",
-        );
+      if (isAbortError(error)) {
+        throw new ApiError({
+          message: didTimeout()
+            ? `Request timed out after ${options?.timeoutMs ?? REQUEST_TIMEOUT_MS}ms`
+            : "Request was cancelled",
+          isTimeout: didTimeout(),
+          url: path,
+        });
       }
-
-      try {
-        return JSON.parse(trimmed) as T;
-      } catch {
-        return text as unknown as T;
-      }
+      throw error;
     } finally {
       cleanup();
     }
@@ -283,6 +311,10 @@ export class ApiClient {
 
   get<T>(path: string, options?: RequestOptions): Promise<T> {
     return this.request<T>(path, { options });
+  }
+
+  getData<T>(path: string, options?: RequestOptions): Promise<T> {
+    return this.get<T>(path, { ...options, unwrapEnvelope: true });
   }
 
   post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
@@ -295,6 +327,10 @@ export class ApiClient {
     });
   }
 
+  postData<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.post<T>(path, body, { ...options, unwrapEnvelope: true });
+  }
+
   put<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
     return this.request<T>(path, {
       init: {
@@ -303,6 +339,10 @@ export class ApiClient {
       },
       options,
     });
+  }
+
+  putData<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.put<T>(path, body, { ...options, unwrapEnvelope: true });
   }
 
   patch<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
@@ -315,6 +355,10 @@ export class ApiClient {
     });
   }
 
+  patchData<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.patch<T>(path, body, { ...options, unwrapEnvelope: true });
+  }
+
   delete<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
     return this.request<T>(path, {
       init: {
@@ -323,6 +367,10 @@ export class ApiClient {
       },
       options,
     });
+  }
+
+  deleteData<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+    return this.delete<T>(path, body, { ...options, unwrapEnvelope: true });
   }
 
   postForm<T>(path: string, formData: FormData, options?: RequestOptions): Promise<T> {
@@ -360,7 +408,7 @@ export class ApiClient {
     options?: RequestOptions,
   ): Promise<void> {
     this.assertAuthActive();
-    const { controller, cleanup } = this.createAbortController(options);
+    const { controller, cleanup, didTimeout } = this.createAbortController(options);
 
     try {
       const url = this.buildUrl(path, options?.params);
@@ -374,14 +422,14 @@ export class ApiClient {
       this.applyVersionHeaders(response);
 
       if (!response.ok) {
-        const message = await this.buildErrorMessage(response);
-        if (this.shouldSuspendAuth(response.status, message)) {
+        const error = await this.buildApiError(response);
+        if (error.isAuthError) {
           this.suspendAuth();
         }
-        throw new Error(message);
+        throw error;
       }
 
-      const filename = this.extractDownloadFilename(response.headers, preferredFilename);
+      const filename = extractDownloadFilename(response.headers, preferredFilename);
       const pickerWindow = window as BrowserFilePickerWindow;
 
       if (pickerWindow.showSaveFilePicker && response.body) {
@@ -414,7 +462,21 @@ export class ApiClient {
       link.href = objectUrl;
       link.download = filename;
       link.click();
-      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+      globalThis.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      if (isAbortError(error)) {
+        throw new ApiError({
+          message: didTimeout()
+            ? `Request timed out after ${options?.timeoutMs ?? REQUEST_TIMEOUT_MS}ms`
+            : "Request was cancelled",
+          isTimeout: didTimeout(),
+          url: path,
+        });
+      }
+      throw error;
     } finally {
       cleanup();
     }
@@ -422,3 +484,5 @@ export class ApiClient {
 }
 
 export const apiClient = new ApiClient();
+export type { ApiSuccessEnvelope };
+export { ApiError, unwrapApiEnvelope };

--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -2,6 +2,7 @@ export const MANAGEMENT_API_PREFIX = "/v0/management";
 export const DEFAULT_API_PORT = 8317;
 export const REQUEST_TIMEOUT_MS = 30000;
 export const AUTH_STORAGE_KEY = "code-proxy-admin-auth";
+export const AUTH_PERSIST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 export const VERSION_HEADER_KEYS = ["x-cpa-version", "x-server-version"];
 export const BUILD_DATE_HEADER_KEYS = ["x-cpa-build-date", "x-server-build-date"];
 

--- a/packages/api-client/src/client/download.ts
+++ b/packages/api-client/src/client/download.ts
@@ -1,0 +1,47 @@
+export type BrowserFilePickerWindow = Window &
+  typeof globalThis & {
+    showSaveFilePicker?: (options?: { suggestedName?: string }) => Promise<{
+      createWritable: () => Promise<{
+        write: (data: BufferSource | Blob | string) => Promise<void>;
+        close: () => Promise<void>;
+      }>;
+    }>;
+  };
+
+export const sanitizeDownloadFilename = (filename: string, fallback: string): string => {
+  const sanitized = filename
+    .replace(/[\\/]+/g, "-")
+    .split("")
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code >= 32 && code !== 127;
+    })
+    .join("")
+    .trim();
+
+  if (!sanitized || sanitized === "." || sanitized === "..") {
+    return fallback;
+  }
+  return sanitized.slice(0, 180);
+};
+
+export const extractDownloadFilename = (headers: Headers, fallback: string): string => {
+  const safeFallback = sanitizeDownloadFilename(fallback, "download");
+  const header = headers.get("Content-Disposition")?.trim();
+  if (!header) return safeFallback;
+
+  const utf8Match = header.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return sanitizeDownloadFilename(decodeURIComponent(utf8Match[1]), safeFallback);
+    } catch {
+      return sanitizeDownloadFilename(utf8Match[1], safeFallback);
+    }
+  }
+
+  const quotedMatch = header.match(/filename="([^"]+)"/i);
+  if (quotedMatch?.[1]) return sanitizeDownloadFilename(quotedMatch[1], safeFallback);
+
+  const plainMatch = header.match(/filename=([^;]+)/i);
+  return sanitizeDownloadFilename(plainMatch?.[1]?.trim() || safeFallback, safeFallback);
+};

--- a/packages/api-client/src/client/errors.ts
+++ b/packages/api-client/src/client/errors.ts
@@ -1,0 +1,97 @@
+import { isRecord } from "./response";
+
+const MAX_ERROR_TEXT_LENGTH = 2000;
+
+export interface ApiErrorOptions {
+  message: string;
+  status?: number;
+  statusText?: string;
+  url?: string;
+  method?: string;
+  payload?: unknown;
+  data?: unknown;
+  isTimeout?: boolean;
+  isAuthError?: boolean;
+  cause?: unknown;
+}
+
+export type ApiClientErrorOptions = ApiErrorOptions;
+export type ApiErrorBody = Record<string, unknown> | string | null;
+
+export const isAbortError = (error: unknown): error is DOMException =>
+  typeof DOMException !== "undefined" &&
+  error instanceof DOMException &&
+  error.name === "AbortError";
+
+export const truncateErrorText = (text: string): string => {
+  if (text.length <= MAX_ERROR_TEXT_LENGTH) return text;
+  return `${text.slice(0, MAX_ERROR_TEXT_LENGTH)}...`;
+};
+
+export const extractApiErrorMessage = (payload: unknown, fallback: string): string => {
+  if (typeof payload === "string" && payload.trim()) {
+    return truncateErrorText(payload.trim());
+  }
+  if (!isRecord(payload)) return fallback;
+
+  const nestedError = isRecord(payload.error) ? payload.error : null;
+  const candidates = [payload.error, nestedError?.message, payload.message, payload.detail];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return truncateErrorText(candidate.trim());
+    }
+  }
+  return fallback;
+};
+
+export class ApiError extends Error {
+  readonly name: string = "ApiError";
+
+  readonly status: number;
+
+  readonly statusText: string;
+
+  readonly url: string;
+
+  readonly method: string;
+
+  readonly payload: unknown;
+
+  readonly data: unknown;
+
+  readonly isTimeout: boolean;
+
+  readonly isAuthError: boolean;
+
+  constructor({
+    message,
+    status = 0,
+    statusText = "",
+    url = "",
+    method = "",
+    payload = null,
+    data,
+    isTimeout = false,
+    isAuthError = false,
+    cause,
+  }: ApiErrorOptions) {
+    super(message);
+    this.status = status;
+    this.statusText = statusText;
+    this.url = url;
+    this.method = method;
+    this.payload = data ?? payload;
+    this.data = this.payload;
+    this.isTimeout = isTimeout;
+    this.isAuthError = isAuthError;
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class ApiClientError extends ApiError {
+  readonly name = "ApiClientError";
+}
+
+export const isApiClientError = (error: unknown): error is ApiError => error instanceof ApiError;

--- a/packages/api-client/src/client/public-client.ts
+++ b/packages/api-client/src/client/public-client.ts
@@ -1,0 +1,64 @@
+import { MANAGEMENT_API_PREFIX, detectApiBaseFromLocation } from "./constants";
+import { ApiClientError, extractApiErrorMessage } from "./errors";
+
+interface PublicRequestOptions {
+  base?: string;
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+}
+
+const parseJsonOrText = async (response: Response): Promise<unknown> => {
+  const text = await response.text();
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return trimmed;
+  }
+};
+
+const normalizePublicPath = (path: string): string => {
+  const trimmed = path.trim();
+  if (!trimmed) return "/";
+  if (/^(?:https?:)?\/\//i.test(trimmed)) {
+    throw new ApiClientError({ message: "Public API paths must be relative." });
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+};
+
+export class PublicApiClient {
+  private buildUrl(path: string, base = detectApiBaseFromLocation()): string {
+    return `${base}${MANAGEMENT_API_PREFIX}/public${normalizePublicPath(path)}`;
+  }
+
+  async post<T>(path: string, body?: unknown, options?: PublicRequestOptions): Promise<T> {
+    const url = this.buildUrl(path, options?.base);
+    const headers = new Headers(options?.headers);
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      signal: options?.signal,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const payload = await parseJsonOrText(response);
+    if (!response.ok) {
+      throw new ApiClientError({
+        message: extractApiErrorMessage(payload, `Request failed (${response.status})`),
+        status: response.status,
+        statusText: response.statusText,
+        url,
+        method: "POST",
+        data: payload ?? null,
+      });
+    }
+    return payload as T;
+  }
+}
+
+export const publicApiClient = new PublicApiClient();

--- a/packages/api-client/src/client/response.ts
+++ b/packages/api-client/src/client/response.ts
@@ -1,0 +1,56 @@
+export interface ApiSuccessEnvelope<T> {
+  data?: T;
+  result?: T;
+  success?: boolean;
+  code?: number | string;
+  status?: number | string;
+  message?: string;
+  error?: unknown;
+}
+
+export type ApiEnvelope<T> = ApiSuccessEnvelope<T>;
+
+export type ApiListPayload<T> =
+  | T[]
+  | {
+      data?: T[];
+      result?: T[];
+      items?: T[];
+      list?: T[];
+      rows?: T[];
+    };
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const isApiEnvelope = (value: unknown): value is ApiSuccessEnvelope<unknown> => {
+  if (!isRecord(value)) return false;
+  return (
+    "data" in value ||
+    "result" in value ||
+    "success" in value ||
+    "code" in value ||
+    "status" in value ||
+    "message" in value
+  );
+};
+
+export const unwrapApiEnvelope = <T>(payload: unknown): T => {
+  if (!isApiEnvelope(payload)) return payload as T;
+
+  const record = payload as Record<string, unknown>;
+  if ("data" in record) return record.data as T;
+  if ("result" in record) return record.result as T;
+  return payload as T;
+};
+
+export const ensureArrayPayload = <T>(payload: ApiListPayload<T> | unknown): T[] => {
+  if (Array.isArray(payload)) return payload as T[];
+  if (!isRecord(payload)) return [];
+
+  for (const key of ["data", "result", "items", "list", "rows"] as const) {
+    const value = payload[key];
+    if (Array.isArray(value)) return value as T[];
+  }
+  return [];
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,6 +1,7 @@
 export { ApiClient, apiClient } from "./client/client";
 export type { RequestOptions } from "./client/client";
 export {
+  AUTH_PERSIST_TTL_MS,
   AUTH_STORAGE_KEY,
   BUILD_DATE_HEADER_KEYS,
   DEFAULT_API_PORT,
@@ -11,6 +12,21 @@ export {
   detectApiBaseFromLocation,
   normalizeApiBase,
 } from "./client/constants";
+export {
+  ApiError,
+  ApiClientError,
+  extractApiErrorMessage,
+  isApiClientError,
+} from "./client/errors";
+export type { ApiErrorBody, ApiErrorOptions, ApiClientErrorOptions } from "./client/errors";
+export { ensureArrayPayload, isApiEnvelope, unwrapApiEnvelope } from "./client/response";
+export type { ApiEnvelope, ApiListPayload, ApiSuccessEnvelope } from "./client/response";
+export { publicApiClient, PublicApiClient } from "./client/public-client";
+export {
+  clearPersistedAuthSnapshot,
+  readPersistedAuthSnapshot,
+  writePersistedAuthSnapshot,
+} from "./client/auth-storage";
 export type * from "./dto/types";
 
 export { configApi } from "./endpoints/config";

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -7,9 +7,12 @@ import { LanguageSelector } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 import { LogContentModal } from "@features/log-content-viewer";
-import { MANAGEMENT_API_PREFIX } from "@code-proxy/api-client";
-import { detectApiBaseFromLocation } from "@code-proxy/api-client";
-import { fetchAvailableModels, fetchPublicChartData, fetchPublicLogs } from "./api";
+import {
+  fetchAvailableModels,
+  fetchPublicChartData,
+  fetchPublicLogContent,
+  fetchPublicLogs,
+} from "./api";
 import { LookupEmptyState } from "./components/LookupEmptyState";
 import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
 import { LookupSearchSection } from "./components/LookupSearchSection";
@@ -644,25 +647,12 @@ export function ApiKeyLookupPage() {
                   part: "input" | "output",
                   options?: { signal?: AbortSignal },
                 ) => {
-                  const base = detectApiBaseFromLocation();
-                  const url = `${base}${MANAGEMENT_API_PREFIX}/public/usage/logs/${id}/content`;
-                  const resp = await fetch(url, {
-                    method: "POST",
+                  return fetchPublicLogContent({
+                    id,
+                    apiKey: queriedKey,
+                    part,
                     signal: options?.signal,
-                    headers: {
-                      "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({
-                      api_key: queriedKey,
-                      part,
-                      format: "json",
-                    }),
                   });
-                  if (!resp.ok) {
-                    const text = await resp.text().catch(() => "");
-                    throw new Error(text || `Request failed (${resp.status})`);
-                  }
-                  return resp.json();
                 }
               : undefined
           }

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -1,6 +1,11 @@
-import { MANAGEMENT_API_PREFIX } from "@code-proxy/api-client";
-import { detectApiBaseFromLocation } from "@code-proxy/api-client";
+import { detectApiBaseFromLocation, publicApiClient } from "@code-proxy/api-client";
 import type { ChartDataResponse, PublicLogsResponse } from "./types";
+
+type LogContentBodyPart = "input" | "output";
+
+type PublicLogContentResponse =
+  | { id: number; model: string; part: LogContentBodyPart; content: string }
+  | { input_content: string; output_content: string; model: string };
 
 type V1ModelsResponse =
   | { data?: Array<{ id?: string }> }
@@ -37,45 +42,49 @@ export async function fetchPublicLogs(params: {
   status?: string;
   signal?: AbortSignal;
 }): Promise<PublicLogsResponse> {
-  const base = detectApiBaseFromLocation();
-  const resp = await fetch(`${base}${MANAGEMENT_API_PREFIX}/public/usage/logs`, {
-    method: "POST",
-    signal: params.signal,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
+  return publicApiClient.post<PublicLogsResponse>(
+    "/usage/logs",
+    {
       api_key: params.apiKey,
       page: params.page,
       size: params.size,
       days: params.days,
       model: params.model,
       status: params.status,
-    }),
-  });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    throw new Error(text || `Request failed (${resp.status})`);
-  }
-  return resp.json() as Promise<PublicLogsResponse>;
+    },
+    { signal: params.signal },
+  );
 }
 
 export async function fetchPublicChartData(params: {
   apiKey: string;
   days?: number;
 }): Promise<ChartDataResponse> {
-  const base = detectApiBaseFromLocation();
-  const resp = await fetch(`${base}${MANAGEMENT_API_PREFIX}/public/usage/chart-data`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      api_key: params.apiKey,
-      days: params.days,
-    }),
+  return publicApiClient.post<ChartDataResponse>("/usage/chart-data", {
+    api_key: params.apiKey,
+    days: params.days,
   });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    throw new Error(text || `Request failed (${resp.status})`);
+}
+
+export async function fetchPublicLogContent(params: {
+  id: number;
+  apiKey: string;
+  part: LogContentBodyPart;
+  signal?: AbortSignal;
+}): Promise<PublicLogContentResponse> {
+  if (!Number.isInteger(params.id) || params.id <= 0) {
+    throw new Error("Invalid log id");
   }
-  return resp.json() as Promise<ChartDataResponse>;
+
+  return publicApiClient.post<PublicLogContentResponse>(
+    `/usage/logs/${params.id}/content`,
+    {
+      api_key: params.apiKey,
+      part: params.part,
+      format: "json",
+    },
+    { signal: params.signal },
+  );
 }
 
 export async function fetchAvailableModels(apiKey: string): Promise<string[]> {

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -3,11 +3,11 @@ import { useTranslation } from "react-i18next";
 import { Check, Copy, Download, ExternalLink } from "lucide-react";
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
-import { AUTH_STORAGE_KEY, MANAGEMENT_API_PREFIX } from "@code-proxy/api-client";
 import {
-  computeManagementApiBase,
+  ApiClient,
   detectApiBaseFromLocation,
-  normalizeApiBase,
+  publicApiClient,
+  readPersistedAuthSnapshot,
 } from "@code-proxy/api-client";
 import {
   ccSwitchImportConfigsApi,
@@ -43,17 +43,9 @@ const clientLabelKey: Record<"codex" | "claude", string> = {
 };
 
 function readStoredManagementAuth(): { apiBase: string; managementKey: string } | null {
-  try {
-    const raw = window.localStorage.getItem(AUTH_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as { apiBase?: unknown; managementKey?: unknown };
-    const apiBase = normalizeApiBase(String(parsed.apiBase ?? ""));
-    const managementKey = String(parsed.managementKey ?? "").trim();
-    if (!apiBase || !managementKey) return null;
-    return { apiBase, managementKey };
-  } catch {
-    return null;
-  }
+  const snapshot = readPersistedAuthSnapshot();
+  if (!snapshot?.apiBase || !snapshot.managementKey) return null;
+  return { apiBase: snapshot.apiBase, managementKey: snapshot.managementKey };
 }
 
 async function fetchPublicQuickImportConfigs(
@@ -62,19 +54,9 @@ async function fetchPublicQuickImportConfigs(
   const key = apiKey.trim();
   if (!key) return [];
 
-  const base = detectApiBaseFromLocation();
-  const resp = await fetch(`${base}${MANAGEMENT_API_PREFIX}/public/ccswitch-import-configs`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ api_key: key }),
+  const data = await publicApiClient.post<Record<string, unknown>>("/ccswitch-import-configs", {
+    api_key: key,
   });
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    throw new Error(text || `Request failed (${resp.status})`);
-  }
-  const data = (await resp.json()) as Record<string, unknown>;
   return normalizeCcSwitchImportConfigs(data["ccswitch-import-configs"] ?? data.items ?? data);
 }
 
@@ -89,18 +71,9 @@ async function fetchQuickImportConfigs(apiKey: string): Promise<CcSwitchImportCo
     }
   }
 
-  const managementBase = computeManagementApiBase(auth.apiBase);
-
-  const response = await fetch(`${managementBase}/ccswitch-import-configs`, {
-    headers: {
-      Authorization: `Bearer ${auth.managementKey}`,
-    },
-  });
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(text || `Request failed (${response.status})`);
-  }
-  const data = (await response.json()) as Record<string, unknown>;
+  const client = new ApiClient();
+  client.setConfig(auth);
+  const data = await client.get<Record<string, unknown>>("/ccswitch-import-configs");
   return normalizeCcSwitchImportConfigs(data["ccswitch-import-configs"] ?? data.items ?? data);
 }
 
@@ -122,15 +95,10 @@ async function fetchQuickImportApiKeyEntry(apiKey: string): Promise<ApiKeyEntry 
   const key = apiKey.trim();
   if (!key) return null;
 
-  const managementBase = computeManagementApiBase(auth.apiBase);
   try {
-    const response = await fetch(`${managementBase}/api-key-entries`, {
-      headers: {
-        Authorization: `Bearer ${auth.managementKey}`,
-      },
-    });
-    if (!response.ok) return null;
-    const data = (await response.json()) as Record<string, unknown>;
+    const client = new ApiClient();
+    client.setConfig(auth);
+    const data = await client.get<Record<string, unknown>>("/api-key-entries");
     const entries = normalizeApiKeyEntries(data["api-key-entries"] ?? data.items ?? data);
     return entries.find((entry) => entry.key === key) ?? null;
   } catch {

--- a/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -202,7 +202,11 @@ describe("QuickImportTabContent", () => {
   test("filters quick import cards by the looked up API key permissions", async () => {
     window.localStorage.setItem(
       "code-proxy-admin-auth",
-      JSON.stringify({ apiBase: "http://localhost:3000", managementKey: "mgmt-test" }),
+      JSON.stringify({
+        apiBase: "http://localhost:3000",
+        managementKey: "mgmt-test",
+        expiresAt: Date.now() + 60_000,
+      }),
     );
     vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
       const url = String(input);


### PR DESCRIPTION
## Summary\n- Split api-client request helpers for errors, responses, downloads, auth storage, and public requests\n- Route public lookup and quick import requests through the public client\n- Keep existing endpoint exports and login behavior compatible\n\n## Verification\n- rtk bun run --filter @code-proxy/admin-panel test:ci -- packages/api-client/src/client/__tests__/client.test.ts pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx\n- rtk bun run lint\n- rtk bun run boundary:imports\n- rtk bun run build\n- rtk bun run bundle:diff