### PR TITLE
fix: persist OpenCode Go models and show sources

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -3570,6 +3570,7 @@
     "title": "System Info",
     "available_models": "Available Models",
     "available_models_tooltip": "This only shows models returned by the default root GET /v1/models endpoint. Use Models to view custom paths, channel groups, aliases, and other protocol paths.",
+    "model_sources": "Sources",
     "subtitle": "Service, version & models",
     "api_base": "API Base",
     "api_key_lookup": "API Key Lookup",

--- a/apps/admin-panel/src/i18n/locales/ru.json
+++ b/apps/admin-panel/src/i18n/locales/ru.json
@@ -2126,6 +2126,7 @@
   "system_page": {
     "title": "Информация о системе",
     "available_models": "Доступные модели",
+    "model_sources": "Sources",
     "subtitle": "Сервис, версия и модели",
     "api_base": "API Base",
     "api_key_lookup": "Поиск API-ключа",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -3725,6 +3725,7 @@
     "title": "系统信息",
     "available_models": "可用模型",
     "available_models_tooltip": "这里只展示默认根路径 GET /v1/models 返回的模型；自定义路径、渠道分组、别名与其他协议路径的模型请到“模型”页面查看。",
+    "model_sources": "来源",
     "subtitle": "服务、版本和模型",
     "api_base": "API 地址",
     "api_key_lookup": "API 密钥查询",

--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -17,11 +17,20 @@ export type ModelAvailabilityItem = {
   owned_by?: string;
   description?: string;
   source?: string;
+  sources?: ModelAvailabilitySource[];
   enabled?: boolean;
   pricing?: ModelPricing;
   inputModalities?: string[];
   outputModalities?: string[];
   supportsVision?: boolean;
+};
+
+export type ModelAvailabilitySource = {
+  label: string;
+  provider?: string;
+  channel?: string;
+  clientId?: string;
+  source?: string;
 };
 
 export type ConfiguredModelAvailability = {
@@ -648,6 +657,34 @@ const augmentPathAvailabilityWithMappedOwners = async (
 
 /* ── New backend aggregation endpoint support ── */
 
+const normalizeAvailabilitySources = (value: unknown): ModelAvailabilitySource[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const seen = new Set<string>();
+  const sources: ModelAvailabilitySource[] = [];
+  for (const item of value) {
+    if (!isRecord(item)) continue;
+    const label = String(
+      item.label ?? item.channel ?? item.provider ?? item.client_id ?? "",
+    ).trim();
+    if (!label) continue;
+    const provider = String(item.provider ?? "").trim();
+    const channel = String(item.channel ?? "").trim();
+    const clientId = String(item.client_id ?? item.clientId ?? "").trim();
+    const source = String(item.source ?? "").trim();
+    const key = [label, provider, channel, clientId, source].join("\x00").toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    sources.push({
+      label,
+      ...(provider ? { provider } : {}),
+      ...(channel ? { channel } : {}),
+      ...(clientId ? { clientId } : {}),
+      ...(source ? { source } : {}),
+    });
+  }
+  return sources.length ? sources : undefined;
+};
+
 const normalizeAvailabilityItem = (raw: unknown): ModelAvailabilityItem | null => {
   if (!raw || typeof raw !== "object") return null;
   const record = raw as Record<string, unknown>;
@@ -693,6 +730,7 @@ const normalizeAvailabilityItem = (raw: unknown): ModelAvailabilityItem | null =
     owned_by: String(record.owned_by ?? ""),
     description: String(record.description ?? ""),
     source: String(record.source ?? record.metadata_source ?? ""),
+    sources: normalizeAvailabilitySources(record.sources),
     enabled: record.enabled !== false,
     pricing,
     inputModalities,

--- a/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
@@ -54,6 +54,7 @@ describe("providersApi OpenCode Go", () => {
         proxyId: "hk",
         proxyUrl: "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
+        models: [{ name: "should-not-surface" }],
         excludedModels: ["disabled-model"],
         visionFallbackModel: "qwen3.5-plus",
         workspaceId: "wrk_123",
@@ -87,7 +88,7 @@ describe("providersApi OpenCode Go", () => {
     ]);
   });
 
-  test("serializes and deletes OpenCode Go configs without Base URL or models", async () => {
+  test("serializes and deletes OpenCode Go configs without Base URL", async () => {
     const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
     putMock.mockResolvedValue({ status: "ok" });
     deleteMock.mockResolvedValue({ status: "ok" });
@@ -117,6 +118,7 @@ describe("providersApi OpenCode Go", () => {
         "proxy-id": "hk",
         "proxy-url": "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
+        models: [{ name: "should-not-save" }],
         "excluded-models": ["disabled-model"],
         "vision-fallback-model": "qwen3.5-plus",
         "workspace-id": "wrk_123",

--- a/packages/api-client/src/endpoints/helpers.ts
+++ b/packages/api-client/src/endpoints/helpers.ts
@@ -141,6 +141,8 @@ export const serializeOpenCodeGoKey = (config: ProviderSimpleConfig) => {
   if (proxyId) payload["proxy-id"] = proxyId;
   const headers = serializeHeaders(config.headers);
   if (headers) payload.headers = headers;
+  const models = serializeModels(config.models);
+  if (models && models.length) payload.models = models;
   if (config.excludedModels && config.excludedModels.length) {
     payload["excluded-models"] = config.excludedModels;
   }

--- a/packages/api-client/src/endpoints/providers.ts
+++ b/packages/api-client/src/endpoints/providers.ts
@@ -131,6 +131,7 @@ export const providersApi = {
         const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
         const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
+        const models = normalizeModels(item.models);
         const excludedModels = normalizeExcludedModels(
           item["excluded-models"] ?? item.excludedModels,
         );
@@ -145,6 +146,7 @@ export const providersApi = {
           ...(proxyUrl ? { proxyUrl } : {}),
           ...(proxyId ? { proxyId } : {}),
           ...(headers ? { headers } : {}),
+          ...(models ? { models } : {}),
           ...(excludedModels ? { excludedModels } : {}),
           ...(visionFallbackModel ? { visionFallbackModel } : {}),
           ...(workspaceId ? { workspaceId } : {}),

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3580,6 +3580,7 @@
     "title": "System Info",
     "available_models": "Available Models",
     "available_models_tooltip": "This shows the models currently usable on the default entry. When auth-group owner mappings are configured, the mapped configured model set takes precedence over raw static provider catalogs. Use Models to inspect custom paths, channel groups, aliases, and other protocol paths.",
+    "model_sources": "Sources",
     "subtitle": "Service, version & models",
     "api_base": "API Base",
     "api_key_lookup": "API Key Lookup",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2136,6 +2136,7 @@
   "system_page": {
     "title": "Информация о системе",
     "available_models": "Доступные модели",
+    "model_sources": "Sources",
     "subtitle": "Сервис, версия и модели",
     "api_base": "API Base",
     "api_key_lookup": "Поиск API-ключа",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3735,6 +3735,7 @@
     "title": "系统信息",
     "available_models": "可用模型",
     "available_models_tooltip": "这里展示默认入口当前真正可用的模型；当配置了认证分组到模型归属的统一映射后，会优先按映射后的固定模型集展示，而不是直接使用静态 provider 模型目录。自定义路径、渠道分组、别名与其他协议路径的模型请到“模型”页面查看。",
+    "model_sources": "来源",
     "subtitle": "服务、版本和模型",
     "api_base": "API 地址",
     "api_key_lookup": "API 密钥查询",

--- a/pages/models/__tests__/modelAvailability.test.ts
+++ b/pages/models/__tests__/modelAvailability.test.ts
@@ -24,4 +24,32 @@ describe("model availability normalization", () => {
       { id: "gpt-5" },
     ]);
   });
+
+  test("normalizes model source details from configured availability", () => {
+    const availability = normalizeConfiguredModelAvailability({
+      scoped: true,
+      data: [
+        {
+          id: "gpt-5",
+          sources: [
+            {
+              label: "codex · Codex Pro",
+              provider: "codex",
+              channel: "Codex Pro",
+              client_id: "codex-1",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(availability.items[0]?.sources).toEqual([
+      {
+        label: "codex · Codex Pro",
+        provider: "codex",
+        channel: "Codex Pro",
+        clientId: "codex-1",
+      },
+    ]);
+  });
 });

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -22,6 +22,11 @@ const mocks = vi.hoisted(() => ({
   getOpenCodeGoConfigs: vi.fn(async (): Promise<any[]> => []),
   getOpenAIProviders: vi.fn(async () => []),
   saveOpenCodeGoConfigs: vi.fn(async (_configs: unknown[]) => ({})),
+  getModelDefinitions: vi.fn(async () => [
+    { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
+    { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
+    { id: "kimi-k2.6", object: "model", owned_by: "opencode" },
+  ]),
   apiCallRequest: vi.fn(
     async (_payload: unknown): Promise<MockApiCallResult> => ({
       statusCode: 200,
@@ -33,6 +38,7 @@ const mocks = vi.hoisted(() => ({
           { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
           { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
           { id: "kimi-k2.6", object: "model", owned_by: "opencode" },
+          { id: "qwen3.7-max", object: "model", owned_by: "opencode" },
         ],
       },
     }),
@@ -66,6 +72,10 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       ...mod.apiCallApi,
       request: mocks.apiCallRequest,
     },
+    authFilesApi: {
+      ...mod.authFilesApi,
+      getModelDefinitions: mocks.getModelDefinitions,
+    },
   };
 });
 
@@ -98,6 +108,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     mocks.getOpenCodeGoConfigs.mockImplementation(async () => []);
     mocks.getOpenAIProviders.mockImplementation(async () => []);
     mocks.saveOpenCodeGoConfigs.mockImplementation(async () => ({}));
+    mocks.getModelDefinitions.mockImplementation(async () => [
+      { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
+      { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
+      { id: "kimi-k2.6", object: "model", owned_by: "opencode" },
+    ]);
     mocks.apiCallRequest.mockImplementation(async () => ({
       statusCode: 200,
       header: {},
@@ -108,6 +123,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
           { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
           { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
           { id: "kimi-k2.6", object: "model", owned_by: "opencode" },
+          { id: "qwen3.7-max", object: "model", owned_by: "opencode" },
         ],
       },
     }));
@@ -226,7 +242,8 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
 
     const deepseek = await within(dialog).findByRole("checkbox", { name: /deepseek-v4-flash/i });
-    expect(deepseek).toBeChecked();
+    await waitFor(() => expect(deepseek).toBeChecked());
+    expect(within(dialog).getByRole("checkbox", { name: /qwen3\.7-max/i })).not.toBeChecked();
     await user.click(deepseek);
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
@@ -239,11 +256,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
         expect.objectContaining({
           name: "OpenCode Go",
           apiKey: "sk-opencode-go",
+          models: [{ name: "qwen3.5-plus" }, { name: "kimi-k2.6" }],
           excludedModels: ["deepseek-v4-flash"],
         }),
       ]);
     });
-    expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty("models");
   });
 
   test("offers allowed multimodal OpenCode Go models as vision fallback options from string api-call body", async () => {
@@ -278,7 +295,10 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
     const dialog = await screen.findByRole("dialog", { name: /Add OpenCode Go configuration/i });
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
-    await user.click(await within(dialog).findByRole("checkbox", { name: /minimax-m2.5/i }));
+    await waitFor(() =>
+      expect(within(dialog).getByRole("checkbox", { name: /qwen3\.5-plus/i })).toBeChecked(),
+    );
+    await user.click(await within(dialog).findByRole("checkbox", { name: /mimo-v2-omni/i }));
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
     const fallback = await within(dialog).findByRole("combobox", {
@@ -287,7 +307,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
     await user.click(fallback);
 
     expect(await screen.findByRole("option", { name: /qwen3\.5-plus/i })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /qwen3\.6-plus/i })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /qwen3\.6-plus/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /deepseek-v4-flash/i })).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /mimo-v2-omni/i })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /minimax-m2\.5/i })).not.toBeInTheDocument();
@@ -303,7 +323,12 @@ describe("ProvidersPage OpenCode Go tab", () => {
         expect.objectContaining({
           name: "OpenCode Go",
           apiKey: "sk-opencode-go",
-          excludedModels: ["minimax-m2.5"],
+          models: [
+            { name: "deepseek-v4-flash" },
+            { name: "qwen3.5-plus" },
+            { name: "kimi-k2.6" },
+            { name: "mimo-v2-omni" },
+          ],
           visionFallbackModel: "mimo-v2-omni",
         }),
       ]);

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -8,7 +8,12 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
-import { apiCallApi, getApiCallErrorMessage } from "@code-proxy/api-client";
+import {
+  apiCallApi,
+  authFilesApi,
+  getApiCallErrorMessage,
+  modelsApi,
+} from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
@@ -20,7 +25,6 @@ import {
   normalizeDiscoveredModels,
   stripDisableAllModelsRule,
 } from "../providers-helpers";
-import { modelsApi } from "@code-proxy/api-client";
 import type { ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
@@ -30,6 +34,14 @@ import { ProviderKeyModelsTab } from "./ProviderKeyModelsTab";
 type ProviderKeyModalTab = "basic" | "request" | "models";
 
 const OPENCODE_GO_MODELS_URL = "https://opencode.ai/zen/go/v1/models";
+
+const createModelEntryDraft = (name: string): ModelEntryDraft => ({
+  id: `model-${Date.now()}-${Math.random().toString(16).slice(2)}-${name}`,
+  name,
+  alias: "",
+  priorityText: "",
+  testModel: "",
+});
 
 const isOpenCodeGoVisionModel = (modelId: string): boolean => {
   const normalized = modelId.trim().toLowerCase();
@@ -94,6 +106,10 @@ export function ProviderKeyModal({
   const { t } = useTranslation();
   const [modalTab, setModalTab] = useState<ProviderKeyModalTab>("basic");
   const [openCodeModels, setOpenCodeModels] = useState<{ id: string; owned_by?: string }[]>([]);
+  const [openCodeStaticModels, setOpenCodeStaticModels] = useState<
+    { id: string; owned_by?: string }[]
+  >([]);
+  const [openCodeModelsSeeded, setOpenCodeModelsSeeded] = useState(false);
   const [openCodeModelsLoading, setOpenCodeModelsLoading] = useState(false);
   const [openCodeModelsError, setOpenCodeModelsError] = useState<string | null>(null);
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
@@ -150,6 +166,7 @@ export function ProviderKeyModal({
     setModalTab("basic");
     setOpenCodeModelQuery("");
     setSelectedModelGroup("");
+    setOpenCodeModelsSeeded(false);
   }, [editKeyIndex, editKeyType, open]);
 
   useEffect(() => {
@@ -201,6 +218,25 @@ export function ProviderKeyModal({
     void fetchOpenCodeModels();
   }, [fetchOpenCodeModels, isOpenCodeGo, open]);
 
+  useEffect(() => {
+    if (!open || !isOpenCodeGo) return;
+    let cancelled = false;
+    authFilesApi
+      .getModelDefinitions("opencode-go")
+      .then((items) => {
+        if (cancelled) return;
+        setOpenCodeStaticModels(
+          normalizeDiscoveredModels({ data: items.map((item) => ({ ...item, object: "model" })) }),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setOpenCodeStaticModels([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpenCodeGo, open]);
+
   const excludedModels = useMemo(
     () => excludedModelsFromText(keyDraft.excludedModelsText),
     [keyDraft.excludedModelsText],
@@ -210,6 +246,25 @@ export function ProviderKeyModal({
     () => new Set(stripDisableAllModelsRule(excludedModels).map((model) => model.toLowerCase())),
     [excludedModels],
   );
+  const enabledOpenCodeModelIds = useMemo(
+    () =>
+      new Set(
+        keyDraft.modelEntries.map((entry) => entry.name.trim().toLowerCase()).filter(Boolean),
+      ),
+    [keyDraft.modelEntries],
+  );
+  const isOpenCodeModelAllowed = useCallback(
+    (modelId: string) => {
+      const normalized = modelId.trim().toLowerCase();
+      return (
+        normalized !== "" &&
+        !disableAllModels &&
+        enabledOpenCodeModelIds.has(normalized) &&
+        !excludedModelIds.has(normalized)
+      );
+    },
+    [disableAllModels, enabledOpenCodeModelIds, excludedModelIds],
+  );
   const filteredOpenCodeModels = useMemo(() => {
     const query = openCodeModelQuery.trim().toLowerCase();
     if (!query) return openCodeModels;
@@ -218,36 +273,61 @@ export function ProviderKeyModal({
       return model.id.toLowerCase().includes(query) || owner.includes(query);
     });
   }, [openCodeModelQuery, openCodeModels]);
-  const allowedOpenCodeCount = openCodeModels.filter(
-    (model) => !disableAllModels && !excludedModelIds.has(model.id.toLowerCase()),
+  const allowedOpenCodeCount = openCodeModels.filter((model) =>
+    isOpenCodeModelAllowed(model.id),
   ).length;
   const openCodeVisionFallbackOptions = useMemo(() => {
     const allowedModels = openCodeModels.filter(
-      (model) =>
-        isOpenCodeGoVisionModel(model.id) &&
-        !disableAllModels &&
-        !excludedModelIds.has(model.id.toLowerCase()),
+      (model) => isOpenCodeGoVisionModel(model.id) && isOpenCodeModelAllowed(model.id),
     );
     const modelOptions = allowedModels.map((model) => ({
       value: model.id,
       label: model.owned_by ? `${model.id} · ${model.owned_by}` : model.id,
     }));
     return [{ value: "", label: t("providers.opencode_go_vision_fallback_none") }, ...modelOptions];
-  }, [disableAllModels, excludedModelIds, openCodeModels, t]);
+  }, [isOpenCodeModelAllowed, openCodeModels, t]);
+
+  useEffect(() => {
+    if (!open || !isOpenCodeGo || openCodeModelsSeeded) return;
+    if (disableAllModels || keyDraft.modelEntries.some((entry) => entry.name.trim())) {
+      setOpenCodeModelsSeeded(true);
+      return;
+    }
+    if (openCodeStaticModels.length === 0) return;
+
+    const entries = openCodeStaticModels
+      .map((model) => model.id.trim())
+      .filter((id) => id && !excludedModelIds.has(id.toLowerCase()))
+      .map(createModelEntryDraft);
+    setOpenCodeModelsSeeded(true);
+    if (entries.length === 0) return;
+    setKeyDraft((prev) =>
+      prev.modelEntries.some((entry) => entry.name.trim())
+        ? prev
+        : { ...prev, modelEntries: entries },
+    );
+  }, [
+    disableAllModels,
+    excludedModelIds,
+    isOpenCodeGo,
+    keyDraft.modelEntries,
+    open,
+    openCodeModelsSeeded,
+    openCodeStaticModels,
+    setKeyDraft,
+  ]);
 
   useEffect(() => {
     if (!open || !isOpenCodeGo || openCodeModels.length === 0) return;
     const fallback = keyDraft.visionFallbackModel.trim();
     if (!fallback) return;
     const fallbackLower = fallback.toLowerCase();
-    const allowed =
-      !disableAllModels &&
-      openCodeModels.some(
-        (model) =>
-          model.id.toLowerCase() === fallbackLower &&
-          isOpenCodeGoVisionModel(model.id) &&
-          !excludedModelIds.has(fallbackLower),
-      );
+    const allowed = openCodeModels.some(
+      (model) =>
+        model.id.toLowerCase() === fallbackLower &&
+        isOpenCodeGoVisionModel(model.id) &&
+        isOpenCodeModelAllowed(model.id),
+    );
     if (allowed) return;
     setKeyDraft((prev) =>
       prev.visionFallbackModel.trim().toLowerCase() === fallbackLower
@@ -255,8 +335,7 @@ export function ProviderKeyModal({
         : prev,
     );
   }, [
-    disableAllModels,
-    excludedModelIds,
+    isOpenCodeModelAllowed,
     isOpenCodeGo,
     keyDraft.visionFallbackModel,
     open,
@@ -264,50 +343,56 @@ export function ProviderKeyModal({
     setKeyDraft,
   ]);
 
-  const setExcludedModels = useCallback(
-    (next: string[]) => {
-      const deduped = Array.from(new Set(next.map((model) => model.trim()).filter(Boolean)));
-      setKeyDraft((prev) => ({ ...prev, excludedModelsText: deduped.join("\n") }));
-    },
-    [setKeyDraft],
-  );
-
   const setOpenCodeModelAllowed = useCallback(
     (modelId: string, allowed: boolean) => {
-      const normalized = modelId.toLowerCase();
-      const fetchedIds = new Set(openCodeModels.map((model) => model.id.toLowerCase()));
-      const current = stripDisableAllModelsRule(excludedModels);
-      let next: string[];
-
-      if (disableAllModels) {
-        next = openCodeModels
-          .map((model) => model.id)
-          .filter((id) => id.toLowerCase() !== normalized);
-      } else if (allowed) {
-        next = current.filter((model) => model.toLowerCase() !== normalized);
-      } else {
-        next = [...current, modelId];
-      }
-
-      const unknownExisting = current.filter((model) => !fetchedIds.has(model.toLowerCase()));
-      setExcludedModels([...unknownExisting, ...next]);
+      const normalized = modelId.trim().toLowerCase();
+      if (!normalized) return;
+      setKeyDraft((prev) => {
+        const currentExcluded = stripDisableAllModelsRule(
+          excludedModelsFromText(prev.excludedModelsText),
+        );
+        const nextExcluded = currentExcluded.filter(
+          (model) => model.trim().toLowerCase() !== normalized,
+        );
+        const modelEntries = prev.modelEntries.filter(
+          (entry) => entry.name.trim().toLowerCase() !== normalized,
+        );
+        return {
+          ...prev,
+          modelEntries: allowed ? [...modelEntries, createModelEntryDraft(modelId)] : modelEntries,
+          excludedModelsText: (allowed ? nextExcluded : [...nextExcluded, modelId]).join("\n"),
+        };
+      });
     },
-    [disableAllModels, excludedModels, openCodeModels, setExcludedModels],
+    [setKeyDraft],
   );
 
   const setAllFetchedOpenCodeModelsAllowed = useCallback(
     (allowed: boolean) => {
       const fetchedIds = new Set(openCodeModels.map((model) => model.id.toLowerCase()));
-      const unknownExisting = stripDisableAllModelsRule(excludedModels).filter(
-        (model) => !fetchedIds.has(model.toLowerCase()),
-      );
-      setExcludedModels(
-        allowed
-          ? unknownExisting
-          : [...unknownExisting, ...openCodeModels.map((model) => model.id)],
-      );
+      setKeyDraft((prev) => {
+        const currentExcluded = stripDisableAllModelsRule(
+          excludedModelsFromText(prev.excludedModelsText),
+        );
+        const unknownExcluded = currentExcluded.filter(
+          (model) => !fetchedIds.has(model.toLowerCase()),
+        );
+        const unknownEntries = prev.modelEntries.filter(
+          (entry) => !fetchedIds.has(entry.name.trim().toLowerCase()),
+        );
+        return {
+          ...prev,
+          modelEntries: allowed
+            ? [...unknownEntries, ...openCodeModels.map((model) => createModelEntryDraft(model.id))]
+            : unknownEntries,
+          excludedModelsText: (allowed
+            ? unknownExcluded
+            : [...unknownExcluded, ...openCodeModels.map((model) => model.id)]
+          ).join("\n"),
+        };
+      });
     },
-    [excludedModels, openCodeModels, setExcludedModels],
+    [openCodeModels, setKeyDraft],
   );
 
   const statusBadges = (
@@ -409,6 +494,7 @@ export function ProviderKeyModal({
               allowedOpenCodeCount={allowedOpenCodeCount}
               excludeAll={disableAllModels}
               excludedModelIds={excludedModelIds}
+              enabledOpenCodeModelIds={enabledOpenCodeModelIds}
               fetchOpenCodeModels={fetchOpenCodeModels}
               setAllFetchedOpenCodeModelsAllowed={setAllFetchedOpenCodeModelsAllowed}
               setOpenCodeModelAllowed={setOpenCodeModelAllowed}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -25,6 +25,7 @@ interface ProviderKeyModelsTabProps {
   allowedOpenCodeCount: number;
   excludeAll: boolean;
   excludedModelIds: Set<string>;
+  enabledOpenCodeModelIds: Set<string>;
   fetchOpenCodeModels: () => Promise<void>;
   setAllFetchedOpenCodeModelsAllowed: (allowed: boolean) => void;
   setOpenCodeModelAllowed: (modelId: string, allowed: boolean) => void;
@@ -51,6 +52,7 @@ export function ProviderKeyModelsTab({
   allowedOpenCodeCount,
   excludeAll,
   excludedModelIds,
+  enabledOpenCodeModelIds,
   fetchOpenCodeModels,
   setAllFetchedOpenCodeModelsAllowed,
   setOpenCodeModelAllowed,
@@ -136,7 +138,11 @@ export function ProviderKeyModelsTab({
             ) : filteredOpenCodeModels.length ? (
               <div className="divide-y divide-slate-100 dark:divide-neutral-900">
                 {filteredOpenCodeModels.map((model) => {
-                  const checked = !excludeAll && !excludedModelIds.has(model.id.toLowerCase());
+                  const normalized = model.id.toLowerCase();
+                  const checked =
+                    !excludeAll &&
+                    enabledOpenCodeModelIds.has(normalized) &&
+                    !excludedModelIds.has(normalized);
                   return (
                     <label
                       key={model.id}

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -151,7 +151,7 @@ export function useProviderKeyEditor({
       ...(isOpenCodeGo && keyDraft.authCookie.trim()
         ? { authCookie: keyDraft.authCookie.trim() }
         : {}),
-      ...(!isOpenCodeGo && modelCommit.models ? { models: modelCommit.models } : {}),
+      ...(modelCommit.models ? { models: modelCommit.models } : {}),
       ...(editKeyType === "claude" && keyDraft.skipAnthropicProcessing
         ? { skipAnthropicProcessing: true }
         : {}),

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -24,6 +24,7 @@ import { UpdateDetailsCard } from "@app/update/UpdateDetailsCard";
 import {
   loadConfiguredModelAvailability,
   loadModelPathAvailability,
+  type ModelAvailabilitySource,
 } from "@features/model-availability";
 import {
   buildModelVendorStats,
@@ -124,6 +125,21 @@ function InfoCard({
 
 const _AUTO_REFRESH_INTERVAL = 30_000;
 
+type SystemModelEntry = {
+  id: string;
+  sources?: ModelAvailabilitySource[];
+};
+
+const formatModelSourcesTooltip = (
+  sources: ModelAvailabilitySource[] | undefined,
+  title: string,
+) => {
+  if (!sources?.length) return "";
+  const labels = Array.from(new Set(sources.map((source) => source.label.trim()).filter(Boolean)));
+  if (labels.length === 0) return "";
+  return `${title}\n${labels.join("\n")}`;
+};
+
 export function SystemPage({
   updateHeartbeatIntervalMs,
   updateHeartbeatTimeoutMs,
@@ -137,7 +153,7 @@ export function SystemPage({
 
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
-  const [models, setModels] = useState<string[]>([]);
+  const [models, setModels] = useState<SystemModelEntry[]>([]);
   const [modelFilter, setModelFilter] = useState("");
 
   const loadModels = useCallback(async () => {
@@ -150,11 +166,15 @@ export function SystemPage({
       ]);
 
       const useMappedOwnerModels = configuredAvailability?.usesMappedOwners === true;
+      const configuredById = new Map(
+        (configuredAvailability?.items ?? []).map((item) => [item.id.toLowerCase(), item]),
+      );
       const rootV1ModelIds =
         pathAvailability?.items
           .filter((item) =>
             item.paths.some(
-              (path) => path.scope === "root" && path.method === "GET" && path.path === "/v1/models",
+              (path) =>
+                path.scope === "root" && path.method === "GET" && path.path === "/v1/models",
             ),
           )
           .map((item) => item.id) ?? [];
@@ -164,7 +184,14 @@ export function SystemPage({
           ? rootV1ModelIds
           : (configuredAvailability?.items ?? []).map((item) => item.id);
 
-      setModels(Array.from(new Set(nextModelIds)).sort((a, b) => a.localeCompare(b)));
+      setModels(
+        Array.from(new Set(nextModelIds))
+          .sort((a, b) => a.localeCompare(b))
+          .map((id) => ({
+            id,
+            sources: configuredById.get(id.toLowerCase())?.sources,
+          })),
+      );
     } catch (err: unknown) {
       setModelsError(err instanceof Error ? err.message : t("system_page.load_failed"));
     } finally {
@@ -179,11 +206,14 @@ export function SystemPage({
   const filteredModels = useMemo(() => {
     const needle = modelFilter.trim().toLowerCase();
     if (!needle) return models;
-    return models.filter((id) => id.toLowerCase().includes(needle));
+    return models.filter((model) => model.id.toLowerCase().includes(needle));
   }, [modelFilter, models]);
 
   const vendorStats = useMemo(() => {
-    return buildModelVendorStats(models, t("common.other"));
+    return buildModelVendorStats(
+      models.map((model) => model.id),
+      t("common.other"),
+    );
   }, [models, t]);
 
   const handleModelCopied = useCallback(() => {
@@ -329,15 +359,33 @@ export function SystemPage({
             </div>
           ) : filteredModels.length > 0 ? (
             <div className="flex flex-wrap gap-2">
-              {filteredModels.map((id) => (
-                <CopyableModelTag
-                  key={id}
-                  id={id}
-                  title={t("system_page.click_copy")}
-                  copiedLabel={t("system_page.copied")}
-                  onCopied={handleModelCopied}
-                />
-              ))}
+              {filteredModels.map((model) => {
+                const tooltip = formatModelSourcesTooltip(
+                  model.sources,
+                  t("system_page.model_sources"),
+                );
+                const tag = (
+                  <CopyableModelTag
+                    id={model.id}
+                    title={t("system_page.click_copy")}
+                    copiedLabel={t("system_page.copied")}
+                    onCopied={handleModelCopied}
+                  />
+                );
+                return tooltip ? (
+                  <HoverTooltip key={model.id} content={tooltip} placement="top">
+                    <span className="inline-flex">{tag}</span>
+                  </HoverTooltip>
+                ) : (
+                  <CopyableModelTag
+                    key={model.id}
+                    id={model.id}
+                    title={t("system_page.click_copy")}
+                    copiedLabel={t("system_page.copied")}
+                    onCopied={handleModelCopied}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center py-12 text-slate-400 dark:text-white/30">

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -73,8 +73,7 @@ function renderPage() {
 
 function extractList(payload: unknown, key: string): unknown[] {
   if (Array.isArray(payload)) return payload;
-  const record =
-    payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const record = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
   const value = record[key] ?? record.items ?? record.data;
   return Array.isArray(value) ? value : [];
 }
@@ -94,8 +93,7 @@ function normalizeOpenAIProviders(payload: unknown) {
       models: Array.isArray(item.models) ? item.models : [],
       apiKeyEntries: rawEntries
         .map((raw) => {
-          const keyEntry =
-            raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+          const keyEntry = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
           const apiKey = String(keyEntry["api-key"] ?? keyEntry.apiKey ?? "").trim();
           if (!apiKey) return null;
           return {
@@ -278,6 +276,45 @@ describe("SystemPage", () => {
     expect(screen.queryByText("gpt-group-only")).not.toBeInTheDocument();
     expect(screen.queryByText("gemini-v1beta-only")).not.toBeInTheDocument();
     expect(mocks.apiGet).toHaveBeenCalledWith("/model-path-availability");
+  });
+
+  test("shows model sources in the model tag tooltip", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "gpt-root-model",
+              sources: [
+                { label: "codex · Codex Pro", provider: "codex" },
+                { label: "opencode-go · OpenCode Go", provider: "opencode-go" },
+              ],
+            },
+          ],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-root-model",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    await userEvent.hover(await screen.findByText("gpt-root-model"));
+
+    expect(await screen.findByText(/codex · Codex Pro/)).toBeInTheDocument();
+    expect(screen.getByText(/opencode-go · OpenCode Go/)).toBeInTheDocument();
   });
 
   test("shows persisted mapped owner models on the system page", async () => {


### PR DESCRIPTION
## Summary
- save OpenCode Go fetched model selections as explicit `models`, so newly fetched models stay unchecked until enabled
- show configured model source labels in the system model tooltip
- update API client, i18n, and focused coverage

## Tests
- `rtk bun run --filter @code-proxy/admin-panel test -- ../../packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts ../../pages/models/__tests__/modelAvailability.test.ts ../../pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx ../../pages/system/__tests__/SystemPage.test.tsx`
- `rtk bun run --filter @code-proxy/admin-panel build`
- `rtk git -C codeProxy diff --cached --check`