### PR TITLE
fix: download Codex CC Switch model catalog

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -2496,6 +2496,8 @@
     "copy_import_link_copied": "Import link copied",
     "copy_import_link_success": "Import link copied",
     "copy_import_link_failed": "Failed to copy import link",
+    "download_codex_model_catalog": "Download Codex model catalog",
+    "download_codex_model_catalog_success": "Codex model catalog downloaded",
     "import_no_compatible_configs": "No compatible CC Switch configs found. Create one in CC Switch import settings first.",
     "config_new": "New config",
     "config_table_title": "Config list",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -2765,6 +2765,8 @@
     "copy_import_link_copied": "导入链接已复制",
     "copy_import_link_success": "导入链接已复制",
     "copy_import_link_failed": "复制导入链接失败",
+    "download_codex_model_catalog": "下载 Codex 模型目录",
+    "download_codex_model_catalog_success": "Codex 模型目录已下载",
     "import_no_compatible_configs": "没有可用的 CC Switch 配置，请先在 CC Switch 导入设置中创建预设。",
     "config_new": "新建配置",
     "config_table_title": "配置列表",

--- a/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { apiClient } from "../../client/client";
-import { ccSwitchImportConfigsApi } from "@code-proxy/api-client/endpoints/ccswitch-import-configs";
+import {
+  ccSwitchImportConfigsApi,
+  normalizeCcSwitchImportConfigs,
+} from "@code-proxy/api-client/endpoints/ccswitch-import-configs";
 
 vi.mock("../../client/client", () => ({
   apiClient: {
@@ -52,5 +55,39 @@ describe("ccSwitchImportConfigsApi", () => {
         ],
       }),
     ]);
+  });
+
+  test("normalizes backend Codex model catalog fields", () => {
+    const configs = normalizeCcSwitchImportConfigs([
+      {
+        id: "codex-deepseek",
+        "client-type": "codex",
+        "provider-name": "Pro pool + DeepSeek",
+        "default-model": "gpt-5.5",
+        "model-mappings": [
+          { "request-model": "gpt-5.5", "target-model": "gpt-5.5" },
+          { "request-model": "deepseek-v4-flash", "target-model": "deepseek-chat" },
+        ],
+        "allowed-channel-groups": ["pro"],
+        "route-path": "/pro/cs_deepseek",
+        "endpoint-path": "/v1",
+        "usage-auto-interval": 30,
+        "codex-model-catalog-filename": "cc-switch-model-catalog.json",
+        "codex-model-catalog": {
+          models: [
+            { slug: "gpt-5.5", display_name: "gpt-5.5" },
+            { slug: "deepseek-v4-flash", display_name: "deepseek-v4-flash" },
+          ],
+        },
+      },
+    ]);
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0]).toMatchObject({
+      codexModelCatalogFilename: "cc-switch-model-catalog.json",
+      codexModelCatalog: {
+        models: [{ slug: "gpt-5.5" }, { slug: "deepseek-v4-flash" }],
+      },
+    });
   });
 });

--- a/packages/api-client/src/endpoints/ccswitch-import-configs.ts
+++ b/packages/api-client/src/endpoints/ccswitch-import-configs.ts
@@ -1,6 +1,7 @@
 import { apiClient } from "../client/client";
 import {
   createCcSwitchImportConfig,
+  type CcSwitchImportCodexModelCatalog,
   type CcSwitchModelMapping,
   type CcSwitchImportConfigListItem,
 } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
@@ -53,6 +54,19 @@ const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
     .filter((item): item is CcSwitchModelMapping => Boolean(item));
 };
 
+const normalizeCodexModelCatalog = (
+  value: unknown,
+): CcSwitchImportCodexModelCatalog | undefined => {
+  const record = asRecord(value);
+  if (!record || !Array.isArray(record.models)) return undefined;
+
+  const models = record.models.filter(
+    (entry): entry is Record<string, unknown> => asRecord(entry) !== null,
+  );
+  const hasSlug = models.some((entry) => normalizeString(entry.slug));
+  return hasSlug ? { models: models.map((entry) => ({ ...entry })) } : undefined;
+};
+
 export function normalizeCcSwitchImportConfigs(raw: unknown): CcSwitchImportConfigListItem[] {
   if (!Array.isArray(raw)) return [];
 
@@ -78,6 +92,12 @@ export function normalizeCcSwitchImportConfigs(raw: unknown): CcSwitchImportConf
         routePath: normalizeString(record["route-path"] ?? record.routePath),
         endpointPath: normalizeString(record["endpoint-path"]),
         usageAutoInterval: normalizeNumber(record["usage-auto-interval"]),
+        codexModelCatalogFilename: normalizeString(
+          record["codex-model-catalog-filename"] ?? record.codexModelCatalogFilename,
+        ),
+        codexModelCatalog: normalizeCodexModelCatalog(
+          record["codex-model-catalog"] ?? record.codexModelCatalog,
+        ),
         apiKeyField:
           record["api-key-field"] === "ANTHROPIC_AUTH_TOKEN"
             ? "ANTHROPIC_AUTH_TOKEN"

--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -14,8 +14,72 @@ export interface CcSwitchModelMappingInput {
   role?: CcSwitchClaudeModelRole;
 }
 
-interface CcSwitchCodexCatalogModel {
+export const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME = "cc-switch-model-catalog.json";
+
+export interface CcSwitchCodexCatalogModel {
   model: string;
+  displayName?: string;
+  contextWindow?: number;
+}
+
+export interface CcSwitchCodexModelCatalog {
+  models: CcSwitchCodexModelCatalogEntry[];
+}
+
+export interface CcSwitchCodexModelCatalogEntry {
+  slug: string;
+  display_name: string;
+  description: string;
+  default_reasoning_level: "medium";
+  supported_reasoning_levels: Array<{
+    effort: "low" | "medium" | "high" | "xhigh";
+    description: string;
+  }>;
+  shell_type: "shell_command";
+  visibility: "list";
+  supported_in_api: true;
+  priority: number;
+  additional_speed_tiers: string[];
+  service_tiers: Array<{ id: string; name: string; description: string }>;
+  availability_nux: null;
+  upgrade: null;
+  base_instructions: string;
+  model_messages: {
+    instructions_template: string;
+    instructions_variables: Record<string, never>;
+    supports_reasoning_summaries: true;
+    default_reasoning_summary: "none";
+    support_verbosity: true;
+    default_verbosity: "low";
+    apply_patch_tool_type: "freeform";
+    web_search_tool_type: "text_and_image";
+    truncation_policy: { mode: "tokens"; limit: number };
+    supports_parallel_tool_calls: true;
+    supports_image_detail_original: true;
+    context_window: number;
+    max_context_window: number;
+    effective_context_window_percent: number;
+    experimental_supported_tools: never[];
+    input_modalities: Array<"text" | "image">;
+    supports_search_tool: true;
+    use_responses_lite: false;
+  };
+  supports_reasoning_summaries: true;
+  default_reasoning_summary: "none";
+  support_verbosity: true;
+  default_verbosity: "low";
+  apply_patch_tool_type: "freeform";
+  web_search_tool_type: "text_and_image";
+  truncation_policy: { mode: "tokens"; limit: number };
+  supports_parallel_tool_calls: true;
+  supports_image_detail_original: true;
+  context_window: number;
+  max_context_window: number;
+  effective_context_window_percent: number;
+  experimental_supported_tools: never[];
+  input_modalities: Array<"text" | "image">;
+  supports_search_tool: true;
+  use_responses_lite: false;
 }
 
 export interface CcSwitchClientConfig {
@@ -186,6 +250,104 @@ const normalizeUsageScriptLanguage = (language: string | undefined): CcSwitchUsa
     ? "en"
     : "zh-CN";
 
+const DEFAULT_CODEX_CONTEXT_WINDOW = 128_000;
+const CODEX_BASE_INSTRUCTIONS = "You are Codex, a coding agent.";
+const CODEX_SUPPORTED_REASONING_LEVELS: CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"] =
+  [
+    { effort: "low", description: "Fast responses with lighter reasoning" },
+    { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+    { effort: "high", description: "Greater reasoning depth for complex problems" },
+    { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+  ];
+
+const normalizeCodexContextWindow = (value: number | undefined): number => {
+  if (!Number.isFinite(value) || !value || value <= 0) return DEFAULT_CODEX_CONTEXT_WINDOW;
+  return Math.round(value);
+};
+
+const buildCodexCatalogEntry = (
+  model: CcSwitchCodexCatalogModel,
+  priority: number,
+): CcSwitchCodexModelCatalogEntry => {
+  const slug = model.model.trim();
+  const displayName = model.displayName?.trim() || slug;
+  const contextWindow = normalizeCodexContextWindow(model.contextWindow);
+
+  return {
+    slug,
+    display_name: displayName,
+    description: displayName,
+    default_reasoning_level: "medium",
+    supported_reasoning_levels: CODEX_SUPPORTED_REASONING_LEVELS,
+    shell_type: "shell_command",
+    visibility: "list",
+    supported_in_api: true,
+    priority: 1000 + priority,
+    additional_speed_tiers: [],
+    service_tiers: [],
+    availability_nux: null,
+    upgrade: null,
+    base_instructions: CODEX_BASE_INSTRUCTIONS,
+    model_messages: {
+      instructions_template: CODEX_BASE_INSTRUCTIONS,
+      instructions_variables: {},
+      supports_reasoning_summaries: true,
+      default_reasoning_summary: "none",
+      support_verbosity: true,
+      default_verbosity: "low",
+      apply_patch_tool_type: "freeform",
+      web_search_tool_type: "text_and_image",
+      truncation_policy: { mode: "tokens", limit: 10_000 },
+      supports_parallel_tool_calls: true,
+      supports_image_detail_original: true,
+      context_window: contextWindow,
+      max_context_window: contextWindow,
+      effective_context_window_percent: 95,
+      experimental_supported_tools: [],
+      input_modalities: ["text", "image"],
+      supports_search_tool: true,
+      use_responses_lite: false,
+    },
+    supports_reasoning_summaries: true,
+    default_reasoning_summary: "none",
+    support_verbosity: true,
+    default_verbosity: "low",
+    apply_patch_tool_type: "freeform",
+    web_search_tool_type: "text_and_image",
+    truncation_policy: { mode: "tokens", limit: 10_000 },
+    supports_parallel_tool_calls: true,
+    supports_image_detail_original: true,
+    context_window: contextWindow,
+    max_context_window: contextWindow,
+    effective_context_window_percent: 95,
+    experimental_supported_tools: [],
+    input_modalities: ["text", "image"],
+    supports_search_tool: true,
+    use_responses_lite: false,
+  };
+};
+
+export const buildCcSwitchCodexModelCatalog = (
+  models: readonly CcSwitchCodexCatalogModel[],
+): CcSwitchCodexModelCatalog => {
+  const seen = new Set<string>();
+  const catalogModels: CcSwitchCodexModelCatalogEntry[] = [];
+
+  for (const model of models) {
+    const slug = model.model.trim();
+    const key = slug.toLowerCase();
+    if (!slug || seen.has(key)) continue;
+    seen.add(key);
+    catalogModels.push(buildCodexCatalogEntry({ ...model, model: slug }, catalogModels.length));
+  }
+
+  return { models: catalogModels };
+};
+
+export const buildCcSwitchCodexModelCatalogJson = (
+  models: readonly CcSwitchCodexCatalogModel[],
+): string => JSON.stringify(buildCcSwitchCodexModelCatalog(models), null, 2);
+
 const buildCodexConfig = (input: {
   apiKey: string;
   endpoint: string;
@@ -195,27 +357,37 @@ const buildCodexConfig = (input: {
 }): string => {
   const tomlString = (value: string) => JSON.stringify(value);
   const model = input.model.trim() || "gpt-5-codex";
+  const catalogModels: CcSwitchCodexCatalogModel[] = [];
+  const seen = new Set<string>();
+  const addCatalogModel = (value: string) => {
+    const normalized = value.trim();
+    const key = normalized.toLowerCase();
+    if (!normalized || seen.has(key)) return;
+    seen.add(key);
+    catalogModels.push({ model: normalized });
+  };
+
+  addCatalogModel(model);
+  for (const mapping of input.modelMappings) {
+    if (mapping.role) continue;
+    addCatalogModel(mapping.requestModel);
+  }
+
+  const catalogPointer =
+    catalogModels.length > 0
+      ? `model_catalog_json = ${tomlString(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)}\n`
+      : "";
   const config = `model_provider = "custom"
 model = ${tomlString(model)}
 model_reasoning_effort = "high"
 disable_response_storage = true
+${catalogPointer}
 
 [model_providers.custom]
 name = ${tomlString(input.providerName.trim() || "CliProxy Codex")}
 base_url = ${tomlString(input.endpoint)}
 wire_api = "responses"
 requires_openai_auth = true`;
-
-  const catalogModels: CcSwitchCodexCatalogModel[] = [];
-  const seen = new Set<string>();
-  for (const mapping of input.modelMappings) {
-    if (mapping.role) continue;
-    const model = mapping.requestModel.trim();
-    const key = model.toLowerCase();
-    if (!model || seen.has(key)) continue;
-    seen.add(key);
-    catalogModels.push({ model });
-  }
 
   return JSON.stringify({
     auth: { OPENAI_API_KEY: input.apiKey.trim() },

--- a/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
+++ b/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
@@ -17,6 +17,10 @@ export interface CcSwitchModelMapping {
   role?: CcSwitchClaudeModelRole;
 }
 
+export interface CcSwitchImportCodexModelCatalog {
+  models: Array<Record<string, unknown>>;
+}
+
 export interface CcSwitchImportConfigListItem {
   id: string;
   clientType: CcSwitchClientType;
@@ -29,6 +33,8 @@ export interface CcSwitchImportConfigListItem {
   endpointPath: string;
   usageAutoInterval: number;
   apiKeyField?: CcSwitchClaudeAuthField;
+  codexModelCatalogFilename?: string;
+  codexModelCatalog?: CcSwitchImportCodexModelCatalog;
 }
 
 const CLIENT_TYPES: CcSwitchClientType[] = ["claude", "codex", "gemini"];
@@ -105,6 +111,22 @@ const normalizeUsageAutoInterval = (value: unknown, fallback: number) => {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
   return Math.round(parsed);
+};
+
+const normalizeCodexModelCatalog = (
+  value: unknown,
+): CcSwitchImportCodexModelCatalog | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  if (!("models" in value)) return undefined;
+  const { models } = value;
+  if (!Array.isArray(models)) return undefined;
+
+  const entries = models.filter(
+    (entry): entry is Record<string, unknown> =>
+      entry !== null && typeof entry === "object" && !Array.isArray(entry),
+  );
+  const hasSlug = entries.some((entry) => typeof entry.slug === "string" && entry.slug.trim());
+  return hasSlug ? { models: entries.map((entry) => ({ ...entry })) } : undefined;
 };
 
 const createConfigId = () => {
@@ -203,6 +225,8 @@ export function createCcSwitchImportConfig(
 ): CcSwitchImportConfigListItem {
   const defaults = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[input.clientType];
   const modelMappings = normalizeModelMappings(input.modelMappings);
+  const codexModelCatalog =
+    input.clientType === "codex" ? normalizeCodexModelCatalog(input.codexModelCatalog) : undefined;
   const mappedDefaultModel =
     input.clientType === "claude"
       ? modelMappings.find((mapping) => mapping.role === "main")?.targetModel
@@ -230,6 +254,12 @@ export function createCcSwitchImportConfig(
     ...(input.clientType === "claude"
       ? {
           apiKeyField: normalizeCcSwitchClaudeAuthField(input.apiKeyField ?? defaults.apiKeyField),
+        }
+      : {}),
+    ...(input.clientType === "codex" && codexModelCatalog
+      ? {
+          codexModelCatalogFilename: String(input.codexModelCatalogFilename ?? "").trim(),
+          codexModelCatalog,
         }
       : {}),
   };

--- a/packages/domain/src/ccswitch/ccswitchImportLinks.ts
+++ b/packages/domain/src/ccswitch/ccswitchImportLinks.ts
@@ -1,4 +1,10 @@
-import { buildCcSwitchImportUrl, type CcSwitchClientType } from "./ccswitchImport";
+import {
+  buildCcSwitchCodexModelCatalogJson,
+  buildCcSwitchImportUrl,
+  CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
+  type CcSwitchClientType,
+  type CcSwitchCodexCatalogModel,
+} from "./ccswitchImport";
 import {
   normalizeCcSwitchClaudeAuthField,
   normalizeCcSwitchImportSettings,
@@ -87,4 +93,34 @@ export function buildCcSwitchImportUrlForConfig({
     usageBaseUrl,
     usageLanguage,
   });
+}
+
+export function getCcSwitchCodexModelCatalogFilenameForConfig(
+  config: CcSwitchImportConfigListItem,
+): string {
+  return config.codexModelCatalogFilename?.trim() || CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME;
+}
+
+export function buildCcSwitchCodexModelCatalogJsonForConfig(
+  config: CcSwitchImportConfigListItem,
+): string {
+  if (config.clientType !== "codex") return "";
+  if (config.codexModelCatalog?.models.length) {
+    return `${JSON.stringify(config.codexModelCatalog, null, 2)}\n`;
+  }
+
+  const models: CcSwitchCodexCatalogModel[] = [];
+  const defaultModel = config.defaultModel.trim();
+  if (defaultModel) {
+    models.push({ model: defaultModel });
+  }
+  for (const mapping of config.modelMappings) {
+    if (mapping.role) continue;
+    const model = (mapping.requestModel || mapping.targetModel).trim();
+    if (model) {
+      models.push({ model });
+    }
+  }
+  if (models.length === 0) return "";
+  return `${buildCcSwitchCodexModelCatalogJson(models)}\n`;
 }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2503,6 +2503,8 @@
     "copy_import_link_copied": "Import link copied",
     "copy_import_link_success": "Import link copied",
     "copy_import_link_failed": "Failed to copy import link",
+    "download_codex_model_catalog": "Download Codex model catalog",
+    "download_codex_model_catalog_success": "Codex model catalog downloaded",
     "import_no_compatible_configs": "No compatible CC Switch configs found. Create one in CC Switch import settings first.",
     "config_new": "New config",
     "config_table_title": "Config list",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2772,6 +2772,8 @@
     "copy_import_link_copied": "导入链接已复制",
     "copy_import_link_success": "导入链接已复制",
     "copy_import_link_failed": "复制导入链接失败",
+    "download_codex_model_catalog": "下载 Codex 模型目录",
+    "download_codex_model_catalog_success": "Codex 模型目录已下载",
     "import_no_compatible_configs": "没有可用的 CC Switch 配置，请先在 CC Switch 导入设置中创建预设。",
     "config_new": "新建配置",
     "config_table_title": "配置列表",

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -20,10 +20,13 @@ import {
 } from "@code-proxy/domain/ccswitch/ccswitchImport";
 import {
   appendCcSwitchRoutePath,
+  buildCcSwitchCodexModelCatalogJsonForConfig,
   buildCcSwitchImportUrlForConfig,
+  getCcSwitchCodexModelCatalogFilenameForConfig,
 } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import { ccSwitchConfigMatchesApiKeyPermissions } from "@code-proxy/domain/ccswitch/ccswitchImportCompatibility";
+import { downloadTextAsFile } from "@code-proxy/domain";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { copyTextToClipboard } from "@code-proxy/ui";
@@ -109,12 +112,16 @@ async function fetchQuickImportApiKeyEntry(apiKey: string): Promise<ApiKeyEntry 
 function QuickImportCard({
   config,
   copied,
+  catalogAvailable,
   onCopyLink,
+  onDownloadCatalog,
   onSelect,
 }: {
   config: CcSwitchImportConfigListItem;
   copied: boolean;
+  catalogAvailable: boolean;
   onCopyLink: (config: CcSwitchImportConfigListItem) => void;
+  onDownloadCatalog: (config: CcSwitchImportConfigListItem) => void;
   onSelect: (config: CcSwitchImportConfigListItem) => void;
 }) {
   const { t } = useTranslation();
@@ -156,7 +163,18 @@ function QuickImportCard({
           </span>
         </span>
       </button>
-      <div className="flex items-start p-3 pl-0">
+      <div className="flex items-start gap-1 p-3 pl-0">
+        {catalogAvailable ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            title={t("ccswitch.download_codex_model_catalog")}
+            onClick={() => onDownloadCatalog(config)}
+            className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
+          >
+            <Download size={14} />
+          </Button>
+        ) : null}
         <Button
           variant="ghost"
           size="xs"
@@ -345,6 +363,17 @@ export function QuickImportTabContent({
     [buildImportUrl, notify, showCopiedImportState, t],
   );
 
+  const handleDownloadCodexCatalog = useCallback(
+    (config: CcSwitchImportConfigListItem) => {
+      const catalogJson = buildCcSwitchCodexModelCatalogJsonForConfig(config);
+      if (!catalogJson) return;
+
+      downloadTextAsFile(catalogJson, getCcSwitchCodexModelCatalogFilenameForConfig(config));
+      notify({ type: "success", message: t("ccswitch.download_codex_model_catalog_success") });
+    },
+    [notify, t],
+  );
+
   return (
     <div className="space-y-4">
       <Card padding="compact" className="border-slate-200/70 bg-white/85 dark:bg-neutral-950/70">
@@ -412,7 +441,11 @@ export function QuickImportTabContent({
                         key={config.id}
                         config={config}
                         copied={copiedImportConfigId === config.id}
+                        catalogAvailable={Boolean(
+                          buildCcSwitchCodexModelCatalogJsonForConfig(config),
+                        )}
                         onCopyLink={(item) => void handleCopyImportLink(item)}
+                        onDownloadCatalog={handleDownloadCodexCatalog}
                         onSelect={handleImport}
                       />
                     ))}

--- a/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -18,7 +18,24 @@ const quickImportConfigs = [
         "request-model": "gpt-5.3-codex",
         "target-model": "gpt-5.3-codex",
       },
+      {
+        "request-model": "deepseek-v4-flash",
+        "target-model": "deepseek-chat",
+      },
     ],
+    "codex-model-catalog-filename": "cc-switch-model-catalog.json",
+    "codex-model-catalog": {
+      models: [
+        {
+          slug: "gpt-5.3-codex",
+          display_name: "gpt-5.3-codex",
+        },
+        {
+          slug: "deepseek-v4-flash",
+          display_name: "deepseek-v4-flash",
+        },
+      ],
+    },
     "allowed-channel-groups": ["pro"],
     "route-path": "/pro/cs_codex",
     "endpoint-path": "/v1",
@@ -162,6 +179,55 @@ describe("QuickImportTabContent", () => {
     }
   });
 
+  test("downloads the Codex model catalog for mapped quick imports", async () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const createObjectURL = vi.fn<(object: Blob | MediaSource) => string>(() => "blob:codex-catalog");
+    const revokeObjectURL = vi.fn();
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    try {
+      render(
+        <ThemeProvider>
+          <ToastProvider>
+            <QuickImportTabContent apiKey="sk-lookup-key" />
+          </ToastProvider>
+        </ThemeProvider>,
+      );
+
+      const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
+      await userEvent.click(
+        within(codexSection).getByRole("button", { name: /download codex model catalog/i }),
+      );
+
+      await waitFor(() => expect(createObjectURL).toHaveBeenCalled());
+      const blob = createObjectURL.mock.calls[0]?.[0];
+      if (!(blob instanceof Blob)) {
+        throw new Error("Expected Codex model catalog download to create a Blob");
+      }
+      await expect(blob.text()).resolves.toContain("deepseek-v4-flash");
+      expect(click).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(URL, "createObjectURL", {
+        configurable: true,
+        value: originalCreateObjectURL,
+      });
+      Object.defineProperty(URL, "revokeObjectURL", {
+        configurable: true,
+        value: originalRevokeObjectURL,
+      });
+      click.mockRestore();
+    }
+  });
+
   test("hides quick import groups that do not have presets", async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(
       new Response(JSON.stringify({ "ccswitch-import-configs": [quickImportConfigs[0]] }), {
@@ -240,7 +306,7 @@ describe("QuickImportTabContent", () => {
               {
                 key: "sk-lookup-key",
                 "allowed-channel-groups": ["pro"],
-                "allowed-models": ["gpt-5.3-codex"],
+                "allowed-models": ["gpt-5.3-codex", "deepseek-chat"],
               },
             ],
           }),

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -33,10 +33,13 @@ import { CcSwitchImportCardList } from "./components/CcSwitchImportCardList";
 import { openCcSwitchImportUrl } from "@code-proxy/domain/ccswitch/ccswitchImport";
 import {
   appendCcSwitchRoutePath,
+  buildCcSwitchCodexModelCatalogJsonForConfig,
   buildCcSwitchImportUrlForConfig,
+  getCcSwitchCodexModelCatalogFilenameForConfig,
 } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import { ccSwitchConfigMatchesApiKeyPermissions } from "@code-proxy/domain/ccswitch/ccswitchImportCompatibility";
+import { downloadTextAsFile } from "@code-proxy/domain";
 import { LogContentModal } from "@features/log-content-viewer";
 import { ErrorDetailModal } from "@features/log-content-viewer";
 import type { ApiKeyFormValues } from "./types";
@@ -480,6 +483,17 @@ export function ApiKeysPage() {
     [buildImportUrlWithConfig, notify, showCopiedCcSwitchImportState, t],
   );
 
+  const handleDownloadCcSwitchCodexCatalog = useCallback(
+    (config: CcSwitchImportConfigListItem) => {
+      const catalogJson = buildCcSwitchCodexModelCatalogJsonForConfig(config);
+      if (!catalogJson) return;
+
+      downloadTextAsFile(catalogJson, getCcSwitchCodexModelCatalogFilenameForConfig(config));
+      notify({ type: "success", message: t("ccswitch.download_codex_model_catalog_success") });
+    },
+    [notify, t],
+  );
+
   /* ─── column definitions ─── */
 
   const apiKeyColumns = useMemo(
@@ -598,6 +612,7 @@ export function ApiKeysPage() {
         configs={compatibleConfigs}
         copiedConfigId={copiedCcSwitchImportConfigId}
         onCopyLink={(config) => void handleCopyCcSwitchImportLink(config)}
+        onDownloadCatalog={handleDownloadCcSwitchCodexCatalog}
         onSelect={handleImportWithConfig}
         onClose={() => {
           setCcSwitchImportEntry(null);

--- a/pages/api-keys/components/CcSwitchImportCardList.tsx
+++ b/pages/api-keys/components/CcSwitchImportCardList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, Download } from "lucide-react";
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
 import iconGemini from "@code-proxy/assets/icons/gemini.svg";
@@ -7,6 +7,7 @@ import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import type { CcSwitchClientType } from "@code-proxy/domain/ccswitch/ccswitchImport";
+import { buildCcSwitchCodexModelCatalogJsonForConfig } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 
 const iconByType: Record<CcSwitchClientType, string> = {
   claude: iconClaude,
@@ -19,6 +20,7 @@ export interface CcSwitchImportCardListProps {
   configs: CcSwitchImportConfigListItem[];
   copiedConfigId: string | null;
   onCopyLink: (config: CcSwitchImportConfigListItem) => void;
+  onDownloadCatalog: (config: CcSwitchImportConfigListItem) => void;
   onSelect: (config: CcSwitchImportConfigListItem) => void;
   onClose: () => void;
 }
@@ -28,6 +30,7 @@ export function CcSwitchImportCardList({
   configs,
   copiedConfigId,
   onCopyLink,
+  onDownloadCatalog,
   onSelect,
   onClose,
 }: CcSwitchImportCardListProps) {
@@ -50,6 +53,7 @@ export function CcSwitchImportCardList({
         ) : (
           configs.map((config) => {
             const isCopied = copiedConfigId === config.id;
+            const catalogAvailable = Boolean(buildCcSwitchCodexModelCatalogJsonForConfig(config));
 
             return (
               <div
@@ -92,7 +96,18 @@ export function CcSwitchImportCardList({
                     </div>
                   </div>
                 </button>
-                <div className="flex items-start p-3 pl-0">
+                <div className="flex items-start gap-1 p-3 pl-0">
+                  {catalogAvailable ? (
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      title={t("ccswitch.download_codex_model_catalog")}
+                      onClick={() => onDownloadCatalog(config)}
+                      className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
+                    >
+                      <Download size={14} />
+                    </Button>
+                  ) : null}
                   <Button
                     variant="ghost"
                     size="xs"

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  buildCcSwitchCodexModelCatalog,
+  buildCcSwitchCodexModelCatalogJson,
   buildCcSwitchImportUrl,
+  CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
   openCcSwitchImportUrl,
   pickCcSwitchDefaultModel,
   resolveCcSwitchImportConfig,
@@ -261,6 +264,56 @@ describe("ccswitchImport", () => {
         models: [{ model: "gpt-6-router" }, { model: "kimi-k2" }],
       },
     });
+    expect(decodeConfig(url).config).toContain(
+      `model_catalog_json = "${CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME}"`,
+    );
+  });
+
+  test("builds a Codex model catalog from request-side mapped model names", () => {
+    const catalog = buildCcSwitchCodexModelCatalog([
+      { model: "gpt-5.5" },
+      { model: "deepseek-v4-flash", displayName: "DeepSeek V4 Flash", contextWindow: 256000 },
+      { model: "DeepSeek-V4-Flash" },
+      { model: "deepseek-v4-pro" },
+    ]);
+
+    expect(catalog.models.map((model) => model.slug)).toEqual([
+      "gpt-5.5",
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+    ]);
+    expect(catalog.models[1]).toMatchObject({
+      display_name: "DeepSeek V4 Flash",
+      context_window: 256000,
+      max_context_window: 256000,
+      visibility: "list",
+      supported_in_api: true,
+      supports_reasoning_summaries: true,
+      support_verbosity: true,
+      model_messages: {
+        context_window: 256000,
+        max_context_window: 256000,
+        input_modalities: ["text", "image"],
+      },
+    });
+  });
+
+  test("serializes a Codex model catalog JSON that preserves all model IDs", () => {
+    const catalog = JSON.parse(
+      buildCcSwitchCodexModelCatalogJson([
+        { model: "gpt-5.5" },
+        { model: "deepseek-v4-flash" },
+        { model: "deepseek-v4-pro" },
+      ]),
+    );
+
+    expect(catalog.models.map((model: { slug: string }) => model.slug)).toEqual([
+      "gpt-5.5",
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+    ]);
+    expect(catalog.models[0]).toHaveProperty("base_instructions");
+    expect(catalog.models[0]).toHaveProperty("model_messages");
   });
 
   test("selects a client-specific default model from available models", () => {


### PR DESCRIPTION
## Summary
- preserve backend Codex model catalog fields in the API client and domain normalization
- add Codex catalog download actions for quick import and API key preset lists
- include model_catalog_json in Codex import TOML so Codex can read request-side model catalog files

## Verification
- rtk bun run check
- rtk bun run --filter @code-proxy/admin-panel test -- ccswitchImport QuickImportTabContent ccswitch-import-configs