### PR TITLE
fix: soften fixed column edges

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 const API_KEYS_COLUMN_WIDTH_STORAGE_KEY = "codeProxy.dataTable.columnWidths.v1.api-keys";
+const STICKY_EDGE_SHADOW_WIDTH = 28;
 
 type SetAuthedOptions = {
   columnWidths?: Record<string, number>;
@@ -399,6 +400,7 @@ test("API Keys: fixed start boundary follows the name column while resizing", as
       startRailRight: startRailRect.right,
       startBoundaryLeft: startBoundaryRect.left,
       startBoundaryRight: startBoundaryRect.right,
+      startBoundaryWidth: startBoundaryRect.width,
       previewCenter: previewRect.left + previewRect.width / 2,
       previewDisplay: getComputedStyle(previewLine).display,
     };
@@ -415,8 +417,16 @@ test("API Keys: fixed start boundary follows the name column while resizing", as
   expect(state.nameCellRight).toBeLessThanOrEqual(state.previewCenter + 2);
   expect(state.startRailRight).toBeGreaterThanOrEqual(state.nameCellRight - 1);
   expect(state.startRailRight).toBeLessThanOrEqual(state.nameCellRight + 1);
-  expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(state.nameCellRight - 2);
-  expect(state.startBoundaryRight).toBeLessThanOrEqual(state.nameCellRight + 1);
+  expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(state.nameCellRight - 1);
+  expect(state.startBoundaryLeft).toBeLessThanOrEqual(state.nameCellRight + 1);
+  expect(state.startBoundaryRight).toBeGreaterThanOrEqual(
+    state.nameCellRight + STICKY_EDGE_SHADOW_WIDTH - 1,
+  );
+  expect(state.startBoundaryRight).toBeLessThanOrEqual(
+    state.nameCellRight + STICKY_EDGE_SHADOW_WIDTH + 1,
+  );
+  expect(state.startBoundaryWidth).toBeGreaterThanOrEqual(STICKY_EDGE_SHADOW_WIDTH - 1);
+  expect(state.startBoundaryWidth).toBeLessThanOrEqual(STICKY_EDGE_SHADOW_WIDTH + 1);
 });
 
 test("API Keys: fixed columns do not cover the created time at the right edge", async ({
@@ -468,11 +478,15 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       startBoundaryLeft: number;
       startBoundaryRight: number;
       startBoundaryBottom: number;
+      startBoundaryWidth: string;
+      startBoundaryOpacity: string;
       endRailRight: number;
       endRailBottom: number;
       endBoundaryLeft: number;
       endBoundaryRight: number;
       endBoundaryBottom: number;
+      endBoundaryWidth: string;
+      endBoundaryOpacity: string;
       fixedRailBottom: number;
       selectHeaderTopLeftRadius: number;
       selectHeaderBottomLeftRadius: number;
@@ -564,11 +578,15 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
         startBoundaryLeft: startBoundaryRect.left,
         startBoundaryRight: startBoundaryRect.right,
         startBoundaryBottom: startBoundaryRect.bottom,
+        startBoundaryWidth: startBoundary.style.width,
+        startBoundaryOpacity: startBoundary.style.opacity,
         endRailRight: endRailRect.right,
         endRailBottom: endRailRect.bottom,
         endBoundaryLeft: endBoundaryRect.left,
         endBoundaryRight: endBoundaryRect.right,
         endBoundaryBottom: endBoundaryRect.bottom,
+        endBoundaryWidth: endBoundary.style.width,
+        endBoundaryOpacity: endBoundary.style.opacity,
         fixedRailBottom: containerRect.bottom - horizontalScrollbarInset,
         selectHeaderTopLeftRadius: Number.parseFloat(selectHeaderStyle.borderTopLeftRadius),
         selectHeaderBottomLeftRadius: Number.parseFloat(selectHeaderStyle.borderBottomLeftRadius),
@@ -592,12 +610,24 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
     expect(state.startRailLeft).toBeLessThanOrEqual(state.containerLeft + 1);
     expect(state.endRailRight).toBeGreaterThanOrEqual(state.containerRight - 1);
     expect(state.endRailRight).toBeLessThanOrEqual(state.containerRight + 1);
-    expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(expectedHeaderNameRight - 2);
-    expect(state.startBoundaryRight).toBeLessThanOrEqual(expectedHeaderNameRight + 1);
-    expect(state.endBoundaryLeft).toBeGreaterThanOrEqual(state.actionsLeft - 1);
-    expect(state.endBoundaryLeft).toBeLessThanOrEqual(state.actionsLeft + 1);
-    expect(state.endBoundaryRight).toBeGreaterThanOrEqual(state.actionsLeft);
-    expect(state.endBoundaryRight).toBeLessThanOrEqual(state.actionsLeft + 2);
+    expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(expectedHeaderNameRight - 1);
+    expect(state.startBoundaryLeft).toBeLessThanOrEqual(expectedHeaderNameRight + 1);
+    expect(state.startBoundaryRight).toBeGreaterThanOrEqual(
+      expectedHeaderNameRight + STICKY_EDGE_SHADOW_WIDTH - 1,
+    );
+    expect(state.startBoundaryRight).toBeLessThanOrEqual(
+      expectedHeaderNameRight + STICKY_EDGE_SHADOW_WIDTH + 1,
+    );
+    expect(state.startBoundaryWidth).toBe(`${STICKY_EDGE_SHADOW_WIDTH}px`);
+    expect(state.endBoundaryLeft).toBeGreaterThanOrEqual(
+      state.actionsLeft - STICKY_EDGE_SHADOW_WIDTH - 1,
+    );
+    expect(state.endBoundaryLeft).toBeLessThanOrEqual(
+      state.actionsLeft - STICKY_EDGE_SHADOW_WIDTH + 1,
+    );
+    expect(state.endBoundaryRight).toBeGreaterThanOrEqual(state.actionsLeft - 1);
+    expect(state.endBoundaryRight).toBeLessThanOrEqual(state.actionsLeft + 1);
+    expect(state.endBoundaryWidth).toBe(`${STICKY_EDGE_SHADOW_WIDTH}px`);
     expect(state.selectHeaderLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
     expect(state.selectHeaderLeft).toBeLessThanOrEqual(state.containerLeft + 1);
     expect(state.nameHeaderLeft).toBeGreaterThanOrEqual(expectedHeaderNameLeft - 1);
@@ -627,6 +657,12 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
   }
 
   const maxScrollState = states.at(-1);
+  expect(states[0]?.startBoundaryOpacity).toBe("0");
+  expect(states[0]?.endBoundaryOpacity).toBe("1");
+  expect(states[1]?.startBoundaryOpacity).toBe("1");
+  expect(states[1]?.endBoundaryOpacity).toBe("1");
+  expect(maxScrollState?.startBoundaryOpacity).toBe("1");
+  expect(maxScrollState?.endBoundaryOpacity).toBe("0");
   expect(maxScrollState?.scrollLeft).toBe(maxScrollState?.maxScrollLeft);
   expect(maxScrollState?.createdAtRight).toBeLessThanOrEqual(
     (maxScrollState?.actionsLeft ?? 0) + 1,
@@ -740,7 +776,9 @@ test("API Keys: fixed columns stay pinned while dragging the horizontal scrollba
       startRailBorderRightWidth: startRailStyle.borderRightWidth,
       endRailBorderLeftWidth: endRailStyle.borderLeftWidth,
       startBoundaryWidth: startBoundaryStyle.width,
+      startBoundaryOpacity: startBoundary.style.opacity,
       endBoundaryWidth: endBoundaryStyle.width,
+      endBoundaryOpacity: endBoundary.style.opacity,
       nameHeaderBorderRightWidth: nameHeaderStyle.borderRightWidth,
       actionsHeaderBorderLeftWidth: actionsHeaderStyle.borderLeftWidth,
       nameCellBorderRightWidth: nameCellStyle.borderRightWidth,
@@ -761,24 +799,36 @@ test("API Keys: fixed columns stay pinned while dragging the horizontal scrollba
   expect(state.startRailLeft).toBeLessThanOrEqual(state.containerLeft + 1);
   expect(state.endRailRight).toBeGreaterThanOrEqual(state.containerRight - 1);
   expect(state.endRailRight).toBeLessThanOrEqual(state.containerRight + 1);
-  expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(state.nameCellRight - 2);
-  expect(state.startBoundaryRight).toBeLessThanOrEqual(state.nameCellRight + 1);
-  expect(state.endBoundaryLeft).toBeGreaterThanOrEqual(state.actionsCellLeft - 1);
-  expect(state.endBoundaryLeft).toBeLessThanOrEqual(state.actionsCellLeft + 1);
-  expect(state.endBoundaryRight).toBeGreaterThanOrEqual(state.actionsCellLeft);
-  expect(state.endBoundaryRight).toBeLessThanOrEqual(state.actionsCellLeft + 2);
+  expect(state.startBoundaryLeft).toBeGreaterThanOrEqual(state.nameCellRight - 1);
+  expect(state.startBoundaryLeft).toBeLessThanOrEqual(state.nameCellRight + 1);
+  expect(state.startBoundaryRight).toBeGreaterThanOrEqual(
+    state.nameCellRight + STICKY_EDGE_SHADOW_WIDTH - 1,
+  );
+  expect(state.startBoundaryRight).toBeLessThanOrEqual(
+    state.nameCellRight + STICKY_EDGE_SHADOW_WIDTH + 1,
+  );
+  expect(state.endBoundaryLeft).toBeGreaterThanOrEqual(
+    state.actionsCellLeft - STICKY_EDGE_SHADOW_WIDTH - 1,
+  );
+  expect(state.endBoundaryLeft).toBeLessThanOrEqual(
+    state.actionsCellLeft - STICKY_EDGE_SHADOW_WIDTH + 1,
+  );
+  expect(state.endBoundaryRight).toBeGreaterThanOrEqual(state.actionsCellLeft - 1);
+  expect(state.endBoundaryRight).toBeLessThanOrEqual(state.actionsCellLeft + 1);
   expect(state.startRailZIndex).toBe("0");
   expect(state.endRailZIndex).toBe("0");
   expect(state.startRailTransform).toBe("none");
   expect(state.endRailTransform).toBe("none");
   expect(state.startRailBorderRightWidth).toBe("0px");
   expect(state.endRailBorderLeftWidth).toBe("0px");
-  expect(state.startBoundaryWidth).toBe("1px");
-  expect(state.endBoundaryWidth).toBe("1px");
-  expect(state.nameHeaderBorderRightWidth).toBe("1px");
-  expect(state.actionsHeaderBorderLeftWidth).toBe("1px");
-  expect(state.nameCellBorderRightWidth).toBe("1px");
-  expect(state.actionsCellBorderLeftWidth).toBe("1px");
+  expect(state.startBoundaryWidth).toBe(`${STICKY_EDGE_SHADOW_WIDTH}px`);
+  expect(state.endBoundaryWidth).toBe(`${STICKY_EDGE_SHADOW_WIDTH}px`);
+  expect(state.startBoundaryOpacity).toBe("1");
+  expect(state.endBoundaryOpacity).toBe("1");
+  expect(state.nameHeaderBorderRightWidth).toBe("0px");
+  expect(state.actionsHeaderBorderLeftWidth).toBe("0px");
+  expect(state.nameCellBorderRightWidth).toBe("0px");
+  expect(state.actionsCellBorderLeftWidth).toBe("0px");
   expect(state.selectHeaderLeft).toBeGreaterThanOrEqual(state.containerLeft - 1);
   expect(state.selectHeaderLeft).toBeLessThanOrEqual(state.containerLeft + 1);
   expect(state.nameHeaderLeft).toBeGreaterThanOrEqual(expectedNameLeft - 1);

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -117,6 +117,14 @@ const COLUMN_RESIZE_DEBUG_STORAGE_KEY = "codeProxy.dataTable.debugResize";
 const DEFAULT_MIN_COLUMN_WIDTH = 72;
 const DEFAULT_MAX_COLUMN_WIDTH = 640;
 const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
+const STICKY_EDGE_SHADOW_WIDTH = 28;
+
+function getStickyEdgeShadowOpacity(metrics: ScrollMetrics, edge: "start" | "end") {
+  const maxScrollLeft = Math.max(0, metrics.scrollWidth - metrics.clientWidth);
+  if (maxScrollLeft <= 1) return 0;
+  if (edge === "start") return metrics.scrollLeft > 1 ? 1 : 0;
+  return metrics.scrollLeft < maxScrollLeft - 1 ? 1 : 0;
+}
 const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
 const TAILWIND_SPACING_UNIT_PX = 4;
 
@@ -838,6 +846,25 @@ export function DataTable<T>({
     [],
   );
 
+  const syncStickyEdgeShadows = useCallback(
+    (metrics: ScrollMetrics) => {
+      if (naturalFlow) return;
+      const root = rootRef.current;
+      if (!root) return;
+
+      const startBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
+      if (startBoundary) {
+        startBoundary.style.opacity = String(getStickyEdgeShadowOpacity(metrics, "start"));
+      }
+
+      const endBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-end-boundary]");
+      if (endBoundary) {
+        endBoundary.style.opacity = String(getStickyEdgeShadowOpacity(metrics, "end"));
+      }
+    },
+    [naturalFlow],
+  );
+
   const updateScrollMetrics = useCallback(
     (options?: { forceState?: boolean }) => {
       const el = containerRef.current;
@@ -858,6 +885,7 @@ export function DataTable<T>({
       };
 
       syncScrollbarThumbs(next);
+      syncStickyEdgeShadows(next);
       scrollMetricsRef.current = next;
 
       setScrollMetrics((prev) => {
@@ -881,7 +909,7 @@ export function DataTable<T>({
         return next;
       });
     },
-    [syncScrollbarThumbs],
+    [syncScrollbarThumbs, syncStickyEdgeShadows],
   );
 
   const scheduleScrollMetricsUpdate = useCallback(() => {
@@ -1239,10 +1267,20 @@ export function DataTable<T>({
       }
 
       const startBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
-      if (startBoundary) startBoundary.style.left = `${Math.max(0, startWidth - 1)}px`;
+      if (startBoundary) {
+        startBoundary.style.left = `${Math.max(0, startWidth)}px`;
+        startBoundary.style.width = `${STICKY_EDGE_SHADOW_WIDTH}px`;
+      }
 
       const endBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-end-boundary]");
-      if (endBoundary) endBoundary.style.left = `${Math.max(0, clientWidth - endWidth)}px`;
+      if (endBoundary) {
+        endBoundary.style.left = `${Math.max(
+          0,
+          clientWidth - endWidth - STICKY_EDGE_SHADOW_WIDTH,
+        )}px`;
+        endBoundary.style.width = `${STICKY_EDGE_SHADOW_WIDTH}px`;
+      }
+      syncStickyEdgeShadows(scrollMetricsRef.current);
 
       const placements = resolveStickyColumnPlacements(columns, widths);
       root.querySelectorAll<HTMLElement>("[data-vt-column-key]").forEach((element) => {
@@ -1259,7 +1297,7 @@ export function DataTable<T>({
         }
       });
     },
-    [naturalFlow],
+    [naturalFlow, syncStickyEdgeShadows],
   );
 
   const applyPendingColumnResize = useCallback(() => {
@@ -2082,8 +2120,13 @@ export function DataTable<T>({
     scrollMetrics.clientHeight - headerHeight - stickyRailBottomInset,
   );
   const stickyBoundaryHeight = Math.max(0, scrollMetrics.clientHeight - stickyRailBottomInset);
-  const stickyStartBoundaryLeft = Math.max(0, stickyStartRailWidth - 1);
-  const stickyEndBoundaryLeft = Math.max(0, scrollMetrics.clientWidth - stickyEndRailWidth);
+  const stickyStartShadowOpacity = getStickyEdgeShadowOpacity(scrollMetrics, "start");
+  const stickyEndShadowOpacity = getStickyEdgeShadowOpacity(scrollMetrics, "end");
+  const stickyStartBoundaryLeft = Math.max(0, stickyStartRailWidth);
+  const stickyEndBoundaryLeft = Math.max(
+    0,
+    scrollMetrics.clientWidth - stickyEndRailWidth - STICKY_EDGE_SHADOW_WIDTH,
+  );
   const stickyEndRailLeft = Math.max(0, scrollMetrics.clientWidth - stickyEndRailWidth);
 
   const resolveColumnStyle = useCallback(
@@ -2523,10 +2566,12 @@ export function DataTable<T>({
         <div
           data-vt-sticky-start-boundary
           aria-hidden="true"
-          className="pointer-events-none absolute top-0 z-[35] hidden w-px bg-slate-200 md:block dark:bg-neutral-800"
+          className="pointer-events-none absolute top-0 z-[75] hidden bg-gradient-to-r from-slate-950/[0.07] to-transparent transition-opacity duration-150 md:block dark:from-black/35"
           style={{
             left: stickyStartBoundaryLeft,
+            width: STICKY_EDGE_SHADOW_WIDTH,
             height: stickyBoundaryHeight,
+            opacity: stickyStartShadowOpacity,
           }}
         />
       ) : null}
@@ -2534,10 +2579,12 @@ export function DataTable<T>({
         <div
           data-vt-sticky-end-boundary
           aria-hidden="true"
-          className="pointer-events-none absolute top-0 z-[35] hidden w-px bg-slate-200 md:block dark:bg-neutral-800"
+          className="pointer-events-none absolute top-0 z-[75] hidden bg-gradient-to-l from-slate-950/[0.07] to-transparent transition-opacity duration-150 md:block dark:from-black/35"
           style={{
             left: stickyEndBoundaryLeft,
+            width: STICKY_EDGE_SHADOW_WIDTH,
             height: stickyBoundaryHeight,
+            opacity: stickyEndShadowOpacity,
           }}
         />
       ) : null}

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -56,13 +56,13 @@ const permissionCountToneClasses: Record<PermissionSummaryTone, string> = {
 const stickySelectHeaderClass = "md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
 const stickySelectCellClass = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
 const stickyNameHeaderClass =
-  "md:sticky md:z-40 md:border-r md:border-slate-200 md:bg-slate-100 md:dark:border-neutral-800 md:dark:bg-neutral-800";
+  "md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
 const stickyNameCellClass =
-  "font-medium md:sticky md:z-30 md:border-r md:border-slate-200 md:bg-white md:dark:border-neutral-800 md:dark:bg-neutral-950";
+  "font-medium md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
 const stickyActionsHeaderClass =
-  "text-center md:sticky md:z-40 md:border-l md:border-slate-200 md:bg-slate-100 md:dark:border-neutral-800 md:dark:bg-neutral-800";
+  "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
 const stickyActionsCellClass =
-  "md:sticky md:z-30 md:border-l md:border-slate-200 md:bg-white md:dark:border-neutral-800 md:dark:bg-neutral-950";
+  "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
 
 function ApiKeyBadge({ value }: { value: string }) {
   return (

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -214,6 +214,17 @@ describe("ApiKeyColumns", () => {
     expect(`${actionsColumn?.headerClassName} ${actionsColumn?.cellClassName}`).not.toMatch(
       /\bmd:(?:left|right)-/,
     );
+    const fixedColumnClassNames = [
+      selectColumn?.headerClassName,
+      selectColumn?.cellClassName,
+      nameColumn?.headerClassName,
+      nameColumn?.cellClassName,
+      actionsColumn?.headerClassName,
+      actionsColumn?.cellClassName,
+    ].join(" ");
+    expect(fixedColumnClassNames).not.toMatch(/\bmd:border-[lr]\b/);
+    expect(fixedColumnClassNames).not.toContain("md:border-slate-200");
+    expect(fixedColumnClassNames).not.toContain("md:dark:border-neutral-800");
     expect(selectColumn?.headerClassName).not.toMatch(/(^|\s)sticky(\s|$)/);
     expect(nameColumn?.cellClassName).not.toMatch(/(^|\s)sticky(\s|$)/);
     expect(actionsColumn?.cellClassName).not.toMatch(/(^|\s)sticky(\s|$)/);


### PR DESCRIPTION
## Summary
- Replace hard fixed-column divider lines with soft 28px fading edge shadows in the shared DataTable.
- Sync sticky edge shadow visibility during horizontal scroll without forcing scroll rerenders.
- Remove API Keys fixed-column hard border classes and cover the behavior with unit/e2e tests.

## Verification
- bun run test pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
- bun run e2e e2e/api-keys-table.spec.ts --project=chromium
- bun run lint
- bun run build
- bun run boundary:imports
- bun run bundle:diff