### PR TITLE
fix: use scoped backend availability for ccswitch models

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -399,13 +399,11 @@ export function CcSwitchImportConfigModal({
           if (!optionMap.has(key)) optionMap.set(key, normalized);
         };
         const needsModelConfigs = authoritativeModelOwnerKeys.size > 0 || modelOwnerKeys.size > 0;
-        let modelConfigs: ModelMetadataLike[] = [];
         if (needsModelConfigs) {
-          modelConfigs =
-            availability.metadataItems && availability.metadataItems.length > 0
-              ? availability.metadataItems
-              : await modelsApi.getModelConfigs("all").catch(() => []);
-          if (cancelled) return;
+          const modelConfigs: ModelMetadataLike[] = [
+            ...(availability.metadataItems ?? []),
+            ...availability.items,
+          ];
           if (modelOwnerKeys.size > 0 && authoritativeModelOwnerKeys.size === 0) {
             const allowedModelIds = new Set(
               modelConfigs

--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -759,15 +759,11 @@ export { invalidateConfiguredModelAvailability };
 export const loadConfiguredModelAvailability = async (options?: {
   allowedChannelGroups?: string[];
 }): Promise<ConfiguredModelAvailability> => {
-  const ownerByAuthGroup = await loadAuthGroupOwnerMappingMap();
-  const hasOwnerMappings = Object.keys(ownerByAuthGroup).length > 0;
   const validGroups = (options?.allowedChannelGroups ?? [])
     .map((g) => String(g ?? "").trim())
     .filter(Boolean);
-
-  if (hasOwnerMappings) {
-    return loadConfiguredModelAvailabilityFallback(ownerByAuthGroup);
-  }
+  const loadFallback = async () =>
+    loadConfiguredModelAvailabilityFallback(await loadAuthGroupOwnerMappingMap());
 
   if (validGroups.length > 0) {
     const cacheKey = validGroups.join(",");
@@ -791,7 +787,7 @@ export const loadConfiguredModelAvailability = async (options?: {
         });
         return result;
       } catch {
-        return loadConfiguredModelAvailabilityFallback(ownerByAuthGroup);
+        return loadFallback();
       }
     })();
     groupAvailabilityCache.set(cacheKey, {
@@ -828,7 +824,7 @@ export const loadConfiguredModelAvailability = async (options?: {
       return result;
     } catch {
       // Fallback to old multi-API aggregation for backward compatibility.
-      return loadConfiguredModelAvailabilityFallback(ownerByAuthGroup);
+      return loadFallback();
     }
   })();
   configuredAvailabilityInFlight = { version: cacheVersion, promise };

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -51,7 +51,8 @@ vi.mock("@code-proxy/api-client/endpoints/models", () => ({
 }));
 
 vi.mock("@features/model-availability", () => ({
-  loadConfiguredModelAvailability: () => loadConfiguredModelAvailability(),
+  loadConfiguredModelAvailability: (options?: { allowedChannelGroups?: string[] }) =>
+    loadConfiguredModelAvailability(options),
   filterByConfiguredModelAvailability: <T extends { id: string }>(
     models: T[],
     availability: { scoped: boolean; idSet: Set<string> },
@@ -372,7 +373,13 @@ describe("CcSwitchImportSettingsPage", () => {
     ]);
     loadConfiguredModelAvailability.mockResolvedValue({
       scoped: true,
-      items: [],
+      items: [
+        { id: "gpt-5", owned_by: "openai" },
+        { id: "gpt-5-codex", owned_by: "openai" },
+        { id: "gpt-5.3-codex", owned_by: "codex" },
+        { id: "gpt-5.5", owned_by: "codex" },
+        { id: "gpt-image-2", owned_by: "openai" },
+      ],
       idSet: new Set([
         "codex-auto-review",
         "gpt-5",
@@ -384,13 +391,6 @@ describe("CcSwitchImportSettingsPage", () => {
         "gpt-image-2",
       ]),
     });
-    getModelConfigs.mockResolvedValue([
-      { id: "gpt-5", owned_by: "openai" },
-      { id: "gpt-5-codex", owned_by: "openai" },
-      { id: "gpt-5.3-codex", owned_by: "codex" },
-      { id: "gpt-5.5", owned_by: "codex" },
-      { id: "gpt-image-2", owned_by: "openai" },
-    ]);
     renderPage();
     const user = userEvent.setup();
 
@@ -405,11 +405,14 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(listAvailableModels).toHaveBeenCalledWith({
       allowedChannelGroups: ["chatgpt-pro"],
     });
-    expect(loadConfiguredModelAvailability).toHaveBeenCalledTimes(1);
-    expect(getModelConfigs).toHaveBeenCalledWith("all");
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith({
+      allowedChannelGroups: ["chatgpt-pro"],
+    });
+    expect(getModelConfigs).not.toHaveBeenCalled();
   });
 
-  test("hydrates fallback channel group models from configured metadata owner keys", async () => {
+  test("hydrates the Kimi and DeepSeek channel group from scoped backend availability", async () => {
+    getAuthGroupModelOwnerMappingMap.mockResolvedValue({ kimi: "kimi-code" });
     listChannelGroups.mockResolvedValue([
       {
         name: "kimi+deepseek v4 flash",
@@ -434,17 +437,31 @@ describe("CcSwitchImportSettingsPage", () => {
         "path-routes": ["/deepseekkimi"],
       },
     ]);
-    listAvailableModels.mockResolvedValue([]);
+    listAvailableModels.mockResolvedValue([
+      { id: "deepseek-v4-flash" },
+      { id: "kimi-k2.5" },
+      { id: "kimi-k2.6" },
+      { id: "qwen3.5-plus" },
+    ]);
     loadConfiguredModelAvailability.mockResolvedValue({
       scoped: true,
-      items: [],
-      metadataItems: [
+      items: [
         { id: "deepseek-v4-flash", owned_by: "opencode", source: "seed" },
+        { id: "kimi-k2.5", owned_by: "kimi-code", source: "seed" },
+        { id: "kimi-k2.6", owned_by: "kimi-code", source: "seed" },
         { id: "kimi-k2.7", owned_by: "kimi-code", source: "seed" },
+        { id: "kimi-k2.7-code", owned_by: "kimi-code", source: "seed" },
         { id: "qwen3.5-plus", owned_by: "opencode", source: "seed" },
         { id: "unrelated-openai", owned_by: "openai", source: "seed" },
       ],
-      idSet: new Set<string>(),
+      idSet: new Set([
+        "deepseek-v4-flash",
+        "kimi-k2.5",
+        "kimi-k2.6",
+        "kimi-k2.7",
+        "kimi-k2.7-code",
+        "qwen3.5-plus",
+      ]),
     });
     renderPage();
     const user = userEvent.setup();
@@ -458,12 +475,18 @@ describe("CcSwitchImportSettingsPage", () => {
     );
 
     expect(await within(dialog).findByDisplayValue("deepseek-v4-flash")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("kimi-k2.5")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("kimi-k2.6")).toBeInTheDocument();
     expect(within(dialog).getByDisplayValue("kimi-k2.7")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("kimi-k2.7-code")).toBeInTheDocument();
     expect(within(dialog).getByDisplayValue("qwen3.5-plus")).toBeInTheDocument();
     expect(within(dialog).queryByDisplayValue("unrelated-openai")).not.toBeInTheDocument();
     expect(
       within(dialog).queryByText(/no models are available for this channel group/i),
     ).not.toBeInTheDocument();
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith({
+      allowedChannelGroups: ["kimi+deepseek v4 flash"],
+    });
     expect(getModelConfigs).not.toHaveBeenCalled();
   });
 
@@ -554,16 +577,14 @@ describe("CcSwitchImportSettingsPage", () => {
     ]);
     loadConfiguredModelAvailability.mockResolvedValue({
       scoped: true,
-      items: [],
+      items: [
+        { id: "kimi-k2.5", owned_by: "kimi-code" },
+        { id: "kimi-k2.6", owned_by: "kimi-code" },
+        { id: "kimi-k2.7", owned_by: "kimi-code" },
+        { id: "kimi-k2.7-code", owned_by: "kimi-code" },
+      ],
       idSet: new Set(["kimi-k2.5", "kimi-k2.6"]),
     });
-    getModelConfigs.mockResolvedValue([
-      { id: "kimi-k2.5", owned_by: "kimi-code" },
-      { id: "kimi-k2.6", owned_by: "kimi-code" },
-      { id: "kimi-k2.7", owned_by: "kimi-code" },
-      { id: "kimi-k2.7-code", owned_by: "kimi-code" },
-      { id: "kimi-k2", owned_by: "moonshot" },
-    ]);
     renderPage();
     const user = userEvent.setup();
 
@@ -584,7 +605,10 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(listAvailableModels).toHaveBeenCalledWith({
       allowedChannelGroups: ["kimicode"],
     });
-    expect(getModelConfigs).toHaveBeenCalledWith("all");
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith({
+      allowedChannelGroups: ["kimicode"],
+    });
+    expect(getModelConfigs).not.toHaveBeenCalled();
   });
 
   test("preserves saved generic model mappings when reopening an edited config", async () => {


### PR DESCRIPTION
## Summary
- stop bypassing backend configured-availability when owner mappings exist
- remove CC Switch modal fallback to /model-configs?scope=all
- cover the kimi+deepseek v4 flash six-model scenario from scoped backend availability

## Tests
- rtk bun run --filter @code-proxy/admin-panel test -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build