### PR TITLE
fix: preload routes before shell navigation

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.test.ts
+++ b/apps/admin-panel/src/app/AppRouter.test.ts
@@ -53,7 +53,9 @@ describe("AppRouter", () => {
 
     expect(mainSource).toContain("dismissAppLoader(true)");
     expect(manageEntrySource).toContain("dismissAppLoader(true)");
-    expect(routerSource).toContain("hasAppLoader() ? null");
+    expect(routerSource).toContain("const RouteFallback = () => null");
+    expect(routerSource).not.toContain("PageLoader");
+    expect(routerSource).not.toContain('variant="initial"');
     expect(routerSource).not.toContain('variant="inline"');
     expect(protectedRouteSource).toContain("if (hasAppLoader()) return null");
   });

--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -3,22 +3,12 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthProvider, useAuth } from "@app/providers/AuthProvider";
 import { ProtectedRoute } from "@/app/guards/ProtectedRoute";
 import { DashboardLayout } from "@app/layout/DashboardLayout";
-import { PageLoader, ThemeProvider, ToastProvider } from "@code-proxy/ui";
+import { ThemeProvider, ToastProvider } from "@code-proxy/ui";
 import { AutoUpdatePrompt } from "@app/update/AutoUpdatePrompt";
-import { dismissAppLoader, hasAppLoader } from "@/app/bootstrap/dismissAppLoader";
+import { dismissAppLoader } from "@/app/bootstrap/dismissAppLoader";
 import { pageRoutes } from "@pages/registry";
 
-interface RouteWithMeta {
-  path: string;
-  element: React.ReactElement;
-  auth: boolean;
-  layout: string;
-  nav: { labelKey: string } | null;
-  redirects?: Array<{ from: string; to: string }>;
-  hasWildcard?: boolean;
-}
-
-const RouteFallback = () => (hasAppLoader() ? null : <PageLoader variant="initial" />);
+const RouteFallback = () => null;
 
 function InitialRouteReady({ children }: { children: React.ReactElement }) {
   useEffect(() => {
@@ -47,7 +37,7 @@ const readyRoute = (element: React.ReactElement) => (
 );
 
 export function AppRouter() {
-  const routes = pageRoutes as RouteWithMeta[];
+  const routes = pageRoutes;
   const publicRoutes = routes.filter((r) => !r.auth);
   const loginRoute = publicRoutes.find((r) => r.path === "/login");
   const standalonePublicRoutes = publicRoutes.filter((r) => r.path !== "/login");

--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -1,8 +1,18 @@
-import { act, fireEvent, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { ThemeProvider } from "@code-proxy/ui";
+import { preloadPageRoute } from "@pages/registry";
 import { AppShell } from "./AppShell";
+
+vi.mock("@pages/registry", () => ({
+  preloadPageRoute: vi.fn(() => Promise.resolve()),
+}));
+
+function LocationEcho() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
 
 function renderShell() {
   return render(
@@ -10,6 +20,7 @@ function renderShell() {
       <MemoryRouter initialEntries={["/dashboard"]}>
         <AppShell>
           <div>Dashboard route</div>
+          <LocationEcho />
         </AppShell>
       </MemoryRouter>
     </ThemeProvider>,
@@ -19,9 +30,55 @@ function renderShell() {
 describe("AppShell route progress", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.mocked(preloadPageRoute).mockClear();
   });
 
-  test("animates a fixed window-top progress bar during sidebar navigation", () => {
+  test("preloads the target route before navigating from the current page", async () => {
+    vi.useFakeTimers();
+    let resolvePreload: (() => void) | undefined;
+    vi.mocked(preloadPageRoute).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolvePreload = resolve;
+      }),
+    );
+    renderShell();
+
+    const link = document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]');
+    expect(link).toBeInstanceOf(HTMLAnchorElement);
+
+    fireEvent.click(link as HTMLAnchorElement);
+
+    expect(preloadPageRoute).toHaveBeenCalledWith("/ai-providers");
+    expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
+
+    const progress = document.querySelector(".rp");
+    expect(progress).toBeInTheDocument();
+    expect(progress).not.toHaveClass("rp-done");
+
+    act(() => {
+      vi.advanceTimersByTime(680);
+    });
+
+    expect(document.querySelector(".rp")).not.toHaveClass("rp-done");
+    expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
+
+    await act(async () => {
+      resolvePreload?.();
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector(".rp")).toHaveClass("rp-done");
+    expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
+
+    act(() => {
+      vi.advanceTimersByTime(360);
+    });
+
+    expect(screen.getByTestId("location")).toHaveTextContent("/ai-providers");
+    expect(document.querySelector(".rp")).not.toBeInTheDocument();
+  });
+
+  test("animates a fixed window-top progress bar during sidebar navigation", async () => {
     vi.useFakeTimers();
     renderShell();
 
@@ -34,20 +91,23 @@ describe("AppShell route progress", () => {
     expect(progress).toBeInTheDocument();
     expect(progress).not.toHaveClass("rp-done");
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(680);
+      await Promise.resolve();
     });
 
     expect(document.querySelector(".rp")).toHaveClass("rp-done");
+    expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
 
     act(() => {
       vi.advanceTimersByTime(360);
     });
 
+    expect(screen.getByTestId("location")).toHaveTextContent("/ai-providers");
     expect(document.querySelector(".rp")).not.toBeInTheDocument();
   });
 
-  test("restarts the progress animation on rapid sidebar navigation", () => {
+  test("restarts the progress animation on rapid sidebar navigation", async () => {
     vi.useFakeTimers();
     renderShell();
 
@@ -59,16 +119,37 @@ describe("AppShell route progress", () => {
 
     fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/models"]')!);
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(679);
+      await Promise.resolve();
     });
 
     expect(document.querySelector(".rp")).not.toHaveClass("rp-done");
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(1);
+      await Promise.resolve();
     });
 
     expect(document.querySelector(".rp")).toHaveClass("rp-done");
+
+    act(() => {
+      vi.advanceTimersByTime(360);
+    });
+
+    expect(screen.getByTestId("location")).toHaveTextContent("/models");
+  });
+
+  test("lets modified clicks keep the browser's native link behavior", () => {
+    vi.useFakeTimers();
+    renderShell();
+
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]')!, {
+      ctrlKey: true,
+    });
+
+    expect(preloadPageRoute).not.toHaveBeenCalled();
+    expect(document.querySelector(".rp")).not.toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
   });
 });

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  type MouseEvent,
   type PropsWithChildren,
   use,
   useCallback,
@@ -30,6 +31,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { LanguageSelector, PageBackground, ThemeToggleButton } from "@code-proxy/ui";
+import { preloadPageRoute } from "@pages/registry";
 
 interface ShellContextState {
   state: {
@@ -103,6 +105,15 @@ const getPageTitleKey = (pathname: string): string => {
   return "shell.page_home";
 };
 
+const shouldUseNativeNavigation = (event: MouseEvent<HTMLAnchorElement>) =>
+  event.defaultPrevented ||
+  event.button !== 0 ||
+  event.metaKey ||
+  event.altKey ||
+  event.ctrlKey ||
+  event.shiftKey ||
+  Boolean(event.currentTarget.target && event.currentTarget.target !== "_self");
+
 function ShellFrame({ children }: PropsWithChildren) {
   return <PageBackground variant="app">{children}</PageBackground>;
 }
@@ -128,6 +139,7 @@ function ShellSidebar({
   const [progressDone, setProgressDone] = useState(false);
   const progressStartedAt = useRef(0);
   const progressTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const navigationRequestId = useRef(0);
 
   const clearProgressTimers = useCallback(() => {
     progressTimers.current.forEach(clearTimeout);
@@ -149,38 +161,59 @@ function ShellSidebar({
   const isMobile = mode === "mobile";
   const accountLogoutLabel = t("shell.logout_button");
 
-  const handleNavClick = useCallback(
-    (to: string) => {
-      // Immediately mark as pending so highlight is instant
-      if (to !== location.pathname) {
-        clearProgressTimers();
-        progressStartedAt.current = Date.now();
-        setProgressDone(false);
-        setPendingTo(to);
-      }
-      onNavigate?.();
-    },
-    [clearProgressTimers, location.pathname, onNavigate],
-  );
+  const warmPageRoute = useCallback((to: string) => {
+    void preloadPageRoute(to).catch(() => undefined);
+  }, []);
 
-  useEffect(() => {
-    if (pendingTo !== location.pathname) return;
-    const delay = Math.max(0, ROUTE_PROGRESS_MIN_MS - (Date.now() - progressStartedAt.current));
-    const finishTimer = setTimeout(() => {
-      setProgressDone(true);
-      progressTimers.current.push(
-        setTimeout(() => {
+  const handleNavClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, to: string) => {
+      if (shouldUseNativeNavigation(event)) return;
+
+      if (to === location.pathname) {
+        onNavigate?.();
+        return;
+      }
+
+      event.preventDefault();
+      onNavigate?.();
+
+      const requestId = navigationRequestId.current + 1;
+      navigationRequestId.current = requestId;
+      clearProgressTimers();
+      progressStartedAt.current = Date.now();
+      setProgressDone(false);
+      setPendingTo(to);
+
+      const minimumProgress = new Promise<void>((resolve) => {
+        const delay = Math.max(0, ROUTE_PROGRESS_MIN_MS - (Date.now() - progressStartedAt.current));
+        const timer = setTimeout(resolve, delay);
+        progressTimers.current.push(timer);
+      });
+
+      void Promise.all([preloadPageRoute(to).catch(() => undefined), minimumProgress]).then(() => {
+        if (navigationRequestId.current !== requestId) return;
+        setProgressDone(true);
+
+        const navigateTimer = setTimeout(() => {
+          if (navigationRequestId.current !== requestId) return;
+          navigate(to, { viewTransition: true });
           setPendingTo("");
           setProgressDone(false);
           progressTimers.current = [];
-        }, ROUTE_PROGRESS_HIDE_MS),
-      );
-    }, delay);
-    progressTimers.current.push(finishTimer);
-    return () => clearTimeout(finishTimer);
-  }, [location.pathname, pendingTo]);
+        }, ROUTE_PROGRESS_HIDE_MS);
+        progressTimers.current.push(navigateTimer);
+      });
+    },
+    [clearProgressTimers, location.pathname, navigate, onNavigate],
+  );
 
-  useEffect(() => clearProgressTimers, [clearProgressTimers]);
+  useEffect(
+    () => () => {
+      navigationRequestId.current += 1;
+      clearProgressTimers();
+    },
+    [clearProgressTimers],
+  );
 
   return (
     <>
@@ -230,7 +263,9 @@ function ShellSidebar({
                 key={item.to}
                 to={item.to}
                 viewTransition
-                onClick={() => handleNavClick(item.to)}
+                onClick={(event) => handleNavClick(event, item.to)}
+                onMouseEnter={() => warmPageRoute(item.to)}
+                onFocus={() => warmPageRoute(item.to)}
                 className={
                   "flex min-w-0 items-center gap-3 rounded-[14px] px-3.5 py-2.5 text-[13px] transition-colors duration-200 ease-out whitespace-nowrap " +
                   (active

--- a/pages/account-security/route.tsx
+++ b/pages/account-security/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const AuthFilesPage = lazy(() =>
+const { Page: AuthFilesPage, preload: preloadAuthFilesPage } = preloadablePage(() =>
   import("../auth-files/AuthFilesPage").then((m) => ({ default: m.AuthFilesPage })),
 );
 
@@ -15,4 +15,5 @@ export const accountSecurityRoute = {
     { from: "/auth-files/oauth-model-alias", to: "/account-security?tab=alias" },
     { from: "/manage/identity-fingerprint", to: "/account-security" },
   ],
+  preload: preloadAuthFilesPage,
 };

--- a/pages/api-key-lookup/route.tsx
+++ b/pages/api-key-lookup/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ApiKeyLookupPage = lazy(() =>
+const { Page: ApiKeyLookupPage, preload: preloadApiKeyLookupPage } = preloadablePage(() =>
   import("./ApiKeyLookupPage").then((m) => ({ default: m.ApiKeyLookupPage })),
 );
 
@@ -10,4 +10,5 @@ export const apiKeyLookupRoute = {
   auth: false,
   layout: "none",
   nav: null,
+  preload: preloadApiKeyLookupPage,
 };

--- a/pages/api-key-permissions/route.tsx
+++ b/pages/api-key-permissions/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ApiKeyPermissionsPage = lazy(() =>
+const { Page: ApiKeyPermissionsPage, preload: preloadApiKeyPermissionsPage } = preloadablePage(() =>
   import("./ApiKeyPermissionsPage").then((m) => ({
     default: m.ApiKeyPermissionsPage,
   })),
@@ -13,4 +13,5 @@ export const apiKeyPermissionsRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.apiKeyPermissions" },
   redirects: [{ from: "/manage/api-key-permissions", to: "/api-key-permissions" }],
+  preload: preloadApiKeyPermissionsPage,
 };

--- a/pages/api-keys/route.tsx
+++ b/pages/api-keys/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ApiKeysPage = lazy(() => import("./ApiKeysPage").then((m) => ({ default: m.ApiKeysPage })));
+const { Page: ApiKeysPage, preload: preloadApiKeysPage } = preloadablePage(() =>
+  import("./ApiKeysPage").then((m) => ({ default: m.ApiKeysPage })),
+);
 
 export const apiKeysRoute = {
   path: "/api-keys",
@@ -8,4 +10,5 @@ export const apiKeysRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.apiKeys" },
+  preload: preloadApiKeysPage,
 };

--- a/pages/ccswitch-import-settings/route.tsx
+++ b/pages/ccswitch-import-settings/route.tsx
@@ -1,10 +1,11 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const CcSwitchImportSettingsPage = lazy(() =>
-  import("./CcSwitchImportSettingsPage").then((m) => ({
-    default: m.CcSwitchImportSettingsPage,
-  })),
-);
+const { Page: CcSwitchImportSettingsPage, preload: preloadCcSwitchImportSettingsPage } =
+  preloadablePage(() =>
+    import("./CcSwitchImportSettingsPage").then((m) => ({
+      default: m.CcSwitchImportSettingsPage,
+    })),
+  );
 
 export const ccswitchImportSettingsRoute = {
   path: "/ccswitch-import-settings",
@@ -13,4 +14,5 @@ export const ccswitchImportSettingsRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.ccswitchImportSettings" },
   redirects: [{ from: "/manage/ccswitch-import-settings", to: "/ccswitch-import-settings" }],
+  preload: preloadCcSwitchImportSettingsPage,
 };

--- a/pages/channel-groups/route.tsx
+++ b/pages/channel-groups/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ChannelGroupsPage = lazy(() =>
+const { Page: ChannelGroupsPage, preload: preloadChannelGroupsPage } = preloadablePage(() =>
   import("./ChannelGroupsPage").then((m) => ({
     default: m.ChannelGroupsPage,
   })),
@@ -12,4 +12,5 @@ export const channelGroupsRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.channelGroups" },
+  preload: preloadChannelGroupsPage,
 };

--- a/pages/config/route.tsx
+++ b/pages/config/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ConfigPage = lazy(() => import("./ConfigPage").then((m) => ({ default: m.ConfigPage })));
+const { Page: ConfigPage, preload: preloadConfigPage } = preloadablePage(() =>
+  import("./ConfigPage").then((m) => ({ default: m.ConfigPage })),
+);
 
 export const configRoute = {
   path: "/config",
@@ -9,4 +11,5 @@ export const configRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.config" },
   redirects: [{ from: "/settings", to: "/config" }],
+  preload: preloadConfigPage,
 };

--- a/pages/dashboard/route.tsx
+++ b/pages/dashboard/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const DashboardPage = lazy(() =>
+const { Page: DashboardPage, preload: preloadDashboardPage } = preloadablePage(() =>
   import("./DashboardPage").then((m) => ({ default: m.DashboardPage })),
 );
 
@@ -10,4 +10,5 @@ export const dashboardRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.dashboard" },
+  preload: preloadDashboardPage,
 };

--- a/pages/image-generation/route.tsx
+++ b/pages/image-generation/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ImageGenerationPage = lazy(() =>
+const { Page: ImageGenerationPage, preload: preloadImageGenerationPage } = preloadablePage(() =>
   import("./ImageGenerationPage").then((m) => ({
     default: m.ImageGenerationPage,
   })),
@@ -12,4 +12,5 @@ export const imageGenerationRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.imageGeneration" },
+  preload: preloadImageGenerationPage,
 };

--- a/pages/login/route.tsx
+++ b/pages/login/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const LoginPage = lazy(() => import("./LoginPage").then((m) => ({ default: m.LoginPage })));
+const { Page: LoginPage, preload: preloadLoginPage } = preloadablePage(() =>
+  import("./LoginPage").then((m) => ({ default: m.LoginPage })),
+);
 
 export const loginRoute = {
   path: "/login",
@@ -8,4 +10,5 @@ export const loginRoute = {
   auth: false,
   layout: "none",
   nav: null,
+  preload: preloadLoginPage,
 };

--- a/pages/logs/route.tsx
+++ b/pages/logs/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const LogsPage = lazy(() => import("./LogsPage").then((m) => ({ default: m.LogsPage })));
+const { Page: LogsPage, preload: preloadLogsPage } = preloadablePage(() =>
+  import("./LogsPage").then((m) => ({ default: m.LogsPage })),
+);
 
 export const logsRoute = {
   path: "/logs",
@@ -8,4 +10,5 @@ export const logsRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.logs" },
+  preload: preloadLogsPage,
 };

--- a/pages/models/route.tsx
+++ b/pages/models/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ModelsPage = lazy(() => import("./ModelsPage").then((m) => ({ default: m.ModelsPage })));
+const { Page: ModelsPage, preload: preloadModelsPage } = preloadablePage(() =>
+  import("./ModelsPage").then((m) => ({ default: m.ModelsPage })),
+);
 
 export const modelsRoute = {
   path: "/models",
@@ -9,4 +11,5 @@ export const modelsRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.models" },
   redirects: [{ from: "/manage/models", to: "/models" }],
+  preload: preloadModelsPage,
 };

--- a/pages/monitor/route.tsx
+++ b/pages/monitor/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const MonitorPage = lazy(() => import("./MonitorPage").then((m) => ({ default: m.MonitorPage })));
+const { Page: MonitorPage, preload: preloadMonitorPage } = preloadablePage(() =>
+  import("./MonitorPage").then((m) => ({ default: m.MonitorPage })),
+);
 
 export const monitorRoute = {
   path: "/monitor",
@@ -9,4 +11,5 @@ export const monitorRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.monitor" },
   redirects: [{ from: "/usage", to: "/monitor" }],
+  preload: preloadMonitorPage,
 };

--- a/pages/preloadablePage.tsx
+++ b/pages/preloadablePage.tsx
@@ -1,0 +1,32 @@
+import type { ComponentType, ReactElement } from "react";
+
+type PageModule = {
+  default: ComponentType;
+};
+
+export function preloadablePage(load: () => Promise<PageModule>): {
+  Page: () => ReactElement;
+  preload: () => Promise<PageModule>;
+} {
+  let loadedModule: PageModule | null = null;
+  let loadingPromise: Promise<PageModule> | null = null;
+
+  const preload = () => {
+    loadingPromise ??= load().then((module) => {
+      loadedModule = module;
+      return module;
+    });
+    return loadingPromise;
+  };
+
+  const Page = () => {
+    if (!loadedModule) {
+      throw preload();
+    }
+
+    const LoadedPage = loadedModule.default;
+    return <LoadedPage />;
+  };
+
+  return { Page, preload };
+}

--- a/pages/providers/route.tsx
+++ b/pages/providers/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ProvidersPage = lazy(() =>
+const { Page: ProvidersPage, preload: preloadProvidersPage } = preloadablePage(() =>
   import("./ProvidersPage").then((m) => ({ default: m.ProvidersPage })),
 );
 
@@ -11,4 +11,5 @@ export const providersRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.providers" },
   hasWildcard: true,
+  preload: preloadProvidersPage,
 };

--- a/pages/proxies/route.tsx
+++ b/pages/proxies/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const ProxiesPage = lazy(() => import("./ProxiesPage").then((m) => ({ default: m.ProxiesPage })));
+const { Page: ProxiesPage, preload: preloadProxiesPage } = preloadablePage(() =>
+  import("./ProxiesPage").then((m) => ({ default: m.ProxiesPage })),
+);
 
 export const proxiesRoute = {
   path: "/proxies",
@@ -9,4 +11,5 @@ export const proxiesRoute = {
   layout: "dashboard",
   nav: { labelKey: "nav.proxies" },
   redirects: [{ from: "/manage/proxies", to: "/proxies" }],
+  preload: preloadProxiesPage,
 };

--- a/pages/registry.ts
+++ b/pages/registry.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { loginRoute } from "./login/route";
 import { dashboardRoute } from "./dashboard/route";
 import { monitorRoute } from "./monitor/route";
@@ -18,7 +19,18 @@ import { imageGenerationRoute } from "./image-generation/route";
 import { ccswitchImportSettingsRoute } from "./ccswitch-import-settings/route";
 import { apiKeyLookupRoute } from "./api-key-lookup/route";
 
-export const pageRoutes = [
+export interface PageRoute {
+  path: string;
+  element: ReactElement;
+  auth: boolean;
+  layout: string;
+  nav: { labelKey: string } | null;
+  redirects?: Array<{ from: string; to: string }>;
+  hasWildcard?: boolean;
+  preload?: () => Promise<unknown>;
+}
+
+export const pageRoutes: PageRoute[] = [
   loginRoute,
   dashboardRoute,
   monitorRoute,
@@ -39,3 +51,25 @@ export const pageRoutes = [
   ccswitchImportSettingsRoute,
   apiKeyLookupRoute,
 ];
+
+const normalizePathname = (to: string) => to.split(/[?#]/, 1)[0] || "/";
+
+const matchesPath = (pathname: string, routePath: string) =>
+  pathname === routePath || pathname.startsWith(`${routePath}/`);
+
+export function preloadPageRoute(to: string): Promise<unknown> {
+  const pathname = normalizePathname(to);
+  let matchedRoute: PageRoute | null = null;
+  let matchedLength = -1;
+
+  for (const route of pageRoutes) {
+    const paths = [route.path, ...(route.redirects ?? []).map((redirect) => redirect.from)];
+    for (const path of paths) {
+      if (!matchesPath(pathname, path) || path.length <= matchedLength) continue;
+      matchedRoute = route;
+      matchedLength = path.length;
+    }
+  }
+
+  return matchedRoute?.preload?.() ?? Promise.resolve();
+}

--- a/pages/request-logs/route.tsx
+++ b/pages/request-logs/route.tsx
@@ -1,6 +1,6 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const RequestLogsPage = lazy(() =>
+const { Page: RequestLogsPage, preload: preloadRequestLogsPage } = preloadablePage(() =>
   import("./RequestLogsPage").then((m) => ({ default: m.RequestLogsPage })),
 );
 
@@ -10,4 +10,5 @@ export const requestLogsRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.requestLogs" },
+  preload: preloadRequestLogsPage,
 };

--- a/pages/system/route.tsx
+++ b/pages/system/route.tsx
@@ -1,6 +1,8 @@
-import { lazy } from "react";
+import { preloadablePage } from "../preloadablePage";
 
-const SystemPage = lazy(() => import("./SystemPage").then((m) => ({ default: m.SystemPage })));
+const { Page: SystemPage, preload: preloadSystemPage } = preloadablePage(() =>
+  import("./SystemPage").then((m) => ({ default: m.SystemPage })),
+);
 
 export const systemRoute = {
   path: "/system",
@@ -8,4 +10,5 @@ export const systemRoute = {
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.system" },
+  preload: preloadSystemPage,
 };


### PR DESCRIPTION
## Summary
- preload admin page chunks before sidebar navigation completes
- keep the existing top progress bar as the only internal navigation loading indicator
- remove the full-page React route fallback after the HTML boot loader

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- AppShell AppRouter
- rtk bun run build