### PR TITLE
fix: keep dragged table edges straight

### DIFF
--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -120,6 +120,10 @@ const readDragVisualState = async (page: Page) =>
           boxShadow: style.boxShadow,
           inlineBackground: element.style.background,
           isOpaque: isOpaque(style, element.style.background),
+          borderTopLeftRadius: style.borderTopLeftRadius,
+          borderTopRightRadius: style.borderTopRightRadius,
+          borderBottomLeftRadius: style.borderBottomLeftRadius,
+          borderBottomRightRadius: style.borderBottomRightRadius,
           opacity: style.opacity,
           overflowX: style.overflowX,
           overflowY: style.overflowY,
@@ -157,7 +161,8 @@ const readDragVisualState = async (page: Page) =>
           element.style.background === "" &&
           element.style.overflow === "" &&
           element.style.contain === "" &&
-          element.style.isolation === "",
+          element.style.isolation === "" &&
+          element.style.borderRadius === "",
       ),
     };
   });
@@ -208,6 +213,10 @@ test("Request Logs: column reorder follows the pointer and auto-scrolls horizont
         style.overflowX === "hidden" &&
         style.overflowY === "hidden" &&
         style.isOpaque &&
+        style.borderTopLeftRadius === "0px" &&
+        style.borderTopRightRadius === "0px" &&
+        style.borderBottomLeftRadius === "0px" &&
+        style.borderBottomRightRadius === "0px" &&
         style.backgroundImage.includes("gradient") &&
         style.boxShadow !== "none" &&
         Number(style.zIndex) >= 90,
@@ -220,6 +229,10 @@ test("Request Logs: column reorder follows the pointer and auto-scrolls horizont
         style.overflowX === "hidden" &&
         style.overflowY === "hidden" &&
         style.isOpaque &&
+        style.borderTopLeftRadius === "0px" &&
+        style.borderTopRightRadius === "0px" &&
+        style.borderBottomLeftRadius === "0px" &&
+        style.borderBottomRightRadius === "0px" &&
         Number(style.zIndex) >= 45,
     ),
   ).toBe(true);
@@ -283,4 +296,67 @@ test("Request Logs: last column does not auto-scroll past the right reorder boun
   const after = await readTableState(page);
   expect(after.draggingCells).toBe(0);
   expect(after.order.at(-1)).toBe("model");
+});
+
+test("Request Logs: first column drag keeps a straight left edge", async ({ page }) => {
+  await setAuthed(page);
+  await mockRequestLogsApis(page);
+
+  await page.goto("/manage/#/monitor/request-logs");
+  await page.locator('th[data-vt-column-key="id"]').waitFor({ state: "visible" });
+
+  const dragStart = await page
+    .locator('th[data-vt-column-key="id"] [data-vt-column-reorder-handle]')
+    .evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    });
+
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.waitForTimeout(130);
+  await page.mouse.move(dragStart.x + 260, dragStart.y, { steps: 10 });
+  await page.waitForTimeout(120);
+
+  const visualDuringDrag = await readDragVisualState(page);
+  expect(visualDuringDrag.dragging.length).toBeGreaterThan(0);
+  expect(
+    visualDuringDrag.dragging.every(
+      (style) => style.borderTopLeftRadius === "0px" && style.borderBottomLeftRadius === "0px",
+    ),
+  ).toBe(true);
+
+  await page.mouse.up();
+});
+
+test("Request Logs: last column drag keeps a straight right edge", async ({ page }) => {
+  await setAuthed(page);
+  await mockRequestLogsApis(page);
+
+  await page.goto("/manage/#/monitor/request-logs");
+  await page.locator('th[data-vt-column-key="model"]').waitFor({ state: "visible" });
+  await scrollTableNearRightEdge(page);
+
+  const dragStart = await page
+    .locator('th[data-vt-column-key="model"] [data-vt-column-reorder-handle]')
+    .evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    });
+
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.waitForTimeout(130);
+  await page.mouse.move(dragStart.x - 260, dragStart.y, { steps: 10 });
+  await page.waitForTimeout(120);
+
+  const visualDuringDrag = await readDragVisualState(page);
+  expect(visualDuringDrag.dragging.length).toBeGreaterThan(0);
+  expect(
+    visualDuringDrag.dragging.every(
+      (style) => style.borderTopRightRadius === "0px" && style.borderBottomRightRadius === "0px",
+    ),
+  ).toBe(true);
+
+  await page.mouse.up();
 });

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -522,6 +522,7 @@ function scheduleColumnReorderSettleCleanup(element: HTMLElement) {
     element.style.overflow = "";
     element.style.contain = "";
     element.style.isolation = "";
+    element.style.borderRadius = "";
   }, COLUMN_REORDER_SETTLE_CLEANUP_MS);
 }
 
@@ -1298,6 +1299,7 @@ export function DataTable<T>({
         element.style.overflow = "";
         element.style.contain = "";
         element.style.isolation = "";
+        element.style.borderRadius = "";
         element.removeAttribute("data-vt-column-dragging-cell");
         element.removeAttribute("data-vt-column-shifted-cell");
       });
@@ -1344,6 +1346,7 @@ export function DataTable<T>({
           element.style.overflow = isMoved ? "hidden" : "";
           element.style.contain = isMoved ? "paint" : "";
           element.style.isolation = isMoved ? "isolate" : "";
+          element.style.borderRadius = isMoved ? "0" : "";
           element.style.boxShadow = isDragged
             ? "inset 2px 0 0 rgba(37, 99, 235, 0.42), inset -2px 0 0 rgba(14, 165, 233, 0.28), 0 10px 26px -22px rgba(15, 23, 42, 0.65)"
             : "";


### PR DESCRIPTION
## Summary
- flatten temporary border radius while table columns are dragged or shifted
- clear the temporary radius after reorder settles
- add left-edge and right-edge drag regression coverage for request logs columns

## Tests
- rtk ./node_modules/.bin/oxlint packages/ui/src/data-table/DataTable.tsx e2e/request-logs-column-reorder.spec.ts
- rtk bun run build
- rtk bun run e2e e2e/request-logs-column-reorder.spec.ts
- rtk node /tmp/datatable-drag-edge-radius-qa.mjs