### PR TITLE
fix: preserve auth file chart entry animation

### DIFF
--- a/packages/ui/src/charts/EChartRenderer.tsx
+++ b/packages/ui/src/charts/EChartRenderer.tsx
@@ -14,6 +14,7 @@ export type EChartProps = {
   overflowVisible?: boolean;
   loading?: boolean;
   loadingText?: string;
+  initialAnimationGuardMs?: number;
 };
 
 export function EChartRenderer({
@@ -25,6 +26,7 @@ export function EChartRenderer({
   overflowVisible = false,
   loading = false,
   loadingText = "",
+  initialAnimationGuardMs = 0,
 }: EChartProps) {
   const {
     state: { mode },
@@ -35,13 +37,37 @@ export function EChartRenderer({
   const instanceRef = useRef<any>(null);
   const rafIdRef = useRef<number | null>(null);
   const lastSizeRef = useRef<{ width: number; height: number } | null>(null);
+  const pendingGuardedResizeRef = useRef<{ width: number; height: number } | null>(null);
+  const guardedResizeTimerRef = useRef<number | null>(null);
+  const initialAnimationGuardUntilRef = useRef(0);
   const didResizeOnceRef = useRef(false);
+
+  const now = () => Date.now();
 
   const requestResize = (width: number, height: number) => {
     const container = containerRef.current;
     if (!container) return;
 
     lastSizeRef.current = { width, height };
+
+    const guardUntil = initialAnimationGuardUntilRef.current;
+    if (guardUntil > 0) {
+      const remainingMs = guardUntil - now();
+      if (remainingMs > 0) {
+        pendingGuardedResizeRef.current = { width, height };
+        if (guardedResizeTimerRef.current === null) {
+          guardedResizeTimerRef.current = window.setTimeout(() => {
+            guardedResizeTimerRef.current = null;
+            const size = pendingGuardedResizeRef.current ?? lastSizeRef.current;
+            pendingGuardedResizeRef.current = null;
+            if (size) requestResize(size.width, size.height);
+          }, remainingMs);
+        }
+        return;
+      }
+      initialAnimationGuardUntilRef.current = 0;
+    }
+
     if (rafIdRef.current !== null) return;
 
     rafIdRef.current = window.requestAnimationFrame(() => {
@@ -79,6 +105,28 @@ export function EChartRenderer({
   };
 
   useEffect(() => {
+    const guardMs = Math.max(0, initialAnimationGuardMs);
+    if (guardMs > 0) {
+      initialAnimationGuardUntilRef.current = now() + guardMs;
+      pendingGuardedResizeRef.current = null;
+      if (guardedResizeTimerRef.current !== null) {
+        window.clearTimeout(guardedResizeTimerRef.current);
+        guardedResizeTimerRef.current = null;
+      }
+      return;
+    }
+
+    initialAnimationGuardUntilRef.current = 0;
+    if (guardedResizeTimerRef.current === null) return;
+
+    window.clearTimeout(guardedResizeTimerRef.current);
+    guardedResizeTimerRef.current = null;
+    const size = pendingGuardedResizeRef.current ?? lastSizeRef.current;
+    pendingGuardedResizeRef.current = null;
+    if (size) requestResize(size.width, size.height);
+  }, [initialAnimationGuardMs]);
+
+  useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
 
@@ -94,6 +142,10 @@ export function EChartRenderer({
       if (rafIdRef.current !== null) {
         window.cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;
+      }
+      if (guardedResizeTimerRef.current !== null) {
+        window.clearTimeout(guardedResizeTimerRef.current);
+        guardedResizeTimerRef.current = null;
       }
     };
   }, []);

--- a/packages/ui/src/charts/__tests__/EChartRenderer.test.tsx
+++ b/packages/ui/src/charts/__tests__/EChartRenderer.test.tsx
@@ -1,0 +1,92 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ThemeProvider } from "../../theme/ThemeProvider";
+import { EChartRenderer } from "../EChartRenderer";
+
+const resizeSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("echarts-for-react", async () => {
+  const React = await import("react");
+
+  const MockReactECharts = React.forwardRef<any, any>(function MockReactECharts(props, ref) {
+    const instanceRef = React.useRef({
+      getHeight: () => 0,
+      getWidth: () => 0,
+      hideLoading: vi.fn(),
+      resize: resizeSpy,
+      showLoading: vi.fn(),
+    });
+
+    React.useImperativeHandle(ref, () => ({
+      getEchartsInstance: () => instanceRef.current,
+    }));
+
+    React.useEffect(() => {
+      props.onChartReady?.(instanceRef.current);
+    }, [props.onChartReady]);
+
+    return <div className={props.className} data-testid="mock-echart" style={props.style} />;
+  });
+
+  return { default: MockReactECharts };
+});
+
+const setElementSize = (width: number, height: number) => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => width,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => height,
+  });
+};
+
+describe("EChartRenderer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    resizeSpy.mockReset();
+    Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+    Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
+  });
+
+  test("defers forced resize calls while the initial animation guard is active", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    setElementSize(640, 320);
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+
+    render(
+      <ThemeProvider>
+        <EChartRenderer option={{ series: [] }} className="h-80" initialAnimationGuardMs={800} />
+      </ThemeProvider>,
+    );
+
+    await act(async () => undefined);
+
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(resizeSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(739);
+    });
+    expect(resizeSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    expect(resizeSpy).toHaveBeenLastCalledWith({
+      animation: { duration: 0 },
+      height: 320,
+      width: 640,
+    });
+  });
+});

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -8,6 +8,7 @@ type DetailModalProps = ComponentProps<typeof AuthFileDetailModal>;
 
 const chartOptions = vi.hoisted(() => [] as any[]);
 const chartEvents = vi.hoisted(() => [] as any[]);
+const chartProps = vi.hoisted(() => [] as any[]);
 
 vi.mock("@code-proxy/ui", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@code-proxy/ui")>()),
@@ -15,13 +16,16 @@ vi.mock("@code-proxy/ui", async (importOriginal) => ({
     option,
     className,
     onEvents,
+    initialAnimationGuardMs,
   }: {
     option: any;
     className?: string;
     onEvents?: Record<string, () => void>;
+    initialAnimationGuardMs?: number;
   }) => {
     chartOptions.push(option);
     chartEvents.push(onEvents);
+    chartProps.push({ initialAnimationGuardMs, onEvents, option });
     return (
       <div
         className={className}
@@ -144,6 +148,7 @@ describe("AuthFileDetailModal", () => {
     window.localStorage.clear();
     chartOptions.length = 0;
     chartEvents.length = 0;
+    chartProps.length = 0;
   });
 
   test("uses usage trend as the primary view for Codex files", () => {
@@ -167,6 +172,7 @@ describe("AuthFileDetailModal", () => {
     expect(screen.getByRole("dialog", { name: "Codex Primary" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
     expect(chartOptions.at(-1)?.animation).toBe(true);
+    expect(chartProps.at(-1)?.initialAnimationGuardMs).toBe(800);
     expect(chartOptions.at(-1)?.grid?.top).toBeGreaterThanOrEqual(70);
     expect(chartOptions.at(-1)?.yAxis?.every((item: any) => !item.name)).toBe(true);
     expect(chartOptions.at(-1)?.series?.every((item: any) => item.animation === true)).toBe(true);
@@ -181,6 +187,7 @@ describe("AuthFileDetailModal", () => {
     });
 
     expect(chartOptions.at(-1)?.animation).toBe(false);
+    expect(chartProps.at(-1)?.initialAnimationGuardMs).toBe(0);
     expect(chartOptions.at(-1)?.series?.every((item: any) => item.animation === false)).toBe(true);
   });
 

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -42,6 +42,9 @@ import {
 type DetailTab = "usage" | "fields" | "models";
 type DetailTrendWindow = "5h" | "week";
 
+const TREND_CHART_ANIMATION_MS = 680;
+const TREND_CHART_ANIMATION_GUARD_MS = TREND_CHART_ANIMATION_MS + 120;
+
 const padTwo = (value: number) => String(value).padStart(2, "0");
 
 const formatLocalDateKey = (timestamp: string) => {
@@ -280,7 +283,7 @@ export function AuthFileDetailModal({
 
     return {
       animation: shouldAnimateTrend,
-      animationDuration: shouldAnimateTrend ? 680 : 0,
+      animationDuration: shouldAnimateTrend ? TREND_CHART_ANIMATION_MS : 0,
       animationDurationUpdate: 0,
       animationEasing: "cubicOut" as const,
       grid: { left: 46, right: 108, top: 74, bottom: 38 },
@@ -343,7 +346,7 @@ export function AuthFileDetailModal({
           type: "bar",
           yAxisIndex: 0,
           animation: shouldAnimateTrend,
-          animationDuration: shouldAnimateTrend ? 680 : 0,
+          animationDuration: shouldAnimateTrend ? TREND_CHART_ANIMATION_MS : 0,
           animationDurationUpdate: 0,
           barMaxWidth: 24,
           itemStyle: { color: "#2563eb", borderRadius: [4, 4, 0, 0] },
@@ -354,7 +357,7 @@ export function AuthFileDetailModal({
           type: "line",
           yAxisIndex: 2,
           animation: shouldAnimateTrend,
-          animationDuration: shouldAnimateTrend ? 680 : 0,
+          animationDuration: shouldAnimateTrend ? TREND_CHART_ANIMATION_MS : 0,
           animationDurationUpdate: 0,
           connectNulls: true,
           showSymbol: false,
@@ -374,7 +377,7 @@ export function AuthFileDetailModal({
           type: "line",
           yAxisIndex: 1,
           animation: shouldAnimateTrend,
-          animationDuration: shouldAnimateTrend ? 680 : 0,
+          animationDuration: shouldAnimateTrend ? TREND_CHART_ANIMATION_MS : 0,
           animationDurationUpdate: 0,
           connectNulls: true,
           showSymbol: false,
@@ -523,6 +526,7 @@ export function AuthFileDetailModal({
             className="h-80 min-w-0"
             onEvents={trendChartEvents}
             replaceMerge="series"
+            initialAnimationGuardMs={shouldAnimateTrend ? TREND_CHART_ANIMATION_GUARD_MS : 0}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- defer forced ECharts resize while auth file detail trend entry animation is active
- keep the auth file trend chart animation enabled for the first real render only
- add regression coverage for the guarded resize behavior and modal chart props

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- packages/ui/src/charts/__tests__/EChartRenderer.test.tsx pages/auth-files/__tests__/AuthFileDetailModal.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx
- rtk bun run lint -- packages/ui/src/charts/EChartRenderer.tsx packages/ui/src/charts/__tests__/EChartRenderer.test.tsx pages/auth-files/components/AuthFileDetailModal.tsx pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- Playwright mock check: trendCalls=1 and canvas frame hashes changed during entry animation