### PR TITLE
fix: preserve ccswitch model mappings

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -160,21 +160,7 @@ function reconcileGenericMappings(
 ): CcSwitchModelMapping[] {
   const currentNonRole = currentMappings.filter((mapping) => !mapping.role);
   if (currentNonRole.length > 0) {
-    const seen = new Set<string>();
-    const preserved: CcSwitchModelMapping[] = [];
-
-    for (const mapping of currentNonRole) {
-      const targetKey = mapping.targetModel.trim().toLowerCase();
-      if (targetKey) {
-        if (seen.has(targetKey)) continue;
-        seen.add(targetKey);
-      }
-      preserved.push(mapping);
-    }
-
-    if (preserved.length > 0) {
-      return preserved;
-    }
+    return currentNonRole;
   }
 
   const autoMappings = dedupeModels(models).map((targetModel) => ({

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -717,7 +717,11 @@ describe("CcSwitchImportSettingsPage", () => {
         modelMappings: [
           {
             requestModel: "gpt-5.5",
-            targetModel: "moonshot-v1-128k",
+            targetModel: "gpt-5.5",
+          },
+          {
+            requestModel: "gpt-5.4-mini",
+            targetModel: "gpt-5.5",
           },
         ],
       },
@@ -731,10 +735,16 @@ describe("CcSwitchImportSettingsPage", () => {
     const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
     expect(
       await within(dialog).findByRole("combobox", { name: /actual channel model 1/i }),
-    ).toHaveTextContent("moonshot-v1-128k");
+    ).toHaveTextContent("gpt-5.5");
     expect(within(dialog).getByLabelText(/cc switch request model for mapping 1/i)).toHaveValue(
       "gpt-5.5",
     );
+    expect(within(dialog).getByLabelText(/cc switch request model for mapping 2/i)).toHaveValue(
+      "gpt-5.4-mini",
+    );
+    expect(
+      within(dialog).getByRole("combobox", { name: /actual channel model 2/i }),
+    ).toHaveTextContent("gpt-5.5");
 
     await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
 
@@ -744,12 +754,16 @@ describe("CcSwitchImportSettingsPage", () => {
           id: "cfg-kimi",
           defaultModel: "gpt-5.5",
           allowedChannelGroups: ["kimicode"],
-          modelMappings: expect.arrayContaining([
+          modelMappings: [
             {
               requestModel: "gpt-5.5",
-              targetModel: "moonshot-v1-128k",
+              targetModel: "gpt-5.5",
             },
-          ]),
+            {
+              requestModel: "gpt-5.4-mini",
+              targetModel: "gpt-5.5",
+            },
+          ],
         }),
       ]),
     );


### PR DESCRIPTION
## Summary
- preserve existing generic CC Switch model mappings instead of deduping by target model
- add regression coverage for multiple request models mapping to the same target model

## Verification
- rtk bun run test -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
- rtk go test ./internal/api ./sdk/api/handlers/openai
- rtk bun run build