### PR TITLE
feat(ui): align auth file tag modal with fieldset style

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -42,6 +42,7 @@ export { Button, buttonClassName } from "./primitives/Button";
 export { Card } from "./primitives/Card";
 export { Checkbox } from "./primitives/Checkbox";
 export { DateTimePicker } from "./primitives/DateTimePicker";
+export { Fieldset } from "./primitives/Fieldset";
 export { TextInput } from "./primitives/Input";
 export { MultiSelect } from "./primitives/MultiSelect";
 export type { MultiSelectOption } from "./primitives/MultiSelect";

--- a/packages/ui/src/overlays/Tooltip.tsx
+++ b/packages/ui/src/overlays/Tooltip.tsx
@@ -408,15 +408,25 @@ export function GlobalIconButtonTooltip({
   const activeRef = useRef<GlobalTooltipState | null>(null);
   const [active, setActive] = useState<GlobalTooltipState | null>(null);
 
-  const hide = useCallback((relatedTarget?: EventTarget | null) => {
+  const dismiss = useCallback(() => {
     const current = activeRef.current;
     if (!current) return;
-    if (relatedTarget instanceof Node && current.anchor.contains(relatedTarget)) return;
 
     restoreNativeTitle(current.anchor);
     activeRef.current = null;
     setActive(null);
   }, []);
+
+  const hide = useCallback(
+    (relatedTarget?: EventTarget | null) => {
+      const current = activeRef.current;
+      if (!current) return;
+      if (relatedTarget instanceof Node && current.anchor.contains(relatedTarget)) return;
+
+      dismiss();
+    },
+    [dismiss],
+  );
 
   const show = useCallback((target: EventTarget | null) => {
     const next = resolveIconButtonTooltip(target);
@@ -435,11 +445,13 @@ export function GlobalIconButtonTooltip({
     const handleMouseOut = (event: MouseEvent) => hide(event.relatedTarget);
     const handleFocusIn = (event: FocusEvent) => show(event.target);
     const handleFocusOut = (event: FocusEvent) => hide(event.relatedTarget);
+    const handlePointerDown = () => dismiss();
 
     document.addEventListener("mouseover", handleMouseOver);
     document.addEventListener("mouseout", handleMouseOut);
     document.addEventListener("focusin", handleFocusIn);
     document.addEventListener("focusout", handleFocusOut);
+    document.addEventListener("pointerdown", handlePointerDown, true);
 
     return () => {
       restoreNativeTitle(activeRef.current?.anchor);
@@ -447,8 +459,9 @@ export function GlobalIconButtonTooltip({
       document.removeEventListener("mouseout", handleMouseOut);
       document.removeEventListener("focusin", handleFocusIn);
       document.removeEventListener("focusout", handleFocusOut);
+      document.removeEventListener("pointerdown", handlePointerDown, true);
     };
-  }, [hide, show]);
+  }, [dismiss, hide, show]);
 
   return (
     <TooltipBubble

--- a/packages/ui/src/primitives/Fieldset.tsx
+++ b/packages/ui/src/primitives/Fieldset.tsx
@@ -1,0 +1,83 @@
+import {
+  type FieldsetHTMLAttributes,
+  type HTMLAttributes,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
+import { cn } from "../utils/selectStyles";
+
+type FieldsetProps = PropsWithChildren<FieldsetHTMLAttributes<HTMLFieldSetElement>>;
+type FieldsetLegendProps = PropsWithChildren<
+  HTMLAttributes<HTMLLegendElement> & {
+    description?: ReactNode;
+  }
+>;
+type FieldsetGroupProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+type FieldsetActionsProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+type FieldsetDescriptionProps = PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>;
+
+function FieldsetRoot({ children, className, ...props }: FieldsetProps) {
+  return (
+    <fieldset
+      data-slot="fieldset"
+      className={cn("flex min-w-0 flex-1 basis-0 flex-col gap-6 border-0 p-0", className)}
+      {...props}
+    >
+      {children}
+    </fieldset>
+  );
+}
+
+function FieldsetLegend({ children, className, description, ...props }: FieldsetLegendProps) {
+  return (
+    <>
+      <legend
+        data-slot="fieldset-legend"
+        className={cn("text-base font-medium text-slate-950 dark:text-white", className)}
+        {...props}
+      >
+        {children}
+      </legend>
+      {description ? <FieldsetDescription>{description}</FieldsetDescription> : null}
+    </>
+  );
+}
+
+function FieldsetGroup({ children, className, ...props }: FieldsetGroupProps) {
+  return (
+    <div data-slot="fieldset-field-group" className={cn("w-full space-y-4", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+function FieldsetActions({ children, className, ...props }: FieldsetActionsProps) {
+  return (
+    <div
+      data-slot="fieldset-actions"
+      className={cn("flex flex-wrap items-center gap-2 pt-1", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function FieldsetDescription({ children, className, ...props }: FieldsetDescriptionProps) {
+  return (
+    <p
+      data-slot="description"
+      className={cn("text-sm leading-6 text-slate-500 dark:text-white/55", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+export const Fieldset = Object.assign(FieldsetRoot, {
+  Actions: FieldsetActions,
+  Description: FieldsetDescription,
+  Group: FieldsetGroup,
+  Legend: FieldsetLegend,
+});

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -45,7 +45,15 @@ const resolveSystemTheme = (): ThemeMode => {
 };
 
 const applyThemeToDom = (mode: ThemeMode): void => {
-  document.documentElement.classList.toggle("dark", mode === "dark");
+  const isDark = mode === "dark";
+
+  document.documentElement.classList.toggle("dark", isDark);
+  document.documentElement.style.colorScheme = mode;
+  if (isDark) {
+    document.documentElement.setAttribute("data-theme", "dark");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
 };
 
 const persistTheme = (mode: ThemeMode): void => {

--- a/pages/auth-files/components/AuthFileTagsModal.tsx
+++ b/pages/auth-files/components/AuthFileTagsModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { Button } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
+import { Fieldset } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import {
@@ -98,116 +99,123 @@ export function AuthFileTagsModal({
       description={file ? resolveAuthFileDisplayName(file) || file.name : undefined}
       onClose={onClose}
       maxWidth="max-w-2xl"
-      footer={
-        <>
-          <Button variant="secondary" onClick={onClose} disabled={saving}>
-            {t("common.cancel")}
-          </Button>
-          <Button variant="primary" onClick={() => void handleSave()} disabled={saving || !file}>
-            {t("common.save")}
-          </Button>
-        </>
-      }
     >
-      <div className="space-y-5">
-        <div className="space-y-2">
-          <div className="flex items-center justify-between gap-3">
-            <label className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("auth_files.custom_tag_label")}
-            </label>
-            <span className="text-xs text-slate-500 dark:text-white/55">
-              {t("auth_files.custom_tag_limit", { count: MAX_CUSTOM_TAGS })}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <TextInput
-              value={customTagInput}
-              onChange={(event) => setCustomTagInput(event.currentTarget.value)}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter") return;
-                event.preventDefault();
-                handleAddCustomTag();
-              }}
-              placeholder={t("auth_files.custom_tag_placeholder")}
-              aria-label={t("auth_files.custom_tag_label")}
-              disabled={saving}
-            />
-            <Button
-              variant="secondary"
-              onClick={handleAddCustomTag}
-              disabled={saving || !canAddCustomTag}
-            >
-              {t("auth_files.custom_tag_add")}
-            </Button>
-          </div>
-
-          {customTags.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {customTags.map((tag) => (
-                <span
-                  key={tag}
-                  className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-700 dark:border-neutral-700/70 dark:bg-neutral-900 dark:text-white/80"
-                >
-                  <span>{tag}</span>
-                  <button
-                    type="button"
-                    onClick={() => handleRemoveCustomTag(tag)}
-                    aria-label={t("auth_files.remove_custom_tag", { tag })}
-                    className="rounded-full p-0.5 text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/80"
-                    disabled={saving}
-                  >
-                    <X size={12} />
-                  </button>
-                </span>
-              ))}
+      <form
+        className="space-y-7"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void handleSave();
+        }}
+      >
+        <Fieldset disabled={saving}>
+          <Fieldset.Legend
+            description={t("auth_files.custom_tag_limit", { count: MAX_CUSTOM_TAGS })}
+          >
+            {t("auth_files.custom_tag_label")}
+          </Fieldset.Legend>
+          <Fieldset.Group>
+            <div className="flex items-center gap-2">
+              <TextInput
+                value={customTagInput}
+                onChange={(event) => setCustomTagInput(event.currentTarget.value)}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") return;
+                  event.preventDefault();
+                  handleAddCustomTag();
+                }}
+                placeholder={t("auth_files.custom_tag_placeholder")}
+                aria-label={t("auth_files.custom_tag_label")}
+                disabled={saving}
+              />
+              <Button
+                variant="default"
+                onClick={handleAddCustomTag}
+                disabled={saving || !canAddCustomTag}
+              >
+                {t("auth_files.custom_tag_add")}
+              </Button>
             </div>
-          ) : (
-            <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>
-          )}
-        </div>
 
-        <div className="space-y-2">
-          <div className="text-sm font-semibold text-slate-900 dark:text-white">
-            {t("auth_files.display_tags_label")}
-          </div>
-          {tagOptions.length > 0 ? (
-            <div className="grid gap-2 sm:grid-cols-2">
-              {tagOptions.map((tag) => {
-                const checked = selectedTagSet.has(tag);
-                const custom = customTags.includes(tag);
-                const inherited = defaultTags.includes(tag);
-                return (
-                  <label
+            {customTags.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {customTags.map((tag) => (
+                  <span
                     key={tag}
-                    className="flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/80 dark:hover:border-neutral-700 dark:hover:bg-neutral-900"
+                    className="inline-flex items-center gap-1.5 rounded-full bg-[#EBEBEC] px-2.5 py-1 text-xs font-medium text-[#3F3F46] dark:bg-[#27272A] dark:text-[#D4D4D8]"
                   >
-                    <span className="min-w-0 truncate font-medium">{tag}</span>
-                    <span className="flex shrink-0 items-center gap-2">
-                      {custom ? (
-                        <span className="rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200">
-                          {t("auth_files.custom_tag_label")}
-                        </span>
-                      ) : inherited ? (
-                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/60">
-                          {t("auth_files.default_tags_label")}
-                        </span>
-                      ) : null}
-                      <Checkbox
-                        checked={checked}
-                        onCheckedChange={(next) => handleToggleDisplayTag(tag, next)}
-                        aria-label={tag}
-                        disabled={saving}
-                      />
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          ) : (
-            <p className="text-xs text-slate-500 dark:text-white/55">{t("auth_files.no_tags")}</p>
-          )}
-        </div>
-      </div>
+                    <span>{tag}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveCustomTag(tag)}
+                      aria-label={t("auth_files.remove_custom_tag", { tag })}
+                      className="rounded-full p-0.5 text-[#71717A] transition-colors hover:bg-black/[0.06] hover:text-[#18181B] disabled:cursor-not-allowed disabled:opacity-50 dark:text-[#A1A1AA] dark:hover:bg-white/10 dark:hover:text-white"
+                      disabled={saving}
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <Fieldset.Description className="text-xs">
+                {t("auth_files.no_tags")}
+              </Fieldset.Description>
+            )}
+          </Fieldset.Group>
+        </Fieldset>
+
+        <Fieldset disabled={saving}>
+          <Fieldset.Legend>{t("auth_files.display_tags_label")}</Fieldset.Legend>
+          <Fieldset.Group>
+            {tagOptions.length > 0 ? (
+              <div className="grid gap-2 sm:grid-cols-2">
+                {tagOptions.map((tag) => {
+                  const checked = selectedTagSet.has(tag);
+                  const custom = customTags.includes(tag);
+                  const inherited = defaultTags.includes(tag);
+                  return (
+                    <label
+                      key={tag}
+                      className="flex cursor-pointer items-center justify-between gap-3 rounded-2xl bg-white px-3 py-2 text-sm text-[#18181B] shadow-[2px_2px_6px_rgb(0_0_0_/_0.055)] transition-colors hover:bg-[#FAFAFA] dark:bg-[#27272A] dark:text-white dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.24)] dark:hover:bg-[#303036]"
+                    >
+                      <span className="min-w-0 truncate font-medium">{tag}</span>
+                      <span className="flex shrink-0 items-center gap-2">
+                        {custom ? (
+                          <span className="rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200">
+                            {t("auth_files.custom_tag_label")}
+                          </span>
+                        ) : inherited ? (
+                          <span className="rounded-full bg-[#EBEBEC] px-2 py-0.5 text-[10px] font-semibold text-[#71717A] dark:bg-white/10 dark:text-white/60">
+                            {t("auth_files.default_tags_label")}
+                          </span>
+                        ) : null}
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(next) => handleToggleDisplayTag(tag, next)}
+                          aria-label={tag}
+                          disabled={saving}
+                        />
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : (
+              <Fieldset.Description className="text-xs">
+                {t("auth_files.no_tags")}
+              </Fieldset.Description>
+            )}
+          </Fieldset.Group>
+          <Fieldset.Actions className="justify-end">
+            <Button variant="default" onClick={onClose} disabled={saving}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" variant="primary" disabled={saving || !file}>
+              {t("common.save")}
+            </Button>
+          </Fieldset.Actions>
+        </Fieldset>
+      </form>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- add a local Fieldset primitive with HeroUI-like slots
- restyle the auth file tags modal to use the new fieldset structure
- align dark-mode DOM state across .dark, data-theme, and color-scheme
- dismiss global icon tooltips on pointer down so they do not linger over modals

## Tests
- bun x oxlint packages/ui/src/primitives/Fieldset.tsx packages/ui/src/overlays/Tooltip.tsx packages/ui/src/theme/ThemeProvider.tsx pages/auth-files/components/AuthFileTagsModal.tsx
- bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "saves auth-file tag visibility"
- bun run --filter @code-proxy/admin-panel build