### PR TITLE
fix: polish auth files filters and pagination layout

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -1,11 +1,9 @@
 import { useTranslation } from "react-i18next";
-import { useMemo } from "react";
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
 import type { UsageLogItem } from "@code-proxy/api-client/endpoints/usage";
 import { parseUsageTimestampMs } from "@features/monitor-widgets/monitor-utils";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
-import { Select } from "@code-proxy/ui";
+import { PaginationBar } from "@code-proxy/ui";
 
 export type TimeRange = 1 | 7 | 14 | 30;
 
@@ -493,112 +491,25 @@ export function RequestLogsPaginationBar({
 }) {
   const { t } = useTranslation();
 
-  const start = totalCount === 0 ? 0 : (currentPage - 1) * pageSize + 1;
-  const end = Math.min(currentPage * pageSize, totalCount);
-
-  const pageNumbers = useMemo(() => {
-    const pages: (number | "...")[] = [];
-    if (totalPages <= 7) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i);
-    } else {
-      pages.push(1);
-      if (currentPage > 3) pages.push("...");
-      const rangeStart = Math.max(2, currentPage - 1);
-      const rangeEnd = Math.min(totalPages - 1, currentPage + 1);
-      for (let i = rangeStart; i <= rangeEnd; i++) pages.push(i);
-      if (currentPage < totalPages - 2) pages.push("...");
-      pages.push(totalPages);
-    }
-    return pages;
-  }, [currentPage, totalPages]);
-
-  const btnBase =
-    "inline-flex h-8 min-w-[32px] items-center justify-center rounded-lg text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-40";
-  const btnNormal = `${btnBase} text-slate-600 hover:bg-slate-100 dark:text-white/60 dark:hover:bg-white/10`;
-  const btnActive = `${btnBase} bg-slate-900 text-white dark:bg-white dark:text-neutral-950`;
-
   return (
-    <div className="flex flex-shrink-0 flex-col gap-2 border-t border-slate-100 px-3 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:px-5 dark:border-neutral-800/60">
-      <span className="text-xs text-slate-500 dark:text-white/50 tabular-nums whitespace-nowrap">
-        {t("request_logs.page_info", { start, end, total: totalCount })}
-      </span>
-
-      <div className="flex items-center gap-1 overflow-x-auto">
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage <= 1}
-          onClick={() => onPageChange(1)}
-          title={t("request_logs.first_page")}
-          aria-label={t("request_logs.first_page")}
-        >
-          <ChevronsLeft size={14} />
-        </button>
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage <= 1}
-          onClick={() => onPageChange(currentPage - 1)}
-          title={t("request_logs.prev_page")}
-          aria-label={t("request_logs.prev_page")}
-        >
-          <ChevronLeft size={14} />
-        </button>
-
-        {pageNumbers.map((p, i) =>
-          p === "..." ? (
-            <span key={`dots-${i}`} className="px-1 text-xs text-slate-400 dark:text-white/30">
-              …
-            </span>
-          ) : (
-            <button
-              key={p}
-              type="button"
-              className={p === currentPage ? btnActive : btnNormal}
-              onClick={() => onPageChange(p)}
-            >
-              {p}
-            </button>
-          ),
-        )}
-
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage >= totalPages}
-          onClick={() => onPageChange(currentPage + 1)}
-          title={t("request_logs.next_page")}
-          aria-label={t("request_logs.next_page")}
-        >
-          <ChevronRight size={14} />
-        </button>
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage >= totalPages}
-          onClick={() => onPageChange(totalPages)}
-          title={t("request_logs.last_page")}
-          aria-label={t("request_logs.last_page")}
-        >
-          <ChevronsRight size={14} />
-        </button>
-      </div>
-
-      <div className="flex items-center gap-1.5">
-        <span className="text-xs text-slate-500 dark:text-white/50 whitespace-nowrap">
-          {t("request_logs.rows_per_page")}
-        </span>
-        <Select
-          value={String(pageSize)}
-          onChange={(value) => onPageSizeChange(Number(value))}
-          options={REQUEST_LOG_PAGE_SIZE_OPTIONS.map((size) => ({
-            value: String(size),
-            label: String(size),
-          }))}
-          aria-label={t("request_logs.rows_per_page")}
-          className="w-[88px]"
-        />
-      </div>
-    </div>
+    <PaginationBar
+      currentPage={currentPage}
+      totalPages={totalPages}
+      totalCount={totalCount}
+      pageSize={pageSize}
+      onPageChange={onPageChange}
+      onPageSizeChange={onPageSizeChange}
+      pageSizeOptions={REQUEST_LOG_PAGE_SIZE_OPTIONS}
+      className="border-t border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60"
+      labels={{
+        firstPage: t("request_logs.first_page"),
+        previousPage: t("request_logs.prev_page"),
+        nextPage: t("request_logs.next_page"),
+        lastPage: t("request_logs.last_page"),
+        rowsPerPage: t("request_logs.rows_per_page"),
+        pageInfo: ({ start, end, total }) =>
+          t("request_logs.page_info", { start, end, total }),
+      }}
+    />
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,13 @@ export type { EChartProps, EChartEvents as EChartRendererEvents } from "./charts
 
 export { PageBackground } from "./layout/PageBackground";
 
+export { PaginationBar, getPaginationItems } from "./navigation/PaginationBar";
+export type {
+  PaginationBarLabels,
+  PaginationBarProps,
+  PaginationRangeInfo,
+} from "./navigation/PaginationBar";
+
 export { ConfirmModal } from "./overlays/ConfirmModal";
 export { ImagePreviewOverlay } from "./overlays/ImagePreviewOverlay";
 export { Modal } from "./overlays/Modal";

--- a/packages/ui/src/navigation/PaginationBar.tsx
+++ b/packages/ui/src/navigation/PaginationBar.tsx
@@ -1,0 +1,208 @@
+import { useMemo, type ReactNode } from "react";
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react";
+import { Select } from "../primitives/Select";
+import { cn } from "../utils/selectStyles";
+
+export interface PaginationRangeInfo {
+  start: number;
+  end: number;
+  total: number;
+  currentPage: number;
+  totalPages: number;
+  pageSize: number;
+}
+
+export interface PaginationBarLabels {
+  firstPage: string;
+  previousPage: string;
+  nextPage: string;
+  lastPage: string;
+  rowsPerPage?: string;
+  pageInfo: (info: PaginationRangeInfo) => ReactNode;
+}
+
+export interface PaginationBarProps {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+  pageSize: number;
+  labels: PaginationBarLabels;
+  onPageChange: (page: number) => void;
+  onPageSizeChange?: (size: number) => void;
+  pageSizeOptions?: number[];
+  className?: string;
+  showFirstLast?: boolean;
+  showPageNumbers?: boolean;
+  showPageSize?: boolean;
+  align?: "split" | "center";
+}
+
+export const getPaginationItems = (
+  currentPage: number,
+  totalPages: number,
+): (number | "...")[] => {
+  const safeTotalPages = Math.max(1, Math.trunc(totalPages));
+  const safeCurrentPage = Math.min(safeTotalPages, Math.max(1, Math.trunc(currentPage)));
+  const pages: (number | "...")[] = [];
+
+  if (safeTotalPages <= 7) {
+    for (let i = 1; i <= safeTotalPages; i += 1) pages.push(i);
+    return pages;
+  }
+
+  pages.push(1);
+  if (safeCurrentPage > 3) pages.push("...");
+
+  const rangeStart = Math.max(2, safeCurrentPage - 1);
+  const rangeEnd = Math.min(safeTotalPages - 1, safeCurrentPage + 1);
+  for (let i = rangeStart; i <= rangeEnd; i += 1) pages.push(i);
+
+  if (safeCurrentPage < safeTotalPages - 2) pages.push("...");
+  pages.push(safeTotalPages);
+
+  return pages;
+};
+
+export function PaginationBar({
+  currentPage,
+  totalPages,
+  totalCount,
+  pageSize,
+  labels,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [],
+  className,
+  showFirstLast = true,
+  showPageNumbers = true,
+  showPageSize = Boolean(onPageSizeChange && pageSizeOptions.length > 0),
+  align = "split",
+}: PaginationBarProps) {
+  const safeTotalPages = Math.max(1, Math.trunc(totalPages));
+  const safeCurrentPage = Math.min(safeTotalPages, Math.max(1, Math.trunc(currentPage)));
+  const safePageSize = Math.max(1, Math.trunc(pageSize));
+  const start = totalCount === 0 ? 0 : (safeCurrentPage - 1) * safePageSize + 1;
+  const end = Math.min(safeCurrentPage * safePageSize, totalCount);
+  const pageNumbers = useMemo(
+    () => getPaginationItems(safeCurrentPage, safeTotalPages),
+    [safeCurrentPage, safeTotalPages],
+  );
+
+  const btnBase =
+    "inline-flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-35";
+  const btnNormal =
+    "text-slate-600 hover:bg-slate-100 dark:text-white/60 dark:hover:bg-white/10";
+  const btnActive = "bg-slate-900 text-white shadow-sm dark:bg-white dark:text-neutral-950";
+  const disabledPrev = safeCurrentPage <= 1;
+  const disabledNext = safeCurrentPage >= safeTotalPages;
+
+  return (
+    <div
+      className={cn(
+        "grid flex-shrink-0 grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center",
+        align === "center" && "sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]",
+        className,
+      )}
+    >
+      <span className="justify-self-start text-xs text-slate-500 dark:text-white/50 tabular-nums whitespace-nowrap">
+        {labels.pageInfo({
+          start,
+          end,
+          total: totalCount,
+          currentPage: safeCurrentPage,
+          totalPages: safeTotalPages,
+          pageSize: safePageSize,
+        })}
+      </span>
+
+      <div className="flex max-w-full items-center justify-self-center gap-1 overflow-x-auto">
+        {showFirstLast ? (
+          <button
+            type="button"
+            className={cn(btnBase, btnNormal)}
+            disabled={disabledPrev}
+            onClick={() => onPageChange(1)}
+            title={labels.firstPage}
+            aria-label={labels.firstPage}
+          >
+            <ChevronsLeft size={14} aria-hidden="true" />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className={cn(btnBase, btnNormal)}
+          disabled={disabledPrev}
+          onClick={() => onPageChange(safeCurrentPage - 1)}
+          title={labels.previousPage}
+          aria-label={labels.previousPage}
+        >
+          <ChevronLeft size={14} aria-hidden="true" />
+        </button>
+
+        {showPageNumbers
+          ? pageNumbers.map((page, index) =>
+              page === "..." ? (
+                <span
+                  key={`dots-${index}`}
+                  className="px-1 text-xs text-slate-400 dark:text-white/30"
+                >
+                  …
+                </span>
+              ) : (
+                <button
+                  key={page}
+                  type="button"
+                  aria-current={page === safeCurrentPage ? "page" : undefined}
+                  className={cn(btnBase, page === safeCurrentPage ? btnActive : btnNormal)}
+                  onClick={() => onPageChange(page)}
+                >
+                  {page}
+                </button>
+              ),
+            )
+          : null}
+
+        <button
+          type="button"
+          className={cn(btnBase, btnNormal)}
+          disabled={disabledNext}
+          onClick={() => onPageChange(safeCurrentPage + 1)}
+          title={labels.nextPage}
+          aria-label={labels.nextPage}
+        >
+          <ChevronRight size={14} aria-hidden="true" />
+        </button>
+        {showFirstLast ? (
+          <button
+            type="button"
+            className={cn(btnBase, btnNormal)}
+            disabled={disabledNext}
+            onClick={() => onPageChange(safeTotalPages)}
+            title={labels.lastPage}
+            aria-label={labels.lastPage}
+          >
+            <ChevronsRight size={14} aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+
+      {showPageSize && onPageSizeChange && labels.rowsPerPage ? (
+        <div className="flex items-center justify-self-end gap-1.5">
+          <span className="text-xs text-slate-500 dark:text-white/50 whitespace-nowrap">
+            {labels.rowsPerPage}
+          </span>
+          <Select
+            value={String(pageSize)}
+            onChange={(value) => onPageSizeChange(Number(value))}
+            options={pageSizeOptions.map((size) => ({
+              value: String(size),
+              label: String(size),
+            }))}
+            aria-label={labels.rowsPerPage}
+            className="w-[88px]"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/navigation/__tests__/PaginationBar.test.tsx
+++ b/packages/ui/src/navigation/__tests__/PaginationBar.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { PaginationBar, getPaginationItems } from "../PaginationBar";
+
+describe("PaginationBar", () => {
+  test("builds compact pagination items with ellipses", () => {
+    expect(getPaginationItems(1, 10)).toEqual([1, 2, "...", 10]);
+    expect(getPaginationItems(5, 10)).toEqual([1, "...", 4, 5, 6, "...", 10]);
+    expect(getPaginationItems(10, 10)).toEqual([1, "...", 9, 10]);
+  });
+
+  test("renders page info and supports page navigation", async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    render(
+      <PaginationBar
+        currentPage={2}
+        totalPages={5}
+        totalCount={43}
+        pageSize={10}
+        onPageChange={onPageChange}
+        labels={{
+          firstPage: "First page",
+          previousPage: "Previous page",
+          nextPage: "Next page",
+          lastPage: "Last page",
+          pageInfo: ({ start, end, total }) => `${start}-${end} of ${total}`,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("11-20 of 43")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+
+    await user.click(screen.getByRole("button", { name: "Last page" }));
+    expect(onPageChange).toHaveBeenCalledWith(5);
+  });
+
+  test("can be configured with page size controls", async () => {
+    const user = userEvent.setup();
+    const onPageSizeChange = vi.fn();
+
+    render(
+      <PaginationBar
+        currentPage={1}
+        totalPages={3}
+        totalCount={120}
+        pageSize={50}
+        pageSizeOptions={[20, 50, 100]}
+        onPageChange={vi.fn()}
+        onPageSizeChange={onPageSizeChange}
+        labels={{
+          firstPage: "First page",
+          previousPage: "Previous page",
+          nextPage: "Next page",
+          lastPage: "Last page",
+          rowsPerPage: "Rows per page",
+          pageInfo: ({ start, end, total }) => `${start}-${end} of ${total}`,
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Rows per page" }));
+    await user.click(screen.getByRole("option", { name: "100" }));
+
+    expect(onPageSizeChange).toHaveBeenCalledWith(100);
+  });
+});

--- a/packages/ui/src/primitives/ScrollArea.tsx
+++ b/packages/ui/src/primitives/ScrollArea.tsx
@@ -35,12 +35,14 @@ export function ScrollArea({
   viewportClassName,
   contentClassName,
   scrollbarVisibility = "hover",
+  scrollbarTrackInset = 8,
   ...divProps
 }: PropsWithChildren<
   {
     viewportClassName?: string;
     contentClassName?: string;
     scrollbarVisibility?: ScrollbarVisibility;
+    scrollbarTrackInset?: number;
   } & HTMLAttributes<HTMLDivElement>
 >) {
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -86,7 +88,7 @@ export function ScrollArea({
   }, [children, measure]);
 
   const thumb = useMemo(() => {
-    const trackInset = 8;
+    const trackInset = Math.max(0, scrollbarTrackInset);
     const hasVerticalOverflow = metrics.scrollHeight > metrics.clientHeight + 1;
     if (!hasVerticalOverflow) return null;
 
@@ -107,7 +109,7 @@ export function ScrollArea({
       trackLength,
       scrollRange,
     };
-  }, [metrics]);
+  }, [metrics, scrollbarTrackInset]);
 
   const handleScroll = useCallback(() => {
     measure();
@@ -188,11 +190,14 @@ export function ScrollArea({
             visibilityClasses,
           )}
         >
-          <div className="absolute inset-y-2 left-0 right-0 rounded-full bg-slate-200/40 dark:bg-white/10" />
+          <div
+            className="absolute left-0 right-0 rounded-full bg-slate-200/40 dark:bg-white/10"
+            style={{ top: Math.max(0, scrollbarTrackInset), bottom: Math.max(0, scrollbarTrackInset) }}
+          />
           <div
             role="presentation"
             className="pointer-events-auto absolute left-0 right-0 cursor-pointer rounded-full bg-slate-500/40 transition-colors hover:bg-slate-500/70 dark:bg-white/25 dark:hover:bg-white/50"
-            style={{ top: thumb.top + 8, height: thumb.height }}
+            style={{ top: thumb.top + Math.max(0, scrollbarTrackInset), height: thumb.height }}
             onPointerDown={handleThumbPointerDown}
             onPointerMove={handleThumbPointerMove}
             onPointerUp={handleThumbPointerUp}

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
-import { ConfirmModal, Modal } from "@code-proxy/ui";
+import {
+  Button,
+  ConfirmModal,
+  Modal,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@code-proxy/ui";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { proxiesApi, type ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { OAuthLoginDialog } from "@features/oauth-login";
@@ -74,6 +82,7 @@ export function AuthFilesPage() {
   const [searchParams] = useSearchParams();
 
   const [configModalTab, setConfigModalTab] = useState<AuthFilesConfigModalTab | null>(null);
+  const [configSaving, setConfigSaving] = useState(false);
   const {
     isPending,
     excludedLoading,
@@ -101,12 +110,12 @@ export function AuthFilesPage() {
     importFilteredModels,
     refreshExcluded,
     refreshAlias,
-    saveExcludedProvider,
     deleteExcludedProvider,
     addExcludedProvider,
     addAliasChannel,
-    saveAliasChannel,
     deleteAliasChannel,
+    saveExcludedAll,
+    saveAliasAll,
     openImport,
     applyImport,
   } = useAuthFilesOAuthConfig(configModalTab ?? "files");
@@ -438,6 +447,24 @@ export function AuthFilesPage() {
     }
   }, [forceRefreshPage, loading, pageItems, refreshFilesForItems, refreshingAll, usageLoading]);
 
+  const closeConfigModal = useCallback(() => {
+    setConfigModalTab(null);
+  }, []);
+
+  const saveConfigModal = useCallback(async () => {
+    if (!configModalTab || configSaving) return;
+    setConfigSaving(true);
+    try {
+      const saved =
+        configModalTab === "alias" ? await saveAliasAll() : await saveExcludedAll();
+      if (saved) {
+        setConfigModalTab(null);
+      }
+    } finally {
+      setConfigSaving(false);
+    }
+  }, [configModalTab, configSaving, saveAliasAll, saveExcludedAll]);
+
   useEffect(() => {
     const previousTab = previousConfigModalTabRef.current;
     previousConfigModalTabRef.current = configModalTab;
@@ -563,7 +590,7 @@ export function AuthFilesPage() {
         uploadProgress={uploadProgress}
         setOauthDialogDefaultTab={setOauthDialogDefaultTab}
         setOauthDialogOpen={setOAuthDialogOpenWithBaseline}
-        openConfigModal={setConfigModalTab}
+        openConfigModal={() => setConfigModalTab("excluded")}
         selectableFilteredFiles={selectableFilteredFiles}
         selectedCount={selectedCount}
         selectCurrentPage={selectCurrentPage}
@@ -615,41 +642,80 @@ export function AuthFilesPage() {
             : t("auth_files_page.excluded_desc")
         }
         maxWidth="max-w-5xl"
-        bodyHeightClassName="max-h-[76vh]"
-        onClose={() => setConfigModalTab(null)}
+        bodyHeightClassName="h-[76vh] max-h-[76vh]"
+        bodyOverflowClassName="overflow-hidden"
+        bodyClassName="flex min-h-0 flex-col"
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={closeConfigModal}
+              disabled={configSaving}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void saveConfigModal()}
+              disabled={configSaving || excludedLoading || aliasLoading || isPending}
+            >
+              {configSaving ? t("common.saving") : t("auth_files.save")}
+            </Button>
+          </>
+        }
+        onClose={closeConfigModal}
       >
-        {configModalTab === "alias" ? (
-          <AuthFilesAliasTab
-            aliasLoading={aliasLoading}
-            isPending={isPending}
-            refreshAlias={refreshAlias}
-            aliasUnsupported={aliasUnsupported}
-            aliasNewChannel={aliasNewChannel}
-            setAliasNewChannel={setAliasNewChannel}
-            addAliasChannel={addAliasChannel}
-            aliasEditing={aliasEditing}
-            setAliasEditing={setAliasEditing}
-            openImport={openImport}
-            saveAliasChannel={saveAliasChannel}
-            deleteAliasChannel={deleteAliasChannel}
-            showHeading={false}
-          />
-        ) : configModalTab === "excluded" ? (
-          <AuthFilesExcludedTab
-            excludedLoading={excludedLoading}
-            isPending={isPending}
-            refreshExcluded={refreshExcluded}
-            excludedUnsupported={excludedUnsupported}
-            excludedNewProvider={excludedNewProvider}
-            setExcludedNewProvider={setExcludedNewProvider}
-            addExcludedProvider={addExcludedProvider}
-            excluded={excluded}
-            excludedDraft={excludedDraft}
-            setExcludedDraft={setExcludedDraft}
-            saveExcludedProvider={saveExcludedProvider}
-            deleteExcludedProvider={deleteExcludedProvider}
-            showHeading={false}
-          />
+        {configModalTab ? (
+          <Tabs
+            value={configModalTab}
+            onValueChange={(next) => setConfigModalTab(next as AuthFilesConfigModalTab)}
+            size="sm"
+          >
+            <div className="mb-4 flex shrink-0 justify-start">
+              <TabsList>
+                <TabsTrigger value="excluded">{t("auth_files_page.excluded_tab")}</TabsTrigger>
+                <TabsTrigger value="alias">{t("auth_files_page.alias_tab")}</TabsTrigger>
+              </TabsList>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+              <TabsContent value="excluded">
+                <AuthFilesExcludedTab
+                  excludedLoading={excludedLoading}
+                  isPending={isPending}
+                  refreshExcluded={refreshExcluded}
+                  excludedUnsupported={excludedUnsupported}
+                  excludedNewProvider={excludedNewProvider}
+                  setExcludedNewProvider={setExcludedNewProvider}
+                  addExcludedProvider={addExcludedProvider}
+                  excluded={excluded}
+                  excludedDraft={excludedDraft}
+                  setExcludedDraft={setExcludedDraft}
+                  deleteExcludedProvider={deleteExcludedProvider}
+                  showHeading={false}
+                />
+              </TabsContent>
+
+              <TabsContent value="alias">
+                <AuthFilesAliasTab
+                  aliasLoading={aliasLoading}
+                  isPending={isPending}
+                  refreshAlias={refreshAlias}
+                  aliasUnsupported={aliasUnsupported}
+                  aliasNewChannel={aliasNewChannel}
+                  setAliasNewChannel={setAliasNewChannel}
+                  addAliasChannel={addAliasChannel}
+                  aliasEditing={aliasEditing}
+                  setAliasEditing={setAliasEditing}
+                  openImport={openImport}
+                  deleteAliasChannel={deleteAliasChannel}
+                  showHeading={false}
+                />
+              </TabsContent>
+            </div>
+          </Tabs>
         ) : null}
       </Modal>
 

--- a/pages/auth-files/__tests__/AuthFilesPage.excluded.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.excluded.test.tsx
@@ -9,6 +9,7 @@ import { AuthFilesPage } from "@pages/auth-files/AuthFilesPage";
 const mocks = vi.hoisted(() => ({
   list: vi.fn(async (): Promise<{ files: any[] }> => ({ files: [] })),
   getOauthExcludedModels: vi.fn(async () => ({})),
+  replaceOauthExcludedModels: vi.fn(async () => ({})),
   getOauthModelAlias: vi.fn(async () => ({})),
   getModelConfigs: vi.fn(async () => []),
   getModelOwnerPresets: vi.fn(async () => []),
@@ -24,6 +25,7 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       ...mod.authFilesApi,
       list: mocks.list,
       getOauthExcludedModels: mocks.getOauthExcludedModels,
+      replaceOauthExcludedModels: mocks.replaceOauthExcludedModels,
       getOauthModelAlias: mocks.getOauthModelAlias,
     },
     modelsApi: {
@@ -45,7 +47,6 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
 
 async function openExcludedConfig(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: "Auth config" }));
-  await user.click(await screen.findByRole("menuitem", { name: "OAuth Excluded Models" }));
   return screen.findByRole("dialog", { name: "OAuth Excluded Models" });
 }
 
@@ -64,6 +65,8 @@ describe("AuthFilesPage OAuth excluded models", () => {
     mocks.list.mockResolvedValue({ files: [] });
     mocks.getOauthExcludedModels.mockReset();
     mocks.getOauthExcludedModels.mockResolvedValue({});
+    mocks.replaceOauthExcludedModels.mockReset();
+    mocks.replaceOauthExcludedModels.mockResolvedValue({});
     mocks.getOauthModelAlias.mockReset();
     mocks.getOauthModelAlias.mockResolvedValue({});
     mocks.getModelConfigs.mockReset();
@@ -155,5 +158,50 @@ describe("AuthFilesPage OAuth excluded models", () => {
 
     await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("after.json")).toBeInTheDocument();
+  });
+
+  test("keeps excluded model edits local until the footer save button is clicked", async () => {
+    const user = userEvent.setup();
+    mocks.getOauthExcludedModels.mockResolvedValue({ codex: ["old-model"] });
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files?tab=excluded"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: "OAuth Excluded Models" });
+    const textarea = await within(dialog).findByRole("textbox", {
+      name: "codex OAuth Excluded Models",
+    });
+
+    await user.clear(textarea);
+    await user.type(textarea, "new-model");
+
+    expect(mocks.replaceOauthExcludedModels).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "OAuth Excluded Models" })).not.toBeInTheDocument();
+    });
+    expect(mocks.replaceOauthExcludedModels).not.toHaveBeenCalled();
+
+    const reopenedDialog = await openExcludedConfig(user);
+    const reopenedTextarea = await within(reopenedDialog).findByRole("textbox", {
+      name: "codex OAuth Excluded Models",
+    });
+    await user.clear(reopenedTextarea);
+    await user.type(reopenedTextarea, "new-model");
+    await user.click(within(reopenedDialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.replaceOauthExcludedModels).toHaveBeenCalledWith({ codex: ["new-model"] });
+    });
   });
 });

--- a/pages/auth-files/components/AuthFilesAliasTab.tsx
+++ b/pages/auth-files/components/AuthFilesAliasTab.tsx
@@ -17,8 +17,7 @@ interface AuthFilesAliasTabProps {
   aliasEditing: Record<string, AliasRow[]>;
   setAliasEditing: Dispatch<SetStateAction<Record<string, AliasRow[]>>>;
   openImport: (channel: string) => Promise<void>;
-  saveAliasChannel: (channel: string) => Promise<void>;
-  deleteAliasChannel: (channel: string) => Promise<void>;
+  deleteAliasChannel: (channel: string) => void;
   showHeading?: boolean;
 }
 
@@ -33,7 +32,6 @@ export function AuthFilesAliasTab({
   aliasEditing,
   setAliasEditing,
   openImport,
-  saveAliasChannel,
   deleteAliasChannel,
   showHeading = true,
 }: AuthFilesAliasTabProps) {
@@ -137,17 +135,9 @@ export function AuthFilesAliasTab({
                             {t("auth_files.import_models")}
                           </Button>
                           <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => void saveAliasChannel(channel)}
-                            disabled={isPending || aliasUnsupported}
-                          >
-                            {t("auth_files.save")}
-                          </Button>
-                          <Button
                             variant="danger"
                             size="sm"
-                            onClick={() => void deleteAliasChannel(channel)}
+                            onClick={() => deleteAliasChannel(channel)}
                             disabled={isPending || aliasUnsupported}
                           >
                             {t("common.delete")}

--- a/pages/auth-files/components/AuthFilesExcludedTab.tsx
+++ b/pages/auth-files/components/AuthFilesExcludedTab.tsx
@@ -16,8 +16,7 @@ interface AuthFilesExcludedTabProps {
   excluded: Record<string, string[]>;
   excludedDraft: Record<string, string>;
   setExcludedDraft: Dispatch<SetStateAction<Record<string, string>>>;
-  saveExcludedProvider: (provider: string, text: string) => Promise<void>;
-  deleteExcludedProvider: (provider: string) => Promise<void>;
+  deleteExcludedProvider: (provider: string) => void;
   showHeading?: boolean;
 }
 
@@ -32,7 +31,6 @@ export function AuthFilesExcludedTab({
   excluded,
   excludedDraft,
   setExcludedDraft,
-  saveExcludedProvider,
   deleteExcludedProvider,
   showHeading = true,
 }: AuthFilesExcludedTabProps) {
@@ -132,19 +130,9 @@ export function AuthFilesExcludedTab({
                         </div>
                         <div className="flex items-center gap-2">
                           <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() =>
-                              void saveExcludedProvider(provider, excludedDraft[provider] ?? text)
-                            }
-                            disabled={isPending || excludedUnsupported}
-                          >
-                            {t("auth_files.save")}
-                          </Button>
-                          <Button
                             variant="danger"
                             size="sm"
-                            onClick={() => void deleteExcludedProvider(provider)}
+                            onClick={() => deleteExcludedProvider(provider)}
                             disabled={isPending || excludedUnsupported}
                           >
                             {t("common.delete")}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -24,6 +24,8 @@ import { EmptyState } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { HoverTooltip } from "@code-proxy/ui";
+import { PaginationBar } from "@code-proxy/ui";
+import { ScrollArea } from "@code-proxy/ui";
 import { Select } from "@code-proxy/ui";
 import { SearchableSelect, type SearchableSelectOption } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
@@ -38,6 +40,7 @@ import type {
   UsageIndex,
 } from "@code-proxy/domain";
 import {
+  AUTH_FILES_PAGE_SIZE,
   AUTH_FILE_STATUS_FILTERS,
   TYPE_BADGE_CLASSES,
   isRuntimeOnlyAuthFile,
@@ -60,6 +63,11 @@ const ACTION_MENU_CONTENT_CLASS =
   "z-[220] min-w-44 rounded-2xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
 const ACTION_MENU_ITEM_CLASS =
   "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
+const FILTER_LABEL_CLASS =
+  "truncate text-[11px] font-semibold uppercase tracking-[0.02em] text-slate-600 dark:text-white/65";
+const FILTER_FIELD_CLASS = "min-w-0 space-y-2";
+const FILTER_GRID_CLASS =
+  "grid min-w-0 grid-cols-1 items-end gap-x-5 gap-y-3 sm:grid-cols-2 xl:grid-cols-[repeat(4,minmax(0,1fr))_minmax(320px,1.8fr)]";
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -496,7 +504,7 @@ interface AuthFilesFilesTabProps {
   uploadProgress: AuthFilesUploadProgress;
   setOauthDialogDefaultTab: (tab: OAuthDialogTab) => void;
   setOauthDialogOpen: (open: boolean) => void;
-  openConfigModal: (tab: "excluded" | "alias") => void;
+  openConfigModal: () => void;
   selectableFilteredFiles: AuthFileItem[];
   selectedCount: number;
   selectCurrentPage: (checked: boolean) => void;
@@ -845,45 +853,83 @@ export function AuthFilesFilesTab({
   ) : null;
 
   const configActionsMenu = (
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger asChild>
-        <button
-          type="button"
-          className={buttonClassName({
-            variant: "secondary",
-            size: "sm",
-            iconOnly: true,
-          })}
-          aria-label={t("auth_files_page.config_menu")}
-          title={t("auth_files_page.config_menu")}
-          data-tooltip-placement="top"
+    <HoverTooltip content={t("auth_files_page.config_menu")}>
+      <button
+        type="button"
+        className={buttonClassName({
+          variant: "secondary",
+          size: "sm",
+          iconOnly: true,
+        })}
+        onClick={openConfigModal}
+        aria-label={t("auth_files_page.config_menu")}
+        title={t("auth_files_page.config_menu")}
+        data-tooltip-placement="top"
+      >
+        <Settings2 size={15} />
+      </button>
+    </HoverTooltip>
+  );
+
+  const selectionToolbar =
+    selectedCount > 0 ? (
+      <div className="inline-flex h-9 max-w-full min-w-0 items-center gap-1.5 rounded-full bg-slate-50/90 px-1.5 text-xs transition-colors duration-200 ease-out dark:bg-white/[0.04]">
+        {selectionActionsMenu}
+        <span className="min-w-0 truncate px-1 font-medium text-slate-600 dark:text-white/65">
+          {t("auth_files.batch_selected", { count: selectedCount })}
+        </span>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="px-2"
+          onClick={() => setSelectedFileNames([])}
         >
-          <Settings2 size={15} />
-        </button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content align="end" sideOffset={8} className={ACTION_MENU_CONTENT_CLASS}>
-          <DropdownMenu.Item
-            className={ACTION_MENU_ITEM_CLASS}
-            onSelect={() => openConfigModal("excluded")}
-          >
-            <SlidersHorizontal size={15} />
-            <span>{t("auth_files_page.excluded_tab")}</span>
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            className={ACTION_MENU_ITEM_CLASS}
-            onSelect={() => openConfigModal("alias")}
-          >
-            <Tags size={15} />
-            <span>{t("auth_files_page.alias_tab")}</span>
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+          {t("auth_files.batch_clear")}
+        </Button>
+        <Button
+          variant="danger"
+          size="xs"
+          className="px-2"
+          onClick={() => setConfirm({ type: "deleteSelection", names: [...selectedFileNames] })}
+          disabled={deletingAll}
+        >
+          {t("auth_files.batch_delete_action", { count: selectedCount })}
+        </Button>
+      </div>
+    ) : (
+      selectionActionsMenu
+    );
+
+  const paginationBar = (
+    <PaginationBar
+      currentPage={safePage}
+      totalPages={totalPages}
+      totalCount={filteredFiles.length}
+      pageSize={AUTH_FILES_PAGE_SIZE}
+      onPageChange={setPage}
+      showPageSize={false}
+      className="border-t border-slate-100 px-4 pb-4 pt-3 sm:px-5 sm:pb-5 dark:border-neutral-800/60"
+      labels={{
+        firstPage: t("request_logs.first_page"),
+        previousPage: t("auth_files.prev"),
+        nextPage: t("auth_files.next"),
+        lastPage: t("request_logs.last_page"),
+        pageInfo: ({ total, currentPage, totalPages: pages }) =>
+          t("auth_files.total_page", {
+            total,
+            page: currentPage,
+            pages,
+          }),
+      }}
+    />
   );
 
   return (
-    <div className="mt-3 space-y-3">
+    <Card
+      padding="none"
+      className="overflow-hidden md:flex md:h-[calc(100dvh-113px)] md:min-h-0 md:flex-col"
+      bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
+    >
       <input
         ref={fileInputRef}
         type="file"
@@ -893,7 +939,7 @@ export function AuthFilesFilesTab({
         onChange={(e) => void handleUpload(e.currentTarget.files)}
       />
 
-      <Card padding="compact">
+      <div className="shrink-0 border-b border-slate-100 p-3.5 dark:border-neutral-800/60">
         <div className="flex flex-col gap-3">
           <div className="flex items-center justify-between gap-2 md:hidden">
             <Button
@@ -920,32 +966,29 @@ export function AuthFilesFilesTab({
           <div
             id="auth-files-mobile-filter-panel"
             data-testid="auth-files-mobile-filter-panel"
-            className={[mobileFiltersOpen ? "grid" : "hidden", "gap-x-1.5 md:grid"].join(" ")}
+            className={[mobileFiltersOpen ? "grid" : "hidden", "gap-4 md:grid"].join(" ")}
           >
-            <div className="flex flex-col gap-1.5">
-              <div className="flex min-w-0 flex-wrap items-start gap-x-1.5 gap-y-2">
-                <div className="min-w-0 basis-[150px]">
-                  <div className="space-y-1.5">
-                    <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
-                      {t("auth_files_page.provider_filter")}
-                    </p>
+            <div className="flex flex-col gap-4">
+              <div className={FILTER_GRID_CLASS}>
+                <div className="w-full">
+                  <div className={FILTER_FIELD_CLASS}>
+                    <p className={FILTER_LABEL_CLASS}>{t("auth_files_page.provider_filter")}</p>
                     <SearchableSelect
                       value={filter}
                       onChange={setFilter}
                       options={providerFilterOptions}
                       searchPlaceholder={t("auth_files_page.provider_filter_search")}
                       aria-label={t("auth_files_page.provider_filter")}
-                      size="sm"
+                      className="w-full"
+                      size="default"
                     />
                   </div>
                 </div>
 
                 {canSetModelOwnerGroup ? (
-                  <div className="min-w-0 basis-[140px]">
-                    <div className="space-y-1.5">
-                      <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
-                        {t("auth_files.model_owner_group")}
-                      </p>
+                  <div className="w-full">
+                    <div className={FILTER_FIELD_CLASS}>
+                      <p className={FILTER_LABEL_CLASS}>{t("auth_files.model_owner_group")}</p>
                       <HoverTooltip content={t("auth_files.model_owner_group")} placement="top">
                         <Button
                           variant="secondary"
@@ -980,11 +1023,9 @@ export function AuthFilesFilesTab({
                 ) : null}
 
                 {customTagOptions.length > 0 ? (
-                  <div className="min-w-0 basis-[140px]">
-                    <div className="space-y-1.5">
-                      <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
-                        {t("auth_files.tag_filter")}
-                      </p>
+                  <div className="w-full">
+                    <div className={FILTER_FIELD_CLASS}>
+                      <p className={FILTER_LABEL_CLASS}>{t("auth_files.tag_filter")}</p>
                       <SearchableSelect
                         value={tagFilter}
                         onChange={setTagFilter}
@@ -992,17 +1033,16 @@ export function AuthFilesFilesTab({
                         placeholder={t("auth_files.all_tags")}
                         searchPlaceholder={t("auth_files.tag_filter_search_placeholder")}
                         aria-label={t("auth_files.tag_filter")}
-                        size="sm"
+                        className="w-full"
+                        size="default"
                       />
                     </div>
                   </div>
                 ) : null}
 
-                <div className="min-w-0 basis-[120px]">
-                  <div className="space-y-1.5">
-                    <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
-                      {t("auth_files.status_filter")}
-                    </p>
+                <div className="w-full">
+                  <div className={FILTER_FIELD_CLASS}>
+                    <p className={FILTER_LABEL_CLASS}>{t("auth_files.status_filter")}</p>
                     <Select
                       value={statusFilter}
                       onChange={(value) => setStatusFilter(value as AuthFileStatusFilter)}
@@ -1010,16 +1050,15 @@ export function AuthFilesFilesTab({
                       placeholder={t("auth_files.status_filter")}
                       aria-label={t("auth_files.status_filter")}
                       disabled={statusFilterOptions.length <= 1 && statusFilter === "all"}
-                      size="sm"
+                      className="w-full"
+                      size="default"
                     />
                   </div>
                 </div>
 
-                <div className="min-w-0 basis-[120px]">
-                  <div className="space-y-1.5">
-                    <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
-                      {t("auth_files.quota_auto_refresh")}
-                    </p>
+                <div className="w-full">
+                  <div className={FILTER_FIELD_CLASS}>
+                    <p className={FILTER_LABEL_CLASS}>{t("auth_files.quota_auto_refresh")}</p>
                     <div
                       className={
                         loading && filesLength === 0 ? "pointer-events-none opacity-60" : ""
@@ -1038,179 +1077,175 @@ export function AuthFilesFilesTab({
                           { value: "60000", label: "60s" },
                         ]}
                         aria-label={t("auth_files.quota_auto_refresh")}
-                        variant="chip"
                         className="w-full"
-                        size="sm"
+                        size="default"
                       />
                     </div>
                   </div>
                 </div>
 
-                <div className="min-w-0 basis-[180px]">
-                  <div className="space-y-1.5">
-                    <p className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
-                      {t("auth_files.search")}
-                    </p>
+                <div className="w-full">
+                  <div className={FILTER_FIELD_CLASS}>
+                    <p className={FILTER_LABEL_CLASS}>{t("auth_files.search")}</p>
                     <TextInput
                       value={search}
                       onChange={(e) => setSearch(e.currentTarget.value)}
                       placeholder={t("auth_files_page.filename_hint")}
                       aria-label={t("auth_files.search")}
                       endAdornment={<Search size={16} className="text-slate-400" />}
-                      size="sm"
+                      size="default"
                     />
                   </div>
                 </div>
               </div>
 
-              <div className="flex flex-wrap items-center gap-1.5">
-                <div
-                  className={loading && filesLength === 0 ? "pointer-events-none opacity-60" : ""}
-                >
-                  {renderFilesViewModeTabs}
+              <div className="flex min-h-9 flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <div
+                    className={
+                      loading && filesLength === 0 ? "pointer-events-none opacity-60" : ""
+                    }
+                  >
+                    {renderFilesViewModeTabs}
+                  </div>
+                  {selectionToolbar}
                 </div>
-                {selectedCount === 0 ? selectionActionsMenu : null}
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="!h-8 px-2 text-xs"
-                  onClick={openGroupOverview}
-                  disabled={loading || groupOverviewLoading || filteredFiles.length === 0}
-                >
-                  <BarChart3 size={14} className={groupOverviewLoading ? "animate-pulse" : ""} />
-                  {t("auth_files.group_overview_button")}
-                </Button>
-                <HoverTooltip content={t("auth_files.refresh")}>
+
+                <div className="flex shrink-0 flex-wrap items-center gap-2">
                   <Button
                     variant="secondary"
                     size="sm"
-                    onClick={() => void refreshFilesAndQuota()}
-                    disabled={loading || usageLoading || refreshingAll}
-                    aria-label={t("auth_files.refresh")}
-                    title={t("auth_files.refresh")}
+                    className="!h-8 px-2 text-xs"
+                    onClick={openGroupOverview}
+                    disabled={loading || groupOverviewLoading || filteredFiles.length === 0}
                   >
-                    <RefreshCw
-                      size={15}
-                      className={loading || usageLoading || refreshingAll ? "animate-spin" : ""}
-                    />
+                    <BarChart3 size={14} className={groupOverviewLoading ? "animate-pulse" : ""} />
+                    {t("auth_files.group_overview_button")}
                   </Button>
-                </HoverTooltip>
-                <HoverTooltip content={t("auth_files.upload")}>
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={uploading}
-                    aria-label={t("auth_files.upload")}
-                    title={t("auth_files.upload")}
-                  >
-                    {uploading ? (
-                      <Loader2 size={15} className="animate-spin" />
-                    ) : (
-                      <Upload size={15} />
-                    )}
-                  </Button>
-                </HoverTooltip>
-                <HoverTooltip content={t("auth_files.paste_json")}>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      setJsonImportError("");
-                      setJsonImportOpen(true);
-                    }}
-                    disabled={uploading}
-                    aria-label={t("auth_files.paste_json")}
-                    title={t("auth_files.paste_json")}
-                  >
-                    {uploading ? (
-                      <Loader2 size={15} className="animate-spin" />
-                    ) : (
-                      <ClipboardPaste size={15} />
-                    )}
-                  </Button>
-                </HoverTooltip>
-                <HoverTooltip content={t("auth_files_page.add_oauth")}>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => {
-                      const normalized = normalizeProviderKey(filter);
-                      const oauthTab =
-                        normalized === "codex" ||
-                        normalized === "anthropic" ||
-                        normalized === "antigravity" ||
-                        normalized === "gemini-cli" ||
-                        normalized === "kimi" ||
-                        normalized === "qwen"
-                          ? (normalized as OAuthDialogTab)
-                          : "codex";
-                      setOauthDialogDefaultTab(oauthTab);
-                      setOauthDialogOpen(true);
-                    }}
-                    aria-label={t("auth_files_page.add_oauth")}
-                    title={t("auth_files_page.add_oauth")}
-                  >
-                    <Plus size={15} />
-                  </Button>
-                </HoverTooltip>
-                {configActionsMenu}
+                  <HoverTooltip content={t("auth_files.refresh")}>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => void refreshFilesAndQuota()}
+                      disabled={loading || usageLoading || refreshingAll}
+                      aria-label={t("auth_files.refresh")}
+                      title={t("auth_files.refresh")}
+                    >
+                      <RefreshCw
+                        size={15}
+                        className={loading || usageLoading || refreshingAll ? "animate-spin" : ""}
+                      />
+                    </Button>
+                  </HoverTooltip>
+                  <HoverTooltip content={t("auth_files.upload")}>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={uploading}
+                      aria-label={t("auth_files.upload")}
+                      title={t("auth_files.upload")}
+                    >
+                      {uploading ? (
+                        <Loader2 size={15} className="animate-spin" />
+                      ) : (
+                        <Upload size={15} />
+                      )}
+                    </Button>
+                  </HoverTooltip>
+                  <HoverTooltip content={t("auth_files.paste_json")}>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        setJsonImportError("");
+                        setJsonImportOpen(true);
+                      }}
+                      disabled={uploading}
+                      aria-label={t("auth_files.paste_json")}
+                      title={t("auth_files.paste_json")}
+                    >
+                      {uploading ? (
+                        <Loader2 size={15} className="animate-spin" />
+                      ) : (
+                        <ClipboardPaste size={15} />
+                      )}
+                    </Button>
+                  </HoverTooltip>
+                  <HoverTooltip content={t("auth_files_page.add_oauth")}>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => {
+                        const normalized = normalizeProviderKey(filter);
+                        const oauthTab =
+                          normalized === "codex" ||
+                          normalized === "anthropic" ||
+                          normalized === "antigravity" ||
+                          normalized === "gemini-cli" ||
+                          normalized === "kimi" ||
+                          normalized === "qwen"
+                            ? (normalized as OAuthDialogTab)
+                            : "codex";
+                        setOauthDialogDefaultTab(oauthTab);
+                        setOauthDialogOpen(true);
+                      }}
+                      aria-label={t("auth_files_page.add_oauth")}
+                      title={t("auth_files_page.add_oauth")}
+                    >
+                      <Plus size={15} />
+                    </Button>
+                  </HoverTooltip>
+                  {configActionsMenu}
+                </div>
               </div>
 
             </div>
           </div>
-
-          {selectedCount > 0 ? (
-            <div className="flex flex-wrap items-center gap-1.5 rounded-2xl bg-slate-50/80 px-2 py-1.5 transition-colors duration-200 ease-out dark:bg-white/[0.03]">
-              {selectionActionsMenu}
-              <span className="ml-1 text-xs font-medium text-slate-600 dark:text-white/65">
-                {t("auth_files.batch_selected", { count: selectedCount })}
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="!h-8 px-2 text-xs"
-                onClick={() => setSelectedFileNames([])}
-              >
-                {t("auth_files.batch_clear")}
-              </Button>
-              <Button
-                variant="danger"
-                size="sm"
-                className="!h-8 px-2 text-xs"
-                onClick={() =>
-                  setConfirm({ type: "deleteSelection", names: [...selectedFileNames] })
-                }
-                disabled={deletingAll}
-              >
-                {t("auth_files.batch_delete_action", { count: selectedCount })}
-              </Button>
-            </div>
-          ) : null}
         </div>
-      </Card>
+      </div>
 
       {loading && filesLength === 0 ? (
-        <Card padding="none" className="relative overflow-hidden">
-          <div className="p-4 sm:p-5" data-testid="auth-files-table-skeleton">
-            <div className="space-y-2">
+        <>
+          <div
+            className="md:min-h-0 md:flex-1 md:overflow-hidden"
+            data-testid="auth-files-table-skeleton"
+          >
+            <ScrollArea
+              className="h-full"
+              contentClassName="space-y-2 px-4 py-4 pr-8 sm:py-5 sm:pl-5 sm:pr-8"
+              scrollbarTrackInset={0}
+            >
               {Array.from({ length: 7 }).map((_, idx) => (
                 <div
                   key={`s-${idx}`}
                   className="h-[84px] rounded-xl bg-slate-50/80 transition-colors duration-200 ease-out motion-safe:animate-pulse dark:bg-white/[0.03]"
                 />
               ))}
-            </div>
+            </ScrollArea>
           </div>
-        </Card>
+          {paginationBar}
+        </>
       ) : pageItems.length === 0 ? (
-        <EmptyState
-          title={t("auth_files_page.no_files")}
-          description={t("auth_files_page.no_files_desc")}
-        />
+        <>
+          <div className="p-4 sm:p-5 md:min-h-0 md:flex-1 md:overflow-hidden">
+            <EmptyState
+              title={t("auth_files_page.no_files")}
+              description={t("auth_files_page.no_files_desc")}
+            />
+          </div>
+          {paginationBar}
+        </>
       ) : (
-        <Card padding="none" className="relative overflow-hidden">
-          <div className="p-4 sm:p-5">
+        <>
+          <div
+            className={[
+              "md:min-h-0 md:flex-1 md:overflow-hidden",
+              filesViewMode === "table" ? "p-4 sm:p-5" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
             {filesViewMode === "table" ? (
               <DataTable<AuthFileItem>
                 tableId="auth-files"
@@ -1223,7 +1258,8 @@ export function AuthFilesFilesTab({
                 caption={t("auth_files.table_caption")}
                 emptyText={t("auth_files_page.no_files_desc")}
                 minWidth="min-w-[1840px]"
-                height="h-[calc(100dvh-452px)]"
+                height="h-full"
+                minHeight="min-h-[360px] md:min-h-0"
                 rowClassName={(row) => {
                   const runtimeOnly = isRuntimeOnlyAuthFile(row);
                   const disabled = Boolean(row.disabled);
@@ -1242,9 +1278,11 @@ export function AuthFilesFilesTab({
                 }}
               />
             ) : (
-              <div
+              <ScrollArea
                 data-testid="auth-files-cards"
-                className="grid grid-cols-1 items-stretch gap-5 md:grid-cols-2 xl:grid-cols-3"
+                className="h-full items-stretch"
+                contentClassName="grid grid-cols-1 items-stretch gap-5 px-4 py-4 pr-8 sm:py-5 sm:pl-5 sm:pr-8 md:grid-cols-2 xl:grid-cols-3"
+                scrollbarTrackInset={0}
               >
                 {pageItems.map((file) => {
                   const runtimeOnly = isRuntimeOnlyAuthFile(file);
@@ -1288,7 +1326,7 @@ export function AuthFilesFilesTab({
                       padding="default"
                       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[
-                        "group flex h-full flex-col transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+                        "group/card flex h-full flex-col transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
                         fileSelected
                           ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                           : "",
@@ -1313,7 +1351,7 @@ export function AuthFilesFilesTab({
                                   "flex h-8 items-center justify-center px-1 transition-opacity",
                                   showSelectionControl
                                     ? "opacity-100 pointer-events-auto"
-                                    : "opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto",
+                                    : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-focus-within/card:opacity-100 group-hover/card:pointer-events-auto group-focus-within/card:pointer-events-auto",
                                 ].join(" ")}
                               >
                                 <input
@@ -1335,7 +1373,7 @@ export function AuthFilesFilesTab({
                               <div
                                 className={[
                                   "flex h-8 items-center justify-center transition-opacity",
-                                  "opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto",
+                                  "opacity-0 pointer-events-none group-hover/card:opacity-100 group-focus-within/card:opacity-100 group-hover/card:pointer-events-auto group-focus-within/card:pointer-events-auto",
                                 ].join(" ")}
                               >
                                 <ToggleSwitch
@@ -1492,39 +1530,12 @@ export function AuthFilesFilesTab({
                     </Card>
                   );
                 })}
-              </div>
+              </ScrollArea>
             )}
           </div>
-        </Card>
+          {paginationBar}
+        </>
       )}
-
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="text-xs text-slate-600 dark:text-white/65 tabular-nums">
-          {t("auth_files.total_page", {
-            total: filteredFiles.length,
-            page: safePage,
-            pages: totalPages,
-          })}
-        </p>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-            disabled={safePage <= 1}
-          >
-            {t("auth_files.prev")}
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
-            disabled={safePage >= totalPages}
-          >
-            {t("auth_files.next")}
-          </Button>
-        </div>
-      </div>
 
       {usageData ? null : (
         <p className="text-xs text-slate-500 dark:text-white/55">
@@ -1794,6 +1805,6 @@ export function AuthFilesFilesTab({
           </div>
         </div>
       </Modal>
-    </div>
+    </Card>
   );
 }

--- a/pages/auth-files/hooks/useAuthFilesOAuthConfig.ts
+++ b/pages/auth-files/hooks/useAuthFilesOAuthConfig.ts
@@ -19,6 +19,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
 
   const [aliasLoading, setAliasLoading] = useState(false);
   const [aliasEditing, setAliasEditing] = useState<Record<string, AliasRow[]>>({});
+  const [aliasSavedChannels, setAliasSavedChannels] = useState<string[]>([]);
   const [aliasNewChannel, setAliasNewChannel] = useState("");
   const [aliasUnsupported, setAliasUnsupported] = useState(false);
 
@@ -63,6 +64,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
     try {
       const map = await authFilesApi.getOauthModelAlias();
       setAliasUnsupported(false);
+      setAliasSavedChannels(Object.keys(map).map((key) => normalizeProviderKey(key)));
       setAliasEditing(
         Object.fromEntries(Object.entries(map).map(([key, value]) => [key, buildAliasRows(value)])),
       );
@@ -70,6 +72,7 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
       const message = err instanceof Error ? err.message : "";
       if (/404|not found/i.test(message)) {
         setAliasUnsupported(true);
+        setAliasSavedChannels([]);
         setAliasEditing({});
         return;
       }
@@ -122,29 +125,20 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   );
 
   const deleteExcludedProvider = useCallback(
-    async (provider: string) => {
-      if (excludedUnsupported) {
-        notify({
-          type: "error",
-          message:
-            "Server does not support OAuth excluded models API (/oauth-excluded-models). Please upgrade.",
-        });
-        return;
-      }
+    (provider: string) => {
       const key = normalizeProviderKey(provider);
-      try {
-        await authFilesApi.deleteOauthExcludedEntry(key);
-        invalidateConfiguredModelAvailability();
-        notify({ type: "success", message: t("auth_files.deleted") });
-        startTransition(() => void refreshExcluded());
-      } catch (err: unknown) {
-        notify({
-          type: "error",
-          message: err instanceof Error ? err.message : t("auth_files.delete_failed"),
-        });
-      }
+      setExcluded((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+      setExcludedDraft((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
     },
-    [excludedUnsupported, notify, refreshExcluded, startTransition, t],
+    [],
   );
 
   const addExcludedProvider = useCallback(() => {
@@ -203,29 +197,94 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
   );
 
   const deleteAliasChannel = useCallback(
-    async (channel: string) => {
-      if (aliasUnsupported) {
-        notify({
-          type: "error",
-          message: t("auth_files.server_no_alias_api"),
-        });
-        return;
-      }
+    (channel: string) => {
       const key = normalizeProviderKey(channel);
-      try {
-        await authFilesApi.deleteOauthModelAlias(key);
-        invalidateConfiguredModelAvailability();
-        notify({ type: "success", message: t("auth_files.deleted") });
-        startTransition(() => void refreshAlias());
-      } catch (err: unknown) {
-        notify({
-          type: "error",
-          message: err instanceof Error ? err.message : t("auth_files.delete_failed"),
-        });
-      }
+      setAliasEditing((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
     },
-    [aliasUnsupported, notify, refreshAlias, startTransition, t],
+    [],
   );
+
+  const saveExcludedAll = useCallback(async (): Promise<boolean> => {
+    if (excludedUnsupported) {
+      notify({ type: "error", message: t("auth_files.server_no_excluded_api") });
+      return false;
+    }
+
+    const nextMap = Object.fromEntries(
+      Object.entries(excludedDraft).flatMap(([provider, text]) => {
+        const key = normalizeProviderKey(provider);
+        if (!key) return [];
+        const models = text
+          .split(/[\n,]+/)
+          .map((item) => item.trim())
+          .filter(Boolean);
+        return [[key, models]];
+      }),
+    );
+
+    try {
+      await authFilesApi.replaceOauthExcludedModels(nextMap);
+      setExcluded(nextMap);
+      setExcludedDraft(
+        Object.fromEntries(Object.entries(nextMap).map(([key, value]) => [key, value.join("\n")])),
+      );
+      invalidateConfiguredModelAvailability();
+      notify({ type: "success", message: t("auth_files.saved") });
+      return true;
+    } catch (err: unknown) {
+      notify({
+        type: "error",
+        message: err instanceof Error ? err.message : t("auth_files.save_failed"),
+      });
+      return false;
+    }
+  }, [excludedDraft, excludedUnsupported, notify, t]);
+
+  const saveAliasAll = useCallback(async (): Promise<boolean> => {
+    if (aliasUnsupported) {
+      notify({ type: "error", message: t("auth_files.server_no_alias_api") });
+      return false;
+    }
+
+    const currentEntries = Object.entries(aliasEditing).flatMap(([channel, rows]) => {
+      const key = normalizeProviderKey(channel);
+      return key ? ([[key, rows]] as const) : [];
+    });
+    const currentChannels = currentEntries.map(([channel]) => channel);
+    const currentSet = new Set(currentChannels);
+    const removedChannels = aliasSavedChannels.filter((channel) => !currentSet.has(channel));
+
+    try {
+      for (const [channel, rows] of currentEntries) {
+        const next = rows
+          .map((row) => ({
+            name: row.name.trim(),
+            alias: row.alias.trim(),
+            ...(row.fork ? { fork: true } : {}),
+          }))
+          .filter((row) => row.name && row.alias);
+        await authFilesApi.saveOauthModelAlias(channel, next);
+      }
+      for (const channel of removedChannels) {
+        await authFilesApi.deleteOauthModelAlias(channel);
+      }
+
+      setAliasSavedChannels(currentChannels);
+      invalidateConfiguredModelAvailability();
+      notify({ type: "success", message: t("auth_files.saved") });
+      return true;
+    } catch (err: unknown) {
+      notify({
+        type: "error",
+        message: err instanceof Error ? err.message : t("auth_files.save_failed"),
+      });
+      return false;
+    }
+  }, [aliasEditing, aliasSavedChannels, aliasUnsupported, notify, t]);
 
   const openImport = useCallback(
     async (channel: string) => {
@@ -339,6 +398,8 @@ export function useAuthFilesOAuthConfig(tab: "files" | "excluded" | "alias") {
     addAliasChannel,
     saveAliasChannel,
     deleteAliasChannel,
+    saveExcludedAll,
+    saveAliasAll,
     openImport,
     applyImport,
   };


### PR DESCRIPTION
## Summary
- unify auth-files pagination into a shared configurable pagination bar
- polish auth-files filter, card, modal, and scroll layouts for desktop consistency
- keep OAuth excluded/alias edits draft-based until explicit save

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- packages/ui/src/navigation/__tests__/PaginationBar.test.tsx pages/auth-files/__tests__/AuthFilesPage.excluded.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run lint
- rtk bun run --filter @code-proxy/admin-panel build