### PR TITLE
fix: refresh provider tab counts

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.bedrock.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.bedrock.test.tsx
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   getGeminiKeys: vi.fn(async () => []),
   getClaudeConfigs: vi.fn(async () => []),
   getCodexConfigs: vi.fn(async () => []),
+  getOpenCodeGoConfigs: vi.fn(async () => []),
+  getClineConfigs: vi.fn(async () => []),
   getVertexConfigs: vi.fn(async () => []),
   getBedrockConfigs: vi.fn(async () => []),
   getOpenAIProviders: vi.fn(async () => []),
@@ -29,6 +31,8 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       getGeminiKeys: mocks.getGeminiKeys,
       getClaudeConfigs: mocks.getClaudeConfigs,
       getCodexConfigs: mocks.getCodexConfigs,
+      getOpenCodeGoConfigs: mocks.getOpenCodeGoConfigs,
+      getClineConfigs: mocks.getClineConfigs,
       getVertexConfigs: mocks.getVertexConfigs,
       getBedrockConfigs: mocks.getBedrockConfigs,
       getOpenAIProviders: mocks.getOpenAIProviders,
@@ -65,6 +69,8 @@ describe("ProvidersPage Bedrock tab", () => {
     mocks.getGeminiKeys.mockImplementation(async () => []);
     mocks.getClaudeConfigs.mockImplementation(async () => []);
     mocks.getCodexConfigs.mockImplementation(async () => []);
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => []);
+    mocks.getClineConfigs.mockImplementation(async () => []);
     mocks.getVertexConfigs.mockImplementation(async () => []);
     mocks.getBedrockConfigs.mockImplementation(async () => []);
     mocks.getOpenAIProviders.mockImplementation(async () => []);

--- a/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   getClaudeConfigs: vi.fn(async () => []),
   getCodexConfigs: vi.fn(async (): Promise<any[]> => []),
   getOpenCodeGoConfigs: vi.fn(async () => []),
+  getClineConfigs: vi.fn(async () => []),
   getVertexConfigs: vi.fn(async () => []),
   getBedrockConfigs: vi.fn(async () => []),
   getOpenAIProviders: vi.fn(async () => []),
@@ -31,6 +32,7 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       getClaudeConfigs: mocks.getClaudeConfigs,
       getCodexConfigs: mocks.getCodexConfigs,
       getOpenCodeGoConfigs: mocks.getOpenCodeGoConfigs,
+      getClineConfigs: mocks.getClineConfigs,
       getVertexConfigs: mocks.getVertexConfigs,
       getBedrockConfigs: mocks.getBedrockConfigs,
       getOpenAIProviders: mocks.getOpenAIProviders,
@@ -86,6 +88,7 @@ describe("ProvidersPage import/export", () => {
         ] as any,
     );
     mocks.getOpenCodeGoConfigs.mockImplementation(async () => []);
+    mocks.getClineConfigs.mockImplementation(async () => []);
     mocks.getVertexConfigs.mockImplementation(async () => []);
     mocks.getBedrockConfigs.mockImplementation(async () => []);
     mocks.getOpenAIProviders.mockImplementation(async () => []);

--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -10,7 +10,10 @@ const mocks = vi.hoisted(() => ({
   getGeminiKeys: vi.fn(async () => []),
   getClaudeConfigs: vi.fn(async () => []),
   getCodexConfigs: vi.fn(async () => []),
+  getOpenCodeGoConfigs: vi.fn(async () => []),
+  getClineConfigs: vi.fn(async () => []),
   getVertexConfigs: vi.fn(async () => []),
+  getBedrockConfigs: vi.fn(async () => []),
   getOpenAIProviders: vi.fn(async () => []),
   saveCodexConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveOpenAIProviders: vi.fn(async (_configs: unknown[]) => ({})),
@@ -30,7 +33,10 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       getGeminiKeys: mocks.getGeminiKeys,
       getClaudeConfigs: mocks.getClaudeConfigs,
       getCodexConfigs: mocks.getCodexConfigs,
+      getOpenCodeGoConfigs: mocks.getOpenCodeGoConfigs,
+      getClineConfigs: mocks.getClineConfigs,
       getVertexConfigs: mocks.getVertexConfigs,
+      getBedrockConfigs: mocks.getBedrockConfigs,
       getOpenAIProviders: mocks.getOpenAIProviders,
       saveCodexConfigs: mocks.saveCodexConfigs,
       saveOpenAIProviders: mocks.saveOpenAIProviders,
@@ -70,7 +76,10 @@ describe("ProvidersPage openai tab", () => {
     mocks.getGeminiKeys.mockReset();
     mocks.getClaudeConfigs.mockReset();
     mocks.getCodexConfigs.mockReset();
+    mocks.getOpenCodeGoConfigs.mockReset();
+    mocks.getClineConfigs.mockReset();
     mocks.getVertexConfigs.mockReset();
+    mocks.getBedrockConfigs.mockReset();
     mocks.getOpenAIProviders.mockReset();
     mocks.saveCodexConfigs.mockReset();
     mocks.saveOpenAIProviders.mockReset();
@@ -83,7 +92,10 @@ describe("ProvidersPage openai tab", () => {
     mocks.getGeminiKeys.mockImplementation(async () => []);
     mocks.getClaudeConfigs.mockImplementation(async () => []);
     mocks.getCodexConfigs.mockImplementation(async () => []);
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => []);
+    mocks.getClineConfigs.mockImplementation(async () => []);
     mocks.getVertexConfigs.mockImplementation(async () => []);
+    mocks.getBedrockConfigs.mockImplementation(async () => []);
     mocks.saveCodexConfigs.mockImplementation(async () => ({}));
     mocks.saveOpenAIProviders.mockImplementation(async () => ({}));
     mocks.patchOpenAIProviderDisabled.mockImplementation(async () => ({}));
@@ -130,6 +142,36 @@ describe("ProvidersPage openai tab", () => {
     );
   });
 
+  test("loads provider counts on first render and hides zero badges", async () => {
+    mocks.getCodexConfigs.mockImplementation(async () => [
+      { name: "Codex 1", apiKey: "sk-codex-1" },
+      { name: "Codex 2", apiKey: "sk-codex-2" },
+    ]);
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      { name: "OpenCode Go", apiKey: "sk-opencode-go" },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const codexTab = await screen.findByRole("tab", { name: /Codex/ });
+    const openCodeGoTab = screen.getByRole("tab", { name: /OpenCode Go/ });
+    const geminiTab = screen.getByRole("tab", { name: /Gemini/ });
+
+    expect(within(codexTab).getByText("2")).toBeInTheDocument();
+    expect(within(openCodeGoTab).getByText("1")).toBeInTheDocument();
+    expect(within(geminiTab).queryByText("0")).not.toBeInTheDocument();
+  });
+
   test("renders openai provider card with masked key and aggregated status", async () => {
     render(
       <MemoryRouter initialEntries={["/ai-providers/openai"]}>
@@ -146,7 +188,7 @@ describe("ProvidersPage openai tab", () => {
     expect(await screen.findByText("OpenAI Main")).toBeInTheDocument();
     expect(screen.getByText("prefix: oa")).toBeInTheDocument();
     expect(screen.getByText("baseUrl: https://example.com/v1")).toBeInTheDocument();
-    expect(screen.getByText(/sk-ope\*\*\*7890/)).toBeInTheDocument();
+    expect(screen.getAllByText(/sk-ope\*\*\*7890/).length).toBeGreaterThan(0);
     expect(screen.getByText("80.0%")).toBeInTheDocument();
     expect(screen.getByText("testModel: gpt-4.1")).toBeInTheDocument();
   });

--- a/pages/providers/components/ProviderTabsWithCounts.tsx
+++ b/pages/providers/components/ProviderTabsWithCounts.tsx
@@ -77,7 +77,7 @@ export function ProviderTabsWithCounts({ tabs, value }: ProviderTabsWithCountsPr
             <TabsTrigger key={tab.id} value={tab.id}>
               {icon}
               {tab.label}
-              {tab.count !== null ? (
+              {tab.count !== null && tab.count > 0 ? (
                 <span
                   className={
                     value === tab.id

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -55,6 +55,9 @@ const PROVIDER_TAB_VALUES: ProviderTab[] = [
   "openai",
   "ampcode",
 ];
+const PROVIDER_LIST_TAB_VALUES: Exclude<ProviderTab, "ampcode">[] = PROVIDER_TAB_VALUES.filter(
+  (item) => item !== "ampcode",
+) as Exclude<ProviderTab, "ampcode">[];
 
 function readSavedProviderTab(): ProviderTab {
   try {
@@ -272,105 +275,107 @@ export function ProvidersPage() {
     });
   }, [openCodeGoKeys]);
 
+  const loadProviderTab = useCallback(async (tabId: ProviderTab) => {
+    switch (tabId) {
+      case "gemini": {
+        const cachedG = getCachedData<ProviderSimpleConfig[]>("gemini");
+        if (cachedG) setGeminiKeys(cachedG);
+        const freshG = await providersApi.getGeminiKeys();
+        setGeminiKeys(freshG);
+        setCachedData("gemini", freshG);
+        break;
+      }
+      case "claude": {
+        const cachedC = getCachedData<ProviderSimpleConfig[]>("claude");
+        if (cachedC) setClaudeKeys(cachedC);
+        const freshC = await providersApi.getClaudeConfigs();
+        setClaudeKeys(freshC);
+        setCachedData("claude", freshC);
+        break;
+      }
+      case "codex": {
+        const cachedX = getCachedData<ProviderSimpleConfig[]>("codex");
+        if (cachedX) setCodexKeys(cachedX);
+        const freshX = await providersApi.getCodexConfigs();
+        setCodexKeys(freshX);
+        setCachedData("codex", freshX);
+        break;
+      }
+      case "opencode-go": {
+        const cachedO = getCachedData<ProviderSimpleConfig[]>("opencode-go");
+        if (cachedO) setOpenCodeGoKeys(cachedO);
+        const freshO = await providersApi.getOpenCodeGoConfigs();
+        setOpenCodeGoKeys(freshO);
+        setCachedData("opencode-go", freshO);
+        break;
+      }
+      case "cline": {
+        const cachedCl = getCachedData<ProviderSimpleConfig[]>("cline");
+        if (cachedCl) setClineKeys(cachedCl);
+        const freshCl = await providersApi.getClineConfigs();
+        setClineKeys(freshCl);
+        setCachedData("cline", freshCl);
+        break;
+      }
+      case "vertex": {
+        const cachedV = getCachedData<ProviderSimpleConfig[]>("vertex");
+        if (cachedV) setVertexKeys(cachedV);
+        const freshV = await providersApi.getVertexConfigs();
+        setVertexKeys(freshV);
+        setCachedData("vertex", freshV);
+        break;
+      }
+      case "bedrock": {
+        const cachedB = getCachedData<BedrockProviderConfig[]>("bedrock");
+        if (cachedB) setBedrockKeys(cachedB);
+        const freshB = await providersApi.getBedrockConfigs();
+        setBedrockKeys(freshB);
+        setCachedData("bedrock", freshB);
+        break;
+      }
+      case "openai": {
+        const cachedA = getCachedData<OpenAIProvider[]>("openai");
+        if (cachedA) setOpenaiProviders(cachedA);
+        const freshA = await providersApi.getOpenAIProviders();
+        setOpenaiProviders(freshA);
+        setCachedData("openai", freshA);
+        break;
+      }
+      case "ampcode": {
+        const [amp, ampMap] = await Promise.all([
+          ampcodeApi.getAmpcode(),
+          ampcodeApi.getModelMappings(),
+        ]);
+        const ampObj =
+          amp && typeof amp === "object" && !Array.isArray(amp)
+            ? (amp as Record<string, unknown>)
+            : {};
+        setAmpcode(ampObj);
+        setAmpUpstreamUrl(readString(ampObj, "upstreamUrl", "upstream-url"));
+        setAmpForceMappings(readBool(ampObj, "forceModelMappings", "force-model-mappings"));
+
+        const mappings = Array.isArray(ampMap) ? ampMap : [];
+        const entries: AmpMappingEntry[] = mappings
+          .map((item, idx) => {
+            if (!item || typeof item !== "object") return null;
+            const record = item as Record<string, unknown>;
+            const from = String(record.from ?? "").trim();
+            const to = String(record.to ?? "").trim();
+            if (!from || !to) return null;
+            return { id: `map-${idx}-${from}`, from, to };
+          })
+          .filter(Boolean) as AmpMappingEntry[];
+        setAmpMappings(entries.length ? entries : [{ id: `map-${Date.now()}`, from: "", to: "" }]);
+        break;
+      }
+    }
+  }, []);
+
   const refreshTab = useCallback(
     async (tabId: typeof tab) => {
       setLoading(true);
       try {
-        switch (tabId) {
-          case "gemini": {
-            const cachedG = getCachedData<ProviderSimpleConfig[]>("gemini");
-            if (cachedG) setGeminiKeys(cachedG);
-            const freshG = await providersApi.getGeminiKeys();
-            setGeminiKeys(freshG);
-            setCachedData("gemini", freshG);
-            break;
-          }
-          case "claude": {
-            const cachedC = getCachedData<ProviderSimpleConfig[]>("claude");
-            if (cachedC) setClaudeKeys(cachedC);
-            const freshC = await providersApi.getClaudeConfigs();
-            setClaudeKeys(freshC);
-            setCachedData("claude", freshC);
-            break;
-          }
-          case "codex": {
-            const cachedX = getCachedData<ProviderSimpleConfig[]>("codex");
-            if (cachedX) setCodexKeys(cachedX);
-            const freshX = await providersApi.getCodexConfigs();
-            setCodexKeys(freshX);
-            setCachedData("codex", freshX);
-            break;
-          }
-          case "opencode-go": {
-            const cachedO = getCachedData<ProviderSimpleConfig[]>("opencode-go");
-            if (cachedO) setOpenCodeGoKeys(cachedO);
-            const freshO = await providersApi.getOpenCodeGoConfigs();
-            setOpenCodeGoKeys(freshO);
-            setCachedData("opencode-go", freshO);
-            break;
-          }
-          case "cline": {
-            const cachedCl = getCachedData<ProviderSimpleConfig[]>("cline");
-            if (cachedCl) setClineKeys(cachedCl);
-            const freshCl = await providersApi.getClineConfigs();
-            setClineKeys(freshCl);
-            setCachedData("cline", freshCl);
-            break;
-          }
-          case "vertex": {
-            const cachedV = getCachedData<ProviderSimpleConfig[]>("vertex");
-            if (cachedV) setVertexKeys(cachedV);
-            const freshV = await providersApi.getVertexConfigs();
-            setVertexKeys(freshV);
-            setCachedData("vertex", freshV);
-            break;
-          }
-          case "bedrock": {
-            const cachedB = getCachedData<BedrockProviderConfig[]>("bedrock");
-            if (cachedB) setBedrockKeys(cachedB);
-            const freshB = await providersApi.getBedrockConfigs();
-            setBedrockKeys(freshB);
-            setCachedData("bedrock", freshB);
-            break;
-          }
-          case "openai": {
-            const cachedA = getCachedData<OpenAIProvider[]>("openai");
-            if (cachedA) setOpenaiProviders(cachedA);
-            const freshA = await providersApi.getOpenAIProviders();
-            setOpenaiProviders(freshA);
-            setCachedData("openai", freshA);
-            break;
-          }
-          case "ampcode": {
-            const [amp, ampMap] = await Promise.all([
-              ampcodeApi.getAmpcode(),
-              ampcodeApi.getModelMappings(),
-            ]);
-            const ampObj =
-              amp && typeof amp === "object" && !Array.isArray(amp)
-                ? (amp as Record<string, unknown>)
-                : {};
-            setAmpcode(ampObj);
-            setAmpUpstreamUrl(readString(ampObj, "upstreamUrl", "upstream-url"));
-            setAmpForceMappings(readBool(ampObj, "forceModelMappings", "force-model-mappings"));
-
-            const mappings = Array.isArray(ampMap) ? ampMap : [];
-            const entries: AmpMappingEntry[] = mappings
-              .map((item, idx) => {
-                if (!item || typeof item !== "object") return null;
-                const record = item as Record<string, unknown>;
-                const from = String(record.from ?? "").trim();
-                const to = String(record.to ?? "").trim();
-                if (!from || !to) return null;
-                return { id: `map-${idx}-${from}`, from, to };
-              })
-              .filter(Boolean) as AmpMappingEntry[];
-            setAmpMappings(
-              entries.length ? entries : [{ id: `map-${Date.now()}`, from: "", to: "" }],
-            );
-            break;
-          }
-        }
+        await loadProviderTab(tabId);
       } catch (err: unknown) {
         notify({
           type: "error",
@@ -380,7 +385,7 @@ export function ProvidersPage() {
         setLoading(false);
       }
     },
-    [notify],
+    [loadProviderTab, notify, t],
   );
 
   const loadUsage = useCallback(async () => {
@@ -425,13 +430,27 @@ export function ProvidersPage() {
   });
 
   const refreshAll = useCallback(async () => {
-    await Promise.all([refreshTab(tab), loadUsage(), loadProxyPool()]);
-  }, [loadProxyPool, loadUsage, refreshTab, tab]);
+    setLoading(true);
+    const tabsToRefresh: ProviderTab[] =
+      tab === "ampcode" ? [...PROVIDER_LIST_TAB_VALUES, "ampcode"] : PROVIDER_LIST_TAB_VALUES;
+    const results = await Promise.allSettled([
+      ...tabsToRefresh.map((tabId) => loadProviderTab(tabId)),
+      loadUsage(),
+      loadProxyPool(),
+    ]);
+    const failed = results.find((result) => result.status === "rejected");
+    if (failed) {
+      notify({
+        type: "error",
+        message:
+          failed.reason instanceof Error ? failed.reason.message : t("providers.load_failed"),
+      });
+    }
+    setLoading(false);
+  }, [loadProviderTab, loadProxyPool, loadUsage, notify, t, tab]);
 
   useEffect(() => {
-    void refreshTab(tab);
-    void loadUsage();
-    void loadProxyPool();
+    void refreshAll();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -892,7 +911,7 @@ export function ProvidersPage() {
         onExport={handleExport}
         onExportSelected={handleExportSelected}
         onSelectAll={selectAllCurrentItems}
-        onRefresh={() => void refreshTab(tab)}
+        onRefresh={() => void refreshAll()}
         onAddCurrent={
           tab === "ampcode"
             ? null


### PR DESCRIPTION
## Summary
- load all regular provider lists on the AI providers page so tab badges have counts immediately
- hide zero-count badges while preserving non-zero badges
- refresh all provider counts after toolbar refresh, saves, and imports

## Tests
- rtk bun run --filter @code-proxy/admin-panel test:ci pages/providers/__tests__/ProvidersPage.openai.test.tsx pages/providers/__tests__/ProvidersPage.bedrock.test.tsx pages/providers/__tests__/ProvidersPage.import-export.test.tsx
- rtk bun run lint (0 errors; existing unrelated warnings in ChannelGroupsPage.tsx and updateShared.ts)