### PR TITLE
fix: use hover tooltip for codex reset credits

### DIFF
--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -4464,8 +4464,12 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("Reset 3 times")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
     const resetButton = within(cards).getByRole("button", { name: "Query reset credits" });
-    expect(resetButton.getAttribute("title")).toContain("Reset credit expiration times:");
-    expect(resetButton.getAttribute("title")).toContain("2026");
+    expect(resetButton).not.toHaveAttribute("title");
+    const user = userEvent.setup();
+    await user.hover(resetButton);
+    const resetTooltip = await screen.findByRole("tooltip");
+    expect(resetTooltip).toHaveTextContent("Reset credit expiration times:");
+    expect(resetTooltip).toHaveTextContent("2026");
     const callsBadge = within(cards).getByText("0 calls");
     expect(
       resetButton.compareDocumentPosition(callsBadge) & Node.DOCUMENT_POSITION_FOLLOWING,
@@ -4474,7 +4478,7 @@ describe("AuthFilesPage files table", () => {
 
     expect(await screen.findByText("Reset 4 times")).toBeInTheDocument();
     const updatedResetButton = within(cards).getByRole("button", { name: "Query reset credits" });
-    expect(updatedResetButton).toHaveAttribute("title", "Query reset credits");
+    expect(updatedResetButton).not.toHaveAttribute("title");
     expect(mocks.fetchQuota).toHaveBeenLastCalledWith(
       "codex",
       expect.objectContaining({ name: "codex.json" }),

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1463,24 +1463,25 @@ export function AuthFilesFilesTab({
                             </span>
                           ) : null}
                           {provider === "codex" ? (
-                            <button
-                              type="button"
-                              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-blue-50 hover:text-blue-700 disabled:cursor-wait disabled:opacity-70 dark:bg-white/10 dark:text-white/70 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
-                              disabled={quotaRefreshing}
-                              onClick={() => void refreshQuota(file, provider)}
-                              title={resetCreditBadgeTitle}
-                              aria-label={t("auth_files.reset_credits_query")}
-                            >
-                              <RefreshCw
-                                size={10}
-                                className={quotaRefreshing ? "animate-spin" : ""}
-                              />
-                              <span className="tabular-nums">
-                                {t("auth_files.reset_credits_badge", {
-                                  count: resetCreditCount,
-                                })}
-                              </span>
-                            </button>
+                            <HoverTooltip content={resetCreditBadgeTitle} className="shrink-0">
+                              <button
+                                type="button"
+                                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-blue-50 hover:text-blue-700 disabled:cursor-wait disabled:opacity-70 dark:bg-white/10 dark:text-white/70 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
+                                disabled={quotaRefreshing}
+                                onClick={() => void refreshQuota(file, provider)}
+                                aria-label={t("auth_files.reset_credits_query")}
+                              >
+                                <RefreshCw
+                                  size={10}
+                                  className={quotaRefreshing ? "animate-spin" : ""}
+                                />
+                                <span className="tabular-nums">
+                                  {t("auth_files.reset_credits_badge", {
+                                    count: resetCreditCount,
+                                  })}
+                                </span>
+                              </button>
+                            </HoverTooltip>
                           ) : null}
                           <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
                             {t("auth_files.calls_count", { count: displayCalls })}


### PR DESCRIPTION
## Summary
- wrap the Codex reset credit badge with the shared HoverTooltip component
- remove the native title attribute from that badge
- update the auth files test to assert the rendered tooltip content on hover

## Validation
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run --filter @code-proxy/admin-panel test -- features/quota-preview/__tests__/quota-helpers.test.ts features/quota-preview/__tests__/quota-fetch.test.ts pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run build
- rtk bun run test:ci
- rtk bun run check
- rtk git diff --check
- production preview Playwright smoke: reset badge has no native title and HoverTooltip shows 2026 expiration times