### PR TITLE
feat: compact request log metrics

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -1,5 +1,13 @@
 import { useTranslation } from "react-i18next";
 import type { UsageLogItem } from "@code-proxy/api-client/endpoints/usage";
+import {
+  formatUsageMetricCost,
+  formatUsageMetricNumber,
+  formatUsageMetricTooltipCost,
+  formatUsageMetricTooltipNumber,
+  isUsageMetricCompact,
+  type UsageMetricVariant,
+} from "@code-proxy/domain";
 import { parseUsageTimestampMs } from "@features/monitor-widgets/monitor-utils";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
@@ -96,6 +104,37 @@ function RequestLogMetricChip({
     >
       {value}
     </span>
+  );
+}
+
+export function RequestLogUsageMetricValue({
+  value,
+  variant = "number",
+  className,
+}: {
+  value: number;
+  variant?: UsageMetricVariant;
+  className?: string;
+}) {
+  const display =
+    variant === "currency" ? formatUsageMetricCost(value) : formatUsageMetricNumber(value);
+  const tooltip =
+    variant === "currency"
+      ? formatUsageMetricTooltipCost(value)
+      : formatUsageMetricTooltipNumber(value);
+  const compact = isUsageMetricCompact(value, variant);
+
+  return (
+    <HoverTooltip
+      content={tooltip}
+      disabled={!compact}
+      placement="top"
+      className={compact ? "cursor-help" : undefined}
+    >
+      <span className={["block min-w-0 truncate", className].filter(Boolean).join(" ")}>
+        {display}
+      </span>
+    </HoverTooltip>
   );
 }
 
@@ -365,14 +404,13 @@ export function buildRequestLogsColumns(
             className="inline-block ml-auto cursor-pointer rounded px-1.5 py-0.5 transition hover:bg-sky-50 dark:hover:bg-sky-950/30"
             title={t("request_logs.view_input")}
           >
-            <span className="truncate text-sky-600 dark:text-sky-400 underline decoration-sky-300/50 dark:decoration-sky-500/40 underline-offset-2">
-              {row.inputTokens.toLocaleString()}
-            </span>
+            <RequestLogUsageMetricValue
+              value={row.inputTokens}
+              className="text-sky-600 dark:text-sky-400 underline decoration-sky-300/50 dark:decoration-sky-500/40 underline-offset-2"
+            />
           </button>
         ) : (
-          <OverflowTooltip content={row.inputTokens.toLocaleString()} className="block min-w-0">
-            <span className="block min-w-0 truncate">{row.inputTokens.toLocaleString()}</span>
-          </OverflowTooltip>
+          <RequestLogUsageMetricValue value={row.inputTokens} />
         ),
     },
     {
@@ -382,13 +420,14 @@ export function buildRequestLogsColumns(
       headerClassName: "text-center",
       cellClassName: "text-center font-mono text-xs tabular-nums",
       render: (row) => (
-        <OverflowTooltip content={row.cachedTokens.toLocaleString()} className="block min-w-0">
-          <span
-            className={`block min-w-0 truncate ${row.cachedTokens > 0 ? "font-semibold text-amber-600 dark:text-amber-400" : "text-slate-400 dark:text-white/30"}`}
-          >
-            {row.cachedTokens > 0 ? row.cachedTokens.toLocaleString() : "0"}
-          </span>
-        </OverflowTooltip>
+        <RequestLogUsageMetricValue
+          value={row.cachedTokens}
+          className={
+            row.cachedTokens > 0
+              ? "font-semibold text-amber-600 dark:text-amber-400"
+              : "text-slate-400 dark:text-white/30"
+          }
+        />
       ),
     },
     {
@@ -406,14 +445,13 @@ export function buildRequestLogsColumns(
             className="inline-block ml-auto cursor-pointer rounded px-1.5 py-0.5 transition hover:bg-emerald-50 dark:hover:bg-emerald-950/30"
             title={t("request_logs.view_output")}
           >
-            <span className="truncate text-emerald-600 dark:text-emerald-400 underline decoration-emerald-300/50 dark:decoration-emerald-500/40 underline-offset-2">
-              {row.outputTokens.toLocaleString()}
-            </span>
+            <RequestLogUsageMetricValue
+              value={row.outputTokens}
+              className="text-emerald-600 dark:text-emerald-400 underline decoration-emerald-300/50 dark:decoration-emerald-500/40 underline-offset-2"
+            />
           </button>
         ) : (
-          <OverflowTooltip content={row.outputTokens.toLocaleString()} className="block min-w-0">
-            <span className="block min-w-0 truncate">{row.outputTokens.toLocaleString()}</span>
-          </OverflowTooltip>
+          <RequestLogUsageMetricValue value={row.outputTokens} />
         ),
     },
     {
@@ -422,11 +460,7 @@ export function buildRequestLogsColumns(
       width: "w-28",
       headerClassName: "text-center",
       cellClassName: "text-center font-mono text-xs tabular-nums text-slate-900 dark:text-white",
-      render: (row) => (
-        <OverflowTooltip content={row.totalTokens.toLocaleString()} className="block min-w-0">
-          <span className="block min-w-0 truncate">{row.totalTokens.toLocaleString()}</span>
-        </OverflowTooltip>
-      ),
+      render: (row) => <RequestLogUsageMetricValue value={row.totalTokens} />,
     },
     {
       key: "cost",
@@ -435,11 +469,7 @@ export function buildRequestLogsColumns(
       headerClassName: "text-center",
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-400",
-      render: (row) => (
-        <OverflowTooltip content={`$${row.cost.toFixed(6)}`} className="block min-w-0">
-          <span className="block min-w-0 truncate">${row.cost.toFixed(4)}</span>
-        </OverflowTooltip>
-      ),
+      render: (row) => <RequestLogUsageMetricValue value={row.cost} variant="currency" />,
     },
     {
       key: "apiKeyName",
@@ -511,8 +541,7 @@ export function RequestLogsPaginationBar({
         nextPage: t("request_logs.next_page"),
         lastPage: t("request_logs.last_page"),
         rowsPerPage: t("request_logs.rows_per_page"),
-        pageInfo: ({ start, end, total }) =>
-          t("request_logs.page_info", { start, end, total }),
+        pageInfo: ({ start, end, total }) => t("request_logs.page_info", { start, end, total }),
       }}
     />
   );

--- a/packages/domain/src/usage/__tests__/formatters.test.ts
+++ b/packages/domain/src/usage/__tests__/formatters.test.ts
@@ -3,8 +3,14 @@ import {
   formatCompactNumber,
   formatCompactUsd,
   formatFixedNumber,
+  formatUsageMetricCost,
+  formatUsageMetricNumber,
+  formatUsageMetricRate,
+  formatUsageMetricTooltipCost,
+  formatUsageMetricTooltipNumber,
   formatUsd,
   getCompactNumberParts,
+  isUsageMetricCompact,
 } from "../formatters";
 
 describe("usage formatters", () => {
@@ -36,5 +42,24 @@ describe("usage formatters", () => {
       "$2,315.2875",
     );
     expect(formatUsd(12_345.67891, { locale: "en-US", fractionDigits: 4 })).toBe("$12,345.6789");
+  });
+
+  test("formats usage metric values with dashboard compact precision", () => {
+    expect(formatUsageMetricNumber(9_999, { locale: "en-US" })).toBe("9,999");
+    expect(formatUsageMetricNumber(23_800, { locale: "en-US" })).toBe("23.8K");
+    expect(formatUsageMetricNumber(2_819_900_000, { locale: "en-US" })).toBe("2.8B");
+    expect(formatUsageMetricTooltipNumber(2_819_900_000, { locale: "en-US" })).toBe(
+      "2,819,900,000.00",
+    );
+    expect(isUsageMetricCompact(9_999)).toBe(false);
+    expect(isUsageMetricCompact(10_000)).toBe(true);
+  });
+
+  test("formats usage metric cost and rate values with dashboard precision", () => {
+    expect(formatUsageMetricCost(9_999.12345, { locale: "en-US" })).toBe("$9,999.1235");
+    expect(formatUsageMetricCost(12_345.67891, { locale: "en-US" })).toBe("$12.35K");
+    expect(formatUsageMetricTooltipCost(12_345.67891, { locale: "en-US" })).toBe("$12,345.6789");
+    expect(isUsageMetricCompact(12_345.67891, "currency")).toBe(true);
+    expect(formatUsageMetricRate(91.234)).toBe("91.23%");
   });
 });

--- a/packages/domain/src/usage/formatters.ts
+++ b/packages/domain/src/usage/formatters.ts
@@ -26,6 +26,26 @@ export type FixedNumberOptions = {
   fractionDigits?: number;
 };
 
+export type UsageMetricFormatOptions = {
+  locale?: string;
+};
+
+export type UsageMetricVariant = "number" | "currency";
+
+export const USAGE_METRIC_COMPACT_OPTIONS = {
+  threshold: 10_000,
+  maximumFractionDigits: 1,
+  standardMaximumFractionDigits: 0,
+} satisfies CompactNumberOptions;
+
+export const USAGE_COST_COMPACT_OPTIONS = {
+  threshold: 10_000,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+  standardMinimumFractionDigits: 4,
+  standardMaximumFractionDigits: 4,
+} satisfies CompactNumberOptions;
+
 const DEFAULT_COMPACT_UNITS: CompactNumberUnit[] = [
   { value: 1, suffix: "" },
   { value: 1_000, suffix: "K" },
@@ -131,6 +151,54 @@ export function formatUsd(value: number, options: FixedNumberOptions = {}): stri
     locale: options.locale,
     fractionDigits: options.fractionDigits ?? 2,
   })}`;
+}
+
+export function formatUsageMetricNumber(
+  value: number,
+  options: UsageMetricFormatOptions = {},
+): string {
+  return formatCompactNumber(value, {
+    ...USAGE_METRIC_COMPACT_OPTIONS,
+    locale: options.locale,
+  });
+}
+
+export function formatUsageMetricTooltipNumber(
+  value: number,
+  options: UsageMetricFormatOptions = {},
+): string {
+  return formatFixedNumber(value, { locale: options.locale, fractionDigits: 2 });
+}
+
+export function formatUsageMetricCost(
+  value: number,
+  options: UsageMetricFormatOptions = {},
+): string {
+  return formatCompactUsd(value, {
+    ...USAGE_COST_COMPACT_OPTIONS,
+    locale: options.locale,
+  });
+}
+
+export function formatUsageMetricTooltipCost(
+  value: number,
+  options: UsageMetricFormatOptions = {},
+): string {
+  return formatUsd(value, { locale: options.locale, fractionDigits: 4 });
+}
+
+export function isUsageMetricCompact(
+  value: number,
+  variant: UsageMetricVariant = "number",
+): boolean {
+  return getCompactNumberParts(
+    value,
+    variant === "currency" ? USAGE_COST_COMPACT_OPTIONS : USAGE_METRIC_COMPACT_OPTIONS,
+  ).compact;
+}
+
+export function formatUsageMetricRate(value: number): string {
+  return `${formatFixedNumber(value, { fractionDigits: 2 })}%`;
 }
 
 export function formatHourLabel(date: Date): string {

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -7,8 +7,15 @@ import type {
   UsageLogItem,
   UsageLogsResponse,
 } from "@code-proxy/api-client/endpoints/usage";
+import {
+  formatUsageMetricNumber,
+  formatUsageMetricRate,
+  formatUsageMetricTooltipNumber,
+  isUsageMetricCompact,
+} from "@code-proxy/domain";
 import { Button } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
+import { HoverTooltip } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { DataTable } from "@code-proxy/ui";
@@ -20,6 +27,7 @@ import {
   buildRequestLogKeyOptions,
   buildRequestLogsColumns,
   DEFAULT_REQUEST_LOG_PAGE_SIZE,
+  RequestLogUsageMetricValue,
   RequestLogsPaginationBar,
   RequestLogsTimeRangeSelector,
   toRequestLogsRow,
@@ -41,6 +49,26 @@ const DEFAULT_CLEAR_OPTIONS: ClearUsageLogsPayload = {
   clear_detail_content: true,
   clear_request_records: false,
 };
+
+function RequestLogsRecordsCount({ count }: { count: number }) {
+  const { t } = useTranslation();
+  const compact = isUsageMetricCompact(count);
+
+  return (
+    <HoverTooltip
+      content={formatUsageMetricTooltipNumber(count)}
+      disabled={!compact}
+      placement="top"
+      className={compact ? "cursor-help" : undefined}
+    >
+      <span>
+        {t("request_logs.records_count", {
+          count: formatUsageMetricNumber(count),
+        } as Record<string, string>)}
+      </span>
+    </HoverTooltip>
+  );
+}
 
 function normalizeFilterSelection<T extends string>(
   selected: MultiSelectFilterState<T>,
@@ -113,7 +141,6 @@ export function RequestLogsPage() {
   // Data state (page-based, no accumulation)
   const [rawItems, setRawItems] = useState<UsageLogItem[]>([]);
   const [loading, setLoading] = useState(false);
-  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
 
   // Pagination state
   const [totalCount, setTotalCount] = useState(0);
@@ -326,7 +353,6 @@ export function RequestLogsPage() {
           ...DEFAULT_LOG_STATS,
           ...resp.stats,
         });
-        setLastUpdatedAt(Date.now());
       } catch (err) {
         if (seq !== requestSeqRef.current) return;
         const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
@@ -368,14 +394,6 @@ export function RequestLogsPage() {
   useEffect(() => {
     fetchLogs(1, pageSize);
   }, [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const lastUpdatedText = useMemo(() => {
-    if (loading) return t("request_logs.refreshing");
-    if (!lastUpdatedAt) return t("request_logs.not_refreshed");
-    return t("request_logs.updated_at", {
-      time: new Date(lastUpdatedAt).toLocaleTimeString(),
-    });
-  }, [lastUpdatedAt, loading, t]);
 
   const handleOpenClearDialog = useCallback(() => {
     setClearOptions(DEFAULT_CLEAR_OPTIONS);
@@ -456,11 +474,7 @@ export function RequestLogsPage() {
             </h2>
             <div className="hidden min-[640px]:flex items-center gap-2 text-xs text-slate-500 dark:text-white/50">
               <span className="text-slate-300 dark:text-white/15">|</span>
-              <span>
-                {t("request_logs.records_count", {
-                  count: stats.total.toLocaleString(),
-                } as Record<string, string>)}
-              </span>
+              <RequestLogsRecordsCount count={stats.total} />
               <span className="text-slate-300 dark:text-white/15">|</span>
               <span>
                 {t("common.success_rate")}{" "}
@@ -472,26 +486,22 @@ export function RequestLogsPage() {
               <span>
                 {t("request_logs.col_total_token")}{" "}
                 <span className="font-mono tabular-nums text-slate-900 dark:text-white">
-                  {stats.total_tokens.toLocaleString()}
+                  <RequestLogUsageMetricValue value={stats.total_tokens} />
                 </span>
               </span>
               <span className="text-slate-300 dark:text-white/15">|</span>
               <span>
                 {t("request_logs.col_cost")}{" "}
                 <span className="font-mono tabular-nums text-emerald-700 dark:text-emerald-400">
-                  ${stats.total_cost.toFixed(4)}
+                  <RequestLogUsageMetricValue value={stats.total_cost} variant="currency" />
                 </span>
               </span>
               <span className="text-slate-300 dark:text-white/15">|</span>
               <span>
                 {t("request_logs.cache_rate")}{" "}
                 <span className="font-mono tabular-nums text-amber-600 dark:text-amber-400">
-                  {stats.cache_rate.toFixed(1)}%
+                  {formatUsageMetricRate(stats.cache_rate)}
                 </span>
-              </span>
-              <span className="text-slate-300 dark:text-white/15">|</span>
-              <span className="text-slate-400 dark:text-white/40">
-                {loading ? t("request_logs.refreshing") : lastUpdatedText}
               </span>
             </div>
           </div>

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -412,12 +412,8 @@ describe("RequestLogsPage", () => {
           buildUsageLogItem({ id: 2, model: "gpt-4.1" }),
         ]),
       )
-      .mockResolvedValueOnce(
-        responseWithRows([buildUsageLogItem({ id: 3, model: "gpt-5.4" })]),
-      )
-      .mockResolvedValueOnce(
-        responseWithRows([buildUsageLogItem({ id: 4, model: "gpt-4.1" })]),
-      );
+      .mockResolvedValueOnce(responseWithRows([buildUsageLogItem({ id: 3, model: "gpt-5.4" })]))
+      .mockResolvedValueOnce(responseWithRows([buildUsageLogItem({ id: 4, model: "gpt-4.1" })]));
 
     render(
       <ThemeProvider>
@@ -442,9 +438,7 @@ describe("RequestLogsPage", () => {
         }),
       ),
     );
-    expect(screen.getByRole("combobox", { name: "Filter by model" })).toHaveTextContent(
-      "gpt-5.4",
-    );
+    expect(screen.getByRole("combobox", { name: "Filter by model" })).toHaveTextContent("gpt-5.4");
 
     await user.click(screen.getByRole("button", { name: "Clear model filter" }));
 
@@ -458,9 +452,7 @@ describe("RequestLogsPage", () => {
       ),
     );
     await waitFor(() =>
-      expect(
-        screen.queryByRole("button", { name: "Clear model filter" }),
-      ).not.toBeInTheDocument(),
+      expect(screen.queryByRole("button", { name: "Clear model filter" })).not.toBeInTheDocument(),
     );
     expect(screen.getByRole("combobox", { name: "Filter by model" })).toHaveTextContent(
       "All Models",
@@ -547,6 +539,70 @@ describe("RequestLogsPage", () => {
 
     await screen.findByRole("table", { name: "请求日志表" });
     expect(container.querySelector(".table-scrollbar")).not.toBeNull();
+  });
+
+  test("uses dashboard compact metric formatting without the updated-at summary text", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue({
+      items: [
+        buildUsageLogItem({
+          input_tokens: 2_806_800_000,
+          cached_tokens: 2_576_200_000,
+          output_tokens: 13_100_000,
+          total_tokens: 2_819_900_000,
+          cost: 12_345.67891,
+          has_content: true,
+        }),
+      ],
+      total: 23_800,
+      page: 1,
+      size: 50,
+      filters: {
+        api_keys: [],
+        api_key_names: {},
+        models: [],
+        channels: [],
+      },
+      stats: {
+        total: 23_800,
+        success_rate: 99.5,
+        total_tokens: 2_819_900_000,
+        total_cost: 12_345.67891,
+        cache_rate: 91.234,
+      },
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const recordsCount = await screen.findByText("23.8K records");
+    expect(screen.queryByText(/Updated at/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Not yet refreshed/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText("2.8B").length).toBeGreaterThan(0);
+    expect(screen.getByText("2.6B")).toBeInTheDocument();
+    expect(screen.getByText("13.1M")).toBeInTheDocument();
+    expect(screen.getAllByText("$12.35K").length).toBeGreaterThan(0);
+    expect(screen.getByText("91.23%")).toBeInTheDocument();
+
+    await user.hover(recordsCount);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("23,800.00");
+    await user.unhover(recordsCount);
+
+    const cachedTokens = screen.getByText("2.6B");
+    await user.hover(cachedTokens);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("2,576,200,000.00");
+    await user.unhover(cachedTokens);
+
+    const cost = screen.getAllByText("$12.35K")[0];
+    await user.hover(cost);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("$12,345.6789");
   });
 
   test("clears bulky request-log content by default while preserving request rows", async () => {


### PR DESCRIPTION
## Summary
- Reuse shared usage metric compact formatting on request logs summary and table values.
- Remove the request logs summary updated-at timestamp.
- Keep request, token, cost, cache token ratio display aligned with dashboard precision and tooltip rules.

## Validation
- rtk bunx oxfmt --check packages/domain/src/usage/formatters.ts packages/domain/src/usage/__tests__/formatters.test.ts features/request-log-viewer/requestLogsShared.tsx pages/request-logs/RequestLogsPage.tsx pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bunx oxlint packages/domain/src/usage/formatters.ts packages/domain/src/usage/__tests__/formatters.test.ts features/request-log-viewer/requestLogsShared.tsx pages/request-logs/RequestLogsPage.tsx pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel test -- packages/domain/src/usage/__tests__/formatters.test.ts
- rtk bun run --filter @code-proxy/admin-panel test -- pages/request-logs/__tests__/RequestLogsPage.test.tsx pages/monitor/__tests__/requestLogsShared.test.ts
- rtk bun run --filter @code-proxy/admin-panel build
- Local mock management API browser validation: no updated-at text, compact K/M/B values visible, tooltip full values verified.