### PR TITLE
fix: polish API key usage refresh state

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -18,9 +18,15 @@ import {
   fetchPublicLogs,
 } from "./api";
 import { LookupEmptyState } from "./components/LookupEmptyState";
-import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
+import {
+  LookupResultsToolbar,
+  type ApiKeyLookupTab,
+} from "./components/LookupResultsToolbar";
 import { ModelsTabContent } from "./components/ModelsTabContent";
-import { buildLogColumns, PublicLogsSection } from "./components/PublicLogsSection";
+import {
+  buildLogColumns,
+  PublicLogsSection,
+} from "./components/PublicLogsSection";
 import { QuickImportTabContent } from "./components/QuickImportTabContent";
 import { UsageTabSection } from "./components/UsageTabSection";
 import { useApiKeyLookupCharts } from "./hooks/useApiKeyLookupCharts";
@@ -28,6 +34,7 @@ import type { ChartDataResponse, LogRow, PublicLogItem } from "./types";
 
 const DEFAULT_PAGE_SIZE = 50;
 const LOOKUP_LAST_API_KEY_STORAGE_KEY = "apiKeyLookup.lastApiKey.v1";
+const LOOKUP_CHART_CACHE_STORAGE_KEY = "apiKeyLookup.chartCache.v1";
 const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -44,7 +51,10 @@ const formatLatencyMs = (value: number): string => {
 
 const readStoredLookupKey = (): string => {
   try {
-    return window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ?? "";
+    return (
+      window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ??
+      ""
+    );
   } catch {
     return "";
   }
@@ -57,6 +67,68 @@ const writeStoredLookupKey = (value: string): void => {
     } else {
       window.sessionStorage.removeItem(LOOKUP_LAST_API_KEY_STORAGE_KEY);
     }
+  } catch {
+    // ignore storage failures
+  }
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isChartDataResponse(value: unknown): value is ChartDataResponse {
+  if (!isRecord(value)) return false;
+  return (
+    Array.isArray(value.daily_series) &&
+    Array.isArray(value.model_distribution) &&
+    isRecord(value.stats)
+  );
+}
+
+const readStoredChartCache = (cacheKey: string): ChartDataResponse | null => {
+  try {
+    const raw = window.sessionStorage.getItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    const cached = parsed[cacheKey];
+    return isChartDataResponse(cached) ? cached : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredChartCache = (
+  cacheKey: string,
+  data: ChartDataResponse,
+): void => {
+  try {
+    const raw = window.sessionStorage.getItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    const entries = isRecord(parsed)
+      ? Object.entries(parsed).filter(
+          (entry): entry is [string, ChartDataResponse] =>
+            isChartDataResponse(entry[1]),
+        )
+      : [];
+    const next: Record<string, ChartDataResponse> = {};
+    const keptEntries = entries.filter(([key]) => key !== cacheKey);
+    const cacheEntry: [string, ChartDataResponse] = [cacheKey, data];
+    for (const [key, value] of [...keptEntries, cacheEntry].slice(-8)) {
+      next[key] = value;
+    }
+    window.sessionStorage.setItem(
+      LOOKUP_CHART_CACHE_STORAGE_KEY,
+      JSON.stringify(next),
+    );
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const clearStoredChartCache = (): void => {
+  try {
+    window.sessionStorage.removeItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
   } catch {
     // ignore storage failures
   }
@@ -114,7 +186,11 @@ const localizeLookupError = (
 const readLegacyLookupKeyFromUrl = (): string => {
   try {
     const url = new URL(window.location.href);
-    return (url.searchParams.get("api_key") || url.searchParams.get("key") || "").trim();
+    return (
+      url.searchParams.get("api_key") ||
+      url.searchParams.get("key") ||
+      ""
+    ).trim();
   } catch {
     return "";
   }
@@ -155,7 +231,10 @@ export function ApiKeyLookupPage() {
     return () => mq.removeEventListener("change", handler);
   }, []);
 
-  const initialLookupKey = useMemo(() => readLegacyLookupKeyFromUrl() || readStoredLookupKey(), []);
+  const initialLookupKey = useMemo(
+    () => readLegacyLookupKeyFromUrl() || readStoredLookupKey(),
+    [],
+  );
   const [apiKeyInput, setApiKeyInput] = useState(initialLookupKey);
   const [queriedKey, setQueriedKey] = useState(initialLookupKey);
   const [apiKeyName, setApiKeyName] = useState("");
@@ -163,21 +242,43 @@ export function ApiKeyLookupPage() {
 
   // ── Content modal state ──
   const [contentModalOpen, setContentModalOpen] = useState(false);
-  const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
-  const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
+  const [contentModalLogId, setContentModalLogId] = useState<number | null>(
+    null,
+  );
+  const [contentModalTab, setContentModalTab] = useState<"input" | "output">(
+    "input",
+  );
 
-  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
-    setContentModalLogId(logId);
-    setContentModalTab(tab);
-    setContentModalOpen(true);
-  }, []);
+  const handleContentClick = useCallback(
+    (logId: number, tab: "input" | "output") => {
+      setContentModalLogId(logId);
+      setContentModalTab(tab);
+      setContentModalOpen(true);
+    },
+    [],
+  );
 
-  const logColumns = useMemo(() => buildLogColumns(t, handleContentClick), [t, handleContentClick]);
+  const logColumns = useMemo(
+    () => buildLogColumns(t, handleContentClick),
+    [t, handleContentClick],
+  );
   const statusOptions = useMemo(
     () => [
-      { value: "", label: t("apikey_lookup.all_status"), searchText: "all status" },
-      { value: "success", label: t("request_logs.status_success"), searchText: "success" },
-      { value: "failed", label: t("request_logs.status_failed"), searchText: "failed" },
+      {
+        value: "",
+        label: t("apikey_lookup.all_status"),
+        searchText: "all status",
+      },
+      {
+        value: "success",
+        label: t("request_logs.status_success"),
+        searchText: "success",
+      },
+      {
+        value: "failed",
+        label: t("request_logs.status_failed"),
+        searchText: "failed",
+      },
     ],
     [t],
   );
@@ -260,7 +361,14 @@ export function ApiKeyLookupPage() {
         setRawItems(resp.items ?? []);
         setTotalCount(resp.total ?? 0);
         setCurrentPage(page);
-        setStats(resp.stats ?? { total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
+        setStats(
+          resp.stats ?? {
+            total: 0,
+            success_rate: 0,
+            total_tokens: 0,
+            total_cost: 0,
+          },
+        );
         setModelOptions(resp.filters?.models ?? []);
         setLastUpdatedAt(Date.now());
         setQueriedKey(key.trim());
@@ -271,7 +379,11 @@ export function ApiKeyLookupPage() {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (myFetchId !== fetchIdRef.current) return;
 
-        const message = localizeLookupError(t, err, "apikey_lookup.query_failed");
+        const message = localizeLookupError(
+          t,
+          err,
+          "apikey_lookup.query_failed",
+        );
         setError(message);
         setRawItems([]);
         setTotalCount(0);
@@ -290,31 +402,47 @@ export function ApiKeyLookupPage() {
   //  Chart data fetching (with caching)
   // ================================================================
 
-  const fetchChartDataFn = useCallback(async (key: string, days: number) => {
-    const cacheKey = `${key}|${days}`;
-    if (chartCacheRef.current[cacheKey]) {
-      setChartData(chartCacheRef.current[cacheKey]);
-      return;
-    }
-    setChartLoading(true);
-    try {
-      const data = await fetchPublicChartData({ apiKey: key.trim(), days });
-      chartCacheRef.current[cacheKey] = data;
-      const nextName = data.api_key_name?.trim() ?? "";
-      if (nextName) setApiKeyName(nextName);
-      setChartData(data);
-    } catch {
-      setChartData(null);
-    } finally {
-      setChartLoading(false);
-    }
-  }, []);
+  const fetchChartDataFn = useCallback(
+    async (key: string, days: number, options?: { force?: boolean }) => {
+      const trimmedKey = key.trim();
+      if (!trimmedKey) return;
+
+      const cacheKey = `${trimmedKey}|${days}`;
+      const cached = options?.force
+        ? null
+        : chartCacheRef.current[cacheKey] || readStoredChartCache(cacheKey);
+      if (cached) {
+        chartCacheRef.current[cacheKey] = cached;
+        const cachedName = cached.api_key_name?.trim() ?? "";
+        if (cachedName) setApiKeyName(cachedName);
+        setChartData(cached);
+      }
+
+      setChartLoading(true);
+      try {
+        const data = await fetchPublicChartData({ apiKey: trimmedKey, days });
+        chartCacheRef.current[cacheKey] = data;
+        writeStoredChartCache(cacheKey, data);
+        const nextName = data.api_key_name?.trim() ?? "";
+        if (nextName) setApiKeyName(nextName);
+        setChartData(data);
+      } catch {
+        // Keep stale chart data visible; logs request owns the user-facing error.
+      } finally {
+        setChartLoading(false);
+      }
+    },
+    [],
+  );
 
   // ================================================================
   //  Derived rows for VirtualTable
   // ================================================================
 
-  const rows = useMemo<LogRow[]>(() => rawItems.map((item) => toLogRow(item)), [rawItems]);
+  const rows = useMemo<LogRow[]>(
+    () => rawItems.map((item) => toLogRow(item)),
+    [rawItems],
+  );
 
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
@@ -357,7 +485,9 @@ export function ApiKeyLookupPage() {
         const ids = await fetchAvailableModels(key);
         setAvailableModels(ids);
       } catch (err: unknown) {
-        setModelsError(localizeLookupError(t, err, "apikey_lookup.load_models_failed"));
+        setModelsError(
+          localizeLookupError(t, err, "apikey_lookup.load_models_failed"),
+        );
       } finally {
         setModelsLoading(false);
       }
@@ -384,7 +514,6 @@ export function ApiKeyLookupPage() {
   useEffect(() => {
     if (!queriedKey) return;
     if (initialLookupKey && !restoredLookupFetchedRef.current) return;
-    chartCacheRef.current = {};
     if (activeTab === "usage") {
       void fetchChartDataFn(queriedKey, timeRange);
     }
@@ -409,6 +538,7 @@ export function ApiKeyLookupPage() {
         setRawItems([]);
         setCurrentPage(1);
         setApiKeyName("");
+        if (val !== queriedKey) setChartData(null);
         chartCacheRef.current = {};
         if (activeTab === "usage") {
           void fetchChartDataFn(val, timeRange);
@@ -422,7 +552,14 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [apiKeyInput, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn],
+    [
+      apiKeyInput,
+      activeTab,
+      timeRange,
+      fetchLogs,
+      fetchChartDataFn,
+      fetchModelsFn,
+    ],
   );
 
   const handleApiKeyInputChange = useCallback((value: string) => {
@@ -434,6 +571,7 @@ export function ApiKeyLookupPage() {
     fetchIdRef.current += 1;
     paginationInFlightRef.current = false;
     chartCacheRef.current = {};
+    clearStoredChartCache();
 
     setError(null);
     setModelsError(null);
@@ -463,8 +601,7 @@ export function ApiKeyLookupPage() {
   const handleRefresh = useCallback(() => {
     if (queriedKey) {
       if (activeTab === "usage") {
-        chartCacheRef.current = {};
-        void fetchChartDataFn(queriedKey, timeRange);
+        void fetchChartDataFn(queriedKey, timeRange, { force: true });
       } else if (activeTab === "models") {
         void fetchModelsFn(queriedKey);
       } else if (activeTab === "quickImport") {
@@ -473,7 +610,14 @@ export function ApiKeyLookupPage() {
         fetchLogs(queriedKey, 1);
       }
     }
-  }, [queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn]);
+  }, [
+    queriedKey,
+    activeTab,
+    timeRange,
+    fetchLogs,
+    fetchChartDataFn,
+    fetchModelsFn,
+  ]);
 
   // Strip legacy sensitive query params from the URL on mount.
   useEffect(() => {
@@ -522,7 +666,11 @@ export function ApiKeyLookupPage() {
   // ── Model filter options for SearchableSelect ──
   const modelFilterOptions = useMemo(
     () => [
-      { value: "", label: t("apikey_lookup.all_models"), searchText: "all models" },
+      {
+        value: "",
+        label: t("apikey_lookup.all_models"),
+        searchText: "all models",
+      },
       ...modelOptions.map((m) => ({ value: m, label: m, searchText: m })),
     ],
     [modelOptions, t],
@@ -535,7 +683,8 @@ export function ApiKeyLookupPage() {
     return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
   }, [lastUpdatedAt]);
 
-  const displayName = apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
+  const displayName =
+    apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
   const keyMenuOptions = useMemo<SelectOption[]>(
     () => [
       {
@@ -633,7 +782,9 @@ export function ApiKeyLookupPage() {
                 setModelMetric={setModelMetric}
                 heatmapSeries={heatmapSeries}
                 modelDistributionData={modelDistributionData}
-                modelDistributionOption={modelDistributionOption as Record<string, unknown>}
+                modelDistributionOption={
+                  modelDistributionOption as Record<string, unknown>
+                }
                 modelDistributionLegend={modelDistributionLegend}
                 dailySeries={dailySeries}
                 dailyTrendOption={dailyTrendOption as Record<string, unknown>}
@@ -681,7 +832,10 @@ export function ApiKeyLookupPage() {
 
             {activeTab === "quickImport" ? (
               <Reveal>
-                <QuickImportTabContent apiKey={queriedKey} reloadToken={quickImportReloadToken} />
+                <QuickImportTabContent
+                  apiKey={queriedKey}
+                  reloadToken={quickImportReloadToken}
+                />
               </Reveal>
             ) : null}
           </>
@@ -737,7 +891,11 @@ export function ApiKeyLookupPage() {
           </Button>
         }
       >
-        <form id="apikey-login-form" onSubmit={handleSubmit} className="space-y-2">
+        <form
+          id="apikey-login-form"
+          onSubmit={handleSubmit}
+          className="space-y-2"
+        >
           <label
             htmlFor="apikey-login-input"
             className="block text-sm font-medium text-slate-700 dark:text-white/80"
@@ -753,9 +911,13 @@ export function ApiKeyLookupPage() {
             autoComplete="off"
             spellCheck={false}
             autoFocus
-            startAdornment={<Search size={16} className="text-slate-400 dark:text-white/40" />}
+            startAdornment={
+              <Search size={16} className="text-slate-400 dark:text-white/40" />
+            }
           />
-          {error ? <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p> : null}
+          {error ? (
+            <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p>
+          ) : null}
         </form>
       </Modal>
     </div>

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -12,7 +12,13 @@ const mocks = vi.hoisted(() => ({
     page: 1,
     size: 50,
     api_key_name: "Primary key",
-    stats: { total: 0, success_rate: 0, total_tokens: 0, total_sessions: 0, total_cost: 0 },
+    stats: {
+      total: 0,
+      success_rate: 0,
+      total_tokens: 0,
+      total_sessions: 0,
+      total_cost: 0,
+    },
     filters: { models: [] },
   })),
   fetchPublicChartData: vi.fn(async () => ({
@@ -20,7 +26,13 @@ const mocks = vi.hoisted(() => ({
     heatmap_series: [],
     model_distribution: [],
     api_key_name: "Primary key",
-    stats: { total: 0, success_rate: 0, total_tokens: 0, total_sessions: 0, total_cost: 0 },
+    stats: {
+      total: 0,
+      success_rate: 0,
+      total_tokens: 0,
+      total_sessions: 0,
+      total_cost: 0,
+    },
   })),
   fetchAvailableModels: vi.fn(async (): Promise<string[]> => []),
 }));
@@ -32,7 +44,17 @@ vi.mock("../api", () => ({
 }));
 
 vi.mock("../components/UsageTabSection", () => ({
-  UsageTabSection: () => <div data-testid="usage-tab" />,
+  UsageTabSection: ({
+    chartLoading,
+    chartStats,
+  }: {
+    chartLoading: boolean;
+    chartStats?: { total: number };
+  }) => (
+    <div data-testid="usage-tab" data-loading={String(chartLoading)}>
+      {chartStats?.total ?? "no-stats"}
+    </div>
+  ),
 }));
 
 vi.mock("@features/log-content-viewer", () => ({
@@ -55,7 +77,9 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByRole("dialog", { name: /enter api key/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /enter api key/i }),
+    ).toBeInTheDocument();
 
     await userEvent.type(
       screen.getByPlaceholderText(/enter api key to lookup usage/i),
@@ -71,7 +95,10 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("restores the last looked up API key after page refresh and shows its name", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
 
     render(
       <ThemeProvider>
@@ -89,12 +116,19 @@ describe("ApiKeyLookupPage", () => {
         expect.objectContaining({ apiKey: "sk-restored-key" }),
       );
     });
-    expect(await screen.findByRole("combobox", { name: /primary key/i })).toBeInTheDocument();
-    expect(screen.queryByRole("dialog", { name: /enter api key/i })).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("combobox", { name: /primary key/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: /enter api key/i }),
+    ).not.toBeInTheDocument();
   });
 
   test("does not duplicate the current key in the header menu", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
 
     render(
       <ThemeProvider>
@@ -104,9 +138,13 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: /primary key/i }),
+    );
 
-    expect(screen.queryByRole("option", { name: /primary key/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /primary key/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /logout/i })).toHaveAttribute(
       "aria-selected",
       "false",
@@ -114,7 +152,10 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("logs out from the header menu and asks for the API key again", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
 
     render(
       <ThemeProvider>
@@ -124,10 +165,83 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: /primary key/i }),
+    );
     await userEvent.click(screen.getByRole("option", { name: /logout/i }));
 
-    expect(window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1")).toBeNull();
-    expect(screen.getByRole("dialog", { name: /enter api key/i })).toBeInTheDocument();
+    expect(
+      window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1"),
+    ).toBeNull();
+    expect(
+      screen.getByRole("dialog", { name: /enter api key/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("shows cached usage data while refreshing chart data", async () => {
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
+    window.sessionStorage.setItem(
+      "apiKeyLookup.chartCache.v1",
+      JSON.stringify({
+        "sk-restored-key|7": {
+          daily_series: [],
+          heatmap_series: [],
+          model_distribution: [],
+          api_key_name: "Cached key",
+          stats: {
+            total: 12,
+            success_rate: 50,
+            total_tokens: 120,
+            total_sessions: 2,
+            total_cost: 1,
+          },
+        },
+      }),
+    );
+
+    let resolveChart: (
+      value: Awaited<ReturnType<typeof mocks.fetchPublicChartData>>,
+    ) => void = () => {};
+    mocks.fetchPublicChartData.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveChart = resolve;
+      }),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const usageTab = await screen.findByTestId("usage-tab");
+    expect(usageTab).toHaveTextContent("12");
+    expect(usageTab).toHaveAttribute("data-loading", "true");
+
+    resolveChart({
+      daily_series: [],
+      heatmap_series: [],
+      model_distribution: [],
+      api_key_name: "Fresh key",
+      stats: {
+        total: 24,
+        success_rate: 75,
+        total_tokens: 240,
+        total_sessions: 4,
+        total_cost: 2,
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"),
+    );
+    expect(
+      window.sessionStorage.getItem("apiKeyLookup.chartCache.v1"),
+    ).toContain('"total":24');
   });
 });

--- a/pages/api-key-lookup/components/UsageTabSection.tsx
+++ b/pages/api-key-lookup/components/UsageTabSection.tsx
@@ -1,5 +1,11 @@
 import { useMemo, type ReactNode } from "react";
-import { Activity, CalendarDays, Coins, MessagesSquare, ShieldCheck, Sigma } from "lucide-react";
+import {
+  Activity,
+  Coins,
+  MessagesSquare,
+  ShieldCheck,
+  Sigma,
+} from "lucide-react";
 import { AnimatedNumber } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
@@ -34,6 +40,8 @@ const HEATMAP_LEVEL_CLASSES = [
   "bg-blue-700 dark:bg-blue-300",
 ] as const;
 
+const formatInteger = (value: number) => Math.round(value).toLocaleString();
+
 function localDateKey(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -48,7 +56,11 @@ function buildHeatmapDays() {
   start.setDate(end.getDate() - 364);
 
   const days: string[] = [];
-  for (let current = new Date(start); current <= end; current.setDate(current.getDate() + 1)) {
+  for (
+    let current = new Date(start);
+    current <= end;
+    current.setDate(current.getDate() + 1)
+  ) {
     days.push(localDateKey(current));
   }
   return { days, leadingEmptyCells: start.getDay() };
@@ -77,9 +89,13 @@ function HeatmapTooltip({
           <span>{t("apikey_lookup.requests")}</span>
           <span className="text-right">{requests.toLocaleString()}</span>
           <span>{t("apikey_lookup.total_sessions")}</span>
-          <span className="text-right">{(point?.sessions ?? 0).toLocaleString()}</span>
+          <span className="text-right">
+            {(point?.sessions ?? 0).toLocaleString()}
+          </span>
           <span>{t("apikey_lookup.token")}</span>
-          <span className="text-right">{(point?.tokens ?? 0).toLocaleString()}</span>
+          <span className="text-right">
+            {(point?.tokens ?? 0).toLocaleString()}
+          </span>
           <span>{t("apikey_lookup.total_cost")}</span>
           <span className="text-right">${(point?.cost ?? 0).toFixed(4)}</span>
         </span>
@@ -106,18 +122,22 @@ function CalendarHeatmap({
     return byDate;
   }, [heatmapSeries]);
   const maxRequests = useMemo(
-    () => heatmapSeries.reduce((max, point) => Math.max(max, point.requests), 0),
+    () =>
+      heatmapSeries.reduce((max, point) => Math.max(max, point.requests), 0),
     [heatmapSeries],
   );
-  const emptyCells: ReactNode[] = Array.from({ length: leadingEmptyCells }, (_, index) => (
-    <span key={`empty-${index}`} className="h-3 w-3" aria-hidden="true" />
-  ));
+  const emptyCells: ReactNode[] = Array.from(
+    { length: leadingEmptyCells },
+    (_, index) => (
+      <span key={`empty-${index}`} className="h-3 w-3" aria-hidden="true" />
+    ),
+  );
 
   return (
     <div className="space-y-3">
       <div className="overflow-x-auto pb-1">
         <div
-          className="grid grid-flow-col grid-rows-7 gap-1"
+          className="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1"
           style={{ gridAutoColumns: "0.75rem" }}
           aria-label={t("apikey_lookup.calendar_heatmap")}
         >
@@ -128,11 +148,13 @@ function CalendarHeatmap({
             return (
               <HoverTooltip
                 key={date}
+                className="h-3 w-3"
                 placement="top"
                 content={<HeatmapTooltip t={t} date={date} point={point} />}
               >
                 <span
-                  className={`h-3 w-3 rounded-[3px] ring-1 ring-black/[0.03] transition-colors dark:ring-white/[0.04] ${HEATMAP_LEVEL_CLASSES[level]}`}
+                  tabIndex={0}
+                  className={`block h-3 w-3 cursor-pointer rounded-[3px] ring-1 ring-black/[0.03] transition duration-150 hover:scale-110 hover:ring-blue-400/70 focus:outline-none focus:ring-2 focus:ring-blue-400/70 dark:ring-white/[0.04] ${HEATMAP_LEVEL_CLASSES[level]}`}
                   aria-label={`${date}: ${point?.requests ?? 0} ${t("apikey_lookup.requests")}`}
                 />
               </HoverTooltip>
@@ -140,7 +162,7 @@ function CalendarHeatmap({
           })}
         </div>
       </div>
-      <div className="flex items-center justify-end gap-1 text-xs text-slate-500 dark:text-white/55">
+      <div className="flex items-center justify-center gap-1 text-xs text-slate-500 dark:text-white/55 sm:justify-end">
         <span>{t("apikey_lookup.heatmap_less")}</span>
         {HEATMAP_LEVEL_CLASSES.map((className) => (
           <span
@@ -152,6 +174,45 @@ function CalendarHeatmap({
         <span>{t("apikey_lookup.heatmap_more")}</span>
       </div>
     </div>
+  );
+}
+
+function HeatmapSkeleton() {
+  return (
+    <div className="space-y-3" aria-hidden="true">
+      <div className="overflow-hidden pb-1">
+        <div
+          className="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1"
+          style={{ gridAutoColumns: "0.75rem" }}
+        >
+          {Array.from({ length: 371 }, (_, index) => (
+            <span
+              key={index}
+              className="h-3 w-3 rounded-[3px] bg-slate-100 motion-safe:animate-pulse dark:bg-white/10"
+            />
+          ))}
+        </div>
+      </div>
+      <div className="ml-auto h-3 w-28 rounded bg-slate-100 motion-safe:animate-pulse dark:bg-white/10" />
+    </div>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div
+      className="h-72 rounded-xl bg-slate-100 motion-safe:animate-pulse dark:bg-white/10"
+      aria-hidden="true"
+    />
+  );
+}
+
+function KpiValueSkeleton() {
+  return (
+    <span
+      className="block h-8 w-24 rounded-md bg-slate-100 motion-safe:animate-pulse dark:bg-white/10"
+      aria-hidden="true"
+    />
   );
 }
 
@@ -197,10 +258,18 @@ export function UsageTabSection({
   }>;
   dailySeries: DailySeriesPoint[];
   dailyTrendOption: Record<string, unknown>;
-  dailyLegendAvailability: { hasInput: boolean; hasOutput: boolean; hasRequests: boolean };
+  dailyLegendAvailability: {
+    hasInput: boolean;
+    hasOutput: boolean;
+    hasRequests: boolean;
+  };
   dailyLegendSelected: Record<string, boolean>;
   toggleDailyLegend: (key: string) => void;
 }) {
+  const showInitialLoading = chartLoading && !chartStats;
+  const renderKpiValue = (value: ReactNode) =>
+    showInitialLoading ? <KpiValueSkeleton /> : value;
+
   return (
     <Reveal>
       <div className="space-y-5">
@@ -209,66 +278,69 @@ export function UsageTabSection({
             title={t("apikey_lookup.total_requests")}
             icon={Activity}
             hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={
+            value={renderKpiValue(
               <AnimatedNumber
                 value={chartStats?.total ?? 0}
-                format={(value) => value.toLocaleString()}
-              />
-            }
+                format={formatInteger}
+              />,
+            )}
           />
           <KpiCard
             title={t("common.success_rate")}
             icon={ShieldCheck}
             hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={
+            value={renderKpiValue(
               <AnimatedNumber
                 value={chartStats?.success_rate ?? 0}
                 format={(value) => `${value.toFixed(1)}%`}
-              />
-            }
+              />,
+            )}
           />
           <KpiCard
             title={t("apikey_lookup.total_tokens")}
             icon={Sigma}
             hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={
+            value={renderKpiValue(
               <AnimatedNumber
                 value={chartStats?.total_tokens ?? 0}
-                format={(value) => value.toLocaleString()}
-              />
-            }
+                format={formatInteger}
+              />,
+            )}
           />
           <KpiCard
             title={t("apikey_lookup.total_sessions")}
             icon={MessagesSquare}
             hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={
+            value={renderKpiValue(
               <AnimatedNumber
                 value={chartStats?.total_sessions ?? 0}
-                format={(value) => value.toLocaleString()}
-              />
-            }
+                format={formatInteger}
+              />,
+            )}
           />
           <KpiCard
             title={t("apikey_lookup.total_cost")}
             icon={Coins}
             hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={
+            value={renderKpiValue(
               <AnimatedNumber
                 value={chartStats?.total_cost ?? 0}
                 format={(value) => `$${value.toFixed(4)}`}
-              />
-            }
+              />,
+            )}
           />
         </div>
 
         <Card
           title={t("apikey_lookup.calendar_heatmap")}
           description={t("apikey_lookup.calendar_heatmap_desc")}
-          loading={chartLoading}
-          actions={<CalendarDays size={18} className="text-slate-500 dark:text-white/55" />}
+          loading={false}
         >
-          <CalendarHeatmap t={t} heatmapSeries={heatmapSeries} />
+          {showInitialLoading ? (
+            <HeatmapSkeleton />
+          ) : (
+            <CalendarHeatmap t={t} heatmapSeries={heatmapSeries} />
+          )}
         </Card>
 
         <section className="grid gap-4 lg:grid-cols-[minmax(0,560px)_minmax(0,1fr)]">
@@ -282,19 +354,30 @@ export function UsageTabSection({
             actions={
               <Tabs
                 value={modelMetric}
-                onValueChange={(next) => setModelMetric(next as "requests" | "tokens")}
+                onValueChange={(next) =>
+                  setModelMetric(next as "requests" | "tokens")
+                }
               >
                 <TabsList>
-                  <TabsTrigger value="requests">{t("apikey_lookup.requests")}</TabsTrigger>
-                  <TabsTrigger value="tokens">{t("apikey_lookup.token")}</TabsTrigger>
+                  <TabsTrigger value="requests">
+                    {t("apikey_lookup.requests")}
+                  </TabsTrigger>
+                  <TabsTrigger value="tokens">
+                    {t("apikey_lookup.token")}
+                  </TabsTrigger>
                 </TabsList>
               </Tabs>
             }
-            loading={chartLoading}
+            loading={false}
           >
-            {modelDistributionData.length > 0 ? (
+            {showInitialLoading ? (
+              <ChartSkeleton />
+            ) : modelDistributionData.length > 0 ? (
               <div className="flex flex-col gap-4 sm:grid sm:h-72 sm:grid-cols-[minmax(0,1fr)_220px]">
-                <EChart option={modelDistributionOption} className="h-52 min-w-0 sm:h-72" />
+                <EChart
+                  option={modelDistributionOption}
+                  className="h-52 min-w-0 sm:h-72"
+                />
                 <div className="flex flex-row flex-wrap justify-center gap-2 overflow-y-auto pr-1 sm:h-72 sm:flex-col">
                   {modelDistributionLegend.map((item) => (
                     <div
@@ -328,10 +411,14 @@ export function UsageTabSection({
 
           <Card
             title={t("apikey_lookup.daily_usage")}
-            description={t("apikey_lookup.daily_usage_desc", { days: timeRange })}
-            loading={chartLoading}
+            description={t("apikey_lookup.daily_usage_desc", {
+              days: timeRange,
+            })}
+            loading={false}
           >
-            {dailySeries.length > 0 ? (
+            {showInitialLoading ? (
+              <ChartSkeleton />
+            ) : dailySeries.length > 0 ? (
               <div className="flex h-72 min-w-0 flex-col overflow-hidden">
                 <EChart
                   option={dailyTrendOption}
@@ -347,7 +434,9 @@ export function UsageTabSection({
                             key: DAILY_LEGEND_KEYS.input,
                             label: t("apikey_lookup.input_token"),
                             colorClass: "bg-violet-400",
-                            enabled: dailyLegendSelected[DAILY_LEGEND_KEYS.input] ?? true,
+                            enabled:
+                              dailyLegendSelected[DAILY_LEGEND_KEYS.input] ??
+                              true,
                             onToggle: toggleDailyLegend,
                           },
                         ]
@@ -358,7 +447,9 @@ export function UsageTabSection({
                             key: DAILY_LEGEND_KEYS.output,
                             label: t("apikey_lookup.output_token"),
                             colorClass: "bg-emerald-400",
-                            enabled: dailyLegendSelected[DAILY_LEGEND_KEYS.output] ?? true,
+                            enabled:
+                              dailyLegendSelected[DAILY_LEGEND_KEYS.output] ??
+                              true,
                             onToggle: toggleDailyLegend,
                           },
                         ]
@@ -369,7 +460,9 @@ export function UsageTabSection({
                             key: DAILY_LEGEND_KEYS.requests,
                             label: t("apikey_lookup.requests"),
                             colorClass: "bg-blue-500",
-                            enabled: dailyLegendSelected[DAILY_LEGEND_KEYS.requests] ?? true,
+                            enabled:
+                              dailyLegendSelected[DAILY_LEGEND_KEYS.requests] ??
+                              true,
                             onToggle: toggleDailyLegend,
                           },
                         ]


### PR DESCRIPTION
## Summary
- keep cached API key usage chart data visible while fresh data refreshes
- replace initial chart loading overlays with skeleton states
- add heatmap cell hover/pointer feedback with existing tooltip and clean up layout/icon details
- keep integer KPI animations visually integer during transitions

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
- rtk bun run build
- Playwright mock visual check for initial skeleton, cached refresh, heatmap tooltip/pointer, centered layout, and removed calendar icon