### PR TITLE
fix: polish table column drag visuals

### DIFF
--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -23,11 +23,11 @@ const mockRequestLogsApis = async (page: Page) => {
       const items = Array.from({ length: 12 }, (_, index) => ({
         id: 2000 + index,
         timestamp: `2026-06-14T08:${String(index).padStart(2, "0")}:00Z`,
-        api_key: `sk-test-${String(index).padStart(4, "0")}`,
-        api_key_name: `QA Key ${index + 1}`,
-        model: index % 2 ? "claude-sonnet-4" : "gpt-4.1",
+        api_key: `sk-test-${String(index).padStart(4, "0")}-extra-long-key-for-drag-visual-qa`,
+        api_key_name: `QA Key ${index + 1} with deliberately long display name`,
+        model: index % 2 ? "claude-sonnet-4-extra-long-context" : "gpt-4.1-long-output-model",
         source: "openai",
-        channel_name: index % 2 ? "Anthropic" : "OpenAI",
+        channel_name: index % 2 ? "Anthropic long provider channel" : "OpenAI fallback channel",
         auth_index: `auth-${index + 1}`,
         failed: index === 4,
         latency_ms: 850 + index * 120,
@@ -94,6 +94,61 @@ const readTableState = async (page: Page) =>
     };
   });
 
+const readDragVisualState = async (page: Page) =>
+  page.evaluate(() => {
+    const isOpaque = (style: CSSStyleDeclaration, inlineBackground: string) =>
+      style.backgroundColor !== "rgba(0, 0, 0, 0)" || inlineBackground.includes("rgb(");
+    const readStyles = (selector: string) =>
+      [...document.querySelectorAll<HTMLElement>(selector)].map((element) => {
+        const style = getComputedStyle(element);
+        return {
+          backgroundColor: style.backgroundColor,
+          backgroundImage: style.backgroundImage,
+          boxShadow: style.boxShadow,
+          inlineBackground: element.style.background,
+          isOpaque: isOpaque(style, element.style.background),
+          opacity: style.opacity,
+          overflowX: style.overflowX,
+          overflowY: style.overflowY,
+          zIndex: style.zIndex,
+        };
+      });
+    const contentClips = [
+      ...document.querySelectorAll<HTMLElement>(
+        "td[data-vt-column-key] > [data-vt-cell-content-clip]",
+      ),
+    ];
+    return {
+      dragging: readStyles("[data-vt-column-dragging-cell]"),
+      shifted: readStyles("[data-vt-column-shifted-cell]"),
+      contentClipCount: contentClips.length,
+      contentClipsAreBounded: contentClips.every((element) => {
+        const parent = element.parentElement;
+        if (!parent) return false;
+        const rect = element.getBoundingClientRect();
+        const parentRect = parent.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return (
+          style.overflowX === "hidden" &&
+          style.overflowY === "hidden" &&
+          rect.left >= parentRect.left - 1 &&
+          rect.right <= parentRect.right + 1
+        );
+      }),
+      inlineStylesCleared: [
+        ...document.querySelectorAll<HTMLElement>("[data-vt-column-key]"),
+      ].every(
+        (element) =>
+          !element.hasAttribute("data-vt-column-dragging-cell") &&
+          !element.hasAttribute("data-vt-column-shifted-cell") &&
+          element.style.background === "" &&
+          element.style.overflow === "" &&
+          element.style.contain === "" &&
+          element.style.isolation === "",
+      ),
+    };
+  });
+
 test("Request Logs: column reorder follows the pointer and auto-scrolls horizontally", async ({
   page,
 }) => {
@@ -109,6 +164,9 @@ test("Request Logs: column reorder follows the pointer and auto-scrolls horizont
   const dragStart = await page
     .locator('th[data-vt-column-key="timestamp"] [data-vt-column-reorder-handle]')
     .evaluate((element) => {
+      if (element.hasAttribute("title") || element.hasAttribute("aria-label")) {
+        throw new Error("Column reorder handle must not expose hover tooltip attributes");
+      }
       const rect = element.getBoundingClientRect();
       return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
     });
@@ -127,6 +185,33 @@ test("Request Logs: column reorder follows the pointer and auto-scrolls horizont
   expect(during.draggingCells).toBeGreaterThan(0);
   expect(during.shiftedCells).toBeGreaterThan(0);
   expect(during.scrollLeft).toBeGreaterThan(before.scrollLeft);
+  const visualDuringDrag = await readDragVisualState(page);
+  expect(visualDuringDrag.dragging.length).toBeGreaterThan(0);
+  expect(visualDuringDrag.shifted.length).toBeGreaterThan(0);
+  expect(
+    visualDuringDrag.dragging.every(
+      (style) =>
+        style.opacity === "1" &&
+        style.overflowX === "hidden" &&
+        style.overflowY === "hidden" &&
+        style.isOpaque &&
+        style.backgroundImage.includes("gradient") &&
+        style.boxShadow !== "none" &&
+        Number(style.zIndex) >= 90,
+    ),
+  ).toBe(true);
+  expect(
+    visualDuringDrag.shifted.every(
+      (style) =>
+        style.opacity === "1" &&
+        style.overflowX === "hidden" &&
+        style.overflowY === "hidden" &&
+        style.isOpaque &&
+        Number(style.zIndex) >= 45,
+    ),
+  ).toBe(true);
+  expect(visualDuringDrag.contentClipCount).toBeGreaterThan(0);
+  expect(visualDuringDrag.contentClipsAreBounded).toBe(true);
 
   await page.mouse.up();
 
@@ -141,4 +226,7 @@ test("Request Logs: column reorder follows the pointer and auto-scrolls horizont
   expect(after.draggingCells).toBe(0);
   expect(after.shiftedCells).toBe(0);
   expect(after.storedOrder).toContain('"timestamp"');
+  await page.waitForTimeout(160);
+  const visualAfterDrag = await readDragVisualState(page);
+  expect(visualAfterDrag.inlineStylesCleared).toBe(true);
 });

--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -94,6 +94,19 @@ const readTableState = async (page: Page) =>
     };
   });
 
+const scrollTableNearRightEdge = async (page: Page) =>
+  page.evaluate(() => {
+    const scroller = document.querySelector<HTMLElement>(".table-scrollbar");
+    if (!scroller) throw new Error("Missing table scroller");
+    const maxScrollLeft = Math.max(0, scroller.scrollWidth - scroller.clientWidth);
+    scroller.scrollLeft = Math.max(0, maxScrollLeft - 120);
+    scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
+    return {
+      maxScrollLeft,
+      scrollLeft: scroller.scrollLeft,
+    };
+  });
+
 const readDragVisualState = async (page: Page) =>
   page.evaluate(() => {
     const isOpaque = (style: CSSStyleDeclaration, inlineBackground: string) =>
@@ -229,4 +242,45 @@ test("Request Logs: column reorder follows the pointer and auto-scrolls horizont
   await page.waitForTimeout(160);
   const visualAfterDrag = await readDragVisualState(page);
   expect(visualAfterDrag.inlineStylesCleared).toBe(true);
+});
+
+test("Request Logs: last column does not auto-scroll past the right reorder boundary", async ({
+  page,
+}) => {
+  await setAuthed(page);
+  await mockRequestLogsApis(page);
+
+  await page.goto("/manage/#/monitor/request-logs");
+  await page.locator('th[data-vt-column-key="model"]').waitFor({ state: "visible" });
+
+  const nearRight = await scrollTableNearRightEdge(page);
+  expect(nearRight.maxScrollLeft).toBeGreaterThan(160);
+  expect(nearRight.scrollLeft).toBeLessThan(nearRight.maxScrollLeft);
+
+  const dragStart = await page
+    .locator('th[data-vt-column-key="model"] [data-vt-column-reorder-handle]')
+    .evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    });
+  const scrollerRight = await page.locator(".table-scrollbar").evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.right;
+  });
+
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.waitForTimeout(130);
+  await page.mouse.move(scrollerRight - 8, dragStart.y, { steps: 8 });
+  await page.waitForTimeout(420);
+
+  const during = await readTableState(page);
+  expect(during.draggingCells).toBeGreaterThan(0);
+  expect(during.scrollLeft).toBeLessThanOrEqual(nearRight.scrollLeft + 2);
+
+  await page.mouse.up();
+
+  const after = await readTableState(page);
+  expect(after.draggingCells).toBe(0);
+  expect(after.order.at(-1)).toBe("model");
 });

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -119,11 +119,12 @@ const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
 // Column Reorder
 // ---------------------------------------------------------------------------
 const COLUMN_ORDER_STORAGE_PREFIX = "codeProxy.dataTable.columnOrder.v1";
-const COLUMN_REORDER_ACTIVATION_DELAY_MS = 180;
+const COLUMN_REORDER_ACTIVATION_DELAY_MS = 90;
 const COLUMN_REORDER_MIN_DRAG_DISTANCE_PX = 4;
 const COLUMN_REORDER_AUTOSCROLL_EDGE_PX = 72;
 const COLUMN_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME = 22;
-const COLUMN_REORDER_SHIFT_TRANSITION = "transform 150ms cubic-bezier(0.22, 1, 0.36, 1)";
+const COLUMN_REORDER_SHIFT_TRANSITION = "transform 72ms cubic-bezier(0.2, 0, 0, 1)";
+const COLUMN_REORDER_SETTLE_CLEANUP_MS = 110;
 const NON_REORDERABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
 
 type ColumnOrder = string[];
@@ -477,6 +478,51 @@ function formatColumnReorderTransform(offsetX: number) {
   if (Math.abs(offsetX) < 0.1) return "";
   const rounded = Math.round(offsetX * 100) / 100;
   return `translate3d(${rounded}px, 0, 0)`;
+}
+
+function getColumnReorderCellBackground(element: HTMLElement, isDragged: boolean) {
+  const isHeader = element.tagName === "TH";
+  const isDark = document.documentElement.classList.contains("dark");
+  const base = isHeader
+    ? isDark
+      ? "rgb(38 38 38)"
+      : "rgb(241 245 249)"
+    : isDark
+      ? "rgb(10 10 10)"
+      : "rgb(255 255 255)";
+
+  if (!isDragged) return base;
+
+  const accent = isDark
+    ? isHeader
+      ? "linear-gradient(90deg, rgba(59, 130, 246, 0.24), rgba(34, 211, 238, 0.12))"
+      : "linear-gradient(90deg, rgba(59, 130, 246, 0.16), rgba(34, 211, 238, 0.08))"
+    : isHeader
+      ? "linear-gradient(90deg, rgba(37, 99, 235, 0.2), rgba(14, 165, 233, 0.1))"
+      : "linear-gradient(90deg, rgba(37, 99, 235, 0.1), rgba(14, 165, 233, 0.05))";
+
+  return `${accent}, ${base}`;
+}
+
+function scheduleColumnReorderSettleCleanup(element: HTMLElement) {
+  window.setTimeout(() => {
+    if (
+      element.hasAttribute("data-vt-column-dragging-cell") ||
+      element.hasAttribute("data-vt-column-shifted-cell") ||
+      element.style.transform
+    ) {
+      return;
+    }
+
+    element.style.transition = "";
+    element.style.willChange = "";
+    element.style.position = "";
+    element.style.zIndex = "";
+    element.style.background = "";
+    element.style.overflow = "";
+    element.style.contain = "";
+    element.style.isolation = "";
+  }, COLUMN_REORDER_SETTLE_CLEANUP_MS);
 }
 
 // ---------------------------------------------------------------------------
@@ -1247,7 +1293,11 @@ export function DataTable<T>({
         element.style.pointerEvents = "";
         element.style.opacity = "";
         element.style.filter = "";
+        element.style.background = "";
         element.style.boxShadow = "";
+        element.style.overflow = "";
+        element.style.contain = "";
+        element.style.isolation = "";
         element.removeAttribute("data-vt-column-dragging-cell");
         element.removeAttribute("data-vt-column-shifted-cell");
       });
@@ -1261,6 +1311,7 @@ export function DataTable<T>({
         const shift = isDragged ? dragOffsetX : (getColumnReorderShift(active, geometry) ?? 0);
         const transform = formatColumnReorderTransform(shift);
         const stableShift = isDragged ? null : shift;
+        const wasShifted = !geometry.appliedDragging && (geometry.appliedShift ?? 0) !== 0;
         if (
           geometry.appliedDragging === isDragged &&
           geometry.appliedShift === stableShift &&
@@ -1273,15 +1324,29 @@ export function DataTable<T>({
         geometry.appliedTransform = transform;
 
         geometry.elements.forEach((element) => {
+          const isSettling = !isDragged && shift === 0 && wasShifted;
+          const isMoved = isDragged || shift !== 0 || isSettling;
           element.style.transform = transform;
-          element.style.transition = isDragged ? "none" : COLUMN_REORDER_SHIFT_TRANSITION;
-          element.style.willChange = "transform";
-          element.style.position = "relative";
-          element.style.zIndex = isDragged ? "80" : shift ? "40" : "";
+          element.style.transition = isDragged
+            ? "none"
+            : shift !== 0 || isSettling
+              ? COLUMN_REORDER_SHIFT_TRANSITION
+              : "";
+          element.style.willChange = isMoved ? "transform" : "";
+          element.style.position = isMoved ? "relative" : "";
+          element.style.zIndex = isDragged ? "90" : shift || isSettling ? "45" : "";
           element.style.pointerEvents = isDragged ? "none" : "";
-          element.style.opacity = isDragged ? "0.96" : "";
-          element.style.filter = isDragged ? "brightness(1.02)" : "";
-          element.style.boxShadow = isDragged ? "0 14px 32px -24px rgba(15, 23, 42, 0.7)" : "";
+          element.style.opacity = "";
+          element.style.filter = "";
+          element.style.background = isMoved
+            ? getColumnReorderCellBackground(element, isDragged)
+            : "";
+          element.style.overflow = isMoved ? "hidden" : "";
+          element.style.contain = isMoved ? "paint" : "";
+          element.style.isolation = isMoved ? "isolate" : "";
+          element.style.boxShadow = isDragged
+            ? "inset 2px 0 0 rgba(37, 99, 235, 0.42), inset -2px 0 0 rgba(14, 165, 233, 0.28), 0 10px 26px -22px rgba(15, 23, 42, 0.65)"
+            : "";
 
           if (isDragged) {
             element.setAttribute("data-vt-column-dragging-cell", "true");
@@ -1292,6 +1357,10 @@ export function DataTable<T>({
           } else {
             element.removeAttribute("data-vt-column-dragging-cell");
             element.removeAttribute("data-vt-column-shifted-cell");
+          }
+
+          if (isSettling) {
+            scheduleColumnReorderSettleCleanup(element);
           }
         });
       });
@@ -1887,9 +1956,9 @@ export function DataTable<T>({
                         headerCellsRef.current[col.key] = node;
                       }}
                       style={resolveColumnStyle(col)}
-                      className={`group/column relative z-50 px-4 py-3 whitespace-nowrap ${headerChromeClass} ${headerCornerClass} ${col.width ?? ""} ${col.headerClassName ?? ""} ${
+                      className={`group/column relative z-50 overflow-hidden px-4 py-3 whitespace-nowrap ${headerChromeClass} ${headerCornerClass} ${col.width ?? ""} ${col.headerClassName ?? ""} ${
                         activeReorderColumnKey === col.key
-                          ? "cursor-grabbing bg-white/70 dark:bg-neutral-800/90"
+                          ? "cursor-grabbing bg-slate-100 text-slate-700 shadow-[inset_2px_0_0_rgba(37,99,235,0.42),inset_-2px_0_0_rgba(14,165,233,0.28)] dark:bg-neutral-800 dark:text-white/80"
                           : ""
                       }`}
                     >
@@ -1897,7 +1966,6 @@ export function DataTable<T>({
                         <button
                           type="button"
                           data-vt-column-reorder-handle
-                          aria-label={t("common.reorder_column", { column: col.label })}
                           className={`absolute left-1 top-1/2 z-10 -translate-y-1/2 inline-flex h-5 w-5 items-center justify-center rounded-md cursor-grab touch-none text-slate-400/55 opacity-0 transition-opacity hover:bg-slate-200/60 hover:text-slate-600 focus-visible:opacity-100 active:cursor-grabbing dark:text-white/30 dark:hover:bg-white/10 dark:hover:text-white/65 ${
                             activeResizeColumnKey !== null
                               ? "pointer-events-none"
@@ -1908,11 +1976,14 @@ export function DataTable<T>({
                           onPointerDown={(event) => handleColumnReorderPointerDown(col, event)}
                         >
                           <GripVertical size={13} aria-hidden="true" />
+                          <span className="sr-only">
+                            {t("common.reorder_column", { column: col.label })}
+                          </span>
                         </button>
                       ) : null}
                       <div
                         data-vt-column-header-content
-                        className={`min-w-0 truncate ${canReorder ? "pl-5" : ""}`}
+                        className={`min-w-0 max-w-full overflow-hidden truncate ${canReorder ? "pl-5" : ""}`}
                       >
                         {col.headerRender ? col.headerRender() : col.label}
                       </div>
@@ -1959,7 +2030,7 @@ export function DataTable<T>({
                         <td
                           key={col.key}
                           data-vt-column-key={col.key}
-                          className={`px-4 py-3 align-middle ${col.cellClassName ?? ""}`}
+                          className={`overflow-hidden px-4 py-3 align-middle ${col.cellClassName ?? ""}`}
                         >
                           <div
                             className={[
@@ -2025,18 +2096,23 @@ export function DataTable<T>({
                               key={col.key}
                               data-vt-column-key={col.key}
                               style={resolveColumnStyle(col)}
-                              className={`px-4 py-2.5 align-middle ${
+                              className={`overflow-hidden px-4 py-2.5 align-middle ${
                                 naturalFlow
                                   ? ""
                                   : "group-hover/row:bg-slate-50 dark:group-hover/row:bg-white/[0.04]"
                               } ${col.cellClassName ?? ""} ${roundCls}`}
                             >
-                              <TableCellOverflowTooltip
-                                tooltipContent={overflowTooltip}
-                                className={col.cellClassName}
+                              <div
+                                data-vt-cell-content-clip
+                                className="min-w-0 max-w-full overflow-hidden"
                               >
-                                {content}
-                              </TableCellOverflowTooltip>
+                                <TableCellOverflowTooltip
+                                  tooltipContent={overflowTooltip}
+                                  className={col.cellClassName}
+                                >
+                                  {content}
+                                </TableCellOverflowTooltip>
+                              </div>
                             </td>
                           );
                         })}

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -1405,6 +1405,15 @@ export function DataTable<T>({
     const maxScrollLeft = Math.max(0, container.scrollWidth - container.clientWidth);
     if (maxScrollLeft <= 0) return;
 
+    const dragOffsetX = getColumnReorderDragOffset(
+      active,
+      active.lastClientX,
+      container.scrollLeft,
+    );
+    active.currentToIndex = findColumnReorderTargetIndex(active, dragOffsetX);
+    const canMoveLeft = active.currentToIndex > active.allowedMinIndex;
+    const canMoveRight = active.currentToIndex < active.allowedMaxIndex;
+
     const leftIntensity = Math.max(
       0,
       Math.min(
@@ -1422,9 +1431,9 @@ export function DataTable<T>({
       ),
     );
     const direction =
-      leftIntensity > 0 && container.scrollLeft > 0
+      canMoveLeft && leftIntensity > 0 && container.scrollLeft > 0
         ? -1
-        : rightIntensity > 0 && container.scrollLeft < maxScrollLeft
+        : canMoveRight && rightIntensity > 0 && container.scrollLeft < maxScrollLeft
           ? 1
           : 0;
 


### PR DESCRIPTION
## Summary
- keep dragged and shifted table columns opaque with stronger drag affordance
- clip cell content during reorder and preserve settling styles while columns animate back
- remove hover tooltip attributes from column reorder handles and cover visual regressions in e2e

## Tests
- rtk ./node_modules/.bin/oxlint packages/ui/src/data-table/DataTable.tsx e2e/request-logs-column-reorder.spec.ts
- rtk bun run build
- rtk bun run e2e e2e/request-logs-column-reorder.spec.ts
- rtk node /tmp/datatable-reorder-qa.mjs