### PR TITLE
fix: mark only mapped system models

### DIFF
--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -386,6 +386,11 @@ export function SystemPage({
                   t("system_page.model_sources"),
                   t("system_page.real_model_id"),
                 );
+                const hasMappedSource = (model.sources ?? []).some(
+                  (source) =>
+                    source.upstreamModelId &&
+                    source.upstreamModelId !== model.id,
+                );
                 const tag = (
                   <CopyableModelTag
                     id={model.id}
@@ -398,11 +403,13 @@ export function SystemPage({
                   <HoverTooltip key={model.id} content={tooltip} placement="top">
                     <span className="relative inline-flex">
                       {tag}
-                      <span
-                        aria-hidden="true"
-                        data-model-source-marker="true"
-                        className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-sky-500 ring-2 ring-white dark:ring-neutral-950"
-                      />
+                      {hasMappedSource ? (
+                        <span
+                          aria-hidden="true"
+                          data-model-source-marker="true"
+                          className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-sky-500 ring-2 ring-white dark:ring-neutral-950"
+                        />
+                      ) : null}
                     </span>
                   </HoverTooltip>
                 ) : (

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -296,6 +296,17 @@ describe("SystemPage", () => {
                 },
               ],
             },
+            {
+              id: "cline-pass/deepseek-v4-pro",
+              sources: [
+                {
+                  label: "cline · Cline",
+                  provider: "cline",
+                  model_id: "cline-pass/deepseek-v4-pro",
+                  upstream_model_id: "cline-pass/deepseek-v4-pro",
+                },
+              ],
+            },
           ],
         });
       }
@@ -318,12 +329,19 @@ describe("SystemPage", () => {
     expect(await screen.findByText("gpt-root-model")).toBeInTheDocument();
     const clineModel = await screen.findByText("mimo-v2.5-pro");
     expect(clineModel).toBeInTheDocument();
+    const realClineModel = await screen.findByText("cline-pass/deepseek-v4-pro");
+    expect(realClineModel).toBeInTheDocument();
 
     await userEvent.hover(clineModel);
 
-    expect(container.querySelector('[data-model-source-marker="true"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-model-source-marker="true"]')).toHaveLength(1);
     expect(await screen.findByText(/cline · Cline/)).toBeInTheDocument();
     expect(screen.getByText(/cline-pass\/mimo-v2\.5-pro/)).toBeInTheDocument();
+
+    await userEvent.unhover(clineModel);
+    await userEvent.hover(realClineModel);
+
+    expect(await screen.findByText(/cline-pass\/deepseek-v4-pro/)).toBeInTheDocument();
   });
 
   test("shows model sources in the model tag tooltip", async () => {


### PR DESCRIPTION
## Summary
- keep system model source tooltips for all sourced models
- show the blue source marker only when the displayed model id differs from `upstreamModelId`
- add regression coverage for mapped Cline aliases and unchanged real Cline model IDs

## Tests
- `rtk bun run test:ci pages/system/__tests__/SystemPage.test.tsx`
- `rtk bun run build`
