### PR TITLE
fix: localize update release notes and language menu

### DIFF
--- a/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
+++ b/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@code-proxy/ui";
 import {
   formatUpdateStatusMessage,
   isAlreadyUpToDateMessage,
+  selectLocalizedReleaseNotes,
   shortCommit,
   uiVersionLabel,
   versionLabel,
@@ -391,7 +392,7 @@ export function UpdateDetailsModal({
   onApply: () => void;
   onClose: () => void;
 }) {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
   const [releaseNotesExpanded, setReleaseNotesExpanded] = useState(false);
   const progressStatus = normalizedProgressStatus(progress);
   const showProgressConsole = Boolean(progress && progressStatus !== "idle");
@@ -429,7 +430,12 @@ export function UpdateDetailsModal({
         : alreadyUpToDate
           ? t("auto_update.up_to_date_description")
           : t("auto_update.description");
-  const releaseNotes = displayCandidate?.release_notes?.trim() || t("auto_update.no_release_notes");
+  const rawReleaseNotes =
+    displayCandidate?.release_notes?.trim() || t("auto_update.no_release_notes");
+  const releaseNotes = useMemo(
+    () => selectLocalizedReleaseNotes(rawReleaseNotes, i18n.language),
+    [i18n.language, rawReleaseNotes],
+  );
   const showReleaseNotes = Boolean(displayCandidate?.update_available) && !showProgressConsole;
   const releaseNotesPreview = useMemo(() => buildReleaseNotesPreview(releaseNotes), [releaseNotes]);
   const visibleReleaseNotes =
@@ -489,7 +495,7 @@ export function UpdateDetailsModal({
 
   useEffect(() => {
     setReleaseNotesExpanded(false);
-  }, [candidate?.latest_commit, candidate?.latest_ui_commit, open]);
+  }, [candidate?.latest_commit, candidate?.latest_ui_commit, i18n.language, open]);
 
   return (
     <Modal

--- a/apps/admin-panel/src/app/update/__tests__/UpdateDetailsModal.test.tsx
+++ b/apps/admin-panel/src/app/update/__tests__/UpdateDetailsModal.test.tsx
@@ -115,4 +115,33 @@ describe("UpdateDetailsModal", () => {
     expect(screen.queryByTestId("update-log-stream")).toBeNull();
     expect(screen.getByTestId("update-details-modal-body")).toHaveClass("max-h-[min(62vh,520px)]");
   });
+
+  test("shows the release notes section that matches the active language", async () => {
+    render(
+      <UpdateDetailsModal
+        open
+        candidate={{
+          ...candidate,
+          release_notes: [
+            "v0.4.0 - dev 全量合并发布 / Full dev-to-main release",
+            "",
+            "中文",
+            "",
+            "这是中文更新说明。",
+            "",
+            "English",
+            "",
+            "This is the English release note.",
+          ].join("\n"),
+        }}
+        onApply={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("v0.4.0 - Full dev-to-main release")).toBeInTheDocument();
+    expect(screen.getByText("This is the English release note.")).toBeInTheDocument();
+    expect(screen.queryByText("中文")).not.toBeInTheDocument();
+    expect(screen.queryByText("这是中文更新说明。")).not.toBeInTheDocument();
+  });
 });

--- a/apps/admin-panel/src/app/update/__tests__/updateShared.test.ts
+++ b/apps/admin-panel/src/app/update/__tests__/updateShared.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { applyUpdateFlow, formatUpdateStatusMessage } from "@app/update/updateShared";
+import {
+  applyUpdateFlow,
+  formatUpdateStatusMessage,
+  selectLocalizedReleaseNotes,
+} from "@app/update/updateShared";
 
 const mocks = vi.hoisted(() => ({
   apiGet: vi.fn(),
@@ -34,6 +38,50 @@ describe("formatUpdateStatusMessage", () => {
 
   test("keeps ordinary status messages unchanged", () => {
     expect(formatUpdateStatusMessage("already up to date")).toBe("already up to date");
+  });
+});
+
+describe("selectLocalizedReleaseNotes", () => {
+  const bilingualNotes = [
+    "v0.4.0 - dev 全量合并发布 / Full dev-to-main release",
+    "",
+    "中文",
+    "",
+    "这是中文更新说明。",
+    "",
+    "- 后端架构整理",
+    "",
+    "English",
+    "",
+    "This is the English release note.",
+    "",
+    "- Backend architecture cleanup",
+  ].join("\n");
+
+  test("selects the English section and localizes the bilingual heading", () => {
+    expect(selectLocalizedReleaseNotes(bilingualNotes, "en")).toBe(
+      [
+        "v0.4.0 - Full dev-to-main release",
+        "",
+        "This is the English release note.",
+        "",
+        "- Backend architecture cleanup",
+      ].join("\n"),
+    );
+  });
+
+  test("keeps the Chinese section for Chinese UI", () => {
+    expect(selectLocalizedReleaseNotes(bilingualNotes, "zh-CN")).toBe(
+      ["v0.4.0 - dev 全量合并发布", "", "这是中文更新说明。", "", "- 后端架构整理"].join(
+        "\n",
+      ),
+    );
+  });
+
+  test("falls back to English for locales without a dedicated release section", () => {
+    expect(selectLocalizedReleaseNotes(bilingualNotes, "ru")).toContain(
+      "This is the English release note.",
+    );
   });
 });
 

--- a/apps/admin-panel/src/app/update/updateShared.ts
+++ b/apps/admin-panel/src/app/update/updateShared.ts
@@ -57,6 +57,101 @@ export const formatUpdateStatusMessage = (message?: string | null) => {
 export const isAlreadyUpToDateMessage = (message?: string | null) =>
   (message?.trim().toLowerCase() ?? "") === "already up to date";
 
+type ReleaseNotesLocale = "zh-CN" | "en" | "ru";
+
+const RELEASE_NOTES_LOCALE_FALLBACKS: Record<ReleaseNotesLocale, ReleaseNotesLocale[]> = {
+  "zh-CN": ["zh-CN", "en", "ru"],
+  en: ["en", "zh-CN", "ru"],
+  ru: ["ru", "en", "zh-CN"],
+};
+
+const resolveReleaseNotesLocale = (language?: string): ReleaseNotesLocale => {
+  const normalized = language?.trim().toLowerCase() ?? "";
+  if (normalized.startsWith("zh")) return "zh-CN";
+  if (normalized.startsWith("ru")) return "ru";
+  return "en";
+};
+
+const normalizeReleaseNotesMarker = (line: string) =>
+  line
+    .trim()
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/^\*\*(.+)\*\*$/, "$1")
+    .replace(/^__(.+)__$/, "$1")
+    .replace(/[:：]$/, "")
+    .trim()
+    .toLowerCase();
+
+const releaseNotesMarkerLocale = (line: string): ReleaseNotesLocale | null => {
+  const marker = normalizeReleaseNotesMarker(line);
+  if (["中文", "简体中文", "chinese", "zh", "zh-cn"].includes(marker)) return "zh-CN";
+  if (["english", "英文", "en", "en-us"].includes(marker)) return "en";
+  if (["русский", "russian", "ru", "ru-ru"].includes(marker)) return "ru";
+  return null;
+};
+
+const trimBlankReleaseNoteLines = (lines: string[]) => {
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start].trim() === "") start += 1;
+  while (end > start && lines[end - 1].trim() === "") end -= 1;
+  return lines.slice(start, end);
+};
+
+const localizeBilingualReleaseNoteLine = (line: string, locale: ReleaseNotesLocale) => {
+  const parts = line.split(/\s+[\/／]\s+/);
+  if (parts.length < 2) return line;
+  if (locale === "zh-CN") return parts[0];
+
+  const left = parts[0];
+  const right = parts.slice(1).join(" / ").trimStart();
+  const prefixMatch = left.match(
+    /^(\s*(?:#{1,6}\s*)?(?:[-*+]\s*)?(?:v?\d[\w.+-]*(?:\s*[-:]\s*)?)?)(.*)$/i,
+  );
+  return `${prefixMatch?.[1] ?? ""}${right}`;
+};
+
+export const selectLocalizedReleaseNotes = (text: string, language?: string) => {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+
+  const lines = trimmed.split(/\r?\n/);
+  const preamble: string[] = [];
+  const sections: Array<{ locale: ReleaseNotesLocale; lines: string[] }> = [];
+  let currentSection: { locale: ReleaseNotesLocale; lines: string[] } | null = null;
+
+  lines.forEach((line) => {
+    const locale = releaseNotesMarkerLocale(line);
+    if (locale) {
+      currentSection = { locale, lines: [] };
+      sections.push(currentSection);
+      return;
+    }
+    if (currentSection) {
+      currentSection.lines.push(line);
+      return;
+    }
+    preamble.push(line);
+  });
+
+  if (sections.length === 0) return trimmed;
+
+  const requestedLocale = resolveReleaseNotesLocale(language);
+  const selectedSection =
+    RELEASE_NOTES_LOCALE_FALLBACKS[requestedLocale]
+      .map((locale) => sections.find((section) => section.locale === locale))
+      .find((section): section is { locale: ReleaseNotesLocale; lines: string[] } =>
+        Boolean(section),
+      ) ?? sections[0];
+  const localizedPreamble = trimBlankReleaseNoteLines(preamble)
+    .map((line) => localizeBilingualReleaseNoteLine(line, selectedSection.locale))
+    .join("\n")
+    .trim();
+  const localizedBody = trimBlankReleaseNoteLines(selectedSection.lines).join("\n").trim();
+
+  return [localizedPreamble, localizedBody].filter(Boolean).join("\n\n").trim();
+};
+
 export const updateDisplayVersion = (info: UpdateCheckResponse) => {
   const backendChanged =
     Boolean(info.latest_commit?.trim()) && !sameCommit(info.current_commit, info.latest_commit);

--- a/packages/ui/src/theme/LanguageSelector.tsx
+++ b/packages/ui/src/theme/LanguageSelector.tsx
@@ -10,15 +10,17 @@ import {
 } from "@code-proxy/i18n";
 
 const SUPPORTED_LANGUAGES = LANGUAGE_ORDER;
-const LANGUAGE_LABEL_KEYS: Record<string, string> = {
-  "zh-CN": "nav.language_cn",
-  en: "nav.language_en",
+const LANGUAGE_LABEL_KEYS: Record<Language, string> = {
+  "zh-CN": "language.chinese",
+  en: "language.english",
+  ru: "language.russian",
 };
 
 /** Short labels for each language, shown next to the icon */
-const SHORT_LABELS: Record<string, string> = {
+const SHORT_LABELS: Record<Language, string> = {
   en: "EN",
   "zh-CN": "中",
+  ru: "RU",
 };
 
 export function LanguageSelector({ className }: { className?: string }) {

--- a/packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
+++ b/packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { LanguageSelector } from "../LanguageSelector";
+
+describe("LanguageSelector", () => {
+  beforeEach(async () => {
+    localStorage.clear();
+    await i18n.changeLanguage("en");
+  });
+
+  test("renders translated language labels instead of missing translation keys", () => {
+    render(<LanguageSelector className="inline-flex" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Language" }));
+
+    expect(screen.getByRole("option", { name: /中文/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /English/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Русский/ })).toBeInTheDocument();
+    expect(screen.queryByText(/nav\.language/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- localize update release notes based on the active UI language
- fix language selector labels so menu items no longer render missing i18n keys
- add regression coverage for release notes language selection and the language selector menu

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- src/app/update/__tests__/updateShared.test.ts src/app/update/__tests__/UpdateDetailsModal.test.tsx ../../packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- rtk git diff --check
- Browser/Playwright mock QA for English update modal and language menu