### PR TITLE
fix: sync CC Switch channel group models

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -68,6 +68,22 @@ const rolePriority: Record<CcSwitchClaudeModelRole, string[]> = {
 };
 
 type ConfigDraft = CcSwitchImportConfigListItem;
+type ModelMetadataLike = {
+  id: string;
+  owned_by?: string;
+  source?: string;
+};
+
+const GENERIC_MODEL_CONFIG_OWNER_KEYS = new Set([
+  "all",
+  "default",
+  "openai",
+  "openai-api",
+  "openai-compat",
+  "openai-compatible",
+  "provider",
+  "registry",
+]);
 
 const normalizeRoutePath = (path: string | undefined): string => {
   const trimmed = String(path ?? "").trim();
@@ -112,6 +128,18 @@ const normalizeModelOwnerKey = (value: unknown): string =>
     .trim()
     .replace(/\s+/g, "-")
     .toLowerCase();
+
+const isSpecificModelConfigOwnerKey = (value: string): boolean => {
+  const key = normalizeModelOwnerKey(value);
+  return Boolean(key && !GENERIC_MODEL_CONFIG_OWNER_KEYS.has(key));
+};
+
+const modelMetadataMatchesOwnerKeys = (
+  model: ModelMetadataLike,
+  ownerKeys: ReadonlySet<string>,
+): boolean =>
+  ownerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
+  ownerKeys.has(normalizeModelOwnerKey(model.source));
 
 function pickClaudeRoleModel(role: CcSwitchClaudeModelRole, models: readonly string[]): string {
   const normalized = dedupeModels(models);
@@ -369,8 +397,9 @@ export function CcSwitchImportConfigModal({
           if (!optionMap.has(key)) optionMap.set(key, normalized);
         };
         const needsModelConfigs = authoritativeModelOwnerKeys.size > 0 || modelOwnerKeys.size > 0;
+        let modelConfigs: ModelMetadataLike[] = [];
         if (needsModelConfigs) {
-          const modelConfigs =
+          modelConfigs =
             availability.metadataItems && availability.metadataItems.length > 0
               ? availability.metadataItems
               : await modelsApi.getModelConfigs("active").catch(() => []);
@@ -378,11 +407,7 @@ export function CcSwitchImportConfigModal({
           if (modelOwnerKeys.size > 0 && authoritativeModelOwnerKeys.size === 0) {
             const allowedModelIds = new Set(
               modelConfigs
-                .filter(
-                  (model) =>
-                    modelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
-                    modelOwnerKeys.has(normalizeModelOwnerKey(model.source)),
-                )
+                .filter((model) => modelMetadataMatchesOwnerKeys(model, modelOwnerKeys))
                 .map((model) => model.id.toLowerCase()),
             );
             if (allowedModelIds.size > 0) {
@@ -393,11 +418,19 @@ export function CcSwitchImportConfigModal({
           }
           if (authoritativeModelOwnerKeys.size > 0) {
             for (const model of modelConfigs) {
-              if (
-                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
-                authoritativeModelOwnerKeys.has(normalizeModelOwnerKey(model.source))
-              ) {
+              if (modelMetadataMatchesOwnerKeys(model, authoritativeModelOwnerKeys)) {
                 addModelId(model.id);
+              }
+            }
+          } else if (modelOwnerKeys.size > 0) {
+            const expandableOwnerKeys = new Set(
+              Array.from(modelOwnerKeys).filter(isSpecificModelConfigOwnerKey),
+            );
+            if (expandableOwnerKeys.size > 0) {
+              for (const model of modelConfigs) {
+                if (modelMetadataMatchesOwnerKeys(model, expandableOwnerKeys)) {
+                  addModelId(model.id);
+                }
               }
             }
           }

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -49,11 +49,17 @@ const normalizeModelOwnerKey = (value: string): string =>
 
 const getChannelGroupModelOwnerKeys = (
   details: readonly ChannelGroupChannelDetail[] | undefined,
+  channels: readonly string[] | undefined,
 ): string[] => {
   const keys = new Set<string>();
+  for (const channel of channels ?? []) {
+    const key = normalizeModelOwnerKey(String(channel ?? ""));
+    if (key) keys.add(key);
+  }
   for (const detail of details ?? []) {
     const values = [
       detail.source,
+      detail.name,
       ...(detail.default_tags ?? []),
       ...(detail.custom_tags ?? []),
       ...(detail.display_tags ?? []),
@@ -68,9 +74,15 @@ const getChannelGroupModelOwnerKeys = (
 
 const getChannelGroupMappedModelOwnerKeys = (
   details: readonly ChannelGroupChannelDetail[] | undefined,
+  channels: readonly string[] | undefined,
   ownerByAuthGroup: Record<string, string>,
 ): string[] => {
   const keys = new Set<string>();
+  for (const channel of channels ?? []) {
+    const authGroup = normalizeProviderKey(String(channel ?? ""));
+    const owner = normalizeModelOwnerKey(ownerByAuthGroup[authGroup] ?? "");
+    if (owner) keys.add(owner);
+  }
   for (const detail of details ?? []) {
     const values = [
       detail.source,
@@ -126,9 +138,10 @@ export function CcSwitchImportSettingsPage() {
               routePath: Array.isArray(item["path-routes"]) ? item["path-routes"][0] : "",
               allowedModels: Array.isArray(item["allowed-models"]) ? item["allowed-models"] : [],
               channels: Array.isArray(item.channels) ? item.channels : [],
-              modelOwnerKeys: getChannelGroupModelOwnerKeys(item.channelDetails),
+              modelOwnerKeys: getChannelGroupModelOwnerKeys(item.channelDetails, item.channels),
               authoritativeModelOwnerKeys: getChannelGroupMappedModelOwnerKeys(
                 item.channelDetails,
+                item.channels,
                 ownerMappings,
               ),
             }))

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -409,6 +409,64 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(getModelConfigs).toHaveBeenCalledWith("active");
   });
 
+  test("hydrates fallback channel group models from configured metadata owner keys", async () => {
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "kimi+deepseek v4 flash",
+        description: "Kimi and DeepSeek route",
+        channels: ["kimi-code", "opencode"],
+        channelDetails: [
+          {
+            name: "kimi-code",
+            source: "openai",
+            default_tags: ["openai"],
+            custom_tags: ["kimi-code"],
+            display_tags: ["kimi-code"],
+          },
+          {
+            name: "opencode",
+            source: "opencode-go",
+            default_tags: ["opencode-go"],
+            custom_tags: ["opencode"],
+            display_tags: ["opencode"],
+          },
+        ],
+        "path-routes": ["/deepseekkimi"],
+      },
+    ]);
+    listAvailableModels.mockResolvedValue([]);
+    loadConfiguredModelAvailability.mockResolvedValue({
+      scoped: true,
+      items: [],
+      metadataItems: [
+        { id: "deepseek-v4-flash", owned_by: "opencode", source: "seed" },
+        { id: "kimi-k2.7", owned_by: "kimi-code", source: "seed" },
+        { id: "qwen3.5-plus", owned_by: "opencode", source: "seed" },
+        { id: "unrelated-openai", owned_by: "openai", source: "seed" },
+      ],
+      idSet: new Set<string>(),
+    });
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /new config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /new cc switch config/i });
+    await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
+    await user.click(
+      await screen.findByRole("option", { name: /kimi\+deepseek v4 flash.*\/deepseekkimi/i }),
+    );
+
+    expect(await within(dialog).findByDisplayValue("deepseek-v4-flash")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("kimi-k2.7")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("qwen3.5-plus")).toBeInTheDocument();
+    expect(within(dialog).queryByDisplayValue("unrelated-openai")).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText(/no models are available for this channel group/i),
+    ).not.toBeInTheDocument();
+    expect(getModelConfigs).not.toHaveBeenCalled();
+  });
+
   test("merges mapped Codex owner models with OpenCode Go channel models in CC Switch presets", async () => {
     getAuthGroupModelOwnerMappingMap.mockResolvedValue({ codex: "codex" });
     listChannelGroups.mockResolvedValue([


### PR DESCRIPTION
## Summary
- include channel names/details as CC Switch model owner hints
- hydrate CC Switch model mappings from configured metadata when group allowed-models is implicit all
- add regression coverage for kimi+deepseek/opencode mixed channel groups

## Verification
- bun run --filter @code-proxy/admin-panel test -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- bun run --filter @code-proxy/admin-panel build
- bun run lint (existing warning in apps/admin-panel/src/app/update/updateShared.ts)
- git diff --check