### PR TITLE
fix: refine request log response metrics column

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -2403,6 +2403,7 @@
     "col_status": "Status",
     "col_mode": "Mode",
     "col_duration": "Duration",
+    "col_response_metrics": "Response Metrics",
     "col_first_token": "First Token",
     "mode_streaming": "Streaming",
     "mode_non_streaming": "Non-streaming",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -2672,6 +2672,7 @@
     "col_status": "状态",
     "col_mode": "类型",
     "col_duration": "耗时",
+    "col_response_metrics": "响应指标",
     "col_first_token": "首 Token",
     "mode_streaming": "流式",
     "mode_non_streaming": "非流式",

--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -3,6 +3,7 @@ import { expect, test, type Page } from "@playwright/test";
 const setAuthed = async (page: Page) => {
   await page.addInitScript(() => {
     localStorage.removeItem("codeProxy.dataTable.columnOrder.v1.request-logs");
+    localStorage.removeItem("codeProxy.dataTable.columnWidths.v1.request-logs");
     localStorage.setItem(
       "code-proxy-admin-auth",
       JSON.stringify({
@@ -189,6 +190,74 @@ const readSettleVisualState = async (page: Page) =>
       }),
     };
   });
+
+const readResponseMetricsColumnState = async (page: Page) =>
+  page.evaluate(() => {
+    const header = document.querySelector<HTMLElement>('th[data-vt-column-key="latency"]');
+    const firstCell = document.querySelector<HTMLElement>('td[data-vt-column-key="latency"]');
+    if (!header || !firstCell) throw new Error("Missing response metrics column");
+
+    const cellRect = firstCell.getBoundingClientRect();
+    const chips = [...firstCell.querySelectorAll<HTMLElement>(".rounded-full")].map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        text: element.textContent?.trim() ?? "",
+        left: rect.left,
+        right: rect.right,
+      };
+    });
+    const storedWidths = JSON.parse(
+      localStorage.getItem("codeProxy.dataTable.columnWidths.v1.request-logs") ?? "{}",
+    ) as Record<string, unknown>;
+
+    return {
+      width: Math.round(header.getBoundingClientRect().width),
+      text: firstCell.textContent?.trim() ?? "",
+      chipsStayInsideCell: chips.every(
+        (chip) => chip.left >= cellRect.left - 1 && chip.right <= cellRect.right + 1,
+      ),
+      storedLatencyWidth:
+        typeof storedWidths.latency === "number" ? Math.round(storedWidths.latency) : null,
+    };
+  });
+
+test("Request Logs: response metrics column resize clamps at its minimum width", async ({
+  page,
+}) => {
+  await setAuthed(page);
+  await mockRequestLogsApis(page);
+
+  await page.goto("/manage/#/monitor/request-logs");
+  await page.locator('th[data-vt-column-key="latency"]').waitFor({ state: "visible" });
+
+  const dragStart = await page
+    .locator('th[data-vt-column-key="latency"] [data-vt-column-resizer]')
+    .evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      const headerRect = element.closest("th")?.getBoundingClientRect();
+      return {
+        x: headerRect ? Math.min(rect.left + rect.width / 2, headerRect.right - 2) : rect.left,
+        y: rect.top + rect.height / 2,
+      };
+    });
+
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.mouse.move(dragStart.x - 520, dragStart.y, { steps: 10 });
+  await page.waitForTimeout(80);
+
+  const during = await readResponseMetricsColumnState(page);
+  expect(during.width).toBeGreaterThanOrEqual(183);
+  expect(during.width).toBeLessThanOrEqual(185);
+  expect(during.text).toMatch(/Streaming|流式/);
+  expect(during.text).not.toContain("--");
+  expect(during.chipsStayInsideCell).toBe(true);
+
+  await page.mouse.up();
+
+  const after = await readResponseMetricsColumnState(page);
+  expect(after.storedLatencyWidth).toBe(184);
+});
 
 test("Request Logs: column reorder follows the pointer and auto-scrolls horizontally", async ({
   page,

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -74,6 +74,11 @@ const formatTokensPerSecond = (value: number | null): string => {
   return `${value.toFixed(2)} t/s`;
 };
 
+const hasRequestLogMetricText = (value: string): boolean => {
+  const trimmed = String(value || "").trim();
+  return trimmed !== "" && trimmed !== "--";
+};
+
 const resolveLatencyToneClasses = (latencyText: string): string => {
   const seconds = parseLatencyTextToSeconds(latencyText);
   if (seconds === null) {
@@ -107,6 +112,26 @@ function RequestLogMetricChip({
       aria-label={ariaLabel}
     >
       {value}
+    </span>
+  );
+}
+
+function RequestLogModeChip({
+  label,
+  streaming,
+}: {
+  label: string;
+  streaming: boolean;
+}) {
+  return (
+    <span
+      className={
+        streaming
+          ? "inline-flex shrink-0 items-center justify-center rounded-full bg-sky-50 px-2.5 py-1 text-xs font-semibold text-sky-600 dark:bg-sky-500/15 dark:text-sky-300"
+          : "inline-flex shrink-0 items-center justify-center rounded-full bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55"
+      }
+    >
+      {label}
     </span>
   );
 }
@@ -369,62 +394,47 @@ export function buildRequestLogsColumns(
         ),
     },
     {
-      key: "mode",
-      label: t("request_logs.col_mode"),
-      width: "w-24",
-      headerClassName: "text-center",
-      cellClassName: "text-center",
-      render: (row) => (
-        <span
-          className={
-            row.streaming
-              ? "inline-flex min-w-[52px] justify-center rounded-full bg-sky-50 px-2.5 py-1 text-xs font-semibold text-sky-600 dark:bg-sky-500/15 dark:text-sky-300"
-              : "inline-flex min-w-[52px] justify-center rounded-full bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55"
-          }
-        >
-          {row.streaming ? t("request_logs.mode_streaming") : t("request_logs.mode_non_streaming")}
-        </span>
-      ),
-    },
-    {
       key: "latency",
-      label: t("request_logs.col_duration"),
-      width: "w-44",
+      label: t("request_logs.col_response_metrics"),
+      width: "w-52",
+      minWidthPx: 184,
       headerClassName: "text-center",
-      cellClassName: "text-center text-xs tabular-nums text-slate-700 dark:text-slate-200 pr-6",
+      cellClassName: "text-center text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) => {
         const tps = computeOutputTokensPerSecond(row);
         const tpsText = formatTokensPerSecond(tps);
-        const firstTokenText = row.streaming
-          ? row.firstTokenText
-          : t("request_logs.first_token_not_applicable");
-        const tooltip =
-          `${t("request_logs.col_duration")}: ${row.latencyText}\n` +
-          `${t("request_logs.col_first_token")}: ${firstTokenText}\n` +
-          `${t("request_logs.tokens_per_second")}: ${tpsText}`;
+        const hasLatency = hasRequestLogMetricText(row.latencyText);
+        const hasFirstToken = row.streaming && hasRequestLogMetricText(row.firstTokenText);
+        const hasTps = hasRequestLogMetricText(tpsText);
+        const tooltipLines = [
+          hasLatency ? `${t("request_logs.col_duration")}: ${row.latencyText}` : null,
+          hasFirstToken ? `${t("request_logs.col_first_token")}: ${row.firstTokenText}` : null,
+          hasTps ? `${t("request_logs.tokens_per_second")}: ${tpsText}` : null,
+        ].filter((line): line is string => Boolean(line));
 
         return (
-          <HoverTooltip content={tooltip} placement="bottom">
+          <HoverTooltip
+            content={tooltipLines.join("\n")}
+            disabled={tooltipLines.length === 0}
+            placement="bottom"
+            className="max-w-full justify-center"
+          >
             <div className="inline-flex max-w-full items-center justify-center gap-1.5 whitespace-nowrap">
-              <RequestLogMetricChip
-                ariaLabel={`${t("request_logs.col_duration")}: ${row.latencyText}`}
-                value={row.latencyText}
-                className={resolveLatencyToneClasses(row.latencyText)}
-              />
-              {row.streaming ? (
+              {hasLatency ? (
                 <RequestLogMetricChip
-                  ariaLabel={`${t("request_logs.col_first_token")}: ${row.firstTokenText}`}
-                  value={row.firstTokenText}
-                  className={
-                    row.firstTokenText === "--"
-                      ? "border-slate-200 bg-slate-50 text-slate-500 dark:border-neutral-800 dark:bg-neutral-950/45 dark:text-white/55"
-                      : "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/20 dark:bg-sky-500/10 dark:text-sky-200"
-                  }
+                  ariaLabel={`${t("request_logs.col_duration")}: ${row.latencyText}`}
+                  value={row.latencyText}
+                  className={resolveLatencyToneClasses(row.latencyText)}
                 />
               ) : null}
-              <span className="font-mono text-[11px] tabular-nums text-slate-400 dark:text-white/35 whitespace-nowrap">
-                {tpsText}
-              </span>
+              <RequestLogModeChip
+                streaming={row.streaming}
+                label={
+                  row.streaming
+                    ? t("request_logs.mode_streaming")
+                    : t("request_logs.mode_non_streaming")
+                }
+              />
             </div>
           </HoverTooltip>
         );

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2437,6 +2437,7 @@
     "col_status": "Status",
     "col_mode": "Mode",
     "col_duration": "Duration",
+    "col_response_metrics": "Response Metrics",
     "col_first_token": "First Token",
     "mode_streaming": "Streaming",
     "mode_non_streaming": "Non-streaming",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2706,6 +2706,7 @@
     "col_status": "状态",
     "col_mode": "类型",
     "col_duration": "耗时",
+    "col_response_metrics": "响应指标",
     "col_first_token": "首 Token",
     "mode_streaming": "流式",
     "mode_non_streaming": "非流式",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -252,6 +252,22 @@ function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
   return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
 }
 
+function normalizeColumnWidths<T>(columns: DataTableColumn<T>[], widths: ColumnWidthMap) {
+  const next: ColumnWidthMap = {};
+  columns.forEach((column) => {
+    const width = widths[column.key];
+    if (width !== undefined) next[column.key] = clampColumnWidth(column, width);
+  });
+  return next;
+}
+
+function areColumnWidthMapsEqual(left: ColumnWidthMap, right: ColumnWidthMap) {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key) => left[key] === right[key]);
+}
+
 function getColumnWidthStorageKey(tableId?: string) {
   const trimmed = tableId?.trim();
   return trimmed ? `${COLUMN_WIDTH_STORAGE_PREFIX}.${trimmed}` : null;
@@ -573,7 +589,7 @@ export function DataTable<T>({
   const columnElementsRef = useRef<Record<string, HTMLTableColElement | null>>({});
   const headerHeightRef = useRef(0);
   const [columnWidths, setColumnWidths] = useState<ColumnWidthMap>(() =>
-    readStoredColumnWidths(tableId),
+    normalizeColumnWidths(columns, readStoredColumnWidths(tableId)),
   );
   const columnWidthsRef = useRef<ColumnWidthMap>(columnWidths);
   const [resizePreview, setResizePreview] = useState<ColumnResizePreview | null>(null);
@@ -647,7 +663,7 @@ export function DataTable<T>({
   const colCount = orderedColumns.length;
 
   useEffect(() => {
-    setColumnWidths(readStoredColumnWidths(tableId));
+    setColumnWidths(normalizeColumnWidths(columns, readStoredColumnWidths(tableId)));
     if (canUseColumnOrder) {
       setColumnOrder(
         normalizeColumnOrder(columns, canPersistColumnOrder ? readStoredColumnOrder(tableId) : []),
@@ -684,19 +700,9 @@ export function DataTable<T>({
   useEffect(() => {
     const validKeys = new Set(columns.map((column) => column.key));
     setColumnWidths((prev) => {
-      let changed = false;
-      const next: ColumnWidthMap = {};
-      columns.forEach((column) => {
-        const width = prev[column.key];
-        if (width !== undefined) next[column.key] = clampColumnWidth(column, width);
-      });
-      Object.keys(prev).forEach((key) => {
-        if (!validKeys.has(key)) changed = true;
-      });
-      columns.forEach((column) => {
-        if (next[column.key] !== prev[column.key]) changed = true;
-      });
-      return changed ? next : prev;
+      const next = normalizeColumnWidths(columns, prev);
+      const removedStaleKey = Object.keys(prev).some((key) => !validKeys.has(key));
+      return removedStaleKey || !areColumnWidthMapsEqual(prev, next) ? next : prev;
     });
   }, [columns]);
 
@@ -1887,7 +1893,8 @@ export function DataTable<T>({
     (column: DataTableColumn<T>): CSSProperties | undefined => {
       const width = columnWidths[column.key];
       if (!width) return undefined;
-      return { width, minWidth: width, maxWidth: width };
+      const clampedWidth = clampColumnWidth(column, width);
+      return { width: clampedWidth, minWidth: clampedWidth, maxWidth: clampedWidth };
     },
     [columnWidths],
   );

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -61,7 +61,11 @@ describe("requestLogsShared", () => {
     const columns = buildRequestLogsColumns((key) => key);
     const keys = columns.map((column) => column.key);
 
-    expect(keys).toContain("mode");
+    expect(keys).not.toContain("mode");
+    expect(columns.find((column) => column.key === "latency")?.label).toBe(
+      "request_logs.col_response_metrics",
+    );
+    expect(columns.find((column) => column.key === "latency")?.minWidthPx).toBe(184);
     expect(keys.indexOf("latency")).toBeLessThan(keys.indexOf("apiKeyName"));
     expect(keys.indexOf("inputTokens")).toBeLessThan(keys.indexOf("apiKeyName"));
     expect(keys.indexOf("cachedTokens")).toBeLessThan(keys.indexOf("model"));

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import i18n from "@code-proxy/i18n";
@@ -153,8 +153,9 @@ describe("RequestLogsPage", () => {
     mocks.clearUsageLogs.mockReset();
   });
 
-  test("renders the first token latency column from backend data", async () => {
+  test("renders first token latency in the response metrics tooltip", async () => {
     await i18n.changeLanguage("en");
+    const user = userEvent.setup();
 
     mocks.getUsageLogs.mockResolvedValue({
       items: [
@@ -204,9 +205,14 @@ describe("RequestLogsPage", () => {
       </ThemeProvider>,
     );
 
-    expect(await screen.findByText("Duration")).toBeInTheDocument();
-    expect(await screen.findByText("Streaming")).toBeInTheDocument();
-    expect(await screen.findByText("183ms")).toBeInTheDocument();
+    const table = await screen.findByRole("table", { name: "Request Logs Table" });
+    expect(within(table).getByRole("columnheader", { name: "Response Metrics" })).toBeInTheDocument();
+    expect(within(table).getByText("Streaming")).toBeInTheDocument();
+    expect(within(table).getByText("1.20s")).toBeInTheDocument();
+    expect(within(table).queryByText("183ms")).not.toBeInTheDocument();
+
+    await user.hover(within(table).getByLabelText("Duration: 1.20s"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("First Token: 183ms");
   });
 
   test("labels non-streaming logs without rendering a first token placeholder", async () => {
@@ -565,6 +571,58 @@ describe("RequestLogsPage", () => {
 
     await screen.findByRole("table", { name: "请求日志表" });
     expect(container.querySelector(".table-scrollbar")).not.toBeNull();
+  });
+
+  test("renders response metrics without missing-value placeholders", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue(
+      responseWithRows([
+        buildUsageLogItem({
+          id: 1,
+          streaming: true,
+          latency_ms: 354,
+          first_token_ms: 0,
+          output_tokens: 0,
+        }),
+        buildUsageLogItem({
+          id: 2,
+          streaming: false,
+          latency_ms: -1,
+          first_token_ms: 0,
+          output_tokens: 0,
+        }),
+      ]),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const table = await screen.findByRole("table", { name: "请求日志表" });
+    expect(within(table).getByRole("columnheader", { name: "响应指标" })).toBeInTheDocument();
+    expect(within(table).queryByRole("columnheader", { name: "类型" })).not.toBeInTheDocument();
+    expect(within(table).getByText("354ms")).toBeInTheDocument();
+    expect(within(table).getByText("流式")).toBeInTheDocument();
+    expect(within(table).getByText("非流式")).toBeInTheDocument();
+    expect(within(table).queryByText("--")).not.toBeInTheDocument();
+
+    await user.hover(within(table).getByLabelText("耗时: 354ms"));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("耗时: 354ms");
+    expect(tooltip).not.toHaveTextContent("首 Token");
+    expect(tooltip).not.toHaveTextContent("每秒 Token");
+    expect(tooltip).not.toHaveTextContent("--");
+    await user.unhover(within(table).getByLabelText("耗时: 354ms"));
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+
+    await user.hover(within(table).getByText("非流式"));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
   test("shows full numeric values in the table while keeping the summary bar compact", async () => {


### PR DESCRIPTION
## Summary
- move streaming/non-streaming badges into the response metrics column
- rename the duration column to Response Metrics / 响应指标
- clamp request log column resizing at its minimum width and avoid missing-value placeholders in cells/tooltips

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/monitor/__tests__/requestLogsShared.test.ts pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run e2e e2e/request-logs-column-reorder.spec.ts
- rtk bun run --filter @code-proxy/admin-panel build
- rtk bun run lint