### PR TITLE
feat: embed Codex catalog in CC Switch imports

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
@@ -76,7 +76,17 @@ describe("ccSwitchImportConfigsApi", () => {
         codexModelCatalogFilename: "cc-switch-model-catalog.json",
         codexModelCatalog: {
           models: [
-            { slug: "gpt-5.5", display_name: "gpt-5.5" },
+            {
+              slug: "gpt-5.5",
+              display_name: "gpt-5.5",
+              default_reasoning_level: "medium",
+              supported_reasoning_levels: [
+                { effort: "low", description: "Fast" },
+                { effort: "medium", description: "Balanced" },
+                { effort: "high", description: "Deep" },
+                { effort: "xhigh", description: "Extra deep" },
+              ],
+            },
             { slug: "deepseek-v4-flash", display_name: "deepseek-v4-flash" },
           ],
         },
@@ -90,7 +100,16 @@ describe("ccSwitchImportConfigsApi", () => {
         "codex-model-catalog-filename": "cc-switch-model-catalog.json",
         "codex-model-catalog": expect.objectContaining({
           models: expect.arrayContaining([
-            expect.objectContaining({ slug: "gpt-5.5" }),
+            expect.objectContaining({
+              slug: "gpt-5.5",
+              default_reasoning_level: "medium",
+              supported_reasoning_levels: [
+                { effort: "low", description: "Fast" },
+                { effort: "medium", description: "Balanced" },
+                { effort: "high", description: "Deep" },
+                { effort: "xhigh", description: "Extra deep" },
+              ],
+            }),
             expect.objectContaining({ slug: "deepseek-v4-flash" }),
           ]),
         }),
@@ -116,7 +135,12 @@ describe("ccSwitchImportConfigsApi", () => {
         "codex-model-catalog-filename": "cc-switch-model-catalog.json",
         "codex-model-catalog": {
           models: [
-            { slug: "gpt-5.5", display_name: "gpt-5.5" },
+            {
+              model: "gpt-5.5",
+              display_name: "gpt-5.5",
+              default_reasoning_level: "medium",
+              supported_reasoning_levels: ["low", "medium", "high", "xhigh"],
+            },
             { slug: "deepseek-v4-flash", display_name: "deepseek-v4-flash" },
           ],
         },
@@ -127,7 +151,14 @@ describe("ccSwitchImportConfigsApi", () => {
     expect(configs[0]).toMatchObject({
       codexModelCatalogFilename: "cc-switch-model-catalog.json",
       codexModelCatalog: {
-        models: [{ slug: "gpt-5.5" }, { slug: "deepseek-v4-flash" }],
+        models: [
+          {
+            model: "gpt-5.5",
+            default_reasoning_level: "medium",
+            supported_reasoning_levels: ["low", "medium", "high", "xhigh"],
+          },
+          { slug: "deepseek-v4-flash" },
+        ],
       },
     });
   });

--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -20,6 +20,14 @@ export interface CcSwitchCodexCatalogModel {
   model: string;
   displayName?: string;
   contextWindow?: number;
+  defaultReasoningLevel?: string;
+  supportedReasoningLevels?: Array<
+    | string
+    | {
+        effort: string;
+        description?: string;
+      }
+  >;
 }
 
 export interface CcSwitchCodexModelCatalog {
@@ -35,9 +43,9 @@ export interface CcSwitchCodexModelCatalogEntry {
   model: string;
   display_name: string;
   description: string;
-  default_reasoning_level: "medium";
+  default_reasoning_level: string;
   supported_reasoning_levels: Array<{
-    effort: "low" | "medium" | "high" | "xhigh";
+    effort: string;
     description: string;
   }>;
   shell_type: "shell_command";
@@ -271,6 +279,35 @@ const normalizeCodexContextWindow = (value: number | undefined): number => {
   return Math.round(value);
 };
 
+const normalizeCodexReasoningLevels = (
+  levels: CcSwitchCodexCatalogModel["supportedReasoningLevels"],
+): CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"] => {
+  if (!Array.isArray(levels) || levels.length === 0) return CODEX_SUPPORTED_REASONING_LEVELS;
+
+  const normalized = levels
+    .map((level) => {
+      if (typeof level === "string") {
+        const effort = level.trim();
+        if (!effort) return null;
+        const builtIn = CODEX_SUPPORTED_REASONING_LEVELS.find((item) => item.effort === effort);
+        return builtIn ?? { effort, description: effort };
+      }
+
+      const effort = String(level.effort ?? "").trim();
+      if (!effort) return null;
+      const builtIn = CODEX_SUPPORTED_REASONING_LEVELS.find((item) => item.effort === effort);
+      return {
+        effort,
+        description: String(level.description ?? builtIn?.description ?? effort),
+      };
+    })
+    .filter((level): level is CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"][number] =>
+      Boolean(level),
+    );
+
+  return normalized.length > 0 ? normalized : CODEX_SUPPORTED_REASONING_LEVELS;
+};
+
 const buildCodexCatalogEntry = (
   model: CcSwitchCodexCatalogModel,
   priority: number,
@@ -278,14 +315,16 @@ const buildCodexCatalogEntry = (
   const slug = model.model.trim();
   const displayName = model.displayName?.trim() || slug;
   const contextWindow = normalizeCodexContextWindow(model.contextWindow);
+  const defaultReasoningLevel = model.defaultReasoningLevel?.trim() || "medium";
+  const supportedReasoningLevels = normalizeCodexReasoningLevels(model.supportedReasoningLevels);
 
   return {
     slug,
     model: slug,
     display_name: displayName,
     description: displayName,
-    default_reasoning_level: "medium",
-    supported_reasoning_levels: CODEX_SUPPORTED_REASONING_LEVELS,
+    default_reasoning_level: defaultReasoningLevel,
+    supported_reasoning_levels: supportedReasoningLevels,
     shell_type: "shell_command",
     visibility: "list",
     supported_in_api: true,
@@ -389,7 +428,11 @@ const buildCodexConfig = (input: {
     const key = normalized.toLowerCase();
     if (!normalized || seen.has(key)) return;
     seen.add(key);
-    catalogModels.push({ model: normalized });
+    catalogModels.push({
+      model: normalized,
+      defaultReasoningLevel: "medium",
+      supportedReasoningLevels: CODEX_SUPPORTED_REASONING_LEVELS,
+    });
   };
 
   for (const entry of input.codexModelCatalog?.models ?? []) {

--- a/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
+++ b/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
@@ -125,8 +125,12 @@ const normalizeCodexModelCatalog = (
     (entry): entry is Record<string, unknown> =>
       entry !== null && typeof entry === "object" && !Array.isArray(entry),
   );
-  const hasSlug = entries.some((entry) => typeof entry.slug === "string" && entry.slug.trim());
-  return hasSlug ? { models: entries.map((entry) => ({ ...entry })) } : undefined;
+  const hasModelId = entries.some((entry) => {
+    const slug = typeof entry.slug === "string" ? entry.slug.trim() : "";
+    const model = typeof entry.model === "string" ? entry.model.trim() : "";
+    return slug || model;
+  });
+  return hasModelId ? { models: entries.map((entry) => ({ ...entry })) } : undefined;
 };
 
 const createConfigId = () => {

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -20,13 +20,10 @@ import {
 } from "@code-proxy/domain/ccswitch/ccswitchImport";
 import {
   appendCcSwitchRoutePath,
-  buildCcSwitchCodexModelCatalogJsonForConfig,
   buildCcSwitchImportUrlForConfig,
-  getCcSwitchCodexModelCatalogFilenameForConfig,
 } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import { ccSwitchConfigMatchesApiKeyPermissions } from "@code-proxy/domain/ccswitch/ccswitchImportCompatibility";
-import { downloadTextAsFile } from "@code-proxy/domain";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { copyTextToClipboard } from "@code-proxy/ui";
@@ -112,16 +109,12 @@ async function fetchQuickImportApiKeyEntry(apiKey: string): Promise<ApiKeyEntry 
 function QuickImportCard({
   config,
   copied,
-  catalogAvailable,
   onCopyLink,
-  onDownloadCatalog,
   onSelect,
 }: {
   config: CcSwitchImportConfigListItem;
   copied: boolean;
-  catalogAvailable: boolean;
   onCopyLink: (config: CcSwitchImportConfigListItem) => void;
-  onDownloadCatalog: (config: CcSwitchImportConfigListItem) => void;
   onSelect: (config: CcSwitchImportConfigListItem) => void;
 }) {
   const { t } = useTranslation();
@@ -164,17 +157,6 @@ function QuickImportCard({
         </span>
       </button>
       <div className="flex items-start gap-1 p-3 pl-0">
-        {catalogAvailable ? (
-          <Button
-            variant="ghost"
-            size="xs"
-            title={t("ccswitch.download_codex_model_catalog")}
-            onClick={() => onDownloadCatalog(config)}
-            className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
-          >
-            <Download size={14} />
-          </Button>
-        ) : null}
         <Button
           variant="ghost"
           size="xs"
@@ -363,17 +345,6 @@ export function QuickImportTabContent({
     [buildImportUrl, notify, showCopiedImportState, t],
   );
 
-  const handleDownloadCodexCatalog = useCallback(
-    (config: CcSwitchImportConfigListItem) => {
-      const catalogJson = buildCcSwitchCodexModelCatalogJsonForConfig(config);
-      if (!catalogJson) return;
-
-      downloadTextAsFile(catalogJson, getCcSwitchCodexModelCatalogFilenameForConfig(config));
-      notify({ type: "success", message: t("ccswitch.download_codex_model_catalog_success") });
-    },
-    [notify, t],
-  );
-
   return (
     <div className="space-y-4">
       <Card padding="compact" className="border-slate-200/70 bg-white/85 dark:bg-neutral-950/70">
@@ -441,11 +412,7 @@ export function QuickImportTabContent({
                         key={config.id}
                         config={config}
                         copied={copiedImportConfigId === config.id}
-                        catalogAvailable={Boolean(
-                          buildCcSwitchCodexModelCatalogJsonForConfig(config),
-                        )}
                         onCopyLink={(item) => void handleCopyImportLink(item)}
-                        onDownloadCatalog={handleDownloadCodexCatalog}
                         onSelect={handleImport}
                       />
                     ))}

--- a/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -29,6 +29,13 @@ const quickImportConfigs = [
         {
           slug: "gpt-5.3-codex",
           display_name: "gpt-5.3-codex",
+          default_reasoning_level: "medium",
+          supported_reasoning_levels: [
+            { effort: "low", description: "Fast" },
+            { effort: "medium", description: "Balanced" },
+            { effort: "high", description: "Deep" },
+            { effort: "xhigh", description: "Extra deep" },
+          ],
         },
         {
           slug: "deepseek-v4-flash",
@@ -73,6 +80,17 @@ const quickImportConfigs = [
     "usage-auto-interval": 60,
   },
 ];
+
+const decodeConfigFromImportUrl = (url: string) => {
+  const encoded = new URL(url).searchParams.get("config");
+  expect(encoded).toBeTruthy();
+  const binary = atob(encoded!);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
+};
 
 describe("QuickImportTabContent", () => {
   beforeEach(async () => {
@@ -131,6 +149,14 @@ describe("QuickImportTabContent", () => {
     expect(parsed.searchParams.get("name")).toBe("Team Codex");
     expect(parsed.searchParams.get("apiKey")).toBe("sk-lookup-key");
     expect(parsed.searchParams.get("endpoint")).toMatch(/\/pro\/cs_codex\/v1$/);
+    expect(decodeConfigFromImportUrl(openedUrl)).toMatchObject({
+      modelCatalog: {
+        models: [
+          expect.objectContaining({ slug: "gpt-5.3-codex" }),
+          expect.objectContaining({ slug: "deepseek-v4-flash" }),
+        ],
+      },
+    });
   });
 
   test("copies the selected quick import link without launching CC Switch", async () => {
@@ -171,6 +197,14 @@ describe("QuickImportTabContent", () => {
       expect(parsed.searchParams.get("name")).toBe("Team Codex");
       expect(parsed.searchParams.get("apiKey")).toBe("sk-lookup-key");
       expect(parsed.searchParams.get("endpoint")).toMatch(/\/pro\/cs_codex\/v1$/);
+      expect(decodeConfigFromImportUrl(copiedUrl)).toMatchObject({
+        modelCatalog: {
+          models: [
+              expect.objectContaining({ slug: "gpt-5.3-codex" }),
+            expect.objectContaining({ slug: "deepseek-v4-flash" }),
+          ],
+        },
+      });
     } finally {
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,
@@ -179,53 +213,19 @@ describe("QuickImportTabContent", () => {
     }
   });
 
-  test("downloads the Codex model catalog for mapped quick imports", async () => {
-    const originalCreateObjectURL = URL.createObjectURL;
-    const originalRevokeObjectURL = URL.revokeObjectURL;
-    const createObjectURL = vi.fn<(object: Blob | MediaSource) => string>(() => "blob:codex-catalog");
-    const revokeObjectURL = vi.fn();
-    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
-    Object.defineProperty(URL, "createObjectURL", {
-      configurable: true,
-      value: createObjectURL,
-    });
-    Object.defineProperty(URL, "revokeObjectURL", {
-      configurable: true,
-      value: revokeObjectURL,
-    });
+  test("does not expose a separate Codex model catalog download action", async () => {
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <QuickImportTabContent apiKey="sk-lookup-key" />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
 
-    try {
-      render(
-        <ThemeProvider>
-          <ToastProvider>
-            <QuickImportTabContent apiKey="sk-lookup-key" />
-          </ToastProvider>
-        </ThemeProvider>,
-      );
-
-      const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
-      await userEvent.click(
-        within(codexSection).getByRole("button", { name: /download codex model catalog/i }),
-      );
-
-      await waitFor(() => expect(createObjectURL).toHaveBeenCalled());
-      const blob = createObjectURL.mock.calls[0]?.[0];
-      if (!(blob instanceof Blob)) {
-        throw new Error("Expected Codex model catalog download to create a Blob");
-      }
-      await expect(blob.text()).resolves.toContain("deepseek-v4-flash");
-      expect(click).toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(URL, "createObjectURL", {
-        configurable: true,
-        value: originalCreateObjectURL,
-      });
-      Object.defineProperty(URL, "revokeObjectURL", {
-        configurable: true,
-        value: originalRevokeObjectURL,
-      });
-      click.mockRestore();
-    }
+    const codexSection = await screen.findByRole("region", { name: /codex quick imports/i });
+    expect(
+      within(codexSection).queryByRole("button", { name: /download codex model catalog/i }),
+    ).not.toBeInTheDocument();
   });
 
   test("hides quick import groups that do not have presets", async () => {

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -33,13 +33,10 @@ import { CcSwitchImportCardList } from "./components/CcSwitchImportCardList";
 import { openCcSwitchImportUrl } from "@code-proxy/domain/ccswitch/ccswitchImport";
 import {
   appendCcSwitchRoutePath,
-  buildCcSwitchCodexModelCatalogJsonForConfig,
   buildCcSwitchImportUrlForConfig,
-  getCcSwitchCodexModelCatalogFilenameForConfig,
 } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import { ccSwitchConfigMatchesApiKeyPermissions } from "@code-proxy/domain/ccswitch/ccswitchImportCompatibility";
-import { downloadTextAsFile } from "@code-proxy/domain";
 import { LogContentModal } from "@features/log-content-viewer";
 import { ErrorDetailModal } from "@features/log-content-viewer";
 import type { ApiKeyFormValues } from "./types";
@@ -549,17 +546,6 @@ export function ApiKeysPage() {
     [buildImportUrlWithConfig, notify, showCopiedCcSwitchImportState, t],
   );
 
-  const handleDownloadCcSwitchCodexCatalog = useCallback(
-    (config: CcSwitchImportConfigListItem) => {
-      const catalogJson = buildCcSwitchCodexModelCatalogJsonForConfig(config);
-      if (!catalogJson) return;
-
-      downloadTextAsFile(catalogJson, getCcSwitchCodexModelCatalogFilenameForConfig(config));
-      notify({ type: "success", message: t("ccswitch.download_codex_model_catalog_success") });
-    },
-    [notify, t],
-  );
-
   /* ─── column definitions ─── */
 
   const apiKeyColumns = useMemo(
@@ -716,7 +702,6 @@ export function ApiKeysPage() {
         configs={compatibleConfigs}
         copiedConfigId={copiedCcSwitchImportConfigId}
         onCopyLink={(config) => void handleCopyCcSwitchImportLink(config)}
-        onDownloadCatalog={handleDownloadCcSwitchCodexCatalog}
         onSelect={handleImportWithConfig}
         onClose={() => {
           setCcSwitchImportEntry(null);

--- a/pages/api-keys/components/CcSwitchImportCardList.tsx
+++ b/pages/api-keys/components/CcSwitchImportCardList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Check, Copy, Download } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
 import iconGemini from "@code-proxy/assets/icons/gemini.svg";
@@ -7,7 +7,6 @@ import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import type { CcSwitchClientType } from "@code-proxy/domain/ccswitch/ccswitchImport";
-import { buildCcSwitchCodexModelCatalogJsonForConfig } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 
 const iconByType: Record<CcSwitchClientType, string> = {
   claude: iconClaude,
@@ -20,7 +19,6 @@ export interface CcSwitchImportCardListProps {
   configs: CcSwitchImportConfigListItem[];
   copiedConfigId: string | null;
   onCopyLink: (config: CcSwitchImportConfigListItem) => void;
-  onDownloadCatalog: (config: CcSwitchImportConfigListItem) => void;
   onSelect: (config: CcSwitchImportConfigListItem) => void;
   onClose: () => void;
 }
@@ -30,7 +28,6 @@ export function CcSwitchImportCardList({
   configs,
   copiedConfigId,
   onCopyLink,
-  onDownloadCatalog,
   onSelect,
   onClose,
 }: CcSwitchImportCardListProps) {
@@ -53,7 +50,6 @@ export function CcSwitchImportCardList({
         ) : (
           configs.map((config) => {
             const isCopied = copiedConfigId === config.id;
-            const catalogAvailable = Boolean(buildCcSwitchCodexModelCatalogJsonForConfig(config));
 
             return (
               <div
@@ -97,17 +93,6 @@ export function CcSwitchImportCardList({
                   </div>
                 </button>
                 <div className="flex items-start gap-1 p-3 pl-0">
-                  {catalogAvailable ? (
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      title={t("ccswitch.download_codex_model_catalog")}
-                      onClick={() => onDownloadCatalog(config)}
-                      className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
-                    >
-                      <Download size={14} />
-                    </Button>
-                  ) : null}
                   <Button
                     variant="ghost"
                     size="xs"

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -231,6 +231,13 @@ describe("ccswitchImport", () => {
               slug: "gpt-5.5",
               display_name: "GPT 5.5",
               context_window: 512000,
+              default_reasoning_level: "medium",
+              supported_reasoning_levels: [
+                { effort: "low", description: "Fast" },
+                { effort: "medium", description: "Balanced" },
+                { effort: "high", description: "Deep" },
+                { effort: "xhigh", description: "Extra deep" },
+              ],
               model_messages: { context_window: 512000 },
             },
             {
@@ -252,6 +259,13 @@ describe("ccswitchImport", () => {
         model: "gpt-5.5",
         display_name: "GPT 5.5",
         context_window: 512000,
+        default_reasoning_level: "medium",
+        supported_reasoning_levels: [
+          { effort: "low", description: "Fast" },
+          { effort: "medium", description: "Balanced" },
+          { effort: "high", description: "Deep" },
+          { effort: "xhigh", description: "Extra deep" },
+        ],
         model_messages: { context_window: 512000 },
       },
       {
@@ -260,7 +274,16 @@ describe("ccswitchImport", () => {
         display_name: "DeepSeek V4 Flash",
         context_window: 256000,
       },
-      { model: "glm-4.6" },
+      {
+        model: "glm-4.6",
+        defaultReasoningLevel: "medium",
+        supportedReasoningLevels: [
+          { effort: "low", description: "Fast responses with lighter reasoning" },
+          { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+          { effort: "high", description: "Greater reasoning depth for complex problems" },
+          { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+        ],
+      },
     ]);
     expect(config.config).toContain(
       `model_catalog_json = "${CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME}"`,
@@ -325,7 +348,19 @@ describe("ccswitchImport", () => {
       auth: { OPENAI_API_KEY: "sk-test-key" },
       apiFormat: CC_SWITCH_CODEX_API_FORMAT,
       modelCatalog: {
-        models: [{ model: "gpt-6-router" }, { model: "kimi-k2" }],
+        models: [
+          expect.objectContaining({
+            model: "gpt-6-router",
+            defaultReasoningLevel: "medium",
+            supportedReasoningLevels: [
+              { effort: "low", description: "Fast responses with lighter reasoning" },
+              { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+              { effort: "high", description: "Greater reasoning depth for complex problems" },
+              { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+            ],
+          }),
+          expect.objectContaining({ model: "kimi-k2" }),
+        ],
       },
     });
     expect(decodeConfig(url).config).toContain(
@@ -355,6 +390,13 @@ describe("ccswitchImport", () => {
       display_name: "DeepSeek V4 Flash",
       context_window: 256000,
       max_context_window: 256000,
+      default_reasoning_level: "medium",
+      supported_reasoning_levels: [
+        { effort: "low", description: "Fast responses with lighter reasoning" },
+        { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+        { effort: "high", description: "Greater reasoning depth for complex problems" },
+        { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+      ],
       visibility: "list",
       supported_in_api: true,
       supports_reasoning_summaries: true,
@@ -383,6 +425,34 @@ describe("ccswitchImport", () => {
     ]);
     expect(catalog.models[0]).toHaveProperty("base_instructions");
     expect(catalog.models[0]).toHaveProperty("model_messages");
+    expect(catalog.models[0]).toMatchObject({
+      default_reasoning_level: "medium",
+      supported_reasoning_levels: [
+        { effort: "low", description: "Fast responses with lighter reasoning" },
+        { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+        { effort: "high", description: "Greater reasoning depth for complex problems" },
+        { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
+      ],
+    });
+  });
+
+  test("allows a generated Codex catalog entry to narrow reasoning levels explicitly", () => {
+    const catalog = buildCcSwitchCodexModelCatalog([
+      {
+        model: "thinking-toggle-model",
+        defaultReasoningLevel: "high",
+        supportedReasoningLevels: ["none", "high"],
+      },
+    ]);
+
+    expect(catalog.models[0]).toMatchObject({
+      slug: "thinking-toggle-model",
+      default_reasoning_level: "high",
+      supported_reasoning_levels: [
+        { effort: "none", description: "none" },
+        { effort: "high", description: "Greater reasoning depth for complex problems" },
+      ],
+    });
   });
 
   test("selects a client-specific default model from available models", () => {


### PR DESCRIPTION
## Summary\n- embed Codex modelCatalog metadata into CC Switch import deeplinks\n- preserve custom default/supported reasoning levels for Codex catalog entries\n- remove the ordinary user flow that required downloading cc-switch-model-catalog.json separately\n\n## Tests\n- rtk bun run --filter @code-proxy/admin-panel test:ci -- pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts\n- rtk bun run build