### PR TITLE
feat: update codex auth file quota summary

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -712,6 +712,8 @@
     "trend_last_7_days_requests": "Last 7 days requests",
     "trend_current_weekly_cycle": "Current weekly cycle",
     "trend_current_cycle_cost": "Current cycle cost",
+    "trend_predicted_5h_window_quota": "Predicted 5-hour window quota",
+    "trend_predicted_week_window_quota": "Predicted weekly window quota",
     "trend_weekly_quota_used": "Weekly quota used",
     "trend_cycle_start": "Cycle start",
     "trend_window_title": "Quota and request trends",

--- a/apps/admin-panel/src/i18n/locales/ru.json
+++ b/apps/admin-panel/src/i18n/locales/ru.json
@@ -698,6 +698,8 @@
     "trend_last_7_days_requests": "Запросы за 7 дней",
     "trend_current_weekly_cycle": "Текущий недельный цикл",
     "trend_current_cycle_cost": "Стоимость текущего цикла",
+    "trend_predicted_5h_window_quota": "Прогноз квоты за 5 часов",
+    "trend_predicted_week_window_quota": "Прогноз недельной квоты",
     "trend_weekly_quota_used": "Использовано недельной квоты",
     "trend_cycle_start": "Начало цикла",
     "trend_window_title": "Тренды квоты и запросов",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -726,6 +726,8 @@
     "trend_last_7_days_requests": "近 7 天请求数",
     "trend_current_weekly_cycle": "当前周周期",
     "trend_current_cycle_cost": "当前周期费用消耗",
+    "trend_predicted_5h_window_quota": "预测 5 小时窗口额度",
+    "trend_predicted_week_window_quota": "预测周窗口额度",
     "trend_weekly_quota_used": "周额度已消耗",
     "trend_cycle_start": "周期开始",
     "trend_window_title": "额度与请求趋势",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -712,6 +712,8 @@
     "trend_last_7_days_requests": "Last 7 days requests",
     "trend_current_weekly_cycle": "Current weekly cycle",
     "trend_current_cycle_cost": "Current cycle cost",
+    "trend_predicted_5h_window_quota": "Predicted 5-hour window quota",
+    "trend_predicted_week_window_quota": "Predicted weekly window quota",
     "trend_weekly_quota_used": "Weekly quota used",
     "trend_cycle_start": "Cycle start",
     "trend_window_title": "Quota and request trends",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -698,6 +698,8 @@
     "trend_last_7_days_requests": "Запросы за 7 дней",
     "trend_current_weekly_cycle": "Текущий недельный цикл",
     "trend_current_cycle_cost": "Стоимость текущего цикла",
+    "trend_predicted_5h_window_quota": "Прогноз квоты за 5 часов",
+    "trend_predicted_week_window_quota": "Прогноз недельной квоты",
     "trend_weekly_quota_used": "Использовано недельной квоты",
     "trend_cycle_start": "Начало цикла",
     "trend_window_title": "Тренды квоты и запросов",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -726,6 +726,8 @@
     "trend_last_7_days_requests": "近 7 天请求数",
     "trend_current_weekly_cycle": "当前周周期",
     "trend_current_cycle_cost": "当前周期费用消耗",
+    "trend_predicted_5h_window_quota": "预测 5 小时窗口额度",
+    "trend_predicted_week_window_quota": "预测周窗口额度",
     "trend_weekly_quota_used": "周额度已消耗",
     "trend_cycle_start": "周期开始",
     "trend_window_title": "额度与请求趋势",

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -53,6 +53,15 @@ const basePrefixProxyEditor: DetailModalProps["prefixProxyEditor"] = {
   subscriptionPeriod: "monthly",
 };
 
+const expectSummaryCard = (label: string, value: string) => {
+  const labelNode = screen.getByText(label);
+  const card = labelNode.closest("div");
+  if (!(card instanceof HTMLElement)) {
+    throw new Error(`Missing summary card for ${label}`);
+  }
+  expect(within(card).getByText(value)).toBeInTheDocument();
+};
+
 const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
   const props: DetailModalProps = {
     open: true,
@@ -161,14 +170,12 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByRole("tab", { name: "Channel" })).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Usage" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Fields" })).toBeInTheDocument();
-    expect(screen.getByText("Last 7 days requests")).toBeInTheDocument();
-    expect(screen.getByText("3")).toBeInTheDocument();
-    expect(screen.getByText("Current weekly cycle")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("Current cycle cost")).toBeInTheDocument();
-    expect(screen.getByText("$1.2345")).toBeInTheDocument();
-    expect(screen.getByText("Weekly quota used")).toBeInTheDocument();
-    expect(screen.getByText("8%")).toBeInTheDocument();
+    expect(screen.queryByText("Last 7 days requests")).not.toBeInTheDocument();
+    expectSummaryCard("Current weekly cycle", "2");
+    expectSummaryCard("Current cycle cost", "$1.2345");
+    expectSummaryCard("Predicted 5-hour window quota", "$0.0500");
+    expectSummaryCard("Predicted weekly window quota", "$15.4312");
+    expectSummaryCard("Weekly quota used", "8%");
     expect(screen.getByRole("dialog", { name: "Codex Primary" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download" })).toBeEnabled();
     expect(chartOptions.at(-1)?.animation).toBe(true);
@@ -176,6 +183,27 @@ describe("AuthFileDetailModal", () => {
     expect(chartOptions.at(-1)?.grid?.top).toBeGreaterThanOrEqual(70);
     expect(chartOptions.at(-1)?.yAxis?.every((item: any) => !item.name)).toBe(true);
     expect(chartOptions.at(-1)?.series?.every((item: any) => item.animation === true)).toBe(true);
+  });
+
+  test("renders zero predicted quota values when Codex trend data is incomplete", () => {
+    renderDetailModal({
+      detailTrend: {
+        auth_index: "auth-1",
+        days: 7,
+        hours: 5,
+        request_total: 3,
+        cycle_request_total: 2,
+        cycle_cost_total: 0,
+        weekly_quota_used_percent: null,
+        cycle_start: "",
+        daily_usage: [],
+        hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1 }],
+        quota_series: [],
+      },
+    });
+
+    expectSummaryCard("Predicted 5-hour window quota", "$0.0000");
+    expectSummaryCard("Predicted weekly window quota", "$0.0000");
   });
 
   test("disables trend chart animation after the first render completes", () => {
@@ -223,7 +251,7 @@ describe("AuthFileDetailModal", () => {
     renderDetailModal({ detailTrendLoading: true });
 
     expect(screen.getByText("Quota and request trends")).toBeInTheDocument();
-    expect(screen.getByText("Last 7 days requests")).toBeInTheDocument();
+    expect(screen.getByText("Predicted 5-hour window quota")).toBeInTheDocument();
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
@@ -231,7 +259,7 @@ describe("AuthFileDetailModal", () => {
     renderDetailModal({ detailTrend: null, detailTrendLoading: true });
 
     const loading = screen.getByTestId("auth-file-trend-loading");
-    expect(loading.querySelectorAll(".animate-pulse")).toHaveLength(8);
+    expect(loading.querySelectorAll(".animate-pulse")).toHaveLength(9);
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
     expect(screen.queryByTestId("auth-file-trend-chart")).not.toBeInTheDocument();
     expect(chartOptions).toHaveLength(0);

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -41,9 +41,17 @@ import {
 
 type DetailTab = "usage" | "fields" | "models";
 type DetailTrendWindow = "5h" | "week";
+type TrendQuotaSeries = AuthFileTrendResponse["quota_series"][number];
+type TrendUsagePoint = AuthFileTrendResponse["hourly_usage"][number];
 
+const FIVE_HOUR_WINDOW_SECONDS = 18000;
+const WEEK_WINDOW_SECONDS = 604800;
 const TREND_CHART_ANIMATION_MS = 680;
 const TREND_CHART_ANIMATION_GUARD_MS = TREND_CHART_ANIMATION_MS + 120;
+const SUMMARY_CARD_CLASS_NAME = "min-w-0 rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]";
+const SUMMARY_LABEL_CLASS_NAME = "text-xs font-semibold text-slate-500 dark:text-white/55";
+const SUMMARY_VALUE_CLASS_NAME =
+  "mt-2 min-w-0 break-words text-2xl font-semibold leading-tight text-slate-950 dark:text-white";
 
 const padTwo = (value: number) => String(value).padStart(2, "0");
 
@@ -73,6 +81,44 @@ const formatPercent = (value: number | null | undefined) => {
   return `${new Intl.NumberFormat(undefined, {
     maximumFractionDigits: Number.isInteger(value) ? 0 : 1,
   }).format(clampPercent(value))}%`;
+};
+
+const sumUsageCost = (points: TrendUsagePoint[]) =>
+  points.reduce((total, point) => {
+    const cost = typeof point.cost === "number" && Number.isFinite(point.cost) ? point.cost : 0;
+    return total + Math.max(0, cost);
+  }, 0);
+
+const latestQuotaUsedPercent = (
+  seriesList: TrendQuotaSeries[],
+  quotaKey: string,
+  matchesWindow: (windowSeconds: number) => boolean,
+) => {
+  let latestTimestamp = -Infinity;
+  let latestUsedPercent: number | null = null;
+
+  seriesList.forEach((series) => {
+    if (!matchesWindow(series.window_seconds) || series.quota_key !== quotaKey) return;
+
+    series.points.forEach((point) => {
+      const usedPercent = toQuotaUsedPercent(point.percent);
+      if (usedPercent === null) return;
+      const timestamp = Date.parse(point.timestamp);
+      if (!Number.isFinite(timestamp) || timestamp < latestTimestamp) return;
+      latestTimestamp = timestamp;
+      latestUsedPercent = usedPercent;
+    });
+  });
+
+  return latestUsedPercent;
+};
+
+const estimateQuotaBudget = (cost: number, usedPercent: number | null | undefined) => {
+  if (!Number.isFinite(cost) || cost <= 0) return 0;
+  if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) return 0;
+  const normalizedUsedPercent = clampPercent(usedPercent);
+  if (normalizedUsedPercent <= 0) return 0;
+  return cost / (normalizedUsedPercent / 100);
 };
 
 interface AuthFileDetailModalProps {
@@ -202,7 +248,9 @@ export function AuthFileDetailModal({
   const activeQuotaSeries = useMemo(() => {
     const series = detailTrend?.quota_series ?? [];
     return series.filter((item) =>
-      detailTrendWindow === "5h" ? item.window_seconds === 18000 : item.window_seconds >= 604800,
+      detailTrendWindow === "5h"
+        ? item.window_seconds === FIVE_HOUR_WINDOW_SECONDS
+        : item.window_seconds >= WEEK_WINDOW_SECONDS,
     );
   }, [detailTrend, detailTrendWindow]);
   useLayoutEffect(() => {
@@ -218,15 +266,11 @@ export function AuthFileDetailModal({
     setDetailOpenKey(`${fileName}:${detailOpenCounterRef.current}`);
   }, [detailFile?.name, open]);
   const trendAnimationKey =
-    detailFile && detailTrend && detailOpenKey
-      ? `${detailOpenKey}:${detailTrend.auth_index}`
-      : "";
+    detailFile && detailTrend && detailOpenKey ? `${detailOpenKey}:${detailTrend.auth_index}` : "";
   const shouldAnimateTrend = Boolean(trendAnimationKey && animatedTrendKey !== trendAnimationKey);
   const markTrendAnimationDone = useCallback(() => {
     if (!trendAnimationKey) return;
-    setAnimatedTrendKey((current) =>
-      current === trendAnimationKey ? current : trendAnimationKey,
-    );
+    setAnimatedTrendKey((current) => (current === trendAnimationKey ? current : trendAnimationKey));
   }, [trendAnimationKey]);
   useEffect(() => {
     if (!shouldAnimateTrend) return;
@@ -392,7 +436,14 @@ export function AuthFileDetailModal({
         })),
       ],
     };
-  }, [activeQuotaSeries, detailTrend, detailTrendWindow, shouldAnimateTrend, t, translateQuotaLabel]);
+  }, [
+    activeQuotaSeries,
+    detailTrend,
+    detailTrendWindow,
+    shouldAnimateTrend,
+    t,
+    translateQuotaLabel,
+  ]);
 
   const closeModal = () => {
     setDetailOpen(false);
@@ -410,14 +461,19 @@ export function AuthFileDetailModal({
   };
 
   const renderUsageTrend = () => {
+    const isCodexDetail = detailProviderKey === "codex";
+    const summaryGridClassName = isCodexDetail
+      ? "grid gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6"
+      : "grid gap-3 sm:grid-cols-2 xl:grid-cols-5";
+    const summarySkeletonCount = isCodexDetail ? 6 : 5;
+
     if (detailTrendLoading && !detailTrend) {
-      const skeletonClass =
-        "animate-pulse rounded-lg bg-slate-100/80 dark:bg-white/[0.06]";
+      const skeletonClass = "animate-pulse rounded-lg bg-slate-100/80 dark:bg-white/[0.06]";
 
       return (
         <div className="space-y-4" data-testid="auth-file-trend-loading" aria-hidden="true">
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-            {Array.from({ length: 5 }).map((_, index) => (
+          <div className={summaryGridClassName}>
+            {Array.from({ length: summarySkeletonCount }).map((_, index) => (
               <div key={index} className={`${skeletonClass} h-20`} />
             ))}
           </div>
@@ -451,46 +507,76 @@ export function AuthFileDetailModal({
       ? new Date(detailTrend.cycle_start).toLocaleString()
       : "--";
     const weeklyQuotaUsed = formatPercent(detailTrend.weekly_quota_used_percent);
+    const fiveHourQuotaUsedPercent = isCodexDetail
+      ? latestQuotaUsedPercent(
+          detailTrend.quota_series,
+          "code_5h",
+          (windowSeconds) => windowSeconds === FIVE_HOUR_WINDOW_SECONDS,
+        )
+      : null;
+    const weeklyQuotaUsedPercent =
+      detailTrend.weekly_quota_used_percent ??
+      (isCodexDetail
+        ? latestQuotaUsedPercent(
+            detailTrend.quota_series,
+            "code_week",
+            (windowSeconds) => windowSeconds >= WEEK_WINDOW_SECONDS,
+          )
+        : null);
+    const estimatedFiveHourQuota = estimateQuotaBudget(
+      sumUsageCost(detailTrend.hourly_usage),
+      fiveHourQuotaUsedPercent,
+    );
+    const estimatedWeeklyQuota = estimateQuotaBudget(
+      detailTrend.cycle_cost_total,
+      weeklyQuotaUsedPercent,
+    );
 
     return (
       <div className="space-y-4">
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-          <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
-            <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
-              {t("auth_files.trend_last_7_days_requests")}
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
-              {formatCount(detailTrend.request_total)}
-            </p>
-          </div>
-          <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
-            <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
-              {t("auth_files.trend_current_weekly_cycle")}
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
+        <div className={summaryGridClassName}>
+          {!isCodexDetail ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>
+                {t("auth_files.trend_last_7_days_requests")}
+              </p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCount(detailTrend.request_total)}</p>
+            </div>
+          ) : null}
+          <div className={SUMMARY_CARD_CLASS_NAME}>
+            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_weekly_cycle")}</p>
+            <p className={SUMMARY_VALUE_CLASS_NAME}>
               {formatCount(detailTrend.cycle_request_total)}
             </p>
           </div>
-          <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
-            <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
-              {t("auth_files.trend_current_cycle_cost")}
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
+          <div className={SUMMARY_CARD_CLASS_NAME}>
+            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_cycle_cost")}</p>
+            <p className={SUMMARY_VALUE_CLASS_NAME}>
               {formatCurrency(detailTrend.cycle_cost_total)}
             </p>
           </div>
-          <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
-            <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
-              {t("auth_files.trend_weekly_quota_used")}
-            </p>
-            <p className="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
-              {weeklyQuotaUsed}
-            </p>
+          {isCodexDetail ? (
+            <>
+              <div className={SUMMARY_CARD_CLASS_NAME}>
+                <p className={SUMMARY_LABEL_CLASS_NAME}>
+                  {t("auth_files.trend_predicted_5h_window_quota")}
+                </p>
+                <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedFiveHourQuota)}</p>
+              </div>
+              <div className={SUMMARY_CARD_CLASS_NAME}>
+                <p className={SUMMARY_LABEL_CLASS_NAME}>
+                  {t("auth_files.trend_predicted_week_window_quota")}
+                </p>
+                <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
+              </div>
+            </>
+          ) : null}
+          <div className={SUMMARY_CARD_CLASS_NAME}>
+            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_weekly_quota_used")}</p>
+            <p className={SUMMARY_VALUE_CLASS_NAME}>{weeklyQuotaUsed}</p>
           </div>
-          <div className="rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]">
-            <p className="text-xs font-semibold text-slate-500 dark:text-white/55">
-              {t("auth_files.trend_cycle_start")}
-            </p>
+          <div className={SUMMARY_CARD_CLASS_NAME}>
+            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_cycle_start")}</p>
             <p className="mt-2 truncate text-sm font-semibold text-slate-800 dark:text-white/85">
               {cycleStart}
             </p>
@@ -544,7 +630,7 @@ export function AuthFileDetailModal({
           </span>
         ) : undefined
       }
-      maxWidth="max-w-4xl"
+      maxWidth="max-w-6xl"
       bodyHeightClassName="h-[70vh]"
       bodyClassName="flex flex-col !overflow-hidden"
       bodyTestId="auth-file-detail-body"


### PR DESCRIPTION
## Summary
- show Codex auth file predicted 5-hour and weekly quota cards in the detail modal
- remove the last 7 days request card only for Codex details
- display predicted quota as 0 when source trend data is insufficient

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- AuthFileDetailModal
- rtk bun run lint
- rtk bun run --filter @code-proxy/admin-panel build