### PR TITLE
fix: polish auth file detail modal

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -911,6 +911,19 @@ const readCodexFilenameChannelName = (fileName: string): string => {
   return "";
 };
 
+const readCodexFilenamePlanType = (fileName: string): string | null => {
+  const normalized = String(fileName ?? "")
+    .trim()
+    .toLowerCase();
+  const base = trimAuthFileExtension(normalized);
+  if (!base.startsWith("codex-")) return null;
+  const rest = base.slice("codex-".length);
+  if (!rest) return null;
+  const parts = rest.split("-").filter(Boolean);
+  const lastPart = parts.at(-1) ?? "";
+  return codexFilenamePlanSuffixes.has(lastPart) ? lastPart : null;
+};
+
 export const readAuthFileChannelName = (file: AuthFileItem): string => {
   const candidates = [file.label, file.email];
   for (const candidate of candidates) {
@@ -998,7 +1011,10 @@ export const shouldShowAuthFileDisplayTag = (file: AuthFileItem, tag: unknown): 
 export const resolveAuthFilePlanType = (
   file: AuthFileItem,
   quotaState?: QuotaState | null,
-): string | null => resolveCodexPlanType(file) ?? normalizePlanType(quotaState?.planType);
+): string | null =>
+  resolveCodexPlanType(file) ??
+  readCodexFilenamePlanType(String(file.name || "")) ??
+  normalizePlanType(quotaState?.planType);
 
 export const resolveAuthFileSupplementalTags = (
   file: AuthFileItem,

--- a/packages/ui/src/overlays/Modal.tsx
+++ b/packages/ui/src/overlays/Modal.tsx
@@ -21,7 +21,7 @@ export function Modal({
 }: PropsWithChildren<{
   open: boolean;
   title: string;
-  description?: string;
+  description?: ReactNode;
   footer?: ReactNode;
   maxWidth?: string;
   panelClassName?: string;

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -153,9 +153,11 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByText("$1.2345")).toBeInTheDocument();
     expect(screen.getByText("Weekly quota used")).toBeInTheDocument();
     expect(screen.getByText("8%")).toBeInTheDocument();
-    expect(screen.getByRole("dialog", { name: "View: codex.json" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Codex Primary" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
     expect(chartOptions[0]?.animation).toBe(true);
+    expect(chartOptions[0]?.grid?.top).toBeGreaterThanOrEqual(70);
+    expect(chartOptions[0]?.yAxis?.every((item: any) => !item.name)).toBe(true);
     expect(chartOptions[0]?.series?.every((item: any) => item.animation === true)).toBe(true);
   });
 
@@ -168,6 +170,8 @@ describe("AuthFileDetailModal", () => {
     });
 
     expect(screen.getByRole("tab", { name: "Usage" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "pcamtu927@gmail.com" })).toBeInTheDocument();
+    expect(screen.getByText("plus")).toBeInTheDocument();
     expect(screen.getByText("Current cycle cost")).toBeInTheDocument();
     expect(screen.getByText("$1.2345")).toBeInTheDocument();
   });
@@ -184,7 +188,8 @@ describe("AuthFileDetailModal", () => {
     renderDetailModal({ detailTrend: null, detailTrendLoading: true });
 
     expect(screen.getByTestId("auth-file-trend-loading")).toBeInTheDocument();
-    expect(screen.getByTestId("auth-file-trend-chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("auth-file-trend-chart")).not.toBeInTheDocument();
+    expect(chartOptions).toHaveLength(0);
   });
 
   test("does not render quota sample summary cards below the trend chart", () => {
@@ -220,7 +225,7 @@ describe("AuthFileDetailModal", () => {
         quota_series: [
           {
             quota_key: "code_5h",
-            quota_label: "m_quota.code_5h",
+            quota_label: "GPT-5.3-Codex-Spark: 五小时",
             window_seconds: 18000,
             points: [
               { timestamp: oldQuotaAt22, percent: 100 },
@@ -243,6 +248,7 @@ describe("AuthFileDetailModal", () => {
     const series = JSON.parse(chart.dataset.series ?? "[]");
     expect(series[0].data).toEqual([0, 2, 1, 1, 10]);
     expect(series[1].data).toEqual([0, 0.002, 0.001, 0.001, 0.01]);
+    expect(series[2].name).toBe("五小时 used");
     expect(series[2].data).toEqual([null, null, null, null, 6]);
   });
 

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2512,7 +2512,7 @@ describe("AuthFilesPage files table", () => {
     const cards = await screen.findByTestId("auth-files-cards");
     expect(cards).not.toHaveTextContent(/d left/);
     fireEvent.click(within(cards).getByRole("button", { name: "View" }));
-    const dialog = await screen.findByRole("dialog", { name: "View: codex-subscription.json" });
+    const dialog = await screen.findByRole("dialog", { name: "Codex Subscriber" });
     fireEvent.click(within(dialog).getByRole("tab", { name: "Fields" }));
 
     const input = await within(dialog).findByLabelText("Subscription start date");
@@ -2525,7 +2525,7 @@ describe("AuthFilesPage files table", () => {
     expect(uploadedJson.subscription_started_at).toBe(new Date(startedAtInput).toISOString());
     await waitFor(() =>
       expect(
-        screen.queryByRole("dialog", { name: "View: codex-subscription.json" }),
+        screen.queryByRole("dialog", { name: "Codex Subscriber" }),
       ).not.toBeInTheDocument(),
     );
     await waitFor(() => expect(screen.getByTestId("auth-files-cards")).toHaveTextContent(/d left/));
@@ -2564,8 +2564,9 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(within(cards).getByRole("button", { name: "View" }));
 
     const dialog = await screen.findByRole("dialog", {
-      name: "View: codex-pcamtu927@gmail.com-plus.json",
+      name: "pcamtu927@gmail.com",
     });
+    expect(within(dialog).getByText("plus")).toBeInTheDocument();
     expect(within(dialog).getByRole("tab", { name: "Usage" })).toBeInTheDocument();
     expect(await within(dialog).findByText("Current cycle cost")).toBeInTheDocument();
     expect(within(dialog).getByText("$1.2345")).toBeInTheDocument();
@@ -2632,7 +2633,7 @@ describe("AuthFilesPage files table", () => {
     expect(authGroupOwnerMappingMap).toEqual({ codex: "openai" });
 
     fireEvent.click(screen.getByRole("button", { name: "View" }));
-    const dialog = await screen.findByRole("dialog", { name: "View: codex.json" });
+    const dialog = await screen.findByRole("dialog", { name: "Codex Main" });
     fireEvent.click(within(dialog).getByRole("tab", { name: "Models" }));
 
     expect(

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -225,6 +225,7 @@ describe("Auth Files helper coverage", () => {
 
     expect(resolveFileType(file)).toBe("codex");
     expect(resolveAuthFileDisplayName(file)).toBe("pcamtu927@gmail.com");
+    expect(resolveAuthFilePlanType(file)).toBe("plus");
   });
 
   test("treats an explicit empty display tag list as hiding every tag", () => {

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -21,6 +21,8 @@ import {
   normalizeProviderKey,
   parseAdditionalQuotaWindowLabel,
   readAuthFileChannelName,
+  resolveAuthFileDisplayName,
+  resolveAuthFilePlanType,
   resolveFileType,
   type AuthFileModelItem,
   type AuthFileModelOwnerGroup,
@@ -139,6 +141,10 @@ export function AuthFileDetailModal({
   const providerKey = normalizeProviderKey(modelsFileType);
   const detailProviderKey = detailFile ? normalizeProviderKey(resolveFileType(detailFile)) : "";
   const supportsUsageTrend = detailProviderKey === "kimi" || detailProviderKey === "codex";
+  const detailTitle = detailFile
+    ? resolveAuthFileDisplayName(detailFile) || String(detailFile.name || "")
+    : t("auth_files.view_auth_file");
+  const detailPlanType = detailFile ? resolveAuthFilePlanType(detailFile) : null;
   const excludedModels = excluded[providerKey] ?? [];
   const canRenameChannel = detailFile ? canRenameAuthFileChannel(detailFile) : false;
   const channelBaseline = detailFile ? readAuthFileChannelName(detailFile) : "";
@@ -208,6 +214,14 @@ export function AuthFileDetailModal({
     const sortedKeys = Array.from(xKeys).sort();
     const formatAxisLabel = (key: string) =>
       detailTrendWindow === "5h" ? key.slice(5) : key.slice(5);
+    const compactQuotaLegendLabel = (label: string) => {
+      const translated = translateQuotaLabel(label).trim();
+      if (translated.length <= 14) return translated;
+      const colonIndex = Math.max(translated.lastIndexOf(":"), translated.lastIndexOf("："));
+      const suffix = colonIndex >= 0 ? translated.slice(colonIndex + 1).trim() : "";
+      if (suffix) return suffix.length > 14 ? `${suffix.slice(0, 14)}...` : suffix;
+      return `${translated.slice(0, 14)}...`;
+    };
     const palette = ["#2563eb", "#db2777", "#16a34a", "#9333ea", "#0f766e", "#dc2626"];
 
     return {
@@ -216,25 +230,35 @@ export function AuthFileDetailModal({
       animationDurationUpdate: 420,
       animationEasing: "cubicOut" as const,
       animationEasingUpdate: "cubicOut" as const,
-      grid: { left: 38, right: 78, top: 38, bottom: 34 },
+      grid: { left: 46, right: 108, top: 74, bottom: 38 },
       tooltip: { trigger: "axis", confine: true },
       legend: {
-        top: 0,
+        top: 8,
+        left: 8,
+        right: 8,
         type: "scroll",
-        textStyle: { color: "#64748b" },
+        itemGap: 14,
+        pageButtonPosition: "end",
+        pageIconColor: "#64748b",
+        pageIconInactiveColor: "#cbd5e1",
+        pageTextStyle: { color: "#64748b" },
+        textStyle: {
+          color: "#64748b",
+          width: 154,
+          overflow: "truncate",
+        },
       },
       xAxis: {
         type: "category",
         data: sortedKeys.map(formatAxisLabel),
-        axisLabel: { color: "#64748b" },
+        axisLabel: { color: "#64748b", hideOverlap: true },
         axisLine: { lineStyle: { color: "#cbd5e1" } },
       },
       yAxis: [
         {
           type: "value",
           min: 0,
-          name: t("auth_files.trend_requests"),
-          axisLabel: { color: "#64748b" },
+          axisLabel: { color: "#64748b", hideOverlap: true },
           splitLine: { lineStyle: { color: "#e2e8f0" } },
         },
         {
@@ -242,16 +266,15 @@ export function AuthFileDetailModal({
           min: 0,
           max: 100,
           offset: 46,
-          name: "%",
-          axisLabel: { color: "#64748b", formatter: "{value}%" },
+          axisLabel: { color: "#64748b", formatter: "{value}%", hideOverlap: true },
           splitLine: { show: false },
         },
         {
           type: "value",
           min: 0,
-          name: "$",
           axisLabel: {
             color: "#64748b",
+            hideOverlap: true,
             formatter: (value: number) => {
               if (!Number.isFinite(value)) return "$0";
               if (Math.abs(value) < 1) return `$${value.toFixed(3)}`;
@@ -288,7 +311,7 @@ export function AuthFileDetailModal({
           data: sortedKeys.map((key) => costByKey.get(key) ?? 0),
         },
         ...quotaBySeries.map(({ series, values }, index) => ({
-          name: `${translateQuotaLabel(series.quota_label)} ${t(
+          name: `${compactQuotaLegendLabel(series.quota_label)} ${t(
             "auth_files.trend_quota_used_suffix",
           )}`,
           type: "line",
@@ -341,12 +364,17 @@ export function AuthFileDetailModal({
             {t("common.loading_ellipsis")}
           </div>
           <div className="min-w-0 rounded-lg bg-slate-50/70 p-3 dark:bg-white/[0.04]">
-            <EChart
-              option={trendChartOption}
-              className="h-72 min-w-0"
-              loading
-              loadingText={t("common.loading_ellipsis")}
-            />
+            <div className="h-80 min-w-0 overflow-hidden rounded-md border border-slate-200/70 bg-white/70 dark:border-white/10 dark:bg-white/[0.03]">
+              <div className="flex h-full items-end gap-2 px-4 pb-5 pt-8">
+                {Array.from({ length: 14 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="min-w-0 flex-1 animate-pulse rounded-t bg-slate-200/80 dark:bg-white/10"
+                    style={{ height: `${24 + ((index * 17) % 52)}%` }}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       );
@@ -445,7 +473,7 @@ export function AuthFileDetailModal({
         <div className="min-w-0 rounded-lg bg-slate-50/70 p-3 dark:bg-white/[0.04]">
           <EChart
             option={trendChartOption}
-            className="h-72 min-w-0"
+            className="h-80 min-w-0"
             replaceMerge="series"
             loading={detailTrendLoading}
             loadingText={t("common.loading_ellipsis")}
@@ -458,10 +486,13 @@ export function AuthFileDetailModal({
   return (
     <Modal
       open={open}
-      title={
-        detailFile
-          ? t("auth_files.view_file_title", { name: detailFile.name })
-          : t("auth_files.view_auth_file")
+      title={detailTitle}
+      description={
+        detailPlanType ? (
+          <span className="inline-flex h-6 max-w-full items-center rounded-full border border-blue-200 bg-blue-50 px-2 text-xs font-semibold tracking-normal text-blue-700 dark:border-blue-400/30 dark:bg-blue-400/10 dark:text-blue-200">
+            {detailPlanType}
+          </span>
+        ) : undefined
       }
       maxWidth="max-w-4xl"
       bodyHeightClassName="h-[70vh]"

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -231,6 +231,9 @@ export function useAuthFilesDetailEditors(
 
       const request = (async () => {
         const trend = await usageApi.getAuthFileTrend(authIndex, { days: 7, hours: 5 });
+        if (shouldShowLoading) {
+          setDetailTrendLoading(false);
+        }
         setDetailTrend(trend);
       })();
       detailTrendInFlightRef.current.set(authIndex, request);
@@ -245,7 +248,7 @@ export function useAuthFilesDetailEditors(
         if (detailTrendInFlightRef.current.get(authIndex) === request) {
           detailTrendInFlightRef.current.delete(authIndex);
         }
-        if (shouldShowLoading) {
+        if (shouldShowLoading && !detailTrend) {
           setDetailTrendLoading(false);
         }
       }


### PR DESCRIPTION
## Summary
- show the auth file detail modal title as the account email with a plan badge instead of the raw file name
- avoid mounting ECharts during first trend loading so the chart animation only starts with real data
- clean up trend chart spacing by reserving legend space, removing crowded axis titles, and shortening long quota legend labels

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- Playwright mock check: loading canvas count 0, trend request count 1, rendered chart canvas count 1