### PR TITLE
fix: simplify auth file trend loading

### DIFF
--- a/packages/ui/src/overlays/Modal.tsx
+++ b/packages/ui/src/overlays/Modal.tsx
@@ -7,6 +7,7 @@ const ANIMATION_MS = 180;
 export function Modal({
   open,
   title,
+  titleAccessory,
   description,
   footer,
   maxWidth = "max-w-3xl",
@@ -21,6 +22,7 @@ export function Modal({
 }: PropsWithChildren<{
   open: boolean;
   title: string;
+  titleAccessory?: ReactNode;
   description?: ReactNode;
   footer?: ReactNode;
   maxWidth?: string;
@@ -122,8 +124,15 @@ export function Modal({
         ) : (
           <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-neutral-800">
             <div className="min-w-0">
-              <h2 className="truncate text-base font-semibold tracking-tight text-slate-900 dark:text-white">
-                <span id={titleId}>{title}</span>
+              <h2 className="flex min-w-0 items-center gap-2 text-base font-semibold tracking-tight text-slate-900 dark:text-white">
+                <span id={titleId} className="min-w-0 truncate">
+                  {title}
+                </span>
+                {titleAccessory ? (
+                  <span className="shrink-0" aria-hidden="true">
+                    {titleAccessory}
+                  </span>
+                ) : null}
               </h2>
               {description ? (
                 <p className="mt-1 text-sm text-slate-600 dark:text-white/65">{description}</p>

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -155,10 +155,10 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByText("8%")).toBeInTheDocument();
     expect(screen.getByRole("dialog", { name: "Codex Primary" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
-    expect(chartOptions[0]?.animation).toBe(true);
+    expect(chartOptions[0]?.animation).toBe(false);
     expect(chartOptions[0]?.grid?.top).toBeGreaterThanOrEqual(70);
     expect(chartOptions[0]?.yAxis?.every((item: any) => !item.name)).toBe(true);
-    expect(chartOptions[0]?.series?.every((item: any) => item.animation === true)).toBe(true);
+    expect(chartOptions[0]?.series?.every((item: any) => item.animation === false)).toBe(true);
   });
 
   test("keeps the usage cost card visible for codex files inferred from dotted email file names", () => {
@@ -171,7 +171,7 @@ describe("AuthFileDetailModal", () => {
 
     expect(screen.getByRole("tab", { name: "Usage" })).toBeInTheDocument();
     expect(screen.getByRole("dialog", { name: "pcamtu927@gmail.com" })).toBeInTheDocument();
-    expect(screen.getByText("plus")).toBeInTheDocument();
+    expect(screen.getByText("Plus")).toBeInTheDocument();
     expect(screen.getByText("Current cycle cost")).toBeInTheDocument();
     expect(screen.getByText("$1.2345")).toBeInTheDocument();
   });
@@ -184,10 +184,11 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
-  test("renders an animated loading state before the first trend payload arrives", () => {
+  test("keeps first trend loading quiet before the first payload arrives", () => {
     renderDetailModal({ detailTrend: null, detailTrendLoading: true });
 
-    expect(screen.getByTestId("auth-file-trend-loading")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-file-trend-loading")).toBeEmptyDOMElement();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
     expect(screen.queryByTestId("auth-file-trend-chart")).not.toBeInTheDocument();
     expect(chartOptions).toHaveLength(0);
   });

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2566,7 +2566,7 @@ describe("AuthFilesPage files table", () => {
     const dialog = await screen.findByRole("dialog", {
       name: "pcamtu927@gmail.com",
     });
-    expect(within(dialog).getByText("plus")).toBeInTheDocument();
+    expect(within(dialog).getByText("Plus")).toBeInTheDocument();
     expect(within(dialog).getByRole("tab", { name: "Usage" })).toBeInTheDocument();
     expect(await within(dialog).findByText("Current cycle cost")).toBeInTheDocument();
     expect(within(dialog).getByText("$1.2345")).toBeInTheDocument();

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -1,6 +1,6 @@
 import { useMemo, type Dispatch, type SetStateAction } from "react";
 import { useTranslation } from "react-i18next";
-import { Download, Loader2, RefreshCw, ShieldCheck } from "lucide-react";
+import { Download, RefreshCw, ShieldCheck } from "lucide-react";
 import type { AuthFileTrendResponse } from "@code-proxy/api-client/endpoints/usage";
 import type { AuthFileItem, AuthFileSubscriptionPeriod } from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
@@ -145,6 +145,15 @@ export function AuthFileDetailModal({
     ? resolveAuthFileDisplayName(detailFile) || String(detailFile.name || "")
     : t("auth_files.view_auth_file");
   const detailPlanType = detailFile ? resolveAuthFilePlanType(detailFile) : null;
+  const detailPlanLabel = useMemo(() => {
+    if (!detailPlanType) return "";
+    const normalized = detailPlanType.trim().toLowerCase();
+    if (!normalized) return "";
+    if (normalized === "plus" || normalized === "team" || normalized === "free") {
+      return t(`codex_quota.plan_${normalized}`);
+    }
+    return normalized;
+  }, [detailPlanType, t]);
   const excludedModels = excluded[providerKey] ?? [];
   const canRenameChannel = detailFile ? canRenameAuthFileChannel(detailFile) : false;
   const channelBaseline = detailFile ? readAuthFileChannelName(detailFile) : "";
@@ -225,11 +234,9 @@ export function AuthFileDetailModal({
     const palette = ["#2563eb", "#db2777", "#16a34a", "#9333ea", "#0f766e", "#dc2626"];
 
     return {
-      animation: true,
-      animationDuration: 720,
-      animationDurationUpdate: 420,
-      animationEasing: "cubicOut" as const,
-      animationEasingUpdate: "cubicOut" as const,
+      animation: false,
+      animationDuration: 0,
+      animationDurationUpdate: 0,
       grid: { left: 46, right: 108, top: 74, bottom: 38 },
       tooltip: { trigger: "axis", confine: true },
       legend: {
@@ -289,7 +296,7 @@ export function AuthFileDetailModal({
           name: t("auth_files.trend_requests"),
           type: "bar",
           yAxisIndex: 0,
-          animation: true,
+          animation: false,
           barMaxWidth: 24,
           itemStyle: { color: "#2563eb", borderRadius: [4, 4, 0, 0] },
           data: sortedKeys.map((key) => requestByKey.get(key) ?? 0),
@@ -298,7 +305,7 @@ export function AuthFileDetailModal({
           name: t("auth_files.trend_cost"),
           type: "line",
           yAxisIndex: 2,
-          animation: true,
+          animation: false,
           connectNulls: true,
           showSymbol: false,
           smooth: true,
@@ -316,7 +323,7 @@ export function AuthFileDetailModal({
           )}`,
           type: "line",
           yAxisIndex: 1,
-          animation: true,
+          animation: false,
           connectNulls: true,
           showSymbol: false,
           smooth: true,
@@ -349,35 +356,7 @@ export function AuthFileDetailModal({
 
   const renderUsageTrend = () => {
     if (detailTrendLoading && !detailTrend) {
-      return (
-        <div className="space-y-4" data-testid="auth-file-trend-loading">
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-            {Array.from({ length: 5 }).map((_, index) => (
-              <div key={index} className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
-                <div className="h-3 w-24 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
-                <div className="mt-3 h-7 w-28 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
-              </div>
-            ))}
-          </div>
-          <div className="flex items-center gap-2 text-sm text-slate-600 dark:text-white/65">
-            <Loader2 size={16} className="animate-spin" />
-            {t("common.loading_ellipsis")}
-          </div>
-          <div className="min-w-0 rounded-lg bg-slate-50/70 p-3 dark:bg-white/[0.04]">
-            <div className="h-80 min-w-0 overflow-hidden rounded-md border border-slate-200/70 bg-white/70 dark:border-white/10 dark:bg-white/[0.03]">
-              <div className="flex h-full items-end gap-2 px-4 pb-5 pt-8">
-                {Array.from({ length: 14 }).map((_, index) => (
-                  <div
-                    key={index}
-                    className="min-w-0 flex-1 animate-pulse rounded-t bg-slate-200/80 dark:bg-white/10"
-                    style={{ height: `${24 + ((index * 17) % 52)}%` }}
-                  />
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      );
+      return <div className="min-h-80" data-testid="auth-file-trend-loading" aria-hidden="true" />;
     }
 
     if (detailTrendError) {
@@ -475,8 +454,6 @@ export function AuthFileDetailModal({
             option={trendChartOption}
             className="h-80 min-w-0"
             replaceMerge="series"
-            loading={detailTrendLoading}
-            loadingText={t("common.loading_ellipsis")}
           />
         </div>
       </div>
@@ -487,10 +464,10 @@ export function AuthFileDetailModal({
     <Modal
       open={open}
       title={detailTitle}
-      description={
-        detailPlanType ? (
-          <span className="inline-flex h-6 max-w-full items-center rounded-full border border-blue-200 bg-blue-50 px-2 text-xs font-semibold tracking-normal text-blue-700 dark:border-blue-400/30 dark:bg-blue-400/10 dark:text-blue-200">
-            {detailPlanType}
+      titleAccessory={
+        detailPlanLabel ? (
+          <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+            {detailPlanLabel}
           </span>
         ) : undefined
       }
@@ -524,7 +501,7 @@ export function AuthFileDetailModal({
               onClick={() => void refreshDetailTrend(detailFile)}
               disabled={detailTrendLoading}
             >
-              <RefreshCw size={14} className={detailTrendLoading ? "animate-spin" : ""} />
+              <RefreshCw size={14} />
               {t("auth_files.trend_refresh")}
             </Button>
           ) : null}


### PR DESCRIPTION
## Summary
- disable ECharts animation in the auth file detail trend chart
- remove the first-load skeleton, loading text, and spinner so the trend area stays quiet before data arrives
- align the modal account plan badge with the card amber badge and place it beside the account title

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- Playwright mock check: no loading text/spinner/skeleton/canvas before trend data, one static chart after data