### PR TITLE
fix: use linked request log filter options

### DIFF
--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -340,6 +340,7 @@ export const usageApi = {
         api_key_names: isStringRecord(filters?.api_key_names) ? filters.api_key_names : {},
         models: Array.isArray(filters?.models) ? filters.models : [],
         channels: Array.isArray(filters?.channels) ? filters.channels : [],
+        statuses: Array.isArray(filters?.statuses) ? filters.statuses : ["success", "failed"],
       },
       stats: {
         total: resp?.stats?.total ?? 0,
@@ -511,6 +512,7 @@ export interface UsageLogsResponse {
     api_key_names: Record<string, string>;
     models: string[];
     channels: string[];
+    statuses: string[];
   };
   stats: {
     total: number;
@@ -526,6 +528,7 @@ type UsageLogsFilterPayload = {
   api_key_names?: unknown;
   models?: unknown;
   channels?: unknown;
+  statuses?: unknown;
 };
 
 type UsageLogsPayload = {

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -156,11 +156,13 @@ export function RequestLogsPage() {
     api_key_names: Record<string, string>;
     models: string[];
     channels: string[];
+    statuses: string[];
   }>({
     api_keys: [],
     api_key_names: {},
     models: [],
     channels: [],
+    statuses: ["success", "failed"],
   });
   const [stats, setStats] = useState<{
     total: number;
@@ -220,11 +222,17 @@ export function RequestLogsPage() {
   }, [filterOptions.channels]);
 
   const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
-    return [
-      { value: "success", label: t("request_logs.status_success"), searchText: "success" },
-      { value: "failed", label: t("request_logs.status_failed"), searchText: "failed" },
-    ];
-  }, [t]);
+    return (filterOptions.statuses ?? ["success", "failed"]).map((status) => ({
+      value: status,
+      label:
+        status === "success"
+          ? t("request_logs.status_success")
+          : status === "failed"
+            ? t("request_logs.status_failed")
+            : status,
+      searchText: status,
+    }));
+  }, [filterOptions.statuses, t]);
 
   const apiKeyFilterValues = useMemo(() => keyOptions.map((option) => option.value), [keyOptions]);
   const modelFilterValues = useMemo(

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -27,6 +27,7 @@ const emptyLogsResponse = {
     api_key_names: {},
     models: [],
     channels: [],
+    statuses: [],
   },
   stats: {
     total: 0,
@@ -49,6 +50,7 @@ const responseWithFilterOptions = {
     },
     models: ["gpt-5.4", "gpt-4.1"],
     channels: ["Codex", "Relay"],
+    statuses: ["success", "failed"],
   },
   stats: {
     total: 0,
@@ -377,6 +379,33 @@ describe("RequestLogsPage", () => {
       "aria-selected",
       "true",
     );
+  });
+
+  test("uses backend status filter candidates", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+
+    mocks.getUsageLogs.mockResolvedValue({
+      ...responseWithFilterOptions,
+      filters: {
+        ...responseWithFilterOptions.filters,
+        statuses: ["success"],
+      },
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const [, , , statusFilter] = await screen.findAllByRole("combobox");
+    await user.click(statusFilter);
+
+    expect(await screen.findByRole("option", { name: "Success" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Failed" })).not.toBeInTheDocument();
   });
 
   test("only applies request-log multi-select changes after confirmation and restores full selection", async () => {


### PR DESCRIPTION
## Summary
- accept backend status candidates in usage log filters
- render request-log status options from backend filter metadata
- cover linked status candidates in the request logs page test

## Tests
- rtk bun run --filter @code-proxy/admin-panel test -- pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run build