### PR TITLE
fix: use official Cline icon

### DIFF
--- a/packages/assets/src/icons/cline.svg
+++ b/packages/assets/src/icons/cline.svg
@@ -1,14 +1,5 @@
-<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="128" height="128" rx="28" fill="url(#cline-bg)"/>
-  <path d="M82.5 36.5C76.9 31.8 69.7 29 61.8 29C43.9 29 29.4 43.5 29.4 61.4C29.4 79.3 43.9 93.8 61.8 93.8C70.4 93.8 78.2 90.5 84 85" stroke="white" stroke-width="13" stroke-linecap="round"/>
-  <path d="M78.5 60.5H103.5" stroke="white" stroke-width="13" stroke-linecap="round"/>
-  <path d="M91 48V73" stroke="white" stroke-width="13" stroke-linecap="round"/>
-  <circle cx="94" cy="32" r="7" fill="#D9FFF7"/>
-  <defs>
-    <linearGradient id="cline-bg" x1="16" y1="112" x2="112" y2="16" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#0F766E"/>
-      <stop offset="0.48" stop-color="#0EA5E9"/>
-      <stop offset="1" stop-color="#2563EB"/>
-    </linearGradient>
-  </defs>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Ebene_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 466.73 487.04">
+  <!-- Generator: Adobe Illustrator 29.8.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 2)  -->
+  <path d="M463.6,275.08l-29.26-58.75v-33.83c0-56.08-45.01-101.5-100.53-101.5h-50.01c3.62-7.43,5.61-15.79,5.61-24.61,0-31.17-25.08-56.39-56.07-56.39s-56.07,25.22-56.07,56.39c0,8.82,1.99,17.17,5.61,24.61h-50.01c-55.51,0-100.52,45.42-100.52,101.5v33.83l-29.87,58.59c-3.01,5.9-3.01,12.92,0,18.81l29.87,57.93v33.83c0,56.08,45.01,101.5,100.52,101.5h200.95c55.51,0,100.53-45.42,100.53-101.5v-33.83l29.21-58.13c2.9-5.79,2.9-12.61.05-18.46ZM202.75,322.96c0,25.48-20.54,46.14-45.88,46.14s-45.88-20.66-45.88-46.14v-82.02c0-25.48,20.54-46.14,45.88-46.14s45.88,20.66,45.88,46.14v82.02ZM350.58,322.96c0,25.48-20.54,46.14-45.88,46.14s-45.88-20.66-45.88-46.14v-82.02c0-25.48,20.54-46.14,45.88-46.14s45.88,20.66,45.88,46.14v82.02Z"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the hand-drawn Cline tab icon with the official Cline brand Bot SVG from https://cline.bot/brand

## Tests
- rtk bun run lint
- rtk bun run build
- rtk bun run test:ci
- Playwright visual check on /manage/#/ai-providers with mocked management APIs