### PR TITLE
fix: refine request log metrics and table clipping

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -2404,7 +2404,7 @@
     "col_mode": "Mode",
     "col_duration": "Duration",
     "col_response_metrics": "Response Metrics",
-    "col_first_token": "First Token",
+    "col_first_token": "First Token Latency",
     "mode_streaming": "Streaming",
     "mode_non_streaming": "Non-streaming",
     "first_token_not_applicable": "Not applicable for non-streaming",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -2673,7 +2673,7 @@
     "col_mode": "类型",
     "col_duration": "耗时",
     "col_response_metrics": "响应指标",
-    "col_first_token": "首 Token",
+    "col_first_token": "首 Token 耗时",
     "mode_streaming": "流式",
     "mode_non_streaming": "非流式",
     "first_token_not_applicable": "非流式不适用",

--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -247,8 +247,10 @@ test("Request Logs: response metrics column resize clamps at its minimum width",
   await page.waitForTimeout(80);
 
   const during = await readResponseMetricsColumnState(page);
-  expect(during.width).toBeGreaterThanOrEqual(183);
-  expect(during.width).toBeLessThanOrEqual(185);
+  expect(during.width).toBeGreaterThanOrEqual(239);
+  expect(during.width).toBeLessThanOrEqual(241);
+  expect(during.text).toMatch(/First Token Latency|首 Token 耗时/);
+  expect(during.text).toMatch(/90ms/);
   expect(during.text).toMatch(/Streaming|流式/);
   expect(during.text).not.toContain("--");
   expect(during.chipsStayInsideCell).toBe(true);
@@ -256,7 +258,7 @@ test("Request Logs: response metrics column resize clamps at its minimum width",
   await page.mouse.up();
 
   const after = await readResponseMetricsColumnState(page);
-  expect(after.storedLatencyWidth).toBe(184);
+  expect(after.storedLatencyWidth).toBe(240);
 });
 
 test("Request Logs: column reorder follows the pointer and auto-scrolls horizontally", async ({

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -96,22 +96,27 @@ const resolveLatencyToneClasses = (latencyText: string): string => {
 
 function RequestLogMetricChip({
   ariaLabel,
+  label,
   value,
   className,
 }: {
   ariaLabel: string;
+  label?: string;
   value: string;
   className: string;
 }) {
   return (
     <span
       className={[
-        "inline-flex items-center rounded-full border px-1.5 py-0.5 font-mono text-[11px] font-semibold tabular-nums whitespace-nowrap",
+        "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] whitespace-nowrap",
         className,
       ].join(" ")}
       aria-label={ariaLabel}
     >
-      {value}
+      {label ? (
+        <span className="font-sans text-[10px] font-medium leading-none opacity-80">{label}</span>
+      ) : null}
+      <span className="font-mono font-semibold tabular-nums">{value}</span>
     </span>
   );
 }
@@ -396,15 +401,15 @@ export function buildRequestLogsColumns(
     {
       key: "latency",
       label: t("request_logs.col_response_metrics"),
-      width: "w-52",
-      minWidthPx: 184,
+      width: "w-64",
+      minWidthPx: 240,
       headerClassName: "text-center",
       cellClassName: "text-center text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) => {
         const tps = computeOutputTokensPerSecond(row);
         const tpsText = formatTokensPerSecond(tps);
         const hasLatency = hasRequestLogMetricText(row.latencyText);
-        const hasFirstToken = row.streaming && hasRequestLogMetricText(row.firstTokenText);
+        const hasFirstToken = hasRequestLogMetricText(row.firstTokenText);
         const hasTps = hasRequestLogMetricText(tpsText);
         const tooltipLines = [
           hasLatency ? `${t("request_logs.col_duration")}: ${row.latencyText}` : null,
@@ -417,14 +422,23 @@ export function buildRequestLogsColumns(
             content={tooltipLines.join("\n")}
             disabled={tooltipLines.length === 0}
             placement="bottom"
-            className="max-w-full justify-center"
+            className="block max-w-full"
           >
-            <div className="inline-flex max-w-full items-center justify-center gap-1.5 whitespace-nowrap">
+            <div className="flex max-w-full flex-wrap items-center justify-center gap-1.5">
               {hasLatency ? (
                 <RequestLogMetricChip
                   ariaLabel={`${t("request_logs.col_duration")}: ${row.latencyText}`}
+                  label={t("request_logs.col_duration")}
                   value={row.latencyText}
                   className={resolveLatencyToneClasses(row.latencyText)}
+                />
+              ) : null}
+              {hasFirstToken ? (
+                <RequestLogMetricChip
+                  ariaLabel={`${t("request_logs.col_first_token")}: ${row.firstTokenText}`}
+                  label={t("request_logs.col_first_token")}
+                  value={row.firstTokenText}
+                  className="border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/20 dark:bg-sky-500/10 dark:text-sky-200"
                 />
               ) : null}
               <RequestLogModeChip

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2438,7 +2438,7 @@
     "col_mode": "Mode",
     "col_duration": "Duration",
     "col_response_metrics": "Response Metrics",
-    "col_first_token": "First Token",
+    "col_first_token": "First Token Latency",
     "mode_streaming": "Streaming",
     "mode_non_streaming": "Non-streaming",
     "first_token_not_applicable": "Not applicable for non-streaming",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2707,7 +2707,7 @@
     "col_mode": "类型",
     "col_duration": "耗时",
     "col_response_metrics": "响应指标",
-    "col_first_token": "首 Token",
+    "col_first_token": "首 Token 耗时",
     "mode_streaming": "流式",
     "mode_non_streaming": "非流式",
     "first_token_not_applicable": "非流式不适用",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -118,6 +118,7 @@ const DEFAULT_MIN_COLUMN_WIDTH = 72;
 const DEFAULT_MAX_COLUMN_WIDTH = 640;
 const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
 const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
+const TAILWIND_SPACING_UNIT_PX = 4;
 
 // ---------------------------------------------------------------------------
 // Column Reorder
@@ -247,9 +248,43 @@ function calculateScrollbarThumbs(scrollMetrics: ScrollMetrics, headerHeight: nu
 }
 
 function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
-  const minWidth = column.minWidthPx ?? DEFAULT_MIN_COLUMN_WIDTH;
-  const maxWidth = column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH;
+  const minWidth = resolveColumnMinWidth(column);
+  const maxWidth = resolveColumnMaxWidth(column, minWidth);
   return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
+}
+
+function parseTailwindSizePx(token: string) {
+  const arbitrary = token.match(/^\[(\d+(?:\.\d+)?)(px|rem)\]$/);
+  if (arbitrary) {
+    const value = Number(arbitrary[1]);
+    if (!Number.isFinite(value)) return null;
+    return arbitrary[2] === "rem" ? Math.round(value * 16) : Math.round(value);
+  }
+
+  if (token === "px") return 1;
+
+  const numeric = Number(token);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.round(numeric * TAILWIND_SPACING_UNIT_PX);
+}
+
+function resolveWidthClassPx(width: string | undefined, prefix: string) {
+  if (!width) return null;
+  const classes = width.split(/\s+/).filter(Boolean).reverse();
+  for (const className of classes) {
+    if (!className.startsWith(`${prefix}-`)) continue;
+    const parsed = parseTailwindSizePx(className.slice(prefix.length + 1));
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function resolveColumnMinWidth<T>(column: DataTableColumn<T>) {
+  return column.minWidthPx ?? resolveWidthClassPx(column.width, "min-w") ?? DEFAULT_MIN_COLUMN_WIDTH;
+}
+
+function resolveColumnMaxWidth<T>(column: DataTableColumn<T>, minWidth = resolveColumnMinWidth(column)) {
+  return Math.max(minWidth, column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH);
 }
 
 function normalizeColumnWidths<T>(columns: DataTableColumn<T>[], widths: ColumnWidthMap) {
@@ -1207,8 +1242,8 @@ export function DataTable<T>({
       const rect = headerCell.getBoundingClientRect();
       const containerRect = containerRef.current?.getBoundingClientRect();
       const startWidth = rect.width;
-      const minWidth = column.minWidthPx ?? DEFAULT_MIN_COLUMN_WIDTH;
-      const maxWidth = column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH;
+      const minWidth = resolveColumnMinWidth(column);
+      const maxWidth = resolveColumnMaxWidth(column, minWidth);
       const nextStartWidth = Math.max(minWidth, Math.min(maxWidth, startWidth));
 
       e.preventDefault();

--- a/packages/ui/src/data-table/__tests__/tableStorage.test.ts
+++ b/packages/ui/src/data-table/__tests__/tableStorage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import type { DataTableColumn } from "../DataTable.types";
+import { clampColumnWidth, resolveColumnMinWidth } from "../tableStorage";
+
+const column = (overrides: Partial<DataTableColumn<unknown>> = {}): DataTableColumn<unknown> => ({
+  key: "name",
+  label: "Name",
+  render: () => null,
+  ...overrides,
+});
+
+describe("tableStorage column widths", () => {
+  test("uses explicit minWidthPx before width classes", () => {
+    const target = column({ minWidthPx: 180, width: "w-[320px] min-w-[320px]" });
+
+    expect(resolveColumnMinWidth(target)).toBe(180);
+    expect(clampColumnWidth(target, 120)).toBe(180);
+  });
+
+  test("clamps drag resize to the min-w width class", () => {
+    const target = column({ width: "w-[320px] min-w-[320px]" });
+
+    expect(resolveColumnMinWidth(target)).toBe(320);
+    expect(clampColumnWidth(target, 72)).toBe(320);
+  });
+
+  test("keeps the default minimum when no min-w class is provided", () => {
+    const target = column({ width: "w-52" });
+
+    expect(resolveColumnMinWidth(target)).toBe(72);
+    expect(clampColumnWidth(target, 48)).toBe(72);
+  });
+});

--- a/packages/ui/src/data-table/tableStorage.ts
+++ b/packages/ui/src/data-table/tableStorage.ts
@@ -13,6 +13,7 @@ export const DEFAULT_MIN_COLUMN_WIDTH = 72;
 export const DEFAULT_MAX_COLUMN_WIDTH = 640;
 export const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
 export const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
+const TAILWIND_SPACING_UNIT_PX = 4;
 
 // ---------------------------------------------------------------------------
 // Column Reorder
@@ -129,9 +130,46 @@ export function calculateScrollbarThumbs(scrollMetrics: ScrollMetrics, headerHei
 }
 
 export function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
-  const minWidth = column.minWidthPx ?? DEFAULT_MIN_COLUMN_WIDTH;
-  const maxWidth = column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH;
+  const minWidth = resolveColumnMinWidth(column);
+  const maxWidth = resolveColumnMaxWidth(column, minWidth);
   return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
+}
+
+function parseTailwindSizePx(token: string) {
+  const arbitrary = token.match(/^\[(\d+(?:\.\d+)?)(px|rem)\]$/);
+  if (arbitrary) {
+    const value = Number(arbitrary[1]);
+    if (!Number.isFinite(value)) return null;
+    return arbitrary[2] === "rem" ? Math.round(value * 16) : Math.round(value);
+  }
+
+  if (token === "px") return 1;
+
+  const numeric = Number(token);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.round(numeric * TAILWIND_SPACING_UNIT_PX);
+}
+
+function resolveWidthClassPx(width: string | undefined, prefix: string) {
+  if (!width) return null;
+  const classes = width.split(/\s+/).filter(Boolean).reverse();
+  for (const className of classes) {
+    if (!className.startsWith(`${prefix}-`)) continue;
+    const parsed = parseTailwindSizePx(className.slice(prefix.length + 1));
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+export function resolveColumnMinWidth<T>(column: DataTableColumn<T>) {
+  return column.minWidthPx ?? resolveWidthClassPx(column.width, "min-w") ?? DEFAULT_MIN_COLUMN_WIDTH;
+}
+
+export function resolveColumnMaxWidth<T>(
+  column: DataTableColumn<T>,
+  minWidth = resolveColumnMinWidth(column),
+) {
+  return Math.max(minWidth, column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH);
 }
 
 export function getColumnWidthStorageKey(tableId?: string) {

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -31,6 +31,16 @@ type CreateApiKeyColumnsOptions = {
   onDelete: (index: number) => void;
 };
 
+function ApiKeyBadge({ value }: { value: string }) {
+  return (
+    <OverflowTooltip as="div" content={value} className="block min-w-0 max-w-full">
+      <code className="inline-flex min-w-0 max-w-full items-center rounded-md bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-700 dark:bg-neutral-800 dark:text-white/70">
+        <span className="block min-w-0 truncate">{value}</span>
+      </code>
+    </OverflowTooltip>
+  );
+}
+
 export const createApiKeyColumns = ({
   t,
   onToggleDisable,
@@ -85,11 +95,7 @@ export const createApiKeyColumns = ({
     label: t("api_keys_page.col_key"),
     width: "w-[320px] min-w-[320px]",
     cellClassName: "whitespace-nowrap",
-    render: (row) => (
-      <code className="rounded-md bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-700 dark:bg-neutral-800 dark:text-white/70">
-        {maskApiKey(row.key)}
-      </code>
-    ),
+    render: (row) => <ApiKeyBadge value={maskApiKey(row.key)} />,
   },
   {
     key: "dailyLimit",

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -101,6 +101,40 @@ describe("ApiKeyColumns", () => {
     expect(keyColumn?.width).toBe("w-[320px] min-w-[320px]");
   });
 
+  test("truncates API key text inside an intact rounded badge", () => {
+    const row: ApiKeyEntry = {
+      key: "sk-abcdefghijklmnopqrstuvwxyz0123456789",
+      name: "Test key",
+      "created-at": "2026-04-28T00:00:00Z",
+    };
+    const columns = createApiKeyColumns({
+      t,
+      onCopy: vi.fn(),
+      onDelete: vi.fn(),
+      onEdit: vi.fn(),
+      onImportToCcSwitch: vi.fn(),
+      onToggleDisable: vi.fn(),
+      onViewUsage: vi.fn(),
+    });
+    const keyColumn = columns.find((column) => column.key === "key");
+    const maskedKey = `sk-ab${"•".repeat(20)}789`;
+
+    render(<div>{keyColumn?.render(row, 0)}</div>);
+
+    const text = screen.getByText(maskedKey);
+    const badge = text.closest("code");
+    const tooltipTrigger = badge?.parentElement;
+
+    expect(badge).not.toBeNull();
+    expect(tooltipTrigger).not.toBeNull();
+    if (!badge || !tooltipTrigger) return;
+
+    expect(text).toHaveClass("truncate");
+    expect(badge).toHaveClass("inline-flex", "max-w-full", "rounded-md");
+    expect(tooltipTrigger).toHaveAttribute("data-tooltip-managed", "true");
+    expect(tooltipTrigger).toHaveClass("block", "max-w-full");
+  });
+
   test("shows API key spending limits as a dedicated cost column", async () => {
     const row: ApiKeyEntry = {
       key: "sk-test",

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -65,7 +65,7 @@ describe("requestLogsShared", () => {
     expect(columns.find((column) => column.key === "latency")?.label).toBe(
       "request_logs.col_response_metrics",
     );
-    expect(columns.find((column) => column.key === "latency")?.minWidthPx).toBe(184);
+    expect(columns.find((column) => column.key === "latency")?.minWidthPx).toBe(240);
     expect(keys.indexOf("latency")).toBeLessThan(keys.indexOf("apiKeyName"));
     expect(keys.indexOf("inputTokens")).toBeLessThan(keys.indexOf("apiKeyName"));
     expect(keys.indexOf("cachedTokens")).toBeLessThan(keys.indexOf("model"));

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -153,7 +153,7 @@ describe("RequestLogsPage", () => {
     mocks.clearUsageLogs.mockReset();
   });
 
-  test("renders first token latency in the response metrics tooltip", async () => {
+  test("renders first token latency in the visible response metrics column", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();
 
@@ -209,10 +209,11 @@ describe("RequestLogsPage", () => {
     expect(within(table).getByRole("columnheader", { name: "Response Metrics" })).toBeInTheDocument();
     expect(within(table).getByText("Streaming")).toBeInTheDocument();
     expect(within(table).getByText("1.20s")).toBeInTheDocument();
-    expect(within(table).queryByText("183ms")).not.toBeInTheDocument();
+    expect(within(table).getByText("First Token Latency")).toBeInTheDocument();
+    expect(within(table).getByText("183ms")).toBeInTheDocument();
 
     await user.hover(within(table).getByLabelText("Duration: 1.20s"));
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("First Token: 183ms");
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("First Token Latency: 183ms");
   });
 
   test("labels non-streaming logs without rendering a first token placeholder", async () => {
@@ -236,7 +237,7 @@ describe("RequestLogsPage", () => {
     );
 
     expect(await screen.findByText("Non-streaming")).toBeInTheDocument();
-    expect(screen.queryByLabelText("First Token: --")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("First Token Latency: --")).not.toBeInTheDocument();
   });
 
   test("does not crash when backend returns null filter arrays", async () => {
@@ -615,7 +616,7 @@ describe("RequestLogsPage", () => {
     await user.hover(within(table).getByLabelText("耗时: 354ms"));
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip).toHaveTextContent("耗时: 354ms");
-    expect(tooltip).not.toHaveTextContent("首 Token");
+    expect(tooltip).not.toHaveTextContent("首 Token 耗时");
     expect(tooltip).not.toHaveTextContent("每秒 Token");
     expect(tooltip).not.toHaveTextContent("--");
     await user.unhover(within(table).getByLabelText("耗时: 354ms"));


### PR DESCRIPTION
## Summary
- Show first-token latency directly inside the request log response metrics column and omit empty metric placeholders/tooltips.
- Clamp table column resizing to configured minimum widths, including Tailwind min-w classes.
- Keep API key badges visually intact while truncating only the inner key text.

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/request-logs/__tests__/RequestLogsPage.test.tsx pages/monitor/__tests__/requestLogsShared.test.ts pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx packages/ui/src/data-table/__tests__/tableStorage.test.ts
- rtk bun run e2e e2e/request-logs-column-reorder.spec.ts
- rtk bun run lint
- rtk bun run build