### PR TITLE
fix: remove persistent menu active states

### DIFF
--- a/packages/ui/src/theme/LanguageSelector.tsx
+++ b/packages/ui/src/theme/LanguageSelector.tsx
@@ -153,9 +153,7 @@ export function LanguageSelector({ className }: { className?: string }) {
                     onClick={() => handleLanguageChange(lng)}
                     className={cn(
                       selectOptionBase,
-                      selected
-                        ? `${selectOptionSelected} bg-[#EBEBEC] dark:bg-[#46464C]`
-                        : selectOptionIdle,
+                      selected ? selectOptionSelected : selectOptionIdle,
                     )}
                   >
                     <span className="shrink-0 text-base leading-none" aria-hidden="true">

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -298,9 +298,7 @@ export function ThemeToggleButton({ className, label }: { className?: string; la
                     onClick={() => handleModeChange(value)}
                     className={cn(
                       selectOptionBase,
-                      selected
-                        ? `${selectOptionSelected} bg-[#EBEBEC] dark:bg-[#46464C]`
-                        : selectOptionIdle,
+                      selected ? selectOptionSelected : selectOptionIdle,
                     )}
                   >
                     <Icon size={16} className="shrink-0" aria-hidden="true" />

--- a/packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
+++ b/packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
@@ -20,6 +20,9 @@ describe("LanguageSelector", () => {
     expect(screen.getAllByText("🇨🇳").length).toBeGreaterThan(0);
     expect(screen.getAllByText("🇬🇧").length).toBeGreaterThan(0);
     expect(screen.getAllByText("🇷🇺").length).toBeGreaterThan(0);
+    expect(screen.getByRole("option", { name: /English/ }).className).not.toMatch(
+      /(^|\s)bg-\[#EBEBEC\](\s|$)/,
+    );
     expect(screen.queryByText(/nav\.language/)).not.toBeInTheDocument();
   });
 });

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -538,10 +538,6 @@ export function ApiKeyLookupPage() {
   const keyMenuOptions = useMemo<SelectOption[]>(
     () => [
       {
-        value: queriedKey,
-        label: displayName,
-      },
-      {
         value: LOGOUT_SELECT_VALUE,
         label: (
           <span className="flex items-center gap-2">
@@ -551,7 +547,7 @@ export function ApiKeyLookupPage() {
         ),
       },
     ],
-    [displayName, queriedKey, t],
+    [t],
   );
   const handleKeyMenuChange = useCallback(
     (value: string) => {
@@ -586,6 +582,7 @@ export function ApiKeyLookupPage() {
                 value={queriedKey}
                 onChange={handleKeyMenuChange}
                 options={keyMenuOptions}
+                placeholder={displayName}
                 aria-label={displayName}
                 className="max-w-[34vw] sm:max-w-56"
                 size="sm"

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -89,6 +89,26 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.queryByRole("dialog", { name: /enter api key/i })).not.toBeInTheDocument();
   });
 
+  test("does not duplicate the current key in the header menu", async () => {
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
+
+    expect(screen.queryByRole("option", { name: /primary key/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /logout/i })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
   test("logs out from the header menu and asks for the API key again", async () => {
     window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 


### PR DESCRIPTION
## Summary
- remove the duplicate current API key row from the lookup header menu
- keep logout from rendering as a selected option
- remove persistent selected backgrounds from language and theme menus while keeping checkmarks

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
- rtk bun run --filter @code-proxy/admin-panel test -- packages/ui/src/theme/__tests__/LanguageSelector.test.tsx
- rtk bun run build