### PR TITLE
fix: refine request log metrics and API key summaries

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const setAuthed = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem("codeProxy.dataTable.columnOrder.v1.api-keys");
+    localStorage.removeItem("codeProxy.dataTable.columnWidths.v1.api-keys");
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+  });
+};
+
+const mockApiKeysApis = async (page: Page) => {
+  const entries = [
+    {
+      key: "sk-e2e-limited-model-summary-1234567890",
+      name: "Limited Models",
+      "allowed-models": [
+        "deepseek-v4-flash-ultra-long-model-name",
+        "deepseek-v4-pro",
+        "kimi-k2.5",
+        "kimi-k2.6",
+      ],
+      "allowed-channel-groups": ["all-channel-groups-with-a-long-name"],
+      "allowed-channels": ["primary-channel-with-a-long-name"],
+      "created-at": "2026-05-13T15:32:00Z",
+    },
+  ];
+
+  await page.route("**/v0/management/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname.endsWith("/v0/management/config")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/api-key-entries")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "api-key-entries": entries }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/api-keys")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "api-keys": [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/api-key-permission-profiles")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "api-key-permission-profiles": [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/ccswitch-import-configs")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "ccswitch-import-configs": [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/channel-groups")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/models")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/auth-files")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ files: [] }),
+      });
+      return;
+    }
+
+    const providerListPayloads: Record<string, Record<string, unknown[]>> = {
+      "/v0/management/gemini-api-key": { "gemini-api-key": [] },
+      "/v0/management/claude-api-key": { "claude-api-key": [] },
+      "/v0/management/codex-api-key": { "codex-api-key": [] },
+      "/v0/management/vertex-api-key": { "vertex-api-key": [] },
+      "/v0/management/openai-compatibility": { "openai-compatibility": [] },
+    };
+    const providerPayload = providerListPayloads[pathname];
+    if (providerPayload) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(providerPayload),
+      });
+      return;
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+};
+
+test("API Keys: limited model summary truncates inside the rounded pill", async ({ page }) => {
+  await page.setViewportSize({ width: 2048, height: 1180 });
+  await setAuthed(page);
+  await mockApiKeysApis(page);
+
+  await page.goto("/#/api-keys");
+  await page.locator('td[data-vt-column-key="allowedModels"]').waitFor({ state: "visible" });
+
+  const summaryState = await page.evaluate(() => {
+    const cell = document.querySelector<HTMLElement>('td[data-vt-column-key="allowedModels"]');
+    const tooltip = cell?.querySelector<HTMLElement>("[data-tooltip-managed='true']");
+    const pill = tooltip?.querySelector<HTMLElement>(".rounded-full.border");
+    const count = pill?.querySelector<HTMLElement>(".tabular-nums");
+    const text = pill?.querySelector<HTMLElement>(".truncate");
+
+    if (!cell || !tooltip || !pill || !count || !text) {
+      throw new Error("Missing limited model summary elements");
+    }
+
+    const cellRect = cell.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const pillRect = pill.getBoundingClientRect();
+    const countRect = count.getBoundingClientRect();
+    const textRect = text.getBoundingClientRect();
+    const pillStyle = getComputedStyle(pill);
+
+    return {
+      cellRight: cellRect.right,
+      tooltipRight: tooltipRect.right,
+      pillLeft: pillRect.left,
+      pillRight: pillRect.right,
+      countLeft: countRect.left,
+      countRight: countRect.right,
+      textLeft: textRect.left,
+      textRight: textRect.right,
+      textClientWidth: text.clientWidth,
+      textScrollWidth: text.scrollWidth,
+      borderRightWidth: pillStyle.borderRightWidth,
+      borderTopRightRadius: pillStyle.borderTopRightRadius,
+      visibleText: text.textContent?.trim() ?? "",
+    };
+  });
+
+  expect(summaryState.visibleText).toBe("deepseek-v4-flash-ultra-long-model-name");
+  expect(summaryState.tooltipRight).toBeLessThanOrEqual(summaryState.cellRight + 1);
+  expect(summaryState.pillRight).toBeLessThanOrEqual(summaryState.cellRight + 1);
+  expect(summaryState.countLeft).toBeGreaterThanOrEqual(summaryState.pillLeft - 1);
+  expect(summaryState.countRight).toBeLessThanOrEqual(summaryState.pillRight + 1);
+  expect(summaryState.textLeft).toBeGreaterThanOrEqual(summaryState.pillLeft - 1);
+  expect(summaryState.textRight).toBeLessThanOrEqual(summaryState.pillRight + 1);
+  expect(summaryState.textScrollWidth).toBeGreaterThan(summaryState.textClientWidth);
+  expect(summaryState.borderRightWidth).toBe("1px");
+  expect(Number.parseFloat(summaryState.borderTopRightRadius)).toBeGreaterThan(0);
+});

--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -200,10 +200,12 @@ const readResponseMetricsColumnState = async (page: Page) =>
     const cellRect = firstCell.getBoundingClientRect();
     const chips = [...firstCell.querySelectorAll<HTMLElement>(".rounded-full")].map((element) => {
       const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
       return {
         text: element.textContent?.trim() ?? "",
         left: rect.left,
         right: rect.right,
+        borderTopWidth: style.borderTopWidth,
       };
     });
     const storedWidths = JSON.parse(
@@ -213,6 +215,7 @@ const readResponseMetricsColumnState = async (page: Page) =>
     return {
       width: Math.round(header.getBoundingClientRect().width),
       text: firstCell.textContent?.trim() ?? "",
+      chips,
       chipsStayInsideCell: chips.every(
         (chip) => chip.left >= cellRect.left - 1 && chip.right <= cellRect.right + 1,
       ),
@@ -249,11 +252,12 @@ test("Request Logs: response metrics column resize clamps at its minimum width",
   const during = await readResponseMetricsColumnState(page);
   expect(during.width).toBeGreaterThanOrEqual(239);
   expect(during.width).toBeLessThanOrEqual(241);
-  expect(during.text).toMatch(/First Token Latency|首 Token 耗时/);
+  expect(during.text).not.toMatch(/First Token Latency|首 Token 耗时/);
   expect(during.text).toMatch(/90ms/);
   expect(during.text).toMatch(/Streaming|流式/);
   expect(during.text).not.toContain("--");
   expect(during.chipsStayInsideCell).toBe(true);
+  expect(during.chips.find((chip) => /Streaming|流式/.test(chip.text))?.borderTopWidth).toBe("1px");
 
   await page.mouse.up();
 

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -57,9 +57,7 @@ const computeOutputTokensPerSecond = (row: RequestLogsRow): number | null => {
   const totalSeconds = parseLatencyTextToSeconds(row.latencyText);
   if (totalSeconds === null || totalSeconds <= 0) return null;
 
-  const firstSeconds = row.streaming
-    ? (parseLatencyTextToSeconds(row.firstTokenText) ?? 0)
-    : 0;
+  const firstSeconds = row.streaming ? (parseLatencyTextToSeconds(row.firstTokenText) ?? 0) : 0;
   const generationSeconds = Math.max(0, totalSeconds - firstSeconds);
   if (generationSeconds <= 0) return null;
 
@@ -96,12 +94,10 @@ const resolveLatencyToneClasses = (latencyText: string): string => {
 
 function RequestLogMetricChip({
   ariaLabel,
-  label,
   value,
   className,
 }: {
   ariaLabel: string;
-  label?: string;
   value: string;
   className: string;
 }) {
@@ -113,27 +109,18 @@ function RequestLogMetricChip({
       ].join(" ")}
       aria-label={ariaLabel}
     >
-      {label ? (
-        <span className="font-sans text-[10px] font-medium leading-none opacity-80">{label}</span>
-      ) : null}
       <span className="font-mono font-semibold tabular-nums">{value}</span>
     </span>
   );
 }
 
-function RequestLogModeChip({
-  label,
-  streaming,
-}: {
-  label: string;
-  streaming: boolean;
-}) {
+function RequestLogModeChip({ label, streaming }: { label: string; streaming: boolean }) {
   return (
     <span
       className={
         streaming
-          ? "inline-flex shrink-0 items-center justify-center rounded-full bg-sky-50 px-2.5 py-1 text-xs font-semibold text-sky-600 dark:bg-sky-500/15 dark:text-sky-300"
-          : "inline-flex shrink-0 items-center justify-center rounded-full bg-slate-50 px-2.5 py-1 text-xs font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55"
+          ? "inline-flex shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs font-semibold text-sky-600 dark:border-sky-500/25 dark:bg-sky-500/15 dark:text-sky-300"
+          : "inline-flex shrink-0 items-center justify-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 dark:border-white/10 dark:bg-neutral-900 dark:text-white/55"
       }
     >
       {label}
@@ -422,13 +409,12 @@ export function buildRequestLogsColumns(
             content={tooltipLines.join("\n")}
             disabled={tooltipLines.length === 0}
             placement="bottom"
-            className="block max-w-full"
+            className="!flex min-w-0 max-w-full justify-center"
           >
-            <div className="flex max-w-full flex-wrap items-center justify-center gap-1.5">
+            <div className="flex min-w-0 max-w-full flex-nowrap items-center justify-center gap-1.5">
               {hasLatency ? (
                 <RequestLogMetricChip
                   ariaLabel={`${t("request_logs.col_duration")}: ${row.latencyText}`}
-                  label={t("request_logs.col_duration")}
                   value={row.latencyText}
                   className={resolveLatencyToneClasses(row.latencyText)}
                 />
@@ -436,7 +422,6 @@ export function buildRequestLogsColumns(
               {hasFirstToken ? (
                 <RequestLogMetricChip
                   ariaLabel={`${t("request_logs.col_first_token")}: ${row.firstTokenText}`}
-                  label={t("request_logs.col_first_token")}
                   value={row.firstTokenText}
                   className="border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-500/20 dark:bg-sky-500/10 dark:text-sky-200"
                 />

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -1,4 +1,5 @@
 import type { TFunction } from "i18next";
+import type { ReactNode } from "react";
 import {
   BarChart3,
   Copy,
@@ -31,6 +32,22 @@ type CreateApiKeyColumnsOptions = {
   onDelete: (index: number) => void;
 };
 
+type PermissionSummaryTone = "cyan" | "indigo" | "violet";
+
+const permissionSummaryToneClasses: Record<PermissionSummaryTone, string> = {
+  cyan: "border-cyan-100 bg-cyan-50/65 text-cyan-700 dark:border-cyan-500/20 dark:bg-cyan-500/10 dark:text-cyan-200",
+  indigo:
+    "border-indigo-100 bg-indigo-50/65 text-indigo-700 dark:border-indigo-500/20 dark:bg-indigo-500/10 dark:text-indigo-200",
+  violet:
+    "border-violet-100 bg-violet-50/65 text-violet-700 dark:border-violet-500/20 dark:bg-violet-500/10 dark:text-violet-200",
+};
+
+const permissionCountToneClasses: Record<PermissionSummaryTone, string> = {
+  cyan: "bg-cyan-100 text-cyan-700 dark:bg-cyan-500/20 dark:text-cyan-200",
+  indigo: "bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-200",
+  violet: "bg-violet-100 text-violet-700 dark:bg-violet-500/20 dark:text-violet-200",
+};
+
 function ApiKeyBadge({ value }: { value: string }) {
   return (
     <OverflowTooltip as="div" content={value} className="block min-w-0 max-w-full">
@@ -38,6 +55,35 @@ function ApiKeyBadge({ value }: { value: string }) {
         <span className="block min-w-0 truncate">{value}</span>
       </code>
     </OverflowTooltip>
+  );
+}
+
+function ApiKeyPermissionSummary({
+  count,
+  firstValue,
+  tone,
+  tooltipContent,
+}: {
+  count: number;
+  firstValue: string;
+  tone: PermissionSummaryTone;
+  tooltipContent: ReactNode;
+}) {
+  return (
+    <HoverTooltip content={tooltipContent} className="!flex min-w-0 max-w-full">
+      <span
+        className={`flex min-w-0 max-w-full items-center gap-1 rounded-full border px-1 py-0.5 text-xs ${permissionSummaryToneClasses[tone]}`}
+      >
+        <span
+          className={`inline-flex h-5 min-w-[20px] shrink-0 items-center justify-center rounded-full px-1.5 font-semibold tabular-nums ${permissionCountToneClasses[tone]}`}
+        >
+          {count}
+        </span>
+        <span className="block min-w-0 flex-1 truncate font-mono text-[11px] leading-5">
+          {firstValue}
+        </span>
+      </span>
+    </HoverTooltip>
   );
 }
 
@@ -210,8 +256,11 @@ export const createApiKeyColumns = ({
     cellClassName: "min-w-0 overflow-hidden text-slate-700 dark:text-white/70",
     render: (row) =>
       row["allowed-models"]?.length ? (
-        <HoverTooltip
-          content={
+        <ApiKeyPermissionSummary
+          count={row["allowed-models"].length}
+          firstValue={row["allowed-models"][0]}
+          tone="indigo"
+          tooltipContent={
             <div className="flex max-w-xs flex-wrap gap-1.5">
               {row["allowed-models"].map((model) => (
                 <span
@@ -224,17 +273,7 @@ export const createApiKeyColumns = ({
               ))}
             </div>
           }
-          className="block min-w-0"
-        >
-          <span className="inline-flex min-w-0 w-full items-center gap-1.5 text-xs">
-            <span className="inline-flex h-5 min-w-[20px] flex-shrink-0 items-center justify-center rounded-md bg-indigo-50 px-1.5 font-semibold tabular-nums text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300">
-              {row["allowed-models"].length}
-            </span>
-            <span className="block min-w-0 flex-1 truncate text-slate-500 dark:text-white/50">
-              {row["allowed-models"][0]}
-            </span>
-          </span>
-        </HoverTooltip>
+        />
       ) : (
         <span className="inline-flex items-center gap-1 whitespace-nowrap text-green-600 dark:text-green-400">
           <ShieldCheck size={14} /> {t("api_keys_page.all_models")}
@@ -248,8 +287,11 @@ export const createApiKeyColumns = ({
     cellClassName: "min-w-0 overflow-hidden text-slate-700 dark:text-white/70",
     render: (row) =>
       row["allowed-channel-groups"]?.length ? (
-        <HoverTooltip
-          content={
+        <ApiKeyPermissionSummary
+          count={row["allowed-channel-groups"].length}
+          firstValue={row["allowed-channel-groups"][0]}
+          tone="violet"
+          tooltipContent={
             <div className="flex max-w-xs flex-wrap gap-1.5">
               {row["allowed-channel-groups"].map((group) => (
                 <span
@@ -261,17 +303,7 @@ export const createApiKeyColumns = ({
               ))}
             </div>
           }
-          className="block min-w-0"
-        >
-          <span className="inline-flex min-w-0 w-full items-center gap-1.5 text-xs">
-            <span className="inline-flex h-5 min-w-[20px] flex-shrink-0 items-center justify-center rounded-md bg-violet-50 px-1.5 font-semibold tabular-nums text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
-              {row["allowed-channel-groups"].length}
-            </span>
-            <span className="block min-w-0 flex-1 truncate text-slate-500 dark:text-white/50">
-              {row["allowed-channel-groups"][0]}
-            </span>
-          </span>
-        </HoverTooltip>
+        />
       ) : (
         <span className="inline-flex items-center gap-1 whitespace-nowrap text-green-600 dark:text-green-400">
           <ShieldCheck size={14} /> {t("api_keys_page.all_channel_groups")}
@@ -285,8 +317,11 @@ export const createApiKeyColumns = ({
     cellClassName: "min-w-0 overflow-hidden text-slate-700 dark:text-white/70",
     render: (row) =>
       row["allowed-channels"]?.length ? (
-        <HoverTooltip
-          content={
+        <ApiKeyPermissionSummary
+          count={row["allowed-channels"].length}
+          firstValue={row["allowed-channels"][0]}
+          tone="cyan"
+          tooltipContent={
             <div className="flex max-w-xs flex-wrap gap-1.5">
               {row["allowed-channels"].map((channel) => (
                 <span
@@ -298,17 +333,7 @@ export const createApiKeyColumns = ({
               ))}
             </div>
           }
-          className="block min-w-0"
-        >
-          <span className="inline-flex min-w-0 w-full items-center gap-1.5 text-xs">
-            <span className="inline-flex h-5 min-w-[20px] flex-shrink-0 items-center justify-center rounded-md bg-cyan-50 px-1.5 font-semibold tabular-nums text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300">
-              {row["allowed-channels"].length}
-            </span>
-            <span className="block min-w-0 flex-1 truncate text-slate-500 dark:text-white/50">
-              {row["allowed-channels"][0]}
-            </span>
-          </span>
-        </HoverTooltip>
+        />
       ) : (
         <span className="inline-flex items-center gap-1 whitespace-nowrap text-green-600 dark:text-green-400">
           <ShieldCheck size={14} /> {t("api_keys_page.all_channels")}

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -135,6 +135,46 @@ describe("ApiKeyColumns", () => {
     expect(tooltipTrigger).toHaveClass("block", "max-w-full");
   });
 
+  test("truncates limited model summaries inside an intact rounded pill", () => {
+    const row: ApiKeyEntry = {
+      key: "sk-test",
+      name: "Test key",
+      "allowed-models": [
+        "deepseek-v4-flash-ultra-long-model-name",
+        "deepseek-v4-pro",
+        "kimi-k2.5",
+        "kimi-k2.6",
+      ],
+      "created-at": "2026-04-28T00:00:00Z",
+    };
+    const columns = createApiKeyColumns({
+      t,
+      onCopy: vi.fn(),
+      onDelete: vi.fn(),
+      onEdit: vi.fn(),
+      onImportToCcSwitch: vi.fn(),
+      onToggleDisable: vi.fn(),
+      onViewUsage: vi.fn(),
+    });
+    const modelColumn = columns.find((column) => column.key === "allowedModels");
+
+    render(<div>{modelColumn?.render(row, 0)}</div>);
+
+    const modelText = screen.getByText("deepseek-v4-flash-ultra-long-model-name");
+    const pill = modelText.parentElement;
+    const tooltipTrigger = pill?.parentElement;
+
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(pill).not.toBeNull();
+    expect(tooltipTrigger).not.toBeNull();
+    if (!pill || !tooltipTrigger) return;
+
+    expect(modelText).toHaveClass("min-w-0", "truncate");
+    expect(pill).toHaveClass("flex", "min-w-0", "max-w-full", "rounded-full", "border");
+    expect(tooltipTrigger).toHaveAttribute("data-tooltip-managed", "true");
+    expect(tooltipTrigger).toHaveClass("!flex", "min-w-0", "max-w-full");
+  });
+
   test("shows API key spending limits as a dedicated cost column", async () => {
     const row: ApiKeyEntry = {
       key: "sk-test",

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -153,7 +153,7 @@ describe("RequestLogsPage", () => {
     mocks.clearUsageLogs.mockReset();
   });
 
-  test("renders first token latency in the visible response metrics column", async () => {
+  test("renders first token latency value in the response metrics column", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();
 
@@ -206,11 +206,13 @@ describe("RequestLogsPage", () => {
     );
 
     const table = await screen.findByRole("table", { name: "Request Logs Table" });
-    expect(within(table).getByRole("columnheader", { name: "Response Metrics" })).toBeInTheDocument();
+    expect(
+      within(table).getByRole("columnheader", { name: "Response Metrics" }),
+    ).toBeInTheDocument();
     expect(within(table).getByText("Streaming")).toBeInTheDocument();
     expect(within(table).getByText("1.20s")).toBeInTheDocument();
-    expect(within(table).getByText("First Token Latency")).toBeInTheDocument();
     expect(within(table).getByText("183ms")).toBeInTheDocument();
+    expect(within(table).queryByText("First Token Latency")).not.toBeInTheDocument();
 
     await user.hover(within(table).getByLabelText("Duration: 1.20s"));
     expect(await screen.findByRole("tooltip")).toHaveTextContent("First Token Latency: 183ms");


### PR DESCRIPTION
## Summary
- show request log metric chip values without visible text labels while preserving accessible labels/tooltips
- keep streaming/non-streaming chips bordered and avoid clipping in narrow metric columns
- safely truncate API key permission summaries inside rounded pills and keep count badges visible

## Validation
- rtk bunx oxfmt --check e2e/request-logs-column-reorder.spec.ts e2e/api-keys-table.spec.ts features/request-log-viewer/requestLogsShared.tsx pages/api-keys/components/ApiKeyColumns.tsx pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel test pages/request-logs/__tests__/RequestLogsPage.test.tsx pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- rtk bun run lint
- rtk bun run e2e e2e/api-keys-table.spec.ts e2e/request-logs-column-reorder.spec.ts --workers=1
- rtk bun run build
- git diff --check