### PR TITLE
fix: respect mapped owner models on system page

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -29,6 +29,7 @@ export type ConfiguredModelAvailability = {
   items: ModelAvailabilityItem[];
   idSet: Set<string>;
   metadataItems?: ModelAvailabilityItem[];
+  usesMappedOwners?: boolean;
 };
 
 export type ModelPricingMode = "token" | "call";
@@ -109,10 +110,11 @@ const PROVIDER_CHANNELS = [
   { key: "vertex", load: () => providersApi.getVertexConfigs() },
 ] as const;
 
-const emptyAvailability = (): ConfiguredModelAvailability => ({
+const emptyAvailability = (usesMappedOwners = false): ConfiguredModelAvailability => ({
   scoped: false,
   items: [],
   idSet: new Set(),
+  usesMappedOwners,
 });
 
 export const emptyModelPricing = (): ModelPricing => ({
@@ -722,6 +724,7 @@ export const normalizeConfiguredModelAvailability = (
     items,
     metadataItems,
     idSet: new Set(items.map((item) => item.id.toLowerCase())),
+    usesMappedOwners: false,
   };
 };
 
@@ -838,6 +841,7 @@ export const loadConfiguredModelAvailability = async (options?: {
 const loadConfiguredModelAvailabilityFallback = async (
   ownerByAuthGroup?: AuthGroupOwnerMappingMap,
 ): Promise<ConfiguredModelAvailability> => {
+  const usesMappedOwners = Object.keys(ownerByAuthGroup ?? {}).length > 0;
   const [authFiles, libraryPayload, providerItems] = await Promise.all([
     loadAuthFiles(),
     apiClient.get("/model-configs?scope=library").catch(() => null),
@@ -856,7 +860,7 @@ const loadConfiguredModelAvailabilityFallback = async (
   for (const item of providerItems) addModel(map, withLibraryModelMetadata(item, libraryIndex));
 
   if (!authFileAvailability.scoped && providerItems.length === 0) {
-    return emptyAvailability();
+    return emptyAvailability(usesMappedOwners);
   }
 
   const items = Array.from(map.values()).sort((a, b) => a.id.localeCompare(b.id));
@@ -864,6 +868,7 @@ const loadConfiguredModelAvailabilityFallback = async (
     scoped: true,
     items,
     idSet: new Set(items.map((item) => item.id.toLowerCase())),
+    usesMappedOwners,
   };
 };
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3513,7 +3513,7 @@
   "system_page": {
     "title": "System Info",
     "available_models": "Available Models",
-    "available_models_tooltip": "This only shows models returned by the default root GET /v1/models endpoint. Use Models to view custom paths, channel groups, aliases, and other protocol paths.",
+    "available_models_tooltip": "This shows the models currently usable on the default entry. When auth-group owner mappings are configured, the mapped configured model set takes precedence over raw static provider catalogs. Use Models to inspect custom paths, channel groups, aliases, and other protocol paths.",
     "subtitle": "Service, version & models",
     "api_base": "API Base",
     "api_key_lookup": "API Key Lookup",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3668,7 +3668,7 @@
   "system_page": {
     "title": "系统信息",
     "available_models": "可用模型",
-    "available_models_tooltip": "这里只展示默认根路径 GET /v1/models 返回的模型；自定义路径、渠道分组、别名与其他协议路径的模型请到“模型”页面查看。",
+    "available_models_tooltip": "这里展示默认入口当前真正可用的模型；当配置了认证分组到模型归属的统一映射后，会优先按映射后的固定模型集展示，而不是直接使用静态 provider 模型目录。自定义路径、渠道分组、别名与其他协议路径的模型请到“模型”页面查看。",
     "subtitle": "服务、版本和模型",
     "api_base": "API 地址",
     "api_key_lookup": "API 密钥查询",

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -21,7 +21,10 @@ import { Card } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { UpdateDetailsCard } from "@app/update/UpdateDetailsCard";
-import { loadModelPathAvailability } from "@features/model-availability";
+import {
+  loadConfiguredModelAvailability,
+  loadModelPathAvailability,
+} from "@features/model-availability";
 import { HoverTooltip } from "@code-proxy/ui";
 
 // Vendor SVG icons
@@ -339,15 +342,27 @@ export function SystemPage({
     setModelsLoading(true);
     setModelsError(null);
     try {
-      const availability = await loadModelPathAvailability();
-      const rootV1ModelIds = availability.items
-        .filter((item) =>
-          item.paths.some(
-            (path) => path.scope === "root" && path.method === "GET" && path.path === "/v1/models",
-          ),
-        )
-        .map((item) => item.id);
-      setModels(Array.from(new Set(rootV1ModelIds)).sort((a, b) => a.localeCompare(b)));
+      const [configuredAvailability, pathAvailability] = await Promise.all([
+        loadConfiguredModelAvailability().catch(() => null),
+        loadModelPathAvailability().catch(() => null),
+      ]);
+
+      const useMappedOwnerModels = configuredAvailability?.usesMappedOwners === true;
+      const rootV1ModelIds =
+        pathAvailability?.items
+          .filter((item) =>
+            item.paths.some(
+              (path) => path.scope === "root" && path.method === "GET" && path.path === "/v1/models",
+            ),
+          )
+          .map((item) => item.id) ?? [];
+      const nextModelIds = useMappedOwnerModels
+        ? (configuredAvailability?.items ?? []).map((item) => item.id)
+        : rootV1ModelIds.length > 0
+          ? rootV1ModelIds
+          : (configuredAvailability?.items ?? []).map((item) => item.id);
+
+      setModels(Array.from(new Set(nextModelIds)).sort((a, b) => a.localeCompare(b)));
     } catch (err: unknown) {
       setModelsError(err instanceof Error ? err.message : t("system_page.load_failed"));
     } finally {

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -248,7 +248,18 @@ describe("SystemPage", () => {
         });
       }
       if (path === "/model-path-availability") {
-        return Promise.resolve({ data: [] });
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-5.5",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+            {
+              id: "gpt-5-codex",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
       }
       if (path === "/model-configs?scope=library") {
         return Promise.resolve({
@@ -276,6 +287,7 @@ describe("SystemPage", () => {
     renderPage();
 
     expect(await screen.findByText("gpt-5.5")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
   });
 
   test("rechecks the target version before treating the update as successful", async () => {


### PR DESCRIPTION
## Summary
- make the system info model list prefer configured auth-group owner mappings when present
- avoid showing raw static Codex/OpenAI catalog entries once a mapped owner model set is fixed
- add a regression test and update the tooltip copy to match the actual behavior

## Testing
- rtk bun run --cwd /Users/kittors/Developer/opensource/CliProxy/codeProxy --filter @code-proxy/admin-panel test -- --run /Users/kittors/Developer/opensource/CliProxy/codeProxy/pages/system/__tests__/SystemPage.test.tsx
- rtk bun run --cwd /Users/kittors/Developer/opensource/CliProxy/codeProxy --filter @code-proxy/admin-panel build