### PR TITLE
fix: repair api keys fixed columns

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -278,3 +278,51 @@ test("API Keys: restored wider columns keep resize preview at the minimum bounda
     )
     .toBe(168);
 });
+
+test("API Keys: fixed columns do not cover the created time at the right edge", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 2048, height: 1180 });
+  await setAuthed(page);
+  await mockApiKeysApis(page);
+
+  await page.goto("/#/api-keys");
+  await page.locator('td[data-vt-column-key="createdAt"]').waitFor({ state: "visible" });
+
+  const state = await page.evaluate(async () => {
+    const scrollContent = document.querySelector<HTMLElement>("[data-vt-scroll-content]");
+    const container = scrollContent?.parentElement;
+    if (!scrollContent || !container) throw new Error("Missing API keys table viewport");
+
+    container.scrollLeft = container.scrollWidth;
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+    const createdAt = document.querySelector<HTMLElement>('td[data-vt-column-key="createdAt"]');
+    const actions = document.querySelector<HTMLElement>('td[data-vt-column-key="actions"]');
+    const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
+    const endRail = document.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
+    if (!createdAt || !actions || !startRail || !endRail) {
+      throw new Error("Missing fixed-column geometry");
+    }
+
+    const createdAtRect = createdAt.getBoundingClientRect();
+    const actionsRect = actions.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const startRailRect = startRail.getBoundingClientRect();
+    const endRailRect = endRail.getBoundingClientRect();
+    const horizontalScrollbarInset = 14;
+
+    return {
+      createdAtRight: createdAtRect.right,
+      actionsLeft: actionsRect.left,
+      startRailBottom: startRailRect.bottom,
+      endRailBottom: endRailRect.bottom,
+      fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
+    };
+  });
+
+  expect(state.createdAtRight).toBeLessThanOrEqual(state.actionsLeft + 1);
+  expect(state.startRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
+  expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
+});

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -292,6 +292,33 @@ function resolveColumnMaxWidth<T>(
   return Math.max(minWidth, column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH);
 }
 
+function hasStickyColumnClass<T>(column: DataTableColumn<T>) {
+  return `${column.headerClassName ?? ""} ${column.cellClassName ?? ""}`
+    .split(/\s+/)
+    .some((className) => className === "sticky" || className.endsWith(":sticky"));
+}
+
+function resolveColumnLayoutWidth<T>(column: DataTableColumn<T>, widths: ColumnWidthMap) {
+  const resizedWidth = widths[column.key];
+  return resizedWidth ? clampColumnWidth(column, resizedWidth) : resolveColumnMinWidth(column);
+}
+
+function resolveStickyRailWidth<T>(
+  columns: DataTableColumn<T>[],
+  widths: ColumnWidthMap,
+  edge: "start" | "end",
+) {
+  const edgeColumns = edge === "start" ? columns : [...columns].reverse();
+  let width = 0;
+
+  for (const column of edgeColumns) {
+    if (resolveColumnOrderLock(column) !== edge || !hasStickyColumnClass(column)) break;
+    width += resolveColumnLayoutWidth(column, widths);
+  }
+
+  return width;
+}
+
 function normalizeColumnWidths<T>(columns: DataTableColumn<T>[], widths: ColumnWidthMap) {
   const next: ColumnWidthMap = {};
   columns.forEach((column) => {
@@ -1933,6 +1960,20 @@ export function DataTable<T>({
   const { vThumb, hThumb } = useMemo(() => {
     return calculateScrollbarThumbs(scrollMetrics, headerHeight);
   }, [headerHeight, scrollMetrics]);
+  const stickyStartRailWidth = useMemo(
+    () => resolveStickyRailWidth(orderedColumns, columnWidths, "start"),
+    [columnWidths, orderedColumns],
+  );
+  const stickyEndRailWidth = useMemo(
+    () => resolveStickyRailWidth(orderedColumns, columnWidths, "end"),
+    [columnWidths, orderedColumns],
+  );
+  const stickyRailBottomInset = hThumb ? 14 : 0;
+  const stickyRailTop = scrollMetrics.scrollTop + headerHeight;
+  const stickyRailHeight = Math.max(
+    0,
+    scrollMetrics.clientHeight - headerHeight - stickyRailBottomInset,
+  );
 
   const resolveColumnStyle = useCallback(
     (column: DataTableColumn<T>): CSSProperties | undefined => {
@@ -2013,7 +2054,36 @@ export function DataTable<T>({
               }`
         }
       >
-        <div data-vt-scroll-content className={`relative ${scrollContentClassName ?? ""}`}>
+        <div
+          data-vt-scroll-content
+          className={`relative min-h-full ${scrollContentClassName ?? ""}`}
+        >
+          {!naturalFlow && stickyStartRailWidth > 0 && stickyRailHeight > 0 ? (
+            <div
+              data-vt-sticky-start-rail
+              aria-hidden="true"
+              className="pointer-events-none absolute z-20 hidden border-r border-slate-200 bg-white md:block dark:border-neutral-800 dark:bg-neutral-950"
+              style={{
+                left: scrollMetrics.scrollLeft,
+                top: stickyRailTop,
+                width: stickyStartRailWidth,
+                height: stickyRailHeight,
+              }}
+            />
+          ) : null}
+          {!naturalFlow && stickyEndRailWidth > 0 && stickyRailHeight > 0 ? (
+            <div
+              data-vt-sticky-end-rail
+              aria-hidden="true"
+              className="pointer-events-none absolute z-20 hidden border-l border-slate-200 bg-white md:block dark:border-neutral-800 dark:bg-neutral-950"
+              style={{
+                left: scrollMetrics.scrollLeft + scrollMetrics.clientWidth - stickyEndRailWidth,
+                top: stickyRailTop,
+                width: stickyEndRailWidth,
+                height: stickyRailHeight,
+              }}
+            />
+          ) : null}
           {!naturalFlow && rowHoverOverlay ? (
             <div
               data-vt-row-hover-overlay

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -658,7 +658,7 @@ export function ApiKeysPage() {
               rowHeight={44}
               height="h-[calc(100dvh-260px)] max-h-[70vh]"
               minHeight="min-h-[320px]"
-              minWidth="min-w-[1860px]"
+              minWidth="min-w-[2002px]"
               caption={t("api_keys_page.table_caption")}
               emptyText={t("api_keys_page.no_api_keys")}
               rowClassName={(row) => (row.disabled ? "opacity-50" : "")}


### PR DESCRIPTION
## Summary
- add fixed-column background rails in shared DataTable so pinned column borders reach the table bottom
- align the API keys table min width with its column widths so created time is not covered by actions
- add e2e coverage for the right-edge fixed-column layout

## Tests
- bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- bun run build
- git diff --check