### PR TITLE
feat(ccswitch): derive model_reasoning_effort from catalog + e2e coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ playwright-report/
 .helloagents/
 output/playwright/
 .playwright-cli/
+
+# Local-only screenshot helper (hardcoded absolute paths, dev preview only)
+packages/ui/src/feedback/screenshot.mjs

--- a/e2e/api-key-lookup.spec.ts
+++ b/e2e/api-key-lookup.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const LOOKUP_SESSION_KEY = "apiKeyLookup.lastApiKey.v1";
+const TEST_API_KEY = "sk-e2e-lookup-quick-import";
+
+const setQueriedLookupKey = async (page: Page) => {
+  // Pre-seed sessionStorage so the lookup page mounts with a queried key and
+  // renders the results toolbar + tabs (including quickImport) without
+  // requiring a click through the search form.
+  await page.addInitScript((key) => {
+    try {
+      window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", key);
+    } catch {
+      // ignore
+    }
+  }, TEST_API_KEY);
+};
+
+const mockLookupApisForQuickImport = async (page: Page) => {
+  await page.route("**/v0/management/public/usage/logs", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [], total: 0 }),
+    });
+  });
+
+  await page.route("**/v0/management/public/usage/chart-data", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        model_distribution: [],
+        daily_trend: [],
+        stat: { total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 },
+      }),
+    });
+  });
+
+  await page.route("**/v0/management/public/ccswitch-import-configs", async (route) => {
+    const preset = {
+      id: "codex-pro-quick-import",
+      "client-type": "codex",
+      "provider-name": "Pro 池+codex",
+      note: "Pro pool codex card",
+      "default-model": "gpt-5.5",
+      "model-mappings": [
+        { "request-model": "gpt-5.5", "target-model": "gpt-5.5" },
+        { "request-model": "deepseek-v4-flash", "target-model": "deepseek-chat" },
+      ],
+      "allowed-channel-groups": ["pro"],
+      "route-path": "/pro/cs_lookup",
+      "endpoint-path": "/v1",
+      "usage-auto-interval": 30,
+      "codex-model-catalog-filename": "cc-switch-model-catalog.json",
+      "codex-model-catalog": {
+        models: [
+          {
+            slug: "gpt-5.5",
+            model: "gpt-5.5",
+            default_reasoning_level: "medium",
+            supported_reasoning_levels: [
+              { effort: "low", description: "Fast" },
+              { effort: "medium", description: "Balanced" },
+              { effort: "high", description: "Deep" },
+              { effort: "xhigh", description: "Extra deep" },
+            ],
+          },
+          {
+            slug: "deepseek-v4-flash",
+            model: "deepseek-v4-flash",
+            default_reasoning_level: "high",
+            supported_reasoning_levels: [
+              { effort: "low" },
+              { effort: "medium" },
+              { effort: "high" },
+              { effort: "xhigh" },
+            ],
+          },
+        ],
+      },
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        "ccswitch-import-configs": [preset],
+        api_key: TEST_API_KEY,
+        api_key_masked: "sk-...-port",
+        found: true,
+      }),
+    });
+  });
+
+  await page.route("**/v1/models", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [{ id: "gpt-5.5" }, { id: "deepseek-v4-flash" }],
+      }),
+    });
+  });
+};
+
+const decodeCodexConfigBlob = (url: string) => {
+  const encoded = new URL(url).searchParams.get("config");
+  if (!encoded) throw new Error("missing config param");
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return JSON.parse(new TextDecoder().decode(bytes)) as {
+    auth: { OPENAI_API_KEY?: string };
+    config: string;
+    apiFormat?: string;
+    modelCatalog?: { models: Array<Record<string, unknown>> };
+  };
+};
+
+test("API Key Lookup: Quick Import codex card opens a ccswitch deep link with embedded catalog", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await setQueriedLookupKey(page);
+  await mockLookupApisForQuickImport(page);
+
+  await page.addInitScript(() => {
+    window.open = (url?: string | URL) => {
+      if (typeof url === "string") {
+        (window as unknown as { __ccswitchOpenedUrl?: string[] }).__ccswitchOpenedUrl =
+          (window as unknown as { __ccswitchOpenedUrl?: string }).__ccswitchOpenedUrl ?? [];
+        (window as unknown as { __ccswitchOpenedUrl?: string[] }).__ccswitchOpenedUrl!.push(url);
+      }
+      return null;
+    };
+  });
+
+  await page.goto("/#/apikey-lookup");
+
+  // Switch to the quickImport tab. The tab is labeled with an i18n key that
+  // renders as "快速导入" / "Quick Import" depending on the UI locale.
+  const quickImportTab = page.getByRole("tab", { name: /快速导入|Quick Import/i });
+  await expect(quickImportTab).toBeVisible();
+  await quickImportTab.click();
+
+  // The codex preset card uses the provider name as the visible button text.
+  const cardButton = page.getByRole("button", { name: /Pro 池\+codex/ });
+  await expect(cardButton).toBeVisible();
+
+  await cardButton.click();
+
+  const openedUrl = await page.evaluate(() => {
+    const list = (window as unknown as { __ccswitchOpenedUrl?: string[] }).__ccswitchOpenedUrl;
+    return list?.[0];
+  });
+  expect(openedUrl).toBeTruthy();
+  expect(openedUrl!.startsWith("ccswitch://v1/import?")).toBe(true);
+
+  const parsed = new URL(openedUrl!);
+  expect(parsed.searchParams.get("app")).toBe("codex");
+  expect(parsed.searchParams.get("apiFormat")).toBe("openai_responses");
+
+  const decoded = decodeCodexConfigBlob(openedUrl!);
+  expect(decoded.apiFormat).toBe("openai_responses");
+  expect(decoded.auth.OPENAI_API_KEY).toBe(TEST_API_KEY);
+  expect(decoded.modelCatalog?.models).toBeTruthy();
+  expect(decoded.modelCatalog!.models.length).toBe(2);
+  expect(decoded.modelCatalog!.models[0]).toMatchObject({
+    slug: "gpt-5.5",
+    default_reasoning_level: "medium",
+  });
+  // Catalog default for the selected model (gpt-5.5) is medium, so the
+  // generated config.toml should use model_reasoning_effort = "medium".
+  expect(decoded.config).toContain(`model_reasoning_effort = "medium"`);
+  expect(decoded.config).toContain(`model_catalog_json = "cc-switch-model-catalog.json"`);
+});
+
+test("API Key Lookup: Quick Import copy button surfaces the ccswitch link via clipboard", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await setQueriedLookupKey(page);
+  await mockLookupApisForQuickImport(page);
+
+  await page.goto("/#/apikey-lookup");
+  // Grant clipboard read+write permissions for the running dev origin so
+  // copyTextToClipboard succeeds and we can read the copied link back to
+  // assert its payload.
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+    origin: new URL(page.url()).origin,
+  });
+
+  const quickImportTab = page.getByRole("tab", { name: /快速导入|Quick Import/i });
+  await expect(quickImportTab).toBeVisible();
+  await quickImportTab.click();
+
+  const cardButton = page.getByRole("button", { name: /Pro 池\+codex/ });
+  await expect(cardButton).toBeVisible();
+
+  // The copy button is the ghost action next to each import card. We target
+  // it via its accessible name, which is the "ccswitch.copy_import_link"
+  // tooltip/title string. The card body's accessible name is the provider
+  // name, so the copy button is uniquely identified by the copy label.
+  const copyButton = page.getByRole("button", { name: /Copy import link|复制导入链接/i });
+  await expect(copyButton).toBeVisible();
+  await copyButton.first().click();
+
+  // The copy button flips to a "copied" state immediately, then resets after
+  // ~1.8s. We assert the pressed-state visual: the title becomes
+  // "Import link copied" / "导入链接已复制". If the clipboard write failed,
+  // the button would not flip and the assertion fails.
+  const copiedButton = page.getByRole("button", { name: /Import link copied|导入链接已复制/i });
+  await expect(copiedButton).toBeVisible({ timeout: 1500 });
+
+  // Verify the clipboard content matches a ccswitch:// deep link with the
+  // catalog payload intact.
+  const clipText = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipText.startsWith("ccswitch://v1/import?")).toBe(true);
+  const clipParsed = new URL(clipText);
+  expect(clipParsed.searchParams.get("app")).toBe("codex");
+  const clipDecoded = decodeCodexConfigBlob(clipText);
+  expect(clipDecoded.modelCatalog?.models.length).toBe(2);
+  expect(clipDecoded.modelCatalog!.models[0]).toMatchObject({
+    slug: "gpt-5.5",
+    default_reasoning_level: "medium",
+  });
+});

--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -940,3 +940,237 @@ test("API Keys: fixed columns stay pinned while dragging the horizontal scrollba
   expect(state.nameCellHitColumn).toBe("name");
   expect(state.actionsCellHitColumn).toBe("actions");
 });
+
+const codexImportPreset = {
+  id: "codex-pro-deepseek",
+  "client-type": "codex",
+  "provider-name": "Pro Pool + DeepSeek",
+  note: "Pro 号池+deepseek",
+  "default-model": "gpt-5.5",
+  "model-mappings": [
+    { "request-model": "gpt-5.5", "target-model": "gpt-5.5" },
+    { "request-model": "deepseek-v4-pro", "target-model": "deepseek-reasoner" },
+    { "request-model": "deepseek-v4-flash", "target-model": "deepseek-chat" },
+  ],
+  "allowed-channel-groups": ["all-channel-groups-with-a-long-name"],
+  "route-path": "/pro/cs_test",
+  "endpoint-path": "/v1",
+  "usage-auto-interval": 30,
+  "codex-model-catalog-filename": "cc-switch-model-catalog.json",
+  "codex-model-catalog": {
+    models: [
+      {
+        slug: "gpt-5.5",
+        model: "gpt-5.5",
+        display_name: "GPT-5.5",
+        default_reasoning_level: "medium",
+        supported_reasoning_levels: [
+          { effort: "low", description: "Fast" },
+          { effort: "medium", description: "Balanced" },
+          { effort: "high", description: "Deep" },
+          { effort: "xhigh", description: "Extra deep" },
+        ],
+      },
+      {
+        slug: "deepseek-v4-pro",
+        model: "deepseek-v4-pro",
+        default_reasoning_level: "high",
+        supported_reasoning_levels: [
+          { effort: "low" },
+          { effort: "medium" },
+          { effort: "high" },
+          { effort: "xhigh" },
+        ],
+      },
+      {
+        slug: "deepseek-v4-flash",
+        model: "deepseek-v4-flash",
+        default_reasoning_level: "medium",
+      },
+    ],
+  },
+};
+
+const decodeCodexConfigBlob = (url: string) => {
+  const encoded = new URL(url).searchParams.get("config");
+  if (!encoded) throw new Error("missing config param");
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return JSON.parse(new TextDecoder().decode(bytes)) as {
+    auth: { OPENAI_API_KEY?: string };
+    config: string;
+    apiFormat?: string;
+    modelCatalog?: { models: Array<Record<string, unknown>> };
+  };
+};
+
+const mockApiKeysApisForImport = async (page: Page) => {
+  const entry = {
+    key: `sk-e2e-import-${"y".repeat(20)}-imp`,
+    name: "Compat Codex Import",
+    "allowed-models": ["gpt-5.5", "deepseek-reasoner", "deepseek-chat", "deepseek-v4-pro"],
+    "allowed-channel-groups": ["all-channel-groups-with-a-long-name"],
+    "allowed-channels": ["primary-channel-with-a-long-name"],
+    "created-at": "2026-05-13T15:32:00Z",
+  };
+
+  await page.route("**/v0/management/**", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname.endsWith("/v0/management/config")) {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/api-key-entries")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "api-key-entries": [entry] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/api-keys")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "api-keys": [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/api-key-permission-profiles")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "api-key-permission-profiles": [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/ccswitch-import-configs")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ "ccswitch-import-configs": [codexImportPreset] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/channel-groups")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/models")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+      return;
+    }
+
+    if (pathname.endsWith("/v0/management/auth-files")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ files: [] }),
+      });
+      return;
+    }
+
+    const providerListPayloads: Record<string, Record<string, unknown[]>> = {
+      "/v0/management/gemini-api-key": { "gemini-api-key": [] },
+      "/v0/management/claude-api-key": { "claude-api-key": [] },
+      "/v0/management/codex-api-key": { "codex-api-key": [] },
+      "/v0/management/vertex-api-key": { "vertex-api-key": [] },
+      "/v0/management/openai-compatibility": { "openai-compatibility": [] },
+    };
+    const providerPayload = providerListPayloads[pathname];
+    if (providerPayload) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(providerPayload),
+      });
+      return;
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+};
+
+test("API Keys: import-to-CC-Switch opens a codex deep link with embedded model catalog", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1360, height: 980 });
+  await setAuthed(page);
+  await mockApiKeysApisForImport(page);
+
+  await page.addInitScript(() => {
+    window.open = (url?: string | URL) => {
+      if (typeof url === "string") {
+        (window as unknown as { __ccswitchOpenedUrl?: string[] }).__ccswitchOpenedUrl =
+          (window as unknown as { __ccswitchOpenedUrl?: string }).__ccswitchOpenedUrl ?? [];
+        (window as unknown as { __ccswitchOpenedUrl?: string[] }).__ccswitchOpenedUrl!.push(url);
+      }
+      return null;
+    };
+  });
+
+  await page.goto("/#/api-keys");
+  await page.locator('td[data-vt-column-key="actions"]').first().waitFor({ state: "visible" });
+
+  // The import-to-CC-Switch button is distinguishable by its aria-label, which
+  // carries the i18n label "ccswitch.import_to_ccswitch". Other row actions
+  // (toggle / view usage / copy / edit / delete) use different labels, so we
+  // target the import button specifically inside the actions cell.
+  const importButton = page
+    .locator('td[data-vt-column-key="actions"]')
+    .first()
+    .getByRole("button", { name: /import to CC Switch|导入到 CC Switch/i });
+  await importButton.click({ force: true });
+
+  // The modal renders the codex preset card with the provider name as button text.
+  const cardButton = page.getByRole("button", { name: /Pro Pool \+ DeepSeek/ });
+  await expect(cardButton).toBeVisible();
+
+  // Clicking the card body opens the ccswitch:// deep link.
+  await cardButton.click();
+
+  const openedUrl = await page.evaluate(() => {
+    const list = (window as unknown as { __ccswitchOpenedUrl?: string[] }).__ccswitchOpenedUrl;
+    return list?.[0];
+  });
+  expect(openedUrl).toBeTruthy();
+  expect(openedUrl!.startsWith("ccswitch://v1/import?")).toBe(true);
+
+  const parsed = new URL(openedUrl!);
+  expect(parsed.searchParams.get("app")).toBe("codex");
+  expect(parsed.searchParams.get("apiFormat")).toBe("openai_responses");
+  expect(parsed.searchParams.get("config")).toBeTruthy();
+
+  const decoded = decodeCodexConfigBlob(openedUrl!);
+  expect(decoded.apiFormat).toBe("openai_responses");
+  expect(decoded.auth.OPENAI_API_KEY).toBe("sk-e2e-import-yyyyyyyyyyyyyyyyyyyy-imp");
+  expect(decoded.modelCatalog?.models).toBeTruthy();
+  expect(decoded.modelCatalog!.models.length).toBe(3);
+  expect(decoded.modelCatalog!.models[0]).toMatchObject({
+    slug: "gpt-5.5",
+    model: "gpt-5.5",
+    default_reasoning_level: "medium",
+  });
+  // The default model catalogs's default_reasoning_level for the selected
+  // model (gpt-5.5) should drive model_reasoning_effort (medium) instead of
+  // the old hardcoded "high".
+  expect(decoded.config).toContain(`model_reasoning_effort = "medium"`);
+  expect(decoded.config).toContain(`model_catalog_json = "cc-switch-model-catalog.json"`);
+});

--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -405,6 +405,12 @@ const buildCodexConfig = (input: {
   const tomlString = (value: string) => JSON.stringify(value);
   const model = input.model.trim() || "gpt-5-codex";
   const catalogModels: Array<Record<string, unknown>> = [];
+  // Entries the caller supplied explicitly via codexModelCatalog (as opposed to
+  // bare strings we synthesize to guarantee the selected model lives in the
+  // catalog). We only derive model_reasoning_effort from explicit entries so
+  // that the prior "high" default is preserved for callers that pass no
+  // per-model reasoning metadata.
+  const explicitCatalogModels: Array<Record<string, unknown>> = [];
   const seen = new Set<string>();
 
   const getCatalogModelId = (entry: Record<string, unknown>): string => {
@@ -422,6 +428,7 @@ const buildCodexConfig = (input: {
       normalizedEntry.model = normalized;
     }
     catalogModels.push(normalizedEntry);
+    explicitCatalogModels.push(normalizedEntry);
   };
   const addCatalogModel = (value: string) => {
     const normalized = value.trim();
@@ -445,13 +452,34 @@ const buildCodexConfig = (input: {
     addCatalogModel(mapping.requestModel);
   }
 
+  // Derive the default reasoning effort from the explicit catalog entry for
+  // the selected model so the generated config.toml stays consistent with
+  // modelCatalog's per-model default_reasoning_level. Falls back to "high"
+  // for backward compatibility when no matching explicit entry exists (e.g.
+  // callers that pass no codexModelCatalog at all).
+  const resolveDefaultReasoningEffort = (): string => {
+    const selected = model.trim().toLowerCase();
+    if (!selected) return "high";
+    for (const entry of explicitCatalogModels) {
+      const id = getCatalogModelId(entry).toLowerCase();
+      if (id !== selected) continue;
+      const camel = String(entry.defaultReasoningLevel ?? "").trim();
+      if (camel) return camel;
+      const snake = String(entry.default_reasoning_level ?? "").trim();
+      if (snake) return snake;
+      return "high";
+    }
+    return "high";
+  };
+  const reasoningEffort = resolveDefaultReasoningEffort();
+
   const catalogPointer =
     catalogModels.length > 0
       ? `model_catalog_json = ${tomlString(CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME)}\n`
       : "";
   const config = `model_provider = "custom"
 model = ${tomlString(model)}
-model_reasoning_effort = "high"
+model_reasoning_effort = ${tomlString(reasoningEffort)}
 disable_response_storage = true
 ${catalogPointer}
 

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -490,4 +490,97 @@ describe("ccswitchImport", () => {
     expect(openSpy).toHaveBeenCalledWith("ccswitch://v1/import?resource=provider", "_self");
     expect(onProtocolUnavailable).not.toHaveBeenCalled();
   });
+
+  test("derives model_reasoning_effort from the catalog entry's default_reasoning_level", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      model: "deepseek-v4-pro",
+      codexModelCatalog: {
+        models: [
+          {
+            slug: "deepseek-v4-pro",
+            model: "deepseek-v4-pro",
+            default_reasoning_level: "medium",
+            supported_reasoning_levels: [
+              { effort: "low" },
+              { effort: "medium" },
+              { effort: "high" },
+              { effort: "xhigh" },
+            ],
+          },
+          {
+            slug: "gpt-5.5",
+            model: "gpt-5.5",
+            default_reasoning_level: "low",
+          },
+        ],
+      },
+    });
+
+    expect(decodeConfig(url).config).toContain(`model_reasoning_effort = "medium"`);
+    expect(decodeConfig(url).config).toContain(`model = "deepseek-v4-pro"`);
+  });
+
+  test("derives model_reasoning_effort from camelCase defaultReasoningLevel when snake_case is absent", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      model: "gpt-5.5",
+      codexModelCatalog: {
+        models: [
+          {
+            model: "gpt-5.5",
+            defaultReasoningLevel: "low",
+            supportedReasoningLevels: ["low", "medium", "high", "xhigh"],
+          },
+        ],
+      },
+    });
+
+    expect(decodeConfig(url).config).toContain(`model_reasoning_effort = "low"`);
+  });
+
+  test("falls back to model_reasoning_effort = high when no matching catalog entry exists", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      model: "gpt-5.5",
+      codexModelCatalog: {
+        models: [
+          {
+            model: "deepseek-v4-pro",
+            default_reasoning_level: "medium",
+          },
+        ],
+      },
+    });
+
+    // The selected model is not in the explicit catalog, so the configured
+    // effort falls back to the legacy "high" default even though a separate
+    // entry carries reasoning metadata.
+    expect(decodeConfig(url).config).toContain(`model_reasoning_effort = "high"`);
+  });
+
+  test("falls back to model_reasoning_effort = high when catalog is empty for backward compatibility", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test-key",
+      baseUrl: "https://relay.example.com/",
+      clientType: "codex",
+      providerName: "Relay Provider",
+      model: "gpt-5.5",
+    });
+
+    // No codexModelCatalog passed: the selected model is auto-synthesized
+    // into the catalog (so the catalog pointer is present) but the effort
+    // falls back to the legacy "high" default to preserve prior behavior.
+    expect(decodeConfig(url).config).toContain(`model_reasoning_effort = "high"`);
+    expect(decodeConfig(url).config).toContain(`model_catalog_json = "${CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME}"`);
+  });
 });


### PR DESCRIPTION
## Context

Codex Desktop 自定义模型导入链路（docs/plan/050）的一部分。codeProxy 此前已合入把 Codex model catalog 嵌入 `ccswitch://` 导入 payload 的能力，但生成的 `config.toml` 片段把 `model_reasoning_effort` 硬编码为 `"high"`，与 `config.modelCatalog.models[].default_reasoning_level` 不联动。导致 catalog 声明默认 `medium`（或 `low`）时，导入后的 Codex 仍以 `high` 启动，菜单初始推理等级与 catalog 不一致。

## Changes

- `packages/domain/src/ccswitch/ccswitchImport.ts`：`buildCodexConfig` 从显式 catalog 中查匹配选中 model 的条目，取其 `defaultReasoningLevel`（camelCase first，`default_reasoning_level` snake_case fallback）写入 `model_reasoning_effort`；无匹配显式 entry 时回退历史默认 `"high"`，保证后台兼容。
- 单测：4 条覆盖 snake / camelCase / 显式未命中 / 无 catalog 四条路径。
- `e2e/api-keys-table.spec.ts`：新增「导入到 CC Switch」端到端用例，断言管理端卡片打开 `ccswitch://v1/import?...`，`app=codex`、`apiFormat=openai_responses`、`config` base64 块解码后 `modelCatalog.models` 长 3 且首条带 `default_reasoning_level`，且 `config.toml` 中 `model_reasoning_effort = "medium"`，含 `model_catalog_json` 指针。
- `e2e/api-key-lookup.spec.ts`（新）：公开 API key 查询页 quickImport tab 端到端用例，覆盖卡片点击与复制按钮两条入口，验证剪贴板拿到的同一 deep link 与 catalog 完整透传。
- `.gitignore`：忽略仅本地的 `packages/ui/src/feedback/screenshot.mjs` 预览助手。

## Impact

- 影响目录：`packages/domain/src/ccswitch/`、`pages/ccswitch-import-settings/__tests__/`、`e2e/`、`.gitignore`。
- 不涉及 `CliRelay/`；`cc-switch/` 的 deep-link 解析 + provider 持久化 + catalog 投影 + models_cache + 诊断将在另一条 PR 推进。

## Verification

- `bun run test:ci` → 521 passed (70 files)
- `bun run build` → pass
- `bun run lint` → 0 errors
- Playwright `api-keys-table.spec.ts` + `api-key-lookup.spec.ts` → 10 passed