### PR TITLE
fix: defer API key lookup logs fetch

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -416,9 +416,13 @@ export function ApiKeyLookupPage() {
         const cachedName = cached.api_key_name?.trim() ?? "";
         if (cachedName) setApiKeyName(cachedName);
         setChartData(cached);
+        setQueriedKey(trimmedKey);
+        writeStoredLookupKey(trimmedKey);
+        setLoginModalOpen(false);
       }
 
       setChartLoading(true);
+      setError(null);
       try {
         const data = await fetchPublicChartData({ apiKey: trimmedKey, days });
         chartCacheRef.current[cacheKey] = data;
@@ -426,13 +430,18 @@ export function ApiKeyLookupPage() {
         const nextName = data.api_key_name?.trim() ?? "";
         if (nextName) setApiKeyName(nextName);
         setChartData(data);
-      } catch {
-        // Keep stale chart data visible; logs request owns the user-facing error.
+        setQueriedKey(trimmedKey);
+        writeStoredLookupKey(trimmedKey);
+        setLoginModalOpen(false);
+      } catch (err) {
+        if (!cached) {
+          setError(localizeLookupError(t, err, "apikey_lookup.query_failed"));
+        }
       } finally {
         setChartLoading(false);
       }
     },
-    [],
+    [t],
   );
 
   // ================================================================
@@ -525,8 +534,7 @@ export function ApiKeyLookupPage() {
     restoredLookupFetchedRef.current = true;
     chartCacheRef.current = {};
     void fetchChartDataFn(initialLookupKey, timeRange);
-    fetchLogs(initialLookupKey, 1);
-  }, [fetchChartDataFn, fetchLogs, initialLookupKey, timeRange]);
+  }, [fetchChartDataFn, initialLookupKey, timeRange]);
 
   const handleSubmit = useCallback(
     (event?: React.FormEvent) => {
@@ -542,9 +550,8 @@ export function ApiKeyLookupPage() {
         chartCacheRef.current = {};
         if (activeTab === "usage") {
           void fetchChartDataFn(val, timeRange);
-          fetchLogs(val, 1);
         } else if (activeTab === "models") {
-          fetchLogs(val, 1);
+          void fetchChartDataFn(val, timeRange);
           void fetchModelsFn(val);
         } else {
           fetchLogs(val, 1);

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -88,10 +88,11 @@ describe("ApiKeyLookupPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /login/i }));
 
     await waitFor(() => {
-      expect(mocks.fetchPublicLogs).toHaveBeenCalledWith(
+      expect(mocks.fetchPublicChartData).toHaveBeenCalledWith(
         expect.objectContaining({ apiKey: "sk-new-key" }),
       );
     });
+    expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
   });
 
   test("restores the last looked up API key after page refresh and shows its name", async () => {
@@ -109,19 +110,47 @@ describe("ApiKeyLookupPage", () => {
     );
 
     await waitFor(() => {
-      expect(mocks.fetchPublicLogs).toHaveBeenCalledWith(
-        expect.objectContaining({ apiKey: "sk-restored-key" }),
-      );
       expect(mocks.fetchPublicChartData).toHaveBeenCalledWith(
         expect.objectContaining({ apiKey: "sk-restored-key" }),
       );
     });
+    expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
     expect(
       await screen.findByRole("combobox", { name: /primary key/i }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("dialog", { name: /enter api key/i }),
     ).not.toBeInTheDocument();
+  });
+
+  test("loads public logs only after switching to the request logs tab", async () => {
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.fetchPublicChartData).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "sk-restored-key" }),
+      );
+    });
+    expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("tab", { name: /request logs/i }));
+
+    await waitFor(() => {
+      expect(mocks.fetchPublicLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "sk-restored-key", page: 1 }),
+      );
+    });
   });
 
   test("does not duplicate the current key in the header menu", async () => {


### PR DESCRIPTION
## Summary
- make API key lookup login/restore load chart overview without immediately fetching request logs
- keep cached chart data visible while refreshing and close the login modal after chart validation succeeds
- fetch public logs only when the user opens the request logs tab

## Tests
- rtk bun run --filter @code-proxy/admin-panel test pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
- rtk bun run build