### PR TITLE
fix: render log paths without pill badges

### DIFF
--- a/pages/logs/__tests__/LogsPage.test.tsx
+++ b/pages/logs/__tests__/LogsPage.test.tsx
@@ -77,4 +77,26 @@ describe("LogsPage", () => {
     expect(await screen.findByText("暂无错误日志")).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchErrorLogs).toHaveBeenCalledTimes(1));
   });
+
+  test("renders long request paths without a full-pill badge", async () => {
+    await i18n.changeLanguage("zh-CN");
+
+    const longPath =
+      "/v0/management/usage/entity-stats?days=30&auth_index=c354956ed44cc510&source=t%3Aantigravity-yuan364299311%40gmail.com.json";
+    mocks.fetchLogs.mockResolvedValue({
+      lines: [
+        `2026-06-14 09:25:21 [INFO] [gin_logger.go:96] 200 | 288ms | 36.159.232.171 | GET "${longPath}"`,
+      ],
+      "latest-timestamp": null,
+    });
+
+    renderLogsPage();
+
+    const path = await screen.findByText(longPath);
+    const pathContainer = path.closest("code");
+
+    expect(pathContainer).toBeInTheDocument();
+    expect(pathContainer).toHaveClass("rounded-md");
+    expect(pathContainer).not.toHaveClass("rounded-full");
+  });
 });

--- a/pages/logs/components/LiveLogsTab.tsx
+++ b/pages/logs/components/LiveLogsTab.tsx
@@ -20,6 +20,14 @@ function Badge({ children, className }: { children: React.ReactNode; className: 
   );
 }
 
+function RequestPath({ children }: { children: string }) {
+  return (
+    <code className="inline-block max-w-full rounded-md border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-[11px] font-medium leading-relaxed text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70">
+      <span className="break-all">{children}</span>
+    </code>
+  );
+}
+
 export function LiveLogsTab({
   t,
   loading,
@@ -267,11 +275,7 @@ export function LiveLogsTab({
                                 {line.method}
                               </Badge>
                             ) : null}
-                            {line.path ? (
-                              <Badge className="border-slate-200 bg-white font-mono text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/70">
-                                <span className="break-all">{line.path}</span>
-                              </Badge>
-                            ) : null}
+                            {line.path ? <RequestPath>{line.path}</RequestPath> : null}
                           </div>
                           <div className="mt-1 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-slate-900 dark:text-slate-100">
                             {line.message}


### PR DESCRIPTION
## Summary
- render parsed log request paths as compact code snippets instead of full-pill badges
- add a regression test covering long management log URLs

## Verification
- bun run --filter @code-proxy/admin-panel test -- pages/logs/__tests__/LogsPage.test.tsx
- bun run lint (passes with existing no-useless-escape warning in apps/admin-panel/src/app/update/updateShared.ts)
- bun run build
- Browser mock QA on /manage/#/logs with long /v0/management/usage/entity-stats URL