### PR TITLE
fix: remove duplicate admin loading fallback

### DIFF
--- a/apps/admin-panel/src/app/layout/DashboardLayout.tsx
+++ b/apps/admin-panel/src/app/layout/DashboardLayout.tsx
@@ -1,36 +1,17 @@
-import { lazy, Suspense } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { Reveal } from "@code-proxy/ui";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
-
-const LazyAppShell = lazy(() => import("./AppShell").then((m) => ({ default: m.AppShell })));
-
-function ShellFallback() {
-  return (
-    <div
-      role="status"
-      aria-label="Loading"
-      className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-700 dark:bg-neutral-950 dark:text-white/80"
-    >
-      <span
-        aria-hidden="true"
-        className="h-6 w-6 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white"
-      />
-    </div>
-  );
-}
+import { AppShell } from "./AppShell";
 
 export function DashboardLayout() {
   const location = useLocation();
   const auth = useOptionalAuth();
 
   return (
-    <Suspense fallback={<ShellFallback />}>
-      <LazyAppShell onLogout={() => auth?.actions?.logout?.()}>
-        <Reveal key={location.pathname}>
-          <Outlet />
-        </Reveal>
-      </LazyAppShell>
-    </Suspense>
+    <AppShell onLogout={() => auth?.actions?.logout?.()}>
+      <Reveal key={location.pathname}>
+        <Outlet />
+      </Reveal>
+    </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- remove the lazy AppShell Suspense fallback that showed a second full-screen spinner
- keep the existing HTML #app-loader as the only initial loading UI

## Verification
- rtk bun run test:ci
- rtk bun run build
- Playwright smoke check with delayed AppShell module: #app-loader visible, secondary loading count 0, dashboard settles normally