### PR TITLE
fix: scope channel group details by group

### DIFF
--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -318,6 +318,7 @@ export function RoutingConfigEditor({
   disabled,
   availableChannels,
   availableChannelDetails = {},
+  availableChannelDetailsByGroup = {},
   onRefreshAvailableChannels,
   loadModelsForChannels,
   onChange,
@@ -326,6 +327,7 @@ export function RoutingConfigEditor({
   disabled?: boolean;
   availableChannels: string[];
   availableChannelDetails?: Record<string, ChannelGroupChannelDetail>;
+  availableChannelDetailsByGroup?: Record<string, Record<string, ChannelGroupChannelDetail>>;
   onRefreshAvailableChannels?: () => Promise<void> | void;
   loadModelsForChannels?: (
     channels: string[],
@@ -435,6 +437,19 @@ export function RoutingConfigEditor({
       availableChannels.map((channel) => normalizeChannelName(channel)).filter(Boolean),
     );
   }, [availableChannels]);
+
+  const getChannelDetail = useCallback(
+    (channelName: string, groupName?: string) => {
+      const channelKey = normalizeChannelName(channelName);
+      if (!channelKey) return undefined;
+      const groupKey = normalizeChannelName(groupName ?? "");
+      return (
+        (groupKey ? availableChannelDetailsByGroup[groupKey]?.[channelKey] : undefined) ??
+        availableChannelDetails[channelKey]
+      );
+    },
+    [availableChannelDetails, availableChannelDetailsByGroup],
+  );
 
   const resolveGroupChannels = useCallback(
     (group: Pick<RoutingChannelGroupEntry, "channels" | "matchMode" | "tags">) => {
@@ -1175,7 +1190,7 @@ export function RoutingConfigEditor({
         label: t("channel_groups_page.table_channels"),
         cellClassName: "min-w-0 whitespace-nowrap",
         render: (channel) => {
-          const detail = availableChannelDetails[normalizeChannelName(channel.name)];
+          const detail = getChannelDetail(channel.name, groupDraft.name);
           const displayTags = readChannelDisplayTags(detail);
           const isStale = draftStaleChannelIds.has(channel.id);
           const isDisabled = isDisabledChannel(detail);
@@ -1266,9 +1281,10 @@ export function RoutingConfigEditor({
           ]),
     ],
     [
-      availableChannelDetails,
       disabled,
       draftStaleChannelIds,
+      getChannelDetail,
+      groupDraft.name,
       groupDraft.matchMode,
       removeDraftChannel,
       t,

--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -61,9 +61,12 @@ type MappedOwnerSelection = {
   hasUnmappedChannels: boolean;
 };
 
+type ChannelDetailsByName = Record<string, ChannelGroupChannelDetail>;
+type ChannelDetailsByGroup = Record<string, ChannelDetailsByName>;
+
 const collectMappedOwnersForChannels = (
   channels: string[],
-  detailsByName: Record<string, ChannelGroupChannelDetail>,
+  detailsByName: ChannelDetailsByName,
   ownerByAuthGroup: Record<string, string>,
 ): MappedOwnerSelection => {
   const owners = new Set<string>();
@@ -226,16 +229,18 @@ export function ChannelGroupsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [availableChannels, setAvailableChannels] = useState<string[]>([]);
-  const [availableChannelDetails, setAvailableChannelDetails] = useState<
-    Record<string, ChannelGroupChannelDetail>
-  >({});
+  const [availableChannelDetails, setAvailableChannelDetails] = useState<ChannelDetailsByName>({});
+  const [availableChannelDetailsByGroup, setAvailableChannelDetailsByGroup] =
+    useState<ChannelDetailsByGroup>({});
   const [authGroupOwnerMap, setAuthGroupOwnerMap] = useState<Record<string, string>>({});
 
   const loadAvailableChannels = useCallback(async () => {
     const items = await channelGroupsApi.list();
     const known = new Set<string>();
-    const detailsByName: Record<string, ChannelGroupChannelDetail> = {};
+    const detailsByName: ChannelDetailsByName = {};
+    const detailsByGroup: ChannelDetailsByGroup = {};
     for (const item of items) {
+      const groupKey = item.name.trim().toLowerCase();
       for (const channel of item.channels ?? []) {
         const name = String(channel ?? "").trim();
         if (name) known.add(name);
@@ -244,12 +249,22 @@ export function ChannelGroupsPage() {
         const name = String(detail.name ?? "").trim();
         if (!name) continue;
         known.add(name);
-        detailsByName[name.trim().toLowerCase()] = detail;
+        const channelKey = name.toLowerCase();
+        if (groupKey) {
+          detailsByGroup[groupKey] = {
+            ...(detailsByGroup[groupKey] ?? {}),
+            [channelKey]: detail,
+          };
+        }
+        if (!detailsByName[channelKey] || detailsByName[channelKey].disabled === true) {
+          detailsByName[channelKey] = detail;
+        }
       }
     }
     return {
       names: Array.from(known).sort((a, b) => a.localeCompare(b)),
       detailsByName,
+      detailsByGroup,
     };
   }, []);
 
@@ -257,6 +272,7 @@ export function ChannelGroupsPage() {
     const channels = await loadAvailableChannels();
     setAvailableChannels(channels.names);
     setAvailableChannelDetails(channels.detailsByName);
+    setAvailableChannelDetailsByGroup(channels.detailsByGroup);
   }, [loadAvailableChannels]);
 
   const loadModelsForChannels = useCallback(
@@ -280,9 +296,12 @@ export function ChannelGroupsPage() {
         ? data.data.map((model) => String(model.id ?? "").trim()).filter(Boolean)
         : [];
       const availability = await loadConfiguredModelAvailability();
+      const detailsForGroup =
+        (normalizedGroup ? availableChannelDetailsByGroup[normalizedGroup.toLowerCase()] : undefined) ??
+        availableChannelDetails;
       const ownerSelection = collectMappedOwnersForChannels(
         normalizedChannels,
-        availableChannelDetails,
+        detailsForGroup,
         authGroupOwnerMap,
       );
       let visibleModels = filterByConfiguredModelAvailability(
@@ -329,7 +348,7 @@ export function ChannelGroupsPage() {
 
       return Array.from(optionMap.values()).sort((a, b) => a.id.localeCompare(b.id));
     },
-    [authGroupOwnerMap, availableChannelDetails],
+    [authGroupOwnerMap, availableChannelDetails, availableChannelDetailsByGroup],
   );
 
   const loadPage = useCallback(async () => {
@@ -338,13 +357,14 @@ export function ChannelGroupsPage() {
     try {
       const [routing, channels, ownerMappings] = await Promise.all([
         routingConfigApi.get(),
-        loadAvailableChannels().catch(() => ({ names: [], detailsByName: {} })),
+        loadAvailableChannels().catch(() => ({ names: [], detailsByName: {}, detailsByGroup: {} })),
         modelsApi.getAuthGroupModelOwnerMappingMap().catch(() => ({})),
       ]);
       const nextValues = hydrateRoutingValues(routing);
       setVisualValues(nextValues);
       setAvailableChannels(channels.names);
       setAvailableChannelDetails(channels.detailsByName);
+      setAvailableChannelDetailsByGroup(channels.detailsByGroup);
       setAuthGroupOwnerMap(ownerMappings);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : t("channel_groups_page.load_failed");
@@ -370,12 +390,14 @@ export function ChannelGroupsPage() {
           loadAvailableChannels().catch(() => ({
             names: availableChannels,
             detailsByName: availableChannelDetails,
+            detailsByGroup: availableChannelDetailsByGroup,
           })),
         ]);
         const hydrated = hydrateRoutingValues(latest);
         setVisualValues(hydrated);
         setAvailableChannels(channels.names);
         setAvailableChannelDetails(channels.detailsByName);
+        setAvailableChannelDetailsByGroup(channels.detailsByGroup);
         notify({ type: "success", message: t("channel_groups_page.saved") });
       } catch (err: unknown) {
         setVisualValues(visualValues);
@@ -389,7 +411,15 @@ export function ChannelGroupsPage() {
         setSaving(false);
       }
     },
-    [availableChannelDetails, availableChannels, loadAvailableChannels, notify, t, visualValues],
+    [
+      availableChannelDetails,
+      availableChannelDetailsByGroup,
+      availableChannels,
+      loadAvailableChannels,
+      notify,
+      t,
+      visualValues,
+    ],
   );
 
   const handleEditorChange = useCallback(
@@ -416,6 +446,7 @@ export function ChannelGroupsPage() {
             disabled={loading || saving}
             availableChannels={availableChannels}
             availableChannelDetails={availableChannelDetails}
+            availableChannelDetailsByGroup={availableChannelDetailsByGroup}
             onRefreshAvailableChannels={refreshAvailableChannels}
             loadModelsForChannels={loadModelsForChannels}
             onChange={handleEditorChange}

--- a/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -31,6 +31,7 @@ function Harness({
   loadModelsForChannels,
   availableChannels = ["Team A Claude", "Main Codex", "Backup Claude"],
   availableChannelDetails,
+  availableChannelDetailsByGroup,
 }: {
   initialValues?: VisualConfigValues;
   loadModelsForChannels?: (
@@ -39,6 +40,7 @@ function Harness({
   ) => Promise<Array<string | RoutingModelOption>>;
   availableChannels?: string[];
   availableChannelDetails?: Record<string, ChannelGroupChannelDetail>;
+  availableChannelDetailsByGroup?: Record<string, Record<string, ChannelGroupChannelDetail>>;
 }) {
   const [values, setValues] = useState<VisualConfigValues>({
     ...DEFAULT_VISUAL_VALUES,
@@ -54,6 +56,7 @@ function Harness({
           values={values}
           availableChannels={availableChannels}
           availableChannelDetails={availableChannelDetails}
+          availableChannelDetailsByGroup={availableChannelDetailsByGroup}
           loadModelsForChannels={loadModelsForChannels}
           onChange={(patch) => setValues((prev) => ({ ...prev, ...patch }))}
         />
@@ -631,5 +634,79 @@ describe("RoutingConfigEditor", () => {
     const disabledRow = screen.getByRole("row", { name: /GptPlus8/ });
     expect(within(disabledRow).getByText("已禁用")).toBeInTheDocument();
     expect(within(disabledRow).queryByText("已删除")).not.toBeInTheDocument();
+  });
+
+  test("uses group-scoped channel details for duplicate channel names", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+
+    render(
+      <Harness
+        availableChannels={["Shared Codex"]}
+        availableChannelDetails={{
+          "shared codex": {
+            name: "Shared Codex",
+            source: "codex",
+            disabled: true,
+            default_tags: [],
+            custom_tags: [],
+            hidden_default_tags: [],
+            display_tags: ["codex"],
+          },
+        }}
+        availableChannelDetailsByGroup={{
+          "active-pool": {
+            "shared codex": {
+              name: "Shared Codex",
+              source: "codex",
+              disabled: false,
+              default_tags: [],
+              custom_tags: [],
+              hidden_default_tags: [],
+              display_tags: ["codex"],
+            },
+          },
+          "disabled-pool": {
+            "shared codex": {
+              name: "Shared Codex",
+              source: "codex",
+              disabled: true,
+              default_tags: [],
+              custom_tags: [],
+              hidden_default_tags: [],
+              display_tags: ["codex"],
+            },
+          },
+        }}
+        initialValues={{
+          ...DEFAULT_VISUAL_VALUES,
+          routingChannelGroups: [
+            {
+              id: "group-active",
+              name: "active-pool",
+              description: "",
+              strategy: "round-robin",
+              allowedModels: [],
+              channels: [{ id: "channel-active", name: "Shared Codex", priority: "" }],
+            },
+            {
+              id: "group-disabled",
+              name: "disabled-pool",
+              description: "",
+              strategy: "round-robin",
+              allowedModels: [],
+              channels: [{ id: "channel-disabled", name: "Shared Codex", priority: "" }],
+            },
+          ],
+        }}
+      />,
+    );
+
+    const activeGroupRow = screen.getByRole("row", { name: /active-pool/ });
+    await user.click(within(activeGroupRow).getByRole("button", { name: "编辑分组" }));
+
+    const dialog = screen.getByRole("dialog", { name: "编辑分组" });
+    const activeChannelRow = within(dialog).getByRole("row", { name: /Shared Codex/ });
+    expect(within(activeChannelRow).queryByText("已禁用")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- keep channel details grouped by channel group in ChannelGroupsPage
- prefer group-scoped channel detail when rendering routing group members
- prevent duplicate channel names from leaking disabled badges across groups

## Tests
- bun run test pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
- bun run test pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
- bun run test
- bun run build