### PR TITLE
fix(request-logs): center column headers and show full numeric values

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import type { UsageLogItem } from "@code-proxy/api-client/endpoints/usage";
 import {
+  formatFixedNumber,
   formatUsageMetricCost,
   formatUsageMetricNumber,
   formatUsageMetricTooltipCost,
@@ -113,26 +114,39 @@ function RequestLogMetricChip({
 export function RequestLogUsageMetricValue({
   value,
   variant = "number",
+  compact = false,
   className,
 }: {
   value: number;
   variant?: UsageMetricVariant;
+  /**
+   * When true, renders the value in compact form (e.g. "23.8K", "$12.35K")
+   * with a hover tooltip carrying the full precision value. Defaults to false
+   * so the request-logs table always shows the complete numeric value.
+   */
+  compact?: boolean;
   className?: string;
 }) {
+  const useCompact = compact && isUsageMetricCompact(value, variant);
   const display =
-    variant === "currency" ? formatUsageMetricCost(value) : formatUsageMetricNumber(value);
+    variant === "currency"
+      ? useCompact
+        ? formatUsageMetricCost(value)
+        : formatUsageMetricTooltipCost(value)
+      : useCompact
+        ? formatUsageMetricNumber(value)
+        : formatFixedNumber(value, { fractionDigits: 0 });
   const tooltip =
     variant === "currency"
       ? formatUsageMetricTooltipCost(value)
       : formatUsageMetricTooltipNumber(value);
-  const compact = isUsageMetricCompact(value, variant);
 
   return (
     <HoverTooltip
       content={tooltip}
-      disabled={!compact}
+      disabled={!useCompact}
       placement="top"
-      className={compact ? "cursor-help" : undefined}
+      className={useCompact ? "cursor-help" : undefined}
     >
       <span className={["block min-w-0 truncate", className].filter(Boolean).join(" ")}>
         {display}

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2042,7 +2042,12 @@ export function DataTable<T>({
                       ) : null}
                       <div
                         data-vt-column-header-content
-                        className={`min-w-0 max-w-full overflow-hidden truncate ${canReorder ? "pl-5" : ""}`}
+                        className={`min-w-0 max-w-full overflow-hidden truncate ${
+                          canReorder
+                            ? "group-hover/column:pl-5 group-hover/column:transition-[padding] group-focus-within/column:pl-5 data-[vt-reorder-active=true]:pl-5"
+                            : ""
+                        }`}
+                        data-vt-reorder-active={activeReorderColumnKey === col.key ? "true" : undefined}
                       >
                         {col.headerRender ? col.headerRender() : col.label}
                       </div>

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -486,14 +486,14 @@ export function RequestLogsPage() {
               <span>
                 {t("request_logs.col_total_token")}{" "}
                 <span className="font-mono tabular-nums text-slate-900 dark:text-white">
-                  <RequestLogUsageMetricValue value={stats.total_tokens} />
+                  <RequestLogUsageMetricValue value={stats.total_tokens} compact />
                 </span>
               </span>
               <span className="text-slate-300 dark:text-white/15">|</span>
               <span>
                 {t("request_logs.col_cost")}{" "}
                 <span className="font-mono tabular-nums text-emerald-700 dark:text-emerald-400">
-                  <RequestLogUsageMetricValue value={stats.total_cost} variant="currency" />
+                  <RequestLogUsageMetricValue value={stats.total_cost} variant="currency" compact />
                 </span>
               </span>
               <span className="text-slate-300 dark:text-white/15">|</span>

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -567,7 +567,7 @@ describe("RequestLogsPage", () => {
     expect(container.querySelector(".table-scrollbar")).not.toBeNull();
   });
 
-  test("uses dashboard compact metric formatting without the updated-at summary text", async () => {
+  test("shows full numeric values in the table while keeping the summary bar compact", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();
 
@@ -611,23 +611,30 @@ describe("RequestLogsPage", () => {
     const recordsCount = await screen.findByText("23.8K records");
     expect(screen.queryByText(/Updated at/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Not yet refreshed/i)).not.toBeInTheDocument();
-    expect(screen.getAllByText("2.8B").length).toBeGreaterThan(0);
-    expect(screen.getByText("2.6B")).toBeInTheDocument();
-    expect(screen.getByText("13.1M")).toBeInTheDocument();
-    expect(screen.getAllByText("$12.35K").length).toBeGreaterThan(0);
     expect(screen.getByText("91.23%")).toBeInTheDocument();
+
+    // Summary bar keeps compact metric formatting, with a full-precision tooltip.
+    expect(screen.getAllByText("2.8B").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$12.35K").length).toBeGreaterThan(0);
+
+    // Table rows render complete numeric values (no k/M/B compact suffix).
+    expect(screen.getByText("2,806,800,000")).toBeInTheDocument();
+    expect(screen.getByText("2,576,200,000")).toBeInTheDocument();
+    expect(screen.getByText("13,100,000")).toBeInTheDocument();
+    expect(screen.getByText("2,819,900,000")).toBeInTheDocument();
+    expect(screen.getByText("$12,345.6789")).toBeInTheDocument();
 
     await user.hover(recordsCount);
     expect(await screen.findByRole("tooltip")).toHaveTextContent("23,800.00");
     await user.unhover(recordsCount);
 
-    const cachedTokens = screen.getByText("2.6B");
-    await user.hover(cachedTokens);
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("2,576,200,000.00");
-    await user.unhover(cachedTokens);
+    const summaryTotalTokens = screen.getAllByText("2.8B")[0];
+    await user.hover(summaryTotalTokens);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("2,819,900,000.00");
+    await user.unhover(summaryTotalTokens);
 
-    const cost = screen.getAllByText("$12.35K")[0];
-    await user.hover(cost);
+    const summaryCost = screen.getAllByText("$12.35K")[0];
+    await user.hover(summaryCost);
     expect(await screen.findByRole("tooltip")).toHaveTextContent("$12,345.6789");
   });
 


### PR DESCRIPTION
## 修改范围

修复 request-logs 页面两个视觉 bug，均在 `codeProxy/` 子仓内：

1. **表头列名不居中（向右偏）**
2. **表格数据用 k/M/B 紧凑格式，要求完整显示数值**

## 改动文件

- `packages/ui/src/data-table/DataTable.tsx` — 表头对齐根因修复
- `features/request-log-viewer/requestLogsShared.tsx` — `RequestLogUsageMetricValue` 默认完整数值 + `compact` opt-in
- `pages/request-logs/RequestLogsPage.tsx` — 汇总统计栏显式传 `compact` 保留原紧凑样式
- `pages/request-logs/__tests__/RequestLogsPage.test.tsx` — 更新回归断言匹配新契约

## 根因与修法

### 表头对齐
`DataTable` 每个可重排列的表头文字外层 `<div>` 静态加了 `pl-5`，给绝对定位、默认 `opacity-0` 的拖拽手柄让位。手柄并不占布局空间，这个非对称左 padding 把 `text-center` 的内容盒向右推，导致居中列名整体偏右（`text-left` 的 ID 列因同向而看不出偏移）。改为只在 hover/focus/拖拽激活态加 padding，静态严格居中。单元格本就对称，不动。

### 数值显示
`RequestLogUsageMetricValue` 默认改用完整数值（token 计数整数、cost 4 位小数），新增 `compact` 开关。汇总统计栏显式传 `compact` 保持紧凑看板风格 + 完整精度 tooltip；表格行默认完整显示（如 `2,819,900,000`、`$12,345.6789`）。

## 校验

- `bun run lint`：0 error（2 预存 warning，非本次改动文件）
- `bun run boundary:imports`：clean
- `bun run build`（tsc --noEmit + vite build）：pass
- `bun run bundle:diff`：PASS
- 单元测试：467 passed（66 files）
- e2e：`request-logs-column-reorder` + `request-logs-detail` 共 5 passed

## 影响目录

仅 `codeProxy/`，不涉及 `CliRelay/` 与根治理仓。