### PR TITLE
fix: show cline and image model metadata

### DIFF
--- a/features/model-tags/index.tsx
+++ b/features/model-tags/index.tsx
@@ -7,6 +7,7 @@ export type ModelVendorKey =
   | "amp"
   | "antigravity"
   | "claude"
+  | "cline"
   | "codex"
   | "deepseek"
   | "gemini"
@@ -43,6 +44,11 @@ export const MODEL_VENDOR_COLORS: Record<ModelVendorKey, ModelVendorTone> = {
     bg: "bg-orange-50 dark:bg-orange-950/20",
     text: "text-orange-700 dark:text-orange-300",
     border: "border-orange-200/60 dark:border-orange-800/30",
+  },
+  cline: {
+    bg: "bg-teal-50 dark:bg-teal-950/20",
+    text: "text-teal-700 dark:text-teal-300",
+    border: "border-teal-200/60 dark:border-teal-800/30",
   },
   gpt: {
     bg: "bg-emerald-50 dark:bg-emerald-950/20",
@@ -151,6 +157,11 @@ const MODEL_VENDOR_DEFINITIONS: ModelVendorDefinition[] = [
     key: "claude",
     label: "claude",
     matches: (modelId) => startsWithAny(modelId, ["claude", "anthropic"]),
+  },
+  {
+    key: "cline",
+    label: "cline",
+    matches: (modelId) => startsWithAny(modelId, ["cline", "cline-pass"]),
   },
   {
     key: "gpt",

--- a/features/model-tags/modelTags.test.ts
+++ b/features/model-tags/modelTags.test.ts
@@ -7,12 +7,14 @@ describe("model tags", () => {
     expect(getModelVendorKey("gpt-5.4")).toBe("gpt");
     expect(getModelVendorKey("codex-mini")).toBe("codex");
     expect(getModelVendorKey("openai-realtime")).toBe("openai");
+    expect(getModelVendorKey("cline-pass/deepseek-v4-flash")).toBe("cline");
     expect(getModelVendorKey("deepseek-v4-flash")).toBe("deepseek");
 
     expect(getModelVendorColor("claude-opus-4-8").text).toContain("orange");
     expect(getModelVendorColor("gpt-5.4").text).toContain("emerald");
     expect(getModelVendorColor("codex-mini").text).toContain("emerald");
     expect(getModelVendorColor("openai-realtime").text).toContain("emerald");
+    expect(getModelVendorColor("cline-pass/deepseek-v4-flash").text).toContain("teal");
     expect(getModelVendorColor("deepseek-v4-flash").text).toContain("cyan");
   });
 });

--- a/packages/assets/src/vendor-icons/VendorIcon.tsx
+++ b/packages/assets/src/vendor-icons/VendorIcon.tsx
@@ -1,6 +1,7 @@
 import iconAmp from "@code-proxy/assets/icons/amp.svg";
 import iconAntigravity from "@code-proxy/assets/icons/antigravity.svg";
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
+import iconCline from "@code-proxy/assets/icons/cline.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
 import iconDeepseek from "@code-proxy/assets/icons/deepseek.svg";
 import iconGemini from "@code-proxy/assets/icons/gemini.svg";
@@ -23,6 +24,7 @@ const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
   amp: { light: iconAmp, dark: iconAmp },
   antigravity: { light: iconAntigravity, dark: iconAntigravity },
   claude: { light: iconClaude, dark: iconClaude },
+  cline: { light: iconCline, dark: iconCline },
   codex: { light: iconCodex, dark: iconCodex },
   deepseek: { light: iconDeepseek, dark: iconDeepseek },
   gemini: { light: iconGemini, dark: iconGemini },

--- a/pages/models/__tests__/ModelsPage.test.tsx
+++ b/pages/models/__tests__/ModelsPage.test.tsx
@@ -307,6 +307,12 @@ describe("ModelsPage", () => {
   test("renders model capability badges from modality metadata", async () => {
     renderPage();
 
+    const imageModelCell = await screen.findByText("gpt-image-2");
+    const imageModelRow = imageModelCell.closest("tr");
+    expect(imageModelRow).not.toBeNull();
+    expect(within(imageModelRow!).getByText("Image output")).toBeInTheDocument();
+    expect(within(imageModelRow!).queryByText("Text")).not.toBeInTheDocument();
+
     expect(await screen.findByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Capabilities" })).toBeInTheDocument();
     expect(screen.getByText("Vision")).toBeInTheDocument();

--- a/pages/models/components/ModelCapabilityBadges.tsx
+++ b/pages/models/components/ModelCapabilityBadges.tsx
@@ -5,8 +5,9 @@ import { modelHasTextCapability } from "../modelsUtils";
 export function ModelCapabilityBadges({ model }: { model: ModelItem }) {
   const { t } = useTranslation();
   const badges: Array<{ key: string; label: string; className: string }> = [];
+  const hasImageOutput = model.outputModalities.includes("image");
 
-  if (modelHasTextCapability(model)) {
+  if (!hasImageOutput && modelHasTextCapability(model)) {
     badges.push({
       key: "text",
       label: t("models_page.capability_text"),
@@ -20,7 +21,7 @@ export function ModelCapabilityBadges({ model }: { model: ModelItem }) {
       className: "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300",
     });
   }
-  if (model.outputModalities.includes("image")) {
+  if (hasImageOutput) {
     badges.push({
       key: "image-output",
       label: t("models_page.capability_image_output"),

--- a/pages/models/components/ModelVendorIcon.tsx
+++ b/pages/models/components/ModelVendorIcon.tsx
@@ -1,53 +1,5 @@
-import iconClaude from "@code-proxy/assets/icons/claude.svg";
-import iconCodex from "@code-proxy/assets/icons/codex.svg";
-import iconDeepseek from "@code-proxy/assets/icons/deepseek.svg";
-import iconGemini from "@code-proxy/assets/icons/gemini.svg";
-import iconGlm from "@code-proxy/assets/icons/glm.svg";
-import iconGrok from "@code-proxy/assets/icons/grok.svg";
-import iconIflow from "@code-proxy/assets/icons/iflow.svg";
-import iconKimiDark from "@code-proxy/assets/icons/kimi-dark.svg";
-import iconKimiLight from "@code-proxy/assets/icons/kimi-light.svg";
-import iconKiro from "@code-proxy/assets/icons/kiro.svg";
-import iconMinimax from "@code-proxy/assets/icons/minimax.svg";
-import iconOpenai from "@code-proxy/assets/icons/openai.svg";
-import iconQwen from "@code-proxy/assets/icons/qwen.svg";
-import iconVertex from "@code-proxy/assets/icons/vertex.svg";
-
-const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
-  claude: { light: iconClaude, dark: iconClaude },
-  codex: { light: iconCodex, dark: iconCodex },
-  deepseek: { light: iconDeepseek, dark: iconDeepseek },
-  gemini: { light: iconGemini, dark: iconGemini },
-  glm: { light: iconGlm, dark: iconGlm },
-  gpt: { light: iconOpenai, dark: iconOpenai },
-  grok: { light: iconGrok, dark: iconGrok },
-  iflow: { light: iconIflow, dark: iconIflow },
-  kiro: { light: iconKiro, dark: iconKiro },
-  kimi: { light: iconKimiLight, dark: iconKimiDark },
-  minimax: { light: iconMinimax, dark: iconMinimax },
-  o1: { light: iconOpenai, dark: iconOpenai },
-  o3: { light: iconOpenai, dark: iconOpenai },
-  o4: { light: iconOpenai, dark: iconOpenai },
-  qwen: { light: iconQwen, dark: iconQwen },
-  vertex: { light: iconVertex, dark: iconVertex },
-};
-
-function getVendorPrefix(modelId: string): string {
-  const lower = modelId.toLowerCase();
-  for (const prefix of Object.keys(VENDOR_ICONS)) {
-    if (lower.startsWith(prefix)) return prefix;
-  }
-  return "";
-}
+import { VendorIcon } from "@code-proxy/assets";
 
 export function ModelVendorIcon({ modelId, size = 14 }: { modelId: string; size?: number }) {
-  const prefix = getVendorPrefix(modelId);
-  const icons = prefix ? VENDOR_ICONS[prefix] : null;
-  if (!icons) return null;
-  return (
-    <>
-      <img src={icons.light} alt="" width={size} height={size} className="dark:hidden" />
-      <img src={icons.dark} alt="" width={size} height={size} className="hidden dark:block" />
-    </>
-  );
+  return <VendorIcon modelId={modelId} size={size} />;
 }


### PR DESCRIPTION
## Summary
- treat image-output models as image generation in the capability badges instead of also showing Text
- add Cline vendor classification and icon support for shared model tags
- reuse the shared VendorIcon in the models page

## Tests
- rtk bun run --filter @code-proxy/admin-panel test features/model-tags/modelTags.test.ts pages/models/__tests__/ModelsPage.test.tsx
- rtk bun run build