### PR TITLE
fix: align cc switch group model lookup

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -377,18 +377,19 @@ export function CcSwitchImportConfigModal({
     const modelOwnerKeys = new Set(
       (selectedGroupOption?.modelOwnerKeys ?? []).map(normalizeModelOwnerKey).filter(Boolean),
     );
-    const lookupParams = selectedGroup
-      ? { allowedChannelGroups: [selectedGroup] }
-      : { allowedChannels: lookupChannels };
+    const useResolvedChannels = lookupChannels.length > 0;
+    const lookupParams = useResolvedChannels
+      ? { allowedChannels: lookupChannels }
+      : { allowedChannelGroups: [selectedGroup] };
 
     setModelsLoading(true);
     modelsApi
       .listAvailableModels(lookupParams)
       .then(async (models) => {
         if (cancelled) return;
-        const availability = await loadConfiguredModelAvailability(
-          selectedGroup ? { allowedChannelGroups: [selectedGroup] } : undefined,
-        );
+        const availability = useResolvedChannels
+          ? await loadConfiguredModelAvailability()
+          : await loadConfiguredModelAvailability({ allowedChannelGroups: [selectedGroup] });
         if (cancelled) return;
         let visibleModels = filterByConfiguredModelAvailability(models, availability);
         const optionMap = new Map<string, string>();

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -403,15 +403,13 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(await within(dialog).findByDisplayValue("gpt-5.5")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("gpt-5-codex")).not.toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
-      allowedChannelGroups: ["chatgpt-pro"],
+      allowedChannels: ["A_GptPro"],
     });
-    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith({
-      allowedChannelGroups: ["chatgpt-pro"],
-    });
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith(undefined);
     expect(getModelConfigs).not.toHaveBeenCalled();
   });
 
-  test("hydrates the Kimi and DeepSeek channel group from scoped backend availability", async () => {
+  test("hydrates the Kimi and DeepSeek channel group from resolved channels", async () => {
     getAuthGroupModelOwnerMappingMap.mockResolvedValue({ kimi: "kimi-code" });
     listChannelGroups.mockResolvedValue([
       {
@@ -484,10 +482,98 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(
       within(dialog).queryByText(/no models are available for this channel group/i),
     ).not.toBeInTheDocument();
-    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith({
-      allowedChannelGroups: ["kimi+deepseek v4 flash"],
+    expect(listAvailableModels).toHaveBeenCalledWith({
+      allowedChannels: ["kimi-code", "opencode"],
     });
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith(undefined);
     expect(getModelConfigs).not.toHaveBeenCalled();
+  });
+
+  test("loads resolved tag group channel models for CC Switch presets", async () => {
+    getAuthGroupModelOwnerMappingMap.mockResolvedValue({ codex: "codex" });
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "group1",
+        description: "plus pool and opencode go",
+        channels: ["inroi", "haoxinren", "opencode go", "便宜的"],
+        channelDetails: [
+          {
+            name: "inroi",
+            source: "codex",
+            default_tags: ["codex"],
+            custom_tags: [],
+            display_tags: ["codex"],
+          },
+          {
+            name: "haoxinren",
+            source: "codex",
+            default_tags: ["codex"],
+            custom_tags: [],
+            display_tags: ["codex"],
+          },
+          {
+            name: "opencode go",
+            source: "opencode-go",
+            default_tags: ["opencode-go"],
+            custom_tags: [],
+            display_tags: ["opencode-go"],
+          },
+          {
+            name: "便宜的",
+            source: "codex",
+            default_tags: ["codex"],
+            custom_tags: [],
+            display_tags: ["codex"],
+          },
+        ],
+        "path-routes": ["/group1"],
+      },
+    ]);
+    listAvailableModels.mockResolvedValue([
+      { id: "deepseek-v4-flash" },
+      { id: "deepseek-v4-pro" },
+      { id: "gpt-5.3-codex-spark" },
+    ]);
+    loadConfiguredModelAvailability.mockImplementation(
+      async (options?: { allowedChannelGroups?: string[] }) => {
+        if (options?.allowedChannelGroups?.includes("group1")) {
+          return {
+            scoped: true,
+            items: [{ id: "gpt-5.3-codex-spark", owned_by: "codex", source: "seed" }],
+            idSet: new Set(["gpt-5.3-codex-spark"]),
+          };
+        }
+        return {
+          scoped: true,
+          items: [
+            { id: "deepseek-v4-flash", owned_by: "deepseek", source: "openrouter" },
+            { id: "deepseek-v4-pro", owned_by: "deepseek", source: "openrouter" },
+            { id: "gpt-5.3-codex-spark", owned_by: "codex", source: "seed" },
+          ],
+          idSet: new Set(["deepseek-v4-flash", "deepseek-v4-pro", "gpt-5.3-codex-spark"]),
+        };
+      },
+    );
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /new config/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: /new cc switch config/i });
+    await user.click(within(dialog).getByRole("combobox", { name: /select channel group/i }));
+    await user.click(await screen.findByRole("option", { name: /group1.*\/group1/i }));
+
+    expect(await within(dialog).findByDisplayValue("deepseek-v4-flash")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("deepseek-v4-pro")).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("gpt-5.3-codex-spark")).toBeInTheDocument();
+    expect(listAvailableModels).toHaveBeenCalledWith({
+      allowedChannels: expect.arrayContaining(["haoxinren", "inroi", "opencode go", "便宜的"]),
+    });
+    expect(listAvailableModels.mock.calls.at(-1)?.[0]?.allowedChannels).toHaveLength(4);
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith(undefined);
+    expect(loadConfiguredModelAvailability).not.toHaveBeenCalledWith({
+      allowedChannelGroups: ["group1"],
+    });
   });
 
   test("merges mapped Codex owner models with OpenCode Go channel models in CC Switch presets", async () => {
@@ -546,7 +632,7 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(screen.getByDisplayValue("minimax-m2.7")).toBeInTheDocument();
     expect(screen.getByDisplayValue("kimi-k2.6")).toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
-      allowedChannelGroups: ["opencodego+gpt"],
+      allowedChannels: ["A_GptPro", "opencode go"],
     });
   });
 
@@ -603,11 +689,9 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(screen.getByRole("option", { name: "kimi-k2.7-code" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "kimi-k2" })).not.toBeInTheDocument();
     expect(listAvailableModels).toHaveBeenCalledWith({
-      allowedChannelGroups: ["kimicode"],
+      allowedChannels: ["kimi"],
     });
-    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith({
-      allowedChannelGroups: ["kimicode"],
-    });
+    expect(loadConfiguredModelAvailability).toHaveBeenCalledWith(undefined);
     expect(getModelConfigs).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Use resolved channel-group channels for CC Switch model lookup when available, matching the channel group editor model boundary.
- Keep group-scoped lookup as fallback for groups without resolved channels.
- Add regression coverage for group1-like tag groups where group-scoped availability misses DeepSeek models.

## Verification
- bun run --filter @code-proxy/admin-panel test pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- bun run --filter @code-proxy/admin-panel test pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- bun run --filter @code-proxy/admin-panel build
- bun run --filter @code-proxy/admin-panel test
- bun run lint (0 errors, existing warnings only)
- Playwright mock flow for /manage/#/ccswitch-import-settings group1 shows deepseek-v4-flash/pro and verifies allowed_channels request