### PR TITLE
fix: round fixed table header bottom corners

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -475,7 +475,9 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       endBoundaryBottom: number;
       fixedRailBottom: number;
       selectHeaderTopLeftRadius: number;
+      selectHeaderBottomLeftRadius: number;
       actionsHeaderTopRightRadius: number;
+      actionsHeaderBottomRightRadius: number;
     }> = [];
     for (const scrollLeft of positions) {
       container.scrollLeft = scrollLeft;
@@ -569,7 +571,11 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
         endBoundaryBottom: endBoundaryRect.bottom,
         fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
         selectHeaderTopLeftRadius: Number.parseFloat(selectHeaderStyle.borderTopLeftRadius),
+        selectHeaderBottomLeftRadius: Number.parseFloat(selectHeaderStyle.borderBottomLeftRadius),
         actionsHeaderTopRightRadius: Number.parseFloat(actionsHeaderStyle.borderTopRightRadius),
+        actionsHeaderBottomRightRadius: Number.parseFloat(
+          actionsHeaderStyle.borderBottomRightRadius,
+        ),
       });
     }
 
@@ -615,7 +621,9 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
     expect(state.startBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.endBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.selectHeaderTopLeftRadius).toBeGreaterThan(0);
+    expect(state.selectHeaderBottomLeftRadius).toBeGreaterThan(0);
     expect(state.actionsHeaderTopRightRadius).toBeGreaterThan(0);
+    expect(state.actionsHeaderBottomRightRadius).toBeGreaterThan(0);
   }
 
   const maxScrollState = states.at(-1);

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2259,9 +2259,9 @@ export function DataTable<T>({
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
                     naturalFlow && colIndex === orderedColumns.length - 1 ? "rounded-r-xl" : "",
-                    !naturalFlow && colIndex === 0 ? "rounded-tl-xl" : "",
+                    !naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
                     !naturalFlow && !vThumb && colIndex === orderedColumns.length - 1
-                      ? "rounded-tr-xl"
+                      ? "rounded-r-xl"
                       : "",
                   ]
                     .filter(Boolean)


### PR DESCRIPTION
## Summary
- round fixed DataTable header edge cells on the full left/right side so the bottom outer corners do not turn square
- add API Keys e2e coverage for fixed header bottom-left and bottom-right radii across horizontal scroll positions

## Tests
- bun run e2e e2e/api-keys-table.spec.ts --project=chromium --grep "fixed columns do not cover" (failed before the fix, passed after)
- bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- bun run lint
- bun run build