### PR TITLE
fix: keep API key sticky columns pinned

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -295,53 +295,152 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
     if (!scrollContent || !container) throw new Error("Missing API keys table viewport");
 
     const maxScrollLeft = container.scrollWidth - container.clientWidth;
-    const positions = [Math.round(maxScrollLeft / 2), maxScrollLeft];
+    const positions = [0, Math.round(maxScrollLeft / 2), maxScrollLeft];
     const horizontalScrollbarInset = 14;
 
-    return Promise.all(
-      positions.map(async (scrollLeft) => {
-        container.scrollLeft = scrollLeft;
-        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
-        await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+    const states: Array<{
+      scrollLeft: number;
+      maxScrollLeft: number;
+      createdAtRight: number;
+      actionsLeft: number;
+      actionsRight: number;
+      containerLeft: number;
+      containerRight: number;
+      selectHeaderLeft: number;
+      selectHeaderWidth: number;
+      nameHeaderLeft: number;
+      nameHeaderRight: number;
+      nameHeaderWidth: number;
+      actionsHeaderRight: number;
+      selectCellLeft: number;
+      selectCellWidth: number;
+      nameCellLeft: number;
+      nameCellRight: number;
+      nameCellWidth: number;
+      nameHeaderHitColumn: string | null;
+      nameCellHitColumn: string | null;
+      startRailLeft: number;
+      startRailBottom: number;
+      endRailRight: number;
+      endRailBottom: number;
+      fixedRailBottom: number;
+    }> = [];
+    for (const scrollLeft of positions) {
+      container.scrollLeft = scrollLeft;
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
 
-        const createdAt = document.querySelector<HTMLElement>(
-          'td[data-vt-column-key="createdAt"]',
-        );
-        const actions = document.querySelector<HTMLElement>('td[data-vt-column-key="actions"]');
-        const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
-        const endRail = document.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
-        if (!createdAt || !actions || !startRail || !endRail) {
-          throw new Error("Missing fixed-column geometry");
-        }
+      const createdAt = document.querySelector<HTMLElement>('td[data-vt-column-key="createdAt"]');
+      const actions = document.querySelector<HTMLElement>('td[data-vt-column-key="actions"]');
+      const selectHeader = document.querySelector<HTMLElement>('th[data-vt-column-key="select"]');
+      const nameHeader = document.querySelector<HTMLElement>('th[data-vt-column-key="name"]');
+      const actionsHeader = document.querySelector<HTMLElement>('th[data-vt-column-key="actions"]');
+      const selectCell = document.querySelector<HTMLElement>('td[data-vt-column-key="select"]');
+      const nameCell = document.querySelector<HTMLElement>('td[data-vt-column-key="name"]');
+      const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
+      const endRail = document.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
+      if (
+        !createdAt ||
+        !actions ||
+        !selectHeader ||
+        !nameHeader ||
+        !actionsHeader ||
+        !selectCell ||
+        !nameCell ||
+        !startRail ||
+        !endRail
+      ) {
+        throw new Error("Missing fixed-column geometry");
+      }
 
-        const createdAtRect = createdAt.getBoundingClientRect();
-        const actionsRect = actions.getBoundingClientRect();
-        const containerRect = container.getBoundingClientRect();
-        const startRailRect = startRail.getBoundingClientRect();
-        const endRailRect = endRail.getBoundingClientRect();
+      const createdAtRect = createdAt.getBoundingClientRect();
+      const actionsRect = actions.getBoundingClientRect();
+      const selectHeaderRect = selectHeader.getBoundingClientRect();
+      const nameHeaderRect = nameHeader.getBoundingClientRect();
+      const actionsHeaderRect = actionsHeader.getBoundingClientRect();
+      const selectCellRect = selectCell.getBoundingClientRect();
+      const nameCellRect = nameCell.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      const startRailRect = startRail.getBoundingClientRect();
+      const endRailRect = endRail.getBoundingClientRect();
+      const nameHeaderHit = document.elementFromPoint(
+        nameHeaderRect.right - 8,
+        nameHeaderRect.top + nameHeaderRect.height / 2,
+      );
+      const nameCellHit = document.elementFromPoint(
+        nameCellRect.right - 8,
+        nameCellRect.top + nameCellRect.height / 2,
+      );
 
-        return {
-          createdAtRight: createdAtRect.right,
-          actionsLeft: actionsRect.left,
-          containerLeft: containerRect.left,
-          containerRight: containerRect.right,
-          startRailLeft: startRailRect.left,
-          startRailBottom: startRailRect.bottom,
-          endRailRight: endRailRect.right,
-          endRailBottom: endRailRect.bottom,
-          fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
-        };
-      }),
-    );
+      states.push({
+        scrollLeft,
+        maxScrollLeft,
+        createdAtRight: createdAtRect.right,
+        actionsLeft: actionsRect.left,
+        actionsRight: actionsRect.right,
+        containerLeft: containerRect.left,
+        containerRight: containerRect.right,
+        selectHeaderLeft: selectHeaderRect.left,
+        selectHeaderWidth: selectHeaderRect.width,
+        nameHeaderLeft: nameHeaderRect.left,
+        nameHeaderRight: nameHeaderRect.right,
+        nameHeaderWidth: nameHeaderRect.width,
+        actionsHeaderRight: actionsHeaderRect.right,
+        selectCellLeft: selectCellRect.left,
+        selectCellWidth: selectCellRect.width,
+        nameCellLeft: nameCellRect.left,
+        nameCellRight: nameCellRect.right,
+        nameCellWidth: nameCellRect.width,
+        nameHeaderHitColumn:
+          nameHeaderHit?.closest<HTMLElement>("[data-vt-column-key]")?.dataset.vtColumnKey ?? null,
+        nameCellHitColumn:
+          nameCellHit?.closest<HTMLElement>("[data-vt-column-key]")?.dataset.vtColumnKey ?? null,
+        startRailLeft: startRailRect.left,
+        startRailBottom: startRailRect.bottom,
+        endRailRight: endRailRect.right,
+        endRailBottom: endRailRect.bottom,
+        fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
+      });
+    }
+
+    return states;
   });
 
   for (const state of states) {
-    expect(state.createdAtRight).toBeLessThanOrEqual(state.actionsLeft + 1);
+    const expectedHeaderNameLeft = state.containerLeft + state.selectHeaderWidth;
+    const expectedHeaderNameRight = expectedHeaderNameLeft + state.nameHeaderWidth;
+    const expectedCellNameLeft = state.containerLeft + state.selectCellWidth;
+    const expectedCellNameRight = expectedCellNameLeft + state.nameCellWidth;
+
     expect(state.startRailLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
     expect(state.startRailLeft).toBeLessThanOrEqual(state.containerLeft + 1);
     expect(state.endRailRight).toBeGreaterThanOrEqual(state.containerRight - 1);
     expect(state.endRailRight).toBeLessThanOrEqual(state.containerRight + 1);
+    expect(state.selectHeaderLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
+    expect(state.selectHeaderLeft).toBeLessThanOrEqual(state.containerLeft + 1);
+    expect(state.nameHeaderLeft).toBeGreaterThanOrEqual(expectedHeaderNameLeft - 1);
+    expect(state.nameHeaderLeft).toBeLessThanOrEqual(expectedHeaderNameLeft + 1);
+    expect(state.nameHeaderRight).toBeGreaterThanOrEqual(expectedHeaderNameRight - 1);
+    expect(state.nameHeaderRight).toBeLessThanOrEqual(expectedHeaderNameRight + 1);
+    expect(state.actionsHeaderRight).toBeGreaterThanOrEqual(state.containerRight - 1);
+    expect(state.actionsHeaderRight).toBeLessThanOrEqual(state.containerRight + 1);
+    expect(state.selectCellLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
+    expect(state.selectCellLeft).toBeLessThanOrEqual(state.containerLeft + 1);
+    expect(state.nameCellLeft).toBeGreaterThanOrEqual(expectedCellNameLeft - 1);
+    expect(state.nameCellLeft).toBeLessThanOrEqual(expectedCellNameLeft + 1);
+    expect(state.nameCellRight).toBeGreaterThanOrEqual(expectedCellNameRight - 1);
+    expect(state.nameCellRight).toBeLessThanOrEqual(expectedCellNameRight + 1);
+    expect(state.actionsRight).toBeGreaterThanOrEqual(state.containerRight - 1);
+    expect(state.actionsRight).toBeLessThanOrEqual(state.containerRight + 1);
+    expect(state.nameHeaderHitColumn).toBe("name");
+    expect(state.nameCellHitColumn).toBe("name");
     expect(state.startRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
   }
+
+  const maxScrollState = states.at(-1);
+  expect(maxScrollState?.scrollLeft).toBe(maxScrollState?.maxScrollLeft);
+  expect(maxScrollState?.createdAtRight).toBeLessThanOrEqual(
+    (maxScrollState?.actionsLeft ?? 0) + 1,
+  );
 });

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -197,6 +197,16 @@ interface ScrollMetrics {
   clientWidth: number;
 }
 
+type StickyColumnPlacement = {
+  edge: "start" | "end";
+  offset: number;
+};
+
+type DataTableColumnStyle = CSSProperties & {
+  "--vt-sticky-left"?: string;
+  "--vt-sticky-right"?: string;
+};
+
 function hasHorizontalOverflow(metrics: ScrollMetrics) {
   return metrics.scrollWidth > metrics.clientWidth + 1;
 }
@@ -317,6 +327,26 @@ function resolveStickyRailWidth<T>(
   }
 
   return width;
+}
+
+function resolveStickyColumnPlacements<T>(columns: DataTableColumn<T>[], widths: ColumnWidthMap) {
+  const placements: Record<string, StickyColumnPlacement> = {};
+
+  let startOffset = 0;
+  for (const column of columns) {
+    if (resolveColumnOrderLock(column) !== "start" || !hasStickyColumnClass(column)) break;
+    placements[column.key] = { edge: "start", offset: startOffset };
+    startOffset += resolveColumnLayoutWidth(column, widths);
+  }
+
+  let endOffset = 0;
+  for (const column of [...columns].reverse()) {
+    if (resolveColumnOrderLock(column) !== "end" || !hasStickyColumnClass(column)) break;
+    placements[column.key] = { edge: "end", offset: endOffset };
+    endOffset += resolveColumnLayoutWidth(column, widths);
+  }
+
+  return placements;
 }
 
 function normalizeColumnWidths<T>(columns: DataTableColumn<T>[], widths: ColumnWidthMap) {
@@ -1974,6 +2004,10 @@ export function DataTable<T>({
     () => resolveStickyRailWidth(orderedColumns, columnWidths, "end"),
     [columnWidths, orderedColumns],
   );
+  const stickyColumnPlacements = useMemo(
+    () => resolveStickyColumnPlacements(orderedColumns, columnWidths),
+    [columnWidths, orderedColumns],
+  );
   const stickyRailBottomInset = hThumb ? 14 : 0;
   const stickyRailTop = headerHeight;
   const stickyRailHeight = Math.max(
@@ -1985,13 +2019,30 @@ export function DataTable<T>({
   const stickyEndRailLeft = Math.max(0, scrollMetrics.clientWidth - stickyEndRailWidth);
 
   const resolveColumnStyle = useCallback(
-    (column: DataTableColumn<T>): CSSProperties | undefined => {
+    (column: DataTableColumn<T>, area: "header" | "cell" = "cell"): DataTableColumnStyle => {
       const width = columnWidths[column.key];
-      if (!width) return undefined;
-      const clampedWidth = clampColumnWidth(column, width);
-      return { width: clampedWidth, minWidth: clampedWidth, maxWidth: clampedWidth };
+      const placement = naturalFlow ? undefined : stickyColumnPlacements[column.key];
+      const style: DataTableColumnStyle = {};
+
+      if (width) {
+        const clampedWidth = clampColumnWidth(column, width);
+        style.width = clampedWidth;
+        style.minWidth = clampedWidth;
+        style.maxWidth = clampedWidth;
+      }
+
+      if (placement) {
+        style.zIndex = area === "header" ? 70 : 30;
+        if (placement.edge === "start") {
+          style["--vt-sticky-left"] = `${placement.offset}px`;
+        } else {
+          style["--vt-sticky-right"] = `${placement.offset}px`;
+        }
+      }
+
+      return style;
     },
-    [columnWidths],
+    [columnWidths, naturalFlow, stickyColumnPlacements],
   );
 
   const resizePreviewOverlay =
@@ -2137,6 +2188,7 @@ export function DataTable<T>({
                   const canReorder = canUseColumnOrder && shouldAllowColumnReorder(col);
                   const isResizingThisColumn = activeResizeColumnKey === col.key;
                   const isSettledReorderColumn = settledReorderColumnKey === col.key;
+                  const stickyPlacement = naturalFlow ? undefined : stickyColumnPlacements[col.key];
                   const headerChromeClass = naturalFlow ? "bg-slate-100 dark:bg-neutral-800" : "";
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
@@ -2153,8 +2205,12 @@ export function DataTable<T>({
                       ref={(node) => {
                         headerCellsRef.current[col.key] = node;
                       }}
-                      style={resolveColumnStyle(col)}
-                      className={`group/column relative z-50 overflow-hidden px-4 py-3 whitespace-nowrap ${headerChromeClass} ${headerCornerClass} ${col.width ?? ""} ${col.headerClassName ?? ""} ${
+                      style={resolveColumnStyle(col, "header")}
+                      className={`group/column relative overflow-hidden px-4 py-3 whitespace-nowrap ${
+                        stickyPlacement?.edge === "start" ? "md:left-[var(--vt-sticky-left)]" : ""
+                      } ${
+                        stickyPlacement?.edge === "end" ? "md:right-[var(--vt-sticky-right)]" : ""
+                      } ${headerChromeClass} ${headerCornerClass} ${col.width ?? ""} ${col.headerClassName ?? ""} ${
                         activeReorderColumnKey === col.key
                           ? "cursor-grabbing bg-slate-100 text-slate-700 shadow-[inset_2px_0_0_rgba(37,99,235,0.42),inset_-2px_0_0_rgba(14,165,233,0.28)] dark:bg-neutral-800 dark:text-white/80"
                           : ""
@@ -2311,6 +2367,9 @@ export function DataTable<T>({
                           const isFirst = colIdx === 0;
                           const isLast = colIdx === orderedColumns.length - 1;
                           const isSettledReorderColumn = settledReorderColumnKey === col.key;
+                          const stickyPlacement = naturalFlow
+                            ? undefined
+                            : stickyColumnPlacements[col.key];
                           const content = col.render(row, globalIdx);
                           const overflowTooltip = resolveCellOverflowTooltip(col, row, globalIdx);
                           const roundCls = [
@@ -2326,8 +2385,16 @@ export function DataTable<T>({
                               data-vt-column-settled-cell={
                                 isSettledReorderColumn ? true : undefined
                               }
-                              style={resolveColumnStyle(col)}
+                              style={resolveColumnStyle(col, "cell")}
                               className={`overflow-hidden px-4 py-2.5 align-middle ${
+                                stickyPlacement?.edge === "start"
+                                  ? "md:left-[var(--vt-sticky-left)]"
+                                  : ""
+                              } ${
+                                stickyPlacement?.edge === "end"
+                                  ? "md:right-[var(--vt-sticky-right)]"
+                                  : ""
+                              } ${
                                 naturalFlow
                                   ? ""
                                   : "group-hover/row:bg-slate-50 dark:group-hover/row:bg-white/[0.04]"

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -53,17 +53,16 @@ const permissionCountToneClasses: Record<PermissionSummaryTone, string> = {
   violet: "bg-violet-100 text-violet-700 dark:bg-violet-500/20 dark:text-violet-200",
 };
 
-const stickySelectHeaderClass =
-  "md:sticky md:left-0 md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
-const stickySelectCellClass = "md:sticky md:left-0 md:z-30 md:bg-white md:dark:bg-neutral-950";
+const stickySelectHeaderClass = "md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
+const stickySelectCellClass = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
 const stickyNameHeaderClass =
-  "md:sticky md:left-12 md:z-40 md:border-r md:border-slate-200 md:bg-slate-100 md:dark:border-neutral-800 md:dark:bg-neutral-800";
+  "md:sticky md:z-40 md:border-r md:border-slate-200 md:bg-slate-100 md:dark:border-neutral-800 md:dark:bg-neutral-800";
 const stickyNameCellClass =
-  "font-medium md:sticky md:left-12 md:z-30 md:border-r md:border-slate-200 md:bg-white md:dark:border-neutral-800 md:dark:bg-neutral-950";
+  "font-medium md:sticky md:z-30 md:border-r md:border-slate-200 md:bg-white md:dark:border-neutral-800 md:dark:bg-neutral-950";
 const stickyActionsHeaderClass =
-  "text-center md:sticky md:right-0 md:z-40 md:border-l md:border-slate-200 md:bg-slate-100 md:dark:border-neutral-800 md:dark:bg-neutral-800";
+  "text-center md:sticky md:z-40 md:border-l md:border-slate-200 md:bg-slate-100 md:dark:border-neutral-800 md:dark:bg-neutral-800";
 const stickyActionsCellClass =
-  "md:sticky md:right-0 md:z-30 md:border-l md:border-slate-200 md:bg-white md:dark:border-neutral-800 md:dark:bg-neutral-950";
+  "md:sticky md:z-30 md:border-l md:border-slate-200 md:bg-white md:dark:border-neutral-800 md:dark:bg-neutral-950";
 
 function ApiKeyBadge({ value }: { value: string }) {
   return (

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -200,8 +200,20 @@ describe("ApiKeyColumns", () => {
     expect(nameColumn?.lockOrder).toBe("start");
     expect(actionsColumn?.lockOrder).toBe("end");
     expect(selectColumn?.headerClassName).toContain("md:sticky");
-    expect(nameColumn?.cellClassName).toContain("md:left-12");
-    expect(actionsColumn?.cellClassName).toContain("md:right-0");
+    expect(selectColumn?.cellClassName).toContain("md:sticky");
+    expect(nameColumn?.headerClassName).toContain("md:sticky");
+    expect(nameColumn?.cellClassName).toContain("md:sticky");
+    expect(actionsColumn?.headerClassName).toContain("md:sticky");
+    expect(actionsColumn?.cellClassName).toContain("md:sticky");
+    expect(`${selectColumn?.headerClassName} ${selectColumn?.cellClassName}`).not.toMatch(
+      /\bmd:(?:left|right)-/,
+    );
+    expect(`${nameColumn?.headerClassName} ${nameColumn?.cellClassName}`).not.toMatch(
+      /\bmd:(?:left|right)-/,
+    );
+    expect(`${actionsColumn?.headerClassName} ${actionsColumn?.cellClassName}`).not.toMatch(
+      /\bmd:(?:left|right)-/,
+    );
     expect(selectColumn?.headerClassName).not.toMatch(/(^|\s)sticky(\s|$)/);
     expect(nameColumn?.cellClassName).not.toMatch(/(^|\s)sticky(\s|$)/);
     expect(actionsColumn?.cellClassName).not.toMatch(/(^|\s)sticky(\s|$)/);


### PR DESCRIPTION
## Summary
- compute sticky column offsets in DataTable from the actual locked column widths
- remove hardcoded API key table sticky left/right offsets from column definitions
- expand API key table mock e2e coverage for horizontal scroll pinned columns and header/cell overlap

## Verification
- rtk bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- rtk bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- rtk bun run build
- rtk bun run lint
- rtk git diff --check