### PR TITLE
fix: smooth dark theme switching

### DIFF
--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -13,17 +13,24 @@
     <script>
       (function () {
         try {
+          var root = document.documentElement;
+          var apply = function (isDark) {
+            root.classList.toggle("dark", isDark);
+            root.style.colorScheme = isDark ? "dark" : "light";
+            if (isDark) {
+              root.setAttribute("data-theme", "dark");
+            } else {
+              root.removeAttribute("data-theme");
+            }
+          };
           var t = localStorage.getItem("code-proxy-admin-theme");
           if (t === "dark") {
-            document.documentElement.classList.add("dark");
-            document.documentElement.style.colorScheme = "dark";
+            apply(true);
           } else if (t === "light") {
-            document.documentElement.classList.remove("dark");
-            document.documentElement.style.colorScheme = "light";
+            apply(false);
           } else {
             if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-              document.documentElement.classList.add("dark");
-              document.documentElement.style.colorScheme = "dark";
+              apply(true);
             }
           }
         } catch (e) {}

--- a/apps/admin-panel/manage.html
+++ b/apps/admin-panel/manage.html
@@ -14,18 +14,25 @@
     <script>
       (function () {
         try {
+          var root = document.documentElement;
+          var apply = function (isDark) {
+            root.classList.toggle("dark", isDark);
+            root.style.colorScheme = isDark ? "dark" : "light";
+            if (isDark) {
+              root.setAttribute("data-theme", "dark");
+            } else {
+              root.removeAttribute("data-theme");
+            }
+          };
           var t = localStorage.getItem("code-proxy-admin-theme");
           if (t === "dark") {
-            document.documentElement.classList.add("dark");
-            document.documentElement.style.colorScheme = "dark";
+            apply(true);
           } else if (t === "light") {
-            document.documentElement.classList.remove("dark");
-            document.documentElement.style.colorScheme = "light";
+            apply(false);
           } else {
             // 跟随系统偏好
             if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-              document.documentElement.classList.add("dark");
-              document.documentElement.style.colorScheme = "dark";
+              apply(true);
             }
           }
         } catch (e) {}

--- a/apps/admin-panel/src/stores/useThemeStore.ts
+++ b/apps/admin-panel/src/stores/useThemeStore.ts
@@ -26,10 +26,15 @@ const getSystemTheme = (): ResolvedTheme => {
 };
 
 const applyTheme = (resolved: ResolvedTheme) => {
-  if (resolved === "dark") {
-    document.documentElement.setAttribute("data-theme", "dark");
+  const isDark = resolved === "dark";
+  const root = document.documentElement;
+
+  root.classList.toggle("dark", isDark);
+  root.style.colorScheme = resolved;
+  if (isDark) {
+    root.setAttribute("data-theme", "dark");
   } else {
-    document.documentElement.removeAttribute("data-theme");
+    root.removeAttribute("data-theme");
   }
 };
 

--- a/apps/admin-panel/src/styles/index.css
+++ b/apps/admin-panel/src/styles/index.css
@@ -11,6 +11,15 @@
   --font-sans: "Inter", "SF Pro Text", "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 
+html.theme-transition-lock,
+html.theme-transition-lock *,
+html.theme-transition-lock *::before,
+html.theme-transition-lock *::after {
+  transition-property: none !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}
+
 /* 统一交互元素鼠标样式，便于用户识别可点击区域 */
 :where(
   a[href],

--- a/index.html
+++ b/index.html
@@ -13,17 +13,24 @@
     <script>
       (function () {
         try {
+          var root = document.documentElement;
+          var apply = function (isDark) {
+            root.classList.toggle("dark", isDark);
+            root.style.colorScheme = isDark ? "dark" : "light";
+            if (isDark) {
+              root.setAttribute("data-theme", "dark");
+            } else {
+              root.removeAttribute("data-theme");
+            }
+          };
           var t = localStorage.getItem("code-proxy-admin-theme");
           if (t === "dark") {
-            document.documentElement.classList.add("dark");
-            document.documentElement.style.colorScheme = "dark";
+            apply(true);
           } else if (t === "light") {
-            document.documentElement.classList.remove("dark");
-            document.documentElement.style.colorScheme = "light";
+            apply(false);
           } else {
             if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-              document.documentElement.classList.add("dark");
-              document.documentElement.style.colorScheme = "dark";
+              apply(true);
             }
           }
         } catch (e) {}

--- a/manage.html
+++ b/manage.html
@@ -14,18 +14,25 @@
     <script>
       (function () {
         try {
+          var root = document.documentElement;
+          var apply = function (isDark) {
+            root.classList.toggle("dark", isDark);
+            root.style.colorScheme = isDark ? "dark" : "light";
+            if (isDark) {
+              root.setAttribute("data-theme", "dark");
+            } else {
+              root.removeAttribute("data-theme");
+            }
+          };
           var t = localStorage.getItem("code-proxy-admin-theme");
           if (t === "dark") {
-            document.documentElement.classList.add("dark");
-            document.documentElement.style.colorScheme = "dark";
+            apply(true);
           } else if (t === "light") {
-            document.documentElement.classList.remove("dark");
-            document.documentElement.style.colorScheme = "light";
+            apply(false);
           } else {
             // 跟随系统偏好
             if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-              document.documentElement.classList.add("dark");
-              document.documentElement.style.colorScheme = "dark";
+              apply(true);
             }
           }
         } catch (e) {}

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -7,9 +7,12 @@ import {
   useMemo,
   useState,
 } from "react";
-import { flushSync } from "react-dom";
 import { Moon, Sun } from "lucide-react";
 const THEME_STORAGE_KEY = "code-proxy-admin-theme";
+const THEME_TRANSITION_LOCK_CLASS = "theme-transition-lock";
+const THEME_TRANSITION_LOCK_RELEASE_MS = 120;
+
+let transitionLockTimer: number | null = null;
 
 export type ThemeMode = "light" | "dark";
 
@@ -45,6 +48,10 @@ const resolveSystemTheme = (): ThemeMode => {
 };
 
 const applyThemeToDom = (mode: ThemeMode): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
   const isDark = mode === "dark";
 
   document.documentElement.classList.toggle("dark", isDark);
@@ -57,22 +64,44 @@ const applyThemeToDom = (mode: ThemeMode): void => {
 };
 
 const persistTheme = (mode: ThemeMode): void => {
-  localStorage.setItem(THEME_STORAGE_KEY, mode);
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch {
+    // Ignore unavailable storage, e.g. hardened browser settings.
+  }
 };
 
-const runWithViewTransition = (fn: () => void) => {
-  const startViewTransition = document.startViewTransition;
-  if (typeof startViewTransition !== "function") {
-    fn();
+const lockThemeTransitions = (): void => {
+  if (typeof document === "undefined") {
     return;
   }
-  try {
-    startViewTransition(() => {
-      flushSync(fn);
-    });
-  } catch {
-    fn();
+
+  const root = document.documentElement;
+  root.classList.add(THEME_TRANSITION_LOCK_CLASS);
+
+  if (transitionLockTimer !== null) {
+    window.clearTimeout(transitionLockTimer);
+    transitionLockTimer = null;
   }
+
+  // Ensure the transition lock wins in computed styles before color classes change.
+  void root.offsetHeight;
+
+  const release = () => {
+    transitionLockTimer = window.setTimeout(() => {
+      root.classList.remove(THEME_TRANSITION_LOCK_CLASS);
+      transitionLockTimer = null;
+    }, THEME_TRANSITION_LOCK_RELEASE_MS);
+  };
+
+  if (typeof window.requestAnimationFrame !== "function") {
+    release();
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(release);
+  });
 };
 
 export function ThemeProvider({ children }: PropsWithChildren) {
@@ -86,9 +115,10 @@ export function ThemeProvider({ children }: PropsWithChildren) {
   }, [mode]);
 
   const setMode = useCallback((next: ThemeMode) => {
+    lockThemeTransitions();
     applyThemeToDom(next);
     persistTheme(next);
-    runWithViewTransition(() => setModeState(next));
+    setModeState(next);
   }, []);
 
   const toggle = useCallback(() => {

--- a/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,62 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ThemeProvider, ThemeToggleButton } from "../ThemeProvider";
+
+const THEME_STORAGE_KEY = "code-proxy-admin-theme";
+const THEME_TRANSITION_LOCK_CLASS = "theme-transition-lock";
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.colorScheme = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.colorScheme = "";
+  });
+
+  test("locks transitions while applying a manual dark mode switch", () => {
+    vi.useFakeTimers();
+    const rafCallbacks: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    });
+
+    render(
+      <ThemeProvider>
+        <ThemeToggleButton />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to dark" }));
+
+    expect(document.documentElement).toHaveClass(THEME_TRANSITION_LOCK_CLASS);
+    expect(document.documentElement).toHaveClass("dark");
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+
+    act(() => {
+      rafCallbacks.shift()?.(0);
+      rafCallbacks.shift()?.(16);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(119);
+    });
+    expect(document.documentElement).toHaveClass(THEME_TRANSITION_LOCK_CLASS);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(document.documentElement).not.toHaveClass(THEME_TRANSITION_LOCK_CLASS);
+  });
+});


### PR DESCRIPTION
## Summary
- suppress theme-related CSS transitions during manual dark/light mode changes
- keep early HTML theme restoration in sync across .dark, data-theme, and color-scheme
- add ThemeProvider coverage for transition lock lifecycle

## Verification
- bun run --cwd apps/admin-panel test -- ../../packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
- bun run lint
- bun run build
- bun run boundary:imports
- Playwright sampled /manage/#/config at desktop and mobile widths: theme switching reported 0 active transitions during the lock window