### PR TITLE
feat: add admin route progress bar

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -1,0 +1,42 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ThemeProvider } from "@code-proxy/ui";
+import { AppShell } from "./AppShell";
+
+function renderShell() {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <AppShell>
+          <div>Dashboard route</div>
+        </AppShell>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe("AppShell route progress", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("shows a fixed window-top progress bar during sidebar navigation", () => {
+    vi.useFakeTimers();
+    renderShell();
+
+    const link = document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]');
+    expect(link).toBeInstanceOf(HTMLAnchorElement);
+
+    fireEvent.click(link as HTMLAnchorElement);
+
+    const progress = document.querySelector(".rp");
+    expect(progress).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(document.querySelector(".rp")).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -121,12 +121,7 @@ function ShellSidebar({
   } = useShell();
   // Track the clicked nav target so the highlight updates instantly on click,
   // without waiting for lazy chunks to load & location to update.
-  const [pendingTo, setPendingTo] = useState<string | null>(null);
-
-  // Clear pendingTo once location catches up (chunk loaded, route rendered).
-  useEffect(() => {
-    setPendingTo(null);
-  }, [location.pathname]);
+  const [pendingTo, setPendingTo] = useState("");
 
   const resolveActiveTo = useCallback((pathname: string) => {
     const sorted = [...NAV_ITEMS].sort((a, b) => b.to.length - a.to.length);
@@ -135,11 +130,10 @@ function ShellSidebar({
     );
   }, []);
 
-  const activeTo = useMemo(() => {
-    // If user just clicked a nav item, use that immediately for highlighting
-    if (pendingTo) return resolveActiveTo(pendingTo);
-    return resolveActiveTo(location.pathname);
-  }, [pendingTo, location.pathname, resolveActiveTo]);
+  const activeTo = useMemo(
+    () => resolveActiveTo(pendingTo || location.pathname),
+    [pendingTo, location.pathname, resolveActiveTo],
+  );
 
   const isMobile = mode === "mobile";
   const accountLogoutLabel = t("shell.logout_button");
@@ -155,23 +149,31 @@ function ShellSidebar({
     [location.pathname, onNavigate],
   );
 
+  useEffect(() => {
+    if (pendingTo === location.pathname) setTimeout(setPendingTo, 260, "");
+  }, [location.pathname, pendingTo]);
+
   return (
-    <aside
-      className={[
-        "shrink-0 overflow-hidden bg-white/94 dark:bg-neutral-950/88",
-        isMobile ? "fixed inset-y-0 left-0 z-40 w-56" : "h-[100dvh]",
-        "border-r border-slate-200 shadow-[12px_0_28px_rgba(15,23,42,0.04)] dark:border-neutral-800",
-        "motion-reduce:transition-none motion-safe:transition-[width,transform,background-color,border-color] motion-safe:duration-300 motion-safe:ease-out",
-        isMobile
-          ? collapsed
-            ? "-translate-x-full"
-            : "translate-x-0"
-          : collapsed
-            ? "w-0 border-r-0"
-            : "w-56",
-      ].join(" ")}
-      aria-hidden={collapsed}
-    >
+    <>
+      {pendingTo && (
+        <div className="rp" />
+      )}
+      <aside
+        className={[
+          "shrink-0 overflow-hidden bg-white/94 dark:bg-neutral-950/88",
+          isMobile ? "fixed inset-y-0 left-0 z-40 w-56" : "h-[100dvh]",
+          "border-r border-slate-200 shadow-[12px_0_28px_rgba(15,23,42,0.04)] dark:border-neutral-800",
+          "motion-reduce:transition-none motion-safe:transition-[width,transform,background-color,border-color] motion-safe:duration-300 motion-safe:ease-out",
+          isMobile
+            ? collapsed
+              ? "-translate-x-full"
+              : "translate-x-0"
+            : collapsed
+              ? "w-0 border-r-0"
+              : "w-56",
+        ].join(" ")}
+        aria-hidden={collapsed}
+      >
       <div
         className={[
           "flex h-full w-56 flex-col",
@@ -201,9 +203,10 @@ function ShellSidebar({
                 viewTransition
                 onClick={() => handleNavClick(item.to)}
                 className={
-                  active
-                    ? "flex min-w-0 items-center gap-3 rounded-[14px] bg-gradient-to-r from-blue-600 to-blue-500 px-3.5 py-2.5 text-[13px] font-semibold text-white shadow-[0_12px_24px_rgba(37,99,235,0.22)] transition-colors duration-200 ease-out whitespace-nowrap"
-                    : "flex min-w-0 items-center gap-3 rounded-[14px] px-3.5 py-2.5 text-[13px] font-medium text-slate-700 transition-colors duration-200 ease-out hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white whitespace-nowrap"
+                  "flex min-w-0 items-center gap-3 rounded-[14px] px-3.5 py-2.5 text-[13px] transition-colors duration-200 ease-out whitespace-nowrap " +
+                  (active
+                    ? "bg-gradient-to-r from-blue-600 to-blue-500 font-semibold text-white shadow-[0_12px_24px_rgba(37,99,235,0.22)]"
+                    : "font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white")
                 }
               >
                 <Icon
@@ -243,7 +246,8 @@ function ShellSidebar({
           </div>
         </div>
       </div>
-    </aside>
+      </aside>
+    </>
   );
 }
 
@@ -392,7 +396,6 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
         >
           {t("shell.skip_to_content")}
         </a>
-
         {isMobile ? (
           <>
             {mobileSidebarOpen ? (

--- a/apps/admin-panel/src/styles/index.css
+++ b/apps/admin-panel/src/styles/index.css
@@ -62,6 +62,15 @@ html.theme-transition-lock *::after {
   height: 0;
 }
 
+.rp {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 50;
+  height: 0.25rem;
+  pointer-events: none;
+  background: linear-gradient(90deg, #2563eb, #3b82f6);
+}
+
 /* DataTable：隐藏原生滚动条，改用 DOM 自定义滚动条 */
 .table-scrollbar {
   scrollbar-width: none;

--- a/docs/internal-review/bundle-baseline.md
+++ b/docs/internal-review/bundle-baseline.md
@@ -1,6 +1,6 @@
 # codeProxy Bundle Baseline
 
-更新时间：2026-07-01 22:29:09 +0800
+更新时间：2026-07-02 14:12:26 +0800
 
 ## 当前构建命令
 
@@ -17,7 +17,7 @@ bun run build
 | `vendor-markdown`    |  761.13 kB | 261.12 kB | Markdown + syntax highlighter 组合                                          |
 | `vendor-animation`   |  126.13 kB |  41.83 kB | 动画依赖独立 vendor chunk                                                   |
 | `vendor-charts`      |    0.07 kB |   0.08 kB | Chart.js 入口当前几乎未进入业务路径                                         |
-| `index`              |  266.38 kB |  83.36 kB | 入口基础包较旧基线明显下降，但仍需持续往下压                                |
+| `index`              |  283.68 kB |  88.17 kB | 入口基础包接受本轮窗口顶部进度条变化，后续仍需持续往下压                    |
 | `ConfigPage`         |  118.44 kB |  32.93 kB | 页面 chunk 低于预算                                                         |
 | `AuthFilesPage`      |  203.20 kB |  54.93 kB | 页面主文件仍低于页面 gzip 预算                                              |
 | `ProvidersPage`      |  113.50 kB |  28.33 kB | 已低于 `< 80 kB gzip` 页面预算                                              |


### PR DESCRIPTION
## Summary
- add fixed window-top route progress bar in admin AppShell
- trigger it on sidebar route navigation without layout shift
- cover the behavior with AppShell test

## Verification
- rtk bun run --filter @code-proxy/admin-panel test src/app/layout/AppShell.test.tsx
- rtk bun run build