### PR TITLE
fix: improve account security mobile scrolling

### DIFF
--- a/e2e/account-security-identity-fingerprint.spec.ts
+++ b/e2e/account-security-identity-fingerprint.spec.ts
@@ -2,6 +2,18 @@ import { expect, test, type Page } from "@playwright/test";
 
 const codexTerminalUserAgent = "codex_cli_rs/0.125.0 (Mac OS 26.0.1; arm64) Apple_Terminal/464";
 const codexBetaFeatures = "terminal_resize_reflow,memories,goals";
+const codexExtraLearnedFields = Object.fromEntries(
+  Array.from({ length: 18 }, (_, index) => {
+    const number = String(index + 1).padStart(2, "0");
+    return [`x-codex-learned-${number}`, `learned-value-${number}`];
+  }),
+);
+const codexExtraEffectiveFields = Object.fromEntries(
+  Object.entries(codexExtraLearnedFields).map(([key, value]) => [
+    key,
+    { value, source: "learned" },
+  ]),
+);
 
 const identitySummaries = {
   claude: {
@@ -27,9 +39,9 @@ const identitySummaries = {
     enabled: true,
     primary_source: "learned",
     learned: true,
-    learned_fields: 4,
-    effective_fields: 5,
-    source_counts: { learned: 4, preset: 0, builtin_default: 1 },
+    learned_fields: 22,
+    effective_fields: 23,
+    source_counts: { learned: 22, preset: 0, builtin_default: 1 },
     client_product: "codex_cli_rs",
     client_variant: "Codex Desktop",
     version: "0.125.0",
@@ -176,6 +188,7 @@ const accountDetails = {
         version: { value: "0.125.0", source: "learned" },
         originator: { value: "Codex Desktop", source: "learned" },
         "x-codex-beta-features": { value: codexBetaFeatures, source: "learned" },
+        ...codexExtraEffectiveFields,
         "websocket-beta": {
           value: "responses_websockets=2026-02-06",
           source: "builtin_default",
@@ -194,6 +207,7 @@ const accountDetails = {
         version: "0.125.0",
         originator: "Codex Desktop",
         "x-codex-beta-features": codexBetaFeatures,
+        ...codexExtraLearnedFields,
       },
       observed_headers: {
         "User-Agent": codexTerminalUserAgent,
@@ -246,6 +260,46 @@ const setAuthed = async (page: Page, viewMode: "table" | "cards" = "table") => {
     localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify(mode));
     localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
   }, viewMode);
+};
+
+const swipeVerticallyFromPoint = async (page: Page, x: number, y: number, deltaY: number) => {
+  const client = await page.context().newCDPSession(page);
+  const touchPoint = (nextY: number) => ({
+    x,
+    y: nextY,
+    radiusX: 1,
+    radiusY: 1,
+    force: 1,
+  });
+
+  await client.send("Emulation.setTouchEmulationEnabled", {
+    enabled: true,
+    maxTouchPoints: 1,
+  });
+
+  try {
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [touchPoint(y)],
+    });
+
+    const steps = 8;
+    for (let step = 1; step <= steps; step += 1) {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [touchPoint(y + (deltaY * step) / steps)],
+      });
+      await page.waitForTimeout(16);
+    }
+
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await client.send("Emulation.setTouchEmulationEnabled", { enabled: false });
+    await client.detach();
+  }
 };
 
 const routeManagementMocks = async (page: Page) => {
@@ -429,6 +483,30 @@ test("Account & Security shows auth files and account identity fingerprint detai
     throw new Error("identity fingerprint summary and fields columns must be visible");
   }
   expect(fieldsBox.x).toBeGreaterThan(summaryBox.x + summaryBox.width - 8);
+  const identityDetailScroller = dialog.getByTestId("auth-file-detail-scroll");
+  await expect(identityDetailScroller).toHaveCSS("overflow-x", "hidden");
+  await expect(identityDetailScroller).toHaveCSS("overflow-y", "hidden");
+  const identityTableViewport = identityFields.locator('[data-scrollbar-visibility="hover"]');
+  await expect(identityTableViewport).toBeVisible();
+  const desktopTableScrollState = await identityTableViewport.evaluate((node: HTMLElement) => {
+    node.scrollTop = 120;
+    node.scrollLeft = 160;
+    const style = window.getComputedStyle(node);
+    return {
+      canScrollX: node.scrollWidth > node.clientWidth,
+      canScrollY: node.scrollHeight > node.clientHeight,
+      overflowX: style.overflowX,
+      overflowY: style.overflowY,
+      scrollLeft: node.scrollLeft,
+      scrollTop: node.scrollTop,
+    };
+  });
+  expect(desktopTableScrollState.overflowX).toBe("auto");
+  expect(desktopTableScrollState.overflowY).toBe("auto");
+  expect(desktopTableScrollState.canScrollX).toBe(true);
+  expect(desktopTableScrollState.canScrollY).toBe(true);
+  expect(desktopTableScrollState.scrollLeft).toBeGreaterThan(0);
+  expect(desktopTableScrollState.scrollTop).toBeGreaterThan(0);
 
   await dialog.getByRole("button", { name: /^(Close|关闭)$/ }).click();
 
@@ -465,6 +543,80 @@ test("Account & Security keeps card mode usable and redirects old identity route
   ).toBeVisible();
 });
 
+test("Account & Security mobile table scroll chains from the middle of the page", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 640 });
+  await setAuthed(page, "table");
+  await routeManagementMocks(page);
+
+  await page.goto("/#/account-security");
+
+  const filterToggle = page.getByTestId("auth-files-mobile-filter-toggle");
+  await filterToggle.click();
+  await expect(filterToggle).toHaveAttribute("aria-expanded", "true");
+
+  const tableViewport = page.locator('[data-scrollbar-visibility="hover"]').first();
+  await expect(tableViewport).toBeVisible();
+  await expect(tableViewport).toHaveCSS("overscroll-behavior-y", "auto");
+  const tableScrollMetrics = await tableViewport.evaluate((node: HTMLElement) => ({
+    clientHeight: node.clientHeight,
+    scrollHeight: node.scrollHeight,
+    scrollTop: node.scrollTop,
+  }));
+  expect(tableScrollMetrics.scrollHeight).toBeLessThanOrEqual(tableScrollMetrics.clientHeight + 2);
+  expect(tableScrollMetrics.scrollTop).toBe(0);
+  await tableViewport.evaluate((node: HTMLElement) =>
+    node.scrollIntoView({ block: "start", inline: "nearest" }),
+  );
+
+  const shellScrollState = await page.evaluate(() => {
+    const shellScroller = document.getElementById("main-content")?.parentElement;
+    if (!(shellScroller instanceof HTMLElement)) return null;
+    return {
+      clientHeight: shellScroller.clientHeight,
+      scrollHeight: shellScroller.scrollHeight,
+      scrollTop: shellScroller.scrollTop,
+      maxScrollTop: shellScroller.scrollHeight - shellScroller.clientHeight,
+    };
+  });
+  if (!shellScrollState) {
+    throw new Error("Account & Security shell scroll container must exist");
+  }
+  expect(shellScrollState.scrollHeight).toBeGreaterThan(shellScrollState.clientHeight + 20);
+  expect(shellScrollState.scrollTop).toBeGreaterThan(20);
+
+  const box = await tableViewport.boundingBox();
+  const viewportSize = page.viewportSize();
+  if (!box) {
+    throw new Error("Account & Security table viewport must be visible on mobile");
+  }
+  if (!viewportSize) {
+    throw new Error("Account & Security mobile viewport must be available");
+  }
+  const visibleLeft = Math.max(box.x, 16);
+  const visibleRight = Math.min(box.x + box.width, viewportSize.width - 16);
+  const visibleTop = Math.max(box.y, 80);
+  const visibleBottom = Math.min(box.y + box.height, viewportSize.height - 80);
+  expect(visibleRight).toBeGreaterThan(visibleLeft + 20);
+  expect(visibleBottom).toBeGreaterThan(visibleTop + 20);
+  await swipeVerticallyFromPoint(
+    page,
+    (visibleLeft + visibleRight) / 2,
+    (visibleTop + visibleBottom) / 2,
+    260,
+  );
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const shellScroller = document.getElementById("main-content")?.parentElement;
+        return shellScroller instanceof HTMLElement ? shellScroller.scrollTop : 0;
+      }),
+    )
+    .toBeLessThan(shellScrollState.scrollTop);
+});
+
 test("Account & Security identity detail stacks cleanly on mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await setAuthed(page, "cards");
@@ -493,6 +645,30 @@ test("Account & Security identity detail stacks cleanly on mobile", async ({ pag
   }
   expect(fieldsBox.y).toBeGreaterThan(summaryBox.y + summaryBox.height - 8);
   expect(Math.abs(fieldsBox.x - summaryBox.x)).toBeLessThanOrEqual(8);
+  const detailScroller = dialog.getByTestId("auth-file-detail-scroll");
+  await expect(detailScroller).toHaveCSS("overflow-x", "hidden");
+  await expect(detailScroller).toHaveCSS("overflow-y", "hidden");
+  const identityTableViewport = identityFields.locator('[data-scrollbar-visibility="hover"]');
+  await expect(identityTableViewport).toBeVisible();
+  const mobileTableScrollState = await identityTableViewport.evaluate((node: HTMLElement) => {
+    node.scrollTop = 120;
+    node.scrollLeft = 160;
+    const style = window.getComputedStyle(node);
+    return {
+      canScrollX: node.scrollWidth > node.clientWidth,
+      canScrollY: node.scrollHeight > node.clientHeight,
+      overflowX: style.overflowX,
+      overflowY: style.overflowY,
+      scrollLeft: node.scrollLeft,
+      scrollTop: node.scrollTop,
+    };
+  });
+  expect(mobileTableScrollState.overflowX).toBe("auto");
+  expect(mobileTableScrollState.overflowY).toBe("auto");
+  expect(mobileTableScrollState.canScrollX).toBe(true);
+  expect(mobileTableScrollState.canScrollY).toBe(true);
+  expect(mobileTableScrollState.scrollLeft).toBeGreaterThan(0);
+  expect(mobileTableScrollState.scrollTop).toBeGreaterThan(0);
 
   const documentOverflowX = await page.evaluate(
     () => document.documentElement.scrollWidth - document.documentElement.clientWidth,

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -93,7 +93,7 @@ export interface DataTableProps<T> {
   onRowClick?: (row: T, index: number) => void;
   /** Optional selected state for row interaction semantics. */
   rowAriaSelected?: (row: T, index: number) => boolean;
-  /** Let parent scroll containers handle wheel events when this table is already at an edge. */
+  /** Let parent scroll containers handle wheel/touch scroll chaining when this table is already at an edge. */
   allowWheelPropagationAtBoundary?: boolean;
   /** Render the table in normal document flow without any internal table scrollbars. */
   naturalFlow?: boolean;
@@ -2008,7 +2008,9 @@ export function DataTable<T>({
         className={
           naturalFlow
             ? "relative z-10 min-h-0 overflow-visible rounded-xl"
-            : "relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overflow-auto overscroll-x-none overscroll-y-none"
+            : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overflow-auto overscroll-x-none ${
+                allowWheelPropagationAtBoundary ? "overscroll-y-auto" : "overscroll-y-none"
+              }`
         }
       >
         <div data-vt-scroll-content className={`relative ${scrollContentClassName ?? ""}`}>

--- a/packages/ui/src/data-table/DataTable.types.ts
+++ b/packages/ui/src/data-table/DataTable.types.ts
@@ -75,7 +75,7 @@ export interface DataTableProps<T> {
   showAllLoadedMessage?: boolean;
   /** Extra row className */
   rowClassName?: string | ((row: T, index: number) => string);
-  /** Let parent scroll containers handle wheel events when this table is already at an edge. */
+  /** Let parent scroll containers handle wheel/touch scroll chaining when this table is already at an edge. */
   allowWheelPropagationAtBoundary?: boolean;
   /** Render the table in normal document flow without any internal table scrollbars. */
   naturalFlow?: boolean;

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -373,6 +373,7 @@ describe("AuthFileDetailModal", () => {
     const panel = screen.getByTestId("auth-file-identity-fingerprint");
     const summary = within(panel).getByTestId("auth-file-identity-summary");
     const fields = within(panel).getByTestId("auth-file-identity-fields");
+    const scroller = screen.getByTestId("auth-file-detail-scroll");
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
       "Usage",
       "Identity",
@@ -380,6 +381,10 @@ describe("AuthFileDetailModal", () => {
       "Models",
     ]);
     expect(screen.getByRole("tab", { name: "Identity" })).toBeInTheDocument();
+    expect(scroller.className).toContain("overflow-hidden");
+    expect(scroller.className).not.toContain("overflow-y-auto");
+    expect(panel.className).toContain("h-full");
+    expect(fields.className).toContain("flex");
     expect(summary).toHaveTextContent("codex-account-1");
     expect(within(summary).getByText("auth-subject-1")).toBeInTheDocument();
     expect(within(summary).getByText("codex-tui / terminal")).toBeInTheDocument();
@@ -401,6 +406,13 @@ describe("AuthFileDetailModal", () => {
     expect(within(fields).getByText("websocket-beta")).toBeInTheDocument();
     expect(within(fields).getByText("realtime=v1")).toBeInTheDocument();
     expect(within(panel).queryByText("Custom")).not.toBeInTheDocument();
+    const tableViewport = fields.querySelector('[data-scrollbar-visibility="hover"]');
+    if (!(tableViewport instanceof HTMLElement)) {
+      throw new Error("identity fingerprint fields table must own its scroll viewport");
+    }
+    expect(tableViewport.className).toContain("overflow-auto");
+    expect(tableViewport.className).toContain("overscroll-y-none");
+    expect(fields.querySelector("[data-vt-natural-flow]")).toBeNull();
   });
 
   test("five-hour trend uses only the latest five hourly buckets and maps quota timestamps to local hours", () => {

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -720,10 +720,13 @@ export function AuthFileDetailModal({
     const identityFieldRows = [...effectiveRows, ...learnedRows, ...observedHeaderRows];
 
     return (
-      <div className="space-y-4" data-testid="auth-file-identity-fingerprint">
-        <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(17rem,0.78fr)_minmax(0,1.65fr)]">
+      <div
+        className="flex h-full min-h-0 flex-col overflow-hidden"
+        data-testid="auth-file-identity-fingerprint"
+      >
+        <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] gap-4 overflow-hidden lg:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)] lg:grid-rows-1">
           <aside
-            className="min-w-0 rounded-lg bg-slate-50/80 px-4 py-4 dark:bg-white/[0.04]"
+            className="min-h-0 min-w-0 overflow-hidden rounded-lg bg-slate-50/80 px-4 py-4 dark:bg-white/[0.04]"
             data-testid="auth-file-identity-summary"
           >
             <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
@@ -775,7 +778,10 @@ export function AuthFileDetailModal({
             </div>
           </aside>
 
-          <section className="min-w-0 space-y-3" data-testid="auth-file-identity-fields">
+          <section
+            className="flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden"
+            data-testid="auth-file-identity-fields"
+          >
             {identityFingerprintLoading && !identityFingerprintDetail ? (
               <div
                 className="grid gap-2 rounded-lg bg-slate-50/80 px-3 py-3 dark:bg-white/[0.04]"
@@ -796,7 +802,7 @@ export function AuthFileDetailModal({
 
             {identityFingerprintDetail ? (
               <>
-                <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+                <div className="flex min-w-0 shrink-0 flex-wrap items-center justify-between gap-3">
                   <p className="text-sm font-semibold text-slate-900 dark:text-white">
                     {t("auth_files.identity_fingerprint_title")}
                   </p>
@@ -804,21 +810,22 @@ export function AuthFileDetailModal({
                     {t("auth_files.count_items", { count: identityFieldRows.length })}
                   </span>
                 </div>
-                <DataTable<IdentityFingerprintFieldRow>
-                  rows={identityFieldRows}
-                  columns={identityFieldColumns}
-                  rowKey={(row) => row.id}
-                  rowHeight={48}
-                  minWidth="min-w-[920px]"
-                  minHeight="min-h-0"
-                  height="h-auto"
-                  naturalFlow
-                  caption={t("auth_files.identity_fingerprint_title")}
-                  emptyText={t("auth_files.identity_fingerprint_no_fields")}
-                  showAllLoadedMessage={false}
-                  columnReorderable={false}
-                  persistColumnOrder={false}
-                />
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  <DataTable<IdentityFingerprintFieldRow>
+                    rows={identityFieldRows}
+                    columns={identityFieldColumns}
+                    rowKey={(row) => row.id}
+                    rowHeight={48}
+                    minWidth="min-w-[920px]"
+                    minHeight="min-h-0"
+                    height="h-full"
+                    caption={t("auth_files.identity_fingerprint_title")}
+                    emptyText={t("auth_files.identity_fingerprint_no_fields")}
+                    showAllLoadedMessage={false}
+                    columnReorderable={false}
+                    persistColumnOrder={false}
+                  />
+                </div>
               </>
             ) : null}
           </section>
@@ -1079,7 +1086,12 @@ export function AuthFileDetailModal({
             </div>
 
             <div
-              className="mt-4 min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1"
+              className={[
+                "mt-4 min-h-0 flex-1",
+                detailTab === "identity"
+                  ? "overflow-hidden pr-0"
+                  : "overflow-y-auto overscroll-contain pr-1",
+              ].join(" ")}
               data-testid="auth-file-detail-scroll"
             >
               {supportsUsageTrend ? (
@@ -1089,7 +1101,7 @@ export function AuthFileDetailModal({
               ) : null}
 
               {hasIdentityFingerprint ? (
-                <TabsContent value="identity" className="pb-1">
+                <TabsContent value="identity" className="h-full min-h-0 pb-0">
                   {renderIdentityFingerprint()}
                 </TabsContent>
               ) : null}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -967,7 +967,7 @@ export function AuthFilesFilesTab({
   return (
     <Card
       padding="none"
-      className="overflow-hidden md:flex md:h-[calc(100dvh-113px)] md:min-h-0 md:flex-col"
+      className="md:flex md:h-[calc(100dvh-113px)] md:min-h-0 md:flex-col md:overflow-hidden"
       bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
     >
       <input
@@ -1267,6 +1267,7 @@ export function AuthFilesFilesTab({
                 minWidth="min-w-[1840px]"
                 height="h-full"
                 minHeight="min-h-[360px] md:min-h-0"
+                allowWheelPropagationAtBoundary
                 rowClassName={(row) => {
                   const runtimeOnly = isRuntimeOnlyAuthFile(row);
                   const disabled = Boolean(row.disabled);


### PR DESCRIPTION
## Summary
- allow the account security table to pass mobile touch scrolling to the page at scroll boundaries
- keep the identity tab modal content fixed while the fingerprint fields table owns horizontal and vertical scrolling
- cover desktop and mobile identity detail layout with focused unit and e2e tests

## Tests
- `rtk bun run test:ci -- AuthFileDetailModal`
- `rtk bun run e2e -- e2e/account-security-identity-fingerprint.spec.ts`
- `rtk bun run lint`
- `rtk bun run build`