### PR TITLE
feat: show Codex reset credit expiry tooltip

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -327,6 +327,85 @@ describe("fetchQuota for codex", () => {
       }),
     ]);
   });
+
+  test("requests reset credit details when Codex usage reports available credits", async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        header: {},
+        bodyText: "",
+        body: {
+          plan_type: "plus",
+          rate_limit_reset_credits: { available_count: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        header: {},
+        bodyText: "",
+        body: {
+          credits: [
+            { expires_at: "2026-07-04T10:00:00Z" },
+            { expiresAt: "2026-07-03T10:00:00Z" },
+          ],
+        },
+      });
+
+    const result = await fetchQuota("codex", {
+      name: "codex.json",
+      provider: "codex",
+      auth_index: "codex-1",
+    } as any);
+
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    expect(mocks.request.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        url: "https://chatgpt.com/backend-api/wham/usage",
+      }),
+    );
+    expect(mocks.request.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        url: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+      }),
+    );
+    expect(result.resetCreditCount).toBe(2);
+    expect(result.resetCreditExpirations).toEqual([
+      "2026-07-03T10:00:00Z",
+      "2026-07-04T10:00:00Z",
+    ]);
+  });
+
+  test("keeps Codex quota result when reset credit details fail", async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        header: {},
+        bodyText: "",
+        body: {
+          plan_type: "plus",
+          rate_limit_reset_credits: { available_count: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        statusCode: 500,
+        header: {},
+        bodyText: "upstream failed",
+        body: "",
+      });
+
+    const result = await fetchQuota("codex", {
+      name: "codex.json",
+      provider: "codex",
+      auth_index: "codex-1",
+    } as any);
+
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    expect(result.planType).toBe("plus");
+    expect(result.resetCreditCount).toBe(1);
+    expect(result.resetCreditExpirations).toBeUndefined();
+  });
 });
 
 describe("fetchQuota for claude", () => {

--- a/features/quota-preview/__tests__/quota-helpers.test.ts
+++ b/features/quota-preview/__tests__/quota-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   formatRelativeResetLabel,
   parseAntigravityPayload,
   parseKimiUsagePayload,
+  resolveCodexResetCreditExpirations,
   resolveCodexResetCreditCount,
 } from "@features/quota-preview/quota-helpers";
 
@@ -157,6 +158,29 @@ describe("buildCodexItems", () => {
         rate_limit_reset_credits: { available_count: "3" },
       }),
     ).toBe(3);
+  });
+
+  test("reads reset credit expiration times sorted by expiry", () => {
+    expect(
+      resolveCodexResetCreditExpirations({
+        credits: [
+          { expires_at: "2026-07-04T10:00:00Z" },
+          { expiresAt: "2026-07-03T10:00:00Z" },
+          { expires_at: "" },
+          { expires_at: "not-a-date" },
+        ],
+      }),
+    ).toEqual(["2026-07-03T10:00:00Z", "2026-07-04T10:00:00Z", "not-a-date"]);
+  });
+
+  test("reads reset credit expiration times from wrapped detail payloads", () => {
+    expect(
+      resolveCodexResetCreditExpirations({
+        rate_limit_reset_credits: {
+          data: [{ expiresAt: "2026-07-02T10:00:00Z" }],
+        },
+      }),
+    ).toEqual(["2026-07-02T10:00:00Z"]);
   });
 });
 

--- a/features/quota-preview/quota-codex.ts
+++ b/features/quota-preview/quota-codex.ts
@@ -42,6 +42,11 @@ type CodexAdditionalRateLimit = {
 type CodexRateLimitResetCredits = {
   available_count?: number | string;
   availableCount?: number | string;
+  credits?: CodexRateLimitResetCreditDetail[];
+  rate_limit_reset_credits?: CodexRateLimitResetCreditDetail[];
+  rateLimitResetCredits?: CodexRateLimitResetCreditDetail[];
+  items?: CodexRateLimitResetCreditDetail[];
+  data?: CodexRateLimitResetCreditDetail[];
 };
 
 export type CodexUsagePayload = {
@@ -55,6 +60,11 @@ export type CodexUsagePayload = {
   additionalRateLimits?: CodexAdditionalRateLimit[];
   rate_limit_reset_credits?: CodexRateLimitResetCredits | null;
   rateLimitResetCredits?: CodexRateLimitResetCredits | null;
+};
+
+type CodexRateLimitResetCreditDetail = {
+  expires_at?: string;
+  expiresAt?: string;
 };
 
 export const resolveCodexChatgptAccountId = (file: AuthFileItem): string | null => {
@@ -126,6 +136,56 @@ export const resolveCodexResetCreditCount = (payload: CodexUsagePayload): number
   const credits = payload.rate_limit_reset_credits ?? payload.rateLimitResetCredits ?? null;
   const count = normalizeNumberValue(credits?.available_count ?? credits?.availableCount);
   return count === null ? 0 : Math.max(0, Math.floor(count));
+};
+
+const parseCodexResetCreditsPayload = (payload: unknown): unknown => {
+  if (typeof payload !== "string") return payload;
+  const trimmed = payload.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+const readCodexResetCreditList = (payload: unknown, depth = 0): unknown[] => {
+  const parsed = parseCodexResetCreditsPayload(payload);
+  if (Array.isArray(parsed)) return parsed;
+  if (!isRecord(parsed)) return [];
+  for (const key of [
+    "credits",
+    "rate_limit_reset_credits",
+    "rateLimitResetCredits",
+    "items",
+    "data",
+  ]) {
+    const value = parsed[key];
+    if (Array.isArray(value) && value.length > 0) return value;
+    if (depth < 1 && isRecord(value)) {
+      const nested = readCodexResetCreditList(value, depth + 1);
+      if (nested.length > 0) return nested;
+    }
+  }
+  return [];
+};
+
+export const resolveCodexResetCreditExpirations = (payload: unknown): string[] => {
+  const sorted = readCodexResetCreditList(payload)
+    .map((credit) => {
+      if (!isRecord(credit)) return null;
+      return normalizeStringValue(credit.expires_at ?? credit.expiresAt);
+    })
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => {
+      const leftMs = Date.parse(left);
+      const rightMs = Date.parse(right);
+      const leftSort = Number.isNaN(leftMs) ? Number.POSITIVE_INFINITY : leftMs;
+      const rightSort = Number.isNaN(rightMs) ? Number.POSITIVE_INFINITY : rightMs;
+      if (leftSort === rightSort) return 0;
+      return leftSort < rightSort ? -1 : 1;
+    });
+  return [...new Set(sorted)];
 };
 
 const resolveCodexResetAtMs = (window?: CodexUsageWindow | null): number | undefined => {

--- a/features/quota-preview/quota-fetch.ts
+++ b/features/quota-preview/quota-fetch.ts
@@ -6,6 +6,7 @@ import {
   CLAUDE_REQUEST_HEADERS,
   CLAUDE_USAGE_URL,
   CODEX_REQUEST_HEADERS,
+  CODEX_RESET_CREDITS_URL,
   CODEX_RESET_CREDITS_CONSUME_URL,
   CODEX_USAGE_URL,
   DEFAULT_ANTIGRAVITY_PROJECT_ID,
@@ -38,6 +39,7 @@ import {
   parseResetTimeToMs,
   resolveAuthProvider,
   resolveCodexChatgptAccountId,
+  resolveCodexResetCreditExpirations,
   resolveCodexResetCreditCount,
   resolveGeminiCliProjectId,
   type QuotaItem,
@@ -48,6 +50,7 @@ export type QuotaFetchResult = {
   items: QuotaItem[];
   planType?: string | null;
   resetCreditCount?: number;
+  resetCreditExpirations?: string[];
 };
 
 const createRedeemRequestId = (): string =>
@@ -167,20 +170,40 @@ export const fetchQuota = async (
   }
 
   if (type === "codex") {
+    const header = buildCodexRequestHeaders(file);
     const result = await apiCallApi.request({
       authIndex,
       method: "GET",
       url: CODEX_USAGE_URL,
-      header: buildCodexRequestHeaders(file),
+      header,
     });
     if (result.statusCode < 200 || result.statusCode >= 300)
       throw new Error(getApiCallErrorMessage(result));
     const payload = parseCodexUsagePayload(result.body ?? result.bodyText);
     if (!payload) throw new Error("parse_codex_failed");
+    const resetCreditCount = resolveCodexResetCreditCount(payload);
+    let resetCreditExpirations: string[] | undefined;
+    if (resetCreditCount > 0) {
+      try {
+        const details = await apiCallApi.request({
+          authIndex,
+          method: "GET",
+          url: CODEX_RESET_CREDITS_URL,
+          header,
+        });
+        if (details.statusCode >= 200 && details.statusCode < 300) {
+          const expirations = resolveCodexResetCreditExpirations(details.body ?? details.bodyText);
+          resetCreditExpirations = expirations.length > 0 ? expirations : undefined;
+        }
+      } catch {
+        resetCreditExpirations = undefined;
+      }
+    }
     return {
       items: buildCodexItems(payload),
       planType: normalizeStringValue(payload.plan_type ?? payload.planType)?.toLowerCase() ?? null,
-      resetCreditCount: resolveCodexResetCreditCount(payload),
+      resetCreditCount,
+      resetCreditExpirations,
     };
   }
 

--- a/features/quota-preview/quota-helpers.ts
+++ b/features/quota-preview/quota-helpers.ts
@@ -12,6 +12,7 @@ export { type CodexUsagePayload } from "@features/quota-preview/quota-codex";
 export {
   buildCodexItems,
   parseCodexUsagePayload,
+  resolveCodexResetCreditExpirations,
   resolveCodexResetCreditCount,
   resolveCodexChatgptAccountId,
 } from "@features/quota-preview/quota-codex";
@@ -65,6 +66,8 @@ export const GEMINI_CLI_REQUEST_HEADERS = {
 };
 
 export const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+export const CODEX_RESET_CREDITS_URL =
+  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 export const CODEX_RESET_CREDITS_CONSUME_URL =
   "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
 export const CODEX_REQUEST_HEADERS = {

--- a/features/quota-preview/quota-types.ts
+++ b/features/quota-preview/quota-types.ts
@@ -14,6 +14,7 @@ export type QuotaState = {
   items: QuotaItem[];
   planType?: string;
   resetCreditCount?: number;
+  resetCreditExpirations?: string[];
   error?: string;
   updatedAt?: number;
 };

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -458,6 +458,14 @@ const sanitizeResetCreditCountForCache = (value: unknown): number | undefined =>
   return Math.max(0, Math.floor(count));
 };
 
+const sanitizeResetCreditExpirationsForCache = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const expirations = value
+    .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    .map((item) => item.trim());
+  return expirations.length > 0 ? expirations : undefined;
+};
+
 const sanitizeQuotaByFileNameForCache = (
   quotaByFileName: unknown,
   fileNames?: Set<string>,
@@ -481,12 +489,16 @@ const sanitizeQuotaByFileNameForCache = (
         : undefined;
     const planType = normalizePlanType(state.planType ?? state.plan_type);
     const resetCreditCount = sanitizeResetCreditCountForCache(state.resetCreditCount);
+    const resetCreditExpirations = sanitizeResetCreditExpirationsForCache(
+      state.resetCreditExpirations,
+    );
     const error = typeof state.error === "string" ? state.error : undefined;
     output[fileName] = {
       status: status === "loading" ? "success" : (status as QuotaStatus),
       items,
       planType: planType ?? undefined,
       resetCreditCount,
+      resetCreditExpirations,
       updatedAt,
       error: status === "error" ? error : undefined,
     };

--- a/packages/domain/src/quota/types.ts
+++ b/packages/domain/src/quota/types.ts
@@ -20,6 +20,7 @@ export type QuotaState = {
   items: QuotaItem[];
   planType?: string;
   resetCreditCount?: number;
+  resetCreditExpirations?: string[];
   error?: string;
   updatedAt?: number;
   fetchedAt?: number;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -583,6 +583,7 @@
     "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}",
     "reset_credits_badge": "Reset {{count}} times",
     "reset_credits_query": "Query reset credits",
+    "reset_credit_expirations": "Reset credit expiration times:\n{{times}}",
     "reset_credit_consume": "Reset quota",
     "reset_credit_no_credits": "No reset credits available",
     "reset_credit_confirm_title": "Reset quota?",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -581,6 +581,7 @@
     "quota_updated_at": "Обновлено",
     "reset_credits_badge": "Reset {{count}} times",
     "reset_credits_query": "Query reset credits",
+    "reset_credit_expirations": "Reset credit expiration times:\n{{times}}",
     "reset_credit_consume": "Reset quota",
     "reset_credit_no_credits": "No reset credits available",
     "reset_credit_confirm_title": "Reset quota?",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -591,6 +591,7 @@
     "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}",
     "reset_credits_badge": "重置 {{count}} 次",
     "reset_credits_query": "查询重置次数",
+    "reset_credit_expirations": "每次重置令牌过期时间：\n{{times}}",
     "reset_credit_consume": "重置额度",
     "reset_credit_no_credits": "暂无可用重置次数",
     "reset_credit_confirm_title": "确认重置额度",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -4421,6 +4421,7 @@ describe("AuthFilesPage files table", () => {
         items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
         planType: "plus",
         resetCreditCount: 3,
+        resetCreditExpirations: ["2026-07-03T10:00:00Z", "2026-07-04T10:00:00Z"],
       })
       .mockResolvedValueOnce({
         items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
@@ -4463,6 +4464,8 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("Reset 3 times")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
     const resetButton = within(cards).getByRole("button", { name: "Query reset credits" });
+    expect(resetButton.getAttribute("title")).toContain("Reset credit expiration times:");
+    expect(resetButton.getAttribute("title")).toContain("2026");
     const callsBadge = within(cards).getByText("0 calls");
     expect(
       resetButton.compareDocumentPosition(callsBadge) & Node.DOCUMENT_POSITION_FOLLOWING,
@@ -4470,6 +4473,8 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(resetButton);
 
     expect(await screen.findByText("Reset 4 times")).toBeInTheDocument();
+    const updatedResetButton = within(cards).getByRole("button", { name: "Query reset credits" });
+    expect(updatedResetButton).toHaveAttribute("title", "Query reset credits");
     expect(mocks.fetchQuota).toHaveBeenLastCalledWith(
       "codex",
       expect.objectContaining({ name: "codex.json" }),
@@ -4483,6 +4488,7 @@ describe("AuthFilesPage files table", () => {
       const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
       expect(raw).toContain('"planType":"plus"');
       expect(raw).toContain('"resetCreditCount":4');
+      expect(raw).not.toContain("resetCreditExpirations");
     });
   });
 

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -100,6 +100,18 @@ const sanitizeCodexFilenamePart = (value: unknown): string =>
     .slice(0, MAX_FILENAME_PART_LENGTH)
     .replace(/^-+|-+$/g, "");
 
+const formatResetCreditExpiry = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+};
+
 const readStringField = (record: Record<string, unknown>, keys: string[]): string => {
   for (const key of keys) {
     const value = record[key];
@@ -1341,6 +1353,18 @@ export function AuthFilesFilesTab({
                     provider === "codex" && typeof state.resetCreditCount === "number"
                       ? state.resetCreditCount
                       : 0;
+                  const resetCreditExpirations =
+                    provider === "codex" && Array.isArray(state.resetCreditExpirations)
+                      ? state.resetCreditExpirations
+                      : [];
+                  const resetCreditBadgeTitle =
+                    resetCreditCount <= 0
+                      ? t("auth_files.reset_credit_no_credits")
+                      : resetCreditExpirations.length > 0
+                        ? t("auth_files.reset_credit_expirations", {
+                            times: resetCreditExpirations.map(formatResetCreditExpiry).join("\n"),
+                          })
+                        : t("auth_files.reset_credits_query");
                   const resetCreditBusy = resettingCreditFileName === file.name;
                   const clearStatusBusy = clearingStatusFileName === file.name;
                   const clearStatusDisabled = !authIndex || clearStatusBusy;
@@ -1444,7 +1468,7 @@ export function AuthFilesFilesTab({
                               className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-blue-50 hover:text-blue-700 disabled:cursor-wait disabled:opacity-70 dark:bg-white/10 dark:text-white/70 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
                               disabled={quotaRefreshing}
                               onClick={() => void refreshQuota(file, provider)}
-                              title={t("auth_files.reset_credits_query")}
+                              title={resetCreditBadgeTitle}
                               aria-label={t("auth_files.reset_credits_query")}
                             >
                               <RefreshCw

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -280,6 +280,7 @@ export function useAuthFilesQuotaState({
             items: prev[name]?.items ?? [],
             planType: prev[name]?.planType,
             resetCreditCount: prev[name]?.resetCreditCount,
+            resetCreditExpirations: prev[name]?.resetCreditExpirations,
             error: prev[name]?.error,
             updatedAt: prev[name]?.updatedAt,
           },
@@ -291,6 +292,10 @@ export function useAuthFilesQuotaState({
         const items = Array.isArray(result) ? result : result.items;
         const nextPlanType = Array.isArray(result) ? null : (result.planType ?? null);
         const nextResetCreditCount = Array.isArray(result) ? undefined : result.resetCreditCount;
+        const nextResetCreditExpirations =
+          !Array.isArray(result) && Array.isArray(result.resetCreditExpirations)
+            ? result.resetCreditExpirations
+            : undefined;
         const rawAuthIndex = (file as { auth_index?: unknown }).auth_index ?? file.authIndex;
         const authIndex = normalizeAuthIndexValue(rawAuthIndex);
         if (authIndex) {
@@ -346,6 +351,7 @@ export function useAuthFilesQuotaState({
               typeof nextResetCreditCount === "number"
                 ? nextResetCreditCount
                 : prev[name]?.resetCreditCount,
+            resetCreditExpirations: nextResetCreditExpirations,
             updatedAt: Date.now(),
           },
         }));
@@ -361,6 +367,7 @@ export function useAuthFilesQuotaState({
             items: prev[name]?.items ?? [],
             planType: prev[name]?.planType,
             resetCreditCount: prev[name]?.resetCreditCount,
+            resetCreditExpirations: prev[name]?.resetCreditExpirations,
             error: message,
             updatedAt: Date.now(),
           },
@@ -428,6 +435,7 @@ export function useAuthFilesQuotaState({
             items: prev[target.file.name]?.items ?? [],
             planType: prev[target.file.name]?.planType,
             resetCreditCount: prev[target.file.name]?.resetCreditCount,
+            resetCreditExpirations: prev[target.file.name]?.resetCreditExpirations,
             error: prev[target.file.name]?.error,
             updatedAt: prev[target.file.name]?.updatedAt,
           };


### PR DESCRIPTION
## Summary
- query Codex reset-credit details when usage reports available reset credits
- carry reset credit expiration times through quota state/cache
- show the expiration list in the existing reset-count badge title

## Verification
- rtk bun run test:ci
- rtk bun run check
- rtk git diff --check
- production preview Playwright smoke for the reset-credit tooltip

## Notes
- Full chromium e2e currently has two stable failures unrelated to this change: the old /auth-files?tab=excluded route expectation and an OpenCode Go language assertion expecting Chinese while the page renders English.