### PR TITLE
feat: target api key entry actions by id

### DIFF
--- a/packages/api-client/src/endpoints/api-keys.ts
+++ b/packages/api-client/src/endpoints/api-keys.ts
@@ -1,6 +1,7 @@
 import { apiClient } from "../client/client";
 
 export interface ApiKeyEntry {
+  id?: string;
   key: string;
   name?: string;
   disabled?: boolean;
@@ -41,12 +42,14 @@ export const apiKeyEntriesApi = {
 
   replace: (entries: ApiKeyEntry[]) => apiClient.put("/api-key-entries", entries),
 
-  update: (payload: { index?: number; match?: string; value: Partial<ApiKeyEntry> }) =>
+  update: (payload: { id?: string; index?: number; match?: string; value: Partial<ApiKeyEntry> }) =>
     apiClient.patch("/api-key-entries", payload),
 
-  delete: (params: { index?: number; key?: string; deleteLogs?: boolean }) => {
+  delete: (params: { id?: string; index?: number; key?: string; deleteLogs?: boolean }) => {
     const query = new URLSearchParams();
-    if (params.key) {
+    if (params.id) {
+      query.set("id", params.id);
+    } else if (params.key) {
       query.set("key", params.key);
     } else if (params.index !== undefined) {
       query.set("index", String(params.index));

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -313,6 +313,7 @@ export function ApiKeysPage() {
     setSaving(true);
     try {
       await apiKeyEntriesApi.update({
+        id: entries[editIndex].id,
         index: editIndex,
         value: {
           ...(newKey !== originalKey ? { key: newKey } : {}),
@@ -357,6 +358,7 @@ export function ApiKeysPage() {
     setSaving(true);
     try {
       const response = (await apiKeyEntriesApi.delete({
+        id: entries[deleteIndex]?.id,
         index: deleteIndex,
         deleteLogs: deleteLogsOnDelete,
       })) as { logs_deleted?: number } | undefined;


### PR DESCRIPTION
## Summary
- target api key entry delete/update actions by stable entry id when available
- keep API key entry deletes aligned with current row identity in the admin panel

## Verification
- rtk env NODE_OPTIONS="--localstorage-file=/tmp/codex-vitest-localstorage" node ../../node_modules/vitest/vitest.mjs run --config vite.config.ts ../../pages/api-keys/__tests__/ApiKeysPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build