### PR TITLE
feat: show Codex reset credits on auth cards

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -580,6 +580,8 @@
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",
     "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}",
+    "reset_credits_badge": "Reset {{count}} times",
+    "reset_credits_query": "Query reset credits",
     "restriction_http_label": "{{status}} Error",
     "restriction_quota_label": "Quota Limited",
     "restriction_generic_label": "Restricted",

--- a/apps/admin-panel/src/i18n/locales/ru.json
+++ b/apps/admin-panel/src/i18n/locales/ru.json
@@ -574,6 +574,8 @@
     "quota_auto_refresh": "Автообновление",
     "quota_refresh_off": "Выкл",
     "quota_updated_at": "Обновлено",
+    "reset_credits_badge": "Reset {{count}} times",
+    "reset_credits_query": "Query reset credits",
     "calls_count": "{{count}} вызовов",
     "too_many_files_warning": "Слишком много учётных данных. Полный список может повлиять на производительность, используйте постраничный режим.",
     "filter_all": "Все",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -588,6 +588,8 @@
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",
     "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}",
+    "reset_credits_badge": "重置 {{count}} 次",
+    "reset_credits_query": "查询重置次数",
     "restriction_http_label": "{{status}} 错误",
     "restriction_quota_label": "配额限制",
     "restriction_generic_label": "已限制",

--- a/features/quota-preview/__tests__/quota-helpers.test.ts
+++ b/features/quota-preview/__tests__/quota-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   formatRelativeResetLabel,
   parseAntigravityPayload,
   parseKimiUsagePayload,
+  resolveCodexResetCreditCount,
 } from "@features/quota-preview/quota-helpers";
 
 describe("formatRelativeResetLabel", () => {
@@ -147,6 +148,14 @@ describe("buildCodexItems", () => {
         windowSeconds: 2628000,
       }),
     ]);
+  });
+
+  test("reads available reset credits from Codex usage payload", () => {
+    expect(
+      resolveCodexResetCreditCount({
+        rate_limit_reset_credits: { available_count: "3" },
+      }),
+    ).toBe(3);
   });
 });
 

--- a/features/quota-preview/quota-codex.ts
+++ b/features/quota-preview/quota-codex.ts
@@ -39,6 +39,11 @@ type CodexAdditionalRateLimit = {
   rateLimit?: CodexRateLimitInfo | null;
 };
 
+type CodexRateLimitResetCredits = {
+  available_count?: number | string;
+  availableCount?: number | string;
+};
+
 export type CodexUsagePayload = {
   plan_type?: string;
   planType?: string;
@@ -48,6 +53,8 @@ export type CodexUsagePayload = {
   codeReviewRateLimit?: CodexRateLimitInfo | null;
   additional_rate_limits?: CodexAdditionalRateLimit[];
   additionalRateLimits?: CodexAdditionalRateLimit[];
+  rate_limit_reset_credits?: CodexRateLimitResetCredits | null;
+  rateLimitResetCredits?: CodexRateLimitResetCredits | null;
 };
 
 export const resolveCodexChatgptAccountId = (file: AuthFileItem): string | null => {
@@ -113,6 +120,12 @@ export const parseCodexUsagePayload = (payload: unknown): CodexUsagePayload | nu
     }
   }
   return typeof payload === "object" ? (payload as CodexUsagePayload) : null;
+};
+
+export const resolveCodexResetCreditCount = (payload: CodexUsagePayload): number => {
+  const credits = payload.rate_limit_reset_credits ?? payload.rateLimitResetCredits ?? null;
+  const count = normalizeNumberValue(credits?.available_count ?? credits?.availableCount);
+  return count === null ? 0 : Math.max(0, Math.floor(count));
 };
 
 const resolveCodexResetAtMs = (window?: CodexUsageWindow | null): number | undefined => {

--- a/features/quota-preview/quota-fetch.ts
+++ b/features/quota-preview/quota-fetch.ts
@@ -37,6 +37,7 @@ import {
   parseResetTimeToMs,
   resolveAuthProvider,
   resolveCodexChatgptAccountId,
+  resolveCodexResetCreditCount,
   resolveGeminiCliProjectId,
   type QuotaItem,
 } from "@features/quota-preview/quota-helpers";
@@ -45,6 +46,7 @@ export type QuotaProvider = "antigravity" | "claude" | "codex" | "gemini-cli" | 
 export type QuotaFetchResult = {
   items: QuotaItem[];
   planType?: string | null;
+  resetCreditCount?: number;
 };
 
 export const resolveQuotaProvider = (file: AuthFileItem): QuotaProvider | null => {
@@ -149,6 +151,7 @@ export const fetchQuota = async (
     return {
       items: buildCodexItems(payload),
       planType: normalizeStringValue(payload.plan_type ?? payload.planType)?.toLowerCase() ?? null,
+      resetCreditCount: resolveCodexResetCreditCount(payload),
     };
   }
 

--- a/features/quota-preview/quota-helpers.ts
+++ b/features/quota-preview/quota-helpers.ts
@@ -12,6 +12,7 @@ export { type CodexUsagePayload } from "@features/quota-preview/quota-codex";
 export {
   buildCodexItems,
   parseCodexUsagePayload,
+  resolveCodexResetCreditCount,
   resolveCodexChatgptAccountId,
 } from "@features/quota-preview/quota-codex";
 export { type ClaudeUsagePayload } from "@features/quota-preview/quota-claude";

--- a/features/quota-preview/quota-types.ts
+++ b/features/quota-preview/quota-types.ts
@@ -13,6 +13,7 @@ export type QuotaState = {
   status: QuotaStatus;
   items: QuotaItem[];
   planType?: string;
+  resetCreditCount?: number;
   error?: string;
   updatedAt?: number;
 };

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -270,6 +270,12 @@ const sanitizeQuotaItemsForCache = (items: unknown): QuotaItem[] => {
     .filter((item): item is QuotaItem => Boolean(item));
 };
 
+const sanitizeResetCreditCountForCache = (value: unknown): number | undefined => {
+  const count = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(count)) return undefined;
+  return Math.max(0, Math.floor(count));
+};
+
 const sanitizeQuotaByFileNameForCache = (
   quotaByFileName: unknown,
   fileNames?: Set<string>,
@@ -292,11 +298,13 @@ const sanitizeQuotaByFileNameForCache = (
         ? state.updatedAt
         : undefined;
     const planType = normalizePlanType(state.planType ?? state.plan_type);
+    const resetCreditCount = sanitizeResetCreditCountForCache(state.resetCreditCount);
     const error = typeof state.error === "string" ? state.error : undefined;
     output[fileName] = {
       status: status === "loading" ? "success" : (status as QuotaStatus),
       items,
       planType: planType ?? undefined,
+      resetCreditCount,
       updatedAt,
       error: status === "error" ? error : undefined,
     };

--- a/packages/domain/src/quota/types.ts
+++ b/packages/domain/src/quota/types.ts
@@ -19,6 +19,7 @@ export type QuotaState = {
   status: QuotaStatus;
   items: QuotaItem[];
   planType?: string;
+  resetCreditCount?: number;
   error?: string;
   updatedAt?: number;
   fetchedAt?: number;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -580,6 +580,8 @@
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",
     "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}",
+    "reset_credits_badge": "Reset {{count}} times",
+    "reset_credits_query": "Query reset credits",
     "restriction_http_label": "{{status}} Error",
     "restriction_quota_label": "Quota Limited",
     "restriction_generic_label": "Restricted",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -574,6 +574,8 @@
     "quota_auto_refresh": "Автообновление",
     "quota_refresh_off": "Выкл",
     "quota_updated_at": "Обновлено",
+    "reset_credits_badge": "Reset {{count}} times",
+    "reset_credits_query": "Query reset credits",
     "calls_count": "{{count}} вызовов",
     "too_many_files_warning": "Слишком много учётных данных. Полный список может повлиять на производительность, используйте постраничный режим.",
     "filter_all": "Все",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -588,6 +588,8 @@
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",
     "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}",
+    "reset_credits_badge": "重置 {{count}} 次",
+    "reset_credits_query": "查询重置次数",
     "restriction_http_label": "{{status}} 错误",
     "restriction_quota_label": "配额限制",
     "restriction_generic_label": "已限制",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -4276,7 +4276,7 @@ describe("AuthFilesPage files table", () => {
     expect(table).toBeInTheDocument();
   });
 
-  test("quota refresh updates the plan badge from api-call payload", async () => {
+  test("quota refresh updates the plan and reset credit badges from api-call payload", async () => {
     const now = Date.now();
     const file = {
       name: "codex.json",
@@ -4291,10 +4291,17 @@ describe("AuthFilesPage files table", () => {
     } as any;
 
     mocks.list.mockImplementationOnce(async () => ({ files: [file] }));
-    mocks.fetchQuota.mockResolvedValue({
-      items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
-      planType: "plus",
-    });
+    mocks.fetchQuota
+      .mockResolvedValueOnce({
+        items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
+        planType: "plus",
+        resetCreditCount: 3,
+      })
+      .mockResolvedValueOnce({
+        items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
+        planType: "plus",
+        resetCreditCount: 4,
+      });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem(
@@ -4308,6 +4315,7 @@ describe("AuthFilesPage files table", () => {
             status: "success",
             updatedAt: now,
             planType: "free",
+            resetCreditCount: 0,
             items: [{ label: "m_quota.code_5h", percent: 20, resetAtMs: now + 30_000 }],
           },
         },
@@ -4327,10 +4335,20 @@ describe("AuthFilesPage files table", () => {
     );
 
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    fireEvent.click(
-      within(screen.getByTestId("auth-files-cards")).getByRole("button", { name: "Refresh" }),
-    );
+    expect(await screen.findByText("Reset 3 times")).toBeInTheDocument();
+    const cards = screen.getByTestId("auth-files-cards");
+    const resetButton = within(cards).getByRole("button", { name: "Query reset credits" });
+    const callsBadge = within(cards).getByText("0 calls");
+    expect(
+      resetButton.compareDocumentPosition(callsBadge) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    fireEvent.click(resetButton);
 
+    expect(await screen.findByText("Reset 4 times")).toBeInTheDocument();
+    expect(mocks.fetchQuota).toHaveBeenLastCalledWith(
+      "codex",
+      expect.objectContaining({ name: "codex.json" }),
+    );
     expect(
       (await screen.findAllByText((_, node) => node?.textContent?.includes("Plan Plus") ?? false))
         .length,
@@ -4339,6 +4357,7 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() => {
       const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
       expect(raw).toContain('"planType":"plus"');
+      expect(raw).toContain('"resetCreditCount":4');
     });
   });
 

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1312,6 +1312,10 @@ export function AuthFilesFilesTab({
                   const quotaRefreshing = provider
                     ? quotaByFileName[file.name]?.status === "loading"
                     : false;
+                  const resetCreditCount =
+                    provider === "codex" && typeof state.resetCreditCount === "number"
+                      ? state.resetCreditCount
+                      : 0;
                   const showSelectionControl = fileSelected;
 
                   return (
@@ -1396,6 +1400,26 @@ export function AuthFilesFilesTab({
                             <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
                               {t("codex_quota.plan_label")} {formatPlanTypeLabel(planType)}
                             </span>
+                          ) : null}
+                          {provider === "codex" ? (
+                            <button
+                              type="button"
+                              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-blue-50 hover:text-blue-700 disabled:cursor-wait disabled:opacity-70 dark:bg-white/10 dark:text-white/70 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
+                              disabled={quotaRefreshing}
+                              onClick={() => void refreshQuota(file, provider)}
+                              title={t("auth_files.reset_credits_query")}
+                              aria-label={t("auth_files.reset_credits_query")}
+                            >
+                              <RefreshCw
+                                size={10}
+                                className={quotaRefreshing ? "animate-spin" : ""}
+                              />
+                              <span className="tabular-nums">
+                                {t("auth_files.reset_credits_badge", {
+                                  count: resetCreditCount,
+                                })}
+                              </span>
+                            </button>
                           ) : null}
                           <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
                             {t("auth_files.calls_count", { count: totalCalls })}

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -278,6 +278,7 @@ export function useAuthFilesQuotaState({
             status: "loading",
             items: prev[name]?.items ?? [],
             planType: prev[name]?.planType,
+            resetCreditCount: prev[name]?.resetCreditCount,
             error: prev[name]?.error,
             updatedAt: prev[name]?.updatedAt,
           },
@@ -288,6 +289,9 @@ export function useAuthFilesQuotaState({
         const result = await fetchQuota(provider, file);
         const items = Array.isArray(result) ? result : result.items;
         const nextPlanType = Array.isArray(result) ? null : (result.planType ?? null);
+        const nextResetCreditCount = Array.isArray(result)
+          ? undefined
+          : result.resetCreditCount;
         const rawAuthIndex = (file as { auth_index?: unknown }).auth_index ?? file.authIndex;
         const authIndex = normalizeAuthIndexValue(rawAuthIndex);
         if (authIndex) {
@@ -339,6 +343,10 @@ export function useAuthFilesQuotaState({
             status: "success",
             items,
             planType: nextPlanType ?? prev[name]?.planType,
+            resetCreditCount:
+              typeof nextResetCreditCount === "number"
+                ? nextResetCreditCount
+                : prev[name]?.resetCreditCount,
             updatedAt: Date.now(),
           },
         }));
@@ -353,6 +361,7 @@ export function useAuthFilesQuotaState({
             status: "error",
             items: prev[name]?.items ?? [],
             planType: prev[name]?.planType,
+            resetCreditCount: prev[name]?.resetCreditCount,
             error: message,
             updatedAt: Date.now(),
           },
@@ -419,6 +428,7 @@ export function useAuthFilesQuotaState({
             status: "loading",
             items: prev[target.file.name]?.items ?? [],
             planType: prev[target.file.name]?.planType,
+            resetCreditCount: prev[target.file.name]?.resetCreditCount,
             error: prev[target.file.name]?.error,
             updatedAt: prev[target.file.name]?.updatedAt,
           };


### PR DESCRIPTION
## Summary
- parse Codex reset credit count from quota usage payload
- show a compact reset credits tag before the calls tag on auth file cards
- preserve reset credit count in quota state/cache and locale resources

## Verification
- rtk git -C codeProxy diff --check
- rtk bun run --filter @code-proxy/admin-panel test -- features/quota-preview/__tests__/quota-helpers.test.ts
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx -t "quota refresh updates the plan and reset credit badges from api-call payload"
- rtk bun run build