### PR TITLE
fix: hide disabled OpenAI compatible models

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -452,9 +452,13 @@ const addStaticProviderModels = (
 const hasCredential = (config: ProviderSimpleConfig): boolean =>
   String(config.apiKey ?? "").trim().length > 0;
 
-const hasOpenAIProviderCredential = (provider: OpenAIProvider): boolean =>
-  Array.isArray(provider.apiKeyEntries) &&
-  provider.apiKeyEntries.some((entry) => String(entry.apiKey ?? "").trim());
+const isOpenAIProviderServiceable = (provider: OpenAIProvider): boolean => {
+  if (provider.disabled === true) return false;
+  if (!Array.isArray(provider.apiKeyEntries) || provider.apiKeyEntries.length === 0) return true;
+  return provider.apiKeyEntries.some(
+    (entry) => entry.disabled !== true && Boolean(String(entry.apiKey ?? "").trim()),
+  );
+};
 
 const loadStaticDefinitions = async (provider: string): Promise<ModelDefinition[]> => {
   try {
@@ -493,7 +497,7 @@ const loadProviderModelItems = async (): Promise<ModelAvailabilityItem[]> => {
 
   let openAIProviders: OpenAIProvider[] = [];
   try {
-    openAIProviders = (await providersApi.getOpenAIProviders()).filter(hasOpenAIProviderCredential);
+    openAIProviders = (await providersApi.getOpenAIProviders()).filter(isOpenAIProviderServiceable);
   } catch {
     openAIProviders = [];
   }

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import i18n from "@code-proxy/i18n";
+import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 import { SystemPage } from "../SystemPage";
 import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
@@ -33,7 +34,8 @@ vi.mock("@code-proxy/api-client", () => ({
     getCodexConfigs: async () => [],
     getOpenCodeGoConfigs: async () => [],
     getVertexConfigs: async () => [],
-    getOpenAIProviders: async () => [],
+    getOpenAIProviders: async () =>
+      normalizeOpenAIProviders(await mocks.apiGet("/openai-compatibility")),
   },
 }));
 
@@ -69,10 +71,48 @@ function renderPage() {
   );
 }
 
+function extractList(payload: unknown, key: string): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  const record =
+    payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const value = record[key] ?? record.items ?? record.data;
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeOpenAIProviders(payload: unknown) {
+  return extractList(payload, "openai-compatibility").map((entry) => {
+    const item = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+    const rawEntries = Array.isArray(item["api-key-entries"])
+      ? item["api-key-entries"]
+      : Array.isArray(item.apiKeyEntries)
+        ? item.apiKeyEntries
+        : [];
+    return {
+      name: String(item.name ?? ""),
+      disabled: item.disabled === true,
+      prefix: typeof item.prefix === "string" ? item.prefix : undefined,
+      models: Array.isArray(item.models) ? item.models : [],
+      apiKeyEntries: rawEntries
+        .map((raw) => {
+          const keyEntry =
+            raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+          const apiKey = String(keyEntry["api-key"] ?? keyEntry.apiKey ?? "").trim();
+          if (!apiKey) return null;
+          return {
+            apiKey,
+            disabled: keyEntry.disabled === true,
+          };
+        })
+        .filter(Boolean),
+    };
+  });
+}
+
 describe("SystemPage", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
     window.localStorage.clear();
+    invalidateConfiguredModelAvailability();
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
       if (path === "/model-path-availability") return Promise.resolve({ data: [] });
@@ -288,6 +328,57 @@ describe("SystemPage", () => {
 
     expect(await screen.findByText("gpt-5.5")).toBeInTheDocument();
     expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
+  });
+
+  test("hides disabled OpenAI compatible provider models in mapped owner mode", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") {
+        return Promise.resolve({
+          items: [{ auth_group: "codex", owner: "codex" }],
+        });
+      }
+      if (path === "/model-path-availability") return Promise.resolve({ data: [] });
+      if (path === "/model-configs?scope=library") return Promise.resolve({ data: [] });
+      if (path === "/auth-files") return Promise.resolve({ files: [] });
+      if (path === "/openai-compatibility") {
+        return Promise.resolve({
+          "openai-compatibility": [
+            {
+              name: "Disabled Compat",
+              disabled: true,
+              "api-key-entries": [{ "api-key": "sk-disabled" }],
+              models: [{ name: "upstream-disabled", alias: "disabled-provider-model" }],
+            },
+            {
+              name: "Disabled Key Compat",
+              "api-key-entries": [{ "api-key": "sk-entry-disabled", disabled: true }],
+              models: [{ name: "upstream-entry-disabled", alias: "disabled-key-model" }],
+            },
+            {
+              name: "Active Compat",
+              "api-key-entries": [{ "api-key": "sk-active" }],
+              models: [{ name: "upstream-active", alias: "active-compat-model" }],
+            },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key"
+      ) {
+        return Promise.resolve([]);
+      }
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("active-compat-model")).toBeInTheDocument();
+    expect(screen.queryByText("disabled-provider-model")).not.toBeInTheDocument();
+    expect(screen.queryByText("disabled-key-model")).not.toBeInTheDocument();
   });
 
   test("rechecks the target version before treating the update as successful", async () => {


### PR DESCRIPTION
## Summary
- exclude disabled OpenAI compatible providers from fallback model availability aggregation
- exclude OpenAI compatible API key entries marked disabled while preserving keyless/header-based providers
- add SystemPage regression coverage for mapped owner fallback mode

## Tests
- rtk bun run --filter @code-proxy/admin-panel test -- pages/models/__tests__/modelAvailability.test.ts pages/system/__tests__/SystemPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- rtk git diff --check -- features/model-availability/modelAvailability.ts pages/system/__tests__/SystemPage.test.tsx
- rtk go test ./sdk/cliproxy -run 'TestApplyConfigReloadDropsDisabledOpenAICompatibleProviderModels|TestApplyConfigReloadDisableAllModelsPreventsClaudeAPIKeySelection|TestApplyConfigReloadRefreshesModelRegistryForConfigAuths'\n- rtk go test ./internal/watcher/synthesizer -run 'TestConfigSynthesizer_OpenAICompat'