### PR TITLE
fix: suppress dashboard update restart error toasts

### DIFF
--- a/packages/api-client/src/client/__tests__/client.test.ts
+++ b/packages/api-client/src/client/__tests__/client.test.ts
@@ -105,6 +105,27 @@ describe("ApiClient request standardization", () => {
       isAuthError: false,
     } satisfies Partial<ApiError>);
   });
+
+  test("sanitizes HTML error pages returned by upstream proxies", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("<!doctype html><html><head><title>502 Bad Gateway</title></head></html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      }),
+    );
+    globalThis.fetch = fetchMock;
+
+    const client = new ApiClient();
+    client.setConfig({ apiBase: "http://localhost:8317", managementKey: "test-key" });
+
+    await expect(client.get("/dashboard-summary")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 502,
+      message: "Management API temporarily returned an HTML error page (502 Bad Gateway).",
+      payload: expect.stringContaining("<!doctype html>"),
+    } satisfies Partial<ApiError>);
+  });
 });
 
 describe("ApiClient authentication failure handling", () => {

--- a/packages/api-client/src/client/client.ts
+++ b/packages/api-client/src/client/client.ts
@@ -41,6 +41,18 @@ const dispatchWindowEvent = (event: Event): void => {
   }
 };
 
+const isHtmlDocument = (contentType: string, text: string) =>
+  contentType.toLowerCase().includes("text/html") &&
+  /^<!doctype html|^<html[\s>]/i.test(text.trim());
+
+const buildHtmlErrorMessage = (response: Response) => {
+  const status = response.status || 0;
+  const suffix = response.statusText?.trim()
+    ? `${status} ${response.statusText.trim()}`
+    : String(status);
+  return `Management API temporarily returned an HTML error page (${suffix}).`;
+};
+
 const normalizeRequestPath = (path: string): string => {
   const trimmed = path.trim();
   if (!trimmed) return "/";
@@ -156,10 +168,7 @@ export class ApiClient {
     if (!trimmed) return undefined;
 
     const contentType = response.headers.get("Content-Type") ?? "";
-    if (
-      contentType.toLowerCase().includes("text/html") &&
-      /^<!doctype html|^<html[\s>]/i.test(trimmed)
-    ) {
+    if (isHtmlDocument(contentType, trimmed)) {
       throw new ApiError({
         message:
           "Management API returned the web panel HTML instead of JSON. Check the API base URL.",
@@ -185,12 +194,17 @@ export class ApiClient {
       const text = await response.text();
       const trimmed = text.trim();
       if (trimmed) {
-        try {
-          payload = JSON.parse(trimmed) as unknown;
-          message = extractApiErrorMessage(payload, truncateErrorText(trimmed));
-        } catch {
+        if (isHtmlDocument(response.headers.get("Content-Type") ?? "", trimmed)) {
           payload = truncateErrorText(trimmed);
-          message = truncateErrorText(trimmed);
+          message = buildHtmlErrorMessage(response);
+        } else {
+          try {
+            payload = JSON.parse(trimmed) as unknown;
+            message = extractApiErrorMessage(payload, truncateErrorText(trimmed));
+          } catch {
+            payload = truncateErrorText(trimmed);
+            message = truncateErrorText(trimmed);
+          }
         }
       }
     } catch {

--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Activity,
@@ -369,6 +369,7 @@ export function DashboardPage() {
   const { notify } = useToast();
   const { stats, connected } = useSystemStats(5);
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
+  const summaryRef = useRef<DashboardSummary | null>(null);
   const [range, setRange] = useState<DashboardRange>(7);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -378,15 +379,22 @@ export function DashboardPage() {
     async (days: DashboardRange, silent = false) => {
       if (!silent) {
         setLoading(true);
+        setError(null);
       }
-      setError(null);
       try {
         const data = await usageApi.getDashboardSummary(days);
+        summaryRef.current = data;
         setSummary(data);
+        setError(null);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : t("dashboard.load_failed");
-        setError(message);
-        notify({ type: "error", message });
+        const hasSummary = summaryRef.current !== null;
+        if (!silent || !hasSummary) {
+          setError(message);
+        }
+        if (!silent) {
+          notify({ type: "error", message });
+        }
       } finally {
         if (!silent) {
           setLoading(false);

--- a/pages/dashboard/__tests__/DashboardPage.test.tsx
+++ b/pages/dashboard/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { DashboardPage } from "../DashboardPage";
+
+const mocks = vi.hoisted(() => ({
+  getDashboardSummary: vi.fn(),
+  notify: vi.fn(),
+  useSystemStats: vi.fn(),
+  intervalCallback: null as null | (() => void),
+}));
+
+vi.mock("@code-proxy/api-client/endpoints/usage", () => ({
+  usageApi: {
+    getDashboardSummary: mocks.getDashboardSummary,
+  },
+}));
+
+vi.mock("../useSystemStats", () => ({
+  useSystemStats: mocks.useSystemStats,
+}));
+
+vi.mock("../SystemMonitorSection", () => ({
+  SystemMonitorSection: () => <div data-testid="system-monitor-section" />,
+}));
+
+vi.mock("@code-proxy/ui", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    AnimatedNumber: ({
+      value,
+      format,
+    }: {
+      value: number;
+      format?: (value: number) => string;
+    }) => <span>{format ? format(value) : value}</span>,
+    Button: ({ children, type = "button", ...props }: any) => (
+      <button type={type} {...props}>
+        {children}
+      </button>
+    ),
+    Card: ({
+      title,
+      description,
+      actions,
+      children,
+    }: any) => (
+      <section>
+        {title ? <h3>{title}</h3> : null}
+        {description ? <p>{description}</p> : null}
+        {actions}
+        {children}
+      </section>
+    ),
+    EmptyState: ({ title, description, action }: any) => (
+      <div data-testid="empty-state">
+        <h3>{title}</h3>
+        <p>{description}</p>
+        {action}
+      </div>
+    ),
+    Tabs: ({ children }: any) => <div>{children}</div>,
+    TabsList: ({ children }: any) => <div>{children}</div>,
+    TabsTrigger: ({ children, value }: any) => <button data-value={value}>{children}</button>,
+    EChart: () => <div data-testid="chart" />,
+    ChartLegend: () => <div data-testid="legend" />,
+    useToast: () => ({ notify: mocks.notify }),
+    useInterval: (callback: () => void) => {
+      mocks.intervalCallback = callback;
+      React.useEffect(() => {
+        mocks.intervalCallback = callback;
+      }, [callback]);
+    },
+  };
+});
+
+const summary = {
+  kpi: {
+    total_requests: 1234,
+    success_requests: 1200,
+    failed_requests: 34,
+    success_rate: 97.24,
+    input_tokens: 1000,
+    output_tokens: 2000,
+    reasoning_tokens: 0,
+    cached_tokens: 300,
+    total_tokens: 3300,
+    total_cost: 1.23,
+    cache_rate: 30,
+  },
+  trends: {
+    request_volume: [{ label: "Mon", value: 100 }],
+    success_rate: [{ label: "Mon", value: 97.24 }],
+    total_tokens: [{ label: "Mon", value: 3300 }],
+    total_cost: [{ label: "Mon", value: 1.23 }],
+    failed_requests: [{ label: "Mon", value: 34 }],
+    throughput_series: [{ label: "10:00", rpm: 12, tpm: 345 }],
+  },
+  meta: {
+    generated_at: "2026-06-10T00:00:00Z",
+  },
+  counts: {
+    api_keys: 2,
+    providers_total: 1,
+    gemini_keys: 0,
+    claude_keys: 0,
+    codex_keys: 0,
+    vertex_keys: 0,
+    openai_providers: 1,
+    auth_files: 0,
+  },
+  days: 7,
+} as const;
+
+describe("DashboardPage", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+    mocks.notify.mockReset();
+    mocks.getDashboardSummary.mockReset();
+    mocks.intervalCallback = null;
+    mocks.useSystemStats.mockReturnValue({
+      stats: {
+        total_rpm: 12,
+        total_tpm: 345,
+      },
+      connected: true,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("keeps the last dashboard snapshot and skips error toasts when silent refresh fails", async () => {
+    mocks.getDashboardSummary
+      .mockResolvedValueOnce(summary)
+      .mockRejectedValueOnce(
+        new Error(
+          "Management API temporarily returned an HTML error page (502 Bad Gateway).",
+        ),
+      );
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(mocks.getDashboardSummary).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.queryByTestId("empty-state")).toBeNull();
+
+    await act(async () => {
+      mocks.intervalCallback?.();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mocks.getDashboardSummary).toHaveBeenCalledTimes(2);
+    });
+    expect(mocks.notify).not.toHaveBeenCalled();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.queryByTestId("empty-state")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- keep dashboard auto-refresh silent during updater restarts so transient 502s do not spam error toasts
- sanitize HTML gateway/error pages into concise API errors instead of dumping raw markup into notifications
- add regression tests for the silent dashboard refresh path and HTML error sanitization

## Verification
- rtk bun run test:ci -- ../../pages/dashboard/__tests__/DashboardPage.test.tsx ../../packages/api-client/src/client/__tests__/client.test.ts ../../src/app/update/__tests__/updateShared.test.ts
- rtk bun run lint
- rtk bun run build

## Notes
- direct pushes to dev are blocked by branch protection, so this change is routed through a PR as required
