### PR TITLE
fix: show auth file card actions on mobile

### DIFF
--- a/e2e/auth-files-oauth-excluded.spec.ts
+++ b/e2e/auth-files-oauth-excluded.spec.ts
@@ -141,3 +141,76 @@ test("Auth Files: OAuth dialog should submit callback url through management api
     .or(page.getByText("已提交", { exact: true }));
   await expect(submittedStatus).toBeVisible();
 });
+
+test("Auth Files: mobile cards expose the selection checkbox without hover", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+    localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+  });
+
+  await page.route("**/v0/management/config", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+  await page.route("**/v0/management/auth-files", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        files: [
+          {
+            name: "qwen.json",
+            type: "qwen",
+            size: 1024,
+            modified: Date.now(),
+            disabled: false,
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("**/v0/management/usage**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ source: [], auth_index: [] }),
+    });
+  });
+  await page.route("**/v0/management/model-configs**", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/v0/management/model-owner-presets", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/v0/management/auth-group-model-owner-mappings", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{\"items\":[]}" });
+  });
+  await page.route("**/v0/management/proxy-pool", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{\"items\":[]}" });
+  });
+
+  await page.goto("/#/auth-files");
+
+  await expect(page.getByText("qwen.json")).toBeVisible();
+  const checkbox = page.getByRole("checkbox", { name: "Select qwen.json" });
+  await expect
+    .poll(async () =>
+      checkbox.evaluate((input) => {
+        const style = getComputedStyle(input.parentElement as HTMLElement);
+        return `${style.opacity}:${style.pointerEvents}`;
+      }),
+    )
+    .toBe("1:auto");
+
+  await checkbox.click();
+  await expect(checkbox).toBeChecked();
+});

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1563,6 +1563,62 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("Total 1 · Page 1 / 1")).toBeInTheDocument();
   });
 
+  test("keeps an emptied custom tag filter clearable after deleting selected files", async () => {
+    const user = userEvent.setup();
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-vip.json",
+          type: "codex",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          custom_tags: ["vip-team"],
+          display_tags: ["vip-team"],
+        },
+        {
+          name: "qwen-lab.json",
+          type: "qwen",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          custom_tags: ["lab"],
+          display_tags: ["lab"],
+        },
+      ],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("codex-vip.json")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "Custom tag" }));
+    await user.click(screen.getByRole("option", { name: "vip-team" }));
+
+    fireEvent.click(screen.getByLabelText("Select codex-vip.json"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete selected (1)" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("codex-vip.json")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Custom tag" }));
+    await user.click(screen.getByRole("option", { name: "All tags" }));
+
+    expect(await screen.findByText("qwen-lab.json")).toBeInTheDocument();
+  });
+
   test("keeps custom tag filter options stable while searching", async () => {
     const user = userEvent.setup();
     const now = Date.now();
@@ -4559,6 +4615,8 @@ describe("AuthFilesPage files table", () => {
 
     const checkbox = screen.getByLabelText("Select qwen.json") as HTMLInputElement;
     expect(checkbox).toBeInTheDocument();
+    expect(checkbox.parentElement).not.toHaveClass("opacity-0");
+    expect(checkbox.parentElement).not.toHaveClass("pointer-events-none");
     expect(checkbox.checked).toBe(false);
 
     fireEvent.click(checkbox);

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -45,6 +45,7 @@ import {
   TYPE_BADGE_CLASSES,
   isRuntimeOnlyAuthFile,
   normalizeProviderKey,
+  normalizeTagValue,
   resolveAuthFileDisplayName,
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
@@ -633,10 +634,11 @@ export function AuthFilesFilesTab({
   const [uploadProgressDismissed, setUploadProgressDismissed] = useState(false);
   const [modelOwnerDialogSaving, setModelOwnerDialogSaving] = useState(false);
   const normalizedFilter = normalizeProviderKey(filter);
+  const normalizedTagFilter = normalizeTagValue(tagFilter);
   const canSetModelOwnerGroup = normalizedFilter !== "all";
   const activeFilterCount = [
     normalizedFilter !== "all",
-    customTagOptions.length > 0 && tagFilter.trim() !== "",
+    normalizedTagFilter !== "",
     statusFilter !== "all",
     search.trim() !== "",
     canSetModelOwnerGroup && selectedModelOwner.trim() !== "",
@@ -666,19 +668,25 @@ export function AuthFilesFilesTab({
     [modelOwnerGroups, t],
   );
   const customTagSelectOptions = useMemo<SearchableSelectOption[]>(
-    () => [
-      {
-        value: "",
-        label: t("auth_files.all_tags"),
-        searchText: t("auth_files.all_tags"),
-      },
-      ...customTagOptions.map((tag) => ({
-        value: tag,
-        label: tag,
-        searchText: tag,
-      })),
-    ],
-    [customTagOptions, t],
+    () => {
+      const options =
+        normalizedTagFilter && !customTagOptions.includes(normalizedTagFilter)
+          ? [normalizedTagFilter, ...customTagOptions]
+          : customTagOptions;
+      return [
+        {
+          value: "",
+          label: t("auth_files.all_tags"),
+          searchText: t("auth_files.all_tags"),
+        },
+        ...options.map((tag) => ({
+          value: tag,
+          label: tag,
+          searchText: tag,
+        })),
+      ];
+    },
+    [customTagOptions, normalizedTagFilter, t],
   );
   const providerFilterOptions = useMemo<SearchableSelectOption[]>(
     () =>
@@ -1010,7 +1018,7 @@ export function AuthFilesFilesTab({
                   </div>
                 </div>
 
-                {customTagOptions.length > 0 ? (
+                {customTagOptions.length > 0 || normalizedTagFilter ? (
                   <div className="w-full">
                     <div className={FILTER_FIELD_CLASS}>
                       <p className={FILTER_LABEL_CLASS}>{t("auth_files.tag_filter")}</p>
@@ -1337,7 +1345,7 @@ export function AuthFilesFilesTab({
                                   "flex h-8 items-center justify-center px-1 transition-opacity",
                                   showSelectionControl
                                     ? "opacity-100 pointer-events-auto"
-                                    : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-focus-within/card:opacity-100 group-hover/card:pointer-events-auto group-focus-within/card:pointer-events-auto",
+                                    : "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
                                 ].join(" ")}
                               >
                                 <input
@@ -1359,7 +1367,7 @@ export function AuthFilesFilesTab({
                               <div
                                 className={[
                                   "flex h-8 items-center justify-center transition-opacity",
-                                  "opacity-0 pointer-events-none group-hover/card:opacity-100 group-focus-within/card:opacity-100 group-hover/card:pointer-events-auto group-focus-within/card:pointer-events-auto",
+                                  "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
                                 ].join(" ")}
                               >
                                 <ToggleSwitch


### PR DESCRIPTION
## Summary
- show auth-file card selection and enable controls by default on mobile card view
- keep an emptied custom tag filter clearable after deleting selected files
- add unit and e2e coverage for the mobile/card and tag-filter regressions

## Tests
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run e2e -- e2e/auth-files-oauth-excluded.spec.ts
- rtk bun run lint
- rtk bun run build