### PR TITLE
fix: show auth file cycle call counts

### DIFF
--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -80,6 +80,7 @@ export interface AuthFileTrendResponse {
   cycle_request_total: number;
   cycle_cost_total: number;
   weekly_quota_used_percent: number | null;
+  cycle_known?: boolean;
   cycle_start: string;
   daily_usage: AuthFileTrendUsagePoint[];
   hourly_usage: AuthFileTrendUsagePoint[];
@@ -258,6 +259,7 @@ export const usageApi = {
         Number.isFinite(resp.weekly_quota_used_percent)
           ? resp.weekly_quota_used_percent
           : null,
+      cycle_known: resp?.cycle_known === true,
       cycle_start: resp?.cycle_start ?? "",
       daily_usage: Array.isArray(resp?.daily_usage) ? resp.daily_usage : [],
       hourly_usage: Array.isArray(resp?.hourly_usage) ? resp.hourly_usage : [],

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -22,6 +22,7 @@ import { AuthFileTagsModal } from "./components/AuthFileTagsModal";
 import { ImportModelsModal } from "./components/ImportModelsModal";
 import { GroupOverviewModal } from "./components/GroupOverviewModal";
 import { useAuthFilesDataState } from "./hooks/useAuthFilesDataState";
+import { useAuthFilesCycleUsageState } from "./hooks/useAuthFilesCycleUsageState";
 import { useAuthFilesDetailEditors } from "./hooks/useAuthFilesDetailEditors";
 import {
   useAuthFilesFileActions,
@@ -386,6 +387,16 @@ export function AuthFilesPage() {
     refreshUsageDataForFiles,
   });
 
+  const { callsByAuthIndex, refreshCycleUsageForFiles } = useAuthFilesCycleUsageState();
+
+  const refreshQuotaAndCycleUsage = useCallback(
+    async (file: AuthFileItem, provider: NonNullable<ReturnType<typeof resolveQuotaProvider>>) => {
+      await refreshQuota(file, provider);
+      await refreshCycleUsageForFiles([file], { force: true });
+    },
+    [refreshCycleUsageForFiles, refreshQuota],
+  );
+
   const refreshQuotaForFiles = useCallback(
     async (targetFiles: AuthFileItem[]) => {
       const targets = targetFiles.flatMap((file) => {
@@ -454,6 +465,7 @@ export function AuthFilesPage() {
       try {
         await consumeCodexResetCredit(file);
         await refreshQuota(file, "codex", { showLoading: true });
+        await refreshCycleUsageForFiles([file], { force: true });
         notify({
           type: "success",
           message: t("auth_files.reset_credit_success", { name }),
@@ -468,7 +480,7 @@ export function AuthFilesPage() {
         setResettingCreditFileName(null);
       }
     },
-    [notify, refreshQuota, resettingCreditFileName, t],
+    [notify, refreshCycleUsageForFiles, refreshQuota, resettingCreditFileName, t],
   );
 
   const refreshFilesAndQuota = useCallback(async () => {
@@ -479,14 +491,30 @@ export function AuthFilesPage() {
     try {
       const quotaRefreshPromise = forceRefreshPage();
       const filesRefreshPromise = refreshFilesForItems(currentPageItems);
-      await Promise.all([filesRefreshPromise, quotaRefreshPromise]);
+      const [updatedFiles] = await Promise.all([filesRefreshPromise, quotaRefreshPromise]);
+      if (filesViewMode === "cards") {
+        const updatedByName = new Map(updatedFiles.map((file) => [file.name, file]));
+        await refreshCycleUsageForFiles(
+          currentPageItems.map((file) => updatedByName.get(file.name) ?? file),
+          { force: true },
+        );
+      }
     } finally {
       refreshingFilesAndQuotaRef.current = false;
       if (isMountedRef.current) {
         setRefreshingCurrentPage(false);
       }
     }
-  }, [forceRefreshPage, loading, pageItems, refreshFilesForItems, refreshingAll, usageLoading]);
+  }, [
+    filesViewMode,
+    forceRefreshPage,
+    loading,
+    pageItems,
+    refreshCycleUsageForFiles,
+    refreshFilesForItems,
+    refreshingAll,
+    usageLoading,
+  ]);
 
   const closeConfigModal = useCallback(() => {
     setConfigModalTab(null);
@@ -515,6 +543,11 @@ export function AuthFilesPage() {
       await forceRefreshPage();
     })();
   }, [configModalTab, forceRefreshPage, loadAll]);
+
+  useEffect(() => {
+    if (filesViewMode !== "cards" || loading) return;
+    void refreshCycleUsageForFiles(pageItems);
+  }, [filesViewMode, loading, pageItems, refreshCycleUsageForFiles]);
 
   const {
     groupOverviewOpen,
@@ -649,9 +682,10 @@ export function AuthFilesPage() {
         filesViewMode={filesViewMode}
         selectedFileNameSet={selectedFileNameSet}
         quotaByFileName={quotaByFileName}
+        cycleCallsByAuthIndex={callsByAuthIndex}
         resolveQuotaProvider={resolveQuotaProvider}
         resolveQuotaCardSlots={resolveQuotaCardSlots}
-        refreshQuota={refreshQuota}
+        refreshQuota={refreshQuotaAndCycleUsage}
         requestResetCredit={requestResetCredit}
         resettingCreditFileName={resettingCreditFileName}
         setFileEnabled={setFileEnabled}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -26,14 +26,15 @@ const mocks = vi.hoisted(() => ({
     ],
   })),
   getEntityStats: vi.fn(async () => ({ source: [], auth_index: [] })),
-  getAuthFileTrend: vi.fn(async () => ({
-    auth_index: "auth-1",
+  getAuthFileTrend: vi.fn(async (authIndex: string) => ({
+    auth_index: authIndex,
     days: 7,
     hours: 5,
     request_total: 3,
     cycle_request_total: 2,
     cycle_cost_total: 1.2345,
     weekly_quota_used_percent: 8,
+    cycle_known: true,
     cycle_start: "2026-04-27T16:01:21Z",
     daily_usage: [{ date: "2026-04-30", requests: 2, cost: 0.0123 }],
     hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1, cost: 0.0045 }],
@@ -151,6 +152,21 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+const createAuthFileTrend = (authIndex: string, cycleRequestTotal: number) => ({
+  auth_index: authIndex,
+  days: 7,
+  hours: 5,
+  request_total: cycleRequestTotal,
+  cycle_request_total: cycleRequestTotal,
+  cycle_cost_total: 1.2345,
+  weekly_quota_used_percent: 8,
+  cycle_known: true,
+  cycle_start: "2026-04-27T16:01:21Z",
+  daily_usage: [{ date: "2026-04-30", requests: cycleRequestTotal, cost: 0.0123 }],
+  hourly_usage: [{ hour: "2026-04-30 16:00", requests: cycleRequestTotal, cost: 0.0045 }],
+  quota_series: [],
+});
+
 const useTableFilesView = () => {
   window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("table"));
 };
@@ -181,14 +197,15 @@ describe("AuthFilesPage files table", () => {
     mocks.getEntityStats.mockReset();
     mocks.getEntityStats.mockImplementation(async () => ({ source: [], auth_index: [] }));
     mocks.getAuthFileTrend.mockReset();
-    mocks.getAuthFileTrend.mockImplementation(async () => ({
-      auth_index: "auth-1",
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) => ({
+      auth_index: authIndex,
       days: 7,
       hours: 5,
       request_total: 3,
       cycle_request_total: 2,
       cycle_cost_total: 1.2345,
       weekly_quota_used_percent: 8,
+      cycle_known: true,
       cycle_start: "2026-04-27T16:01:21Z",
       daily_usage: [{ date: "2026-04-30", requests: 2, cost: 0.0123 }],
       hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1, cost: 0.0045 }],
@@ -1501,6 +1518,9 @@ describe("AuthFilesPage files table", () => {
           ],
         }) as any,
     );
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) =>
+      createAuthFileTrend(authIndex, 5),
+    );
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -1520,6 +1540,55 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).getByText("5 calls")).toBeInTheDocument();
     expect(within(card as HTMLElement).getByText("Success Rate")).toBeInTheDocument();
     expect(within(card as HTMLElement).getByText("80.0%")).toBeInTheDocument();
+  });
+
+  test("cards view shows current cycle call volume from auth-file trend", async () => {
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "codex-pro.json",
+          label: "A_GptPro",
+          account_type: "oauth",
+          type: "codex",
+          auth_index: "77",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+        },
+      ],
+    }));
+    mocks.getEntityStats.mockImplementation(
+      async () =>
+        ({
+          source: [],
+          auth_index: [
+            { entity_name: "77", requests: 99, failed: 0, avg_latency: 0, total_tokens: 0 },
+          ],
+        }) as any,
+    );
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) =>
+      createAuthFileTrend(authIndex, 7),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("A_GptPro");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(await within(card as HTMLElement).findByText("7 calls")).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("99 calls")).not.toBeInTheDocument();
+    expect(mocks.getAuthFileTrend).toHaveBeenCalledWith("77", { days: 7, hours: 5 });
   });
 
   test("filters auth files by custom tag options", async () => {
@@ -1739,7 +1808,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByRole("combobox", { name: "File group" })).toHaveTextContent("All (3)");
   });
 
-  test("refreshes only the clicked auth-file card usage stats after quota refresh", async () => {
+  test("refreshes only the clicked auth-file card cycle call count after quota refresh", async () => {
     const now = Date.now();
     const files = [
       {
@@ -1802,6 +1871,15 @@ describe("AuthFilesPage files table", () => {
     mocks.fetchQuota.mockImplementation(async () => [
       { key: "code_5h", label: "m_quota.code_5h", percent: 60 },
     ]);
+    const cycleCountsByAuthIndex = new Map<string, number[]>([
+      ["77", [1, 4]],
+      ["88", [10]],
+    ]);
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) => {
+      const counts = cycleCountsByAuthIndex.get(authIndex) ?? [0];
+      const count = counts.length > 1 ? counts.shift() : counts[0];
+      return createAuthFileTrend(authIndex, count ?? 0);
+    });
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -2282,6 +2360,9 @@ describe("AuthFilesPage files table", () => {
             { entity_name: "2", requests: 2, failed: 0, avg_latency: 0, total_tokens: 0 },
           ],
         }) as any,
+    );
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) =>
+      createAuthFileTrend(authIndex, authIndex === "1" ? 9 : 2),
     );
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
 
@@ -3662,6 +3743,14 @@ describe("AuthFilesPage files table", () => {
       .mockResolvedValue({ source: [], auth_index: nextStats } as any)
       .mockResolvedValueOnce({ source: [], auth_index: oldStats } as any)
       .mockResolvedValueOnce({ source: [], auth_index: nextStats } as any);
+    const trendCallsByAuthIndex = new Map<string, number>();
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) => {
+      const seenCount = trendCallsByAuthIndex.get(authIndex) ?? 0;
+      trendCallsByAuthIndex.set(authIndex, seenCount + 1);
+      const number = Number(authIndex);
+      const cycleCount = seenCount === 0 ? number : 100 + number;
+      return createAuthFileTrend(authIndex, cycleCount);
+    });
     mocks.fetchQuota.mockResolvedValue({
       items: [{ label: "m_quota.code_5h", percent: 55, resetAtMs: now + 60_000 }],
     });
@@ -4296,6 +4385,9 @@ describe("AuthFilesPage files table", () => {
     } as any;
 
     mocks.list.mockImplementationOnce(async () => ({ files: [file] }));
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) =>
+      createAuthFileTrend(authIndex, 0),
+    );
     mocks.fetchQuota
       .mockResolvedValueOnce({
         items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -463,7 +463,7 @@ export function AuthFileDetailModal({
   const renderUsageTrend = () => {
     const isCodexDetail = detailProviderKey === "codex";
     const summaryGridClassName = isCodexDetail
-      ? "grid gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6"
+      ? "grid gap-3 sm:grid-cols-2 xl:grid-cols-6"
       : "grid gap-3 sm:grid-cols-2 xl:grid-cols-5";
     const summarySkeletonCount = isCodexDetail ? 6 : 5;
 

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -45,6 +45,7 @@ import {
   AUTH_FILE_STATUS_FILTERS,
   TYPE_BADGE_CLASSES,
   isRuntimeOnlyAuthFile,
+  normalizeAuthIndexValue,
   normalizeProviderKey,
   normalizeTagValue,
   resolveAuthFileDisplayName,
@@ -523,6 +524,7 @@ interface AuthFilesFilesTabProps {
   filesViewMode: FilesViewMode;
   selectedFileNameSet: Set<string>;
   quotaByFileName: Record<string, QuotaState>;
+  cycleCallsByAuthIndex: Record<string, number>;
   resolveQuotaProvider: (file: AuthFileItem) => QuotaProvider | null;
   resolveQuotaCardSlots: (
     provider: QuotaProvider,
@@ -606,6 +608,7 @@ export function AuthFilesFilesTab({
   filesViewMode,
   selectedFileNameSet,
   quotaByFileName,
+  cycleCallsByAuthIndex,
   resolveQuotaProvider,
   resolveQuotaCardSlots,
   refreshQuota,
@@ -1303,8 +1306,13 @@ export function AuthFilesFilesTab({
                     : false;
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const stats = resolveAuthFileStats(file, usageIndex);
-                  const totalCalls = stats.success + stats.failure;
-                  const successRate = totalCalls > 0 ? (stats.success / totalCalls) * 100 : null;
+                  const usageTotalCalls = stats.success + stats.failure;
+                  const authIndex = normalizeAuthIndexValue(file.auth_index ?? file.authIndex);
+                  const cycleCalls = authIndex ? cycleCallsByAuthIndex[authIndex] : undefined;
+                  const displayCalls =
+                    typeof cycleCalls === "number" ? cycleCalls : usageTotalCalls;
+                  const successRate =
+                    usageTotalCalls > 0 ? (stats.success / usageTotalCalls) * 100 : null;
                   const successRateClass =
                     successRate === null
                       ? "text-slate-500 dark:text-white/45"
@@ -1440,7 +1448,7 @@ export function AuthFilesFilesTab({
                             </button>
                           ) : null}
                           <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
-                            {t("auth_files.calls_count", { count: totalCalls })}
+                            {t("auth_files.calls_count", { count: displayCalls })}
                           </span>
                           <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
                             <span>{t("common.success_rate")}</span>

--- a/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
+++ b/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usageApi, type AuthFileItem } from "@code-proxy/api-client";
+import { normalizeAuthIndexValue, normalizeProviderKey, resolveFileType } from "@code-proxy/domain";
+
+type RefreshCycleUsageOptions = {
+  force?: boolean;
+};
+
+const supportsCycleUsage = (file: AuthFileItem): boolean => {
+  const provider = normalizeProviderKey(resolveFileType(file));
+  return provider === "codex" || provider === "kimi";
+};
+
+const resolveCycleUsageAuthIndex = (file: AuthFileItem): string | null => {
+  if (!supportsCycleUsage(file)) return null;
+  return normalizeAuthIndexValue(file.auth_index ?? file.authIndex);
+};
+
+export function useAuthFilesCycleUsageState() {
+  const mountedRef = useRef(true);
+  const inFlightRef = useRef<Map<string, Promise<number | null>>>(new Map());
+  const callsByAuthIndexRef = useRef<Record<string, number>>({});
+  const [callsByAuthIndex, setCallsByAuthIndex] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    callsByAuthIndexRef.current = callsByAuthIndex;
+  }, [callsByAuthIndex]);
+
+  const fetchCycleUsage = useCallback(async (authIndex: string): Promise<number | null> => {
+    const existing = inFlightRef.current.get(authIndex);
+    if (existing) return existing;
+
+    let request: Promise<number | null>;
+    request = usageApi
+      .getAuthFileTrend(authIndex, { days: 7, hours: 5 })
+      .then((trend) => {
+        const rawCount = trend.cycle_request_total;
+        if (typeof rawCount !== "number" || !Number.isFinite(rawCount)) return null;
+
+        const nextCount = Math.max(0, Math.round(rawCount));
+        if (mountedRef.current) {
+          setCallsByAuthIndex((prev) =>
+            prev[authIndex] === nextCount ? prev : { ...prev, [authIndex]: nextCount },
+          );
+        }
+        return nextCount;
+      })
+      .catch(() => null)
+      .finally(() => {
+        if (inFlightRef.current.get(authIndex) === request) {
+          inFlightRef.current.delete(authIndex);
+        }
+      });
+
+    inFlightRef.current.set(authIndex, request);
+    return request;
+  }, []);
+
+  const refreshCycleUsageForFiles = useCallback(
+    async (files: AuthFileItem[], options?: RefreshCycleUsageOptions): Promise<void> => {
+      const authIndexes = Array.from(
+        new Set(
+          files
+            .map(resolveCycleUsageAuthIndex)
+            .filter((authIndex): authIndex is string => Boolean(authIndex)),
+        ),
+      );
+      const targets = options?.force
+        ? authIndexes
+        : authIndexes.filter((authIndex) => callsByAuthIndexRef.current[authIndex] === undefined);
+      if (targets.length === 0) return;
+
+      await Promise.allSettled(targets.map((authIndex) => fetchCycleUsage(authIndex)));
+    },
+    [fetchCycleUsage],
+  );
+
+  return {
+    callsByAuthIndex,
+    refreshCycleUsageForFiles,
+  };
+}


### PR DESCRIPTION
## Summary
- show Codex detail usage summaries in one desktop row
- show auth-file card call badges from current subscription/quota cycle trend totals
- refresh cycle call counts after card quota refresh, reset credit consumption, and current-page toolbar refresh

## Tests
- rtk bun run test -- AuthFilesPage.files-table.test.tsx
- rtk bun run build
- rtk bun run boundary:imports
- rtk bun run lint
- rtk git diff --check