### PR TITLE
fix: sync fixed columns during resize

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -352,6 +352,73 @@ test("API Keys: resize preview does not paint over the fixed action column", asy
   await page.mouse.up();
 });
 
+test("API Keys: fixed start boundary follows the name column while resizing", async ({ page }) => {
+  await page.setViewportSize({ width: 2048, height: 1180 });
+  await setAuthed(page);
+  await mockApiKeysApis(page);
+
+  await page.goto("/#/api-keys");
+  await page.locator('td[data-vt-column-key="name"]').first().waitFor({ state: "visible" });
+
+  const header = page.locator('th[data-vt-column-key="name"]');
+  const dragStart = await header.locator("[data-vt-column-resizer]").evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const headerRect = element.closest("th")?.getBoundingClientRect();
+    return {
+      x: headerRect ? Math.min(rect.left + rect.width / 2, headerRect.right - 2) : rect.left,
+      y: rect.top + rect.height / 2,
+    };
+  });
+
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.mouse.move(dragStart.x + 238, dragStart.y, { steps: 12 });
+  await page.locator("[data-vt-column-resize-preview-line]").waitFor({ state: "visible" });
+
+  const state = await page.evaluate(() => {
+    const nameHeader = document.querySelector<HTMLElement>('th[data-vt-column-key="name"]');
+    const nameCell = document.querySelector<HTMLElement>('td[data-vt-column-key="name"]');
+    const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
+    const startBoundary = document.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
+    const previewLine = document.querySelector<HTMLElement>("[data-vt-column-resize-preview-line]");
+    if (!nameHeader || !nameCell || !startRail || !startBoundary || !previewLine) {
+      throw new Error("Missing fixed-column resize geometry");
+    }
+
+    const nameHeaderRect = nameHeader.getBoundingClientRect();
+    const nameCellRect = nameCell.getBoundingClientRect();
+    const startRailRect = startRail.getBoundingClientRect();
+    const startBoundaryRect = startBoundary.getBoundingClientRect();
+    const previewRect = previewLine.getBoundingClientRect();
+
+    return {
+      nameHeaderRight: nameHeaderRect.right,
+      nameHeaderWidth: nameHeaderRect.width,
+      nameCellRight: nameCellRect.right,
+      nameCellWidth: nameCellRect.width,
+      startRailRight: startRailRect.right,
+      startBoundaryLeft: startBoundaryRect.left,
+      startBoundaryRight: startBoundaryRect.right,
+      previewCenter: previewRect.left + previewRect.width / 2,
+      previewDisplay: getComputedStyle(previewLine).display,
+    };
+  });
+
+  await page.mouse.up();
+
+  expect(state.previewDisplay).not.toBe("none");
+  expect(state.nameHeaderWidth).toBeGreaterThanOrEqual(356);
+  expect(state.nameCellWidth).toBeGreaterThanOrEqual(356);
+  expect(state.nameHeaderRight).toBeGreaterThanOrEqual(state.previewCenter - 2);
+  expect(state.nameHeaderRight).toBeLessThanOrEqual(state.previewCenter + 2);
+  expect(state.nameCellRight).toBeGreaterThanOrEqual(state.previewCenter - 2);
+  expect(state.nameCellRight).toBeLessThanOrEqual(state.previewCenter + 2);
+  expect(state.startRailRight).toBeGreaterThanOrEqual(state.nameCellRight - 1);
+  expect(state.startRailRight).toBeLessThanOrEqual(state.nameCellRight + 1);
+  expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(state.nameCellRight - 2);
+  expect(state.startBoundaryRight).toBeLessThanOrEqual(state.nameCellRight + 1);
+});
+
 test("API Keys: fixed columns do not cover the created time at the right edge", async ({
   page,
 }) => {

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -1216,6 +1216,52 @@ export function DataTable<T>({
     col.style.maxWidth = widthPx;
   }, []);
 
+  const applyStickyLayoutToDom = useCallback(
+    (widths: ColumnWidthMap) => {
+      if (naturalFlow) return;
+
+      const columns = orderedColumnsRef.current;
+      const startWidth = resolveStickyRailWidth(columns, widths, "start");
+      const endWidth = resolveStickyRailWidth(columns, widths, "end");
+      stickyRailWidthsRef.current = { start: startWidth, end: endWidth };
+
+      const root = rootRef.current;
+      if (!root) return;
+
+      const clientWidth = scrollMetricsRef.current.clientWidth;
+      const startRail = root.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
+      if (startRail) startRail.style.width = `${startWidth}px`;
+
+      const endRail = root.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
+      if (endRail) {
+        endRail.style.left = `${Math.max(0, clientWidth - endWidth)}px`;
+        endRail.style.width = `${endWidth}px`;
+      }
+
+      const startBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
+      if (startBoundary) startBoundary.style.left = `${Math.max(0, startWidth - 1)}px`;
+
+      const endBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-end-boundary]");
+      if (endBoundary) endBoundary.style.left = `${Math.max(0, clientWidth - endWidth)}px`;
+
+      const placements = resolveStickyColumnPlacements(columns, widths);
+      root.querySelectorAll<HTMLElement>("[data-vt-column-key]").forEach((element) => {
+        const key = element.dataset.vtColumnKey;
+        const placement = key ? placements[key] : undefined;
+        if (!placement) return;
+
+        if (placement.edge === "start") {
+          element.style.setProperty("--vt-sticky-left", `${placement.offset}px`);
+          element.style.removeProperty("--vt-sticky-right");
+        } else {
+          element.style.setProperty("--vt-sticky-right", `${placement.offset}px`);
+          element.style.removeProperty("--vt-sticky-left");
+        }
+      });
+    },
+    [naturalFlow],
+  );
+
   const applyPendingColumnResize = useCallback(() => {
     columnResizeRafRef.current = null;
     const active = columnResizeRef.current;
@@ -1227,7 +1273,10 @@ export function DataTable<T>({
     const roundedWidth = resolveColumnResizeWidth(active, pointer.clientX);
 
     active.currentWidth = roundedWidth;
+    const nextWidths = { ...columnWidthsRef.current, [active.columnKey]: roundedWidth };
+    columnWidthsRef.current = nextWidths;
     applyColumnWidthToDom(active.columnKey, roundedWidth);
+    applyStickyLayoutToDom(nextWidths);
     const preview = {
       ...(buildColumnResizePreview(active, pointer.clientX, pointer.clientY) ?? {
         width: roundedWidth,
@@ -1267,6 +1316,7 @@ export function DataTable<T>({
   }, [
     applyColumnResizePreview,
     applyColumnWidthToDom,
+    applyStickyLayoutToDom,
     buildColumnResizePreview,
     scheduleScrollMetricsUpdate,
     tableId,
@@ -1339,12 +1389,14 @@ export function DataTable<T>({
         maxWidth,
         previewTop: Math.max(0, containerRect?.top ?? rect.top),
         previewBottom: Math.max(0, containerRect?.bottom ?? rect.bottom),
-        previewMinClientX: containerRect && !naturalFlow && railWidths.start > 0
-          ? containerRect.left + railWidths.start
-          : Number.NEGATIVE_INFINITY,
-        previewMaxClientX: containerRect && !naturalFlow && railWidths.end > 0
-          ? containerRect.right - railWidths.end
-          : Number.POSITIVE_INFINITY,
+        previewMinClientX:
+          containerRect && !naturalFlow && railWidths.start > 0
+            ? containerRect.left + railWidths.start
+            : Number.NEGATIVE_INFINITY,
+        previewMaxClientX:
+          containerRect && !naturalFlow && railWidths.end > 0
+            ? containerRect.right - railWidths.end
+            : Number.POSITIVE_INFINITY,
         currentWidth: nextStartWidth,
         lastDebugAtMs: 0,
         debugEnabled: shouldDebugColumnResize(),
@@ -1355,6 +1407,7 @@ export function DataTable<T>({
       document.body.style.userSelect = "none";
       setActiveResizeColumnKey(column.key);
       applyColumnWidthToDom(column.key, nextStartWidth);
+      applyStickyLayoutToDom({ ...columnWidthsRef.current, [column.key]: nextStartWidth });
       pendingColumnResizePointerRef.current = null;
       const preview = buildColumnResizePreview(resizeState, e.clientX, e.clientY);
       setResizePreview(preview);
@@ -1373,7 +1426,7 @@ export function DataTable<T>({
         });
       }
     },
-    [applyColumnWidthToDom, buildColumnResizePreview, naturalFlow, tableId],
+    [applyColumnWidthToDom, applyStickyLayoutToDom, buildColumnResizePreview, naturalFlow, tableId],
   );
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- sync sticky rail, boundary, and sticky offsets during column resize frames
- add API Keys e2e coverage for resizing the fixed name column without releasing the pointer

## Tests
- rtk bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- rtk bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- rtk bun run lint (0 errors; existing warnings in ChannelGroupsPage.tsx and updateShared.ts)
- rtk bun run build