### PR TITLE
fix: remove API key sticky rail ghost borders

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -511,6 +511,12 @@ test("API Keys: fixed columns stay pinned while dragging the horizontal scrollba
     const actionsCellRect = actionsCell.getBoundingClientRect();
     const startRailRect = startRail.getBoundingClientRect();
     const endRailRect = endRail.getBoundingClientRect();
+    const startRailStyle = getComputedStyle(startRail);
+    const endRailStyle = getComputedStyle(endRail);
+    const nameHeaderStyle = getComputedStyle(nameHeader);
+    const actionsHeaderStyle = getComputedStyle(actionsHeader);
+    const nameCellStyle = getComputedStyle(nameCell);
+    const actionsCellStyle = getComputedStyle(actionsCell);
     const nameCellHit = document.elementFromPoint(
       nameCellRect.left + Math.min(24, nameCellRect.width / 2),
       nameCellRect.top + nameCellRect.height / 2,
@@ -536,6 +542,12 @@ test("API Keys: fixed columns stay pinned while dragging the horizontal scrollba
       endRailRight: endRailRect.right,
       startRailZIndex: getComputedStyle(startRail).zIndex,
       endRailZIndex: getComputedStyle(endRail).zIndex,
+      startRailBorderRightWidth: startRailStyle.borderRightWidth,
+      endRailBorderLeftWidth: endRailStyle.borderLeftWidth,
+      nameHeaderBorderRightWidth: nameHeaderStyle.borderRightWidth,
+      actionsHeaderBorderLeftWidth: actionsHeaderStyle.borderLeftWidth,
+      nameCellBorderRightWidth: nameCellStyle.borderRightWidth,
+      actionsCellBorderLeftWidth: actionsCellStyle.borderLeftWidth,
       nameCellHitColumn:
         nameCellHit?.closest<HTMLElement>("[data-vt-column-key]")?.dataset.vtColumnKey ?? null,
       actionsCellHitColumn:
@@ -554,6 +566,12 @@ test("API Keys: fixed columns stay pinned while dragging the horizontal scrollba
   expect(state.endRailRight).toBeLessThanOrEqual(state.containerRight + 1);
   expect(state.startRailZIndex).toBe("0");
   expect(state.endRailZIndex).toBe("0");
+  expect(state.startRailBorderRightWidth).toBe("0px");
+  expect(state.endRailBorderLeftWidth).toBe("0px");
+  expect(state.nameHeaderBorderRightWidth).toBe("1px");
+  expect(state.actionsHeaderBorderLeftWidth).toBe("1px");
+  expect(state.nameCellBorderRightWidth).toBe("1px");
+  expect(state.actionsCellBorderLeftWidth).toBe("1px");
   expect(state.selectHeaderLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
   expect(state.selectHeaderLeft).toBeLessThanOrEqual(state.containerLeft + 1);
   expect(state.nameHeaderLeft).toBeGreaterThanOrEqual(expectedNameLeft - 1);

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2123,7 +2123,7 @@ export function DataTable<T>({
               ref={stickyStartRailRef}
               data-vt-sticky-start-rail
               aria-hidden="true"
-              className="pointer-events-none absolute z-0 hidden border-r border-slate-200 bg-white md:block dark:border-neutral-800 dark:bg-neutral-950"
+              className="pointer-events-none absolute z-0 hidden bg-white md:block dark:bg-neutral-950"
               style={{
                 left: 0,
                 top: stickyRailTop,
@@ -2138,7 +2138,7 @@ export function DataTable<T>({
               ref={stickyEndRailRef}
               data-vt-sticky-end-rail
               aria-hidden="true"
-              className="pointer-events-none absolute z-0 hidden border-l border-slate-200 bg-white md:block dark:border-neutral-800 dark:bg-neutral-950"
+              className="pointer-events-none absolute z-0 hidden bg-white md:block dark:bg-neutral-950"
               style={{
                 left: stickyEndRailLeft,
                 top: stickyRailTop,


### PR DESCRIPTION
## Summary
- remove duplicated borders from DataTable sticky background rails
- keep real API key fixed-column boundary borders on the sticky header/cell columns
- add regression assertions for rail border widths while dragging the horizontal scrollbar

## Verification
- rtk bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- rtk bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- rtk bun run lint
- rtk bun run build
- Chrome/CDP local mock verification on /#/api-keys