### PR TITLE
fix: type provider count test mocks

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -9,8 +9,8 @@ import { ToastProvider } from "@code-proxy/ui";
 const mocks = vi.hoisted(() => ({
   getGeminiKeys: vi.fn(async () => []),
   getClaudeConfigs: vi.fn(async () => []),
-  getCodexConfigs: vi.fn(async () => []),
-  getOpenCodeGoConfigs: vi.fn(async () => []),
+  getCodexConfigs: vi.fn(async (): Promise<unknown[]> => []),
+  getOpenCodeGoConfigs: vi.fn(async (): Promise<unknown[]> => []),
   getClineConfigs: vi.fn(async () => []),
   getVertexConfigs: vi.fn(async () => []),
   getBedrockConfigs: vi.fn(async () => []),


### PR DESCRIPTION
## Summary
- fix provider count test mock return types so production build passes

## Tests
- rtk bun run build
- rtk bun run --filter @code-proxy/admin-panel test:ci pages/providers/__tests__/ProvidersPage.openai.test.tsx pages/providers/__tests__/ProvidersPage.bedrock.test.tsx pages/providers/__tests__/ProvidersPage.import-export.test.tsx

## Deployment note
- The previous dev deploy failed during `bun run build` with `Promise<never[]>` mock type errors in `ProvidersPage.openai.test.tsx`. This PR fixes that build blocker.