### PR TITLE
fix: keep API keys fixed columns aligned

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -289,40 +289,59 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
   await page.goto("/#/api-keys");
   await page.locator('td[data-vt-column-key="createdAt"]').waitFor({ state: "visible" });
 
-  const state = await page.evaluate(async () => {
+  const states = await page.evaluate(async () => {
     const scrollContent = document.querySelector<HTMLElement>("[data-vt-scroll-content]");
     const container = scrollContent?.parentElement;
     if (!scrollContent || !container) throw new Error("Missing API keys table viewport");
 
-    container.scrollLeft = container.scrollWidth;
-    await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
-    await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
-
-    const createdAt = document.querySelector<HTMLElement>('td[data-vt-column-key="createdAt"]');
-    const actions = document.querySelector<HTMLElement>('td[data-vt-column-key="actions"]');
-    const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
-    const endRail = document.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
-    if (!createdAt || !actions || !startRail || !endRail) {
-      throw new Error("Missing fixed-column geometry");
-    }
-
-    const createdAtRect = createdAt.getBoundingClientRect();
-    const actionsRect = actions.getBoundingClientRect();
-    const containerRect = container.getBoundingClientRect();
-    const startRailRect = startRail.getBoundingClientRect();
-    const endRailRect = endRail.getBoundingClientRect();
+    const maxScrollLeft = container.scrollWidth - container.clientWidth;
+    const positions = [Math.round(maxScrollLeft / 2), maxScrollLeft];
     const horizontalScrollbarInset = 14;
 
-    return {
-      createdAtRight: createdAtRect.right,
-      actionsLeft: actionsRect.left,
-      startRailBottom: startRailRect.bottom,
-      endRailBottom: endRailRect.bottom,
-      fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
-    };
+    return Promise.all(
+      positions.map(async (scrollLeft) => {
+        container.scrollLeft = scrollLeft;
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+
+        const createdAt = document.querySelector<HTMLElement>(
+          'td[data-vt-column-key="createdAt"]',
+        );
+        const actions = document.querySelector<HTMLElement>('td[data-vt-column-key="actions"]');
+        const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
+        const endRail = document.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
+        if (!createdAt || !actions || !startRail || !endRail) {
+          throw new Error("Missing fixed-column geometry");
+        }
+
+        const createdAtRect = createdAt.getBoundingClientRect();
+        const actionsRect = actions.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+        const startRailRect = startRail.getBoundingClientRect();
+        const endRailRect = endRail.getBoundingClientRect();
+
+        return {
+          createdAtRight: createdAtRect.right,
+          actionsLeft: actionsRect.left,
+          containerLeft: containerRect.left,
+          containerRight: containerRect.right,
+          startRailLeft: startRailRect.left,
+          startRailBottom: startRailRect.bottom,
+          endRailRight: endRailRect.right,
+          endRailBottom: endRailRect.bottom,
+          fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
+        };
+      }),
+    );
   });
 
-  expect(state.createdAtRight).toBeLessThanOrEqual(state.actionsLeft + 1);
-  expect(state.startRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
-  expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
+  for (const state of states) {
+    expect(state.createdAtRight).toBeLessThanOrEqual(state.actionsLeft + 1);
+    expect(state.startRailLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
+    expect(state.startRailLeft).toBeLessThanOrEqual(state.containerLeft + 1);
+    expect(state.endRailRight).toBeGreaterThanOrEqual(state.containerRight - 1);
+    expect(state.endRailRight).toBeLessThanOrEqual(state.containerRight + 1);
+    expect(state.startRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
+    expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
+  }
 });

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -687,6 +687,8 @@ export function DataTable<T>({
   const metricsRafRef = useRef<number | null>(null);
   const verticalThumbRef = useRef<HTMLDivElement | null>(null);
   const horizontalThumbRef = useRef<HTMLDivElement | null>(null);
+  const stickyStartRailRef = useRef<HTMLDivElement | null>(null);
+  const stickyEndRailRef = useRef<HTMLDivElement | null>(null);
   const columnResizeRafRef = useRef<number | null>(null);
   const pendingColumnResizePointerRef = useRef<{ clientX: number; clientY: number } | null>(null);
   const bottomTimeoutRef = useRef<number | null>(null);
@@ -799,6 +801,10 @@ export function DataTable<T>({
         horizontalThumb.style.left = `${nextHThumb.left}px`;
         horizontalThumb.style.width = `${nextHThumb.width}px`;
       }
+
+      const railTransform = `translate(${metrics.scrollLeft}px, ${metrics.scrollTop}px)`;
+      if (stickyStartRailRef.current) stickyStartRailRef.current.style.transform = railTransform;
+      if (stickyEndRailRef.current) stickyEndRailRef.current.style.transform = railTransform;
     },
     [],
   );
@@ -1969,11 +1975,14 @@ export function DataTable<T>({
     [columnWidths, orderedColumns],
   );
   const stickyRailBottomInset = hThumb ? 14 : 0;
-  const stickyRailTop = scrollMetrics.scrollTop + headerHeight;
+  const stickyRailTop = headerHeight;
   const stickyRailHeight = Math.max(
     0,
     scrollMetrics.clientHeight - headerHeight - stickyRailBottomInset,
   );
+  const latestScrollMetrics = scrollMetricsRef.current;
+  const stickyRailTransform = `translate(${latestScrollMetrics.scrollLeft}px, ${latestScrollMetrics.scrollTop}px)`;
+  const stickyEndRailLeft = Math.max(0, scrollMetrics.clientWidth - stickyEndRailWidth);
 
   const resolveColumnStyle = useCallback(
     (column: DataTableColumn<T>): CSSProperties | undefined => {
@@ -2060,27 +2069,31 @@ export function DataTable<T>({
         >
           {!naturalFlow && stickyStartRailWidth > 0 && stickyRailHeight > 0 ? (
             <div
+              ref={stickyStartRailRef}
               data-vt-sticky-start-rail
               aria-hidden="true"
               className="pointer-events-none absolute z-20 hidden border-r border-slate-200 bg-white md:block dark:border-neutral-800 dark:bg-neutral-950"
               style={{
-                left: scrollMetrics.scrollLeft,
+                left: 0,
                 top: stickyRailTop,
                 width: stickyStartRailWidth,
                 height: stickyRailHeight,
+                transform: stickyRailTransform,
               }}
             />
           ) : null}
           {!naturalFlow && stickyEndRailWidth > 0 && stickyRailHeight > 0 ? (
             <div
+              ref={stickyEndRailRef}
               data-vt-sticky-end-rail
               aria-hidden="true"
               className="pointer-events-none absolute z-20 hidden border-l border-slate-200 bg-white md:block dark:border-neutral-800 dark:bg-neutral-950"
               style={{
-                left: scrollMetrics.scrollLeft + scrollMetrics.clientWidth - stickyEndRailWidth,
+                left: stickyEndRailLeft,
                 top: stickyRailTop,
                 width: stickyEndRailWidth,
                 height: stickyRailHeight,
+                transform: stickyRailTransform,
               }}
             />
           ) : null}


### PR DESCRIPTION
## Summary
- keep DataTable fixed-column background rails aligned through direct scroll metric sync
- cover API keys horizontal scroll positions in e2e geometry assertions

## Verification
- bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- bun run build
- git diff --check