### PR TITLE
fix: align api key summary count badge

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -156,9 +156,13 @@ test("API Keys: limited model summary truncates inside the rounded pill", async 
       cellRight: cellRect.right,
       tooltipRight: tooltipRect.right,
       pillLeft: pillRect.left,
+      pillTop: pillRect.top,
       pillRight: pillRect.right,
+      pillBottom: pillRect.bottom,
       countLeft: countRect.left,
+      countTop: countRect.top,
       countRight: countRect.right,
+      countBottom: countRect.bottom,
       textLeft: textRect.left,
       textRight: textRect.right,
       textClientWidth: text.clientWidth,
@@ -174,6 +178,20 @@ test("API Keys: limited model summary truncates inside the rounded pill", async 
   expect(summaryState.pillRight).toBeLessThanOrEqual(summaryState.cellRight + 1);
   expect(summaryState.countLeft).toBeGreaterThanOrEqual(summaryState.pillLeft - 1);
   expect(summaryState.countRight).toBeLessThanOrEqual(summaryState.pillRight + 1);
+  expect(
+    Math.abs(
+      summaryState.countLeft -
+        summaryState.pillLeft -
+        (summaryState.countTop - summaryState.pillTop),
+    ),
+  ).toBeLessThanOrEqual(1.5);
+  expect(
+    Math.abs(
+      summaryState.countLeft -
+        summaryState.pillLeft -
+        (summaryState.pillBottom - summaryState.countBottom),
+    ),
+  ).toBeLessThanOrEqual(1.5);
   expect(summaryState.textLeft).toBeGreaterThanOrEqual(summaryState.pillLeft - 1);
   expect(summaryState.textRight).toBeLessThanOrEqual(summaryState.pillRight + 1);
   expect(summaryState.textScrollWidth).toBeGreaterThan(summaryState.textClientWidth);

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -72,7 +72,7 @@ function ApiKeyPermissionSummary({
   return (
     <HoverTooltip content={tooltipContent} className="!flex min-w-0 max-w-full">
       <span
-        className={`flex min-w-0 max-w-full items-center gap-1 rounded-full border px-1 py-0.5 text-xs ${permissionSummaryToneClasses[tone]}`}
+        className={`flex min-w-0 max-w-full items-center gap-1 rounded-full border py-0.5 pl-0.5 pr-1.5 text-xs ${permissionSummaryToneClasses[tone]}`}
       >
         <span
           className={`inline-flex h-5 min-w-[20px] shrink-0 items-center justify-center rounded-full px-1.5 font-semibold tabular-nums ${permissionCountToneClasses[tone]}`}


### PR DESCRIPTION
## Summary
- reduce the left padding of API key permission summary pills so the count badge aligns with the vertical spacing
- keep right-side padding for truncated summary text and intact rounded borders
- add an e2e layout assertion for the badge left/top/bottom spacing

## Validation
- rtk bunx oxfmt --check pages/api-keys/components/ApiKeyColumns.tsx e2e/api-keys-table.spec.ts
- rtk bun run --filter @code-proxy/admin-panel test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- rtk bun run e2e e2e/api-keys-table.spec.ts --workers=1
- git diff --check