### PR TITLE
feat: smooth route progress animation

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -21,7 +21,7 @@ describe("AppShell route progress", () => {
     vi.useRealTimers();
   });
 
-  test("shows a fixed window-top progress bar during sidebar navigation", () => {
+  test("animates a fixed window-top progress bar during sidebar navigation", () => {
     vi.useFakeTimers();
     renderShell();
 
@@ -32,11 +32,43 @@ describe("AppShell route progress", () => {
 
     const progress = document.querySelector(".rp");
     expect(progress).toBeInTheDocument();
+    expect(progress).not.toHaveClass("rp-done");
+
+    act(() => {
+      vi.advanceTimersByTime(680);
+    });
+
+    expect(document.querySelector(".rp")).toHaveClass("rp-done");
+
+    act(() => {
+      vi.advanceTimersByTime(360);
+    });
+
+    expect(document.querySelector(".rp")).not.toBeInTheDocument();
+  });
+
+  test("restarts the progress animation on rapid sidebar navigation", () => {
+    vi.useFakeTimers();
+    renderShell();
+
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]')!);
 
     act(() => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(document.querySelector(".rp")).not.toBeInTheDocument();
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/models"]')!);
+
+    act(() => {
+      vi.advanceTimersByTime(679);
+    });
+
+    expect(document.querySelector(".rp")).not.toHaveClass("rp-done");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(document.querySelector(".rp")).toHaveClass("rp-done");
   });
 });

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -42,6 +43,8 @@ interface ShellContextState {
 const ShellContext = createContext<ShellContextState | null>(null);
 const STORAGE_KEY_SIDEBAR_COLLAPSED = "cli-proxy-sidebar-collapsed";
 const SIDEBAR_MOBILE_MEDIA = "(max-width: 767px)";
+const ROUTE_PROGRESS_MIN_MS = 680;
+const ROUTE_PROGRESS_HIDE_MS = 360;
 
 const NAV_ITEMS = [
   { to: "/dashboard", i18nKey: "shell.nav_dashboard", icon: LayoutDashboard },
@@ -122,6 +125,14 @@ function ShellSidebar({
   // Track the clicked nav target so the highlight updates instantly on click,
   // without waiting for lazy chunks to load & location to update.
   const [pendingTo, setPendingTo] = useState("");
+  const [progressDone, setProgressDone] = useState(false);
+  const progressStartedAt = useRef(0);
+  const progressTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const clearProgressTimers = useCallback(() => {
+    progressTimers.current.forEach(clearTimeout);
+    progressTimers.current = [];
+  }, []);
 
   const resolveActiveTo = useCallback((pathname: string) => {
     const sorted = [...NAV_ITEMS].sort((a, b) => b.to.length - a.to.length);
@@ -142,21 +153,39 @@ function ShellSidebar({
     (to: string) => {
       // Immediately mark as pending so highlight is instant
       if (to !== location.pathname) {
+        clearProgressTimers();
+        progressStartedAt.current = Date.now();
+        setProgressDone(false);
         setPendingTo(to);
       }
       onNavigate?.();
     },
-    [location.pathname, onNavigate],
+    [clearProgressTimers, location.pathname, onNavigate],
   );
 
   useEffect(() => {
-    if (pendingTo === location.pathname) setTimeout(setPendingTo, 260, "");
+    if (pendingTo !== location.pathname) return;
+    const delay = Math.max(0, ROUTE_PROGRESS_MIN_MS - (Date.now() - progressStartedAt.current));
+    const finishTimer = setTimeout(() => {
+      setProgressDone(true);
+      progressTimers.current.push(
+        setTimeout(() => {
+          setPendingTo("");
+          setProgressDone(false);
+          progressTimers.current = [];
+        }, ROUTE_PROGRESS_HIDE_MS),
+      );
+    }, delay);
+    progressTimers.current.push(finishTimer);
+    return () => clearTimeout(finishTimer);
   }, [location.pathname, pendingTo]);
+
+  useEffect(() => clearProgressTimers, [clearProgressTimers]);
 
   return (
     <>
       {pendingTo && (
-        <div className="rp" />
+        <div className={progressDone ? "rp rp-done" : "rp"} />
       )}
       <aside
         className={[

--- a/apps/admin-panel/src/styles/index.css
+++ b/apps/admin-panel/src/styles/index.css
@@ -67,8 +67,84 @@ html.theme-transition-lock *::after {
   inset: 0 0 auto;
   z-index: 50;
   height: 0.25rem;
+  overflow: hidden;
   pointer-events: none;
-  background: linear-gradient(90deg, #2563eb, #3b82f6);
+  opacity: 1;
+}
+
+.rp::before,
+.rp::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+.rp::before {
+  transform-origin: left;
+  background: linear-gradient(90deg, #2563eb, #3b82f6 58%, #22c55e);
+  box-shadow: 0 0 14px rgba(59, 130, 246, 0.45);
+  animation: rp-load 1.2s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.rp::after {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.75), transparent);
+  animation: rp-shine 0.9s linear infinite;
+}
+
+.rp-done {
+  opacity: 0;
+  transition: opacity 220ms ease 120ms;
+}
+
+.rp-done::before {
+  animation: rp-done 180ms ease-out forwards;
+}
+
+@keyframes rp-load {
+  0% {
+    transform: scaleX(0.08);
+  }
+  55% {
+    transform: scaleX(0.62);
+  }
+  100% {
+    transform: scaleX(0.88);
+  }
+}
+
+@keyframes rp-done {
+  from {
+    transform: scaleX(0.88);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes rp-shine {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rp,
+  .rp::before,
+  .rp::after {
+    animation: none;
+    transition: none;
+  }
+
+  .rp::before {
+    transform: scaleX(1);
+  }
+
+  .rp::after {
+    display: none;
+  }
 }
 
 /* DataTable：隐藏原生滚动条，改用 DOM 自定义滚动条 */


### PR DESCRIPTION
## Summary
- keep route progress visible long enough for fast admin page navigation
- animate the top progress bar to completion and fade it out
- cover normal and rapid sidebar navigation with AppShell tests

## Validation
- rtk bun run --filter @code-proxy/admin-panel test src/app/layout/AppShell.test.tsx
- rtk bun run build
- rtk bun run bundle:diff