### PR TITLE
fix: validate provider model ownership

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -154,14 +154,26 @@ describe("ProvidersPage OpenCode Go tab", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("tab", { name: /OpenCode Go/ })).toBeInTheDocument();
-    const dialog = await screen.findByRole("dialog", { name: /Add OpenCode Go configuration/i });
+    expect(
+      await screen.findByRole("tab", { name: /OpenCode Go/ }),
+    ).toBeInTheDocument();
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add OpenCode Go configuration/i,
+    });
 
     expect(within(dialog).queryByText("Base URL")).not.toBeInTheDocument();
-    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("Models (optional)"),
+    ).not.toBeInTheDocument();
 
-    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");
-    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-opencode-go");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
+      "OpenCode Go",
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText(/Paste API Key/i),
+      "sk-opencode-go",
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -172,7 +184,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
         }),
       ]);
     });
-    expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty("baseUrl");
+    expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty(
+      "baseUrl",
+    );
   });
 
   test("keeps failed OpenCode Go saves out of the rendered provider list", async () => {
@@ -183,7 +197,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
         apiKey: "sk-existing-opencode-go",
       },
     ]);
-    mocks.saveOpenCodeGoConfigs.mockRejectedValue(new Error("channel name already used"));
+    mocks.saveOpenCodeGoConfigs.mockRejectedValue(
+      new Error("channel name already used"),
+    );
 
     render(
       <MemoryRouter initialEntries={["/ai-providers/opencode-go/new"]}>
@@ -198,10 +214,18 @@ describe("ProvidersPage OpenCode Go tab", () => {
     );
 
     expect(await screen.findByText("Existing OpenCode Go")).toBeInTheDocument();
-    const dialog = await screen.findByRole("dialog", { name: /Add OpenCode Go configuration/i });
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add OpenCode Go configuration/i,
+    });
 
-    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "New OpenCode Go");
-    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-new-opencode-go");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
+      "New OpenCode Go",
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText(/Paste API Key/i),
+      "sk-new-opencode-go",
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -214,6 +238,57 @@ describe("ProvidersPage OpenCode Go tab", () => {
     expect(
       screen.getByRole("dialog", { name: /Add OpenCode Go configuration/i }),
     ).toBeInTheDocument();
+  });
+
+  test("blocks saving OpenCode Go keys that still contain ClinePass models", async () => {
+    const user = userEvent.setup();
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "Existing OpenCode Go",
+        apiKey: "sk-existing-opencode-go",
+        models: [{ name: "cline-pass/glm-5.2" }],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Edit OpenCode Go configuration/i,
+    });
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    expect(
+      await within(dialog).findByText(
+        /OpenCode Go models cannot use cline-pass model IDs/i,
+      ),
+    ).toBeInTheDocument();
+    expect(mocks.saveOpenCodeGoConfigs).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
+    await user.click(within(dialog).getByLabelText(/Delete model/i));
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => {
+      expect(mocks.saveOpenCodeGoConfigs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: "Existing OpenCode Go",
+          apiKey: "sk-existing-opencode-go",
+        }),
+      ]);
+    });
+    expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty(
+      "models",
+    );
   });
 
   test("uses fixed tabs and saves OpenCode Go model exclusions from fetched models", async () => {
@@ -231,10 +306,18 @@ describe("ProvidersPage OpenCode Go tab", () => {
       </MemoryRouter>,
     );
 
-    const dialog = await screen.findByRole("dialog", { name: /Add OpenCode Go configuration/i });
-    expect(within(dialog).getByRole("tab", { name: /Basic/i })).toBeInTheDocument();
-    expect(within(dialog).getByRole("tab", { name: /Request/i })).toBeInTheDocument();
-    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add OpenCode Go configuration/i,
+    });
+    expect(
+      within(dialog).getByRole("tab", { name: /Basic/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("tab", { name: /Request/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("tab", { name: /Models/i }),
+    ).toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
 
@@ -247,14 +330,24 @@ describe("ProvidersPage OpenCode Go tab", () => {
       );
     });
 
-    const deepseek = await within(dialog).findByRole("checkbox", { name: /deepseek-v4-flash/i });
+    const deepseek = await within(dialog).findByRole("checkbox", {
+      name: /deepseek-v4-flash/i,
+    });
     await waitFor(() => expect(deepseek).toBeChecked());
-    expect(within(dialog).getByRole("checkbox", { name: /qwen3\.7-max/i })).not.toBeChecked();
+    expect(
+      within(dialog).getByRole("checkbox", { name: /qwen3\.7-max/i }),
+    ).not.toBeChecked();
     await user.click(deepseek);
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
-    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");
-    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-opencode-go");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
+      "OpenCode Go",
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText(/Paste API Key/i),
+      "sk-opencode-go",
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -299,12 +392,18 @@ describe("ProvidersPage OpenCode Go tab", () => {
       </MemoryRouter>,
     );
 
-    const dialog = await screen.findByRole("dialog", { name: /Add OpenCode Go configuration/i });
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add OpenCode Go configuration/i,
+    });
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
     await waitFor(() =>
-      expect(within(dialog).getByRole("checkbox", { name: /qwen3\.5-plus/i })).toBeChecked(),
+      expect(
+        within(dialog).getByRole("checkbox", { name: /qwen3\.5-plus/i }),
+      ).toBeChecked(),
     );
-    await user.click(await within(dialog).findByRole("checkbox", { name: /mimo-v2-omni/i }));
+    await user.click(
+      await within(dialog).findByRole("checkbox", { name: /mimo-v2-omni/i }),
+    );
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
     const fallback = await within(dialog).findByRole("combobox", {
@@ -312,16 +411,32 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
     await user.click(fallback);
 
-    expect(await screen.findByRole("option", { name: /qwen3\.5-plus/i })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: /qwen3\.6-plus/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: /deepseek-v4-flash/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /mimo-v2-omni/i })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: /minimax-m2\.5/i })).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: /qwen3\.5-plus/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /qwen3\.6-plus/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /deepseek-v4-flash/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /mimo-v2-omni/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /minimax-m2\.5/i }),
+    ).not.toBeInTheDocument();
     await user.click(screen.getByRole("option", { name: /mimo-v2-omni/i }));
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
-    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");
-    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-opencode-go");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
+      "OpenCode Go",
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText(/Paste API Key/i),
+      "sk-opencode-go",
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -360,8 +475,16 @@ describe("ProvidersPage Cline tab", () => {
         ? [
             { id: "cline-pass/glm-5.2", object: "model", owned_by: "cline" },
             { id: "cline-pass/minimax-m3", object: "model", owned_by: "cline" },
-            { id: "cline-pass/qwen3.7-max", object: "model", owned_by: "cline" },
-            { id: "cline-pass/mimo-v2.5-pro", object: "model", owned_by: "cline" },
+            {
+              id: "cline-pass/qwen3.7-max",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/mimo-v2.5-pro",
+              object: "model",
+              owned_by: "cline",
+            },
           ]
         : [
             { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
@@ -395,18 +518,30 @@ describe("ProvidersPage Cline tab", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("tab", { name: /ClinePass/ })).toBeInTheDocument();
-    const dialog = await screen.findByRole("dialog", { name: /Add ClinePass configuration/i });
+    expect(
+      await screen.findByRole("tab", { name: /ClinePass/ }),
+    ).toBeInTheDocument();
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add ClinePass configuration/i,
+    });
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
-    expect(within(dialog).getByDisplayValue("https://api.cline.bot/api/v1")).toBeInTheDocument();
+    expect(
+      within(dialog).getByDisplayValue("https://api.cline.bot/api/v1"),
+    ).toBeInTheDocument();
     expect(
       within(dialog).getByText("https://api.cline.bot/api/v1/chat/completions"),
     ).toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
-    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "Cline");
-    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-cline");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
+      "Cline",
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText(/Paste API Key/i),
+      "sk-cline",
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -427,14 +562,38 @@ describe("ProvidersPage Cline tab", () => {
         ? [
             { id: "cline-pass/glm-5.2", object: "model", owned_by: "cline" },
             { id: "cline-pass/minimax-m3", object: "model", owned_by: "cline" },
-            { id: "cline-pass/qwen3.7-max", object: "model", owned_by: "cline" },
-            { id: "cline-pass/mimo-v2.5-pro", object: "model", owned_by: "cline" },
-            { id: "cline-pass/qwen3-coder", object: "model", owned_by: "cline" },
-            { id: "cline-pass/deepseek-v4", object: "model", owned_by: "cline" },
+            {
+              id: "cline-pass/qwen3.7-max",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/mimo-v2.5-pro",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/qwen3-coder",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/deepseek-v4",
+              object: "model",
+              owned_by: "cline",
+            },
             { id: "cline-pass/kimi-k2.6", object: "model", owned_by: "cline" },
-            { id: "cline-pass/claude-sonnet-4.5", object: "model", owned_by: "cline" },
+            {
+              id: "cline-pass/claude-sonnet-4.5",
+              object: "model",
+              owned_by: "cline",
+            },
             { id: "cline-pass/gpt-5.2", object: "model", owned_by: "cline" },
-            { id: "cline-pass/gemini-3-pro", object: "model", owned_by: "cline" },
+            {
+              id: "cline-pass/gemini-3-pro",
+              object: "model",
+              owned_by: "cline",
+            },
           ]
         : [],
     );
@@ -451,13 +610,19 @@ describe("ProvidersPage Cline tab", () => {
       </MemoryRouter>,
     );
 
-    const dialog = await screen.findByRole("dialog", { name: /Add ClinePass configuration/i });
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add ClinePass configuration/i,
+    });
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
 
-    expect(await within(dialog).findByText("cline-pass/mimo-v2.5-pro")).toBeInTheDocument();
+    expect(
+      await within(dialog).findByText("cline-pass/mimo-v2.5-pro"),
+    ).toBeInTheDocument();
     expect(within(dialog).queryByText("cline")).not.toBeInTheDocument();
 
-    const table = within(dialog).getByText("cline-pass/mimo-v2.5-pro").closest("table");
+    const table = within(dialog)
+      .getByText("cline-pass/mimo-v2.5-pro")
+      .closest("table");
     if (!table) {
       throw new Error("expected Cline models table");
     }
@@ -483,7 +648,9 @@ describe("ProvidersPage Cline tab", () => {
       </MemoryRouter>,
     );
 
-    const dialog = await screen.findByRole("dialog", { name: /Add ClinePass configuration/i });
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add ClinePass configuration/i,
+    });
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
 
     await waitFor(() => {
@@ -500,11 +667,19 @@ describe("ProvidersPage Cline tab", () => {
       name: /Vision fallback model/i,
     });
     await user.click(fallback);
-    await user.click(screen.getByRole("option", { name: /cline-pass\/mimo-v2\.5-pro/i }));
+    await user.click(
+      screen.getByRole("option", { name: /cline-pass\/mimo-v2\.5-pro/i }),
+    );
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
-    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "Cline");
-    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-cline");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
+      "Cline",
+    );
+    await user.type(
+      within(dialog).getByPlaceholderText(/Paste API Key/i),
+      "sk-cline",
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -529,14 +704,18 @@ describe("mergeOpenCodeGoUsage", () => {
   test("returns incoming when existing is empty", async () => {
     const { mergeOpenCodeGoUsage } =
       await import("@pages/providers/components/OpenCodeGoUsageCardSection");
-    const incoming = [{ type: "rolling", label: "Rolling", percentage: 50, resets_in: "30m" }];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 50, resets_in: "30m" },
+    ];
     expect(mergeOpenCodeGoUsage([], incoming)).toEqual(incoming);
   });
 
   test("returns existing when incoming is empty", async () => {
     const { mergeOpenCodeGoUsage } =
       await import("@pages/providers/components/OpenCodeGoUsageCardSection");
-    const existing = [{ type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" }];
+    const existing = [
+      { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
+    ];
     expect(mergeOpenCodeGoUsage(existing, [])).toEqual(existing);
   });
 
@@ -548,7 +727,9 @@ describe("mergeOpenCodeGoUsage", () => {
       { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
       { type: "monthly", label: "Monthly", percentage: 10, resets_in: "20d" },
     ];
-    const incoming = [{ type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" }];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" },
+    ];
     const result = mergeOpenCodeGoUsage(existing, incoming);
 
     expect(result).toHaveLength(3);
@@ -560,8 +741,12 @@ describe("mergeOpenCodeGoUsage", () => {
   test("handles case-insensitive type matching", async () => {
     const { mergeOpenCodeGoUsage } =
       await import("@pages/providers/components/OpenCodeGoUsageCardSection");
-    const existing = [{ type: "Rolling", label: "Rolling", percentage: 50, resets_in: "30m" }];
-    const incoming = [{ type: "rolling", label: "Rolling", percentage: 75, resets_in: "25m" }];
+    const existing = [
+      { type: "Rolling", label: "Rolling", percentage: 50, resets_in: "30m" },
+    ];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 75, resets_in: "25m" },
+    ];
     const result = mergeOpenCodeGoUsage(existing, incoming);
 
     expect(result).toHaveLength(1);
@@ -575,7 +760,9 @@ describe("mergeOpenCodeGoUsage", () => {
       { type: "monthly", label: "Monthly", percentage: 10, resets_in: "20d" },
       { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
     ];
-    const incoming = [{ type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" }];
+    const incoming = [
+      { type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" },
+    ];
     const result = mergeOpenCodeGoUsage(existing, incoming);
 
     expect(result).toHaveLength(3);

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -4,8 +4,12 @@ import {
   buildProviderKeyDraft,
   maskApiKey,
   normalizeDiscoveredModels,
+  validateProviderModelOwnership,
 } from "@pages/providers/providers-helpers";
-import { buildCandidateUsageSourceIds, normalizeUsageSourceId } from "@code-proxy/domain";
+import {
+  buildCandidateUsageSourceIds,
+  normalizeUsageSourceId,
+} from "@code-proxy/domain";
 
 describe("providers helpers", () => {
   test("masks api keys consistently for provider cards", () => {
@@ -24,7 +28,14 @@ describe("providers helpers", () => {
       proxyId: "hk",
       excludedModels: ["claude-3-opus", "claude-3-haiku"],
       headers: { "x-test": "1" },
-      models: [{ name: "claude-3-opus", alias: "opus", priority: 10, testModel: "probe-model" }],
+      models: [
+        {
+          name: "claude-3-opus",
+          alias: "opus",
+          priority: 10,
+          testModel: "probe-model",
+        },
+      ],
       skipAnthropicProcessing: true,
     });
 
@@ -32,7 +43,9 @@ describe("providers helpers", () => {
     expect(draft.apiKey).toBe("sk-ant-123456");
     expect(draft.proxyId).toBe("hk");
     expect(draft.excludedModelsText).toBe("claude-3-opus\nclaude-3-haiku");
-    expect(draft.headersEntries).toEqual([{ id: expect.any(String), key: "x-test", value: "1" }]);
+    expect(draft.headersEntries).toEqual([
+      { id: expect.any(String), key: "x-test", value: "1" },
+    ]);
     expect(draft.modelEntries).toEqual([
       {
         id: expect.any(String),
@@ -79,7 +92,9 @@ describe("providers helpers", () => {
         disabled: false,
         proxyUrl: "https://proxy.example.com",
         proxyId: "hk",
-        headersEntries: [{ id: expect.any(String), key: "x-entry", value: "edge" }],
+        headersEntries: [
+          { id: expect.any(String), key: "x-entry", value: "edge" },
+        ],
       },
     ]);
   });
@@ -115,9 +130,39 @@ describe("providers helpers", () => {
     ]);
   });
 
+  test("validates OpenCode Go and ClinePass model ownership", () => {
+    expect(
+      validateProviderModelOwnership("opencode-go", {
+        models: [{ name: "cline-pass/glm-5.2" }],
+      }),
+    ).toContain("OpenCode Go models cannot use cline-pass model IDs");
+    expect(
+      validateProviderModelOwnership("opencode-go", {
+        models: [{ name: "glm-5.2" }],
+        excludedModels: ["*"],
+        visionFallbackModel: "qwen3.5-plus",
+      }),
+    ).toBeNull();
+    expect(
+      validateProviderModelOwnership("cline", {
+        models: [{ name: "glm-5.2" }],
+      }),
+    ).toContain("ClinePass models must use cline-pass model IDs");
+    expect(
+      validateProviderModelOwnership("cline", {
+        models: [{ name: "cline-pass/glm-5.2" }],
+        excludedModels: ["*", "cline-pass/minimax-m3"],
+        visionFallbackModel: "cline-pass/mimo-v2.5-pro",
+      }),
+    ).toBeNull();
+  });
+
   test("normalizes usage sources and matches raw plus masked api key candidates", () => {
     const masked = maskApiKey("sk-openai-provider-1234567890");
-    const normalized = normalizeUsageSourceId("sk-openai-provider-1234567890", maskApiKey);
+    const normalized = normalizeUsageSourceId(
+      "sk-openai-provider-1234567890",
+      maskApiKey,
+    );
     const candidates = buildCandidateUsageSourceIds({
       apiKey: "sk-openai-provider-1234567890",
       prefix: "oa",

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -84,10 +84,40 @@ export function ProviderKeyModelsTab({
 }: ProviderKeyModelsTabProps) {
   const { t } = useTranslation();
   const isModelAccessProvider = isOpenCodeGo || isCline;
+  const knownModelIds = useMemo(
+    () =>
+      new Set(
+        openCodeModels
+          .map((model) => model.id.trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    [openCodeModels],
+  );
+  const manualModelEntries = useMemo(() => {
+    if (!isModelAccessProvider) return [];
+    return keyDraft.modelEntries.filter((entry) => {
+      const name = entry.name.trim().toLowerCase();
+      return name && !knownModelIds.has(name);
+    });
+  }, [isModelAccessProvider, keyDraft.modelEntries, knownModelIds]);
+  const setManualModelEntries = useCallback(
+    (next: typeof keyDraft.modelEntries) => {
+      setKeyDraft((prev) => {
+        const knownEntries = prev.modelEntries.filter((entry) =>
+          knownModelIds.has(entry.name.trim().toLowerCase()),
+        );
+        return { ...prev, modelEntries: [...knownEntries, ...next] };
+      });
+    },
+    [knownModelIds, setKeyDraft],
+  );
   const clineRows = useMemo<ClineModelRow[]>(() => {
     if (!isCline) return [];
     const entriesByName = new Map(
-      keyDraft.modelEntries.map((entry) => [entry.name.trim().toLowerCase(), entry]),
+      keyDraft.modelEntries.map((entry) => [
+        entry.name.trim().toLowerCase(),
+        entry,
+      ]),
     );
     return filteredOpenCodeModels.map((model) => {
       const normalized = model.id.toLowerCase();
@@ -96,7 +126,9 @@ export function ProviderKeyModelsTab({
         id: model.id,
         publicName: entry ? entry.alias : model.id,
         checked:
-          !excludeAll && enabledOpenCodeModelIds.has(normalized) && !excludedModelIds.has(normalized),
+          !excludeAll &&
+          enabledOpenCodeModelIds.has(normalized) &&
+          !excludedModelIds.has(normalized),
       };
     });
   }, [
@@ -108,41 +140,51 @@ export function ProviderKeyModelsTab({
     excludedModelIds,
   ]);
 
-  const updateClineModelAlias = useCallback((modelId: string, alias: string) => {
-    const normalized = modelId.trim().toLowerCase();
-    if (!normalized) return;
-    setKeyDraft((prev) => {
-      const excludedModels = excludedModelsFromText(prev.excludedModelsText);
-      const excludeAllModels = hasDisableAllModelsRule(excludedModels);
-      const currentExcluded = stripDisableAllModelsRule(excludedModels);
-      const hadEntry = prev.modelEntries.some(
-        (entry) => entry.name.trim().toLowerCase() === normalized,
-      );
-      const wasExcluded = currentExcluded.some((model) => model.trim().toLowerCase() === normalized);
-      const nextExcluded = currentExcluded.filter(
-        (model) => model.trim().toLowerCase() !== normalized,
-      );
-      const found = prev.modelEntries.some(
-        (entry) => entry.name.trim().toLowerCase() === normalized,
-      );
-      const nextEntries = found
-        ? prev.modelEntries.map((entry) =>
-            entry.name.trim().toLowerCase() === normalized ? { ...entry, alias } : entry,
-          )
-        : [{ ...createEmptyModelEntry(), name: modelId, alias }, ...prev.modelEntries];
-      let nextExcludedModels = currentExcluded;
-      if (excludeAllModels) {
-        nextExcludedModels = excludedModels;
-      } else if (!hadEntry && !wasExcluded) {
-        nextExcludedModels = [...nextExcluded, modelId];
-      }
-      return {
-        ...prev,
-        modelEntries: nextEntries,
-        excludedModelsText: nextExcludedModels.join("\n"),
-      };
-    });
-  }, [setKeyDraft]);
+  const updateClineModelAlias = useCallback(
+    (modelId: string, alias: string) => {
+      const normalized = modelId.trim().toLowerCase();
+      if (!normalized) return;
+      setKeyDraft((prev) => {
+        const excludedModels = excludedModelsFromText(prev.excludedModelsText);
+        const excludeAllModels = hasDisableAllModelsRule(excludedModels);
+        const currentExcluded = stripDisableAllModelsRule(excludedModels);
+        const hadEntry = prev.modelEntries.some(
+          (entry) => entry.name.trim().toLowerCase() === normalized,
+        );
+        const wasExcluded = currentExcluded.some(
+          (model) => model.trim().toLowerCase() === normalized,
+        );
+        const nextExcluded = currentExcluded.filter(
+          (model) => model.trim().toLowerCase() !== normalized,
+        );
+        const found = prev.modelEntries.some(
+          (entry) => entry.name.trim().toLowerCase() === normalized,
+        );
+        const nextEntries = found
+          ? prev.modelEntries.map((entry) =>
+              entry.name.trim().toLowerCase() === normalized
+                ? { ...entry, alias }
+                : entry,
+            )
+          : [
+              { ...createEmptyModelEntry(), name: modelId, alias },
+              ...prev.modelEntries,
+            ];
+        let nextExcludedModels = currentExcluded;
+        if (excludeAllModels) {
+          nextExcludedModels = excludedModels;
+        } else if (!hadEntry && !wasExcluded) {
+          nextExcludedModels = [...nextExcluded, modelId];
+        }
+        return {
+          ...prev,
+          modelEntries: nextEntries,
+          excludedModelsText: nextExcludedModels.join("\n"),
+        };
+      });
+    },
+    [setKeyDraft],
+  );
 
   const clineColumns = useMemo<DataTableColumn<ClineModelRow>[]>(
     () => [
@@ -166,7 +208,9 @@ export function ProviderKeyModelsTab({
         render: (row) => (
           <TextInput
             value={row.publicName}
-            onChange={(event) => updateClineModelAlias(row.id, event.currentTarget.value)}
+            onChange={(event) =>
+              updateClineModelAlias(row.id, event.currentTarget.value)
+            }
             className="h-8 font-mono text-xs"
             aria-label={t("providers.cline_public_model_name")}
           />
@@ -214,7 +258,10 @@ export function ProviderKeyModelsTab({
               onClick={() => void fetchOpenCodeModels()}
               disabled={openCodeModelsLoading}
             >
-              <RefreshCw size={14} className={openCodeModelsLoading ? "animate-spin" : ""} />
+              <RefreshCw
+                size={14}
+                className={openCodeModelsLoading ? "animate-spin" : ""}
+              />
               {t("providers.refresh")}
             </Button>
           </div>
@@ -277,58 +324,83 @@ export function ProviderKeyModelsTab({
             </div>
           ) : (
             <div className="mt-3 max-h-80 overflow-y-auto rounded-xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
-            {openCodeModelsLoading && openCodeModels.length === 0 ? (
-              <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-white/55">
-                {t("providers.models_loading")}
-              </div>
-            ) : filteredOpenCodeModels.length ? (
-              <div className="divide-y divide-slate-100 dark:divide-neutral-900">
-                {filteredOpenCodeModels.map((model) => {
-                  const normalized = model.id.toLowerCase();
-                  const checked =
-                    !excludeAll &&
-                    enabledOpenCodeModelIds.has(normalized) &&
-                    !excludedModelIds.has(normalized);
-                  return (
-                    <label
-                      key={model.id}
-                      className="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
-                    >
-                      <Checkbox
-                        checked={checked}
-                        onCheckedChange={(next) => setOpenCodeModelAllowed(model.id, next)}
-                        aria-label={model.id}
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate font-mono text-xs font-semibold text-slate-800 dark:text-white/85">
-                          {model.id}
-                        </span>
-                        {model.owned_by ? (
-                          <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
-                            {model.owned_by}
-                          </span>
-                        ) : null}
-                      </span>
-                      <span
-                        className={
-                          checked
-                            ? "rounded-full bg-emerald-500/15 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:text-emerald-200"
-                            : "rounded-full bg-rose-500/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:text-rose-200"
-                        }
+              {openCodeModelsLoading && openCodeModels.length === 0 ? (
+                <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-white/55">
+                  {t("providers.models_loading")}
+                </div>
+              ) : filteredOpenCodeModels.length ? (
+                <div className="divide-y divide-slate-100 dark:divide-neutral-900">
+                  {filteredOpenCodeModels.map((model) => {
+                    const normalized = model.id.toLowerCase();
+                    const checked =
+                      !excludeAll &&
+                      enabledOpenCodeModelIds.has(normalized) &&
+                      !excludedModelIds.has(normalized);
+                    return (
+                      <label
+                        key={model.id}
+                        className="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
                       >
-                        {checked ? t("providers.model_allowed") : t("providers.model_blocked")}
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-white/55">
-                {t("providers.no_discovered_models")}
-              </div>
-            )}
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(next) =>
+                            setOpenCodeModelAllowed(model.id, next)
+                          }
+                          aria-label={model.id}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-mono text-xs font-semibold text-slate-800 dark:text-white/85">
+                            {model.id}
+                          </span>
+                          {model.owned_by ? (
+                            <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
+                              {model.owned_by}
+                            </span>
+                          ) : null}
+                        </span>
+                        <span
+                          className={
+                            checked
+                              ? "rounded-full bg-emerald-500/15 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:text-emerald-200"
+                              : "rounded-full bg-rose-500/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:text-rose-200"
+                          }
+                        >
+                          {checked
+                            ? t("providers.model_allowed")
+                            : t("providers.model_blocked")}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-white/55">
+                  {t("providers.no_discovered_models")}
+                </div>
+              )}
             </div>
           )}
+        </SectionCard>
+
+        {manualModelEntries.length ? (
+          <SectionCard>
+            <ModelInputList
+              title={t("providers.models_optional_title")}
+              entries={manualModelEntries}
+              onChange={setManualModelEntries}
+              showPriority={false}
+              showTestModel={false}
+            />
+          </SectionCard>
+        ) : null}
+
+        <SectionCard>
+          <ExcludedModelsEditor
+            count={editKeyExcludedCount}
+            editKeyEnabledToggle={editKeyEnabledToggle}
+            keyDraft={keyDraft}
+            setKeyDraft={setKeyDraft}
+          />
         </SectionCard>
       </div>
     );
@@ -348,7 +420,9 @@ export function ProviderKeyModelsTab({
                 onChange={(value) => setSelectedModelGroup(value)}
                 options={modelGroupOptions}
                 placeholder={t("providers.model_group_placeholder")}
-                searchPlaceholder={t("providers.model_group_search_placeholder")}
+                searchPlaceholder={t(
+                  "providers.model_group_search_placeholder",
+                )}
                 aria-label={t("providers.model_group_label")}
               />
             </div>
@@ -375,7 +449,9 @@ export function ProviderKeyModelsTab({
               : t("providers.models_optional_title")
           }
           entries={keyDraft.modelEntries}
-          onChange={(next) => setKeyDraft((prev) => ({ ...prev, modelEntries: next }))}
+          onChange={(next) =>
+            setKeyDraft((prev) => ({ ...prev, modelEntries: next }))
+          }
           showPriority
           showTestModel={false}
         />

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -1,7 +1,16 @@
-import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useToast } from "@code-proxy/ui";
-import type { BedrockProviderConfig, ProviderSimpleConfig } from "@code-proxy/api-client";
+import type {
+  BedrockProviderConfig,
+  ProviderSimpleConfig,
+} from "@code-proxy/api-client";
 import { providersApi } from "@code-proxy/api-client";
 import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 import { keyValueEntriesToRecord } from "../KeyValueInputList";
@@ -11,6 +20,7 @@ import {
   excludedModelsFromText,
   hasDisableAllModelsRule,
   stripDisableAllModelsRule,
+  validateProviderModelOwnership,
   withDisableAllModelsRule,
   withoutDisableAllModelsRule,
   type ProviderKeyDraft,
@@ -69,7 +79,9 @@ export function useProviderKeyEditor({
   const [editKeyOpen, setEditKeyOpen] = useState(false);
   const [editKeyType, setEditKeyType] = useState<ProviderKeyType>("gemini");
   const [editKeyIndex, setEditKeyIndex] = useState<number | null>(null);
-  const [keyDraft, setKeyDraft] = useState<ProviderKeyDraft>(() => buildProviderKeyDraft(null));
+  const [keyDraft, setKeyDraft] = useState<ProviderKeyDraft>(() =>
+    buildProviderKeyDraft(null),
+  );
   const [keyDraftError, setKeyDraftError] = useState<string | null>(null);
 
   const getListByType = useCallback(
@@ -87,7 +99,15 @@ export function useProviderKeyEditor({
                 : type === "vertex"
                   ? vertexKeys
                   : bedrockKeys,
-    [bedrockKeys, claudeKeys, clineKeys, codexKeys, geminiKeys, openCodeGoKeys, vertexKeys],
+    [
+      bedrockKeys,
+      claudeKeys,
+      clineKeys,
+      codexKeys,
+      geminiKeys,
+      openCodeGoKeys,
+      vertexKeys,
+    ],
   );
 
   const closeKeyEditor = useCallback(() => {
@@ -128,7 +148,10 @@ export function useProviderKeyEditor({
         setKeyDraftError(t("providers.api_key_error"));
         return null;
       }
-      if (keyDraft.authMode === "sigv4" && (!bedrockAccessKeyId || !bedrockSecretAccessKey)) {
+      if (
+        keyDraft.authMode === "sigv4" &&
+        (!bedrockAccessKeyId || !bedrockSecretAccessKey)
+      ) {
         setKeyDraftError(t("providers.bedrock_sigv4_error"));
         return null;
       }
@@ -146,20 +169,41 @@ export function useProviderKeyEditor({
     const isModelAccessProvider = isOpenCodeGo || isCline;
 
     const requireAlias = editKeyType === "vertex";
-    const modelCommit = commitModelEntries(keyDraft.modelEntries, { requireAlias });
+    const modelCommit = commitModelEntries(keyDraft.modelEntries, {
+      requireAlias,
+    });
     if (modelCommit.error) {
-      setKeyDraftError(requireAlias ? `Vertex: ${modelCommit.error}` : modelCommit.error);
+      setKeyDraftError(
+        requireAlias ? `Vertex: ${modelCommit.error}` : modelCommit.error,
+      );
+      return null;
+    }
+    const modelOwnershipError = validateProviderModelOwnership(editKeyType, {
+      models: modelCommit.models,
+      excludedModels,
+      visionFallbackModel: keyDraft.visionFallbackModel,
+    });
+    if (modelOwnershipError) {
+      setKeyDraftError(modelOwnershipError);
       return null;
     }
 
     const result: ProviderSimpleConfig | BedrockProviderConfig = {
       apiKey:
-        editKeyType === "bedrock" && keyDraft.authMode === "sigv4" ? bedrockAccessKeyId : apiKey,
+        editKeyType === "bedrock" && keyDraft.authMode === "sigv4"
+          ? bedrockAccessKeyId
+          : apiKey,
       name,
       ...(keyDraft.prefix.trim() ? { prefix: keyDraft.prefix.trim() } : {}),
-      ...(!isOpenCodeGo && keyDraft.baseUrl.trim() ? { baseUrl: keyDraft.baseUrl.trim() } : {}),
-      ...(isCline && !keyDraft.baseUrl.trim() ? { baseUrl: "https://api.cline.bot/api/v1" } : {}),
-      ...(keyDraft.proxyUrl.trim() ? { proxyUrl: keyDraft.proxyUrl.trim() } : {}),
+      ...(!isOpenCodeGo && keyDraft.baseUrl.trim()
+        ? { baseUrl: keyDraft.baseUrl.trim() }
+        : {}),
+      ...(isCline && !keyDraft.baseUrl.trim()
+        ? { baseUrl: "https://api.cline.bot/api/v1" }
+        : {}),
+      ...(keyDraft.proxyUrl.trim()
+        ? { proxyUrl: keyDraft.proxyUrl.trim() }
+        : {}),
       ...(keyDraft.proxyId.trim() ? { proxyId: keyDraft.proxyId.trim() } : {}),
       ...(headers ? { headers } : {}),
       ...(excludedModels ? { excludedModels } : {}),
@@ -188,7 +232,9 @@ export function useProviderKeyEditor({
                     : {}),
                 }
               : {}),
-            ...(keyDraft.region.trim() ? { region: keyDraft.region.trim() } : {}),
+            ...(keyDraft.region.trim()
+              ? { region: keyDraft.region.trim() }
+              : {}),
             ...(keyDraft.forceGlobal ? { forceGlobal: true } : {}),
           }
         : {}),
@@ -206,7 +252,9 @@ export function useProviderKeyEditor({
     const index = editKeyIndex;
     const apply = (list: ProviderSimpleConfig[]) => {
       if (index === null) return [...list, value];
-      return list.map((item, itemIndex) => (itemIndex === index ? value : item));
+      return list.map((item, itemIndex) =>
+        itemIndex === index ? value : item,
+      );
     };
 
     try {
@@ -246,7 +294,8 @@ export function useProviderKeyEditor({
     } catch (err: unknown) {
       notify({
         type: "error",
-        message: err instanceof Error ? err.message : t("providers.save_failed"),
+        message:
+          err instanceof Error ? err.message : t("providers.save_failed"),
       });
     }
   }, [
@@ -283,32 +332,47 @@ export function useProviderKeyEditor({
       try {
         if (type === "gemini") {
           await providersApi.deleteGeminiKey(entry.apiKey);
-          setGeminiKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setGeminiKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         } else if (type === "claude") {
           await providersApi.deleteClaudeConfig(entry.apiKey);
-          setClaudeKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setClaudeKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         } else if (type === "codex") {
           await providersApi.deleteCodexConfig(entry.apiKey);
-          setCodexKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setCodexKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         } else if (type === "opencode-go") {
           await providersApi.deleteOpenCodeGoConfig(entry.apiKey);
-          setOpenCodeGoKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setOpenCodeGoKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         } else if (type === "cline") {
           await providersApi.deleteClineConfig(entry.apiKey);
-          setClineKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setClineKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         } else if (type === "vertex") {
           await providersApi.deleteVertexConfig(entry.apiKey);
-          setVertexKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setVertexKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         } else {
           await providersApi.deleteBedrockConfig(index);
-          setBedrockKeys((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+          setBedrockKeys((prev) =>
+            prev.filter((_, itemIndex) => itemIndex !== index),
+          );
         }
         invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("providers.deleted") });
       } catch (err: unknown) {
         notify({
           type: "error",
-          message: err instanceof Error ? err.message : t("providers.delete_failed"),
+          message:
+            err instanceof Error ? err.message : t("providers.delete_failed"),
         });
       }
     },
@@ -352,8 +416,13 @@ export function useProviderKeyEditor({
         ? withoutDisableAllModelsRule(current.excludedModels)
         : withDisableAllModelsRule(current.excludedModels);
 
-      const nextItem: ProviderSimpleConfig = { ...current, excludedModels: nextExcluded };
-      const nextList = prev.map((item, itemIndex) => (itemIndex === index ? nextItem : item));
+      const nextItem: ProviderSimpleConfig = {
+        ...current,
+        excludedModels: nextExcluded,
+      };
+      const nextList = prev.map((item, itemIndex) =>
+        itemIndex === index ? nextItem : item,
+      );
 
       try {
         if (type === "gemini") {
@@ -373,11 +442,15 @@ export function useProviderKeyEditor({
           await providersApi.saveClineConfigs(nextList);
         } else {
           setBedrockKeys(nextList as BedrockProviderConfig[]);
-          await providersApi.saveBedrockConfigs(nextList as BedrockProviderConfig[]);
+          await providersApi.saveBedrockConfigs(
+            nextList as BedrockProviderConfig[],
+          );
         }
         notify({
           type: "success",
-          message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),
+          message: enabled
+            ? t("providers.toggle_enabled")
+            : t("providers.toggle_disabled"),
         });
         startRefreshTransition(() => void refreshAll());
       } catch (err: unknown) {
@@ -389,7 +462,8 @@ export function useProviderKeyEditor({
         else setBedrockKeys(prev as BedrockProviderConfig[]);
         notify({
           type: "error",
-          message: err instanceof Error ? err.message : t("providers.update_failed"),
+          message:
+            err instanceof Error ? err.message : t("providers.update_failed"),
         });
       }
     },
@@ -450,7 +524,10 @@ export function useProviderKeyEditor({
   }, [keyDraft.excludedModelsText]);
 
   const editKeyHeaderCount = useMemo(
-    () => keyDraft.headersEntries.filter((entry) => entry.key.trim() && entry.value.trim()).length,
+    () =>
+      keyDraft.headersEntries.filter(
+        (entry) => entry.key.trim() && entry.value.trim(),
+      ).length,
     [keyDraft.headersEntries],
   );
 

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -13,13 +13,16 @@ import type { KeyStatBucket } from "@code-proxy/domain";
 const DISABLE_ALL_MODELS_RULE = "*";
 
 export const hasDisableAllModelsRule = (models?: string[]) =>
-  Array.isArray(models) && models.some((m) => String(m ?? "").trim() === DISABLE_ALL_MODELS_RULE);
+  Array.isArray(models) &&
+  models.some((m) => String(m ?? "").trim() === DISABLE_ALL_MODELS_RULE);
 
-export const isProviderSimpleConfigEnabled = (item: ProviderSimpleConfig): boolean =>
-  !hasDisableAllModelsRule(item.excludedModels);
+export const isProviderSimpleConfigEnabled = (
+  item: ProviderSimpleConfig,
+): boolean => !hasDisableAllModelsRule(item.excludedModels);
 
-export const isBedrockProviderConfigEnabled = (item: BedrockProviderConfig): boolean =>
-  !hasDisableAllModelsRule(item.excludedModels);
+export const isBedrockProviderConfigEnabled = (
+  item: BedrockProviderConfig,
+): boolean => !hasDisableAllModelsRule(item.excludedModels);
 
 export const isOpenAIProviderEnabled = (provider: OpenAIProvider): boolean =>
   provider.disabled !== true;
@@ -34,12 +37,14 @@ export const withDisableAllModelsRule = (models?: string[]) => [
   DISABLE_ALL_MODELS_RULE,
 ];
 
-export const withoutDisableAllModelsRule = (models?: string[]) => stripDisableAllModelsRule(models);
+export const withoutDisableAllModelsRule = (models?: string[]) =>
+  stripDisableAllModelsRule(models);
 
 export const maskApiKey = (value: string): string => {
   const trimmed = value.trim();
   if (!trimmed) return "--";
-  if (trimmed.length <= 10) return `${trimmed.slice(0, 2)}***${trimmed.slice(-2)}`;
+  if (trimmed.length <= 10)
+    return `${trimmed.slice(0, 2)}***${trimmed.slice(-2)}`;
   return `${trimmed.slice(0, 6)}***${trimmed.slice(-4)}`;
 };
 
@@ -97,7 +102,8 @@ export const normalizeDiscoveredModels = (
     const key = id.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
-    const owned_by = typeof item.owned_by === "string" ? item.owned_by : undefined;
+    const owned_by =
+      typeof item.owned_by === "string" ? item.owned_by : undefined;
     result.push({ id, ...(owned_by ? { owned_by } : {}) });
   }
   return result;
@@ -125,7 +131,9 @@ export type ProviderKeyDraft = {
   skipAnthropicProcessing: boolean;
 };
 
-export const buildModelEntries = (models?: ProviderModel[]): ModelEntryDraft[] => {
+export const buildModelEntries = (
+  models?: ProviderModel[],
+): ModelEntryDraft[] => {
   if (!Array.isArray(models) || models.length === 0) return [];
   return models.map((model) => ({
     id: `model-${Date.now()}-${Math.random().toString(16).slice(2)}-${model.name ?? ""}`,
@@ -169,6 +177,66 @@ export const commitModelEntries = (
   return { models: models.length ? models : undefined };
 };
 
+const CLINE_PASS_MODEL_PREFIX = "cline-pass/";
+
+const isClinePassModelId = (model: string): boolean =>
+  model.trim().toLowerCase().startsWith(CLINE_PASS_MODEL_PREFIX);
+
+type ProviderModelOwnershipInput = {
+  models?: ProviderModel[];
+  excludedModels?: string[];
+  visionFallbackModel?: string;
+};
+
+export const validateProviderModelOwnership = (
+  provider: string,
+  input: ProviderModelOwnershipInput,
+): string | null => {
+  const modelEntries = input.models ?? [];
+  const modelNames = modelEntries
+    .map((model) => model.name?.trim() ?? "")
+    .filter((model) => model);
+  const excludedModels = input.excludedModels ?? [];
+  const visionFallback = input.visionFallbackModel?.trim() ?? "";
+
+  if (provider === "opencode-go") {
+    const invalidModel = modelNames.find((model) => isClinePassModelId(model));
+    if (invalidModel) {
+      return `OpenCode Go models cannot use cline-pass model IDs: ${invalidModel}`;
+    }
+    const invalidExcluded = excludedModels.find(
+      (model) =>
+        model.trim() !== DISABLE_ALL_MODELS_RULE && isClinePassModelId(model),
+    );
+    if (invalidExcluded) {
+      return `OpenCode Go excluded models cannot use cline-pass model IDs: ${invalidExcluded.trim()}`;
+    }
+    if (visionFallback && isClinePassModelId(visionFallback)) {
+      return `OpenCode Go vision fallback cannot use cline-pass model IDs: ${visionFallback}`;
+    }
+    return null;
+  }
+
+  if (provider === "cline") {
+    const invalidModel = modelNames.find((model) => !isClinePassModelId(model));
+    if (invalidModel) {
+      return `ClinePass models must use cline-pass model IDs: ${invalidModel}`;
+    }
+    const invalidExcluded = excludedModels.find(
+      (model) =>
+        model.trim() !== DISABLE_ALL_MODELS_RULE && !isClinePassModelId(model),
+    );
+    if (invalidExcluded) {
+      return `ClinePass excluded models must use cline-pass model IDs: ${invalidExcluded.trim()}`;
+    }
+    if (visionFallback && !isClinePassModelId(visionFallback)) {
+      return `ClinePass vision fallback must use cline-pass model IDs: ${visionFallback}`;
+    }
+  }
+
+  return null;
+};
+
 const hasBedrockFields = (
   input?: ProviderSimpleConfig | BedrockProviderConfig | null,
 ): input is BedrockProviderConfig =>
@@ -189,7 +257,8 @@ export const buildProviderKeyDraft = (
     name: input?.name ?? "",
     apiKey: input?.apiKey ?? "",
     authMode: bedrockInput?.authMode ?? "api-key",
-    accessKeyId: bedrockInput?.accessKeyId ?? (bedrockInput ? input?.apiKey : "") ?? "",
+    accessKeyId:
+      bedrockInput?.accessKeyId ?? (bedrockInput ? input?.apiKey : "") ?? "",
     secretAccessKey: bedrockInput?.secretAccessKey ?? "",
     sessionToken: bedrockInput?.sessionToken ?? "",
     region: bedrockInput?.region ?? "us-east-1",
@@ -227,7 +296,9 @@ export type OpenAIDraft = {
   modelEntries: ModelEntryDraft[];
 };
 
-export const buildOpenAIDraft = (input?: OpenAIProvider | null): OpenAIDraft => ({
+export const buildOpenAIDraft = (
+  input?: OpenAIProvider | null,
+): OpenAIDraft => ({
   name: input?.name ?? "",
   disabled: input?.disabled === true,
   baseUrl: input?.baseUrl ?? "",
@@ -260,7 +331,10 @@ export const buildOpenAIDraft = (input?: OpenAIProvider | null): OpenAIDraft => 
 
 export type AmpMappingEntry = { id: string; from: string; to: string };
 
-export const readString = (obj: Record<string, unknown> | null, ...keys: string[]): string => {
+export const readString = (
+  obj: Record<string, unknown> | null,
+  ...keys: string[]
+): string => {
   if (!obj) return "";
   for (const key of keys) {
     const value = obj[key];
@@ -269,7 +343,10 @@ export const readString = (obj: Record<string, unknown> | null, ...keys: string[
   return "";
 };
 
-export const readBool = (obj: Record<string, unknown> | null, ...keys: string[]): boolean => {
+export const readBool = (
+  obj: Record<string, unknown> | null,
+  ...keys: string[]
+): boolean => {
   if (!obj) return false;
   for (const key of keys) {
     const value = obj[key];
@@ -292,7 +369,10 @@ export const sumStatsByCandidates = (
   for (const id of candidates) {
     const bucket = statsBySource[id];
     if (!bucket) continue;
-    total = { success: total.success + bucket.success, failure: total.failure + bucket.failure };
+    total = {
+      success: total.success + bucket.success,
+      failure: total.failure + bucket.failure,
+    };
   }
   return total;
 };


### PR DESCRIPTION
## Summary
- validate OpenCode Go and ClinePass model ownership before saving provider keys
- keep historical/manual model entries visible so invalid persisted models can be removed
- add regression coverage for blocking invalid OpenCode Go ClinePass models and cleanup flow

## Tests
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/providers-helpers.test.ts pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build