### PR TITLE
fix: use readable antigravity quota labels

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -851,9 +851,9 @@
     "empty_models": "No quota data available",
     "refresh_button": "Refresh Quota",
     "fetch_all": "Fetch All",
-    "gemini3_pro": "G3P",
-    "gemini3_flash": "G3F",
-    "gemini_image": "G31FI",
+    "gemini3_pro": "Gemini 3 Pro",
+    "gemini3_flash": "Gemini 3 Flash",
+    "gemini_image": "Gemini 3.1 Flash Image",
     "claude": "Claude"
   },
   "claude_quota": {

--- a/apps/admin-panel/src/i18n/locales/ru.json
+++ b/apps/admin-panel/src/i18n/locales/ru.json
@@ -739,9 +739,9 @@
     "empty_models": "Данные по квоте отсутствуют",
     "refresh_button": "Обновить квоту",
     "fetch_all": "Получить все",
-    "gemini3_pro": "G3P",
-    "gemini3_flash": "G3F",
-    "gemini_image": "G31FI",
+    "gemini3_pro": "Gemini 3 Pro",
+    "gemini3_flash": "Gemini 3 Flash",
+    "gemini_image": "Gemini 3.1 Flash Image",
     "claude": "Claude"
   },
   "claude_quota": {

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -859,9 +859,9 @@
     "empty_models": "暂无额度数据",
     "refresh_button": "刷新额度",
     "fetch_all": "获取全部",
-    "gemini3_pro": "G3P",
-    "gemini3_flash": "G3F",
-    "gemini_image": "G31FI",
+    "gemini3_pro": "Gemini 3 Pro",
+    "gemini3_flash": "Gemini 3 Flash",
+    "gemini_image": "Gemini 3.1 Flash Image",
     "claude": "Claude"
   },
   "claude_quota": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -851,9 +851,9 @@
     "empty_models": "No quota data available",
     "refresh_button": "Refresh Quota",
     "fetch_all": "Fetch All",
-    "gemini3_pro": "G3P",
-    "gemini3_flash": "G3F",
-    "gemini_image": "G31FI",
+    "gemini3_pro": "Gemini 3 Pro",
+    "gemini3_flash": "Gemini 3 Flash",
+    "gemini_image": "Gemini 3.1 Flash Image",
     "claude": "Claude"
   },
   "claude_quota": {

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -739,9 +739,9 @@
     "empty_models": "Данные по квоте отсутствуют",
     "refresh_button": "Обновить квоту",
     "fetch_all": "Получить все",
-    "gemini3_pro": "G3P",
-    "gemini3_flash": "G3F",
-    "gemini_image": "G31FI",
+    "gemini3_pro": "Gemini 3 Pro",
+    "gemini3_flash": "Gemini 3 Flash",
+    "gemini_image": "Gemini 3.1 Flash Image",
     "claude": "Claude"
   },
   "claude_quota": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -859,9 +859,9 @@
     "empty_models": "暂无额度数据",
     "refresh_button": "刷新额度",
     "fetch_all": "获取全部",
-    "gemini3_pro": "G3P",
-    "gemini3_flash": "G3F",
-    "gemini_image": "G31FI",
+    "gemini3_pro": "Gemini 3 Pro",
+    "gemini3_flash": "Gemini 3 Flash",
+    "gemini_image": "Gemini 3.1 Flash Image",
     "claude": "Claude"
   },
   "claude_quota": {

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -3019,9 +3019,9 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("G3P")).toBeInTheDocument();
-    expect(within(cards).getByText("G3F")).toBeInTheDocument();
-    expect(within(cards).getByText("G31FI")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini 3 Pro")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini 3 Flash")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini 3.1 Flash Image")).toBeInTheDocument();
     expect(within(cards).getByText("Claude")).toBeInTheDocument();
     expect(within(cards).getByText("82%")).toBeInTheDocument();
     expect(within(cards).getByText("77%")).toBeInTheDocument();
@@ -3108,7 +3108,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("G3P")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini 3 Pro")).toBeInTheDocument();
     expect(
       within(cards).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
     ).not.toBeInTheDocument();
@@ -3175,7 +3175,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("G3P")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini 3 Pro")).toBeInTheDocument();
     expect(within(cards).getByText("91%")).toBeInTheDocument();
     expect(
       within(cards).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
@@ -3242,10 +3242,10 @@ describe("AuthFilesPage files table", () => {
 
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
-    fireEvent.mouseEnter(within(row as HTMLElement).getByText("G3P"));
+    fireEvent.mouseEnter(within(row as HTMLElement).getByText("Gemini 3 Pro"));
 
     const tooltip = await screen.findByRole("tooltip");
-    expect(within(tooltip).getByText("G3P")).toBeInTheDocument();
+    expect(within(tooltip).getByText("Gemini 3 Pro")).toBeInTheDocument();
     expect(
       within(tooltip).queryByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
     ).not.toBeInTheDocument();
@@ -3320,7 +3320,7 @@ describe("AuthFilesPage files table", () => {
 
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
-    fireEvent.mouseEnter(within(row as HTMLElement).getByText("G3P"));
+    fireEvent.mouseEnter(within(row as HTMLElement).getByText("Gemini 3 Pro"));
 
     const tooltips = await screen.findAllByRole("tooltip");
     expect(tooltips).toHaveLength(1);
@@ -3392,7 +3392,7 @@ describe("AuthFilesPage files table", () => {
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
     expect(within(row as HTMLElement).queryByText("chat_20706")).not.toBeInTheDocument();
-    const visibleModel = within(row as HTMLElement).getByText("G3P");
+    const visibleModel = within(row as HTMLElement).getByText("Gemini 3 Pro");
     expect(visibleModel).toBeInTheDocument();
     expect(
       within(row as HTMLElement).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
@@ -3402,7 +3402,7 @@ describe("AuthFilesPage files table", () => {
 
     const tooltip = await screen.findByRole("tooltip");
     expect(within(tooltip).queryByText("chat_20706")).not.toBeInTheDocument();
-    expect(within(tooltip).getByText("G3P")).toBeInTheDocument();
+    expect(within(tooltip).getByText("Gemini 3 Pro")).toBeInTheDocument();
     expect(
       within(tooltip).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update Antigravity quota labels in auth-files from short codes to readable names: Gemini 3 Pro, Gemini 3 Flash, Gemini 3.1 Flash Image, Claude
- keep the four quota groups aligned with sub2api behavior while using the user-approved full labels in codeProxy
- update auth-files table assertions for the new visible labels

## Verification
- rtk bunx oxfmt --check apps/admin-panel/src/i18n/locales/en.json apps/admin-panel/src/i18n/locales/zh-CN.json apps/admin-panel/src/i18n/locales/ru.json packages/i18n/src/locales/en.json packages/i18n/src/locales/zh-CN.json packages/i18n/src/locales/ru.json pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run --filter @code-proxy/admin-panel test -- features/quota-preview/__tests__/quota-helpers.test.ts features/quota-preview/__tests__/quota-fetch.test.ts pages/auth-files/__tests__/auth-files-helpers.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run --filter @code-proxy/admin-panel build
- mock visual check: output/playwright/auth-files-antigravity-readable-labels.png