### PR TITLE
fix: run auth file trend animation once

### DIFF
--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthFileDetailModal } from "@pages/auth-files/components/AuthFileDetailModal";
 import i18n from "@code-proxy/i18n";
@@ -7,11 +7,21 @@ import i18n from "@code-proxy/i18n";
 type DetailModalProps = ComponentProps<typeof AuthFileDetailModal>;
 
 const chartOptions = vi.hoisted(() => [] as any[]);
+const chartEvents = vi.hoisted(() => [] as any[]);
 
 vi.mock("@code-proxy/ui", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@code-proxy/ui")>()),
-  EChart: ({ option, className }: { option: any; className?: string }) => {
+  EChart: ({
+    option,
+    className,
+    onEvents,
+  }: {
+    option: any;
+    className?: string;
+    onEvents?: Record<string, () => void>;
+  }) => {
     chartOptions.push(option);
+    chartEvents.push(onEvents);
     return (
       <div
         className={className}
@@ -133,6 +143,7 @@ describe("AuthFileDetailModal", () => {
     await i18n.changeLanguage("en");
     window.localStorage.clear();
     chartOptions.length = 0;
+    chartEvents.length = 0;
   });
 
   test("uses usage trend as the primary view for Codex files", () => {
@@ -155,10 +166,22 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByText("8%")).toBeInTheDocument();
     expect(screen.getByRole("dialog", { name: "Codex Primary" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
-    expect(chartOptions[0]?.animation).toBe(false);
-    expect(chartOptions[0]?.grid?.top).toBeGreaterThanOrEqual(70);
-    expect(chartOptions[0]?.yAxis?.every((item: any) => !item.name)).toBe(true);
-    expect(chartOptions[0]?.series?.every((item: any) => item.animation === false)).toBe(true);
+    expect(chartOptions.at(-1)?.animation).toBe(true);
+    expect(chartOptions.at(-1)?.grid?.top).toBeGreaterThanOrEqual(70);
+    expect(chartOptions.at(-1)?.yAxis?.every((item: any) => !item.name)).toBe(true);
+    expect(chartOptions.at(-1)?.series?.every((item: any) => item.animation === true)).toBe(true);
+  });
+
+  test("disables trend chart animation after the first render completes", () => {
+    renderDetailModal();
+
+    expect(chartOptions.at(-1)?.animation).toBe(true);
+    act(() => {
+      chartEvents.at(-1)?.finished?.();
+    });
+
+    expect(chartOptions.at(-1)?.animation).toBe(false);
+    expect(chartOptions.at(-1)?.series?.every((item: any) => item.animation === false)).toBe(true);
   });
 
   test("keeps the usage cost card visible for codex files inferred from dotted email file names", () => {

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -1,4 +1,13 @@
-import { useMemo, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { Download, RefreshCw, ShieldCheck } from "lucide-react";
 import type { AuthFileTrendResponse } from "@code-proxy/api-client/endpoints/usage";
@@ -141,6 +150,10 @@ export function AuthFileDetailModal({
   const providerKey = normalizeProviderKey(modelsFileType);
   const detailProviderKey = detailFile ? normalizeProviderKey(resolveFileType(detailFile)) : "";
   const supportsUsageTrend = detailProviderKey === "kimi" || detailProviderKey === "codex";
+  const openedDetailFileRef = useRef<string | null>(null);
+  const detailOpenCounterRef = useRef(0);
+  const [detailOpenKey, setDetailOpenKey] = useState("");
+  const [animatedTrendKey, setAnimatedTrendKey] = useState("");
   const detailTitle = detailFile
     ? resolveAuthFileDisplayName(detailFile) || String(detailFile.name || "")
     : t("auth_files.view_auth_file");
@@ -189,6 +202,38 @@ export function AuthFileDetailModal({
       detailTrendWindow === "5h" ? item.window_seconds === 18000 : item.window_seconds >= 604800,
     );
   }, [detailTrend, detailTrendWindow]);
+  useLayoutEffect(() => {
+    const fileName = open && detailFile ? detailFile.name : "";
+    if (!fileName) {
+      openedDetailFileRef.current = null;
+      setDetailOpenKey("");
+      return;
+    }
+    if (openedDetailFileRef.current === fileName) return;
+    openedDetailFileRef.current = fileName;
+    detailOpenCounterRef.current += 1;
+    setDetailOpenKey(`${fileName}:${detailOpenCounterRef.current}`);
+  }, [detailFile?.name, open]);
+  const trendAnimationKey =
+    detailFile && detailTrend && detailOpenKey
+      ? `${detailOpenKey}:${detailTrend.auth_index}`
+      : "";
+  const shouldAnimateTrend = Boolean(trendAnimationKey && animatedTrendKey !== trendAnimationKey);
+  const markTrendAnimationDone = useCallback(() => {
+    if (!trendAnimationKey) return;
+    setAnimatedTrendKey((current) =>
+      current === trendAnimationKey ? current : trendAnimationKey,
+    );
+  }, [trendAnimationKey]);
+  useEffect(() => {
+    if (!shouldAnimateTrend) return;
+    const timer = window.setTimeout(markTrendAnimationDone, 900);
+    return () => window.clearTimeout(timer);
+  }, [markTrendAnimationDone, shouldAnimateTrend]);
+  const trendChartEvents = useMemo(
+    () => (shouldAnimateTrend ? { finished: markTrendAnimationDone } : undefined),
+    [markTrendAnimationDone, shouldAnimateTrend],
+  );
   const trendChartOption = useMemo(() => {
     const usagePoints =
       detailTrendWindow === "5h"
@@ -234,9 +279,10 @@ export function AuthFileDetailModal({
     const palette = ["#2563eb", "#db2777", "#16a34a", "#9333ea", "#0f766e", "#dc2626"];
 
     return {
-      animation: false,
-      animationDuration: 0,
+      animation: shouldAnimateTrend,
+      animationDuration: shouldAnimateTrend ? 680 : 0,
       animationDurationUpdate: 0,
+      animationEasing: "cubicOut" as const,
       grid: { left: 46, right: 108, top: 74, bottom: 38 },
       tooltip: { trigger: "axis", confine: true },
       legend: {
@@ -296,7 +342,9 @@ export function AuthFileDetailModal({
           name: t("auth_files.trend_requests"),
           type: "bar",
           yAxisIndex: 0,
-          animation: false,
+          animation: shouldAnimateTrend,
+          animationDuration: shouldAnimateTrend ? 680 : 0,
+          animationDurationUpdate: 0,
           barMaxWidth: 24,
           itemStyle: { color: "#2563eb", borderRadius: [4, 4, 0, 0] },
           data: sortedKeys.map((key) => requestByKey.get(key) ?? 0),
@@ -305,7 +353,9 @@ export function AuthFileDetailModal({
           name: t("auth_files.trend_cost"),
           type: "line",
           yAxisIndex: 2,
-          animation: false,
+          animation: shouldAnimateTrend,
+          animationDuration: shouldAnimateTrend ? 680 : 0,
+          animationDurationUpdate: 0,
           connectNulls: true,
           showSymbol: false,
           smooth: true,
@@ -323,7 +373,9 @@ export function AuthFileDetailModal({
           )}`,
           type: "line",
           yAxisIndex: 1,
-          animation: false,
+          animation: shouldAnimateTrend,
+          animationDuration: shouldAnimateTrend ? 680 : 0,
+          animationDurationUpdate: 0,
           connectNulls: true,
           showSymbol: false,
           smooth: true,
@@ -337,7 +389,7 @@ export function AuthFileDetailModal({
         })),
       ],
     };
-  }, [activeQuotaSeries, detailTrend, detailTrendWindow, t, translateQuotaLabel]);
+  }, [activeQuotaSeries, detailTrend, detailTrendWindow, shouldAnimateTrend, t, translateQuotaLabel]);
 
   const closeModal = () => {
     setDetailOpen(false);
@@ -469,6 +521,7 @@ export function AuthFileDetailModal({
           <EChart
             option={trendChartOption}
             className="h-80 min-w-0"
+            onEvents={trendChartEvents}
             replaceMerge="series"
           />
         </div>


### PR DESCRIPTION
## Summary
- re-enable the auth file trend chart entrance animation for the first real render
- mark the animation complete via ECharts finished event with a timeout fallback, so refreshes, resizes, and later updates do not replay it
- keep the lightweight skeleton before data arrives without mounting ECharts loading

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- Playwright mock check: skeleton has no canvas, trend request count 1, chart canvas remains 1 after animation window