### PR TITLE
fix: emit Codex Desktop model catalog ids

### DIFF
--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -32,6 +32,7 @@ export interface CcSwitchCodexInlineModelCatalog {
 
 export interface CcSwitchCodexModelCatalogEntry {
   slug: string;
+  model: string;
   display_name: string;
   description: string;
   default_reasoning_level: "medium";
@@ -280,6 +281,7 @@ const buildCodexCatalogEntry = (
 
   return {
     slug,
+    model: slug,
     display_name: displayName,
     description: displayName,
     default_reasoning_level: "medium",
@@ -376,7 +378,11 @@ const buildCodexConfig = (input: {
     const key = normalized.toLowerCase();
     if (!normalized || seen.has(key)) return;
     seen.add(key);
-    catalogModels.push({ ...entry });
+    const normalizedEntry: Record<string, unknown> = { ...entry };
+    if (!String(normalizedEntry.model ?? "").trim()) {
+      normalizedEntry.model = normalized;
+    }
+    catalogModels.push(normalizedEntry);
   };
   const addCatalogModel = (value: string) => {
     const normalized = value.trim();

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -249,12 +249,14 @@ describe("ccswitchImport", () => {
     expect(config.modelCatalog.models).toEqual([
       {
         slug: "gpt-5.5",
+        model: "gpt-5.5",
         display_name: "GPT 5.5",
         context_window: 512000,
         model_messages: { context_window: 512000 },
       },
       {
         slug: "deepseek-v4-flash",
+        model: "deepseek-v4-flash",
         display_name: "DeepSeek V4 Flash",
         context_window: 256000,
       },
@@ -340,6 +342,11 @@ describe("ccswitchImport", () => {
     ]);
 
     expect(catalog.models.map((model) => model.slug)).toEqual([
+      "gpt-5.5",
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+    ]);
+    expect(catalog.models.map((model) => model.model)).toEqual([
       "gpt-5.5",
       "deepseek-v4-flash",
       "deepseek-v4-pro",


### PR DESCRIPTION
## Summary
- include model ids in generated cc-switch Codex inline model catalog entries
- preserve imported inline catalog entries while backfilling missing model from slug
- cover generated and preset import catalog shapes in tests

## Tests
- rtk bun run test -- ccswitchImport