### PR TITLE
fix: show configured cline models in management UI

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -419,6 +419,54 @@ describe("ProvidersPage Cline tab", () => {
     });
   });
 
+  test("renders Cline models in a scrollable table without owned_by subtitles", async () => {
+    const user = userEvent.setup();
+    mocks.getModelDefinitions.mockImplementation(async (channel?: string) =>
+      channel === "cline"
+        ? [
+            { id: "cline-pass/glm-5.2", object: "model", owned_by: "cline" },
+            { id: "cline-pass/minimax-m3", object: "model", owned_by: "cline" },
+            { id: "cline-pass/qwen3.7-max", object: "model", owned_by: "cline" },
+            { id: "cline-pass/mimo-v2.5-pro", object: "model", owned_by: "cline" },
+            { id: "cline-pass/qwen3-coder", object: "model", owned_by: "cline" },
+            { id: "cline-pass/deepseek-v4", object: "model", owned_by: "cline" },
+            { id: "cline-pass/kimi-k2.6", object: "model", owned_by: "cline" },
+            { id: "cline-pass/claude-sonnet-4.5", object: "model", owned_by: "cline" },
+            { id: "cline-pass/gpt-5.2", object: "model", owned_by: "cline" },
+            { id: "cline-pass/gemini-3-pro", object: "model", owned_by: "cline" },
+          ]
+        : [],
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/cline/new"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", { name: /Add Cline configuration/i });
+    await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
+
+    expect(await within(dialog).findByText("cline-pass/mimo-v2.5-pro")).toBeInTheDocument();
+    expect(within(dialog).queryByText("cline")).not.toBeInTheDocument();
+
+    const table = within(dialog).getByText("cline-pass/mimo-v2.5-pro").closest("table");
+    if (!table) {
+      throw new Error("expected Cline models table");
+    }
+    const scrollContainer = table.parentElement?.parentElement;
+    const tableRoot = scrollContainer?.parentElement;
+
+    expect(scrollContainer).toHaveClass("overflow-auto");
+    expect(tableRoot).toHaveClass("h-80");
+  });
+
   test("loads Cline model definitions and saves model exclusions", async () => {
     const user = userEvent.setup();
 

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -23,7 +23,6 @@ const SectionCard = ({ children }: { children: React.ReactNode }) => (
 
 type ClineModelRow = {
   id: string;
-  ownedBy: string;
   publicName: string;
   checked: boolean;
 };
@@ -95,7 +94,6 @@ export function ProviderKeyModelsTab({
       const entry = entriesByName.get(normalized);
       return {
         id: model.id,
-        ownedBy: model.owned_by ?? "",
         publicName: entry ? entry.alias : model.id,
         checked:
           !excludeAll && enabledOpenCodeModelIds.has(normalized) && !excludedModelIds.has(normalized),
@@ -158,11 +156,6 @@ export function ProviderKeyModelsTab({
             <span className="block truncate font-mono text-xs font-semibold text-slate-800 dark:text-white/85">
               {row.id}
             </span>
-            {row.ownedBy ? (
-              <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
-                {row.ownedBy}
-              </span>
-            ) : null}
           </div>
         ),
       },
@@ -271,8 +264,8 @@ export function ProviderKeyModelsTab({
                 columns={clineColumns}
                 rowKey={(row) => row.id}
                 loading={openCodeModelsLoading && openCodeModels.length === 0}
-                rowHeight={52}
-                height="h-auto max-h-80"
+                rowHeight={44}
+                height="h-80"
                 minHeight="min-h-[160px]"
                 minWidth="min-w-[720px]"
                 caption={t("providers.cline_models_title")}

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -396,7 +396,14 @@ export function SystemPage({
                 );
                 return tooltip ? (
                   <HoverTooltip key={model.id} content={tooltip} placement="top">
-                    <span className="inline-flex">{tag}</span>
+                    <span className="relative inline-flex">
+                      {tag}
+                      <span
+                        aria-hidden="true"
+                        data-model-source-marker="true"
+                        className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-sky-500 ring-2 ring-white dark:ring-neutral-950"
+                      />
+                    </span>
                   </HoverTooltip>
                 ) : (
                   <CopyableModelTag

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -313,7 +313,7 @@ describe("SystemPage", () => {
       return Promise.resolve({});
     });
 
-    renderPage();
+    const { container } = renderPage();
 
     expect(await screen.findByText("gpt-root-model")).toBeInTheDocument();
     const clineModel = await screen.findByText("mimo-v2.5-pro");
@@ -321,6 +321,7 @@ describe("SystemPage", () => {
 
     await userEvent.hover(clineModel);
 
+    expect(container.querySelector('[data-model-source-marker="true"]')).toBeInTheDocument();
     expect(await screen.findByText(/cline · Cline/)).toBeInTheDocument();
     expect(screen.getByText(/cline-pass\/mimo-v2\.5-pro/)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- make Cline provider model rows show only the real Cline model ID and editable public alias
- give the provider model table a fixed height so the shared DataTable scrolls vertically
- keep system model source tooltips and add a source marker dot on sourced model tags
- add regression coverage for the Cline table and system tooltip upstream model ID

## Tests
- `rtk bun run test:ci pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx pages/system/__tests__/SystemPage.test.tsx packages/api-client/src/endpoints/__tests__/providers-cline.test.ts`
- `rtk bun run build`
