### PR TITLE
feat: add language and theme dropdowns

### DIFF
--- a/packages/ui/src/theme/LanguageSelector.tsx
+++ b/packages/ui/src/theme/LanguageSelector.tsx
@@ -1,13 +1,21 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { Check, Languages } from "lucide-react";
+import { Check } from "lucide-react";
 import {
   ensureLanguageResources,
   LANGUAGE_ORDER,
   STORAGE_KEY_LANGUAGE,
   type Language,
 } from "@code-proxy/i18n";
+import { HoverTooltip } from "../overlays/Tooltip";
+import {
+  cn,
+  selectOptionBase,
+  selectOptionIdle,
+  selectOptionSelected,
+  selectPanel,
+} from "../utils/selectStyles";
 
 const SUPPORTED_LANGUAGES = LANGUAGE_ORDER;
 const LANGUAGE_LABEL_KEYS: Record<Language, string> = {
@@ -21,6 +29,12 @@ const SHORT_LABELS: Record<Language, string> = {
   en: "EN",
   "zh-CN": "中",
   ru: "RU",
+};
+
+const FLAG_ICONS: Record<Language, string> = {
+  "zh-CN": "🇨🇳",
+  en: "🇬🇧",
+  ru: "🇷🇺",
 };
 
 export function LanguageSelector({ className }: { className?: string }) {
@@ -59,7 +73,7 @@ export function LanguageSelector({ className }: { className?: string }) {
     const el = triggerRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const width = 130;
+    const width = 170;
     const margin = 8;
     const nextLeft = rect.right - width;
     const maxLeft = Math.max(margin, window.innerWidth - width - margin);
@@ -100,22 +114,29 @@ export function LanguageSelector({ className }: { className?: string }) {
 
   const label = t("language.switch");
   const shortLabel = SHORT_LABELS[currentValue] ?? currentValue;
+  const tooltip = `${label}: ${t(LANGUAGE_LABEL_KEYS[currentValue])}`;
 
   return (
     <>
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => setOpen((prev) => !prev)}
-        className={className}
-        aria-label={label}
-        title={label}
-        aria-expanded={open}
-        aria-haspopup="listbox"
-      >
-        <Languages size={16} />
-        <span className="ml-1 text-[11px] font-bold leading-none">{shortLabel}</span>
-      </button>
+      <HoverTooltip content={tooltip}>
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className={className}
+          aria-label={label}
+          aria-expanded={open}
+          aria-haspopup="listbox"
+        >
+          <span
+            className="inline-flex h-5 w-7 shrink-0 items-center justify-center overflow-hidden rounded-[4px] bg-white text-base leading-none shadow-[inset_0_0_0_1px_rgb(15_23_42_/_0.08)]"
+            aria-hidden="true"
+          >
+            {FLAG_ICONS[currentValue]}
+          </span>
+          <span className="ml-1 text-[11px] font-bold leading-none">{shortLabel}</span>
+        </button>
+      </HoverTooltip>
 
       {open
         ? createPortal(
@@ -123,7 +144,7 @@ export function LanguageSelector({ className }: { className?: string }) {
               ref={listRef}
               role="listbox"
               aria-label={label}
-              className="fixed z-[9999] w-[130px] overflow-hidden rounded-xl border border-slate-200 bg-white p-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-900"
+              className={cn(selectPanel, "w-[170px]")}
               style={{ top: pos.top, left: pos.left }}
             >
               {SUPPORTED_LANGUAGES.map((lng) => {
@@ -135,22 +156,21 @@ export function LanguageSelector({ className }: { className?: string }) {
                     role="option"
                     aria-selected={selected}
                     onClick={() => handleLanguageChange(lng)}
-                    className={[
-                      "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm outline-none transition-colors",
-                      "hover:bg-slate-100 dark:hover:bg-white/10",
+                    className={cn(
+                      selectOptionBase,
                       selected
-                        ? "font-medium text-slate-900 dark:text-white"
-                        : "text-slate-600 dark:text-slate-300",
-                    ].join(" ")}
+                        ? `${selectOptionSelected} bg-[#EBEBEC] dark:bg-[#46464C]`
+                        : selectOptionIdle,
+                    )}
                   >
+                    <span
+                      className="inline-flex h-5 w-7 shrink-0 items-center justify-center overflow-hidden rounded-[4px] bg-white text-base leading-none shadow-[inset_0_0_0_1px_rgb(15_23_42_/_0.08)]"
+                      aria-hidden="true"
+                    >
+                      {FLAG_ICONS[lng]}
+                    </span>
                     <span className="flex-1 truncate">{t(LANGUAGE_LABEL_KEYS[lng])}</span>
-                    {selected ? (
-                      <Check
-                        size={14}
-                        className="shrink-0 text-slate-400 dark:text-white/50"
-                        aria-hidden="true"
-                      />
-                    ) : null}
+                    {selected ? <Check size={14} className="shrink-0" aria-hidden="true" /> : null}
                   </button>
                 );
               })}

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -4,10 +4,22 @@ import {
   use,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
-import { Moon, Sun } from "lucide-react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { Check, Monitor, Moon, Sun } from "lucide-react";
+import {
+  cn,
+  selectOptionBase,
+  selectOptionIdle,
+  selectOptionSelected,
+  selectPanel,
+} from "../utils/selectStyles";
+
 const THEME_STORAGE_KEY = "code-proxy-admin-theme";
 const THEME_TRANSITION_LOCK_CLASS = "theme-transition-lock";
 const THEME_TRANSITION_LOCK_RELEASE_MS = 120;
@@ -15,24 +27,46 @@ const THEME_TRANSITION_LOCK_RELEASE_MS = 120;
 let transitionLockTimer: number | null = null;
 
 export type ThemeMode = "light" | "dark";
+export type ThemePreference = ThemeMode | "auto";
 
 interface ThemeContextState {
   state: {
     mode: ThemeMode;
+    preference: ThemePreference;
+    systemMode: ThemeMode;
   };
   actions: {
-    setMode: (mode: ThemeMode) => void;
+    setMode: (mode: ThemePreference) => void;
     toggle: () => void;
   };
 }
 
 const ThemeContext = createContext<ThemeContextState | null>(null);
 
-const readThemeSnapshot = (): ThemeMode | null => {
+const THEME_OPTIONS = [
+  { value: "light", labelKey: "theme.light", Icon: Sun },
+  { value: "dark", labelKey: "theme.dark", Icon: Moon },
+  { value: "auto", labelKey: "theme.auto", Icon: Monitor },
+] as const;
+
+const isThemePreference = (value: unknown): value is ThemePreference =>
+  value === "light" || value === "dark" || value === "auto";
+
+const readThemeSnapshot = (): ThemePreference | null => {
   try {
     const raw = localStorage.getItem(THEME_STORAGE_KEY);
-    if (raw === "dark" || raw === "light") {
+    if (isThemePreference(raw)) {
       return raw;
+    }
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (typeof parsed === "object" && parsed !== null) {
+      const state = "state" in parsed ? parsed.state : undefined;
+      if (typeof state === "object" && state !== null && "theme" in state) {
+        const theme = state.theme;
+        if (isThemePreference(theme)) return theme;
+      }
+      if ("theme" in parsed && isThemePreference(parsed.theme)) return parsed.theme;
+      if ("mode" in parsed && isThemePreference(parsed.mode)) return parsed.mode;
     }
     return null;
   } catch {
@@ -63,7 +97,7 @@ const applyThemeToDom = (mode: ThemeMode): void => {
   }
 };
 
-const persistTheme = (mode: ThemeMode): void => {
+const persistTheme = (mode: ThemePreference): void => {
   try {
     localStorage.setItem(THEME_STORAGE_KEY, mode);
   } catch {
@@ -105,32 +139,52 @@ const lockThemeTransitions = (): void => {
 };
 
 export function ThemeProvider({ children }: PropsWithChildren) {
-  const [mode, setModeState] = useState<ThemeMode>(
-    () => readThemeSnapshot() ?? resolveSystemTheme(),
+  const [preference, setPreferenceState] = useState<ThemePreference>(
+    () => readThemeSnapshot() ?? "auto",
   );
+  const [systemMode, setSystemMode] = useState<ThemeMode>(() => resolveSystemTheme());
+  const mode = preference === "auto" ? systemMode : preference;
 
   useEffect(() => {
     applyThemeToDom(mode);
-    persistTheme(mode);
-  }, [mode]);
+    persistTheme(preference);
+  }, [mode, preference]);
 
-  const setMode = useCallback((next: ThemeMode) => {
+  const setMode = useCallback((next: ThemePreference) => {
+    const nextSystemMode = resolveSystemTheme();
+    const nextMode = next === "auto" ? nextSystemMode : next;
     lockThemeTransitions();
-    applyThemeToDom(next);
+    applyThemeToDom(nextMode);
     persistTheme(next);
-    setModeState(next);
+    setSystemMode(nextSystemMode);
+    setPreferenceState(next);
   }, []);
 
   const toggle = useCallback(() => {
     setMode(mode === "dark" ? "light" : "dark");
   }, [mode, setMode]);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => {
+      const next = mediaQuery.matches ? "dark" : "light";
+      setSystemMode(next);
+      if (preference === "auto") {
+        lockThemeTransitions();
+        applyThemeToDom(next);
+      }
+    };
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [preference]);
+
   const value = useMemo<ThemeContextState>(
     () => ({
-      state: { mode },
+      state: { mode, preference, systemMode },
       actions: { setMode, toggle },
     }),
-    [mode, setMode, toggle],
+    [mode, preference, setMode, systemMode, toggle],
   );
 
   return <ThemeContext value={value}>{children}</ThemeContext>;
@@ -145,17 +199,120 @@ export const useTheme = (): ThemeContextState => {
 };
 
 export function ThemeToggleButton({ className, label }: { className?: string; label?: string }) {
+  const { t } = useTranslation();
   const {
-    state: { mode },
-    actions: { toggle },
+    state: { mode, preference },
+    actions: { setMode },
   } = useTheme();
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
 
-  const Icon = mode === "dark" ? Sun : Moon;
-  const text = label ?? (mode === "dark" ? "Switch to light" : "Switch to dark");
+  const selectedOption = THEME_OPTIONS.find((option) => option.value === preference);
+  const TriggerIcon = preference === "auto" ? Monitor : mode === "dark" ? Moon : Sun;
+  const buttonLabel = label ?? t("theme.switch");
+  const tooltip = `${buttonLabel}: ${t(selectedOption?.labelKey ?? "theme.switch")}`;
+
+  const reposition = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const width = 220;
+    const margin = 8;
+    const nextLeft = rect.right - width;
+    const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+    const left = Math.min(Math.max(margin, nextLeft), maxLeft);
+    setPos({ top: rect.bottom + 6, left });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    reposition();
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open, reposition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener("pointerdown", handleClick);
+    return () => document.removeEventListener("pointerdown", handleClick);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  const handleModeChange = (next: ThemePreference) => {
+    setMode(next);
+    setOpen(false);
+  };
 
   return (
-    <button type="button" onClick={toggle} className={className} aria-label={text} title={text}>
-      <Icon size={16} />
-    </button>
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className={className}
+        aria-label={buttonLabel}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        data-tooltip={tooltip}
+        title={tooltip}
+      >
+        <TriggerIcon size={16} />
+      </button>
+
+      {open
+        ? createPortal(
+            <div
+              ref={menuRef}
+              role="menu"
+              aria-label={buttonLabel}
+              className={cn(selectPanel, "w-[220px]")}
+              style={{ top: pos.top, left: pos.left }}
+            >
+              {THEME_OPTIONS.map(({ value, labelKey, Icon }) => {
+                const selected = value === preference;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={selected}
+                    onClick={() => handleModeChange(value)}
+                    className={cn(
+                      selectOptionBase,
+                      selected
+                        ? `${selectOptionSelected} bg-[#EBEBEC] dark:bg-[#46464C]`
+                        : selectOptionIdle,
+                    )}
+                  >
+                    <Icon size={16} className="shrink-0" aria-hidden="true" />
+                    <span className="min-w-0 flex-1 truncate">{t(labelKey)}</span>
+                    {selected ? <Check size={14} className="shrink-0" aria-hidden="true" /> : null}
+                  </button>
+                );
+              })}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
+++ b/packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
@@ -17,6 +17,9 @@ describe("LanguageSelector", () => {
     expect(screen.getByRole("option", { name: /中文/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /English/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /Русский/ })).toBeInTheDocument();
+    expect(screen.getAllByText("🇨🇳").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("🇬🇧").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("🇷🇺").length).toBeGreaterThan(0);
     expect(screen.queryByText(/nav\.language/)).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
@@ -1,12 +1,14 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
 import { ThemeProvider, ThemeToggleButton } from "../ThemeProvider";
 
 const THEME_STORAGE_KEY = "code-proxy-admin-theme";
 const THEME_TRANSITION_LOCK_CLASS = "theme-transition-lock";
 
 describe("ThemeProvider", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     localStorage.clear();
     document.documentElement.className = "";
     document.documentElement.removeAttribute("data-theme");
@@ -22,8 +24,50 @@ describe("ThemeProvider", () => {
     document.documentElement.style.colorScheme = "";
   });
 
+  function mockSystemTheme(initialMatches: boolean) {
+    let matches = initialMatches;
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          get matches() {
+            return matches;
+          },
+          media: query,
+          onchange: null,
+          addEventListener: (_type: "change", listener: (event: MediaQueryListEvent) => void) => {
+            listeners.add(listener);
+          },
+          removeEventListener: (
+            _type: "change",
+            listener: (event: MediaQueryListEvent) => void,
+          ) => {
+            listeners.delete(listener);
+          },
+          addListener: (listener: (event: MediaQueryListEvent) => void) => {
+            listeners.add(listener);
+          },
+          removeListener: (listener: (event: MediaQueryListEvent) => void) => {
+            listeners.delete(listener);
+          },
+          dispatchEvent: () => false,
+        }) as MediaQueryList,
+    );
+    return {
+      setMatches(next: boolean) {
+        matches = next;
+        const event = {
+          matches: next,
+          media: "(prefers-color-scheme: dark)",
+        } as MediaQueryListEvent;
+        listeners.forEach((listener) => listener(event));
+      },
+    };
+  }
+
   test("locks transitions while applying a manual dark mode switch", () => {
     vi.useFakeTimers();
+    mockSystemTheme(false);
     const rafCallbacks: FrameRequestCallback[] = [];
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       rafCallbacks.push(callback);
@@ -36,7 +80,8 @@ describe("ThemeProvider", () => {
       </ThemeProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Switch to dark" }));
+    fireEvent.click(screen.getByRole("button", { name: "Theme" }));
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Dark" }));
 
     expect(document.documentElement).toHaveClass(THEME_TRANSITION_LOCK_CLASS);
     expect(document.documentElement).toHaveClass("dark");
@@ -58,5 +103,27 @@ describe("ThemeProvider", () => {
       vi.advanceTimersByTime(1);
     });
     expect(document.documentElement).not.toHaveClass(THEME_TRANSITION_LOCK_CLASS);
+  });
+
+  test("keeps auto mode synced with the system theme", () => {
+    const systemTheme = mockSystemTheme(false);
+
+    render(
+      <ThemeProvider>
+        <ThemeToggleButton />
+      </ThemeProvider>,
+    );
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("auto");
+    expect(document.documentElement.style.colorScheme).toBe("light");
+
+    act(() => {
+      systemTheme.setMatches(true);
+    });
+
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("auto");
+    expect(document.documentElement).toHaveClass("dark");
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
   });
 });


### PR DESCRIPTION
## Summary
- add flag-based language dropdown with tooltip
- add theme dropdown with light, dark, and auto system-following mode
- keep resolved theme consumers using light/dark mode while persisting the selected preference

## Validation
- bun run --filter @code-proxy/admin-panel test -- packages/ui/src/theme/__tests__/ThemeProvider.test.tsx packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
- bunx oxfmt --check packages/ui/src/theme/ThemeProvider.tsx packages/ui/src/theme/LanguageSelector.tsx packages/ui/src/theme/__tests__/ThemeProvider.test.tsx packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
- bun run --filter @code-proxy/admin-panel build
- Playwright smoke check on /manage/#/apikey-lookup