### PR TITLE
fix: group minor model distribution entries

### DIFF
--- a/features/monitor-widgets/chart-options/__tests__/model-distribution.test.ts
+++ b/features/monitor-widgets/chart-options/__tests__/model-distribution.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { buildModelDistributionData } from "../model-distribution";
+
+describe("buildModelDistributionData", () => {
+  test("keeps the first five models and groups the rest as other", () => {
+    expect(
+      buildModelDistributionData({
+        items: [
+          { model: "m1", requests: 10, tokens: 100 },
+          { model: "m2", requests: 9, tokens: 90 },
+          { model: "m3", requests: 8, tokens: 80 },
+          { model: "m4", requests: 7, tokens: 70 },
+          { model: "m5", requests: 6, tokens: 60 },
+          { model: "m6", requests: 5, tokens: 50 },
+          { model: "m7", requests: 4, tokens: 40 },
+        ],
+        metric: "requests",
+        otherLabel: "其他",
+      }),
+    ).toEqual([
+      { name: "m1", value: 10 },
+      { name: "m2", value: 9 },
+      { name: "m3", value: 8 },
+      { name: "m4", value: 7 },
+      { name: "m5", value: 6 },
+      { name: "其他", value: 9 },
+    ]);
+  });
+});

--- a/features/monitor-widgets/chart-options/index.ts
+++ b/features/monitor-widgets/chart-options/index.ts
@@ -7,4 +7,8 @@ export type {
 export { createDailyTrendOption } from "./daily-trend";
 export { createHourlyModelOption } from "./hourly-model";
 export { createHourlyTokenOption } from "./hourly-token";
-export { createModelDistributionOption } from "./model-distribution";
+export {
+  buildModelDistributionData,
+  createModelDistributionOption,
+  MODEL_DISTRIBUTION_VISIBLE_LIMIT,
+} from "./model-distribution";

--- a/features/monitor-widgets/chart-options/model-distribution.ts
+++ b/features/monitor-widgets/chart-options/model-distribution.ts
@@ -2,6 +2,35 @@ import { CHART_COLORS } from "../monitor-constants";
 import { formatCompact } from "../monitor-format";
 import type { ModelDistributionDatum } from "./types";
 
+export const MODEL_DISTRIBUTION_VISIBLE_LIMIT = 5;
+
+export const buildModelDistributionData = (input: {
+  items: Array<{ model: string; requests: number; tokens: number }>;
+  metric: "requests" | "tokens";
+  otherLabel: string;
+  limit?: number;
+}): ModelDistributionDatum[] => {
+  const limit = input.limit ?? MODEL_DISTRIBUTION_VISIBLE_LIMIT;
+  const sorted = [...input.items].sort((left, right) => {
+    const leftValue = input.metric === "requests" ? left.requests : left.tokens;
+    const rightValue = input.metric === "requests" ? right.requests : right.tokens;
+    return rightValue - leftValue || left.model.localeCompare(right.model);
+  });
+  const data = sorted.slice(0, limit).map((item) => ({
+    name: item.model,
+    value: input.metric === "requests" ? item.requests : item.tokens,
+  }));
+  const otherValue = sorted
+    .slice(limit)
+    .reduce(
+      (acc, item) => acc + (input.metric === "requests" ? item.requests : item.tokens),
+      0,
+    );
+
+  if (otherValue > 0) data.push({ name: input.otherLabel, value: otherValue });
+  return data;
+};
+
 export const createModelDistributionOption = (input: {
   isDark: boolean;
   data: ModelDistributionDatum[];

--- a/pages/api-key-lookup/hooks/useApiKeyLookupCharts.ts
+++ b/pages/api-key-lookup/hooks/useApiKeyLookupCharts.ts
@@ -1,5 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
-import { createModelDistributionOption } from "@features/monitor-widgets/chart-options/model-distribution";
+import {
+  buildModelDistributionData,
+  createModelDistributionOption,
+} from "@features/monitor-widgets/chart-options/model-distribution";
 import { createDailyTrendOption } from "@features/monitor-widgets/chart-options/daily-trend";
 import { CHART_COLOR_CLASSES } from "@features/monitor-widgets/monitor-constants";
 import type {
@@ -93,22 +96,11 @@ export function useApiKeyLookupCharts({
   }, [dailySeries]);
 
   const modelDistributionData: ModelDistributionDatum[] = useMemo(() => {
-    if (!chartData?.model_distribution) return [];
-    const sorted = [...chartData.model_distribution].sort((a, b) => {
-      const aValue = modelMetric === "requests" ? a.requests : a.tokens;
-      const bValue = modelMetric === "requests" ? b.requests : b.tokens;
-      return bValue - aValue || a.model.localeCompare(b.model);
+    return buildModelDistributionData({
+      items: chartData?.model_distribution ?? [],
+      metric: modelMetric,
+      otherLabel: t("common.other"),
     });
-    const top = sorted.slice(0, 10);
-    const otherValue = sorted
-      .slice(10)
-      .reduce((acc, item) => acc + (modelMetric === "requests" ? item.requests : item.tokens), 0);
-    const data = top.map((item) => ({
-      name: item.model,
-      value: modelMetric === "requests" ? item.requests : item.tokens,
-    }));
-    if (otherValue > 0) data.push({ name: t("common.other"), value: otherValue });
-    return data;
   }, [chartData, modelMetric, t]);
 
   const modelDistributionOption = useMemo(

--- a/pages/monitor/MonitorPage.tsx
+++ b/pages/monitor/MonitorPage.tsx
@@ -7,6 +7,7 @@ import {
 } from "@features/monitor-widgets/monitor-constants";
 import { formatCompact, formatMonthDay } from "@features/monitor-widgets/monitor-format";
 import {
+  buildModelDistributionData,
   createDailyTrendOption,
   createHourlyModelOption,
   createHourlyTokenOption,
@@ -206,21 +207,12 @@ export function MonitorPage() {
   );
 
   const modelDistributionData = useMemo(() => {
-    const top = sortedModelsByMetric.slice(0, 10);
-    const otherValue = sortedModelsByMetric.slice(10).reduce((acc, item) => {
-      return acc + (modelMetric === "requests" ? item.requests : item.tokens);
-    }, 0);
-
-    const data = top.map((item) => ({
-      name: item.model,
-      value: modelMetric === "requests" ? item.requests : item.tokens,
-    }));
-
-    if (otherValue > 0) {
-      data.push({ name: t("common.other"), value: otherValue });
-    }
-    return data;
-  }, [modelMetric, sortedModelsByMetric, t]);
+    return buildModelDistributionData({
+      items: chartData?.model_distribution ?? [],
+      metric: modelMetric,
+      otherLabel: t("common.other"),
+    });
+  }, [chartData, modelMetric, t]);
 
   useEffect(() => {
     setModelDistributionSelected((prev) => {


### PR DESCRIPTION
## Summary
- show only the top five model distribution entries
- group remaining model usage into Other
- reuse the same aggregation for monitor and API key lookup charts

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- features/monitor-widgets/chart-options/__tests__/model-distribution.test.ts
- rtk bun run build
- rtk bun run lint (0 errors; existing warnings remain)