### PR TITLE
fix: improve monitor chart loading performance

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -17,6 +17,21 @@ interface RouteWithMeta {
   hasWildcard?: boolean;
 }
 
+function RouteFallback() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-700 dark:bg-neutral-950 dark:text-white/80"
+    >
+      <span
+        aria-hidden="true"
+        className="h-6 w-6 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white"
+      />
+    </div>
+  );
+}
+
 export function AppRouter() {
   const routes = pageRoutes as RouteWithMeta[];
   const publicRoutes = routes.filter((r) => !r.auth);
@@ -28,7 +43,7 @@ export function AppRouter() {
     <ThemeProvider>
       <ToastProvider>
         <div className="font-sans antialiased">
-          <Suspense>
+          <Suspense fallback={<RouteFallback />}>
             <Routes>
               {/* Public routes */}
               {standalonePublicRoutes.map((route) => (
@@ -47,7 +62,7 @@ export function AppRouter() {
                 element={
                   <AuthProvider>
                     <AutoUpdatePrompt />
-                    <Suspense>
+                    <Suspense fallback={<RouteFallback />}>
                       <Routes>
                         {publicRoutes.map((route) =>
                           route.redirects?.map((rd) => (

--- a/apps/admin-panel/src/app/layout/DashboardLayout.tsx
+++ b/apps/admin-panel/src/app/layout/DashboardLayout.tsx
@@ -5,12 +5,27 @@ import { useOptionalAuth } from "@app/providers/AuthProvider";
 
 const LazyAppShell = lazy(() => import("./AppShell").then((m) => ({ default: m.AppShell })));
 
+function ShellFallback() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-700 dark:bg-neutral-950 dark:text-white/80"
+    >
+      <span
+        aria-hidden="true"
+        className="h-6 w-6 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white"
+      />
+    </div>
+  );
+}
+
 export function DashboardLayout() {
   const location = useLocation();
   const auth = useOptionalAuth();
 
   return (
-    <Suspense>
+    <Suspense fallback={<ShellFallback />}>
       <LazyAppShell onLogout={() => auth?.actions?.logout?.()}>
         <Reveal key={location.pathname}>
           <Outlet />

--- a/apps/admin-panel/vite.config.ts
+++ b/apps/admin-panel/vite.config.ts
@@ -71,6 +71,13 @@ export default defineConfig({
         index: path.resolve(__dirname, "index.html"),
         manage: path.resolve(__dirname, "manage.html"),
       },
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-i18n": ["i18next", "react-i18next", "goey-toast"],
+          "vendor-echarts": ["echarts", "echarts-for-react"],
+        },
+      },
     },
   },
 });

--- a/e2e/openai-providers.spec.ts
+++ b/e2e/openai-providers.spec.ts
@@ -64,7 +64,7 @@ test("AI Providers (OpenAI): typing provider name should not crash page", async 
 
   await page.goto("/#/ai-providers");
 
-  await page.getByRole("button", { name: /openai compatible|openai 兼容/i }).click();
+  await page.getByRole("tab", { name: /openai compatible|openai 兼容/i }).click();
 
   await page.getByRole("button", { name: /add provider|添加/i }).click();
 

--- a/e2e/request-logs-detail.spec.ts
+++ b/e2e/request-logs-detail.spec.ts
@@ -112,10 +112,11 @@ test("Request Logs: opens full detail content and switches output raw view", asy
   await page.getByTitle("Click to view output").click();
   await expect(page.getByText("hello output payload")).toBeVisible();
 
-  await page.getByRole("button", { name: "Input" }).click();
+  const detailDialog = page.getByRole("dialog");
+  await detailDialog.getByRole("tab", { name: "Input" }).click();
   await expect(page.getByText("hello input payload")).toBeVisible();
 
-  await page.getByTitle("Raw Data").click();
+  await detailDialog.getByRole("tab", { name: "Raw Data" }).click();
   await expect(page.locator("pre")).toContainText('"messages"');
   await expect(page.locator("pre")).toContainText("hello input payload");
 });

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -171,12 +171,16 @@ export const usageApi = {
     };
   },
 
-  async getChartData(days = 7, apiKey = ""): Promise<ChartDataResponse> {
+  async getChartData(
+    days = 7,
+    apiKey = "",
+    options?: { signal?: AbortSignal },
+  ): Promise<ChartDataResponse> {
     const qs = new URLSearchParams({ days: String(days) });
     if (apiKey && apiKey !== "all") qs.set("api_key", apiKey);
-    const resp = await apiClient.get<ChartDataResponse>(
-      `/usage/chart-data?${qs.toString()}`,
-    );
+    const resp = await apiClient.get<ChartDataResponse>(`/usage/chart-data?${qs.toString()}`, {
+      signal: options?.signal,
+    });
     return {
       daily_series: Array.isArray(resp?.daily_series) ? resp.daily_series : [],
       model_distribution: Array.isArray(resp?.model_distribution)

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,23 +1,22 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import en from "./locales/en.json";
-import ru from "./locales/ru.json";
-import zhCN from "./locales/zh-CN.json";
 
 export const STORAGE_KEY_LANGUAGE = "cli-proxy-language";
 export const LANGUAGE_ORDER = ["zh-CN", "en", "ru"] as const;
 export type Language = (typeof LANGUAGE_ORDER)[number];
+type TranslationResource = Record<string, unknown>;
 
-const resources = {
-  "zh-CN": { translation: zhCN },
-  en: { translation: en },
-  ru: { translation: ru },
+const localeLoaders: Record<Language, () => Promise<TranslationResource>> = {
+  "zh-CN": () => import("./locales/zh-CN.json").then((mod) => mod.default),
+  en: () => import("./locales/en.json").then((mod) => mod.default),
+  ru: () => import("./locales/ru.json").then((mod) => mod.default),
 };
 
-const loadedLanguages = new Set<string>(LANGUAGE_ORDER);
+const loadedLanguages = new Set<string>();
+const pendingLoads = new Map<string, Promise<void>>();
 
-const resolveLanguage = (language: string): string =>
-  LANGUAGE_ORDER.includes(language as Language) ? language : "zh-CN";
+const resolveLanguage = (language: string): Language =>
+  LANGUAGE_ORDER.includes(language as Language) ? (language as Language) : "zh-CN";
 
 const getInitialLanguage = (): string => {
   if (typeof window === "undefined") return "zh-CN";
@@ -41,27 +40,57 @@ const getInitialLanguage = (): string => {
 
 export const ensureLanguageResources = async (language: string): Promise<void> => {
   const resolved = resolveLanguage(language);
-  if (!loadedLanguages.has(resolved)) {
-    i18n.addResourceBundle(
-      resolved,
-      "translation",
-      resources[resolved as Language].translation,
-      true,
-      true,
-    );
-    loadedLanguages.add(resolved);
-  }
+  if (loadedLanguages.has(resolved)) return;
+
+  const pending = pendingLoads.get(resolved);
+  if (pending) return pending;
+
+  const load = localeLoaders[resolved]()
+    .then((resource) => {
+      i18n.addResourceBundle(resolved, "translation", resource, true, true);
+      loadedLanguages.add(resolved);
+    })
+    .finally(() => {
+      pendingLoads.delete(resolved);
+    });
+  pendingLoads.set(resolved, load);
+  return load;
 };
+
+const loadInitialResource = async (language: Language) => {
+  const resource = await localeLoaders[language]();
+  return [language, { translation: resource }] as const;
+};
+
+const initialLanguage = resolveLanguage(getInitialLanguage());
+const initialLanguages = Array.from(new Set<Language>([initialLanguage, "zh-CN"]));
+const initialEntries = await Promise.all(initialLanguages.map(loadInitialResource));
 
 if (!i18n.isInitialized) {
   i18n.use(initReactI18next).init({
-    resources,
-    lng: getInitialLanguage(),
+    resources: Object.fromEntries(initialEntries),
+    lng: initialLanguage,
     fallbackLng: "zh-CN",
     interpolation: { escapeValue: false },
     defaultNS: "translation",
     fallbackNS: "translation",
+    react: {
+      useSuspense: false,
+    },
   });
 }
+
+initialLanguages.forEach((language) => loadedLanguages.add(language));
+
+const originalChangeLanguage = i18n.changeLanguage.bind(i18n);
+i18n.changeLanguage = (async (
+  language?: string,
+  callback?: Parameters<typeof i18n.changeLanguage>[1],
+) => {
+  if (typeof language === "string") {
+    await ensureLanguageResources(language);
+  }
+  return originalChangeLanguage(language, callback);
+}) as typeof i18n.changeLanguage;
 
 export default i18n;

--- a/packages/ui/src/charts/EChartRenderer.tsx
+++ b/packages/ui/src/charts/EChartRenderer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ECBasicOption } from "echarts/types/dist/shared";
 import ReactECharts from "echarts-for-react";
 import { useTheme } from "../theme/ThemeProvider";
@@ -41,6 +41,7 @@ export function EChartRenderer({
   const guardedResizeTimerRef = useRef<number | null>(null);
   const initialAnimationGuardUntilRef = useRef(0);
   const didResizeOnceRef = useRef(false);
+  const [hasMeasuredSize, setHasMeasuredSize] = useState(false);
 
   const now = () => Date.now();
 
@@ -49,6 +50,9 @@ export function EChartRenderer({
     if (!container) return;
 
     lastSizeRef.current = { width, height };
+    if (width > 0 && height > 0) {
+      setHasMeasuredSize(true);
+    }
 
     const guardUntil = initialAnimationGuardUntilRef.current;
     if (guardUntil > 0) {
@@ -137,6 +141,11 @@ export function EChartRenderer({
     });
 
     observer.observe(element);
+    const width = element.clientWidth;
+    const height = element.clientHeight;
+    if (width > 0 && height > 0) {
+      requestResize(width, height);
+    }
     return () => {
       observer.disconnect();
       if (rafIdRef.current !== null) {
@@ -211,56 +220,58 @@ export function EChartRenderer({
         .filter(Boolean)
         .join(" ")}
     >
-      <ReactECharts
-        ref={chartRef}
-        option={option}
-        theme={mode === "dark" ? "dark" : undefined}
-        style={{ height: "100%", width: "100%" }}
-        showLoading={loading}
-        loadingOption={{
-          text: loadingText,
-          color: "#2563eb",
-          textColor: mode === "dark" ? "#e2e8f0" : "#475569",
-          maskColor: mode === "dark" ? "rgba(15, 23, 42, 0.48)" : "rgba(248, 250, 252, 0.64)",
-          zlevel: 1,
-        }}
-        notMerge={notMerge}
-        replaceMerge={replaceMerge}
-        autoResize={false}
-        className="h-full w-full"
-        onEvents={onEvents}
-        onChartReady={(instance: any) => {
-          instanceRef.current = instance;
+      {hasMeasuredSize ? (
+        <ReactECharts
+          ref={chartRef}
+          option={option}
+          theme={mode === "dark" ? "dark" : undefined}
+          style={{ height: "100%", width: "100%" }}
+          showLoading={loading}
+          loadingOption={{
+            text: loadingText,
+            color: "#2563eb",
+            textColor: mode === "dark" ? "#e2e8f0" : "#475569",
+            maskColor: mode === "dark" ? "rgba(15, 23, 42, 0.48)" : "rgba(248, 250, 252, 0.64)",
+            zlevel: 1,
+          }}
+          notMerge={notMerge}
+          replaceMerge={replaceMerge}
+          autoResize={false}
+          className="h-full w-full"
+          onEvents={onEvents}
+          onChartReady={(instance: any) => {
+            instanceRef.current = instance;
 
-          try {
-            if (!loading) {
-              instance?.hideLoading?.();
+            try {
+              if (!loading) {
+                instance?.hideLoading?.();
+              }
+            } catch {
+              // ignore
             }
-          } catch {
-            // ignore
-          }
 
-          const container = containerRef.current;
-          if (!container) return;
-          const width = container.clientWidth;
-          const height = container.clientHeight;
-          if (width > 0 && height > 0) {
-            window.setTimeout(() => {
-              requestResize(container.clientWidth, container.clientHeight);
-            }, 60);
-            window.setTimeout(() => {
-              requestResize(container.clientWidth, container.clientHeight);
-            }, 240);
-            window.setTimeout(() => {
-              requestResize(container.clientWidth, container.clientHeight);
-            }, 500);
-          } else {
-            const size = lastSizeRef.current;
-            if (!size) return;
-            requestResize(size.width, size.height);
-          }
-        }}
-      />
+            const container = containerRef.current;
+            if (!container) return;
+            const width = container.clientWidth;
+            const height = container.clientHeight;
+            if (width > 0 && height > 0) {
+              window.setTimeout(() => {
+                requestResize(container.clientWidth, container.clientHeight);
+              }, 60);
+              window.setTimeout(() => {
+                requestResize(container.clientWidth, container.clientHeight);
+              }, 240);
+              window.setTimeout(() => {
+                requestResize(container.clientWidth, container.clientHeight);
+              }, 500);
+            } else {
+              const size = lastSizeRef.current;
+              if (!size) return;
+              requestResize(size.width, size.height);
+            }
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,7 +14,6 @@ export { ChartLegend } from "./charts/ChartLegend";
 export type { ChartLegendItem } from "./charts/ChartLegend";
 export { EChart } from "./charts/EChart";
 export type { EChartEvents } from "./charts/EChart";
-export { EChartRenderer } from "./charts/EChartRenderer";
 export type { EChartProps, EChartEvents as EChartRendererEvents } from "./charts/EChartRenderer";
 
 export { PageBackground } from "./layout/PageBackground";

--- a/pages/monitor/MonitorDashboardSections.tsx
+++ b/pages/monitor/MonitorDashboardSections.tsx
@@ -1,4 +1,5 @@
 import { Activity, ChartSpline, Coins, ShieldCheck, Sigma } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { HourWindow } from "@features/monitor-widgets/monitor-constants";
 import { formatNumber, formatRate } from "@features/monitor-widgets/monitor-utils";
 import { AnimatedNumber } from "@code-proxy/ui";
@@ -7,6 +8,17 @@ import { EChart } from "@code-proxy/ui";
 import { ChartLegend } from "@code-proxy/ui";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { HourWindowSelector, KpiCard, MonitorCard as Card } from "@features/monitor-widgets";
+
+function useDeferredMount(delayMs = 120) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setMounted(true), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [delayMs]);
+
+  return mounted;
+}
 
 export function MonitorKpiSection({
   t,
@@ -358,49 +370,57 @@ export function MonitorHourlySections({
   hourlyTokenSelected: Record<string, boolean>;
   toggleHourlyTokenLegend: (key: string) => void;
 }) {
-  return (
-    <>
-      <Card
-        title={t("monitor.hourly_model.title")}
-        description={t("monitor.hourly_model_desc")}
-        actions={
-          <HourWindowSelector value={modelHourWindow as any} onChange={setModelHourWindow} />
-        }
-        loading={isRefreshing}
-      >
-        <EChart option={hourlyModelOption} className="h-64 sm:h-72" replaceMerge="series" />
-        <ChartLegend
-          className="max-h-32 justify-start overflow-y-auto pt-4 sm:max-h-none sm:justify-center"
-          items={hourlyModelLegendKeys.map((key) => ({
-            key,
-            label: getHourlyModelSeriesLabel(key),
-            colorClass: hourlyModelPalette.classByKey[key] ?? "bg-slate-400",
-            enabled: hourlyModelSelected[key] ?? true,
-            onToggle: toggleHourlyModelLegend,
-          }))}
-        />
-      </Card>
+  const shouldRenderCharts = useDeferredMount();
 
-      <Card
-        title={t("monitor.hourly_token.title")}
-        description={t("monitor.hourly_token_desc")}
-        actions={
-          <HourWindowSelector value={tokenHourWindow as any} onChange={setTokenHourWindow} />
-        }
-        loading={isRefreshing}
-      >
-        <EChart option={hourlyTokenOption} className="h-64 sm:h-72" replaceMerge="series" />
-        <ChartLegend
-          className="max-h-32 justify-start overflow-y-auto pt-4 sm:max-h-none sm:justify-center"
-          items={hourlySeries.tokenKeys.map((key) => ({
-            key,
-            label: hourlyTokenLabels[key] ?? key,
-            colorClass: hourlyTokenPalette.classByKey[key] ?? "bg-slate-400",
-            enabled: hourlyTokenSelected[key] ?? true,
-            onToggle: toggleHourlyTokenLegend,
-          }))}
-        />
-      </Card>
-    </>
+  return (
+    <section className="space-y-4">
+      {shouldRenderCharts ? (
+        <>
+          <Card
+            title={t("monitor.hourly_model.title")}
+            description={t("monitor.hourly_model_desc")}
+            actions={
+              <HourWindowSelector value={modelHourWindow as any} onChange={setModelHourWindow} />
+            }
+            loading={isRefreshing}
+          >
+            <EChart option={hourlyModelOption} className="h-64 sm:h-72" replaceMerge="series" />
+            <ChartLegend
+              className="max-h-32 justify-start overflow-y-auto pt-4 sm:max-h-none sm:justify-center"
+              items={hourlyModelLegendKeys.map((key) => ({
+                key,
+                label: getHourlyModelSeriesLabel(key),
+                colorClass: hourlyModelPalette.classByKey[key] ?? "bg-slate-400",
+                enabled: hourlyModelSelected[key] ?? true,
+                onToggle: toggleHourlyModelLegend,
+              }))}
+            />
+          </Card>
+
+          <Card
+            title={t("monitor.hourly_token.title")}
+            description={t("monitor.hourly_token_desc")}
+            actions={
+              <HourWindowSelector value={tokenHourWindow as any} onChange={setTokenHourWindow} />
+            }
+            loading={isRefreshing}
+          >
+            <EChart option={hourlyTokenOption} className="h-64 sm:h-72" replaceMerge="series" />
+            <ChartLegend
+              className="max-h-32 justify-start overflow-y-auto pt-4 sm:max-h-none sm:justify-center"
+              items={hourlySeries.tokenKeys.map((key) => ({
+                key,
+                label: hourlyTokenLabels[key] ?? key,
+                colorClass: hourlyTokenPalette.classByKey[key] ?? "bg-slate-400",
+                enabled: hourlyTokenSelected[key] ?? true,
+                onToggle: toggleHourlyTokenLegend,
+              }))}
+            />
+          </Card>
+        </>
+      ) : (
+        <div aria-hidden="true" className="min-h-[42rem]" />
+      )}
+    </section>
   );
 }

--- a/pages/monitor/MonitorPage.tsx
+++ b/pages/monitor/MonitorPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usageApi } from "@code-proxy/api-client";
 import { useTheme } from "@code-proxy/ui";
 import {
@@ -90,19 +90,40 @@ export function MonitorPage() {
   >({});
   const [error, setError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(true);
+  const refreshRequestIdRef = useRef(0);
+  const refreshAbortRef = useRef<AbortController | null>(null);
 
   const refreshData = useCallback(async () => {
+    const requestId = refreshRequestIdRef.current + 1;
+    refreshRequestIdRef.current = requestId;
+    refreshAbortRef.current?.abort();
+
+    const abortController = new AbortController();
+    refreshAbortRef.current = abortController;
     setIsRefreshing(true);
     setError(null);
     try {
-      const chartResp = await usageApi.getChartData(timeRange, apiFilter);
+      const chartResp = await usageApi.getChartData(timeRange, apiFilter, {
+        signal: abortController.signal,
+      });
+      if (refreshRequestIdRef.current !== requestId || abortController.signal.aborted) {
+        return;
+      }
       setChartData(chartResp);
     } catch (requestError) {
+      if (refreshRequestIdRef.current !== requestId || abortController.signal.aborted) {
+        return;
+      }
       const message =
         requestError instanceof Error ? requestError.message : t("monitor.failed_fetch");
       setError(message);
     } finally {
-      setIsRefreshing(false);
+      if (refreshRequestIdRef.current === requestId) {
+        if (refreshAbortRef.current === abortController) {
+          refreshAbortRef.current = null;
+        }
+        setIsRefreshing(false);
+      }
     }
   }, [t, timeRange, apiFilter]);
 
@@ -159,11 +180,12 @@ export function MonitorPage() {
 
   useEffect(() => {
     void refreshData();
+    return () => refreshAbortRef.current?.abort();
   }, [refreshData]);
 
   const modelTotals = useMemo(() => {
     if (!chartData?.model_distribution) return [];
-    return chartData.model_distribution.sort(
+    return [...chartData.model_distribution].sort(
       (left, right) => right.requests - left.requests || left.model.localeCompare(right.model),
     );
   }, [chartData]);


### PR DESCRIPTION
## Summary
- add loading fallbacks for lazy routes and app shell
- split heavy vendor chunks and lazy-load i18n resources
- stabilize monitor chart mounting and abort stale chart data requests
- update e2e selectors for current tab semantics

## Verification
- bun run test:ci
- bun run e2e
- bun run check