### PR TITLE
feat: refine account security identity details

### DIFF
--- a/e2e/account-security-identity-fingerprint.spec.ts
+++ b/e2e/account-security-identity-fingerprint.spec.ts
@@ -405,22 +405,30 @@ test("Account & Security shows auth files and account identity fingerprint detai
   await dialog.getByRole("tab", { name: /Identity|身份/i }).click();
 
   const identityPanel = dialog.getByTestId("auth-file-identity-fingerprint");
-  await expect(identityPanel).toContainText("authsub_codex_terminal");
-  await expect(identityPanel).toContainText("codex_cli_rs / Codex Desktop");
-  await expect(identityPanel).toContainText(codexTerminalUserAgent);
-  await expect(identityPanel).toContainText(codexBetaFeatures);
-  await expect(identityPanel).toContainText(/Section|分组/i);
-  await expect(identityPanel).toContainText(/Field|字段/i);
-  await expect(identityPanel).toContainText(/Value|值/i);
-  await expect(identityPanel).toContainText(/Source|来源/i);
-  await expect(identityPanel).toContainText(/Effective Fields|生效字段/i);
-  await expect(identityPanel).toContainText(/Learned Fields|自学习字段/i);
-  await expect(identityPanel).toContainText(/Observed Headers|观测请求头/i);
+  const identitySummary = identityPanel.getByTestId("auth-file-identity-summary");
+  const identityFields = identityPanel.getByTestId("auth-file-identity-fields");
+  await expect(identitySummary).toContainText("authsub_codex_terminal");
+  await expect(identitySummary).toContainText("codex_cli_rs / Codex Desktop");
+  await expect(identityFields).toContainText(codexTerminalUserAgent);
+  await expect(identityFields).toContainText(codexBetaFeatures);
+  await expect(identityFields).toContainText(/Section|分组/i);
+  await expect(identityFields).toContainText(/Field|字段/i);
+  await expect(identityFields).toContainText(/Value|值/i);
+  await expect(identityFields).toContainText(/Source|来源/i);
+  await expect(identityFields).toContainText(/Effective Fields|生效字段/i);
+  await expect(identityFields).toContainText(/Learned Fields|自学习字段/i);
+  await expect(identityFields).toContainText(/Observed Headers|观测请求头/i);
   await expect(identityPanel.getByText(/Learned|自学习/i).first()).toBeVisible();
   await expect(identityPanel.getByText(/System default|系统默认/i).first()).toBeVisible();
-  await expect(identityPanel.getByText("websocket-beta")).toBeVisible();
+  await expect(identityFields.getByText("websocket-beta")).toBeVisible();
   await expect(identityPanel).not.toContainText("Session_id");
   await expect(identityPanel).not.toContainText("Conversation_id");
+  const summaryBox = await identitySummary.boundingBox();
+  const fieldsBox = await identityFields.boundingBox();
+  if (!summaryBox || !fieldsBox) {
+    throw new Error("identity fingerprint summary and fields columns must be visible");
+  }
+  expect(fieldsBox.x).toBeGreaterThan(summaryBox.x + summaryBox.width - 8);
 
   await dialog.getByRole("button", { name: /^(Close|关闭)$/ }).click();
 

--- a/e2e/account-security-identity-fingerprint.spec.ts
+++ b/e2e/account-security-identity-fingerprint.spec.ts
@@ -464,3 +464,38 @@ test("Account & Security keeps card mode usable and redirects old identity route
     page.locator('[class*="group/card"]', { hasText: "Claude OAuth Primary" }),
   ).toBeVisible();
 });
+
+test("Account & Security identity detail stacks cleanly on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await setAuthed(page, "cards");
+  await routeManagementMocks(page);
+
+  await page.goto("/#/account-security");
+
+  const codexCard = page.locator('[class*="group/card"]', { hasText: "Codex Terminal OAuth" });
+  await expect(codexCard).toBeVisible();
+  await codexCard.getByRole("button", { name: /Details|详情/i }).click();
+
+  const dialog = page.getByRole("dialog", { name: /Codex Terminal OAuth|查看/i });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("tab", { name: /Identity|身份/i }).click();
+
+  const identityPanel = dialog.getByTestId("auth-file-identity-fingerprint");
+  const identitySummary = identityPanel.getByTestId("auth-file-identity-summary");
+  const identityFields = identityPanel.getByTestId("auth-file-identity-fields");
+  await expect(identitySummary).toContainText("authsub_codex_terminal");
+  await expect(identityFields.getByText("websocket-beta")).toBeVisible();
+
+  const summaryBox = await identitySummary.boundingBox();
+  const fieldsBox = await identityFields.boundingBox();
+  if (!summaryBox || !fieldsBox) {
+    throw new Error("identity fingerprint summary and fields columns must be visible on mobile");
+  }
+  expect(fieldsBox.y).toBeGreaterThan(summaryBox.y + summaryBox.height - 8);
+  expect(Math.abs(fieldsBox.x - summaryBox.x)).toBeLessThanOrEqual(8);
+
+  const documentOverflowX = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(documentOverflowX).toBeLessThanOrEqual(2);
+});

--- a/e2e/identity-fingerprint-modal.spec.ts
+++ b/e2e/identity-fingerprint-modal.spec.ts
@@ -308,18 +308,26 @@ test("learned Codex runtime state is visible from account details", async ({ pag
   await dialog.getByRole("tab", { name: /Identity|身份/i }).click();
 
   const panel = page.getByTestId("auth-file-identity-fingerprint");
-  await expect(panel).toContainText("codex-e2e-account");
-  await expect(panel).toContainText("codex_cli_rs / Codex Desktop");
-  await expect(panel).toContainText(codexTerminalUserAgent);
-  await expect(panel).toContainText(codexBetaFeatures);
-  await expect(panel).toContainText(/Section|分组/i);
-  await expect(panel).toContainText(/Field|字段/i);
-  await expect(panel).toContainText(/Value|值/i);
-  await expect(panel).toContainText(/Source|来源/i);
-  await expect(panel).toContainText(/Learned Fields|自学习字段/i);
-  await expect(panel).toContainText(/Observed Headers|观测请求头/i);
+  const summary = panel.getByTestId("auth-file-identity-summary");
+  const fields = panel.getByTestId("auth-file-identity-fields");
+  await expect(summary).toContainText("codex-e2e-account");
+  await expect(summary).toContainText("codex_cli_rs / Codex Desktop");
+  await expect(fields).toContainText(codexTerminalUserAgent);
+  await expect(fields).toContainText(codexBetaFeatures);
+  await expect(fields).toContainText(/Section|分组/i);
+  await expect(fields).toContainText(/Field|字段/i);
+  await expect(fields).toContainText(/Value|值/i);
+  await expect(fields).toContainText(/Source|来源/i);
+  await expect(fields).toContainText(/Learned Fields|自学习字段/i);
+  await expect(fields).toContainText(/Observed Headers|观测请求头/i);
   await expect(panel).not.toContainText("Session_id");
   await expect(panel).not.toContainText("Conversation_id");
+  const summaryBox = await summary.boundingBox();
+  const fieldsBox = await fields.boundingBox();
+  if (!summaryBox || !fieldsBox) {
+    throw new Error("identity fingerprint summary and fields columns must be visible");
+  }
+  expect(fieldsBox.x).toBeGreaterThan(summaryBox.x + summaryBox.width - 8);
 });
 
 test("Gemini account uses builtin defaults without legacy manual save flow", async ({ page }) => {

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -371,6 +371,8 @@ describe("AuthFileDetailModal", () => {
     });
 
     const panel = screen.getByTestId("auth-file-identity-fingerprint");
+    const summary = within(panel).getByTestId("auth-file-identity-summary");
+    const fields = within(panel).getByTestId("auth-file-identity-fields");
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
       "Usage",
       "Identity",
@@ -378,25 +380,26 @@ describe("AuthFileDetailModal", () => {
       "Models",
     ]);
     expect(screen.getByRole("tab", { name: "Identity" })).toBeInTheDocument();
-    expect(panel).toHaveTextContent("codex-account-1");
-    expect(within(panel).getByText("auth-subject-1")).toBeInTheDocument();
-    expect(within(panel).getByText("codex-tui / terminal")).toBeInTheDocument();
+    expect(summary).toHaveTextContent("codex-account-1");
+    expect(within(summary).getByText("auth-subject-1")).toBeInTheDocument();
+    expect(within(summary).getByText("codex-tui / terminal")).toBeInTheDocument();
+    expect(within(summary).getByText("0.125.0")).toBeInTheDocument();
     expect(within(panel).getAllByText("Learned").length).toBeGreaterThanOrEqual(2);
     expect(within(panel).getAllByText("Account preset").length).toBeGreaterThanOrEqual(1);
     expect(within(panel).getAllByText("System default").length).toBeGreaterThanOrEqual(1);
-    expect(within(panel).getByText("Section")).toBeInTheDocument();
-    expect(within(panel).getByText("Field")).toBeInTheDocument();
-    expect(within(panel).getByText("Value")).toBeInTheDocument();
-    expect(within(panel).getByText("Source")).toBeInTheDocument();
-    expect(within(panel).getAllByText("Effective Fields").length).toBeGreaterThanOrEqual(1);
-    expect(within(panel).getAllByText("Learned Fields").length).toBeGreaterThanOrEqual(1);
-    expect(within(panel).getAllByText("Observed Headers").length).toBeGreaterThanOrEqual(1);
-    expect(within(panel).getAllByText("user-agent").length).toBeGreaterThanOrEqual(2);
-    expect(within(panel).getAllByText("codex-cli/0.125.0").length).toBeGreaterThanOrEqual(2);
-    expect(within(panel).getByText("session-mode")).toBeInTheDocument();
-    expect(within(panel).getByText("server-stable")).toBeInTheDocument();
-    expect(within(panel).getByText("websocket-beta")).toBeInTheDocument();
-    expect(within(panel).getByText("realtime=v1")).toBeInTheDocument();
+    expect(within(fields).getByText("Section")).toBeInTheDocument();
+    expect(within(fields).getByText("Field")).toBeInTheDocument();
+    expect(within(fields).getByText("Value")).toBeInTheDocument();
+    expect(within(fields).getByText("Source")).toBeInTheDocument();
+    expect(within(fields).getAllByText("Effective Fields").length).toBeGreaterThanOrEqual(1);
+    expect(within(fields).getAllByText("Learned Fields").length).toBeGreaterThanOrEqual(1);
+    expect(within(fields).getAllByText("Observed Headers").length).toBeGreaterThanOrEqual(1);
+    expect(within(fields).getAllByText("user-agent").length).toBeGreaterThanOrEqual(2);
+    expect(within(fields).getAllByText("codex-cli/0.125.0").length).toBeGreaterThanOrEqual(2);
+    expect(within(fields).getByText("session-mode")).toBeInTheDocument();
+    expect(within(fields).getByText("server-stable")).toBeInTheDocument();
+    expect(within(fields).getByText("websocket-beta")).toBeInTheDocument();
+    expect(within(fields).getByText("realtime=v1")).toBeInTheDocument();
     expect(within(panel).queryByText("Custom")).not.toBeInTheDocument();
   });
 

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -721,101 +721,108 @@ export function AuthFileDetailModal({
 
     return (
       <div className="space-y-4" data-testid="auth-file-identity-fingerprint">
-        <div className="rounded-lg bg-slate-50/80 px-4 py-4 dark:bg-white/[0.04]">
-          <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="min-w-0 break-words text-sm font-semibold text-slate-950 dark:text-white">
-                {clientLabel}
-              </p>
-              <p className="mt-1 min-w-0 break-words text-xs text-slate-500 dark:text-white/55">
-                {formatOptionalText(summary.provider)} · {formatOptionalText(summary.account_key)}
-              </p>
-            </div>
-            <div className="shrink-0">{renderIdentitySourceBadge(summary.primary_source)}</div>
-          </div>
-
-          <dl className="mt-4 grid gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-4">
-            {renderIdentitySummaryItem(
-              t("auth_files.identity_fingerprint_auth_subject"),
-              formatOptionalText(summary.auth_subject_id),
-            )}
-            {renderIdentitySummaryItem(
-              t("auth_files.identity_fingerprint_version"),
-              formatOptionalText(summary.version),
-            )}
-            {renderIdentitySummaryItem(
-              t("auth_files.identity_fingerprint_updated_at"),
-              formatOptionalDate(summary.updated_at),
-            )}
-            {renderIdentitySummaryItem(
-              t("auth_files.identity_fingerprint_last_seen_at"),
-              formatOptionalDate(summary.last_seen_at),
-            )}
-          </dl>
-
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:text-white/65 dark:ring-white/10">
-              {t("auth_files.identity_fingerprint_effective_count")}: {summary.effective_fields}
-            </span>
-            <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:text-white/65 dark:ring-white/10">
-              {t("auth_files.identity_fingerprint_learned_count")}: {summary.learned_fields}
-            </span>
-            {IDENTITY_FINGERPRINT_SOURCE_ORDER.map((source) => (
-              <span
-                key={source}
-                className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:text-white/65 dark:ring-white/10"
-              >
-                {formatIdentitySource(source)}: {summary.source_counts?.[source] ?? 0}
-              </span>
-            ))}
-          </div>
-        </div>
-
-        {identityFingerprintLoading && !identityFingerprintDetail ? (
-          <div
-            className="grid gap-2 rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]"
-            data-testid="auth-file-identity-loading"
+        <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(17rem,0.78fr)_minmax(0,1.65fr)]">
+          <aside
+            className="min-w-0 rounded-lg bg-slate-50/80 px-4 py-4 dark:bg-white/[0.04]"
+            data-testid="auth-file-identity-summary"
           >
-            <div className="h-3 w-36 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
-            <div className="h-3 w-5/6 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
-            <div className="h-3 w-2/3 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
-          </div>
-        ) : null}
-
-        {identityFingerprintError ? (
-          <EmptyState
-            title={t("auth_files.identity_fingerprint_loading_failed")}
-            description={identityFingerprintError}
-          />
-        ) : null}
-
-        {identityFingerprintDetail ? (
-          <section className="min-w-0 space-y-3">
-            <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
-              <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("auth_files.identity_fingerprint_title")}
-              </p>
-              <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
-                {t("auth_files.count_items", { count: identityFieldRows.length })}
-              </span>
+            <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="min-w-0 break-words text-sm font-semibold text-slate-950 dark:text-white">
+                  {clientLabel}
+                </p>
+                <p className="mt-1 min-w-0 break-words text-xs text-slate-500 dark:text-white/55">
+                  {formatOptionalText(summary.provider)} · {formatOptionalText(summary.account_key)}
+                </p>
+              </div>
+              <div className="shrink-0">{renderIdentitySourceBadge(summary.primary_source)}</div>
             </div>
-            <DataTable<IdentityFingerprintFieldRow>
-              rows={identityFieldRows}
-              columns={identityFieldColumns}
-              rowKey={(row) => row.id}
-              rowHeight={48}
-              minWidth="min-w-[980px]"
-              minHeight="min-h-0"
-              height="h-auto"
-              naturalFlow
-              caption={t("auth_files.identity_fingerprint_title")}
-              emptyText={t("auth_files.identity_fingerprint_no_fields")}
-              showAllLoadedMessage={false}
-              columnReorderable={false}
-              persistColumnOrder={false}
-            />
+
+            <dl className="mt-4 grid gap-x-6 gap-y-3 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+              {renderIdentitySummaryItem(
+                t("auth_files.identity_fingerprint_auth_subject"),
+                formatOptionalText(summary.auth_subject_id),
+              )}
+              {renderIdentitySummaryItem(
+                t("auth_files.identity_fingerprint_version"),
+                formatOptionalText(summary.version),
+              )}
+              {renderIdentitySummaryItem(
+                t("auth_files.identity_fingerprint_updated_at"),
+                formatOptionalDate(summary.updated_at),
+              )}
+              {renderIdentitySummaryItem(
+                t("auth_files.identity_fingerprint_last_seen_at"),
+                formatOptionalDate(summary.last_seen_at),
+              )}
+            </dl>
+
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:text-white/65 dark:ring-white/10">
+                {t("auth_files.identity_fingerprint_effective_count")}: {summary.effective_fields}
+              </span>
+              <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:text-white/65 dark:ring-white/10">
+                {t("auth_files.identity_fingerprint_learned_count")}: {summary.learned_fields}
+              </span>
+              {IDENTITY_FINGERPRINT_SOURCE_ORDER.map((source) => (
+                <span
+                  key={source}
+                  className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:text-white/65 dark:ring-white/10"
+                >
+                  {formatIdentitySource(source)}: {summary.source_counts?.[source] ?? 0}
+                </span>
+              ))}
+            </div>
+          </aside>
+
+          <section className="min-w-0 space-y-3" data-testid="auth-file-identity-fields">
+            {identityFingerprintLoading && !identityFingerprintDetail ? (
+              <div
+                className="grid gap-2 rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]"
+                data-testid="auth-file-identity-loading"
+              >
+                <div className="h-3 w-36 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
+                <div className="h-3 w-5/6 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
+                <div className="h-3 w-2/3 animate-pulse rounded bg-slate-200 dark:bg-white/10" />
+              </div>
+            ) : null}
+
+            {identityFingerprintError ? (
+              <EmptyState
+                title={t("auth_files.identity_fingerprint_loading_failed")}
+                description={identityFingerprintError}
+              />
+            ) : null}
+
+            {identityFingerprintDetail ? (
+              <>
+                <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                    {t("auth_files.identity_fingerprint_title")}
+                  </p>
+                  <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                    {t("auth_files.count_items", { count: identityFieldRows.length })}
+                  </span>
+                </div>
+                <DataTable<IdentityFingerprintFieldRow>
+                  rows={identityFieldRows}
+                  columns={identityFieldColumns}
+                  rowKey={(row) => row.id}
+                  rowHeight={48}
+                  minWidth="min-w-[920px]"
+                  minHeight="min-h-0"
+                  height="h-auto"
+                  naturalFlow
+                  caption={t("auth_files.identity_fingerprint_title")}
+                  emptyText={t("auth_files.identity_fingerprint_no_fields")}
+                  showAllLoadedMessage={false}
+                  columnReorderable={false}
+                  persistColumnOrder={false}
+                />
+              </>
+            ) : null}
           </section>
-        ) : null}
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- switch account identity details to a left summary / right DataTable layout
- keep OAuth identity fields readable inside Account & Security detail modal
- add focused unit and E2E coverage for the new layout

## Tests
- rtk bun run --filter @code-proxy/admin-panel test:ci -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
- rtk bun run e2e -- --project=chromium e2e/account-security-identity-fingerprint.spec.ts e2e/identity-fingerprint-modal.spec.ts
- rtk bun run build
- rtk bun run boundary:imports
- rtk bun run lint
- rtk bun run test:ci
