### PR TITLE
fix: fill management page heights

### DIFF
--- a/pages/logs/LogsPage.tsx
+++ b/pages/logs/LogsPage.tsx
@@ -293,14 +293,14 @@ export function LogsPage() {
   }, [latestTimestamp]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:space-y-0 md:gap-4 md:overflow-hidden">
       <Tabs value={tab} onValueChange={(next) => setTab(next as typeof tab)}>
-        <TabsList>
+        <TabsList className="md:shrink-0">
           <TabsTrigger value="content">{t("logs_page.log_content")}</TabsTrigger>
           <TabsTrigger value="errors">{t("logs_page.error_logs")}</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="content">
+        <TabsContent value="content" className="md:flex md:min-h-0 md:flex-1">
           <LiveLogsTab
             t={t}
             loading={loading}
@@ -341,7 +341,7 @@ export function LogsPage() {
           />
         </TabsContent>
 
-        <TabsContent value="errors">
+        <TabsContent value="errors" className="md:flex md:min-h-0 md:flex-1">
           <ErrorLogsTab
             t={t}
             errorLogsLoading={errorLogsLoading}

--- a/pages/logs/components/ErrorLogsTab.tsx
+++ b/pages/logs/components/ErrorLogsTab.tsx
@@ -26,6 +26,8 @@ export function ErrorLogsTab({
 }) {
   return (
     <Card
+      className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
+      bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
       title={t("logs_page.error_logs_title")}
       description={t("logs_page.error_fetch_desc")}
       actions={
@@ -41,8 +43,8 @@ export function ErrorLogsTab({
         </div>
       }
     >
-      <div className="space-y-4">
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+      <div className="space-y-4 md:flex md:min-h-0 md:flex-1 md:flex-col md:space-y-0 md:gap-4">
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:shrink-0 dark:border-neutral-800 dark:bg-neutral-950/60">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="min-w-0">
               <p className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -74,7 +76,7 @@ export function ErrorLogsTab({
           </div>
         </div>
 
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:flex md:min-h-0 md:flex-1 md:flex-col dark:border-neutral-800 dark:bg-neutral-950/60">
           <p className="text-sm font-semibold text-slate-900 dark:text-white">
             {t("logs_page.error_log_files")}
           </p>
@@ -82,7 +84,7 @@ export function ErrorLogsTab({
             {t("logs_page.error_log_list_desc")}
           </p>
 
-          <div className="mt-4">
+          <div className="mt-4 md:min-h-0 md:flex-1 md:overflow-y-auto">
             {errorLogsLoading ? (
               <div className="text-sm text-slate-600 dark:text-white/65">
                 {t("logs_page.loading")}

--- a/pages/logs/components/LiveLogsTab.tsx
+++ b/pages/logs/components/LiveLogsTab.tsx
@@ -85,6 +85,8 @@ export function LiveLogsTab({
 }) {
   return (
     <Card
+      className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
+      bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
       title={t("logs_page.live_logs")}
       description={t("logs_page.latest_label", {
         time: latestLabel,
@@ -120,7 +122,7 @@ export function LiveLogsTab({
       }
       loading={loading}
     >
-      <div className="space-y-3">
+      <div className="space-y-3 md:shrink-0">
         <TextInput
           value={search}
           onChange={(e) => setSearch(e.currentTarget.value)}
@@ -172,7 +174,7 @@ export function LiveLogsTab({
         </div>
       </div>
 
-      <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-white/70 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+      <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-white/70 shadow-sm md:flex md:min-h-0 md:flex-1 md:flex-col dark:border-neutral-800 dark:bg-neutral-950/60">
         <div className="flex min-h-11 items-center justify-between gap-3 border-b border-slate-200 px-4 py-3 text-xs text-slate-600 dark:border-neutral-800 dark:text-white/65">
           <div className="min-w-0">
             <span className="block whitespace-pre-wrap break-words tabular-nums">
@@ -200,7 +202,7 @@ export function LiveLogsTab({
         <div
           ref={containerRef}
           onScroll={onScroll}
-          className="max-h-[60vh] overflow-y-auto bg-slate-50 px-4 py-3 text-slate-900 dark:bg-neutral-950/60 dark:text-slate-100"
+          className="max-h-[60vh] overflow-y-auto bg-slate-50 px-4 py-3 text-slate-900 md:max-h-none md:min-h-0 md:flex-1 dark:bg-neutral-950/60 dark:text-slate-100"
         >
           {visibleLines.length === 0 ? (
             <div className="px-1 py-4">

--- a/pages/models/ModelsPage.tsx
+++ b/pages/models/ModelsPage.tsx
@@ -580,7 +580,7 @@ export function ModelsPage() {
     ) : null;
 
   return (
-    <section className="flex flex-1 flex-col gap-4">
+    <section className="flex flex-1 flex-col gap-4 md:h-[calc(100dvh-112px)] md:min-h-0 md:overflow-hidden">
       <ModelsStatsCards stats={totalStats} totalCost={totalCost} />
 
       <ModelsPageTabs activeTab={activeTab} onTabChange={setActiveTab} />
@@ -588,7 +588,7 @@ export function ModelsPage() {
       {activeTab === "library" ? (
         <div
           data-testid="owner-library-layout"
-          className="grid h-[calc(100dvh-300px)] min-h-[28rem] gap-4 lg:grid-cols-[18rem_minmax(0,1fr)]"
+          className="grid h-[calc(100dvh-300px)] min-h-[28rem] gap-4 md:h-auto md:min-h-0 md:flex-1 lg:grid-cols-[18rem_minmax(0,1fr)]"
         >
           <div data-testid="owner-sidebar-card" className="h-full min-h-0 min-w-0">
             <Card
@@ -714,7 +714,7 @@ export function ModelsPage() {
           <div data-testid="model-library-card" className="h-full min-h-0 min-w-0">
             <Card
               title={t("models_page.model_library")}
-              className="flex h-full flex-col overflow-hidden"
+              className="flex h-full flex-col overflow-hidden md:min-h-0"
               bodyClassName="relative flex min-h-0 flex-1 flex-col"
               actions={
                 <div className="flex flex-wrap items-center justify-end gap-2">
@@ -883,7 +883,7 @@ export function ModelsPage() {
         <Card
           title={t("models_page.model_configs")}
           description={t("models_page.model_configs_desc")}
-          className="flex flex-1 flex-col overflow-hidden"
+          className="flex flex-1 flex-col overflow-hidden md:min-h-0"
           bodyClassName="relative flex min-h-0 flex-1 flex-col"
           actions={
             <div className="flex flex-wrap items-center justify-end gap-2">
@@ -927,7 +927,8 @@ export function ModelsPage() {
             caption={t("models_page.table_caption")}
             emptyText={searchFilter ? t("models_page.no_results") : t("models_page.no_model_data")}
             minWidth="min-w-[1440px]"
-            height="h-[calc(100vh-430px)]"
+            height="h-[calc(100vh-430px)] md:h-auto md:flex-1"
+            minHeight="min-h-[360px] md:min-h-0"
           />
         </Card>
       )}

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -379,7 +379,7 @@ export function ProxiesPage() {
   const modalTitle = editingID ? t("proxies.edit_title") : t("proxies.add_title");
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-5">
+    <div className="flex min-h-0 flex-1 flex-col gap-5 md:h-[calc(100dvh-112px)] md:overflow-hidden">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <h2 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
@@ -401,15 +401,19 @@ export function ProxiesPage() {
         </div>
       </div>
 
-      <Card className="overflow-hidden" loading={loading && entries.length === 0}>
+      <Card
+        className="overflow-hidden md:flex md:min-h-0 md:flex-1 md:flex-col"
+        bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
+        loading={loading && entries.length === 0}
+      >
         <DataTable<ProxyPoolEntry>
           tableId="proxy-pool"
           rows={sortedEntries}
           columns={columns}
           rowKey={(entry) => entry.id}
           rowHeight={56}
-          height="h-auto max-h-[70vh]"
-          minHeight="min-h-[240px]"
+          height="h-auto max-h-[70vh] md:max-h-none md:flex-1"
+          minHeight="min-h-[240px] md:min-h-0"
           minWidth="min-w-[960px]"
           caption={t("proxies.table_caption")}
           emptyText={t("proxies.empty_title")}

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -223,7 +223,7 @@ export function SystemPage({
   const apiKeyLookupUrl = `${window.location.origin}/manage/apikey-lookup`;
 
   return (
-    <div className="min-w-0 space-y-6 overflow-x-hidden">
+    <div className="min-w-0 space-y-6 overflow-x-hidden md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:space-y-0 md:gap-6">
       {/* ── Header ── */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2.5">
@@ -287,7 +287,11 @@ export function SystemPage({
       />
 
       {/* ── Model List ── */}
-      <Card padding="none" className="overflow-hidden" bodyClassName="mt-0">
+      <Card
+        padding="none"
+        className="overflow-hidden md:flex md:min-h-0 md:flex-1 md:flex-col"
+        bodyClassName="mt-0 md:flex md:min-h-0 md:flex-1 md:flex-col"
+      >
         {/* Header */}
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-3.5 dark:border-neutral-800">
           <div className="flex items-center gap-2.5">
@@ -351,7 +355,7 @@ export function SystemPage({
         )}
 
         {/* Model tags */}
-        <div className="max-h-[480px] overflow-y-auto px-5 py-4">
+        <div className="max-h-[480px] overflow-y-auto px-5 py-4 md:max-h-none md:min-h-0 md:flex-1">
           {modelsLoading && models.length === 0 ? (
             <div className="flex items-center justify-center py-12 text-sm text-slate-500 dark:text-white/50">
               <RefreshCw size={14} className="animate-spin mr-2" />


### PR DESCRIPTION
## Summary
- Fill desktop-height layouts for models, proxies, system, and logs management pages.
- Keep mobile scrolling and controls on existing mobile behavior by scoping fill-height changes to `md:` where applicable.
- Preserve table/log functionality while moving large-screen overflow into the intended content panels.

## Verification
- `rtk bun run --filter @code-proxy/admin-panel test pages/models/__tests__/ModelsPage.test.tsx pages/proxies/__tests__/ProxiesPage.test.tsx pages/system/__tests__/SystemPage.test.tsx pages/logs/__tests__/LogsPage.test.tsx`
- `rtk bun run --filter @code-proxy/admin-panel build`
- Playwright mock desktop layout smoke: models, proxies, system, logs render with page overflow removed and cards aligned to the bottom container spacing.
- Playwright mock mobile smoke at 390x844: models library tab/search, proxies add modal, system search, logs search/error tab/request-id input remain operable; no horizontal overflow.