### PR TITLE
fix: show vision fallback model in request logs

### DIFF
--- a/apps/admin-panel/src/i18n/locales/en.json
+++ b/apps/admin-panel/src/i18n/locales/en.json
@@ -2469,6 +2469,7 @@
     "col_key_name": "Key Name",
     "col_model": "Model",
     "real_model_id": "Real model ID",
+    "vision_fallback_model_id": "Vision fallback model ID",
     "col_channel": "Channel",
     "col_status": "Status",
     "col_mode": "Mode",

--- a/apps/admin-panel/src/i18n/locales/zh-CN.json
+++ b/apps/admin-panel/src/i18n/locales/zh-CN.json
@@ -2749,6 +2749,7 @@
     "col_key_name": "密钥名称",
     "col_model": "模型",
     "real_model_id": "真实模型 ID",
+    "vision_fallback_model_id": "视觉补位模型 ID",
     "col_channel": "渠道",
     "col_status": "状态",
     "col_mode": "类型",

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -28,6 +28,7 @@ export type RequestLogsRow = {
   maskedApiKey: string;
   model: string;
   upstreamModel: string;
+  visionFallbackModel: string;
   failed: boolean;
   streaming: boolean;
   latencyText: string;
@@ -237,6 +238,7 @@ export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
     maskedApiKey: maskRequestLogApiKey(item.api_key),
     model: item.model,
     upstreamModel: item.upstream_model || "",
+    visionFallbackModel: item.vision_fallback_model || "",
     failed: item.failed,
     streaming: item.streaming === true,
     latencyText: formatRequestLogLatencyMs(item.latency_ms),
@@ -562,6 +564,17 @@ export function buildRequestLogsColumns(
                 <span
                   className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
                   aria-label={t("request_logs.real_model_id")}
+                />
+              </HoverTooltip>
+            ) : null}
+            {row.visionFallbackModel && row.visionFallbackModel !== row.model ? (
+              <HoverTooltip
+                content={`${t("request_logs.vision_fallback_model_id")}\n${row.visionFallbackModel}`}
+                placement="top"
+              >
+                <span
+                  className="h-1.5 w-1.5 shrink-0 rounded-full bg-sky-500"
+                  aria-label={t("request_logs.vision_fallback_model_id")}
                 />
               </HoverTooltip>
             ) : null}

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -473,6 +473,7 @@ export interface UsageLogItem {
   api_key_name: string;
   model: string;
   upstream_model?: string;
+  vision_fallback_model?: string;
   source: string;
   channel_name: string;
   auth_index: string;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2503,6 +2503,7 @@
     "col_key_name": "Key Name",
     "col_model": "Model",
     "real_model_id": "Real model ID",
+    "vision_fallback_model_id": "Vision fallback model ID",
     "col_channel": "Channel",
     "col_status": "Status",
     "col_mode": "Mode",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2783,6 +2783,7 @@
     "col_key_name": "密钥名称",
     "col_model": "模型",
     "real_model_id": "真实模型 ID",
+    "vision_fallback_model_id": "视觉补位模型 ID",
     "col_channel": "渠道",
     "col_status": "状态",
     "col_mode": "类型",

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -242,6 +242,52 @@ describe("RequestLogsPage", () => {
     expect(screen.queryByLabelText("First Token Latency: --")).not.toBeInTheDocument();
   });
 
+  test("shows vision fallback model separately from real model mapping", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue(
+      responseWithRows([
+        buildUsageLogItem({
+          id: 1,
+          model: "cline-pass/deepseek-v4-pro",
+          upstream_model: "",
+          vision_fallback_model: "cline-pass/mimo-v2.5-pro",
+        }),
+        buildUsageLogItem({
+          id: 2,
+          model: "alias-model",
+          upstream_model: "real-model",
+          vision_fallback_model: "",
+        }),
+      ]),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const table = await screen.findByRole("table", { name: "Request Logs Table" });
+    expect(within(table).getByText("cline-pass/deepseek-v4-pro")).toBeInTheDocument();
+    expect(within(table).getByText("alias-model")).toBeInTheDocument();
+
+    const visionMarker = within(table).getByLabelText("Vision fallback model ID");
+    await user.hover(visionMarker);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Vision fallback model ID cline-pass/mimo-v2.5-pro",
+    );
+    await user.unhover(visionMarker);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+
+    const realModelMarker = within(table).getByLabelText("Real model ID");
+    await user.hover(realModelMarker);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Real model ID real-model");
+  });
+
   test("does not crash when backend returns null filter arrays", async () => {
     await i18n.changeLanguage("en");
 


### PR DESCRIPTION
## Summary\n- add vision_fallback_model to request-log API typing\n- show the vision fallback model as its own tooltip marker\n- preserve the existing real model ID marker for alias mappings\n\n## Verification\n- rtk bun run --filter @code-proxy/admin-panel test -- pages/request-logs/__tests__/RequestLogsPage.test.tsx\n- rtk bun run build