### PR TITLE
fix: include Codex model catalog in CC Switch imports

### DIFF
--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -14,6 +14,10 @@ export interface CcSwitchModelMappingInput {
   role?: CcSwitchClaudeModelRole;
 }
 
+interface CcSwitchCodexCatalogModel {
+  model: string;
+}
+
 export interface CcSwitchClientConfig {
   type: CcSwitchClientType;
   app: string;
@@ -181,6 +185,44 @@ const normalizeUsageScriptLanguage = (language: string | undefined): CcSwitchUsa
     .startsWith("en")
     ? "en"
     : "zh-CN";
+
+const buildCodexConfig = (input: {
+  apiKey: string;
+  endpoint: string;
+  model: string;
+  providerName: string;
+  modelMappings: readonly CcSwitchModelMappingInput[];
+}): string => {
+  const tomlString = (value: string) => JSON.stringify(value);
+  const model = input.model.trim() || "gpt-5-codex";
+  const config = `model_provider = "custom"
+model = ${tomlString(model)}
+model_reasoning_effort = "high"
+disable_response_storage = true
+
+[model_providers.custom]
+name = ${tomlString(input.providerName.trim() || "CliProxy Codex")}
+base_url = ${tomlString(input.endpoint)}
+wire_api = "responses"
+requires_openai_auth = true`;
+
+  const catalogModels: CcSwitchCodexCatalogModel[] = [];
+  const seen = new Set<string>();
+  for (const mapping of input.modelMappings) {
+    if (mapping.role) continue;
+    const model = mapping.requestModel.trim();
+    const key = model.toLowerCase();
+    if (!model || seen.has(key)) continue;
+    seen.add(key);
+    catalogModels.push({ model });
+  }
+
+  return JSON.stringify({
+    auth: { OPENAI_API_KEY: input.apiKey.trim() },
+    config,
+    ...(catalogModels.length > 0 ? { modelCatalog: { models: catalogModels } } : {}),
+  });
+};
 
 export function buildCcSwitchUsageScript(language?: string): string {
   const labels =
@@ -356,6 +398,20 @@ export function buildCcSwitchImportUrl(input: {
     if (haikuModel) params.set("haikuModel", haikuModel);
     if (sonnetModel) params.set("sonnetModel", sonnetModel);
     if (opusModel) params.set("opusModel", opusModel);
+  }
+  if (input.clientType === "codex") {
+    params.set(
+      "config",
+      encodeBase64(
+        buildCodexConfig({
+          apiKey: input.apiKey,
+          endpoint: importConfig.endpoint,
+          model,
+          providerName: params.get("name") ?? input.providerName,
+          modelMappings,
+        }),
+      ),
+    );
   }
 
   return `ccswitch://v1/import?${params.toString()}`;

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -18,6 +18,17 @@ const decodeUsageScript = (url: string) => {
   return new TextDecoder().decode(bytes);
 };
 
+const decodeConfig = (url: string) => {
+  const encoded = new URL(url).searchParams.get("config");
+  expect(encoded).toBeTruthy();
+  const binary = atob(encoded!);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
+};
+
 describe("ccswitchImport", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -244,6 +255,12 @@ describe("ccswitchImport", () => {
 
     const parsed = new URL(url);
     expect(parsed.searchParams.get("model")).toBe("gpt-6-router");
+    expect(decodeConfig(url)).toMatchObject({
+      auth: { OPENAI_API_KEY: "sk-test-key" },
+      modelCatalog: {
+        models: [{ model: "gpt-6-router" }, { model: "kimi-k2" }],
+      },
+    });
   });
 
   test("selects a client-specific default model from available models", () => {


### PR DESCRIPTION
## Summary
- include Codex auth/config/modelCatalog in CC Switch import deeplinks
- derive catalog entries from request-side model mappings
- cover decoded import config in the CC Switch import test

## Tests
- bun run --filter @code-proxy/admin-panel test -- pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
- bun run --filter @code-proxy/admin-panel build