### PR TITLE
fix: clean up API key lookup logs

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -275,7 +275,10 @@ export function ApiKeyLookupPage() {
   }, []);
 
   const logColumns = useMemo(
-    () => buildRequestLogsColumns((key) => t(key), handleContentClick),
+    () =>
+      buildRequestLogsColumns((key) => t(key), handleContentClick).filter(
+        (column) => column.key !== "apiKeyName",
+      ),
     [t, handleContentClick],
   );
   const statusOptions = useMemo(

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -4,9 +4,10 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiKeyLookupPage } from "../ApiKeyLookupPage";
 import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
+import type { PublicLogItem, PublicLogsResponse } from "../types";
 
 const mocks = vi.hoisted(() => ({
-  fetchPublicLogs: vi.fn(async () => ({
+  fetchPublicLogs: vi.fn(async (): Promise<PublicLogsResponse> => ({
     items: [],
     total: 0,
     page: 1,
@@ -134,6 +135,37 @@ describe("ApiKeyLookupPage", () => {
 
   test("loads public logs only after switching to the request logs tab", async () => {
     window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    const logItem: PublicLogItem = {
+      id: 1,
+      timestamp: new Date("2026-07-05T03:01:18Z").toISOString(),
+      channel_name: "Codex 主渠道",
+      model: "gpt-5.5",
+      failed: false,
+      streaming: true,
+      latency_ms: 15100,
+      first_token_ms: 1650,
+      input_tokens: 54908,
+      cached_tokens: 50048,
+      output_tokens: 649,
+      total_tokens: 55557,
+      cost: 0.0688,
+      has_content: false,
+    };
+    mocks.fetchPublicLogs.mockResolvedValueOnce({
+      items: [logItem],
+      total: 1,
+      page: 1,
+      size: 50,
+      api_key_name: "Primary key",
+      stats: {
+        total: 1,
+        success_rate: 100,
+        total_tokens: 55557,
+        total_sessions: 1,
+        total_cost: 0.0688,
+      },
+      filters: { models: ["gpt-5.5"] },
+    });
 
     render(
       <ThemeProvider>
@@ -158,6 +190,8 @@ describe("ApiKeyLookupPage", () => {
       );
     });
     expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Codex 主渠道")).toBeInTheDocument();
+    expect(screen.queryByText(/key name/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: /^duration$/i })).not.toBeInTheDocument();
   });
 

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -1,5 +1,5 @@
 import { RefreshCw } from "lucide-react";
-import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
+import { HoverTooltip, Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { TimeRangeSelector } from "@features/monitor-widgets";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 
@@ -42,18 +42,20 @@ export function LookupResultsToolbar({
         ) : null}
       </div>
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={handleRefresh}
-          disabled={loading || chartLoading || modelsLoading}
-          className="inline-flex h-[34px] items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/80 dark:hover:bg-white/10"
-        >
-          <RefreshCw
-            size={13}
-            className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
-          />
-          {t("common.refresh")}
-        </button>
+        <HoverTooltip content={t("common.refresh")}>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={loading || chartLoading || modelsLoading}
+            aria-label={t("common.refresh")}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
+          >
+            <RefreshCw
+              size={16}
+              className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
+            />
+          </button>
+        </HoverTooltip>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- hide the key name column on API key lookup request logs
- make refresh a compact icon button with tooltip text
- add lookup page coverage for channel display and hidden key name column

## Verification
- rtk bun run --filter @code-proxy/admin-panel test:ci -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
- rtk bun run build