### PR TITLE
test: cover provider models in mapped owner system list

### DIFF
--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -401,6 +401,40 @@ describe("SystemPage", () => {
     expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
   });
 
+  test("keeps provider models returned with mapped owner availability", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          uses_mapped_owners: true,
+          data: [
+            { id: "gpt-5.5", owned_by: "codex" },
+            { id: "qwen3.7-max", owned_by: "opencode" },
+          ],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-5-codex",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("gpt-5.5")).toBeInTheDocument();
+    expect(screen.getByText("qwen3.7-max")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
+  });
+
   test("hides disabled OpenAI compatible provider models in mapped owner mode", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") {


### PR DESCRIPTION
## Summary\n- add SystemPage regression coverage for mapped-owner availability that also includes provider/API key models\n\n## Tests\n- bun run test:ci -- pages/system/__tests__/SystemPage.test.tsx\n- bun run test:ci\n- bun run check