### PR TITLE
fix: add minimal auth file trend skeleton

### DIFF
--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -187,7 +187,8 @@ describe("AuthFileDetailModal", () => {
   test("keeps first trend loading quiet before the first payload arrives", () => {
     renderDetailModal({ detailTrend: null, detailTrendLoading: true });
 
-    expect(screen.getByTestId("auth-file-trend-loading")).toBeEmptyDOMElement();
+    const loading = screen.getByTestId("auth-file-trend-loading");
+    expect(loading.querySelectorAll(".animate-pulse")).toHaveLength(8);
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
     expect(screen.queryByTestId("auth-file-trend-chart")).not.toBeInTheDocument();
     expect(chartOptions).toHaveLength(0);

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -356,7 +356,23 @@ export function AuthFileDetailModal({
 
   const renderUsageTrend = () => {
     if (detailTrendLoading && !detailTrend) {
-      return <div className="min-h-80" data-testid="auth-file-trend-loading" aria-hidden="true" />;
+      const skeletonClass =
+        "animate-pulse rounded-lg bg-slate-100/80 dark:bg-white/[0.06]";
+
+      return (
+        <div className="space-y-4" data-testid="auth-file-trend-loading" aria-hidden="true">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div key={index} className={`${skeletonClass} h-20`} />
+            ))}
+          </div>
+          <div className="space-y-2">
+            <div className={`${skeletonClass} h-4 w-32`} />
+            <div className={`${skeletonClass} h-3 w-56 max-w-full`} />
+          </div>
+          <div className={`${skeletonClass} h-80 min-w-0`} />
+        </div>
+      );
     }
 
     if (detailTrendError) {


### PR DESCRIPTION
## Summary
- restore a lightweight skeleton for auth file trend loading
- keep loading free of text, spinner, and ECharts canvas before data arrives
- cover the skeleton with a focused modal test

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- Playwright mock check: 8 pulse skeleton blocks, no loading text/spinner/canvas, trend request count 1