### PR TITLE
feat: persist auth group owner mappings

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -6,12 +6,7 @@ import type {
   ProviderModel,
   ProviderSimpleConfig,
 } from "@code-proxy/api-client";
-import {
-  matchesModelPattern,
-  normalizeProviderKey,
-  readAuthFilesModelOwnerGroupMap,
-  resolveFileType,
-} from "@code-proxy/domain";
+import { matchesModelPattern, normalizeProviderKey, resolveFileType } from "@code-proxy/domain";
 import {
   getConfiguredAvailabilityCacheVersion,
   invalidateConfiguredModelAvailability,
@@ -104,6 +99,8 @@ type ModelDefinition = {
   owned_by?: string;
 };
 
+type AuthGroupOwnerMappingMap = Record<string, string>;
+
 const PROVIDER_CHANNELS = [
   { key: "gemini", load: () => providersApi.getGeminiKeys() },
   { key: "claude", load: () => providersApi.getClaudeConfigs() },
@@ -130,6 +127,35 @@ export const emptyModelPricing = (): ModelPricing => ({
 
 const normalizeOwnerValue = (value: string): string =>
   value.trim().replace(/\s+/g, "-").toLowerCase();
+
+const normalizeAuthGroupOwnerMappings = (payload: unknown): AuthGroupOwnerMappingMap => {
+  const record = isRecord(payload) ? payload : {};
+  const rawList = Array.isArray(record.items)
+    ? record.items
+    : Array.isArray(record.data)
+      ? record.data
+      : Array.isArray(payload)
+        ? payload
+        : [];
+
+  const output: AuthGroupOwnerMappingMap = {};
+  for (const item of rawList) {
+    if (!isRecord(item)) continue;
+    const authGroup = normalizeProviderKey(String(item.auth_group ?? item.authGroup ?? ""));
+    const owner = normalizeOwnerValue(String(item.owner ?? item.owner_value ?? ""));
+    if (!authGroup || authGroup === "all" || !owner) continue;
+    output[authGroup] = owner;
+  }
+  return output;
+};
+
+const loadAuthGroupOwnerMappingMap = async (): Promise<AuthGroupOwnerMappingMap> => {
+  try {
+    return normalizeAuthGroupOwnerMappings(await apiClient.get("/auth-group-model-owner-mappings"));
+  } catch {
+    return {};
+  }
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -494,10 +520,10 @@ const authFileDisabled = (file: AuthFileItem): boolean => {
 const loadAuthFileModelItems = async (
   authFiles: AuthFileItem[],
   libraryModels: ModelAvailabilityItem[],
+  ownerByAuthGroup: AuthGroupOwnerMappingMap,
 ): Promise<{ items: ModelAvailabilityItem[]; scoped: boolean }> => {
   const map = new Map<string, ModelAvailabilityItem>();
   const libraryIndex = buildLibraryModelIndex(libraryModels);
-  const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
   const modelsByOwner = new Map<string, ModelAvailabilityItem[]>();
   const activeAuthFiles = authFiles.filter((file) => !authFileDisabled(file));
   let scoped = authFiles.length > 0 && activeAuthFiles.length === 0;
@@ -546,6 +572,72 @@ const loadAuthFileModelItems = async (
   );
 
   return { items: Array.from(map.values()), scoped };
+};
+
+const rootModelPath: ModelPathItem = {
+  scope: "root",
+  label: "models",
+  method: "GET",
+  path: "/v1/models",
+  family: "openai-v1-models",
+};
+
+const augmentPathAvailabilityWithMappedOwners = async (
+  availability: ModelPathAvailability,
+): Promise<ModelPathAvailability> => {
+  const ownerByAuthGroup = await loadAuthGroupOwnerMappingMap();
+  if (Object.keys(ownerByAuthGroup).length === 0) return availability;
+
+  const [authFiles, libraryPayload] = await Promise.all([
+    loadAuthFiles(),
+    apiClient.get("/model-configs?scope=library").catch(() => null),
+  ]);
+  const libraryModels = normalizeModelConfigRows(libraryPayload);
+  const authFileAvailability = await loadAuthFileModelItems(
+    authFiles,
+    libraryModels,
+    ownerByAuthGroup,
+  );
+  if (authFileAvailability.items.length === 0) return availability;
+
+  const itemMap = new Map<string, ModelPathAvailabilityItem>(
+    availability.items.map((item): [string, ModelPathAvailabilityItem] => [
+      item.id.toLowerCase(),
+      { ...item, paths: [...item.paths] },
+    ]),
+  );
+
+  for (const model of authFileAvailability.items) {
+    const key = model.id.toLowerCase();
+    const existing = itemMap.get(key);
+    if (existing) {
+      if (
+        !existing.paths.some(
+          (path) => path.method === rootModelPath.method && path.path === rootModelPath.path,
+        )
+      ) {
+        existing.paths = [...existing.paths, rootModelPath];
+      }
+      if (!existing.owned_by && model.owned_by) {
+        existing.owned_by = model.owned_by;
+      }
+      continue;
+    }
+    itemMap.set(key, {
+      id: model.id,
+      owned_by: model.owned_by,
+      kind: "mapped-owner",
+      alias: false,
+      paths: [rootModelPath],
+    });
+  }
+
+  const items = Array.from(itemMap.values()).sort((a, b) => a.id.localeCompare(b.id));
+  return {
+    ...availability,
+    items,
+    idSet: new Set(items.map((item) => item.id.toLowerCase())),
+  };
 };
 
 /* ── New backend aggregation endpoint support ── */
@@ -660,9 +752,15 @@ export { invalidateConfiguredModelAvailability };
 export const loadConfiguredModelAvailability = async (options?: {
   allowedChannelGroups?: string[];
 }): Promise<ConfiguredModelAvailability> => {
+  const ownerByAuthGroup = await loadAuthGroupOwnerMappingMap();
+  const hasOwnerMappings = Object.keys(ownerByAuthGroup).length > 0;
   const validGroups = (options?.allowedChannelGroups ?? [])
     .map((g) => String(g ?? "").trim())
     .filter(Boolean);
+
+  if (hasOwnerMappings) {
+    return loadConfiguredModelAvailabilityFallback(ownerByAuthGroup);
+  }
 
   if (validGroups.length > 0) {
     const cacheKey = validGroups.join(",");
@@ -686,7 +784,7 @@ export const loadConfiguredModelAvailability = async (options?: {
         });
         return result;
       } catch {
-        return loadConfiguredModelAvailabilityFallback();
+        return loadConfiguredModelAvailabilityFallback(ownerByAuthGroup);
       }
     })();
     groupAvailabilityCache.set(cacheKey, {
@@ -723,7 +821,7 @@ export const loadConfiguredModelAvailability = async (options?: {
       return result;
     } catch {
       // Fallback to old multi-API aggregation for backward compatibility.
-      return loadConfiguredModelAvailabilityFallback();
+      return loadConfiguredModelAvailabilityFallback(ownerByAuthGroup);
     }
   })();
   configuredAvailabilityInFlight = { version: cacheVersion, promise };
@@ -737,14 +835,20 @@ export const loadConfiguredModelAvailability = async (options?: {
   }
 };
 
-const loadConfiguredModelAvailabilityFallback = async (): Promise<ConfiguredModelAvailability> => {
+const loadConfiguredModelAvailabilityFallback = async (
+  ownerByAuthGroup?: AuthGroupOwnerMappingMap,
+): Promise<ConfiguredModelAvailability> => {
   const [authFiles, libraryPayload, providerItems] = await Promise.all([
     loadAuthFiles(),
     apiClient.get("/model-configs?scope=library").catch(() => null),
     loadProviderModelItems(),
   ]);
   const libraryModels = normalizeModelConfigRows(libraryPayload);
-  const authFileAvailability = await loadAuthFileModelItems(authFiles, libraryModels);
+  const authFileAvailability = await loadAuthFileModelItems(
+    authFiles,
+    libraryModels,
+    ownerByAuthGroup ?? (await loadAuthGroupOwnerMappingMap()),
+  );
   const libraryIndex = buildLibraryModelIndex(libraryModels);
 
   const map = new Map<string, ModelAvailabilityItem>();
@@ -764,7 +868,9 @@ const loadConfiguredModelAvailabilityFallback = async (): Promise<ConfiguredMode
 };
 
 export const loadModelPathAvailability = async (): Promise<ModelPathAvailability> =>
-  normalizeModelPathAvailability(await apiClient.get("/model-path-availability"));
+  augmentPathAvailabilityWithMappedOwners(
+    normalizeModelPathAvailability(await apiClient.get("/model-path-availability")),
+  );
 
 export const filterByConfiguredModelAvailability = <T extends { id: string }>(
   models: T[],

--- a/packages/api-client/src/endpoints/models.ts
+++ b/packages/api-client/src/endpoints/models.ts
@@ -29,6 +29,12 @@ export type ModelOwnerPresetItem = {
   modelCount?: number;
 };
 
+export type AuthGroupModelOwnerMappingItem = {
+  auth_group: string;
+  owner: string;
+  updated_at?: string;
+};
+
 const normalizeApiBase = (baseUrl: string): string => {
   const trimmed = baseUrl.trim();
   if (!trimmed) return "";
@@ -187,6 +193,45 @@ const normalizeOwnerPresetResponse = (payload: unknown): ModelOwnerPresetItem[] 
     .sort((a, b) => a.label.localeCompare(b.label));
 };
 
+const normalizeAuthGroupKey = (value: string): string =>
+  value.trim().replace(/\s+/g, "-").toLowerCase();
+
+const normalizeAuthGroupModelOwnerMappings = (
+  payload: unknown,
+): AuthGroupModelOwnerMappingItem[] => {
+  const record = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const rawList = Array.isArray(record.items)
+    ? record.items
+    : Array.isArray(record.data)
+      ? record.data
+      : Array.isArray(payload)
+        ? payload
+        : [];
+
+  const seen = new Set<string>();
+  const items = rawList
+    .map((item): AuthGroupModelOwnerMappingItem | null => {
+      if (!item || typeof item !== "object") return null;
+      const row = item as Record<string, unknown>;
+      const authGroup = normalizeAuthGroupKey(String(row.auth_group ?? row.authGroup ?? ""));
+      const owner = normalizeOwnerValue(String(row.owner ?? row.owner_value ?? ""));
+      if (!authGroup || authGroup === "all" || !owner || seen.has(authGroup)) return null;
+      seen.add(authGroup);
+      return {
+        auth_group: authGroup,
+        owner,
+        updated_at:
+          typeof row.updated_at === "string"
+            ? row.updated_at
+            : typeof row.updatedAt === "string"
+              ? row.updatedAt
+              : undefined,
+      };
+    })
+    .filter((item): item is AuthGroupModelOwnerMappingItem => item !== null);
+  return items.sort((a, b) => a.auth_group.localeCompare(b.auth_group));
+};
+
 export const modelsApi = {
   buildClaudeModelsEndpoint,
 
@@ -216,6 +261,30 @@ export const modelsApi = {
 
   async getModelOwnerPresets() {
     return normalizeOwnerPresetResponse(await apiClient.get("/model-owner-presets"));
+  },
+
+  async getAuthGroupModelOwnerMappings() {
+    return normalizeAuthGroupModelOwnerMappings(
+      await apiClient.get("/auth-group-model-owner-mappings"),
+    );
+  },
+
+  async getAuthGroupModelOwnerMappingMap() {
+    const items = normalizeAuthGroupModelOwnerMappings(
+      await apiClient.get("/auth-group-model-owner-mappings"),
+    );
+    return Object.fromEntries(items.map((item) => [item.auth_group, item.owner]));
+  },
+
+  async saveAuthGroupModelOwnerMapping(authGroup: string, owner: string) {
+    const normalizedAuthGroup = normalizeAuthGroupKey(authGroup);
+    if (!normalizedAuthGroup || normalizedAuthGroup === "all") {
+      throw new Error("Invalid auth group");
+    }
+    await apiClient.patch("/auth-group-model-owner-mappings", {
+      auth_group: normalizedAuthGroup,
+      owner: normalizeOwnerValue(owner),
+    });
   },
 
   async fetchV1Models(baseUrl: string, apiKey?: string, headers: Record<string, string> = {}) {

--- a/pages/auth-files/__tests__/AuthFilesPage.excluded.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.excluded.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getOauthModelAlias: vi.fn(async () => ({})),
   getModelConfigs: vi.fn(async () => []),
   getModelOwnerPresets: vi.fn(async () => []),
+  getAuthGroupModelOwnerMappingMap: vi.fn(async () => ({})),
   getUsage: vi.fn(async () => ({ apis: {} })),
   getEntityStats: vi.fn(async () => ({ source: [], auth_index: [] })),
 }));
@@ -32,6 +33,7 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       ...mod.modelsApi,
       getModelConfigs: mocks.getModelConfigs,
       getModelOwnerPresets: mocks.getModelOwnerPresets,
+      getAuthGroupModelOwnerMappingMap: mocks.getAuthGroupModelOwnerMappingMap,
     },
     usageApi: { ...mod.usageApi, getUsage: mocks.getUsage, getEntityStats: mocks.getEntityStats },
     oauthApi: {
@@ -73,6 +75,8 @@ describe("AuthFilesPage OAuth excluded models", () => {
     mocks.getModelConfigs.mockResolvedValue([]);
     mocks.getModelOwnerPresets.mockReset();
     mocks.getModelOwnerPresets.mockResolvedValue([]);
+    mocks.getAuthGroupModelOwnerMappingMap.mockReset();
+    mocks.getAuthGroupModelOwnerMappingMap.mockResolvedValue({});
     mocks.getUsage.mockReset();
     mocks.getUsage.mockResolvedValue({ apis: {} });
     mocks.getEntityStats.mockReset();
@@ -188,7 +192,9 @@ describe("AuthFilesPage OAuth excluded models", () => {
 
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
     await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "OAuth Excluded Models" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: "OAuth Excluded Models" }),
+      ).not.toBeInTheDocument();
     });
     expect(mocks.replaceOauthExcludedModels).not.toHaveBeenCalled();
 

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -58,12 +58,16 @@ const mocks = vi.hoisted(() => ({
     { value: "openai", label: "OpenAI", description: "OpenAI models", enabled: true },
     { value: "anthropic", label: "Anthropic", description: "Anthropic models", enabled: true },
   ]),
+  getAuthGroupModelOwnerMappingMap: vi.fn(async () => ({})),
+  saveAuthGroupModelOwnerMapping: vi.fn(async (_authGroup: string, _owner: string) => undefined),
   upload: vi.fn(async () => ({})),
   submitCallback: vi.fn(async () => ({})),
   getAuthStatus: vi.fn(async () => ({ status: "pending" })),
   startAuth: vi.fn(async () => ({ url: "https://example.test/oauth", state: "state-1" })),
   reconcile: vi.fn(async () => ({})),
 }));
+
+let authGroupOwnerMappingMap: Record<string, string> = {};
 
 vi.mock("@code-proxy/api-client", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@code-proxy/api-client")>();
@@ -88,6 +92,8 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       ...mod.modelsApi,
       getModelConfigs: mocks.getModelConfigs,
       getModelOwnerPresets: mocks.getModelOwnerPresets,
+      getAuthGroupModelOwnerMappingMap: mocks.getAuthGroupModelOwnerMappingMap,
+      saveAuthGroupModelOwnerMapping: mocks.saveAuthGroupModelOwnerMapping,
     },
     quotaApi: { ...mod.quotaApi, reconcile: mocks.reconcile },
     usageApi: {
@@ -218,6 +224,18 @@ describe("AuthFilesPage files table", () => {
       { value: "openai", label: "OpenAI", description: "OpenAI models", enabled: true },
       { value: "anthropic", label: "Anthropic", description: "Anthropic models", enabled: true },
     ]);
+    authGroupOwnerMappingMap = {};
+    mocks.getAuthGroupModelOwnerMappingMap.mockReset();
+    mocks.getAuthGroupModelOwnerMappingMap.mockImplementation(async () => ({
+      ...authGroupOwnerMappingMap,
+    }));
+    mocks.saveAuthGroupModelOwnerMapping.mockReset();
+    mocks.saveAuthGroupModelOwnerMapping.mockImplementation(
+      async (authGroup: string, owner: string) => {
+        if (owner) authGroupOwnerMappingMap[authGroup] = owner;
+        else delete authGroupOwnerMappingMap[authGroup];
+      },
+    );
     mocks.upload.mockReset();
     mocks.upload.mockImplementation(async () => ({}));
     mocks.submitCallback.mockReset();
@@ -2603,12 +2621,13 @@ describe("AuthFilesPage files table", () => {
     expect(ownerSelect).toHaveTextContent("OpenAI");
     expect(await within(settingsDialog).findByText("gpt-4.1")).toBeInTheDocument();
     expect(within(settingsDialog).queryByText("claude-sonnet-4-5")).not.toBeInTheDocument();
-    expect(window.localStorage.getItem("authFilesPage.modelOwnerGroupMap.v1")).toBeNull();
+    expect(authGroupOwnerMappingMap).toEqual({});
 
     fireEvent.click(within(settingsDialog).getByRole("button", { name: "Save" }));
-    expect(window.localStorage.getItem("authFilesPage.modelOwnerGroupMap.v1")).toBe(
-      JSON.stringify({ codex: "openai" }),
-    );
+    await waitFor(() => {
+      expect(mocks.saveAuthGroupModelOwnerMapping).toHaveBeenCalledWith("codex", "openai");
+    });
+    expect(authGroupOwnerMappingMap).toEqual({ codex: "openai" });
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
     const dialog = await screen.findByRole("dialog", { name: "View: codex.json" });

--- a/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -16,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   submitCallback: vi.fn(async () => ({})),
   iflowCookieAuth: vi.fn(async () => ({ status: "ok" })),
   importCredential: vi.fn(async () => ({})),
+  getModelConfigs: vi.fn(async () => []),
+  getModelOwnerPresets: vi.fn(async () => []),
+  getAuthGroupModelOwnerMappingMap: vi.fn(async () => ({})),
   proxiesList: vi.fn<() => Promise<ProxyPoolEntry[]>>(async () => []),
   proxiesCheck: vi.fn<() => Promise<ProxyCheckResult>>(async () => ({ ok: true, latencyMs: 88 })),
 }));
@@ -25,6 +28,12 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
   return {
     ...mod,
     authFilesApi: { ...mod.authFilesApi, list: mocks.list },
+    modelsApi: {
+      ...mod.modelsApi,
+      getModelConfigs: mocks.getModelConfigs,
+      getModelOwnerPresets: mocks.getModelOwnerPresets,
+      getAuthGroupModelOwnerMappingMap: mocks.getAuthGroupModelOwnerMappingMap,
+    },
     usageApi: { ...mod.usageApi, getEntityStats: mocks.getEntityStats },
     oauthApi: {
       ...mod.oauthApi,
@@ -54,6 +63,12 @@ beforeEach(() => {
   mocks.submitCallback.mockClear();
   mocks.iflowCookieAuth.mockClear();
   mocks.importCredential.mockClear();
+  mocks.getModelConfigs.mockReset();
+  mocks.getModelConfigs.mockResolvedValue([]);
+  mocks.getModelOwnerPresets.mockReset();
+  mocks.getModelOwnerPresets.mockResolvedValue([]);
+  mocks.getAuthGroupModelOwnerMappingMap.mockReset();
+  mocks.getAuthGroupModelOwnerMappingMap.mockResolvedValue({});
   mocks.proxiesList.mockReset();
   mocks.proxiesCheck.mockReset();
   mocks.proxiesList.mockResolvedValue([]);

--- a/pages/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx
@@ -24,6 +24,9 @@ const mocks = vi.hoisted(() => ({
   getEntityStats: vi.fn(async () => ({ source: [], auth_index: [] })),
   downloadText: vi.fn(async () => JSON.stringify({ type: "codex" })),
   upload: vi.fn(async () => ({})),
+  getModelConfigs: vi.fn(async () => []),
+  getModelOwnerPresets: vi.fn(async () => []),
+  getAuthGroupModelOwnerMappingMap: vi.fn(async () => ({})),
   proxiesList: vi.fn<() => Promise<ProxyPoolEntry[]>>(async () => []),
   proxiesCheck: vi.fn<() => Promise<ProxyCheckResult>>(async () => ({ ok: true, latencyMs: 420 })),
 }));
@@ -37,6 +40,12 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       list: mocks.list,
       downloadText: mocks.downloadText,
       upload: mocks.upload,
+    },
+    modelsApi: {
+      ...mod.modelsApi,
+      getModelConfigs: mocks.getModelConfigs,
+      getModelOwnerPresets: mocks.getModelOwnerPresets,
+      getAuthGroupModelOwnerMappingMap: mocks.getAuthGroupModelOwnerMappingMap,
     },
     usageApi: { ...mod.usageApi, getEntityStats: mocks.getEntityStats },
   };
@@ -57,6 +66,12 @@ describe("AuthFilesPage proxy fields editor", () => {
     mocks.getEntityStats.mockClear();
     mocks.downloadText.mockClear();
     mocks.upload.mockClear();
+    mocks.getModelConfigs.mockReset();
+    mocks.getModelConfigs.mockResolvedValue([]);
+    mocks.getModelOwnerPresets.mockReset();
+    mocks.getModelOwnerPresets.mockResolvedValue([]);
+    mocks.getAuthGroupModelOwnerMappingMap.mockReset();
+    mocks.getAuthGroupModelOwnerMappingMap.mockResolvedValue({});
     mocks.proxiesList.mockReset();
     mocks.proxiesCheck.mockReset();
     mocks.proxiesList.mockResolvedValue([

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -484,7 +484,7 @@ interface AuthFilesFilesTabProps {
   modelOwnerGroupsLoading: boolean;
   modelOwnerGroups: AuthFileModelOwnerGroup[];
   selectedModelOwner: string;
-  setSelectedModelOwner: (value: string) => void;
+  setSelectedModelOwner: (value: string) => Promise<void> | void;
   search: string;
   setSearch: (value: string) => void;
   loading: boolean;
@@ -631,6 +631,7 @@ export function AuthFilesFilesTab({
   const [jsonImportError, setJsonImportError] = useState("");
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [uploadProgressDismissed, setUploadProgressDismissed] = useState(false);
+  const [modelOwnerDialogSaving, setModelOwnerDialogSaving] = useState(false);
   const normalizedFilter = normalizeProviderKey(filter);
   const canSetModelOwnerGroup = normalizedFilter !== "all";
   const activeFilterCount = [
@@ -878,12 +879,7 @@ export function AuthFilesFilesTab({
         <span className="min-w-0 truncate px-1 font-medium text-slate-600 dark:text-white/65">
           {t("auth_files.batch_selected", { count: selectedCount })}
         </span>
-        <Button
-          variant="ghost"
-          size="xs"
-          className="px-2"
-          onClick={() => setSelectedFileNames([])}
-        >
+        <Button variant="ghost" size="xs" className="px-2" onClick={() => setSelectedFileNames([])}>
           {t("auth_files.batch_clear")}
         </Button>
         <Button
@@ -1094,9 +1090,7 @@ export function AuthFilesFilesTab({
               <div className="flex min-h-9 flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <div
-                    className={
-                      loading && filesLength === 0 ? "pointer-events-none opacity-60" : ""
-                    }
+                    className={loading && filesLength === 0 ? "pointer-events-none opacity-60" : ""}
                   >
                     {renderFilesViewModeTabs}
                   </div>
@@ -1192,7 +1186,6 @@ export function AuthFilesFilesTab({
                   {configActionsMenu}
                 </div>
               </div>
-
             </div>
           </div>
         </div>
@@ -1704,10 +1697,18 @@ export function AuthFilesFilesTab({
             </Button>
             <Button
               variant="primary"
-              onClick={() => {
-                setSelectedModelOwner(draftModelOwner);
-                setModelOwnerDialogOpen(false);
+              onClick={async () => {
+                setModelOwnerDialogSaving(true);
+                try {
+                  await setSelectedModelOwner(draftModelOwner);
+                  setModelOwnerDialogOpen(false);
+                } catch {
+                  // Save failures are surfaced via toast by the parent hook.
+                } finally {
+                  setModelOwnerDialogSaving(false);
+                }
               }}
+              disabled={modelOwnerDialogSaving}
             >
               {t("common.save")}
             </Button>

--- a/pages/auth-files/hooks/useAuthFilesModelOwnerGroups.ts
+++ b/pages/auth-files/hooks/useAuthFilesModelOwnerGroups.ts
@@ -5,11 +5,10 @@ import type {
   ModelConfigItem,
   ModelOwnerPresetItem,
 } from "@code-proxy/api-client/endpoints/models";
+import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 import { useToast } from "@code-proxy/ui";
 import {
   normalizeProviderKey,
-  readAuthFilesModelOwnerGroupMap,
-  writeAuthFilesModelOwnerGroupMap,
   type AuthFileModelOwnerGroup,
   type AuthFilesModelOwnerGroupMap,
 } from "@code-proxy/domain";
@@ -75,27 +74,20 @@ export function useAuthFilesModelOwnerGroups() {
   const [modelOwnerGroupsLoading, setModelOwnerGroupsLoading] = useState(false);
   const [modelOwnerGroups, setModelOwnerGroups] = useState<AuthFileModelOwnerGroup[]>([]);
   const [modelOwnerByAuthGroup, setModelOwnerByAuthGroup] = useState<AuthFilesModelOwnerGroupMap>(
-    () => readAuthFilesModelOwnerGroupMap(),
+    {},
   );
 
   const loadModelOwnerGroups = useCallback(async () => {
     setModelOwnerGroupsLoading(true);
     try {
-      const [models, presets] = await Promise.all([
+      const [models, presets, mappings] = await Promise.all([
         modelsApi.getModelConfigs("library"),
         modelsApi.getModelOwnerPresets(),
+        modelsApi.getAuthGroupModelOwnerMappingMap(),
       ]);
       const groups = buildModelOwnerGroups(models, presets);
-      const validOwners = new Set(groups.map((group) => group.value));
       setModelOwnerGroups(groups);
-      setModelOwnerByAuthGroup((current) => {
-        const next = Object.fromEntries(
-          Object.entries(current).filter(([, owner]) => validOwners.has(owner)),
-        ) as AuthFilesModelOwnerGroupMap;
-        if (sameMap(current, next)) return current;
-        writeAuthFilesModelOwnerGroupMap(next);
-        return next;
-      });
+      setModelOwnerByAuthGroup((current) => (sameMap(current, mappings) ? current : mappings));
     } catch (err: unknown) {
       notify({
         type: "error",
@@ -106,19 +98,30 @@ export function useAuthFilesModelOwnerGroups() {
     }
   }, [notify, t]);
 
-  const setModelOwnerForAuthGroup = useCallback((authGroup: string, ownerValue: string) => {
-    const key = normalizeProviderKey(authGroup);
-    const owner = normalizeOwnerValue(ownerValue);
-    if (!key || key === "all") return;
-    setModelOwnerByAuthGroup((current) => {
-      const next = { ...current };
-      if (owner) next[key] = owner;
-      else delete next[key];
-      if (sameMap(current, next)) return current;
-      writeAuthFilesModelOwnerGroupMap(next);
-      return next;
-    });
-  }, []);
+  const setModelOwnerForAuthGroup = useCallback(
+    async (authGroup: string, ownerValue: string) => {
+      const key = normalizeProviderKey(authGroup);
+      const owner = normalizeOwnerValue(ownerValue);
+      if (!key || key === "all") return;
+      try {
+        await modelsApi.saveAuthGroupModelOwnerMapping(key, owner);
+        invalidateConfiguredModelAvailability();
+        setModelOwnerByAuthGroup((current) => {
+          const next = { ...current };
+          if (owner) next[key] = owner;
+          else delete next[key];
+          return sameMap(current, next) ? current : next;
+        });
+      } catch (err: unknown) {
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("auth_files.failed_get_model_owners"),
+        });
+        throw err;
+      }
+    },
+    [notify, t],
+  );
 
   return {
     modelOwnerGroupsLoading,

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from "react-i18next";
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
 import iconGemini from "@code-proxy/assets/icons/gemini.svg";
-import { detectApiBaseFromLocation } from "@code-proxy/api-client";
+import { detectApiBaseFromLocation, modelsApi } from "@code-proxy/api-client";
 import {
   channelGroupsApi,
   type ChannelGroupChannelDetail,
 } from "@code-proxy/api-client/endpoints/channel-groups";
-import { normalizeProviderKey, readAuthFilesModelOwnerGroupMap } from "@code-proxy/domain";
+import { normalizeProviderKey } from "@code-proxy/domain";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 import { ccSwitchImportConfigsApi } from "@code-proxy/api-client/endpoints/ccswitch-import-configs";
 import { Button } from "@code-proxy/ui";
@@ -68,8 +68,8 @@ const getChannelGroupModelOwnerKeys = (
 
 const getChannelGroupMappedModelOwnerKeys = (
   details: readonly ChannelGroupChannelDetail[] | undefined,
+  ownerByAuthGroup: Record<string, string>,
 ): string[] => {
-  const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
   const keys = new Set<string>();
   for (const detail of details ?? []) {
     const values = [
@@ -103,9 +103,11 @@ export function CcSwitchImportSettingsPage() {
   useEffect(() => {
     let cancelled = false;
     setChannelGroupsLoading(true);
-    channelGroupsApi
-      .list()
-      .then((items) => {
+    Promise.all([
+      channelGroupsApi.list(),
+      modelsApi.getAuthGroupModelOwnerMappingMap().catch(() => ({})),
+    ])
+      .then(([items, ownerMappings]) => {
         if (cancelled) return;
         setChannelGroupOptions(
           items
@@ -125,7 +127,10 @@ export function CcSwitchImportSettingsPage() {
               allowedModels: Array.isArray(item["allowed-models"]) ? item["allowed-models"] : [],
               channels: Array.isArray(item.channels) ? item.channels : [],
               modelOwnerKeys: getChannelGroupModelOwnerKeys(item.channelDetails),
-              authoritativeModelOwnerKeys: getChannelGroupMappedModelOwnerKeys(item.channelDetails),
+              authoritativeModelOwnerKeys: getChannelGroupMappedModelOwnerKeys(
+                item.channelDetails,
+                ownerMappings,
+              ),
             }))
             .filter((item) => item.value)
             .sort((left, right) => left.label.localeCompare(right.label)),

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -10,6 +10,7 @@ import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/c
 const listChannelGroups = vi.fn();
 const listAvailableModels = vi.fn();
 const getModelConfigs = vi.fn();
+const getAuthGroupModelOwnerMappingMap = vi.fn();
 const listConfigs = vi.fn();
 const replaceConfigs = vi.fn();
 const loadConfiguredModelAvailability = vi.fn();
@@ -45,6 +46,7 @@ vi.mock("@code-proxy/api-client/endpoints/models", () => ({
       allowedChannels?: string[];
     }) => listAvailableModels(params),
     getModelConfigs: (scope: "active" | "library") => getModelConfigs(scope),
+    getAuthGroupModelOwnerMappingMap: () => getAuthGroupModelOwnerMappingMap(),
   },
 }));
 
@@ -73,6 +75,7 @@ describe("CcSwitchImportSettingsPage", () => {
     listChannelGroups.mockReset();
     listAvailableModels.mockReset();
     getModelConfigs.mockReset();
+    getAuthGroupModelOwnerMappingMap.mockReset();
     listConfigs.mockReset();
     replaceConfigs.mockReset();
     loadConfiguredModelAvailability.mockReset();
@@ -97,6 +100,7 @@ describe("CcSwitchImportSettingsPage", () => {
     ]);
     listAvailableModels.mockResolvedValue([{ id: "deepseek-v4-flash" }, { id: "kimi-k2" }]);
     getModelConfigs.mockResolvedValue([]);
+    getAuthGroupModelOwnerMappingMap.mockResolvedValue({});
     listConfigs.mockResolvedValue([]);
     replaceConfigs.mockResolvedValue(undefined);
   });
@@ -406,10 +410,7 @@ describe("CcSwitchImportSettingsPage", () => {
   });
 
   test("merges mapped Codex owner models with OpenCode Go channel models in CC Switch presets", async () => {
-    window.localStorage.setItem(
-      "authFilesPage.modelOwnerGroupMap.v1",
-      JSON.stringify({ codex: "codex" }),
-    );
+    getAuthGroupModelOwnerMappingMap.mockResolvedValue({ codex: "codex" });
     listChannelGroups.mockResolvedValue([
       {
         name: "opencodego+gpt",
@@ -469,10 +470,7 @@ describe("CcSwitchImportSettingsPage", () => {
   });
 
   test("uses the auth-file owner model group as the CC Switch actual model source", async () => {
-    window.localStorage.setItem(
-      "authFilesPage.modelOwnerGroupMap.v1",
-      JSON.stringify({ kimi: "kimi-code" }),
-    );
+    getAuthGroupModelOwnerMappingMap.mockResolvedValue({ kimi: "kimi-code" });
     listChannelGroups.mockResolvedValue([
       {
         name: "kimicode",

--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -10,13 +10,9 @@ import {
   type RoutingConfigItem,
   type RoutingConfigPathRouteItem,
 } from "@code-proxy/api-client/endpoints/routing-config";
-import { apiClient } from "@code-proxy/api-client";
+import { apiClient, modelsApi } from "@code-proxy/api-client";
 import { RoutingConfigEditor, type RoutingModelOption } from "@features/routing-config-editor";
-import {
-  normalizeProviderKey,
-  normalizeTagValue,
-  readAuthFilesModelOwnerGroupMap,
-} from "@code-proxy/domain";
+import { normalizeProviderKey, normalizeTagValue } from "@code-proxy/domain";
 import {
   DEFAULT_VISUAL_VALUES,
   makeClientId,
@@ -68,8 +64,8 @@ type MappedOwnerSelection = {
 const collectMappedOwnersForChannels = (
   channels: string[],
   detailsByName: Record<string, ChannelGroupChannelDetail>,
+  ownerByAuthGroup: Record<string, string>,
 ): MappedOwnerSelection => {
-  const ownerByAuthGroup = readAuthFilesModelOwnerGroupMap();
   const owners = new Set<string>();
   let hasUnmappedChannels = false;
   for (const channel of channels) {
@@ -233,6 +229,7 @@ export function ChannelGroupsPage() {
   const [availableChannelDetails, setAvailableChannelDetails] = useState<
     Record<string, ChannelGroupChannelDetail>
   >({});
+  const [authGroupOwnerMap, setAuthGroupOwnerMap] = useState<Record<string, string>>({});
 
   const loadAvailableChannels = useCallback(async () => {
     const items = await channelGroupsApi.list();
@@ -286,6 +283,7 @@ export function ChannelGroupsPage() {
       const ownerSelection = collectMappedOwnersForChannels(
         normalizedChannels,
         availableChannelDetails,
+        authGroupOwnerMap,
       );
       let visibleModels = filterByConfiguredModelAvailability(
         ids.map((id) => ({ id })),
@@ -331,21 +329,23 @@ export function ChannelGroupsPage() {
 
       return Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
     },
-    [availableChannelDetails],
+    [authGroupOwnerMap, availableChannelDetails],
   );
 
   const loadPage = useCallback(async () => {
     setLoading(true);
     setError("");
     try {
-      const [routing, channels] = await Promise.all([
+      const [routing, channels, ownerMappings] = await Promise.all([
         routingConfigApi.get(),
         loadAvailableChannels().catch(() => ({ names: [], detailsByName: {} })),
+        modelsApi.getAuthGroupModelOwnerMappingMap().catch(() => ({})),
       ]);
       const nextValues = hydrateRoutingValues(routing);
       setVisualValues(nextValues);
       setAvailableChannels(channels.names);
       setAvailableChannelDetails(channels.detailsByName);
+      setAuthGroupOwnerMap(ownerMappings);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t("channel_groups_page.load_failed");
       setError(message);

--- a/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -20,6 +20,31 @@ const apiMocks = vi.hoisted(() => ({
   put: vi.fn(),
 }));
 
+function extractList(payload: unknown, key: string): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  const record = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const value = record[key] ?? record.items ?? record.data;
+  return Array.isArray(value) ? value : [];
+}
+
+async function normalizeProviderConfigs(path: string, key: string) {
+  const payload = await apiMocks.get(path);
+  return extractList(payload, key).map((entry) => {
+    const item = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+    return {
+      apiKey: String(item["api-key"] ?? item.apiKey ?? ""),
+      name: typeof item.name === "string" ? item.name : undefined,
+      prefix: typeof item.prefix === "string" ? item.prefix : undefined,
+      models: Array.isArray(item.models) ? item.models : [],
+      excludedModels: Array.isArray(item["excluded-models"])
+        ? item["excluded-models"]
+        : Array.isArray(item.excludedModels)
+          ? item.excludedModels
+          : [],
+    };
+  });
+}
+
 vi.mock("goey-toast", () => ({
   GoeyToaster: () => null,
   goeyToast: {
@@ -34,6 +59,73 @@ vi.mock("@code-proxy/api-client", () => ({
   apiClient: {
     get: apiMocks.get,
     put: apiMocks.put,
+  },
+  authFilesApi: {
+    list: () => apiMocks.get("/auth-files"),
+    getModelsForAuthFile: async (name: string) => {
+      const payload = await apiMocks.get("/auth-files/models", { params: { name } });
+      const record =
+        payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+      return Array.isArray(record.models) ? record.models : [];
+    },
+    getModelDefinitions: async (channel: string) => {
+      const normalizedChannel = String(channel ?? "")
+        .trim()
+        .toLowerCase();
+      const payload = await apiMocks.get(
+        `/model-definitions/${encodeURIComponent(normalizedChannel)}`,
+      );
+      const record =
+        payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+      return Array.isArray(record.models) ? record.models : [];
+    },
+  },
+  providersApi: {
+    getGeminiKeys: () => normalizeProviderConfigs("/gemini-api-key", "gemini-api-key"),
+    getClaudeConfigs: () => normalizeProviderConfigs("/claude-api-key", "claude-api-key"),
+    getCodexConfigs: () => normalizeProviderConfigs("/codex-api-key", "codex-api-key"),
+    getOpenCodeGoConfigs: () =>
+      normalizeProviderConfigs("/opencode-go-api-key", "opencode-go-api-key"),
+    getVertexConfigs: () => normalizeProviderConfigs("/vertex-api-key", "vertex-api-key"),
+    getOpenAIProviders: async () => {
+      const payload = await apiMocks.get("/openai-compatibility");
+      return extractList(payload, "openai-compatibility").map((entry) => {
+        const item = entry as Record<string, unknown>;
+        return {
+          name: String(item.name ?? ""),
+          prefix: typeof item.prefix === "string" ? item.prefix : undefined,
+          models: Array.isArray(item.models) ? item.models : [],
+          apiKeyEntries: Array.isArray(item["api-key-entries"])
+            ? item["api-key-entries"]
+            : Array.isArray(item.apiKeyEntries)
+              ? item.apiKeyEntries
+              : [],
+        };
+      });
+    },
+  },
+  modelsApi: {
+    getAuthGroupModelOwnerMappingMap: async () => {
+      const payload = await apiMocks.get("/auth-group-model-owner-mappings");
+      const record =
+        payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+      const items = Array.isArray(record.items) ? record.items : [];
+      return Object.fromEntries(
+        items
+          .map((entry) => {
+            if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+            const row = entry as Record<string, unknown>;
+            const authGroup = String(row.auth_group ?? "")
+              .trim()
+              .toLowerCase();
+            const owner = String(row.owner ?? "")
+              .trim()
+              .toLowerCase();
+            return authGroup && owner ? ([authGroup, owner] as const) : null;
+          })
+          .filter(Boolean) as Array<readonly [string, string]>,
+      );
+    },
   },
 }));
 
@@ -159,6 +251,9 @@ describe("ChannelGroupsPage", () => {
           ],
         });
       }
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({ items: [] });
+      }
       if (path.startsWith("/models?")) {
         return Promise.resolve({
           data: [{ id: "claude-3-7-sonnet-latest" }, { id: "gpt-should-not-leak" }],
@@ -206,11 +301,100 @@ describe("ChannelGroupsPage", () => {
   });
 
   test("filters group editor models by the auth-file model owner group mapping", async () => {
-    window.localStorage.setItem(
-      "authFilesPage.modelOwnerGroupMap.v1",
-      JSON.stringify({ claude: "anthropic" }),
-    );
     const user = userEvent.setup();
+
+    mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({
+          items: [{ auth_group: "claude", owner: "anthropic" }],
+        });
+      }
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+              pricing: {
+                mode: "token",
+                input_price_per_million: 3,
+                output_price_per_million: 15,
+                cached_price_per_million: 0.3,
+              },
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+            },
+          ],
+        });
+      }
+      if (path === "/routing-config") {
+        return Promise.resolve({
+          strategy: "round-robin",
+          "include-default-group": true,
+          "channel-groups": [],
+          "path-routes": [],
+        });
+      }
+      if (path === "/channel-groups") {
+        return Promise.resolve({
+          items: [
+            {
+              name: "Claude Pool",
+              channels: ["Team A Claude"],
+              "channel-details": [{ name: "Team A Claude", source: "claude" }],
+            },
+          ],
+        });
+      }
+      if (path.startsWith("/models?")) {
+        return Promise.resolve({
+          data: [{ id: "claude-3-7-sonnet-latest" }, { id: "gpt-should-not-leak" }],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "claude-account.json", type: "claude", disabled: false }],
+        });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "claude-3-7-sonnet-latest",
+              owned_by: "anthropic",
+              description: "Mapped Claude model",
+              pricing: {
+                mode: "token",
+                input_price_per_million: 3,
+                output_price_per_million: 15,
+                cached_price_per_million: 0.3,
+              },
+            },
+            {
+              id: "gpt-should-not-leak",
+              owned_by: "openai",
+              description: "Unmapped OpenAI model",
+            },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/opencode-go-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve({});
+    });
 
     renderPage();
 
@@ -231,11 +415,12 @@ describe("ChannelGroupsPage", () => {
   });
 
   test("uses the configured auth-file model owner group as the authoritative model scope", async () => {
-    window.localStorage.setItem(
-      "authFilesPage.modelOwnerGroupMap.v1",
-      JSON.stringify({ kimi: "kimi-code" }),
-    );
     mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({
+          items: [{ auth_group: "kimi", owner: "kimi-code" }],
+        });
+      }
       if (path === "/models/configured-availability") {
         return Promise.resolve({
           scoped: true,
@@ -345,11 +530,12 @@ describe("ChannelGroupsPage", () => {
   });
 
   test("merges mapped owner models with OpenCode Go live models for mixed channel groups", async () => {
-    window.localStorage.setItem(
-      "authFilesPage.modelOwnerGroupMap.v1",
-      JSON.stringify({ codex: "codex" }),
-    );
     mockedApiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({
+          items: [{ auth_group: "codex", owner: "codex" }],
+        });
+      }
       if (path === "/routing-config") {
         return Promise.resolve({
           strategy: "round-robin",

--- a/pages/models/__tests__/ModelsPage.test.tsx
+++ b/pages/models/__tests__/ModelsPage.test.tsx
@@ -329,13 +329,11 @@ describe("ModelsPage", () => {
   });
 
   test("filters current models by auth-file model owner group mapping", async () => {
-    window.localStorage.setItem(
-      "authFilesPage.modelOwnerGroupMap.v1",
-      JSON.stringify({ claude: "anthropic" }),
-    );
     mocks.apiGet.mockImplementation((path: string) => {
-      if (path === "/models/configured-availability") {
-        return Promise.reject(new Error("configured availability unavailable"));
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({
+          items: [{ auth_group: "claude", owner: "anthropic" }],
+        });
       }
       if (path === "/model-configs?scope=active" || path === "/model-configs") {
         return Promise.resolve({
@@ -385,6 +383,9 @@ describe("ModelsPage", () => {
         return Promise.resolve({
           files: [{ name: "claude-account.json", type: "claude", disabled: false }],
         });
+      }
+      if (path === "/models/configured-availability") {
+        return Promise.reject(new Error("configured availability unavailable"));
       }
       if (
         path === "/gemini-api-key" ||

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -18,6 +18,23 @@ vi.mock("@code-proxy/api-client", () => ({
   apiClient: {
     get: mocks.apiGet,
   },
+  authFilesApi: {
+    list: () => mocks.apiGet("/auth-files"),
+    getModelsForAuthFile: async (name: string) => {
+      const payload = await mocks.apiGet("/auth-files/models", { params: { name } });
+      const record =
+        payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+      return Array.isArray(record.models) ? record.models : [];
+    },
+  },
+  providersApi: {
+    getGeminiKeys: async () => [],
+    getClaudeConfigs: async () => [],
+    getCodexConfigs: async () => [],
+    getOpenCodeGoConfigs: async () => [],
+    getVertexConfigs: async () => [],
+    getOpenAIProviders: async () => [],
+  },
 }));
 
 vi.mock("@code-proxy/api-client/endpoints/update", () => ({
@@ -57,6 +74,7 @@ describe("SystemPage", () => {
     await i18n.changeLanguage("en");
     window.localStorage.clear();
     mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
       if (path === "/model-path-availability") return Promise.resolve({ data: [] });
       if (path === "/model-configs?scope=library") return Promise.resolve({ data: [] });
       if (path === "/auth-files") return Promise.resolve({ files: [] });
@@ -182,6 +200,7 @@ describe("SystemPage", () => {
 
   test("shows only default root v1 model discovery results", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
       if (path === "/model-path-availability") {
         return Promise.resolve({
           data: [
@@ -219,6 +238,44 @@ describe("SystemPage", () => {
     expect(screen.queryByText("gpt-group-only")).not.toBeInTheDocument();
     expect(screen.queryByText("gemini-v1beta-only")).not.toBeInTheDocument();
     expect(mocks.apiGet).toHaveBeenCalledWith("/model-path-availability");
+  });
+
+  test("shows persisted mapped owner models on the system page", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({
+          items: [{ auth_group: "codex", owner: "codex" }],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({ data: [] });
+      }
+      if (path === "/model-configs?scope=library") {
+        return Promise.resolve({
+          data: [{ id: "gpt-5.5", owned_by: "codex", description: "Mapped Codex model" }],
+        });
+      }
+      if (path === "/auth-files") {
+        return Promise.resolve({
+          files: [{ name: "codex-main.json", type: "codex", disabled: false }],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve([]);
+      }
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("gpt-5.5")).toBeInTheDocument();
   });
 
   test("rechecks the target version before treating the update as successful", async () => {
@@ -586,10 +643,13 @@ describe("SystemPage", () => {
 
     expect(within(dialog).getByTestId("update-progress-console")).toBeInTheDocument();
     await waitFor(() => {
-      expect(within(dialog).getByRole("heading", { name: /update completed/i })).toBeInTheDocument();
+      expect(
+        within(dialog).getByRole("heading", { name: /update completed/i }),
+      ).toBeInTheDocument();
     });
-    expect(within(dialog).getByText(/docker compose pull clirelay/i)).toBeInTheDocument();
     expect(within(dialog).getByText(/The updater finished all steps\./i)).toBeInTheDocument();
+    expect(within(dialog).queryByText(/docker compose pull clirelay/i)).toBeNull();
+    expect(within(dialog).queryByTestId("update-log-stream")).toBeNull();
     expect(
       within(dialog).getByText((_, element) =>
         Boolean(element?.textContent?.trim().match(/^\d+%$/)),


### PR DESCRIPTION
## Summary
- persist auth-group -> model-owner mappings in the management backend
- update admin pages to read/write the persisted mapping instead of browser local storage
- cover auth-files, channel-groups, system, models, and import-settings regressions

## Verification
- rtk go test ./internal/api/handlers/management ./internal/api/routes ./internal/storage/sqlite/modelconfig ./internal/usage ./internal/management/settings/modelconfig
- rtk env NODE_OPTIONS="--localstorage-file=/tmp/codex-vitest-localstorage" node ../../node_modules/vitest/vitest.mjs run --config vite.config.ts ../../pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx ../../pages/auth-files/__tests__/AuthFilesPage.excluded.test.tsx ../../pages/auth-files/__tests__/AuthFilesPage.proxy-fields.test.tsx ../../pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx ../../pages/models/__tests__/ModelsPage.test.tsx ../../pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx ../../pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx ../../pages/system/__tests__/SystemPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build