### PR TITLE
fix: polish account security mobile scrolling

### DIFF
--- a/e2e/account-security-identity-fingerprint.spec.ts
+++ b/e2e/account-security-identity-fingerprint.spec.ts
@@ -524,7 +524,7 @@ test("Account & Security shows auth files and account identity fingerprint detai
 test("Account & Security keeps card mode usable and redirects old identity route", async ({
   page,
 }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setViewportSize({ width: 390, height: 640 });
   await setAuthed(page, "cards");
   await routeManagementMocks(page);
 
@@ -541,6 +541,98 @@ test("Account & Security keeps card mode usable and redirects old identity route
   await expect(
     page.locator('[class*="group/card"]', { hasText: "Claude OAuth Primary" }),
   ).toBeVisible();
+
+  const cardsRoot = page.getByTestId("auth-files-cards");
+  const cardsContent = cardsRoot.locator("[data-scroll-area-content]");
+  const codexCard = page.locator('[class*="group/card"]', { hasText: "Codex Terminal OAuth" });
+  const cardsContentBox = await cardsContent.boundingBox();
+  const codexCardBox = await codexCard.boundingBox();
+  if (!cardsContentBox || !codexCardBox) {
+    throw new Error("cards content and codex card must be visible on mobile");
+  }
+  const leftGap = codexCardBox.x - cardsContentBox.x;
+  const rightGap =
+    cardsContentBox.x + cardsContentBox.width - (codexCardBox.x + codexCardBox.width);
+  expect(Math.abs(leftGap - rightGap)).toBeLessThanOrEqual(2);
+
+  const shellScrollBefore = await page.evaluate(() => {
+    const shellScroller = document.getElementById("main-content")?.parentElement;
+    if (!(shellScroller instanceof HTMLElement)) return null;
+    shellScroller.scrollTop = 0;
+    return {
+      clientHeight: shellScroller.clientHeight,
+      scrollHeight: shellScroller.scrollHeight,
+      scrollTop: shellScroller.scrollTop,
+    };
+  });
+  if (!shellScrollBefore) {
+    throw new Error("Account & Security shell scroll container must exist");
+  }
+  expect(shellScrollBefore.scrollHeight).toBeGreaterThan(shellScrollBefore.clientHeight + 20);
+
+  const quotaPanel = codexCard.getByTestId("auth-file-card-quota");
+  const quotaBox = await quotaPanel.boundingBox();
+  if (!quotaBox) {
+    throw new Error("Codex quota panel must be visible on mobile");
+  }
+  await swipeVerticallyFromPoint(
+    page,
+    quotaBox.x + quotaBox.width / 2,
+    quotaBox.y + quotaBox.height / 2,
+    -260,
+  );
+
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const shellScroller = document.getElementById("main-content")?.parentElement;
+        return shellScroller instanceof HTMLElement ? shellScroller.scrollTop : 0;
+      }),
+    )
+    .toBeGreaterThan(20);
+});
+
+test("Account & Security keeps wide desktop cards stretched in a three-column grid", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await setAuthed(page, "cards");
+  await routeManagementMocks(page);
+
+  await page.goto("/#/account-security");
+
+  const cardsRoot = page.getByTestId("auth-files-cards");
+  const cardsContent = cardsRoot.locator("[data-scroll-area-content]");
+  await expect(
+    page.locator('[class*="group/card"]', { hasText: "Codex Terminal OAuth" }),
+  ).toBeVisible();
+
+  const desktopCardLayout = await cardsContent.evaluate((node: HTMLElement) => {
+    const style = window.getComputedStyle(node);
+    const cards = Array.from(node.querySelectorAll<HTMLElement>('[class*="group/card"]')).map(
+      (card) => {
+        const box = card.getBoundingClientRect();
+        return {
+          x: box.x,
+          width: box.width,
+          maxWidth: window.getComputedStyle(card).maxWidth,
+        };
+      },
+    );
+    return {
+      gridTemplateColumns: style.gridTemplateColumns,
+      justifyItems: style.justifyItems,
+      cards,
+    };
+  });
+
+  expect(desktopCardLayout.gridTemplateColumns.split(" ").filter(Boolean)).toHaveLength(3);
+  expect(desktopCardLayout.justifyItems).toBe("stretch");
+  expect(desktopCardLayout.cards).toHaveLength(3);
+  expect(desktopCardLayout.cards.every((card) => card.maxWidth === "none")).toBe(true);
+  expect(desktopCardLayout.cards[1].x).toBeGreaterThan(desktopCardLayout.cards[0].x);
+  expect(desktopCardLayout.cards[2].x).toBeGreaterThan(desktopCardLayout.cards[1].x);
+  expect(Math.min(...desktopCardLayout.cards.map((card) => card.width))).toBeGreaterThan(320);
 });
 
 test("Account & Security mobile table scroll chains from the middle of the page", async ({
@@ -647,28 +739,64 @@ test("Account & Security identity detail stacks cleanly on mobile", async ({ pag
   expect(Math.abs(fieldsBox.x - summaryBox.x)).toBeLessThanOrEqual(8);
   const detailScroller = dialog.getByTestId("auth-file-detail-scroll");
   await expect(detailScroller).toHaveCSS("overflow-x", "hidden");
-  await expect(detailScroller).toHaveCSS("overflow-y", "hidden");
-  const identityTableViewport = identityFields.locator('[data-scrollbar-visibility="hover"]');
-  await expect(identityTableViewport).toBeVisible();
-  const mobileTableScrollState = await identityTableViewport.evaluate((node: HTMLElement) => {
-    node.scrollTop = 120;
+  await expect(detailScroller).toHaveCSS("overflow-y", "auto");
+  const mobileTable = identityFields.getByTestId("auth-file-identity-table-mobile");
+  await expect(mobileTable).toBeVisible();
+  await expect(mobileTable.locator("[data-vt-natural-flow]")).toBeVisible();
+  await expect(identityFields.locator('[data-scrollbar-visibility="hover"]')).toHaveCount(0);
+
+  const detailScrollState = await detailScroller.evaluate((node: HTMLElement) => {
+    node.scrollTop = 160;
+    const style = window.getComputedStyle(node);
+    return {
+      canScrollY: node.scrollHeight > node.clientHeight,
+      overflowY: style.overflowY,
+      scrollTop: node.scrollTop,
+    };
+  });
+  expect(detailScrollState.overflowY).toBe("auto");
+  expect(detailScrollState.canScrollY).toBe(true);
+  expect(detailScrollState.scrollTop).toBeGreaterThan(0);
+
+  const mobileTableScrollState = await mobileTable.evaluate((node: HTMLElement) => {
     node.scrollLeft = 160;
     const style = window.getComputedStyle(node);
     return {
       canScrollX: node.scrollWidth > node.clientWidth,
-      canScrollY: node.scrollHeight > node.clientHeight,
       overflowX: style.overflowX,
-      overflowY: style.overflowY,
       scrollLeft: node.scrollLeft,
-      scrollTop: node.scrollTop,
     };
   });
   expect(mobileTableScrollState.overflowX).toBe("auto");
-  expect(mobileTableScrollState.overflowY).toBe("auto");
   expect(mobileTableScrollState.canScrollX).toBe(true);
-  expect(mobileTableScrollState.canScrollY).toBe(true);
   expect(mobileTableScrollState.scrollLeft).toBeGreaterThan(0);
-  expect(mobileTableScrollState.scrollTop).toBeGreaterThan(0);
+
+  await detailScroller.evaluate((node: HTMLElement) => {
+    node.scrollTop = 0;
+  });
+  const mobileTableBox = await mobileTable.boundingBox();
+  const viewportSize = page.viewportSize();
+  if (!mobileTableBox || !viewportSize) {
+    throw new Error("mobile identity fingerprint table must be visible");
+  }
+  const visibleLeft = Math.max(mobileTableBox.x, 16);
+  const visibleRight = Math.min(mobileTableBox.x + mobileTableBox.width, viewportSize.width - 16);
+  const visibleTop = Math.max(mobileTableBox.y, 120);
+  const visibleBottom = Math.min(
+    mobileTableBox.y + mobileTableBox.height,
+    viewportSize.height - 96,
+  );
+  expect(visibleRight).toBeGreaterThan(visibleLeft + 20);
+  expect(visibleBottom).toBeGreaterThan(visibleTop + 20);
+  await swipeVerticallyFromPoint(
+    page,
+    (visibleLeft + visibleRight) / 2,
+    (visibleTop + visibleBottom) / 2,
+    -260,
+  );
+  await expect
+    .poll(async () => detailScroller.evaluate((node: HTMLElement) => node.scrollTop))
+    .toBeGreaterThan(20);
 
   const documentOverflowX = await page.evaluate(
     () => document.documentElement.scrollWidth - document.documentElement.clientWidth,

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -138,6 +138,22 @@ const expectSummaryCard = (label: string, value: string) => {
   expect(within(card).getByText(value)).toBeInTheDocument();
 };
 
+const mockMediaQueryMatches = (matches: boolean) => {
+  vi.spyOn(window, "matchMedia").mockImplementation(
+    (query: string) =>
+      ({
+        matches,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+  );
+};
+
 const renderDetailModal = (overrides: Partial<DetailModalProps> = {}) => {
   const props: DetailModalProps = {
     open: true,
@@ -356,7 +372,7 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByText(/resets/)).not.toBeInTheDocument();
   });
 
-  test("renders account identity fingerprint sources and learned request headers", () => {
+  test("renders account identity fingerprint sources and learned request headers in mobile flow", () => {
     renderDetailModal({
       detailTab: "identity",
       detailFile: {
@@ -381,9 +397,9 @@ describe("AuthFileDetailModal", () => {
       "Models",
     ]);
     expect(screen.getByRole("tab", { name: "Identity" })).toBeInTheDocument();
-    expect(scroller.className).toContain("overflow-hidden");
-    expect(scroller.className).not.toContain("overflow-y-auto");
-    expect(panel.className).toContain("h-full");
+    expect(scroller.className).toContain("overflow-y-auto");
+    expect(scroller.className).toContain("lg:overflow-hidden");
+    expect(panel.className).toContain("lg:h-full");
     expect(fields.className).toContain("flex");
     expect(summary).toHaveTextContent("codex-account-1");
     expect(within(summary).getByText("auth-subject-1")).toBeInTheDocument();
@@ -406,6 +422,35 @@ describe("AuthFileDetailModal", () => {
     expect(within(fields).getByText("websocket-beta")).toBeInTheDocument();
     expect(within(fields).getByText("realtime=v1")).toBeInTheDocument();
     expect(within(panel).queryByText("Custom")).not.toBeInTheDocument();
+    const mobileTable = within(fields).getByTestId("auth-file-identity-table-mobile");
+    expect(mobileTable.className).toContain("overflow-x-auto");
+    expect(
+      within(fields).queryByTestId("auth-file-identity-table-desktop"),
+    ).not.toBeInTheDocument();
+    expect(fields.querySelector("[data-vt-natural-flow]")).toBeInTheDocument();
+    expect(fields.querySelector('[data-scrollbar-visibility="hover"]')).toBeNull();
+  });
+
+  test("keeps identity fingerprint table scroll owned by the table on desktop", () => {
+    mockMediaQueryMatches(true);
+
+    renderDetailModal({
+      detailTab: "identity",
+      detailFile: {
+        name: "codex.json",
+        label: "Codex Primary",
+        type: "codex",
+        size: 256,
+        account_type: "oauth",
+        identity_fingerprint_summary: codexIdentityFingerprintDetail.summary,
+      },
+      identityFingerprintDetail: codexIdentityFingerprintDetail,
+    });
+
+    const fields = screen.getByTestId("auth-file-identity-fields");
+    const desktopTable = within(fields).getByTestId("auth-file-identity-table-desktop");
+    expect(desktopTable.className).toContain("overflow-hidden");
+    expect(within(fields).queryByTestId("auth-file-identity-table-mobile")).not.toBeInTheDocument();
     const tableViewport = fields.querySelector('[data-scrollbar-visibility="hover"]');
     if (!(tableViewport instanceof HTMLElement)) {
       throw new Error("identity fingerprint fields table must own its scroll viewport");

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -77,6 +77,25 @@ const IDENTITY_FINGERPRINT_SOURCE_ORDER: IdentityFingerprintFieldSource[] = [
   "preset",
   "builtin_default",
 ];
+const IDENTITY_DESKTOP_MEDIA_QUERY = "(min-width: 1024px)";
+
+const useIdentityDesktopLayout = () => {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(IDENTITY_DESKTOP_MEDIA_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const media = window.matchMedia(IDENTITY_DESKTOP_MEDIA_QUERY);
+    const updateMatches = (event: MediaQueryListEvent) => setMatches(event.matches);
+    setMatches(media.matches);
+    media.addEventListener("change", updateMatches);
+    return () => media.removeEventListener("change", updateMatches);
+  }, []);
+
+  return matches;
+};
 
 const padTwo = (value: number) => String(value).padStart(2, "0");
 
@@ -228,6 +247,7 @@ export function AuthFileDetailModal({
   saveCodexOAuthAdmission,
 }: AuthFileDetailModalProps) {
   const { t, i18n } = useTranslation();
+  const isIdentityDesktopLayout = useIdentityDesktopLayout();
   const proxyCheckState = useProxyPoolChecks(proxyPoolEntries, open && detailTab === "fields");
   const usesMappedModelOwner = Boolean(mappedModelOwnerValue);
   const visibleModelsList = usesMappedModelOwner
@@ -721,12 +741,12 @@ export function AuthFileDetailModal({
 
     return (
       <div
-        className="flex h-full min-h-0 flex-col overflow-hidden"
+        className="min-h-0 lg:flex lg:h-full lg:flex-col lg:overflow-hidden"
         data-testid="auth-file-identity-fingerprint"
       >
-        <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] gap-4 overflow-hidden lg:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)] lg:grid-rows-1">
+        <div className="grid min-w-0 gap-4 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)] lg:grid-rows-1 lg:overflow-hidden">
           <aside
-            className="min-h-0 min-w-0 overflow-hidden rounded-lg bg-slate-50/80 px-4 py-4 dark:bg-white/[0.04]"
+            className="min-w-0 rounded-lg bg-slate-50/80 px-4 py-4 lg:min-h-0 lg:overflow-hidden dark:bg-white/[0.04]"
             data-testid="auth-file-identity-summary"
           >
             <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
@@ -779,7 +799,7 @@ export function AuthFileDetailModal({
           </aside>
 
           <section
-            className="flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden"
+            className="flex min-w-0 flex-col gap-3 lg:min-h-0 lg:overflow-hidden"
             data-testid="auth-file-identity-fields"
           >
             {identityFingerprintLoading && !identityFingerprintDetail ? (
@@ -810,22 +830,48 @@ export function AuthFileDetailModal({
                     {t("auth_files.count_items", { count: identityFieldRows.length })}
                   </span>
                 </div>
-                <div className="min-h-0 flex-1 overflow-hidden">
-                  <DataTable<IdentityFingerprintFieldRow>
-                    rows={identityFieldRows}
-                    columns={identityFieldColumns}
-                    rowKey={(row) => row.id}
-                    rowHeight={48}
-                    minWidth="min-w-[920px]"
-                    minHeight="min-h-0"
-                    height="h-full"
-                    caption={t("auth_files.identity_fingerprint_title")}
-                    emptyText={t("auth_files.identity_fingerprint_no_fields")}
-                    showAllLoadedMessage={false}
-                    columnReorderable={false}
-                    persistColumnOrder={false}
-                  />
-                </div>
+                {isIdentityDesktopLayout ? (
+                  <div
+                    className="min-h-0 flex-1 overflow-hidden"
+                    data-testid="auth-file-identity-table-desktop"
+                  >
+                    <DataTable<IdentityFingerprintFieldRow>
+                      rows={identityFieldRows}
+                      columns={identityFieldColumns}
+                      rowKey={(row) => row.id}
+                      rowHeight={48}
+                      minWidth="min-w-[920px]"
+                      minHeight="min-h-0"
+                      height="h-full"
+                      caption={t("auth_files.identity_fingerprint_title")}
+                      emptyText={t("auth_files.identity_fingerprint_no_fields")}
+                      showAllLoadedMessage={false}
+                      columnReorderable={false}
+                      persistColumnOrder={false}
+                    />
+                  </div>
+                ) : (
+                  <div
+                    className="min-w-0 overflow-x-auto overscroll-x-contain rounded-xl"
+                    data-testid="auth-file-identity-table-mobile"
+                  >
+                    <DataTable<IdentityFingerprintFieldRow>
+                      rows={identityFieldRows}
+                      columns={identityFieldColumns}
+                      rowKey={(row) => row.id}
+                      rowHeight={48}
+                      minWidth="min-w-[920px]"
+                      minHeight="min-h-0"
+                      height="h-auto"
+                      caption={t("auth_files.identity_fingerprint_title")}
+                      emptyText={t("auth_files.identity_fingerprint_no_fields")}
+                      showAllLoadedMessage={false}
+                      naturalFlow
+                      columnReorderable={false}
+                      persistColumnOrder={false}
+                    />
+                  </div>
+                )}
               </>
             ) : null}
           </section>
@@ -1089,7 +1135,7 @@ export function AuthFileDetailModal({
               className={[
                 "mt-4 min-h-0 flex-1",
                 detailTab === "identity"
-                  ? "overflow-hidden pr-0"
+                  ? "overflow-x-hidden overflow-y-auto overscroll-contain pr-1 lg:overflow-hidden lg:pr-0"
                   : "overflow-y-auto overscroll-contain pr-1",
               ].join(" ")}
               data-testid="auth-file-detail-scroll"
@@ -1101,7 +1147,7 @@ export function AuthFileDetailModal({
               ) : null}
 
               {hasIdentityFingerprint ? (
-                <TabsContent value="identity" className="h-full min-h-0 pb-0">
+                <TabsContent value="identity" className="min-h-0 pb-1 lg:h-full lg:pb-0">
                   {renderIdentityFingerprint()}
                 </TabsContent>
               ) : null}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1288,8 +1288,9 @@ export function AuthFilesFilesTab({
             ) : (
               <ScrollArea
                 data-testid="auth-files-cards"
-                className="h-full items-stretch"
-                contentClassName="grid grid-cols-1 items-stretch gap-5 px-4 py-4 pr-8 sm:py-5 sm:pl-5 sm:pr-8 md:grid-cols-2 xl:grid-cols-3"
+                className="items-stretch md:h-full"
+                viewportClassName="max-md:h-auto max-md:overflow-visible max-md:overscroll-auto"
+                contentClassName="grid grid-cols-1 items-stretch justify-items-center gap-5 px-4 py-4 sm:px-5 sm:py-5 md:grid-cols-2 md:justify-items-stretch md:pr-8 xl:grid-cols-3"
                 scrollbarTrackInset={0}
               >
                 {pageItems.map((file) => {
@@ -1353,7 +1354,7 @@ export function AuthFilesFilesTab({
                       padding="default"
                       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[
-                        "group/card flex h-full flex-col transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+                        "group/card flex h-full w-full max-w-[34rem] flex-col transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
                         fileSelected
                           ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                           : "",


### PR DESCRIPTION
## Summary
- fix mobile Account & Security card scrolling so touch gestures inside quota cards scroll the page
- keep wide desktop card grids stretched and unchanged
- split identity detail table behavior between desktop table-owned scrolling and mobile dialog-owned vertical scrolling

## Tests
- rtk bun run build
- rtk bun run boundary:imports
- rtk bun run lint
- rtk bun run test:ci -- AuthFileDetailModal
- rtk bun run test:ci -- AuthFilesPage.files-table
- rtk bun run e2e -- e2e/account-security-identity-fingerprint.spec.ts
- rtk git diff --check