### PR TITLE
fix: include configured owner models in ccswitch options

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -72,6 +72,7 @@ type ModelMetadataLike = {
   id: string;
   owned_by?: string;
   source?: string;
+  enabled?: boolean;
 };
 
 const GENERIC_MODEL_CONFIG_OWNER_KEYS = new Set([
@@ -138,8 +139,9 @@ const modelMetadataMatchesOwnerKeys = (
   model: ModelMetadataLike,
   ownerKeys: ReadonlySet<string>,
 ): boolean =>
-  ownerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
-  ownerKeys.has(normalizeModelOwnerKey(model.source));
+  model.enabled !== false &&
+  (ownerKeys.has(normalizeModelOwnerKey(model.owned_by)) ||
+    ownerKeys.has(normalizeModelOwnerKey(model.source)));
 
 function pickClaudeRoleModel(role: CcSwitchClaudeModelRole, models: readonly string[]): string {
   const normalized = dedupeModels(models);
@@ -402,7 +404,7 @@ export function CcSwitchImportConfigModal({
           modelConfigs =
             availability.metadataItems && availability.metadataItems.length > 0
               ? availability.metadataItems
-              : await modelsApi.getModelConfigs("active").catch(() => []);
+              : await modelsApi.getModelConfigs("all").catch(() => []);
           if (cancelled) return;
           if (modelOwnerKeys.size > 0 && authoritativeModelOwnerKeys.size === 0) {
             const allowedModelIds = new Set(

--- a/packages/api-client/src/endpoints/models.ts
+++ b/packages/api-client/src/endpoints/models.ts
@@ -5,7 +5,7 @@ const DEFAULT_CLAUDE_BASE_URL = "https://api.anthropic.com";
 const DEFAULT_ANTHROPIC_VERSION = "2023-06-01";
 const CLAUDE_MODELS_IN_FLIGHT = new Map<string, Promise<ModelInfo[]>>();
 
-export type ModelConfigScope = "active" | "library";
+export type ModelConfigScope = "active" | "library" | "all";
 
 export type ModelInfo = {
   id: string;

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -45,7 +45,7 @@ vi.mock("@code-proxy/api-client/endpoints/models", () => ({
       allowedChannelGroups?: string[];
       allowedChannels?: string[];
     }) => listAvailableModels(params),
-    getModelConfigs: (scope: "active" | "library") => getModelConfigs(scope),
+    getModelConfigs: (scope: "active" | "library" | "all") => getModelConfigs(scope),
     getAuthGroupModelOwnerMappingMap: () => getAuthGroupModelOwnerMappingMap(),
   },
 }));
@@ -406,7 +406,7 @@ describe("CcSwitchImportSettingsPage", () => {
       allowedChannelGroups: ["chatgpt-pro"],
     });
     expect(loadConfiguredModelAvailability).toHaveBeenCalledTimes(1);
-    expect(getModelConfigs).toHaveBeenCalledWith("active");
+    expect(getModelConfigs).toHaveBeenCalledWith("all");
   });
 
   test("hydrates fallback channel group models from configured metadata owner keys", async () => {
@@ -560,6 +560,8 @@ describe("CcSwitchImportSettingsPage", () => {
     getModelConfigs.mockResolvedValue([
       { id: "kimi-k2.5", owned_by: "kimi-code" },
       { id: "kimi-k2.6", owned_by: "kimi-code" },
+      { id: "kimi-k2.7", owned_by: "kimi-code" },
+      { id: "kimi-k2.7-code", owned_by: "kimi-code" },
       { id: "kimi-k2", owned_by: "moonshot" },
     ]);
     renderPage();
@@ -576,11 +578,13 @@ describe("CcSwitchImportSettingsPage", () => {
     await user.click(within(dialog).getByRole("combobox", { name: /^main model$/i }));
 
     expect(await screen.findByRole("option", { name: "kimi-k2.6" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "kimi-k2.7" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "kimi-k2.7-code" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "kimi-k2" })).not.toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
       allowedChannelGroups: ["kimicode"],
     });
-    expect(getModelConfigs).toHaveBeenCalledWith("active");
+    expect(getModelConfigs).toHaveBeenCalledWith("all");
   });
 
   test("preserves saved generic model mappings when reopening an edited config", async () => {


### PR DESCRIPTION
## Summary
- include all configured owner-mapped model rows when building CC Switch channel-group model options
- keep disabled configured models out of the dropdown
- cover Kimi owner-mapped models such as kimi-k2.7 and kimi-k2.7-code in CC Switch tests

## Tests
- bun run --filter @code-proxy/admin-panel test -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- bun run --filter @code-proxy/admin-panel build