### PR TITLE
fix: avoid clipped api key heatmap hover cell

### DIFF
--- a/e2e/api-key-lookup.spec.ts
+++ b/e2e/api-key-lookup.spec.ts
@@ -175,14 +175,27 @@ test("API Key Lookup: Heatmap tooltip stays inside the heatmap card when hoverin
     .locator("xpath=ancestor::section[1]");
   await expect(heatmapCard).toBeVisible();
 
-  await page.locator(`[aria-label^="${date}: 382 "]`).hover();
+  const heatmapGrid = page
+    .locator('[aria-label="Request Heatmap"], [aria-label="请求热力图"]')
+    .first();
+  const hoveredCell = page.locator(`[aria-label^="${date}: 382 "]`);
+
+  await hoveredCell.hover();
   const tooltip = page.getByRole("tooltip");
   await expect(tooltip).toBeVisible();
 
-  const positions = await Promise.all([heatmapCard.boundingBox(), tooltip.boundingBox()]);
-  const [cardBox, tooltipBox] = positions;
+  const positions = await Promise.all([
+    heatmapCard.boundingBox(),
+    heatmapGrid.boundingBox(),
+    hoveredCell.boundingBox(),
+    tooltip.boundingBox(),
+  ]);
+  const [cardBox, gridBox, cellBox, tooltipBox] = positions;
   expect(cardBox).not.toBeNull();
+  expect(gridBox).not.toBeNull();
+  expect(cellBox).not.toBeNull();
   expect(tooltipBox).not.toBeNull();
+  expect(cellBox!.y).toBeGreaterThanOrEqual(gridBox!.y);
   expect(tooltipBox!.y).toBeGreaterThanOrEqual(cardBox!.y);
 });
 

--- a/pages/api-key-lookup/components/UsageTabSection.tsx
+++ b/pages/api-key-lookup/components/UsageTabSection.tsx
@@ -137,7 +137,7 @@ function CalendarHeatmap({
     <div className="space-y-3">
       <div className="overflow-x-auto pb-1">
         <div
-          className="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1"
+          className="mx-auto grid w-max grid-flow-col grid-rows-7 gap-1 py-1"
           style={{ gridAutoColumns: "0.75rem" }}
           aria-label={t("apikey_lookup.calendar_heatmap")}
         >


### PR DESCRIPTION
## Summary
- add vertical room inside the API key lookup heatmap grid so hover scaling/ring is not clipped by the scroll container
- extend the heatmap e2e regression to assert the hovered top-row cell stays inside the heatmap grid

## Verification
- rtk bun run e2e e2e/api-key-lookup.spec.ts --project=chromium
- rtk bun run build