### PR TITLE
fix: refresh request logs after clearing filters

### DIFF
--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -390,11 +390,19 @@ export function SearchableCheckboxMultiSelect({
     (event: React.MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
-      onClear?.();
+      if (onClear) {
+        if (manualApply) {
+          setDraftExplicitValue([]);
+          setDraftEmptyMeansAllSelected(emptyValueMeansAllSelected);
+        }
+        onClear();
+        closeDropdown(false);
+        return;
+      }
       updateSelection([]);
       setQuery("");
     },
-    [onClear, updateSelection],
+    [closeDropdown, emptyValueMeansAllSelected, manualApply, onClear, updateSelection],
   );
 
   return (

--- a/pages/request-logs/RequestLogsFilters.tsx
+++ b/pages/request-logs/RequestLogsFilters.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { RotateCcw } from "lucide-react";
 import { SearchableCheckboxMultiSelect } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
@@ -21,6 +21,10 @@ interface RequestLogsFiltersProps {
   onModelsChange: (value: string[]) => void;
   onChannelsChange: (value: string[]) => void;
   onStatusesChange: (value: StatusFilterValue[]) => void;
+  onApiKeysClear: () => void;
+  onModelsClear: () => void;
+  onChannelsClear: () => void;
+  onStatusesClear: () => void;
   onResetFilters: () => void;
   hasActiveFilters: boolean;
 }
@@ -38,6 +42,10 @@ export function RequestLogsFilters({
   onModelsChange,
   onChannelsChange,
   onStatusesChange,
+  onApiKeysClear,
+  onModelsClear,
+  onChannelsClear,
+  onStatusesClear,
   onResetFilters,
   hasActiveFilters,
 }: RequestLogsFiltersProps) {
@@ -47,6 +55,9 @@ export function RequestLogsFilters({
     () => (value: string[]) => onStatusesChange(value as StatusFilterValue[]),
     [onStatusesChange],
   );
+  const statusClearAdapter = useCallback(() => {
+    onStatusesClear();
+  }, [onStatusesClear]);
 
   return (
     <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800/60">
@@ -64,6 +75,7 @@ export function RequestLogsFilters({
             noResultsLabel={t("request_logs.no_filter_results")}
             aria-label={t("request_logs.filter_key")}
             clearLabel={t("request_logs.clear_key_filter")}
+            onClear={onApiKeysClear}
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
@@ -90,6 +102,7 @@ export function RequestLogsFilters({
             noResultsLabel={t("request_logs.no_filter_results")}
             aria-label={t("request_logs.filter_model")}
             clearLabel={t("request_logs.clear_model_filter")}
+            onClear={onModelsClear}
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
@@ -116,6 +129,7 @@ export function RequestLogsFilters({
             noResultsLabel={t("request_logs.no_filter_results")}
             aria-label={t("request_logs.filter_channel")}
             clearLabel={t("request_logs.clear_channel_filter")}
+            onClear={onChannelsClear}
             showClearButton
             size="sm"
             emptyValueMeansAllSelected
@@ -142,6 +156,7 @@ export function RequestLogsFilters({
             noResultsLabel={t("request_logs.no_filter_results")}
             aria-label={t("request_logs.filter_status")}
             clearLabel={t("request_logs.clear_status_filter")}
+            onClear={statusClearAdapter}
             showClearButton
             size="sm"
             emptyValueMeansAllSelected

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -267,6 +267,22 @@ export function RequestLogsPage() {
     setSelectedStatuses(null);
   }, []);
 
+  const clearApiKeyFilter = useCallback(() => {
+    setSelectedApiKeys(null);
+  }, []);
+
+  const clearModelFilter = useCallback(() => {
+    setSelectedModels(null);
+  }, []);
+
+  const clearChannelFilter = useCallback(() => {
+    setSelectedChannels(null);
+  }, []);
+
+  const clearStatusFilter = useCallback(() => {
+    setSelectedStatuses(null);
+  }, []);
+
   // Fetch logs from backend (server-side pagination)
   const fetchLogs = useCallback(
     async (page: number, size: number) => {
@@ -523,6 +539,10 @@ export function RequestLogsPage() {
           onModelsChange={handleModelsChange}
           onChannelsChange={handleChannelsChange}
           onStatusesChange={handleStatusesChange}
+          onApiKeysClear={clearApiKeyFilter}
+          onModelsClear={clearModelFilter}
+          onChannelsClear={clearChannelFilter}
+          onStatusesClear={clearStatusFilter}
           onResetFilters={resetFilters}
           hasActiveFilters={hasActiveFilters}
         />

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -5,6 +5,7 @@ import i18n from "@code-proxy/i18n";
 import { RequestLogsPage } from "@pages/request-logs/RequestLogsPage";
 import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
+import type { UsageLogItem } from "@code-proxy/api-client/endpoints/usage";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -56,6 +57,40 @@ const responseWithFilterOptions = {
     total_cost: 0,
   },
 };
+
+const buildUsageLogItem = (overrides: Partial<UsageLogItem> = {}): UsageLogItem => ({
+  id: 1,
+  timestamp: "2026-04-08T12:00:00Z",
+  api_key: "sk-test-123456",
+  api_key_name: "Primary",
+  model: "gpt-5.4",
+  source: "codex",
+  channel_name: "Codex",
+  auth_index: "auth-1",
+  failed: false,
+  latency_ms: 1200,
+  first_token_ms: 183,
+  input_tokens: 10,
+  output_tokens: 20,
+  reasoning_tokens: 0,
+  cached_tokens: 0,
+  total_tokens: 30,
+  cost: 0.0123,
+  has_content: false,
+  ...overrides,
+});
+
+const responseWithRows = (items: UsageLogItem[]) => ({
+  ...responseWithFilterOptions,
+  items,
+  total: items.length,
+  stats: {
+    ...responseWithFilterOptions.stats,
+    total: items.length,
+    success_rate: 100,
+    total_tokens: items.reduce((sum, item) => sum + item.total_tokens, 0),
+  },
+});
 
 const mocks = vi.hoisted(() => ({
   getUsageLogs: vi.fn(),
@@ -364,6 +399,73 @@ describe("RequestLogsPage", () => {
         }),
       ),
     );
+  });
+
+  test("clears a request-log filter from the trigger and refreshes table data", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs
+      .mockResolvedValueOnce(
+        responseWithRows([
+          buildUsageLogItem({ id: 1, model: "gpt-5.4" }),
+          buildUsageLogItem({ id: 2, model: "gpt-4.1" }),
+        ]),
+      )
+      .mockResolvedValueOnce(
+        responseWithRows([buildUsageLogItem({ id: 3, model: "gpt-5.4" })]),
+      )
+      .mockResolvedValueOnce(
+        responseWithRows([buildUsageLogItem({ id: 4, model: "gpt-4.1" })]),
+      );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const [, modelFilter] = await screen.findAllByRole("combobox");
+
+    await user.click(modelFilter);
+    await user.click(await screen.findByRole("option", { name: "gpt-4.1" }));
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          models: ["gpt-5.4"],
+          models_empty: false,
+        }),
+      ),
+    );
+    expect(screen.getByRole("combobox", { name: "Filter by model" })).toHaveTextContent(
+      "gpt-5.4",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Clear model filter" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          models: undefined,
+          models_empty: false,
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Clear model filter" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("combobox", { name: "Filter by model" })).toHaveTextContent(
+      "All Models",
+    );
+    expect(await screen.findByText("gpt-4.1")).toBeInTheDocument();
   });
 
   test("keeps the filtered-results bulk action hidden until the user actually searches", async () => {


### PR DESCRIPTION
## Summary
- make request-log filter clear buttons commit the cleared state in manual apply mode
- reset individual request-log filters back to the all-selected state so the table refreshes
- add regression coverage for clearing a model filter from the trigger

## Verification
- bun run --filter @code-proxy/admin-panel test -- RequestLogsPage.test.tsx
- bun run --filter @code-proxy/admin-panel build
- bun run lint (passes with existing updateShared.ts no-useless-escape warning)
- Browser smoke test with mocked management API: clear model filter button disappears and request log rows refresh