### PR TITLE
fix: patch proxy pool edits without appending

### DIFF
--- a/apps/admin-panel/src/test/setup.ts
+++ b/apps/admin-panel/src/test/setup.ts
@@ -8,6 +8,34 @@ afterEach(() => {
 });
 
 if (typeof window !== "undefined") {
+  const ensureStorage = (key: "localStorage" | "sessionStorage") => {
+    if (typeof window[key] !== "undefined") {
+      return;
+    }
+    const store = new Map<string, string>();
+    const storage: Storage = {
+      get length() {
+        return store.size;
+      },
+      clear: () => store.clear(),
+      getItem: (itemKey: string) => store.get(itemKey) ?? null,
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      removeItem: (itemKey: string) => {
+        store.delete(itemKey);
+      },
+      setItem: (itemKey: string, value: string) => {
+        store.set(itemKey, String(value));
+      },
+    };
+    Object.defineProperty(window, key, {
+      configurable: true,
+      value: storage,
+    });
+  };
+
+  ensureStorage("localStorage");
+  ensureStorage("sessionStorage");
+
   if (!window.matchMedia) {
     window.matchMedia = ((query: string) =>
       ({

--- a/packages/api-client/src/endpoints/__tests__/proxies.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/proxies.test.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getMock = vi.fn();
 const putMock = vi.fn();
+const patchMock = vi.fn();
 const postMock = vi.fn();
 
 vi.mock("../../client/client", () => ({
   apiClient: {
     get: getMock,
     put: putMock,
+    patch: patchMock,
     post: postMock,
   },
 }));
@@ -16,6 +18,7 @@ describe("proxiesApi", () => {
   beforeEach(() => {
     getMock.mockReset();
     putMock.mockReset();
+    patchMock.mockReset();
     postMock.mockReset();
   });
 
@@ -58,5 +61,24 @@ describe("proxiesApi", () => {
       expect.objectContaining({ timeoutMs: 12000 }),
     );
     expect(result).toEqual({ ok: true, statusCode: 204, latencyMs: 24 });
+  });
+
+  test("updates one proxy entry through the single-item patch API", async () => {
+    const { proxiesApi } = await import("@code-proxy/api-client/endpoints/proxies");
+    patchMock.mockResolvedValue({ status: "ok" });
+
+    await proxiesApi.update("hk", {
+      name: "Updated HK",
+      url: "http://127.0.0.1:7891",
+      enabled: false,
+      description: "rotated",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/proxy-pool/hk", {
+      name: "Updated HK",
+      url: "http://127.0.0.1:7891",
+      enabled: false,
+      description: "rotated",
+    });
   });
 });

--- a/packages/api-client/src/endpoints/proxies.ts
+++ b/packages/api-client/src/endpoints/proxies.ts
@@ -22,6 +22,13 @@ export interface ProxyCheckResult {
   message?: string;
 }
 
+export interface ProxyPoolUpdateInput {
+  name: string;
+  url: string;
+  enabled: boolean;
+  description?: string;
+}
+
 type RawProxyPoolEntry = {
   id?: unknown;
   name?: unknown;
@@ -104,6 +111,15 @@ export const proxiesApi = {
         enabled: entry.enabled,
         ...(entry.description ? { description: entry.description } : {}),
       })),
+    });
+  },
+
+  update(id: string, entry: ProxyPoolUpdateInput) {
+    return apiClient.patch(`/proxy-pool/${encodeURIComponent(id)}`, {
+      name: entry.name,
+      url: entry.url,
+      enabled: entry.enabled,
+      ...(entry.description ? { description: entry.description } : {}),
     });
   },
 

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -141,22 +141,28 @@ export function ProxiesPage() {
       description: draft.description?.trim() ?? "",
       enabled: draft.enabled,
     };
-    const nextEntries =
-      editingID && entries.some((entry) => entry.id === editingID)
-        ? entries.map((entry) => (entry.id === editingID ? normalized : entry))
-        : [...entries, normalized];
 
     setSaving(true);
     try {
-      await proxiesApi.saveAll(nextEntries);
-      setEntries(nextEntries);
-      if (editingID && editingID !== normalized.id) {
+      if (editingID) {
+        await proxiesApi.update(editingID, {
+          name: normalized.name,
+          url: normalized.url,
+          enabled: normalized.enabled,
+          description: normalized.description,
+        });
+        setEntries((prev) => prev.map((entry) => (entry.id === editingID ? normalized : entry)));
         setCheckState((prev) => {
           const next = { ...prev };
           delete next[editingID];
           writeCachedProxyCheckState(next);
           return next;
         });
+        void refreshCheckResults([normalized]);
+      } else {
+        const nextEntries = [...entries, normalized];
+        await proxiesApi.saveAll(nextEntries);
+        setEntries(nextEntries);
       }
       notify({ type: "success", message: t("proxies.saved") });
       closeModal();

--- a/pages/proxies/__tests__/ProxiesPage.test.tsx
+++ b/pages/proxies/__tests__/ProxiesPage.test.tsx
@@ -9,6 +9,7 @@ import { ToastProvider } from "@code-proxy/ui";
 const mocks = vi.hoisted(() => ({
   apiGet: vi.fn(),
   apiPut: vi.fn(),
+  apiPatch: vi.fn(),
   apiPost: vi.fn(),
 }));
 
@@ -18,6 +19,7 @@ vi.mock("@code-proxy/api-client", () => ({
   apiClient: {
     get: mocks.apiGet,
     put: mocks.apiPut,
+    patch: mocks.apiPatch,
     post: mocks.apiPost,
   },
 }));
@@ -37,6 +39,7 @@ vi.mock("@code-proxy/api-client/endpoints/proxies", async (importOriginal) => {
         return items.map(mod.normalizeProxyEntry).filter(Boolean);
       },
       saveAll: (entries: unknown[]) => mocks.apiPut("/proxy-pool", { items: entries }),
+      update: (id: string, entry: unknown) => mocks.apiPatch(`/proxy-pool/${id}`, entry),
       check: async (request: { id?: string; url?: string; testUrl?: string }) =>
         mod.normalizeProxyCheckResult(
           await mocks.apiPost(
@@ -69,6 +72,7 @@ describe("ProxiesPage", () => {
     window.sessionStorage.clear();
     mocks.apiGet.mockReset();
     mocks.apiPut.mockReset();
+    mocks.apiPatch.mockReset();
     mocks.apiPost.mockReset();
     mocks.apiGet.mockResolvedValue({
       items: [
@@ -83,6 +87,7 @@ describe("ProxiesPage", () => {
       ],
     });
     mocks.apiPut.mockResolvedValue({ status: "ok" });
+    mocks.apiPatch.mockResolvedValue({ status: "ok" });
     mocks.apiPost.mockResolvedValue({ ok: true, status_code: 204, latency_ms: 31 });
   });
 
@@ -274,6 +279,63 @@ describe("ProxiesPage", () => {
     await waitFor(() => {
       expect(mocks.apiPut).toHaveBeenCalledWith("/proxy-pool", { items: [] });
     });
+  });
+
+  test("edits an existing proxy through the single-item patch API without appending a new row", async () => {
+    mocks.apiGet
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "hk",
+            name: "HK Proxy",
+            url: "socks5://user:pass@127.0.0.1:1080",
+            masked_url: "socks5://127.0.0.1:1080",
+            enabled: true,
+            description: "Codex egress",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "hk",
+            name: "Updated HK Proxy",
+            url: "http://127.0.0.1:7891",
+            masked_url: "http://127.0.0.1:7891",
+            enabled: false,
+            description: "Rotated egress",
+          },
+        ],
+      });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole("button", { name: /edit hk proxy/i }));
+    const dialog = await screen.findByRole("dialog", { name: /edit proxy/i });
+
+    const nameInput = within(dialog).getByLabelText(/name/i);
+    const urlInput = within(dialog).getByLabelText(/proxy url/i);
+    const remarkInput = within(dialog).getByLabelText(/remark/i);
+
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Updated HK Proxy");
+    await userEvent.clear(urlInput);
+    await userEvent.type(urlInput, "http://127.0.0.1:7891");
+    await userEvent.clear(remarkInput);
+    await userEvent.type(remarkInput, "Rotated egress");
+    await userEvent.click(within(dialog).getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.apiPatch).toHaveBeenCalledWith("/proxy-pool/hk", {
+        name: "Updated HK Proxy",
+        url: "http://127.0.0.1:7891",
+        enabled: true,
+        description: "Rotated egress",
+      });
+    });
+    expect(mocks.apiPut).not.toHaveBeenCalled();
+    expect(await screen.findByText("Updated HK Proxy")).toBeInTheDocument();
+    expect(screen.queryByText("HK Proxy")).not.toBeInTheDocument();
   });
 
   test("checks a proxy and renders the last check result", async () => {


### PR DESCRIPTION
## Summary
- call the single-item proxy pool patch API when editing an existing proxy
- keep create and delete on the existing save-all flow while refreshing only the edited row
- add regression tests for editing without appending, plus test storage shims for vitest

## Testing
- rtk bun x vitest run --config vite.config.ts ../../pages/proxies/__tests__/ProxiesPage.test.tsx ../../packages/api-client/src/endpoints/__tests__/proxies.test.ts