### PR TITLE
fix: honor mapped owner availability on system page

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -768,7 +768,7 @@ export const normalizeConfiguredModelAvailability = (
     items,
     metadataItems,
     idSet: new Set(items.map((item) => item.id.toLowerCase())),
-    usesMappedOwners: false,
+    usesMappedOwners: record.uses_mapped_owners === true || record.usesMappedOwners === true,
   };
 };
 

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -367,6 +367,40 @@ describe("SystemPage", () => {
     expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
   });
 
+  test("uses backend mapped owner availability instead of root path registry models", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          uses_mapped_owners: true,
+          data: [{ id: "gpt-5.5", owned_by: "codex" }],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-5.5",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+            {
+              id: "gpt-5-codex",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("gpt-5.5")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
+  });
+
   test("hides disabled OpenAI compatible provider models in mapped owner mode", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") {


### PR DESCRIPTION
## Summary\n- read uses_mapped_owners from configured availability\n- keep system page on configured mapped-owner results instead of root path registry models\n- add regression coverage for old Codex registry models being hidden\n\n## Tests\n- bun run --filter @code-proxy/admin-panel test pages/system/__tests__/SystemPage.test.tsx\n- bun run test:ci\n- bun run check