### PR TITLE
fix: cap live log fetch limit

### DIFF
--- a/pages/logs/LogsPage.tsx
+++ b/pages/logs/LogsPage.tsx
@@ -11,6 +11,7 @@ import { downloadBlob, type ErrorLogItem, isManagementTraffic, parseLogLine } fr
 const INITIAL_DISPLAY_LINES = 400;
 const LOAD_MORE_LINES = 400;
 const MAX_BUFFER_LINES = 50000;
+const SERVER_LOG_FETCH_LIMIT = 20000;
 const INCREMENTAL_FETCH_LIMIT = 2000;
 const LOAD_MORE_THRESHOLD_PX = 64;
 const STICK_TO_BOTTOM_THRESHOLD_PX = 48;
@@ -99,7 +100,7 @@ export function LogsPage() {
         const result = await logsApi.fetchLogs(
           options.mode === "incremental"
             ? { after, limit: INCREMENTAL_FETCH_LIMIT }
-            : { limit: MAX_BUFFER_LINES },
+            : { limit: SERVER_LOG_FETCH_LIMIT },
         );
         const lines = Array.isArray(result?.lines) ? result.lines : [];
         const nextLatest =

--- a/pages/logs/__tests__/LogsPage.test.tsx
+++ b/pages/logs/__tests__/LogsPage.test.tsx
@@ -45,6 +45,19 @@ describe("LogsPage", () => {
     vi.clearAllMocks();
   });
 
+  test("uses a backend-safe limit for the initial log fetch", async () => {
+    await i18n.changeLanguage("zh-CN");
+
+    mocks.fetchLogs.mockResolvedValue({
+      lines: [],
+      "latest-timestamp": null,
+    });
+
+    renderLogsPage();
+
+    await waitFor(() => expect(mocks.fetchLogs).toHaveBeenCalledWith({ limit: 20000 }));
+  });
+
   test("treats an empty error log list as loaded instead of retrying", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- cap the live logs full fetch request at the backend limit of 20000 rows
- keep the browser-side log buffer at 50000 rows
- add a regression test for the initial fetch limit

## Verification
- bun run --filter @code-proxy/admin-panel test pages/logs/__tests__/LogsPage.test.tsx
- bun run --filter @code-proxy/admin-panel build

## Context
Online CliProxy2 logs showed /v0/management/logs?limit=50000 returning 400 at 2026-06-11 17:14:09 because the backend rejects limits above 20000.