### PR TITLE
feat: align API key lookup request logs

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -18,43 +18,32 @@ import {
   fetchPublicLogs,
 } from "./api";
 import { LookupEmptyState } from "./components/LookupEmptyState";
-import {
-  LookupResultsToolbar,
-  type ApiKeyLookupTab,
-} from "./components/LookupResultsToolbar";
+import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
 import { ModelsTabContent } from "./components/ModelsTabContent";
-import {
-  buildLogColumns,
-  PublicLogsSection,
-} from "./components/PublicLogsSection";
+import { PublicLogsSection } from "./components/PublicLogsSection";
 import { QuickImportTabContent } from "./components/QuickImportTabContent";
 import { UsageTabSection } from "./components/UsageTabSection";
 import { useApiKeyLookupCharts } from "./hooks/useApiKeyLookupCharts";
-import type { ChartDataResponse, LogRow, PublicLogItem } from "./types";
+import type { ChartDataResponse, PublicLogItem } from "./types";
+import {
+  buildRequestLogsColumns,
+  formatOptionalRequestLogLatencyMs,
+  formatRequestLogLatencyMs,
+  maskRequestLogApiKey,
+  type RequestLogsRow,
+} from "@features/request-log-viewer";
 
 const DEFAULT_PAGE_SIZE = 50;
 const LOOKUP_LAST_API_KEY_STORAGE_KEY = "apiKeyLookup.lastApiKey.v1";
 const LOOKUP_CHART_CACHE_STORAGE_KEY = "apiKeyLookup.chartCache.v1";
+const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v1";
 const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-const formatLatencyMs = (value: number): string => {
-  if (!Number.isFinite(value) || value < 0) return "--";
-  if (value < 1) return "<1ms";
-  if (value < 1000) return `${Math.round(value)}ms`;
-  const seconds = value / 1000;
-  const fixed = seconds.toFixed(seconds < 10 ? 2 : 1);
-  const trimmed = fixed.endsWith(".0") ? fixed.slice(0, -2) : fixed;
-  return `${trimmed}s`;
-};
-
 const readStoredLookupKey = (): string => {
   try {
-    return (
-      window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ??
-      ""
-    );
+    return window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ?? "";
   } catch {
     return "";
   }
@@ -98,17 +87,13 @@ const readStoredChartCache = (cacheKey: string): ChartDataResponse | null => {
   }
 };
 
-const writeStoredChartCache = (
-  cacheKey: string,
-  data: ChartDataResponse,
-): void => {
+const writeStoredChartCache = (cacheKey: string, data: ChartDataResponse): void => {
   try {
     const raw = window.sessionStorage.getItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
     const parsed: unknown = raw ? JSON.parse(raw) : {};
     const entries = isRecord(parsed)
-      ? Object.entries(parsed).filter(
-          (entry): entry is [string, ChartDataResponse] =>
-            isChartDataResponse(entry[1]),
+      ? Object.entries(parsed).filter((entry): entry is [string, ChartDataResponse] =>
+          isChartDataResponse(entry[1]),
         )
       : [];
     const next: Record<string, ChartDataResponse> = {};
@@ -117,10 +102,7 @@ const writeStoredChartCache = (
     for (const [key, value] of [...keptEntries, cacheEntry].slice(-8)) {
       next[key] = value;
     }
-    window.sessionStorage.setItem(
-      LOOKUP_CHART_CACHE_STORAGE_KEY,
-      JSON.stringify(next),
-    );
+    window.sessionStorage.setItem(LOOKUP_CHART_CACHE_STORAGE_KEY, JSON.stringify(next));
   } catch {
     // ignore storage failures
   }
@@ -129,6 +111,45 @@ const writeStoredChartCache = (
 const clearStoredChartCache = (): void => {
   try {
     window.sessionStorage.removeItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const sameStringArray = (left: string[], right: string[]): boolean =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+const readStoredModelsCache = (cacheKey: string): string[] | null => {
+  try {
+    const raw = window.sessionStorage.getItem(LOOKUP_MODELS_CACHE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    const cached = parsed[cacheKey];
+    return isStringArray(cached) ? cached : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredModelsCache = (cacheKey: string, models: string[]): void => {
+  try {
+    const raw = window.sessionStorage.getItem(LOOKUP_MODELS_CACHE_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    const entries = isRecord(parsed)
+      ? Object.entries(parsed).filter((entry): entry is [string, string[]] =>
+          isStringArray(entry[1]),
+        )
+      : [];
+    const next: Record<string, string[]> = {};
+    const keptEntries = entries.filter(([key]) => key !== cacheKey);
+    for (const [key, value] of [...keptEntries, [cacheKey, models] as const].slice(-8)) {
+      next[key] = value;
+    }
+    window.sessionStorage.setItem(LOOKUP_MODELS_CACHE_STORAGE_KEY, JSON.stringify(next));
   } catch {
     // ignore storage failures
   }
@@ -186,24 +207,29 @@ const localizeLookupError = (
 const readLegacyLookupKeyFromUrl = (): string => {
   try {
     const url = new URL(window.location.href);
-    return (
-      url.searchParams.get("api_key") ||
-      url.searchParams.get("key") ||
-      ""
-    ).trim();
+    return (url.searchParams.get("api_key") || url.searchParams.get("key") || "").trim();
   } catch {
     return "";
   }
 };
 
-function toLogRow(item: PublicLogItem): LogRow {
+function toLogRow(item: PublicLogItem): RequestLogsRow {
   return {
     id: String(item.id),
     timestamp: item.timestamp,
     timestampMs: new Date(item.timestamp).getTime(),
+    apiKey: item.api_key || "",
+    apiKeyName: item.api_key_name || "",
+    isSystemCall: false,
+    channelName: item.channel_name || "",
+    maskedApiKey: maskRequestLogApiKey(item.api_key || ""),
     model: item.model,
+    upstreamModel: item.upstream_model || "",
+    visionFallbackModel: item.vision_fallback_model || "",
     failed: item.failed,
-    latencyText: formatLatencyMs(item.latency_ms),
+    streaming: item.streaming === true,
+    latencyText: formatRequestLogLatencyMs(item.latency_ms),
+    firstTokenText: formatOptionalRequestLogLatencyMs(item.first_token_ms ?? 0),
     inputTokens: item.input_tokens,
     cachedTokens: item.cached_tokens,
     outputTokens: item.output_tokens,
@@ -231,10 +257,7 @@ export function ApiKeyLookupPage() {
     return () => mq.removeEventListener("change", handler);
   }, []);
 
-  const initialLookupKey = useMemo(
-    () => readLegacyLookupKeyFromUrl() || readStoredLookupKey(),
-    [],
-  );
+  const initialLookupKey = useMemo(() => readLegacyLookupKeyFromUrl() || readStoredLookupKey(), []);
   const [apiKeyInput, setApiKeyInput] = useState(initialLookupKey);
   const [queriedKey, setQueriedKey] = useState(initialLookupKey);
   const [apiKeyName, setApiKeyName] = useState("");
@@ -242,24 +265,17 @@ export function ApiKeyLookupPage() {
 
   // ── Content modal state ──
   const [contentModalOpen, setContentModalOpen] = useState(false);
-  const [contentModalLogId, setContentModalLogId] = useState<number | null>(
-    null,
-  );
-  const [contentModalTab, setContentModalTab] = useState<"input" | "output">(
-    "input",
-  );
+  const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
+  const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
 
-  const handleContentClick = useCallback(
-    (logId: number, tab: "input" | "output") => {
-      setContentModalLogId(logId);
-      setContentModalTab(tab);
-      setContentModalOpen(true);
-    },
-    [],
-  );
+  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
+    setContentModalLogId(logId);
+    setContentModalTab(tab);
+    setContentModalOpen(true);
+  }, []);
 
   const logColumns = useMemo(
-    () => buildLogColumns(t, handleContentClick),
+    () => buildRequestLogsColumns((key) => t(key), handleContentClick),
     [t, handleContentClick],
   );
   const statusOptions = useMemo(
@@ -306,6 +322,7 @@ export function ApiKeyLookupPage() {
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
   const [modelsSearchFilter, setModelsSearchFilter] = useState("");
+  const modelsCacheRef = useRef<Record<string, string[]>>({});
 
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
@@ -379,11 +396,7 @@ export function ApiKeyLookupPage() {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (myFetchId !== fetchIdRef.current) return;
 
-        const message = localizeLookupError(
-          t,
-          err,
-          "apikey_lookup.query_failed",
-        );
+        const message = localizeLookupError(t, err, "apikey_lookup.query_failed");
         setError(message);
         setRawItems([]);
         setTotalCount(0);
@@ -448,10 +461,7 @@ export function ApiKeyLookupPage() {
   //  Derived rows for VirtualTable
   // ================================================================
 
-  const rows = useMemo<LogRow[]>(
-    () => rawItems.map((item) => toLogRow(item)),
-    [rawItems],
-  );
+  const rows = useMemo<RequestLogsRow[]>(() => rawItems.map((item) => toLogRow(item)), [rawItems]);
 
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
@@ -487,16 +497,29 @@ export function ApiKeyLookupPage() {
 
   // ── Models fetching ──
   const fetchModelsFn = useCallback(
-    async (key: string) => {
+    async (key: string, options?: { force?: boolean }) => {
+      const trimmedKey = key.trim();
+      if (!trimmedKey) return;
+
+      const cached = options?.force
+        ? null
+        : modelsCacheRef.current[trimmedKey] || readStoredModelsCache(trimmedKey);
+      if (cached) {
+        modelsCacheRef.current[trimmedKey] = cached;
+        setAvailableModels((prev) => (sameStringArray(prev, cached) ? prev : cached));
+      }
+
       setModelsLoading(true);
       setModelsError(null);
       try {
-        const ids = await fetchAvailableModels(key);
-        setAvailableModels(ids);
+        const ids = await fetchAvailableModels(trimmedKey);
+        modelsCacheRef.current[trimmedKey] = ids;
+        writeStoredModelsCache(trimmedKey, ids);
+        setAvailableModels((prev) => (sameStringArray(prev, ids) ? prev : ids));
       } catch (err: unknown) {
-        setModelsError(
-          localizeLookupError(t, err, "apikey_lookup.load_models_failed"),
-        );
+        if (!cached) {
+          setModelsError(localizeLookupError(t, err, "apikey_lookup.load_models_failed"));
+        }
       } finally {
         setModelsLoading(false);
       }
@@ -546,7 +569,10 @@ export function ApiKeyLookupPage() {
         setRawItems([]);
         setCurrentPage(1);
         setApiKeyName("");
-        if (val !== queriedKey) setChartData(null);
+        if (val !== queriedKey) {
+          setChartData(null);
+          setAvailableModels([]);
+        }
         chartCacheRef.current = {};
         if (activeTab === "usage") {
           void fetchChartDataFn(val, timeRange);
@@ -559,14 +585,7 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [
-      apiKeyInput,
-      activeTab,
-      timeRange,
-      fetchLogs,
-      fetchChartDataFn,
-      fetchModelsFn,
-    ],
+    [apiKeyInput, queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn],
   );
 
   const handleApiKeyInputChange = useCallback((value: string) => {
@@ -583,6 +602,7 @@ export function ApiKeyLookupPage() {
     setError(null);
     setModelsError(null);
     setModelsSearchFilter("");
+    modelsCacheRef.current = {};
     setAvailableModels([]);
     setChartData(null);
 
@@ -610,21 +630,14 @@ export function ApiKeyLookupPage() {
       if (activeTab === "usage") {
         void fetchChartDataFn(queriedKey, timeRange, { force: true });
       } else if (activeTab === "models") {
-        void fetchModelsFn(queriedKey);
+        void fetchModelsFn(queriedKey, { force: true });
       } else if (activeTab === "quickImport") {
         setQuickImportReloadToken((value) => value + 1);
       } else {
         fetchLogs(queriedKey, 1);
       }
     }
-  }, [
-    queriedKey,
-    activeTab,
-    timeRange,
-    fetchLogs,
-    fetchChartDataFn,
-    fetchModelsFn,
-  ]);
+  }, [queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn]);
 
   // Strip legacy sensitive query params from the URL on mount.
   useEffect(() => {
@@ -690,8 +703,7 @@ export function ApiKeyLookupPage() {
     return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
   }, [lastUpdatedAt]);
 
-  const displayName =
-    apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
+  const displayName = apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
   const keyMenuOptions = useMemo<SelectOption[]>(
     () => [
       {
@@ -789,9 +801,7 @@ export function ApiKeyLookupPage() {
                 setModelMetric={setModelMetric}
                 heatmapSeries={heatmapSeries}
                 modelDistributionData={modelDistributionData}
-                modelDistributionOption={
-                  modelDistributionOption as Record<string, unknown>
-                }
+                modelDistributionOption={modelDistributionOption as Record<string, unknown>}
                 modelDistributionLegend={modelDistributionLegend}
                 dailySeries={dailySeries}
                 dailyTrendOption={dailyTrendOption as Record<string, unknown>}
@@ -839,10 +849,7 @@ export function ApiKeyLookupPage() {
 
             {activeTab === "quickImport" ? (
               <Reveal>
-                <QuickImportTabContent
-                  apiKey={queriedKey}
-                  reloadToken={quickImportReloadToken}
-                />
+                <QuickImportTabContent apiKey={queriedKey} reloadToken={quickImportReloadToken} />
               </Reveal>
             ) : null}
           </>
@@ -898,11 +905,7 @@ export function ApiKeyLookupPage() {
           </Button>
         }
       >
-        <form
-          id="apikey-login-form"
-          onSubmit={handleSubmit}
-          className="space-y-2"
-        >
+        <form id="apikey-login-form" onSubmit={handleSubmit} className="space-y-2">
           <label
             htmlFor="apikey-login-input"
             className="block text-sm font-medium text-slate-700 dark:text-white/80"
@@ -918,13 +921,9 @@ export function ApiKeyLookupPage() {
             autoComplete="off"
             spellCheck={false}
             autoFocus
-            startAdornment={
-              <Search size={16} className="text-slate-400 dark:text-white/40" />
-            }
+            startAdornment={<Search size={16} className="text-slate-400 dark:text-white/40" />}
           />
-          {error ? (
-            <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p>
-          ) : null}
+          {error ? <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p> : null}
         </form>
       </Modal>
     </div>

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -316,6 +316,8 @@ export function ApiKeyLookupPage() {
   const [chartData, setChartData] = useState<ChartDataResponse | null>(null);
   const [chartLoading, setChartLoading] = useState(false);
   const chartCacheRef = useRef<Record<string, ChartDataResponse>>({});
+  const chartAbortControllerRef = useRef<AbortController | null>(null);
+  const chartFetchIdRef = useRef(0);
 
   // ── Models state ──
   const [availableModels, setAvailableModels] = useState<string[]>([]);
@@ -434,10 +436,21 @@ export function ApiKeyLookupPage() {
         setLoginModalOpen(false);
       }
 
+      chartAbortControllerRef.current?.abort();
+      const controller = new AbortController();
+      chartAbortControllerRef.current = controller;
+      const myFetchId = ++chartFetchIdRef.current;
+
       setChartLoading(true);
       setError(null);
       try {
-        const data = await fetchPublicChartData({ apiKey: trimmedKey, days });
+        const data = await fetchPublicChartData({
+          apiKey: trimmedKey,
+          days,
+          signal: controller.signal,
+        });
+        if (myFetchId !== chartFetchIdRef.current || controller.signal.aborted) return;
+
         chartCacheRef.current[cacheKey] = data;
         writeStoredChartCache(cacheKey, data);
         const nextName = data.api_key_name?.trim() ?? "";
@@ -447,11 +460,17 @@ export function ApiKeyLookupPage() {
         writeStoredLookupKey(trimmedKey);
         setLoginModalOpen(false);
       } catch (err) {
+        if (controller.signal.aborted || myFetchId !== chartFetchIdRef.current) return;
         if (!cached) {
           setError(localizeLookupError(t, err, "apikey_lookup.query_failed"));
         }
       } finally {
-        setChartLoading(false);
+        if (chartAbortControllerRef.current === controller) {
+          chartAbortControllerRef.current = null;
+        }
+        if (myFetchId === chartFetchIdRef.current && !controller.signal.aborted) {
+          setChartLoading(false);
+        }
       }
     },
     [t],
@@ -596,10 +615,13 @@ export function ApiKeyLookupPage() {
     abortControllerRef.current?.abort();
     fetchIdRef.current += 1;
     paginationInFlightRef.current = false;
+    chartAbortControllerRef.current?.abort();
+    chartFetchIdRef.current += 1;
     chartCacheRef.current = {};
     clearStoredChartCache();
 
     setError(null);
+    setChartLoading(false);
     setModelsError(null);
     setModelsSearchFilter("");
     modelsCacheRef.current = {};

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -77,9 +77,7 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    expect(
-      screen.getByRole("dialog", { name: /enter api key/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: /enter api key/i })).toBeInTheDocument();
 
     await userEvent.type(
       screen.getByPlaceholderText(/enter api key to lookup usage/i),
@@ -96,10 +94,7 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("restores the last looked up API key after page refresh and shows its name", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     render(
       <ThemeProvider>
@@ -115,19 +110,12 @@ describe("ApiKeyLookupPage", () => {
       );
     });
     expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
-    expect(
-      await screen.findByRole("combobox", { name: /primary key/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("dialog", { name: /enter api key/i }),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByRole("combobox", { name: /primary key/i })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: /enter api key/i })).not.toBeInTheDocument();
   });
 
   test("loads public logs only after switching to the request logs tab", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     render(
       <ThemeProvider>
@@ -151,13 +139,20 @@ describe("ApiKeyLookupPage", () => {
         expect.objectContaining({ apiKey: "sk-restored-key", page: 1 }),
       );
     });
+    expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("columnheader", { name: /^duration$/i })).not.toBeInTheDocument();
   });
 
-  test("does not duplicate the current key in the header menu", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+  test("keeps cached models visible while refreshing the available models tab", async () => {
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    let resolveModelsRefresh: (value: string[]) => void = () => {};
+    mocks.fetchAvailableModels
+      .mockResolvedValueOnce(["gpt-5.3-codex", "claude-sonnet-4-5"])
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveModelsRefresh = resolve;
+        }),
+      );
 
     render(
       <ThemeProvider>
@@ -167,13 +162,35 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(
-      await screen.findByRole("combobox", { name: /primary key/i }),
+    await screen.findByTestId("usage-tab");
+    await userEvent.click(screen.getByRole("tab", { name: /models/i }));
+
+    expect(await screen.findByText("gpt-5.3-codex")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("tab", { name: /usage/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /models/i }));
+
+    expect(screen.getByText("gpt-5.3-codex")).toBeInTheDocument();
+    expect(mocks.fetchAvailableModels).toHaveBeenCalledTimes(2);
+
+    resolveModelsRefresh(["gpt-5.3-codex", "claude-sonnet-4-5", "deepseek-v4"]);
+    expect(await screen.findByText("deepseek-v4")).toBeInTheDocument();
+  });
+
+  test("does not duplicate the current key in the header menu", async () => {
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
     );
 
-    expect(
-      screen.queryByRole("option", { name: /primary key/i }),
-    ).not.toBeInTheDocument();
+    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
+
+    expect(screen.queryByRole("option", { name: /primary key/i })).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /logout/i })).toHaveAttribute(
       "aria-selected",
       "false",
@@ -181,10 +198,7 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("logs out from the header menu and asks for the API key again", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     render(
       <ThemeProvider>
@@ -194,24 +208,15 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(
-      await screen.findByRole("combobox", { name: /primary key/i }),
-    );
+    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
     await userEvent.click(screen.getByRole("option", { name: /logout/i }));
 
-    expect(
-      window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1"),
-    ).toBeNull();
-    expect(
-      screen.getByRole("dialog", { name: /enter api key/i }),
-    ).toBeInTheDocument();
+    expect(window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1")).toBeNull();
+    expect(screen.getByRole("dialog", { name: /enter api key/i })).toBeInTheDocument();
   });
 
   test("shows cached usage data while refreshing chart data", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
     window.sessionStorage.setItem(
       "apiKeyLookup.chartCache.v1",
       JSON.stringify({
@@ -266,11 +271,7 @@ describe("ApiKeyLookupPage", () => {
       },
     });
 
-    await waitFor(() =>
-      expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"),
-    );
-    expect(
-      window.sessionStorage.getItem("apiKeyLookup.chartCache.v1"),
-    ).toContain('"total":24');
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"));
+    expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v1")).toContain('"total":24');
   });
 });

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -21,21 +21,39 @@ const mocks = vi.hoisted(() => ({
     },
     filters: { models: [] },
   })),
-  fetchPublicChartData: vi.fn(async () => ({
+  fetchPublicChartData: vi.fn(
+    async (_params?: { apiKey: string; days?: number; signal?: AbortSignal }) => ({
+      daily_series: [],
+      heatmap_series: [],
+      model_distribution: [],
+      api_key_name: "Primary key",
+      stats: {
+        total: 0,
+        success_rate: 0,
+        total_tokens: 0,
+        total_sessions: 0,
+        total_cost: 0,
+      },
+    }),
+  ),
+  fetchAvailableModels: vi.fn(async (): Promise<string[]> => []),
+}));
+
+type ChartResponse = Awaited<ReturnType<typeof mocks.fetchPublicChartData>>;
+
+const chartResponse = (total: number, apiKeyName = "Primary key"): ChartResponse => ({
     daily_series: [],
     heatmap_series: [],
     model_distribution: [],
-    api_key_name: "Primary key",
+    api_key_name: apiKeyName,
     stats: {
-      total: 0,
-      success_rate: 0,
-      total_tokens: 0,
-      total_sessions: 0,
+      total,
+      success_rate: 100,
+      total_tokens: total * 10,
+      total_sessions: 1,
       total_cost: 0,
     },
-  })),
-  fetchAvailableModels: vi.fn(async (): Promise<string[]> => []),
-}));
+  });
 
 vi.mock("../api", () => ({
   fetchPublicLogs: mocks.fetchPublicLogs,
@@ -273,5 +291,50 @@ describe("ApiKeyLookupPage", () => {
 
     await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"));
     expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v1")).toContain('"total":24');
+  });
+
+  test("ignores stale chart responses after rapid time range changes", async () => {
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    const pending: Array<{
+      days: number;
+      signal?: AbortSignal;
+      resolve: (value: ChartResponse) => void;
+    }> = [];
+    mocks.fetchPublicChartData.mockImplementation(
+      (params?: { apiKey: string; days?: number; signal?: AbortSignal }) =>
+        new Promise<ChartResponse>((resolve) => {
+          pending.push({ days: params?.days ?? 7, signal: params?.signal, resolve });
+        }),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await screen.findByRole("tab", { name: /30/i });
+    await userEvent.click(screen.getByRole("tab", { name: /30/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /today|今天/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /7\s*(days|天)/i }));
+
+    await waitFor(() => expect(pending.at(-1)?.days).toBe(7));
+    const latest = pending.at(-1);
+    if (!latest) throw new Error("missing latest chart request");
+
+    latest.resolve(chartResponse(7, "Range 7"));
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("7"));
+
+    for (const request of pending) {
+      if (request !== latest) {
+        request.resolve(chartResponse(request.days * 100, `Range ${request.days}`));
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(screen.getByTestId("usage-tab")).toHaveTextContent("7");
+    expect(pending.some((request) => request.days === 30 && request.signal?.aborted)).toBe(true);
   });
 });

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -59,11 +59,16 @@ export async function fetchPublicLogs(params: {
 export async function fetchPublicChartData(params: {
   apiKey: string;
   days?: number;
+  signal?: AbortSignal;
 }): Promise<ChartDataResponse> {
-  return publicApiClient.post<ChartDataResponse>("/usage/chart-data", {
-    api_key: params.apiKey,
-    days: params.days,
-  });
+  return publicApiClient.post<ChartDataResponse>(
+    "/usage/chart-data",
+    {
+      api_key: params.apiKey,
+      days: params.days,
+    },
+    { signal: params.signal },
+  );
 }
 
 export async function fetchPublicLogContent(params: {

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, Layers, RefreshCw, Search } from "lucide-react";
 import { Card } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
@@ -149,6 +150,7 @@ function VendorIcon({ modelId, size = 14 }: { modelId: string; size?: number }) 
 function ModelTag({ id }: { id: string }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
+  const reduceMotion = useReducedMotion();
   const vc = getVendorColor(id);
 
   const handleClick = () => {
@@ -158,7 +160,12 @@ function ModelTag({ id }: { id: string }) {
   };
 
   return (
-    <button
+    <motion.button
+      layout
+      initial={reduceMotion ? false : { opacity: 0, y: 6, scale: 0.98 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
+      exit={reduceMotion ? undefined : { opacity: 0, y: -4, scale: 0.98 }}
+      transition={reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 420, damping: 34 }}
       type="button"
       onClick={handleClick}
       title={t("apikey_lookup.copy_model")}
@@ -175,7 +182,7 @@ function ModelTag({ id }: { id: string }) {
           {id}
         </>
       )}
-    </button>
+    </motion.button>
   );
 }
 
@@ -193,6 +200,7 @@ export function ModelsTabContent({
   onSearchChange: (value: string) => void;
 }) {
   const { t } = useTranslation();
+  const reduceMotion = useReducedMotion();
 
   const filteredModels = useMemo(() => {
     const needle = searchFilter.trim().toLowerCase();
@@ -242,22 +250,41 @@ export function ModelsTabContent({
         </div>
       </div>
 
-      {vendorStats.length > 0 && !loading ? (
+      {vendorStats.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2 border-b border-slate-100 px-5 py-2.5 dark:border-neutral-800/60">
-          {vendorStats.map(([vendor, count]) => {
-            const vc = VENDOR_COLORS[vendor] ?? DEFAULT_VENDOR_COLOR;
-            const iconKey = `${vendor}-placeholder`;
-            return (
-              <span
-                key={vendor}
-                className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-semibold ${vc.bg} ${vc.text} ${vc.border}`}
-              >
-                <VendorIcon modelId={iconKey} size={12} />
-                {vendor}
-                <span className="tabular-nums">{count}</span>
-              </span>
-            );
-          })}
+          <AnimatePresence initial={false}>
+            {vendorStats.map(([vendor, count]) => {
+              const vc = VENDOR_COLORS[vendor] ?? DEFAULT_VENDOR_COLOR;
+              const iconKey = `${vendor}-placeholder`;
+              return (
+                <motion.span
+                  layout
+                  key={vendor}
+                  initial={reduceMotion ? false : { opacity: 0, y: 4 }}
+                  animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+                  exit={reduceMotion ? undefined : { opacity: 0, y: -4 }}
+                  transition={
+                    reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 420, damping: 36 }
+                  }
+                  className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-semibold ${vc.bg} ${vc.text} ${vc.border}`}
+                >
+                  <VendorIcon modelId={iconKey} size={12} />
+                  {vendor}
+                  <AnimatePresence mode="popLayout" initial={false}>
+                    <motion.span
+                      key={`${vendor}-${count}`}
+                      initial={reduceMotion ? false : { opacity: 0, y: 4 }}
+                      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+                      exit={reduceMotion ? undefined : { opacity: 0, y: -4 }}
+                      className="tabular-nums"
+                    >
+                      {count}
+                    </motion.span>
+                  </AnimatePresence>
+                </motion.span>
+              );
+            })}
+          </AnimatePresence>
         </div>
       ) : null}
 
@@ -275,9 +302,11 @@ export function ModelsTabContent({
           </div>
         ) : filteredModels.length > 0 ? (
           <div className="flex flex-wrap gap-2">
-            {filteredModels.map((id) => (
-              <ModelTag key={id} id={id} />
-            ))}
+            <AnimatePresence initial={false}>
+              {filteredModels.map((id) => (
+                <ModelTag key={id} id={id} />
+              ))}
+            </AnimatePresence>
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center py-12 text-slate-400 dark:text-white/30">

--- a/pages/api-key-lookup/components/PublicLogsSection.tsx
+++ b/pages/api-key-lookup/components/PublicLogsSection.tsx
@@ -1,267 +1,9 @@
-import { useMemo } from "react";
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Filter } from "lucide-react";
+import { Filter } from "lucide-react";
 import { Card } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
 import { SearchableSelect } from "@code-proxy/ui";
-import { Select } from "@code-proxy/ui";
-import { TableCellOverflowTooltip } from "@code-proxy/ui";
-import { OverflowTooltip } from "@code-proxy/ui";
-import type { LogRow, TableColumn } from "../types";
-
-function formatTimestamp(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value || "--";
-  return date.toLocaleString();
-}
-
-export function buildLogColumns(
-  t: (key: string, options?: Record<string, unknown>) => string,
-  onContentClick?: (logId: number, tab: "input" | "output") => void,
-): TableColumn<LogRow>[] {
-  return [
-    {
-      key: "timestamp",
-      label: t("request_logs.col_time"),
-      width: "w-52",
-      cellClassName: "font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
-      render: (row) => (
-        <OverflowTooltip content={formatTimestamp(row.timestamp)} className="block min-w-0">
-          <span className="block min-w-0 truncate">{formatTimestamp(row.timestamp)}</span>
-        </OverflowTooltip>
-      ),
-    },
-    {
-      key: "model",
-      label: t("request_logs.col_model"),
-      width: "w-56",
-      render: (row) => (
-        <OverflowTooltip content={row.model} className="block min-w-0">
-          <span className="block min-w-0 truncate">{row.model}</span>
-        </OverflowTooltip>
-      ),
-    },
-    {
-      key: "status",
-      label: t("request_logs.col_status"),
-      width: "w-20",
-      render: (row) =>
-        row.failed ? (
-          <span className="inline-flex min-w-[52px] justify-center rounded-full bg-rose-50 px-2.5 py-1 text-xs font-semibold text-rose-600 dark:bg-rose-500/15 dark:text-rose-300">
-            {t("request_logs.status_failed")}
-          </span>
-        ) : (
-          <span className="inline-flex min-w-[52px] justify-center rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-300">
-            {t("request_logs.status_success")}
-          </span>
-        ),
-    },
-    {
-      key: "latency",
-      label: t("request_logs.col_duration"),
-      width: "w-24",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
-      render: (row) => (
-        <OverflowTooltip content={row.latencyText} className="block min-w-0">
-          <span className="block min-w-0 truncate">{row.latencyText}</span>
-        </OverflowTooltip>
-      ),
-    },
-    {
-      key: "inputTokens",
-      label: t("request_logs.col_input"),
-      width: "w-24",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
-      render: (row) =>
-        row.hasContent && onContentClick ? (
-          <button
-            type="button"
-            onClick={() => onContentClick(Number(row.id), "input")}
-            className="ml-auto inline-block cursor-pointer rounded px-1.5 py-0.5 transition hover:bg-sky-50 dark:hover:bg-sky-950/30"
-            title={t("apikey_lookup.view_input")}
-          >
-            <span className="truncate text-sky-600 underline decoration-sky-300/50 underline-offset-2 dark:text-sky-400 dark:decoration-sky-500/40">
-              {row.inputTokens.toLocaleString()}
-            </span>
-          </button>
-        ) : (
-          <span>{row.inputTokens.toLocaleString()}</span>
-        ),
-    },
-    {
-      key: "cachedTokens",
-      label: t("request_logs.col_cache_read"),
-      width: "w-24",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums",
-      render: (row) => (
-        <span
-          className={`block min-w-0 truncate ${row.cachedTokens > 0 ? "font-semibold text-amber-600 dark:text-amber-400" : "text-slate-400 dark:text-white/30"}`}
-        >
-          {row.cachedTokens > 0 ? row.cachedTokens.toLocaleString() : "0"}
-        </span>
-      ),
-    },
-    {
-      key: "outputTokens",
-      label: t("request_logs.col_output"),
-      width: "w-24",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
-      render: (row) =>
-        row.hasContent && onContentClick ? (
-          <button
-            type="button"
-            onClick={() => onContentClick(Number(row.id), "output")}
-            className="ml-auto inline-block cursor-pointer rounded px-1.5 py-0.5 transition hover:bg-emerald-50 dark:hover:bg-emerald-950/30"
-            title={t("apikey_lookup.view_output")}
-          >
-            <span className="truncate text-emerald-600 underline decoration-emerald-300/50 underline-offset-2 dark:text-emerald-400 dark:decoration-emerald-500/40">
-              {row.outputTokens.toLocaleString()}
-            </span>
-          </button>
-        ) : (
-          <span>{row.outputTokens.toLocaleString()}</span>
-        ),
-    },
-    {
-      key: "totalTokens",
-      label: t("request_logs.col_total_token"),
-      width: "w-28",
-      headerClassName: "text-right",
-      cellClassName: "text-right font-mono text-xs tabular-nums text-slate-900 dark:text-white",
-      render: (row) => <span>{row.totalTokens.toLocaleString()}</span>,
-    },
-    {
-      key: "cost",
-      label: t("request_logs.col_cost"),
-      width: "w-24",
-      headerClassName: "text-right",
-      cellClassName:
-        "text-right font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-400",
-      render: (row) => <span>${row.cost.toFixed(4)}</span>,
-    },
-  ];
-}
-
-function PaginationBar({
-  currentPage,
-  totalPages,
-  totalCount,
-  pageSize,
-  onPageChange,
-  onPageSizeChange,
-  t,
-}: {
-  currentPage: number;
-  totalPages: number;
-  totalCount: number;
-  pageSize: number;
-  onPageChange: (page: number) => void;
-  onPageSizeChange: (size: number) => void;
-  t: (key: string, opts?: Record<string, unknown>) => string;
-}) {
-  const start = totalCount === 0 ? 0 : (currentPage - 1) * pageSize + 1;
-  const end = Math.min(currentPage * pageSize, totalCount);
-
-  const pageNumbers = useMemo(() => {
-    const pages: (number | "...")[] = [];
-    if (totalPages <= 7) {
-      for (let i = 1; i <= totalPages; i++) pages.push(i);
-    } else {
-      pages.push(1);
-      if (currentPage > 3) pages.push("...");
-      const rangeStart = Math.max(2, currentPage - 1);
-      const rangeEnd = Math.min(totalPages - 1, currentPage + 1);
-      for (let i = rangeStart; i <= rangeEnd; i++) pages.push(i);
-      if (currentPage < totalPages - 2) pages.push("...");
-      pages.push(totalPages);
-    }
-    return pages;
-  }, [currentPage, totalPages]);
-
-  const btnBase =
-    "inline-flex h-8 min-w-[32px] items-center justify-center rounded-lg text-xs font-medium transition-colors disabled:pointer-events-none disabled:opacity-40";
-  const btnNormal = `${btnBase} text-slate-600 hover:bg-slate-100 dark:text-white/60 dark:hover:bg-white/10`;
-  const btnActive = `${btnBase} bg-slate-900 text-white dark:bg-white dark:text-neutral-950`;
-
-  return (
-    <div className="flex flex-shrink-0 flex-col gap-2 border-t border-slate-100 px-3 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:px-5 dark:border-neutral-800/60">
-      <span className="whitespace-nowrap text-xs text-slate-500 dark:text-white/50 tabular-nums">
-        {t("request_logs.page_info", { start, end, total: totalCount })}
-      </span>
-
-      <div className="flex items-center gap-1 overflow-x-auto">
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage <= 1}
-          onClick={() => onPageChange(1)}
-          aria-label={t("request_logs.first_page")}
-        >
-          <ChevronsLeft size={14} />
-        </button>
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage <= 1}
-          onClick={() => onPageChange(currentPage - 1)}
-          aria-label={t("request_logs.prev_page")}
-        >
-          <ChevronLeft size={14} />
-        </button>
-        {pageNumbers.map((page, index) =>
-          page === "..." ? (
-            <span key={`dots-${index}`} className="px-1 text-xs text-slate-400 dark:text-white/30">
-              …
-            </span>
-          ) : (
-            <button
-              key={page}
-              type="button"
-              className={page === currentPage ? btnActive : btnNormal}
-              onClick={() => onPageChange(page)}
-            >
-              {page}
-            </button>
-          ),
-        )}
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage >= totalPages}
-          onClick={() => onPageChange(currentPage + 1)}
-          aria-label={t("request_logs.next_page")}
-        >
-          <ChevronRight size={14} />
-        </button>
-        <button
-          type="button"
-          className={btnNormal}
-          disabled={currentPage >= totalPages}
-          onClick={() => onPageChange(totalPages)}
-          aria-label={t("request_logs.last_page")}
-        >
-          <ChevronsRight size={14} />
-        </button>
-      </div>
-
-      <div className="flex items-center gap-1.5">
-        <span className="whitespace-nowrap text-xs text-slate-500 dark:text-white/50">
-          {t("request_logs.rows_per_page")}
-        </span>
-        <Select
-          value={String(pageSize)}
-          onChange={(value) => onPageSizeChange(Number(value))}
-          options={[20, 50, 100].map((size) => ({ value: String(size), label: String(size) }))}
-          name="pageSize"
-          className="w-auto"
-        />
-      </div>
-    </div>
-  );
-}
+import { DataTable, type DataTableColumn } from "@code-proxy/ui";
+import { RequestLogsPaginationBar, type RequestLogsRow } from "@features/request-log-viewer";
 
 export function PublicLogsSection({
   t,
@@ -295,8 +37,8 @@ export function PublicLogsSection({
   stats: { total: number; success_rate: number; total_tokens: number; total_cost: number };
   lastUpdatedText: string;
   loading: boolean;
-  logColumns: TableColumn<LogRow>[];
-  rows: LogRow[];
+  logColumns: DataTableColumn<RequestLogsRow>[];
+  rows: RequestLogsRow[];
   currentPage: number;
   totalPages: number;
   totalCount: number;
@@ -366,55 +108,21 @@ export function PublicLogsSection({
           </div>
         </div>
 
-        <div className="relative h-[calc(100vh-500px)] min-h-[300px] overflow-hidden px-3 sm:px-5">
-          <div className="h-full overflow-auto">
-            <table className="w-full min-w-[900px] table-fixed border-separate border-spacing-0 text-sm">
-              <caption className="sr-only">{t("request_logs.table_caption")}</caption>
-              <thead className="sticky top-0 z-10">
-                <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-white/55">
-                  {logColumns.map((col, index) => (
-                    <th
-                      key={col.key}
-                      className={`whitespace-nowrap bg-slate-100 px-4 py-3 dark:bg-neutral-800 ${col.width ?? ""} ${col.headerClassName ?? ""} ${index === 0 ? "first:rounded-l-xl" : ""} ${index === logColumns.length - 1 ? "last:rounded-r-xl" : ""}`}
-                    >
-                      {col.label}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="text-slate-900 dark:text-white">
-                {!loading && rows.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={logColumns.length}
-                      className="px-4 py-12 text-center text-sm text-slate-600 dark:text-white/70"
-                    >
-                      {t("request_logs.no_data")}
-                    </td>
-                  </tr>
-                ) : (
-                  rows.map((row, rowIndex) => (
-                    <tr
-                      key={row.id}
-                      className="text-sm transition-colors hover:bg-slate-50 dark:hover:bg-white/[0.04]"
-                      style={{ height: 44 }}
-                    >
-                      {logColumns.map((col, colIndex) => (
-                        <td
-                          key={col.key}
-                          className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${colIndex === 0 ? "first:rounded-l-lg" : ""} ${colIndex === logColumns.length - 1 ? "last:rounded-r-lg" : ""}`}
-                        >
-                          <TableCellOverflowTooltip className={col.cellClassName}>
-                            {col.render(row, rowIndex)}
-                          </TableCellOverflowTooltip>
-                        </td>
-                      ))}
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+        <div className="relative min-h-[360px] h-[calc(100dvh-300px)] overflow-hidden px-3 sm:px-5">
+          <DataTable
+            tableId="apikey-lookup-request-logs"
+            rows={rows}
+            columns={logColumns}
+            rowKey={(row) => row.id}
+            loading={loading}
+            virtualize={false}
+            minWidth="min-w-[1240px]"
+            height="h-full"
+            minHeight="min-h-full"
+            caption={t("request_logs.table_caption")}
+            emptyText={t("request_logs.no_data")}
+            showAllLoadedMessage={false}
+          />
           {loading ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
               <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">
@@ -428,14 +136,13 @@ export function PublicLogsSection({
           ) : null}
         </div>
 
-        <PaginationBar
+        <RequestLogsPaginationBar
           currentPage={currentPage}
           totalPages={totalPages}
           totalCount={totalCount}
           pageSize={pageSize}
           onPageChange={onPageChange}
           onPageSizeChange={onPageSizeChange}
-          t={t}
         />
       </Card>
     </Reveal>

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Check, Copy, Download, ExternalLink } from "lucide-react";
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
@@ -31,6 +32,7 @@ import { useToast } from "@code-proxy/ui";
 
 const CC_SWITCH_RELEASES_URL = "https://github.com/farion1231/cc-switch/releases";
 const QUICK_IMPORT_CLIENTS: CcSwitchClientType[] = ["codex", "claude"];
+const QUICK_IMPORT_CACHE_STORAGE_KEY = "apiKeyLookup.quickImportCache.v1";
 
 const iconByType: Record<"codex" | "claude", string> = {
   codex: iconCodex,
@@ -47,6 +49,92 @@ function readStoredManagementAuth(): { apiBase: string; managementKey: string } 
   if (!snapshot?.apiBase || !snapshot.managementKey) return null;
   return { apiBase: snapshot.apiBase, managementKey: snapshot.managementKey };
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function serializeQuickImportConfig(config: CcSwitchImportConfigListItem): Record<string, unknown> {
+  return {
+    id: config.id,
+    "client-type": config.clientType,
+    "provider-name": config.providerName,
+    note: config.note,
+    "default-model": config.defaultModel,
+    "model-mappings": config.modelMappings.map((mapping) => ({
+      ...(mapping.role ? { role: mapping.role } : {}),
+      "request-model": mapping.requestModel,
+      "target-model": mapping.targetModel,
+    })),
+    "allowed-channel-groups": [...config.allowedChannelGroups],
+    "route-path": config.routePath,
+    "endpoint-path": config.endpointPath,
+    "usage-auto-interval": config.usageAutoInterval,
+    ...(config.apiKeyField ? { "api-key-field": config.apiKeyField } : {}),
+    ...(config.codexModelCatalog
+      ? {
+          "codex-model-catalog-filename": config.codexModelCatalogFilename,
+          "codex-model-catalog": config.codexModelCatalog,
+        }
+      : {}),
+  };
+}
+
+function getQuickImportCacheKey(apiKey: string): string {
+  const auth = readStoredManagementAuth();
+  return [apiKey.trim(), auth?.apiBase ?? "public", auth?.managementKey ?? ""].join("|");
+}
+
+function readStoredQuickImportCache(
+  cacheKey: string,
+): { configs: CcSwitchImportConfigListItem[]; apiKeyEntry: ApiKeyEntry | null } | null {
+  try {
+    const raw = window.sessionStorage.getItem(QUICK_IMPORT_CACHE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+    const cached = parsed[cacheKey];
+    if (!isRecord(cached)) return null;
+    const configs = normalizeCcSwitchImportConfigs(cached.configs);
+    const entries = normalizeApiKeyEntries([cached.apiKeyEntry]);
+    return { configs, apiKeyEntry: entries[0] ?? null };
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredQuickImportCache(
+  cacheKey: string,
+  value: { configs: CcSwitchImportConfigListItem[]; apiKeyEntry: ApiKeyEntry | null },
+): void {
+  try {
+    const raw = window.sessionStorage.getItem(QUICK_IMPORT_CACHE_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : {};
+    const entries = isRecord(parsed)
+      ? Object.entries(parsed).filter((entry): entry is [string, Record<string, unknown>] =>
+          isRecord(entry[1]),
+        )
+      : [];
+    const next: Record<string, Record<string, unknown>> = {};
+    const keptEntries = entries.filter(([key]) => key !== cacheKey);
+    const cacheEntry: [string, Record<string, unknown>] = [
+      cacheKey,
+      {
+        configs: value.configs.map(serializeQuickImportConfig),
+        apiKeyEntry: value.apiKeyEntry,
+      },
+    ];
+    for (const [key, entry] of [...keptEntries, cacheEntry].slice(-8)) {
+      next[key] = entry;
+    }
+    window.sessionStorage.setItem(QUICK_IMPORT_CACHE_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+const sameJsonValue = (left: unknown, right: unknown): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
 
 async function fetchPublicQuickImportConfigs(
   apiKey: string,
@@ -118,10 +206,18 @@ function QuickImportCard({
   onSelect: (config: CcSwitchImportConfigListItem) => void;
 }) {
   const { t } = useTranslation();
+  const reduceMotion = useReducedMotion();
   const clientType = config.clientType as "codex" | "claude";
 
   return (
-    <div className="grid min-h-[116px] w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700">
+    <motion.div
+      layout
+      initial={reduceMotion ? false : { opacity: 0, y: 10, scale: 0.98 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
+      exit={reduceMotion ? undefined : { opacity: 0, y: -6, scale: 0.98 }}
+      transition={reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 420, damping: 36 }}
+      className="group/card grid min-h-[116px] w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
+    >
       <button
         type="button"
         onClick={() => onSelect(config)}
@@ -156,7 +252,7 @@ function QuickImportCard({
           </span>
         </span>
       </button>
-      <div className="flex items-start gap-1 p-3 pl-0">
+      <div className="relative z-10 flex items-start gap-1 p-3 pl-0 opacity-70 transition-opacity group-hover/card:opacity-100 focus-within:opacity-100">
         <Button
           variant="ghost"
           size="xs"
@@ -167,7 +263,7 @@ function QuickImportCard({
           {copied ? <Check size={14} /> : <Copy size={14} />}
         </Button>
       </div>
-    </div>
+    </motion.div>
   );
 }
 
@@ -226,9 +322,16 @@ export function QuickImportTabContent({
 }) {
   const { t, i18n } = useTranslation();
   const { notify } = useToast();
-  const [configs, setConfigs] = useState<CcSwitchImportConfigListItem[]>([]);
-  const [apiKeyEntry, setApiKeyEntry] = useState<ApiKeyEntry | null>(null);
-  const [loading, setLoading] = useState(true);
+  const reduceMotion = useReducedMotion();
+  const cacheKey = useMemo(() => getQuickImportCacheKey(apiKey), [apiKey]);
+  const initialCache = useMemo(() => readStoredQuickImportCache(cacheKey), [cacheKey]);
+  const [configs, setConfigs] = useState<CcSwitchImportConfigListItem[]>(
+    () => initialCache?.configs ?? [],
+  );
+  const [apiKeyEntry, setApiKeyEntry] = useState<ApiKeyEntry | null>(
+    () => initialCache?.apiKeyEntry ?? null,
+  );
+  const [loading, setLoading] = useState(!initialCache);
   const [error, setError] = useState<string | null>(null);
   const [copiedImportConfigId, setCopiedImportConfigId] = useState<string | null>(null);
   const copiedImportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -255,19 +358,30 @@ export function QuickImportTabContent({
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
+    const cached = readStoredQuickImportCache(cacheKey);
+    if (cached) {
+      setConfigs((prev) => (sameJsonValue(prev, cached.configs) ? prev : cached.configs));
+      setApiKeyEntry((prev) =>
+        sameJsonValue(prev, cached.apiKeyEntry) ? prev : cached.apiKeyEntry,
+      );
+    }
+    setLoading(!cached);
     setError(null);
 
     Promise.all([fetchQuickImportConfigs(apiKey), fetchQuickImportApiKeyEntry(apiKey)])
       .then(([items, entry]) => {
         if (cancelled) return;
-        setConfigs(items.filter((item) => QUICK_IMPORT_CLIENTS.includes(item.clientType)));
-        setApiKeyEntry(entry);
+        const nextConfigs = items.filter((item) => QUICK_IMPORT_CLIENTS.includes(item.clientType));
+        writeStoredQuickImportCache(cacheKey, { configs: nextConfigs, apiKeyEntry: entry });
+        setConfigs((prev) => (sameJsonValue(prev, nextConfigs) ? prev : nextConfigs));
+        setApiKeyEntry((prev) => (sameJsonValue(prev, entry) ? prev : entry));
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setConfigs([]);
-        setApiKeyEntry(null);
+        if (!cached) {
+          setConfigs([]);
+          setApiKeyEntry(null);
+        }
         setError(err instanceof Error ? err.message : t("apikey_lookup.quick_import_load_failed"));
       })
       .finally(() => {
@@ -278,7 +392,7 @@ export function QuickImportTabContent({
     return () => {
       cancelled = true;
     };
-  }, [apiKey, reloadToken, t]);
+  }, [apiKey, cacheKey, reloadToken, t]);
 
   const groupedConfigs = useMemo(
     () => ({
@@ -345,6 +459,8 @@ export function QuickImportTabContent({
     [buildImportUrl, notify, showCopiedImportState, t],
   );
 
+  const showSkeleton = loading && configs.length === 0;
+
   return (
     <div className="space-y-4">
       <Card padding="compact" className="border-slate-200/70 bg-white/85 dark:bg-neutral-950/70">
@@ -374,9 +490,9 @@ export function QuickImportTabContent({
         </div>
       </Card>
 
-      {loading ? <QuickImportLoadingSkeleton /> : null}
+      {showSkeleton ? <QuickImportLoadingSkeleton /> : null}
 
-      {!loading ? (
+      {!showSkeleton ? (
         <Card padding="none" className="overflow-hidden">
           {error ? (
             <div className="border-b border-rose-100 bg-rose-50 px-5 py-2.5 text-sm text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">
@@ -384,42 +500,63 @@ export function QuickImportTabContent({
             </div>
           ) : null}
           <div className="space-y-5 px-5 py-4">
-            {QUICK_IMPORT_CLIENTS.map((clientType) => {
-              const typedClient = clientType as "codex" | "claude";
-              const items = groupedConfigs[typedClient];
-              const label = t(clientLabelKey[typedClient]);
+            <AnimatePresence initial={false}>
+              {QUICK_IMPORT_CLIENTS.map((clientType) => {
+                const typedClient = clientType as "codex" | "claude";
+                const items = groupedConfigs[typedClient];
+                const label = t(clientLabelKey[typedClient]);
 
-              if (items.length === 0) return null;
+                if (items.length === 0) return null;
 
-              return (
-                <section
-                  key={typedClient}
-                  aria-label={t("apikey_lookup.quick_import_group_aria", { client: label })}
-                  className="space-y-3"
-                >
-                  <div className="flex items-center gap-2">
-                    <img src={iconByType[typedClient]} alt="" className="h-4 w-4" />
-                    <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-                      {label}
-                    </h3>
-                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-bold tabular-nums text-slate-500 dark:bg-neutral-900 dark:text-white/45">
-                      {items.length}
-                    </span>
-                  </div>
-                  <div className="grid gap-3 md:grid-cols-2">
-                    {items.map((config) => (
-                      <QuickImportCard
-                        key={config.id}
-                        config={config}
-                        copied={copiedImportConfigId === config.id}
-                        onCopyLink={(item) => void handleCopyImportLink(item)}
-                        onSelect={handleImport}
-                      />
-                    ))}
-                  </div>
-                </section>
-              );
-            })}
+                return (
+                  <motion.section
+                    layout
+                    key={typedClient}
+                    aria-label={t("apikey_lookup.quick_import_group_aria", { client: label })}
+                    className="space-y-3"
+                    initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+                    animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+                    exit={reduceMotion ? undefined : { opacity: 0, y: -6 }}
+                    transition={
+                      reduceMotion
+                        ? { duration: 0 }
+                        : { type: "spring", stiffness: 420, damping: 36 }
+                    }
+                  >
+                    <div className="flex items-center gap-2">
+                      <img src={iconByType[typedClient]} alt="" className="h-4 w-4" />
+                      <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {label}
+                      </h3>
+                      <AnimatePresence mode="popLayout" initial={false}>
+                        <motion.span
+                          key={`${typedClient}-${items.length}`}
+                          initial={reduceMotion ? false : { opacity: 0, y: 4 }}
+                          animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+                          exit={reduceMotion ? undefined : { opacity: 0, y: -4 }}
+                          className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-bold tabular-nums text-slate-500 dark:bg-neutral-900 dark:text-white/45"
+                        >
+                          {items.length}
+                        </motion.span>
+                      </AnimatePresence>
+                    </div>
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <AnimatePresence initial={false}>
+                        {items.map((config) => (
+                          <QuickImportCard
+                            key={config.id}
+                            config={config}
+                            copied={copiedImportConfigId === config.id}
+                            onCopyLink={(item) => void handleCopyImportLink(item)}
+                            onSelect={handleImport}
+                          />
+                        ))}
+                      </AnimatePresence>
+                    </div>
+                  </motion.section>
+                );
+              })}
+            </AnimatePresence>
           </div>
         </Card>
       ) : null}

--- a/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
@@ -96,6 +96,7 @@ describe("QuickImportTabContent", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
     window.localStorage.clear();
+    window.sessionStorage.clear();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ "ccswitch-import-configs": quickImportConfigs }), {
         headers: { "Content-Type": "application/json" },
@@ -200,7 +201,7 @@ describe("QuickImportTabContent", () => {
       expect(decodeConfigFromImportUrl(copiedUrl)).toMatchObject({
         modelCatalog: {
           models: [
-              expect.objectContaining({ slug: "gpt-5.3-codex" }),
+            expect.objectContaining({ slug: "gpt-5.3-codex" }),
             expect.objectContaining({ slug: "deepseek-v4-flash" }),
           ],
         },

--- a/pages/api-key-lookup/types.ts
+++ b/pages/api-key-lookup/types.ts
@@ -1,9 +1,16 @@
 export interface PublicLogItem {
   id: number;
   timestamp: string;
+  api_key?: string;
+  api_key_name?: string;
+  channel_name?: string;
   model: string;
+  upstream_model?: string;
+  vision_fallback_model?: string;
   failed: boolean;
+  streaming?: boolean;
   latency_ms: number;
+  first_token_ms?: number;
   input_tokens: number;
   output_tokens: number;
   cached_tokens: number;
@@ -28,21 +35,6 @@ export interface PublicLogsResponse {
   filters: {
     models: string[];
   };
-}
-
-export interface LogRow {
-  id: string;
-  timestamp: string;
-  timestampMs: number;
-  model: string;
-  failed: boolean;
-  latencyText: string;
-  inputTokens: number;
-  cachedTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-  cost: number;
-  hasContent: boolean;
 }
 
 export interface ChartDataResponse {


### PR DESCRIPTION
## Summary
- reuse the shared request logs table in API key lookup, including the Response Metrics column
- cache available models and quick import cards, preserving existing UI while background refreshes
- add layout/change animations for model tags, quick import groups, and cards

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
- rtk bun run build