### PR TITLE
fix: show configured Cline models on system page

### DIFF
--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -196,9 +196,10 @@ export function SystemPage({
           .map((item) => item.id) ?? [];
       const nextModelIds = useMappedOwnerModels
         ? (configuredAvailability?.items ?? []).map((item) => item.id)
-        : rootV1ModelIds.length > 0
-          ? rootV1ModelIds
-          : (configuredAvailability?.items ?? []).map((item) => item.id);
+        : [
+            ...rootV1ModelIds,
+            ...(configuredAvailability?.items ?? []).map((item) => item.id),
+          ];
 
       setModels(
         Array.from(new Set(nextModelIds))

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -278,6 +278,53 @@ describe("SystemPage", () => {
     expect(mocks.apiGet).toHaveBeenCalledWith("/model-path-availability");
   });
 
+  test("keeps configured Cline models when root v1 discovery has other models", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "mimo-v2.5-pro",
+              sources: [
+                {
+                  label: "cline · Cline",
+                  provider: "cline",
+                  model_id: "mimo-v2.5-pro",
+                  upstream_model_id: "cline-pass/mimo-v2.5-pro",
+                },
+              ],
+            },
+          ],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-root-model",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("gpt-root-model")).toBeInTheDocument();
+    const clineModel = await screen.findByText("mimo-v2.5-pro");
+    expect(clineModel).toBeInTheDocument();
+
+    await userEvent.hover(clineModel);
+
+    expect(await screen.findByText(/cline · Cline/)).toBeInTheDocument();
+    expect(screen.getByText(/cline-pass\/mimo-v2\.5-pro/)).toBeInTheDocument();
+  });
+
   test("shows model sources in the model tag tooltip", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });


### PR DESCRIPTION
## Summary
- merge configured model availability with root /v1/models discovery on the system page
- keep mapped-owner mode strict so hidden raw models stay hidden
- add a regression test for Cline alias models and upstream model tooltip text

## Verification
- rtk bun run test:ci pages/system/__tests__/SystemPage.test.tsx
- rtk bun run build