### PR TITLE
feat: add usage CSV export to request logs page

### DIFF
--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -257,6 +257,16 @@ export interface IFlowCookieAuthResponse {
   type?: string;
 }
 
+export interface UsageSummaryItem {
+  person_name: string;
+  api_key: string;
+  request_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  total_cost_usd: number;
+}
+
 export interface LogsQuery {
   after?: number;
   limit?: number;

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -3,6 +3,7 @@ import type {
   UsageData,
   ChartDataResponse,
   EntityStatsResponse,
+  UsageSummaryItem,
 } from "../dto/types";
 
 export interface UsageExportPayload {
@@ -327,6 +328,16 @@ export const usageApi = {
 
   exportUsage(): Promise<UsageExportPayload> {
     return apiClient.get<UsageExportPayload>("/usage/export");
+  },
+
+  async exportSummary(params?: {
+    days?: number;
+    api_key?: string;
+  }): Promise<UsageSummaryItem[]> {
+    const resp = await apiClient.get<UsageSummaryItem[]>("/usage/export/summary", {
+      params: { days: params?.days, api_key: params?.api_key },
+    });
+    return Array.isArray(resp) ? resp : [];
   },
 
   importUsage(payload: unknown): Promise<UsageImportResponse> {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2390,7 +2390,16 @@
     "clear_model_filter": "Clear model filter",
     "clear_channel_filter": "Clear channel filter",
     "clear_status_filter": "Clear status filter",
-    "cache_rate": "Cache Token Ratio"
+    "cache_rate": "Cache Token Ratio",
+    "export_summary": "Export Summary",
+    "export_summary_empty": "No data to export",
+    "csv_person_name": "Person Name",
+    "csv_api_key": "API Key",
+    "csv_request_count": "Request Count",
+    "csv_input_tokens": "Input Tokens",
+    "csv_output_tokens": "Output Tokens",
+    "csv_total_tokens": "Total Tokens",
+    "csv_total_cost": "Cost (USD)"
   },
   "ccswitch": {
     "import_to_ccswitch": "Import to CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2659,7 +2659,16 @@
     "clear_key_filter": "清空密钥筛选",
     "clear_model_filter": "清空模型筛选",
     "clear_channel_filter": "清空渠道筛选",
-    "clear_status_filter": "清空状态筛选"
+    "clear_status_filter": "清空状态筛选",
+    "export_summary": "导出汇总",
+    "export_summary_empty": "导出汇总无数据",
+    "csv_person_name": "人员名",
+    "csv_api_key": "API Key",
+    "csv_request_count": "请求数",
+    "csv_input_tokens": "输入Token",
+    "csv_output_tokens": "输出Token",
+    "csv_total_tokens": "总Token",
+    "csv_total_cost": "费用(USD)"
   },
   "ccswitch": {
     "import_to_ccswitch": "导入到 CC Switch",

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { LoaderCircle, RefreshCw, ScrollText, Trash2 } from "lucide-react";
+import { LoaderCircle, Download, RefreshCw, ScrollText, Trash2 } from "lucide-react";
 import { usageApi } from "@code-proxy/api-client";
 import type {
   ClearUsageLogsPayload,
@@ -14,6 +14,7 @@ import { useToast } from "@code-proxy/ui";
 import { DataTable } from "@code-proxy/ui";
 import { ErrorDetailModal, LogContentModal } from "@features/log-content-viewer";
 import { RequestLogsFilters } from "./RequestLogsFilters";
+import { exportSummaryCsv } from "./exportSummaryCsv";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import {
   buildRequestLogKeyOptions,
@@ -132,6 +133,7 @@ export function RequestLogsPage() {
   const [selectedStatuses, setSelectedStatuses] = useState<StatusFilterValue[]>([]);
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
   const [clearingLogs, setClearingLogs] = useState(false);
+  const [exportingSummary, setExportingSummary] = useState(false);
   const [clearOptions, setClearOptions] = useState<ClearUsageLogsPayload>(DEFAULT_CLEAR_OPTIONS);
 
   const requestSeqRef = useRef(0);
@@ -299,6 +301,34 @@ export function RequestLogsPage() {
     });
   }, [lastUpdatedAt, loading, t]);
 
+  const handleExportSummary = useCallback(async () => {
+    setExportingSummary(true);
+    try {
+      const data = await usageApi.exportSummary({
+        days: timeRange,
+        api_key: selectedApiKeys.length === 1 ? selectedApiKeys[0] : undefined,
+      });
+      if (data.length === 0) {
+        notify({ type: "info", message: t("request_logs.export_summary_empty") });
+        return;
+      }
+      exportSummaryCsv(data, [
+        t("request_logs.csv_person_name"),
+        t("request_logs.csv_api_key"),
+        t("request_logs.csv_request_count"),
+        t("request_logs.csv_input_tokens"),
+        t("request_logs.csv_output_tokens"),
+        t("request_logs.csv_total_tokens"),
+        t("request_logs.csv_total_cost"),
+      ]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
+      notify({ type: "error", message });
+    } finally {
+      setExportingSummary(false);
+    }
+  }, [timeRange, selectedApiKeys, notify, t]);
+
   const handleOpenClearDialog = useCallback(() => {
     setClearOptions(DEFAULT_CLEAR_OPTIONS);
     setConfirmClearOpen(true);
@@ -419,6 +449,20 @@ export function RequestLogsPage() {
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <RequestLogsTimeRangeSelector value={timeRange} onChange={setTimeRange} />
+            <button
+              type="button"
+              onClick={() => void handleExportSummary()}
+              disabled={loading || exportingSummary}
+              aria-label={t("request_logs.export_summary")}
+              title={t("request_logs.export_summary")}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-emerald-50 text-emerald-600 transition hover:bg-emerald-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-emerald-500/15 dark:text-emerald-300 dark:hover:bg-emerald-500/25"
+            >
+              {exportingSummary ? (
+                <span className="h-3.5 w-3.5 rounded-full border-2 border-emerald-300 border-t-emerald-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-emerald-500/30 dark:border-t-emerald-300" aria-hidden="true" />
+              ) : (
+                <Download size={14} aria-hidden="true" />
+              )}
+            </button>
             <button
               type="button"
               onClick={handleOpenClearDialog}

--- a/pages/request-logs/exportSummaryCsv.ts
+++ b/pages/request-logs/exportSummaryCsv.ts
@@ -1,0 +1,51 @@
+import type { UsageSummaryItem } from "@code-proxy/api-client";
+import { downloadBlob } from "../logs/logsHelpers";
+
+function escapeCsvField(value: string | number): string {
+  const str = String(value);
+  // Prevent CSV formula injection: prefix fields starting with dangerous chars with a single quote
+  const needsFormulaSanitize = /^[=+\-@\t\r]/.test(str);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r") || needsFormulaSanitize) {
+    let escaped = str.replace(/"/g, '""');
+    if (needsFormulaSanitize) escaped = "'" + escaped;
+    return `"${escaped}"`;
+  }
+  return str;
+}
+
+const DEFAULT_HEADERS = [
+  "人员名",
+  "API Key",
+  "请求数",
+  "输入Token",
+  "输出Token",
+  "总Token",
+  "费用(USD)",
+];
+
+export function exportSummaryCsv(items: UsageSummaryItem[], headers?: string[]): void {
+  const BOM = "﻿";
+  const resolvedHeaders = headers ?? DEFAULT_HEADERS;
+  const headerLine = resolvedHeaders.map(escapeCsvField).join(",");
+
+  const rows = items.map((item) =>
+    [
+      item.person_name,
+      item.api_key,
+      item.request_count,
+      item.input_tokens,
+      item.output_tokens,
+      item.total_tokens,
+      item.total_cost_usd,
+    ]
+      .map(escapeCsvField)
+      .join(","),
+  );
+
+  const csv = BOM + headerLine + "\n" + rows.join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+
+  const now = new Date();
+  const stamp = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  downloadBlob(blob, `usage-summary-${stamp}.csv`);
+}


### PR DESCRIPTION
- New "Export Summary" button on RequestLogsPage
- Calls GET /usage/export/summary API, converts to CSV
- CSV injection protection (formula prefix sanitization)
- Passes active API key filter to export
- i18n support for CSV headers (en/zh-CN)
- Empty data toast notification
- Reuses downloadBlob from logsHelpers