### PR TITLE
fix: keep provider cards visible during refresh

### DIFF
--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -171,3 +171,37 @@ export function ProviderCard({
     </div>
   );
 }
+
+export function ProviderCardSkeleton({ naturalHeight = false }: { naturalHeight?: boolean }) {
+  return (
+    <div
+      className={[
+        "flex flex-col rounded-xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60",
+        naturalHeight
+          ? "h-fit min-h-[220px] w-full max-w-[22rem] flex-none self-start"
+          : "h-[220px]",
+      ].join(" ")}
+      aria-hidden="true"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="h-4 w-32 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+        <div className="h-5 w-5 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+      </div>
+      <div className="mt-4 space-y-2">
+        <div className="h-3 w-11/12 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+        <div className="h-3 w-3/4 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+      </div>
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div
+            key={index}
+            className="h-5 w-20 animate-pulse rounded-full bg-slate-200 dark:bg-white/10"
+          />
+        ))}
+      </div>
+      <div className="mt-auto pt-3">
+        <div className="h-2 w-full animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+      </div>
+    </div>
+  );
+}

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -3,7 +3,7 @@ import { Loader2, Plus, Zap } from "lucide-react";
 import type { ProviderSimpleConfig } from "@code-proxy/api-client";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
-import { ProviderCard } from "./ProviderCard";
+import { ProviderCard, ProviderCardSkeleton } from "./ProviderCard";
 import { EmptyState } from "@code-proxy/ui";
 import { ProviderStatusBar } from "@features/provider-latency";
 import type { KeyStatBucket, StatusBarData } from "@code-proxy/domain";
@@ -66,12 +66,12 @@ export function ProviderKeyListCard({
   showExcludedModels?: boolean;
 }) {
   const { t } = useTranslation();
+  const showSkeleton = loading && items.length === 0;
 
   return (
     <Card
       className="flex h-full min-h-0 flex-col"
       bodyClassName="min-h-0 flex flex-1 flex-col"
-      loading={loading}
       actions={
         <Button variant="primary" size="sm" onClick={onAdd}>
           <Plus size={14} />
@@ -79,7 +79,26 @@ export function ProviderKeyListCard({
         </Button>
       }
     >
-      {items.length === 0 ? (
+      {showSkeleton ? (
+        <div
+          role="status"
+          aria-label={t("common.loading")}
+          data-testid="providers-list-skeleton"
+          className={[
+            "min-h-0 flex-1 overflow-hidden pr-1 gap-3 items-start content-start justify-start",
+            naturalHeight ? "flex flex-wrap" : "grid",
+          ].join(" ")}
+          style={
+            naturalHeight
+              ? undefined
+              : { gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))" }
+          }
+        >
+          {Array.from({ length: 6 }, (_, index) => (
+            <ProviderCardSkeleton key={index} naturalHeight={naturalHeight} />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
         <EmptyState title={t("providers.no_config")} description={t("providers.no_config_desc")} />
       ) : (
         <div

--- a/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -167,14 +167,16 @@ describe("ProvidersPage import/export", () => {
     expect(importButton).toBeEnabled();
     await waitFor(() => expect(refreshButton).toBeDisabled());
     expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    expect(screen.getByText("Codex Main")).toBeInTheDocument();
+    expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
 
     resolveRefresh?.([]);
     await waitFor(() => expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument());
+    expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
   });
 
-  test("shows page loading when switching to an unloaded provider tab", async () => {
+  test("shows skeleton cards when switching to an unloaded provider tab", async () => {
     const user = userEvent.setup();
     let resolveSwitch: ((configs: any[]) => void) | undefined;
     mocks.getCodexConfigs.mockImplementationOnce(
@@ -198,7 +200,8 @@ describe("ProvidersPage import/export", () => {
 
     await waitFor(() => expect(refreshButton).toBeDisabled());
     expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
-    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+    expect(screen.getByTestId("providers-list-skeleton")).toBeInTheDocument();
+    expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
 
     resolveSwitch?.([
       {
@@ -207,7 +210,9 @@ describe("ProvidersPage import/export", () => {
       },
     ]);
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    await waitFor(() => expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument(),
+    );
   });
 
   test("does not refresh when clicking the active provider tab again", async () => {

--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen, waitFor, within } from "@testing-library/react
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ProviderSimpleConfig } from "@code-proxy/api-client";
 import { ProvidersPage } from "@pages/providers/ProvidersPage";
 import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
@@ -170,6 +171,78 @@ describe("ProvidersPage openai tab", () => {
     expect(within(codexTab).getByText("2")).toBeInTheDocument();
     expect(within(openCodeGoTab).getByText("1")).toBeInTheDocument();
     expect(within(geminiTab).queryByText("0")).not.toBeInTheDocument();
+  });
+
+  test("shows skeleton cards instead of the card loading overlay before the first empty result", async () => {
+    localStorage.setItem("providers-page:tab", "gemini");
+    let resolveGemini: (value: ProviderSimpleConfig[]) => void = () => {};
+    mocks.getGeminiKeys.mockImplementationOnce(
+      () =>
+        new Promise<ProviderSimpleConfig[]>((resolve) => {
+          resolveGemini = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId("providers-list-skeleton")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+
+    resolveGemini([]);
+    expect(await screen.findByText("No configuration")).toBeInTheDocument();
+  });
+
+  test("keeps existing provider cards visible during toolbar refresh", async () => {
+    const user = userEvent.setup();
+    const geminiProvider: ProviderSimpleConfig = {
+      name: "Gemini Main",
+      apiKey: "sk-gemini-main",
+    };
+    localStorage.setItem("providers-page:tab", "gemini");
+    mocks.getGeminiKeys.mockImplementationOnce(async () => [geminiProvider]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Gemini Main")).toBeInTheDocument();
+
+    let resolveRefresh: (value: ProviderSimpleConfig[]) => void = () => {};
+    mocks.getGeminiKeys.mockImplementationOnce(
+      () =>
+        new Promise<ProviderSimpleConfig[]>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /Refresh|刷新/ }));
+
+    expect(screen.getByText("Gemini Main")).toBeInTheDocument();
+    expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+
+    resolveRefresh([geminiProvider]);
+    await waitFor(() => {
+      expect(mocks.getGeminiKeys).toHaveBeenCalledTimes(2);
+    });
   });
 
   test("renders openai provider card with masked key and aggregated status", async () => {

--- a/pages/providers/components/OpenAIProvidersTab.tsx
+++ b/pages/providers/components/OpenAIProvidersTab.tsx
@@ -4,7 +4,7 @@ import type { OpenAIProvider } from "@code-proxy/api-client";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
-import { ProviderCard } from "../ProviderCard";
+import { ProviderCard, ProviderCardSkeleton } from "../ProviderCard";
 import { ProviderStatusBar } from "@features/provider-latency";
 import { ProviderMetricChip } from "./ProviderMetricChip";
 import { ProviderModelChips } from "./ProviderModelChips";
@@ -44,6 +44,7 @@ export function OpenAIProvidersTab({
   onToggleSelected,
 }: OpenAIProvidersTabProps) {
   const { t } = useTranslation();
+  const showSkeleton = loading && providers.length === 0;
 
   return (
     <Card
@@ -51,7 +52,6 @@ export function OpenAIProvidersTab({
       description={t("providers.openai_tab_desc")}
       className="flex h-full min-h-0 flex-col"
       bodyClassName="min-h-0 flex flex-1 flex-col"
-      loading={loading}
       actions={
         <Button variant="primary" size="sm" onClick={() => openOpenAIEditor(null)}>
           <Plus size={14} />
@@ -59,7 +59,19 @@ export function OpenAIProvidersTab({
         </Button>
       }
     >
-      {providers.length === 0 ? (
+      {showSkeleton ? (
+        <div
+          role="status"
+          aria-label={t("common.loading")}
+          data-testid="providers-list-skeleton"
+          className="min-h-0 flex-1 overflow-hidden pr-1 grid gap-3 items-start content-start justify-start"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))" }}
+        >
+          {Array.from({ length: 6 }, (_, index) => (
+            <ProviderCardSkeleton key={index} />
+          ))}
+        </div>
+      ) : providers.length === 0 ? (
         <EmptyState
           title={t("providers.no_openai_providers")}
           description={t("providers.no_openai_desc")}


### PR DESCRIPTION
## Summary
- show provider-card skeletons for first empty loads
- keep existing provider cards visible during toolbar refresh
- cover refresh and skeleton states with provider page tests

## Verification
- rtk bun run --filter @code-proxy/admin-panel test:ci -- pages/providers/__tests__/ProvidersPage.openai.test.tsx
- rtk bun run build