### PR TITLE
fix: keep restored column resize preview within bounds

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -1,9 +1,22 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const setAuthed = async (page: Page) => {
-  await page.addInitScript(() => {
+const API_KEYS_COLUMN_WIDTH_STORAGE_KEY = "codeProxy.dataTable.columnWidths.v1.api-keys";
+
+type SetAuthedOptions = {
+  columnWidths?: Record<string, number>;
+};
+
+const setAuthed = async (page: Page, options: SetAuthedOptions = {}) => {
+  await page.addInitScript((authOptions: SetAuthedOptions) => {
     localStorage.removeItem("codeProxy.dataTable.columnOrder.v1.api-keys");
-    localStorage.removeItem("codeProxy.dataTable.columnWidths.v1.api-keys");
+    if (authOptions.columnWidths) {
+      localStorage.setItem(
+        "codeProxy.dataTable.columnWidths.v1.api-keys",
+        JSON.stringify(authOptions.columnWidths),
+      );
+    } else {
+      localStorage.removeItem("codeProxy.dataTable.columnWidths.v1.api-keys");
+    }
     localStorage.setItem(
       "code-proxy-admin-auth",
       JSON.stringify({
@@ -13,7 +26,7 @@ const setAuthed = async (page: Page) => {
         expiresAt: Date.now() + 24 * 60 * 60 * 1000,
       }),
     );
-  });
+  }, options);
 };
 
 const mockApiKeysApis = async (page: Page) => {
@@ -197,4 +210,71 @@ test("API Keys: limited model summary truncates inside the rounded pill", async 
   expect(summaryState.textScrollWidth).toBeGreaterThan(summaryState.textClientWidth);
   expect(summaryState.borderRightWidth).toBe("1px");
   expect(Number.parseFloat(summaryState.borderTopRightRadius)).toBeGreaterThan(0);
+});
+
+test("API Keys: restored wider columns keep resize preview at the minimum boundary", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1360, height: 980 });
+  await setAuthed(page, { columnWidths: { createdAt: 360 } });
+  await mockApiKeysApis(page);
+
+  await page.goto("/#/api-keys");
+  const header = page.locator('th[data-vt-column-key="createdAt"]');
+  await header.waitFor({ state: "visible" });
+  await header.scrollIntoViewIfNeeded();
+  await expect
+    .poll(async () =>
+      Math.round(await header.evaluate((element) => element.getBoundingClientRect().width)),
+    )
+    .toBeGreaterThanOrEqual(359);
+
+  const dragStart = await header.locator("[data-vt-column-resizer]").evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const headerRect = element.closest("th")?.getBoundingClientRect();
+    return {
+      x: headerRect ? Math.min(rect.left + rect.width / 2, headerRect.right - 2) : rect.left,
+      y: rect.top + rect.height / 2,
+    };
+  });
+
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.mouse.move(dragStart.x - 640, dragStart.y, { steps: 10 });
+  await page.locator("[data-vt-column-resize-preview-line]").waitFor({ state: "visible" });
+
+  const state = await page.evaluate(() => {
+    const headerElement = document.querySelector<HTMLElement>('th[data-vt-column-key="createdAt"]');
+    const previewLine = document.querySelector<HTMLElement>("[data-vt-column-resize-preview-line]");
+    if (!headerElement || !previewLine) throw new Error("Missing resize state");
+
+    const headerRect = headerElement.getBoundingClientRect();
+    const previewRect = previewLine.getBoundingClientRect();
+    const previewCenter = previewRect.left + previewRect.width / 2;
+    return {
+      headerLeft: headerRect.left,
+      headerRight: headerRect.right,
+      headerWidth: headerRect.width,
+      previewCenter,
+      minBoundary: headerRect.left + 168,
+    };
+  });
+  expect(state.previewCenter).toBeGreaterThanOrEqual(state.minBoundary - 1);
+  expect(state.previewCenter).toBeLessThanOrEqual(state.minBoundary + 1);
+
+  await page.mouse.up();
+
+  await expect
+    .poll(async () =>
+      page.evaluate((storageKey) => {
+        const storedWidths = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
+          string,
+          unknown
+        >;
+        return typeof storedWidths.createdAt === "number"
+          ? Math.round(storedWidths.createdAt)
+          : null;
+      }, API_KEYS_COLUMN_WIDTH_STORAGE_KEY),
+    )
+    .toBe(168);
 });

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -280,10 +280,15 @@ function resolveWidthClassPx(width: string | undefined, prefix: string) {
 }
 
 function resolveColumnMinWidth<T>(column: DataTableColumn<T>) {
-  return column.minWidthPx ?? resolveWidthClassPx(column.width, "min-w") ?? DEFAULT_MIN_COLUMN_WIDTH;
+  return (
+    column.minWidthPx ?? resolveWidthClassPx(column.width, "min-w") ?? DEFAULT_MIN_COLUMN_WIDTH
+  );
 }
 
-function resolveColumnMaxWidth<T>(column: DataTableColumn<T>, minWidth = resolveColumnMinWidth(column)) {
+function resolveColumnMaxWidth<T>(
+  column: DataTableColumn<T>,
+  minWidth = resolveColumnMinWidth(column),
+) {
   return Math.max(minWidth, column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH);
 }
 
@@ -351,6 +356,14 @@ function logColumnResizeDebug(event: string, payload: Record<string, unknown>) {
   if (!shouldDebugColumnResize()) return;
   // eslint-disable-next-line no-console
   console.debug("[DataTable resize]", event, payload);
+}
+
+function resolveColumnResizeWidth(active: ColumnResizeState, pointerClientX: number) {
+  const rawBoundaryClientX = pointerClientX + active.pointerBoundaryOffsetClientX;
+  return Math.max(
+    active.minWidth,
+    Math.min(active.maxWidth, Math.round(rawBoundaryClientX - active.startLeftClientX)),
+  );
 }
 
 function shouldAllowColumnResize<T>(
@@ -1078,14 +1091,15 @@ export function DataTable<T>({
       pointerClientX: number,
       pointerClientY: number,
     ): ColumnResizePreview | null => {
-      const minBoundaryClientX = active.startLeftClientX + active.minWidth;
-      const maxBoundaryClientX = active.startLeftClientX + active.maxWidth;
-      const rawBoundaryClientX = pointerClientX + active.pointerBoundaryOffsetClientX;
+      const width = resolveColumnResizeWidth(active, pointerClientX);
+      const headerRect = headerCellsRef.current[active.columnKey]?.getBoundingClientRect();
+      const visualLeftClientX = headerRect?.left ?? active.startLeftClientX;
+      const minBoundaryClientX = visualLeftClientX + active.minWidth;
+      const maxBoundaryClientX = visualLeftClientX + active.maxWidth;
       const lineCenterClientX = Math.max(
         minBoundaryClientX,
-        Math.min(maxBoundaryClientX, rawBoundaryClientX),
+        Math.min(maxBoundaryClientX, visualLeftClientX + width),
       );
-      const width = Math.round(lineCenterClientX - active.startLeftClientX);
       const top = active.previewTop;
       const bottomInset = hasHorizontalOverflow(scrollMetricsRef.current) ? 14 : 0;
       const bottom = Math.max(top, active.previewBottom - bottomInset);
@@ -1142,20 +1156,14 @@ export function DataTable<T>({
 
     pendingColumnResizePointerRef.current = null;
 
-    const minBoundaryClientX = active.startLeftClientX + active.minWidth;
-    const maxBoundaryClientX = active.startLeftClientX + active.maxWidth;
-    const lineCenterClientX = Math.max(
-      minBoundaryClientX,
-      Math.min(maxBoundaryClientX, pointer.clientX + active.pointerBoundaryOffsetClientX),
-    );
-    const roundedWidth = Math.round(lineCenterClientX - active.startLeftClientX);
+    const roundedWidth = resolveColumnResizeWidth(active, pointer.clientX);
 
     active.currentWidth = roundedWidth;
     applyColumnWidthToDom(active.columnKey, roundedWidth);
     const preview = {
       ...(buildColumnResizePreview(active, pointer.clientX, pointer.clientY) ?? {
         width: roundedWidth,
-        left: lineCenterClientX - COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2,
+        left: active.startLeftClientX + roundedWidth - COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2,
         top: active.previewTop,
         height: Math.max(0, active.previewBottom - active.previewTop),
         tooltipTop: active.previewTop,
@@ -1245,6 +1253,8 @@ export function DataTable<T>({
       const minWidth = resolveColumnMinWidth(column);
       const maxWidth = resolveColumnMaxWidth(column, minWidth);
       const nextStartWidth = Math.max(minWidth, Math.min(maxWidth, startWidth));
+      const startLeftClientX = rect.right - nextStartWidth;
+      const startBoundaryClientX = startLeftClientX + nextStartWidth;
 
       e.preventDefault();
       e.stopPropagation();
@@ -1253,8 +1263,8 @@ export function DataTable<T>({
       const resizeState = {
         pointerId: e.pointerId,
         columnKey: column.key,
-        startLeftClientX: rect.left,
-        pointerBoundaryOffsetClientX: rect.right - e.clientX,
+        startLeftClientX,
+        pointerBoundaryOffsetClientX: startBoundaryClientX - e.clientX,
         minWidth,
         maxWidth,
         previewTop: Math.max(0, containerRect?.top ?? rect.top),
@@ -1277,7 +1287,7 @@ export function DataTable<T>({
           tableId,
           columnKey: column.key,
           pointerX: Math.round(e.clientX),
-          headerLeft: Math.round(rect.left),
+          headerLeft: Math.round(startLeftClientX),
           headerRight: Math.round(rect.right),
           headerWidth: Math.round(rect.width),
           previewCenterX: preview
@@ -1940,6 +1950,7 @@ export function DataTable<T>({
           <>
             <div
               ref={resizePreviewLineRef}
+              data-vt-column-resize-preview-line
               aria-hidden="true"
               className="pointer-events-none fixed z-[1000] w-0.5 bg-slate-500/70"
               style={{
@@ -1950,6 +1961,7 @@ export function DataTable<T>({
             />
             <div
               ref={resizePreviewTooltipRef}
+              data-vt-column-resize-preview-tooltip
               role="status"
               className="pointer-events-none fixed z-[1001] rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white shadow-lg dark:bg-white dark:text-neutral-950"
               style={{
@@ -2089,7 +2101,9 @@ export function DataTable<T>({
                             ? "group-hover/column:pl-5 group-hover/column:transition-[padding] group-focus-within/column:pl-5 data-[vt-reorder-active=true]:pl-5"
                             : ""
                         }`}
-                        data-vt-reorder-active={activeReorderColumnKey === col.key ? "true" : undefined}
+                        data-vt-reorder-active={
+                          activeReorderColumnKey === col.key ? "true" : undefined
+                        }
                       >
                         {col.headerRender ? col.headerRender() : col.label}
                       </div>
@@ -2224,7 +2238,9 @@ export function DataTable<T>({
                             <td
                               key={col.key}
                               data-vt-column-key={col.key}
-                              data-vt-column-settled-cell={isSettledReorderColumn ? true : undefined}
+                              data-vt-column-settled-cell={
+                                isSettledReorderColumn ? true : undefined
+                              }
                               style={resolveColumnStyle(col)}
                               className={`overflow-hidden px-4 py-2.5 align-middle ${
                                 naturalFlow


### PR DESCRIPTION
## Summary
- keep DataTable resize preview and persisted width clamped to the same normalized bounds
- align resize preview against the current visible header boundary after restored widths alter table layout
- add an API Keys regression case for dragging a restored wide column back to its minimum width

## Verification
- rtk bun run e2e e2e/api-keys-table.spec.ts --workers=1
- rtk bun run e2e e2e/request-logs-column-reorder.spec.ts --workers=1
- rtk bun run build
- rtk bun run lint
- rtk git diff --check
- rtk bunx oxfmt --check packages/ui/src/data-table/DataTable.tsx e2e/api-keys-table.spec.ts