### PR TITLE
fix: summarize Antigravity quota display

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -850,7 +850,11 @@
     "missing_auth_index": "Auth file missing auth_index",
     "empty_models": "No quota data available",
     "refresh_button": "Refresh Quota",
-    "fetch_all": "Fetch All"
+    "fetch_all": "Fetch All",
+    "gemini3_pro": "G3P",
+    "gemini3_flash": "G3F",
+    "gemini_image": "G31FI",
+    "claude": "Claude"
   },
   "claude_quota": {
     "title": "Claude Quota",

--- a/apps/admin-panel/src/i18n/locales/ru.json
+++ b/apps/admin-panel/src/i18n/locales/ru.json
@@ -738,7 +738,11 @@
     "missing_auth_index": "В файле авторизации отсутствует auth_index",
     "empty_models": "Данные по квоте отсутствуют",
     "refresh_button": "Обновить квоту",
-    "fetch_all": "Получить все"
+    "fetch_all": "Получить все",
+    "gemini3_pro": "G3P",
+    "gemini3_flash": "G3F",
+    "gemini_image": "G31FI",
+    "claude": "Claude"
   },
   "claude_quota": {
     "title": "Квота Claude",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -858,7 +858,11 @@
     "missing_auth_index": "认证文件缺少 auth_index",
     "empty_models": "暂无额度数据",
     "refresh_button": "刷新额度",
-    "fetch_all": "获取全部"
+    "fetch_all": "获取全部",
+    "gemini3_pro": "G3P",
+    "gemini3_flash": "G3F",
+    "gemini_image": "G31FI",
+    "claude": "Claude"
   },
   "claude_quota": {
     "title": "Claude 额度",

--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -151,7 +151,7 @@ describe("consumeCodexResetCredit", () => {
 });
 
 describe("fetchQuota for antigravity", () => {
-  test("requests fetchAvailableModels with the auth project and returns dynamic quota items", async () => {
+  test("requests fetchAvailableModels with the auth project and returns quota summaries", async () => {
     mocks.downloadText.mockResolvedValueOnce(
       JSON.stringify({ project_id: "bamboo-precept-lgxtn" }),
     );
@@ -240,17 +240,27 @@ describe("fetchQuota for antigravity", () => {
       }),
     );
     expect(result.items.map((item) => item.key)).toEqual([
-      "model:gemini-3.1-pro-high",
-      "model:gemini-3.1-pro-low",
-      "model:gemini-3-flash-agent",
-      "model:claude-sonnet-4-6",
-      "model:gpt-oss-120b-medium",
+      "provider:gemini3-pro",
+      "provider:gemini3-flash",
+      "provider:claude",
     ]);
     expect(result.items[0]).toEqual(
       expect.objectContaining({
-        label: "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
-        percent: 100,
+        label: "antigravity_quota.gemini3_pro",
+        percent: 80,
         resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+      }),
+    );
+    expect(result.items[1]).toEqual(
+      expect.objectContaining({
+        label: "antigravity_quota.gemini3_flash",
+        percent: 70,
+      }),
+    );
+    expect(result.items[2]).toEqual(
+      expect.objectContaining({
+        label: "antigravity_quota.claude",
+        percent: 60,
       }),
     );
     expect(result.items[0].meta).toBeUndefined();

--- a/features/quota-preview/__tests__/quota-helpers.test.ts
+++ b/features/quota-preview/__tests__/quota-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildAntigravityItems,
   buildCodexItems,
   buildKimiItems,
+  filterAntigravityQuotaItems,
   formatRelativeResetLabel,
   parseAntigravityPayload,
   parseKimiUsagePayload,
@@ -160,7 +161,7 @@ describe("buildCodexItems", () => {
 });
 
 describe("buildAntigravityItems", () => {
-  test("builds dynamic quota items from fetchAvailableModels and skips reference internal models", () => {
+  test("summarizes fetchAvailableModels quota into sub2api-style Antigravity groups", () => {
     const payload = parseAntigravityPayload(
       JSON.stringify({
         models: {
@@ -276,31 +277,83 @@ describe("buildAntigravityItems", () => {
     const labels = items.map((item) => item.label);
 
     expect(items.map((item) => item.key)).toEqual([
-      "model:gemini-3.1-pro-high",
-      "model:gemini-3.1-pro-low",
-      "model:gemini-3-flash-agent",
-      "model:claude-sonnet-4-6",
-      "model:gpt-oss-120b-medium",
-      "model:gemini-3-flash",
-      "model:gemini-3.1-flash-image",
-      "model:gemini-3.1-flash-lite",
+      "provider:gemini3-pro",
+      "provider:gemini3-flash",
+      "provider:gemini-image",
+      "provider:claude",
     ]);
-    expect(labels).toContain("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]");
+    expect(labels).toEqual([
+      "antigravity_quota.gemini3_pro",
+      "antigravity_quota.gemini3_flash",
+      "antigravity_quota.gemini_image",
+      "antigravity_quota.claude",
+    ]);
+    expect(labels).not.toContain("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]");
+    expect(labels).not.toContain("GPT-OSS 120B (Medium) [gpt-oss-120b-medium]");
     expect(labels).not.toContain("chat_20706");
     expect(labels).not.toContain("chat_23310");
     expect(labels).not.toContain("tab_flash_lite_preview");
     expect(labels).not.toContain("tab_jump_flash_lite_preview");
     expect(labels).not.toContain("Gemini 3.1 Flash Lite [gemini-2.5-flash-thinking]");
     expect(labels).not.toContain("Gemini 2.5 Pro [gemini-2.5-pro]");
-    expect(labels).not.toContain("Claude/GPT");
-    expect(labels).not.toContain("Gemini 3 Pro");
     expect(items[0]).toEqual(
       expect.objectContaining({
-        percent: 75,
+        percent: 50,
         resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
       }),
     );
+    expect(items[1]).toEqual(
+      expect.objectContaining({
+        percent: 70,
+      }),
+    );
+    expect(items[2]).toEqual(
+      expect.objectContaining({
+        percent: 60,
+      }),
+    );
+    expect(items[3]).toEqual(
+      expect.objectContaining({
+        percent: 90,
+      }),
+    );
     expect(items[0].meta).toBeUndefined();
+  });
+
+  test("keeps cached sub2api-style Antigravity summaries when cache only has labels", () => {
+    expect(
+      filterAntigravityQuotaItems([
+        { label: "antigravity_quota.gemini3_pro", percent: 82 },
+        { label: "antigravity_quota.gemini3_flash", percent: 77 },
+        { label: "antigravity_quota.gemini_image", percent: 65 },
+        { label: "antigravity_quota.claude", percent: 73 },
+      ]),
+    ).toEqual([
+      {
+        key: "provider:gemini3-pro",
+        label: "antigravity_quota.gemini3_pro",
+        percent: 82,
+        resetAtMs: undefined,
+      },
+      {
+        key: "provider:gemini3-flash",
+        label: "antigravity_quota.gemini3_flash",
+        percent: 77,
+        resetAtMs: undefined,
+      },
+      {
+        key: "provider:gemini-image",
+        label: "antigravity_quota.gemini_image",
+        percent: 65,
+        resetAtMs: undefined,
+      },
+      {
+        key: "provider:claude",
+        label: "antigravity_quota.claude",
+        percent: 73,
+        resetAtMs: undefined,
+      },
+    ]);
   });
 });
 

--- a/features/quota-preview/quota-antigravity.ts
+++ b/features/quota-preview/quota-antigravity.ts
@@ -11,6 +11,11 @@ type AntigravityQuotaInfo = {
   displayName?: string;
   quotaInfo?: Record<string, unknown>;
   quota_info?: Record<string, unknown>;
+  apiProvider?: unknown;
+  api_provider?: unknown;
+  modelProvider?: unknown;
+  model_provider?: unknown;
+  model?: unknown;
 };
 
 export type AntigravityModelsPayload = Record<string, AntigravityQuotaInfo>;
@@ -54,6 +59,58 @@ export const shouldSkipAntigravityModelId = (id: string): boolean =>
   REFERENCE_SKIPPED_MODEL_IDS.has(id);
 
 const ANTIGRAVITY_MODEL_KEY_PREFIX = "model:";
+const ANTIGRAVITY_SUMMARY_KEY_PREFIX = "provider:";
+
+type AntigravityQuotaGroup = "gemini3Pro" | "gemini3Flash" | "gemini3Image" | "claude";
+
+const ANTIGRAVITY_QUOTA_GROUPS: Array<{
+  group: AntigravityQuotaGroup;
+  key: string;
+  label: string;
+}> = [
+  { group: "gemini3Pro", key: "provider:gemini3-pro", label: "antigravity_quota.gemini3_pro" },
+  {
+    group: "gemini3Flash",
+    key: "provider:gemini3-flash",
+    label: "antigravity_quota.gemini3_flash",
+  },
+  { group: "gemini3Image", key: "provider:gemini-image", label: "antigravity_quota.gemini_image" },
+  { group: "claude", key: "provider:claude", label: "antigravity_quota.claude" },
+];
+
+const ANTIGRAVITY_QUOTA_GROUP_MODEL_IDS: Record<AntigravityQuotaGroup, ReadonlySet<string>> = {
+  gemini3Pro: new Set([
+    "gemini-3-pro-low",
+    "gemini-3-pro-high",
+    "gemini-3-pro-preview",
+    "gemini-3.1-pro-low",
+    "gemini-3.1-pro-high",
+    "gemini-3.1-pro-preview",
+  ]),
+  gemini3Flash: new Set(["gemini-3-flash", "gemini-3-flash-agent"]),
+  gemini3Image: new Set([
+    "gemini-2.5-flash-image",
+    "gemini-3.1-flash-image",
+    "gemini-3-pro-image",
+    "gemini-3-pro-image-preview",
+  ]),
+  claude: new Set([
+    "claude-fable-5",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-thinking",
+    "claude-opus-4-5-thinking",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-opus-4-6-thinking",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+  ]),
+};
+
+const normalizeAntigravityModelIdForGroup = (value: string): string => {
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("models/") ? normalized.slice("models/".length) : normalized;
+};
 
 const resolveAntigravityModelIdFromQuotaItem = (item: QuotaItem): string | null => {
   const key = typeof item.key === "string" ? item.key.trim() : "";
@@ -68,11 +125,89 @@ const resolveAntigravityModelIdFromQuotaItem = (item: QuotaItem): string | null 
   return label && shouldSkipAntigravityModelId(label) ? label : null;
 };
 
-export const filterAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] =>
-  items.filter((item) => {
+const resolveAntigravityQuotaGroupFromModelId = (id: string): AntigravityQuotaGroup | null => {
+  const modelId = normalizeAntigravityModelIdForGroup(id);
+  const match = ANTIGRAVITY_QUOTA_GROUPS.find(({ group }) =>
+    ANTIGRAVITY_QUOTA_GROUP_MODEL_IDS[group].has(modelId),
+  );
+  return match?.group ?? null;
+};
+
+const resolveAntigravityQuotaGroupFromSummaryValue = (
+  value: string,
+): AntigravityQuotaGroup | null =>
+  ANTIGRAVITY_QUOTA_GROUPS.find((group) => group.key === value || group.label === value)?.group ??
+  null;
+
+const resolveAntigravityQuotaGroupFromItem = (item: QuotaItem): AntigravityQuotaGroup | null => {
+  const key = typeof item.key === "string" ? item.key.trim() : "";
+  if (key.startsWith(ANTIGRAVITY_SUMMARY_KEY_PREFIX)) {
+    const group = resolveAntigravityQuotaGroupFromSummaryValue(key);
+    if (group) return group;
+  }
+  const label = String(item.label ?? "").trim();
+  const labelGroup = resolveAntigravityQuotaGroupFromSummaryValue(label);
+  if (labelGroup) return labelGroup;
+  const modelId = resolveAntigravityModelIdFromQuotaItem(item);
+  return modelId ? resolveAntigravityQuotaGroupFromModelId(modelId) : null;
+};
+
+const resolveAntigravityQuotaGroupFromModel = (id: string): AntigravityQuotaGroup | null =>
+  resolveAntigravityQuotaGroupFromModelId(id);
+
+const earlierResetAtMs = (current: number | undefined, next: number | undefined) => {
+  if (typeof next !== "number" || !Number.isFinite(next)) return current;
+  if (typeof current !== "number" || !Number.isFinite(current)) return next;
+  return Math.min(current, next);
+};
+
+export const summarizeAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] => {
+  const grouped = new Map<
+    AntigravityQuotaGroup,
+    { percent: number | null; resetAtMs?: number; count: number }
+  >();
+
+  items.forEach((item) => {
     const modelId = resolveAntigravityModelIdFromQuotaItem(item);
-    return !modelId || !shouldSkipAntigravityModelId(modelId);
+    if (modelId && shouldSkipAntigravityModelId(modelId)) return;
+
+    const group = resolveAntigravityQuotaGroupFromItem(item);
+    if (!group) return;
+
+    const existing = grouped.get(group) ?? { percent: null, count: 0 };
+    const percent =
+      typeof item.percent === "number" && Number.isFinite(item.percent)
+        ? clampPercent(item.percent)
+        : null;
+
+    grouped.set(group, {
+      percent:
+        percent === null
+          ? existing.percent
+          : existing.percent === null
+            ? percent
+            : Math.min(existing.percent, percent),
+      resetAtMs: earlierResetAtMs(existing.resetAtMs, item.resetAtMs),
+      count: existing.count + 1,
+    });
   });
+
+  return ANTIGRAVITY_QUOTA_GROUPS.flatMap(({ group, key, label }) => {
+    const summary = grouped.get(group);
+    if (!summary || summary.count === 0) return [];
+    return [
+      {
+        key,
+        label,
+        percent: summary.percent,
+        resetAtMs: summary.resetAtMs,
+      },
+    ];
+  });
+};
+
+export const filterAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] =>
+  summarizeAntigravityQuotaItems(items);
 
 const resolvePayloadAndModels = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
@@ -137,7 +272,7 @@ const buildModelLabel = (id: string, entry: AntigravityQuotaInfo): string => {
   return `${displayName} [${id}]`;
 };
 
-export const buildAntigravityItems = (
+const buildAntigravityModelItems = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
 ): QuotaItem[] => {
   const { payload, models } = resolvePayloadAndModels(input);
@@ -156,6 +291,7 @@ export const buildAntigravityItems = (
   return order.flatMap((id) => {
     const entry = models[id];
     if (!entry) return [];
+    if (!resolveAntigravityQuotaGroupFromModel(id)) return [];
     const info = quotaInfo(entry);
     if (info.remainingFraction === null && !info.resetTime) return [];
     const percent =
@@ -173,6 +309,10 @@ export const buildAntigravityItems = (
     ];
   });
 };
+
+export const buildAntigravityItems = (
+  input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
+): QuotaItem[] => summarizeAntigravityQuotaItems(buildAntigravityModelItems(input));
 
 export const buildAntigravityGroups = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -253,6 +253,7 @@ const sanitizeQuotaItemsForCache = (items: unknown): QuotaItem[] => {
     .map((item): QuotaItem | null => {
       if (!item || typeof item !== "object" || Array.isArray(item)) return null;
       const record = item as Record<string, unknown>;
+      const key = typeof record.key === "string" && record.key ? record.key : undefined;
       const label = typeof record.label === "string" ? record.label : "";
       if (!label) return null;
       const percent =
@@ -265,7 +266,7 @@ const sanitizeQuotaItemsForCache = (items: unknown): QuotaItem[] => {
           ? record.resetAtMs
           : undefined;
       const meta = typeof record.meta === "string" ? record.meta : undefined;
-      return { label, percent, resetAtMs, meta };
+      return { ...(key ? { key } : {}), label, percent, resetAtMs, meta };
     })
     .filter((item): item is QuotaItem => Boolean(item));
 };

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -850,7 +850,11 @@
     "missing_auth_index": "Auth file missing auth_index",
     "empty_models": "No quota data available",
     "refresh_button": "Refresh Quota",
-    "fetch_all": "Fetch All"
+    "fetch_all": "Fetch All",
+    "gemini3_pro": "G3P",
+    "gemini3_flash": "G3F",
+    "gemini_image": "G31FI",
+    "claude": "Claude"
   },
   "claude_quota": {
     "title": "Claude Quota",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -738,7 +738,11 @@
     "missing_auth_index": "В файле авторизации отсутствует auth_index",
     "empty_models": "Данные по квоте отсутствуют",
     "refresh_button": "Обновить квоту",
-    "fetch_all": "Получить все"
+    "fetch_all": "Получить все",
+    "gemini3_pro": "G3P",
+    "gemini3_flash": "G3F",
+    "gemini_image": "G31FI",
+    "claude": "Claude"
   },
   "claude_quota": {
     "title": "Квота Claude",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -858,7 +858,11 @@
     "missing_auth_index": "认证文件缺少 auth_index",
     "empty_models": "暂无额度数据",
     "refresh_button": "刷新额度",
-    "fetch_all": "获取全部"
+    "fetch_all": "获取全部",
+    "gemini3_pro": "G3P",
+    "gemini3_flash": "G3F",
+    "gemini_image": "G31FI",
+    "claude": "Claude"
   },
   "claude_quota": {
     "title": "Claude 额度",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2963,7 +2963,7 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText(modifiedText)).not.toBeInTheDocument();
   });
 
-  test("cards view shows all antigravity quota items instead of truncating to three", async () => {
+  test("cards view shows sub2api-style Antigravity quota summaries", async () => {
     const now = Date.now();
     const file = {
       name: "antigravity.json",
@@ -2988,10 +2988,16 @@ describe("AuthFilesPage files table", () => {
             status: "success",
             updatedAt: now,
             items: [
-              { key: "model:a", label: "Model A [a]", percent: 91 },
-              { key: "model:b", label: "Model B [b]", percent: 82 },
-              { key: "model:c", label: "Model C [c]", percent: 73 },
-              { key: "model:d", label: "Model D [d]", percent: 64 },
+              { key: "model:gemini-3.1-pro-high", label: "Model A [gemini-a]", percent: 91 },
+              { key: "model:gemini-3.1-pro-low", label: "Model B [gemini-b]", percent: 82 },
+              { key: "model:gemini-3-flash", label: "Model Flash [gemini-flash]", percent: 77 },
+              {
+                key: "model:gemini-3.1-flash-image",
+                label: "Model Image [gemini-image]",
+                percent: 65,
+              },
+              { key: "model:claude-sonnet-4-6", label: "Model C [claude-c]", percent: 73 },
+              { key: "model:gpt-oss-120b-medium", label: "Model D [gpt-d]", percent: 64 },
             ],
           },
         },
@@ -3013,10 +3019,20 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("Model A [a]")).toBeInTheDocument();
-    expect(within(cards).getByText("Model B [b]")).toBeInTheDocument();
-    expect(within(cards).getByText("Model C [c]")).toBeInTheDocument();
-    expect(within(cards).getByText("Model D [d]")).toBeInTheDocument();
+    expect(within(cards).getByText("G3P")).toBeInTheDocument();
+    expect(within(cards).getByText("G3F")).toBeInTheDocument();
+    expect(within(cards).getByText("G31FI")).toBeInTheDocument();
+    expect(within(cards).getByText("Claude")).toBeInTheDocument();
+    expect(within(cards).getByText("82%")).toBeInTheDocument();
+    expect(within(cards).getByText("77%")).toBeInTheDocument();
+    expect(within(cards).getByText("65%")).toBeInTheDocument();
+    expect(within(cards).getByText("73%")).toBeInTheDocument();
+    expect(within(cards).queryByText("Model A [gemini-a]")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("Model B [gemini-b]")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("Model Flash [gemini-flash]")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("Model Image [gemini-image]")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("Model C [claude-c]")).not.toBeInTheDocument();
+    expect(within(cards).queryByText("Model D [gpt-d]")).not.toBeInTheDocument();
   });
 
   test("cards view hides cached antigravity models skipped by the reference implementation", async () => {
@@ -3092,9 +3108,10 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
+    expect(within(cards).getByText("G3P")).toBeInTheDocument();
     expect(
-      within(cards).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
-    ).toBeInTheDocument();
+      within(cards).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).not.toBeInTheDocument();
     expect(within(cards).queryByText("chat_20706")).not.toBeInTheDocument();
     expect(within(cards).queryByText("chat_23310")).not.toBeInTheDocument();
     expect(within(cards).queryByText("tab_flash_lite_preview")).not.toBeInTheDocument();
@@ -3158,10 +3175,11 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(
-      within(cards).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
-    ).toBeInTheDocument();
+    expect(within(cards).getByText("G3P")).toBeInTheDocument();
     expect(within(cards).getByText("91%")).toBeInTheDocument();
+    expect(
+      within(cards).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).not.toBeInTheDocument();
     expect(within(cards).queryByText(/maxTokens=1048576/)).not.toBeInTheDocument();
     expect(within(cards).queryByText(/maxOutputTokens=65535/)).not.toBeInTheDocument();
     expect(
@@ -3224,14 +3242,13 @@ describe("AuthFilesPage files table", () => {
 
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
-    fireEvent.mouseEnter(
-      within(row as HTMLElement).getByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
-    );
+    fireEvent.mouseEnter(within(row as HTMLElement).getByText("G3P"));
 
     const tooltip = await screen.findByRole("tooltip");
+    expect(within(tooltip).getByText("G3P")).toBeInTheDocument();
     expect(
-      within(tooltip).getByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
-    ).toBeInTheDocument();
+      within(tooltip).queryByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
+    ).not.toBeInTheDocument();
     expect(within(tooltip).queryByText(/maxTokens=1048576/)).not.toBeInTheDocument();
     expect(
       within(tooltip).queryByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/),
@@ -3303,15 +3320,11 @@ describe("AuthFilesPage files table", () => {
 
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
-    fireEvent.mouseEnter(
-      within(row as HTMLElement).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
-    );
+    fireEvent.mouseEnter(within(row as HTMLElement).getByText("G3P"));
 
     const tooltips = await screen.findAllByRole("tooltip");
     expect(tooltips).toHaveLength(1);
-    expect(
-      within(tooltips[0]).getByText("Claude Sonnet 4.6 (Thinking) [claude-sonnet-4-6]"),
-    ).toBeInTheDocument();
+    expect(within(tooltips[0]).getByText("Claude")).toBeInTheDocument();
     const resetText = Array.from(tooltips[0].querySelectorAll("span")).find(
       (element) =>
         element.textContent?.includes("秒") && element.className.includes("tabular-nums"),
@@ -3379,18 +3392,20 @@ describe("AuthFilesPage files table", () => {
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
     expect(within(row as HTMLElement).queryByText("chat_20706")).not.toBeInTheDocument();
-    const visibleModel = within(row as HTMLElement).getByText(
-      "Gemini 3.1 Pro (High) [gemini-3.1-pro-high]",
-    );
+    const visibleModel = within(row as HTMLElement).getByText("G3P");
     expect(visibleModel).toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).not.toBeInTheDocument();
 
     fireEvent.mouseEnter(visibleModel);
 
     const tooltip = await screen.findByRole("tooltip");
     expect(within(tooltip).queryByText("chat_20706")).not.toBeInTheDocument();
+    expect(within(tooltip).getByText("G3P")).toBeInTheDocument();
     expect(
-      within(tooltip).getByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
-    ).toBeInTheDocument();
+      within(tooltip).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
+    ).not.toBeInTheDocument();
   });
 
   test("cards view restores cached quota while refreshing in the background", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -187,7 +187,7 @@ describe("Auth Files helper coverage", () => {
           status: "success",
           updatedAt: 456,
           planType: "pro",
-          items: [{ label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
+          items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
         },
       },
     });
@@ -200,7 +200,7 @@ describe("Auth Files helper coverage", () => {
           status: "success",
           updatedAt: 456,
           planType: "pro",
-          items: [{ label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
+          items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 42, resetAtMs: 789 }],
         },
       },
     });

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -182,6 +182,7 @@ export function useAuthFilesFilesPresentation({
       if (!text) return text;
       if (text.startsWith("m_quota.")) return t(text);
       if (text.startsWith("claude_quota.")) return t(text);
+      if (text.startsWith("antigravity_quota.")) return t(text);
       if (KNOWN_QUOTA_TEXT_KEYS.has(text)) return t(`m_quota.${text}`);
       const additionalQuota = parseAdditionalQuotaWindowLabel(text);
       if (additionalQuota) {

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -139,6 +139,7 @@ export function useAuthFilesQuotaState({
           });
         }
         if (text.startsWith("claude_quota.")) return t(text);
+        if (text.startsWith("antigravity_quota.")) return t(text);
         return text;
       };
 
@@ -289,9 +290,7 @@ export function useAuthFilesQuotaState({
         const result = await fetchQuota(provider, file);
         const items = Array.isArray(result) ? result : result.items;
         const nextPlanType = Array.isArray(result) ? null : (result.planType ?? null);
-        const nextResetCreditCount = Array.isArray(result)
-          ? undefined
-          : result.resetCreditCount;
+        const nextResetCreditCount = Array.isArray(result) ? undefined : result.resetCreditCount;
         const rawAuthIndex = (file as { auth_index?: unknown }).auth_index ?? file.authIndex;
         const authIndex = normalizeAuthIndexValue(rawAuthIndex);
         if (authIndex) {


### PR DESCRIPTION
## Summary
- summarize Antigravity auth-file quotas into sub2api-style G3P/G3F/G31FI/Claude groups
- keep cached quota item keys and translate the new summary labels
- update quota and auth-files tests for grouped display

## Reference
- Refs kittors/CliRelay#477
- Checked sub2api AccountUsageCell.vue at e5f38a6 for group order, labels, and aggregation semantics

## Tests
- rtk bunx oxfmt --check features/quota-preview/quota-antigravity.ts features/quota-preview/__tests__/quota-helpers.test.ts features/quota-preview/__tests__/quota-fetch.test.ts pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx pages/auth-files/hooks/useAuthFilesQuotaState.ts pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx packages/domain/src/auth-files/authFiles.ts apps/admin-panel/src/i18n/locales/en.json apps/admin-panel/src/i18n/locales/zh-CN.json apps/admin-panel/src/i18n/locales/ru.json packages/i18n/src/locales/en.json packages/i18n/src/locales/zh-CN.json packages/i18n/src/locales/ru.json
- rtk bun run --filter @code-proxy/admin-panel test -- features/quota-preview/__tests__/quota-helpers.test.ts features/quota-preview/__tests__/quota-fetch.test.ts pages/auth-files/__tests__/auth-files-helpers.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build