### PR TITLE
fix: fill more management page heights

### DIFF
--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -345,6 +345,7 @@ function renderChannelTags(tags: string[]) {
 }
 
 export function RoutingConfigEditor({
+  title,
   values,
   disabled,
   availableChannels,
@@ -354,6 +355,7 @@ export function RoutingConfigEditor({
   loadModelsForChannels,
   onChange,
 }: {
+  title?: string;
   values: VisualConfigValues;
   disabled?: boolean;
   availableChannels: string[];
@@ -1491,8 +1493,13 @@ export function RoutingConfigEditor({
 
   return (
     <>
-      <div className="space-y-3">
-        <div className="flex flex-wrap justify-end gap-3">
+      <div className="space-y-3 md:flex md:min-h-0 md:flex-1 md:flex-col">
+        <div className="flex flex-wrap items-center justify-between gap-3 md:shrink-0">
+          {title ? (
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h3>
+          ) : (
+            <span aria-hidden="true" />
+          )}
           <Button variant="primary" size="sm" onClick={openCreateGroup} disabled={disabled}>
             <Plus size={14} />
             {t("channel_groups_page.add_group")}
@@ -1506,7 +1513,8 @@ export function RoutingConfigEditor({
           rowKey={(group) => group.id}
           virtualize={false}
           rowHeight={44}
-          height="h-[calc(100dvh-200px)]"
+          height="h-[calc(100dvh-200px)] md:h-auto md:flex-1"
+          minHeight="min-h-[320px] md:min-h-0"
           minWidth="min-w-[1360px]"
           caption={t("channel_groups_page.table_group")}
           emptyText={t("channel_groups_page.empty_groups")}

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -378,6 +378,8 @@ export function ApiKeyPermissionsPage() {
   return (
     <div className="space-y-6">
       <Card
+        className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
+        bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
         title={t("api_key_permissions_page.title")}
         description={t("api_key_permissions_page.description")}
         actions={
@@ -414,7 +416,8 @@ export function ApiKeyPermissionsPage() {
             loading={loading}
             virtualize={false}
             minWidth="min-w-[1120px]"
-            height="h-auto max-h-[calc(100dvh-280px)]"
+            height="h-[calc(100dvh-260px)] md:h-auto md:flex-1"
+            minHeight="min-h-[320px] md:min-h-0"
             emptyText={t("api_key_permissions_page.empty_title")}
             caption={t("api_key_permissions_page.table_caption")}
             showAllLoadedMessage={false}

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -305,8 +305,8 @@ export function CcSwitchImportSettingsPage() {
   const importBaseUrl = auth?.state.apiBase || detectApiBaseFromLocation();
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className="space-y-6 md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col">
+      <div className="flex flex-wrap items-start justify-between gap-3 md:shrink-0">
         <div className="space-y-1">
           <h2 className="text-lg font-semibold tracking-normal text-slate-950 dark:text-white">
             {t("ccswitch.settings_title")}
@@ -333,7 +333,8 @@ export function CcSwitchImportSettingsPage() {
         title={t("ccswitch.config_table_title")}
         description={t("ccswitch.config_table_description", { count: configs.length })}
         padding="compact"
-        className="rounded-2xl"
+        className="rounded-2xl md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
+        bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
       >
         <DataTable<CcSwitchImportConfigListItem>
           tableId="ccswitch-import-configs"
@@ -342,8 +343,8 @@ export function CcSwitchImportSettingsPage() {
           rowKey={(row) => row.id}
           virtualize={false}
           minWidth="min-w-[1100px]"
-          height="h-[420px]"
-          minHeight="min-h-[280px]"
+          height="h-[420px] md:h-auto md:flex-1"
+          minHeight="min-h-[280px] md:min-h-0"
           caption={t("ccswitch.config_table_caption")}
           emptyText={t("ccswitch.config_list_empty")}
           showAllLoadedMessage={false}

--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -437,16 +437,28 @@ export function ChannelGroupsPage() {
   );
 
   return (
-    <div className="space-y-4 overflow-x-hidden">
-      <Card title={t("channel_groups_page.title")} loading={loading}>
+    <div className="space-y-4 overflow-x-hidden md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col">
+      <Card
+        className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
+        bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
+        loading={loading}
+      >
         {error ? (
           <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900 dark:border-rose-400/25 dark:bg-rose-500/15 dark:text-white">
             {error}
           </div>
         ) : null}
 
-        <div className={error ? "mt-4 space-y-4" : "space-y-4"}>
+        <div
+          className={[
+            error ? "mt-4" : null,
+            "space-y-4 md:flex md:min-h-0 md:flex-1 md:flex-col",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
           <RoutingConfigEditor
+            title={t("channel_groups_page.title")}
             values={visualValues}
             disabled={loading || saving}
             availableChannels={availableChannels}


### PR DESCRIPTION
## Summary
- make api-key permissions and CC Switch import settings tables fill the large-screen content height
- make channel groups fill the same content height and place the add-group action on the title row
- keep existing DataTable behavior and table configuration intact

## Verification
- bun run --filter @code-proxy/admin-panel test pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
- bun run --filter @code-proxy/admin-panel build
- Playwright DOM measurement at 2048x1180 with mocked management API