### PR TITLE
fix: reuse request log filters in key lookup

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { UsageLogItem } from "@code-proxy/api-client/endpoints/usage";
 import {
@@ -10,12 +11,28 @@ import {
   type UsageMetricVariant,
 } from "@code-proxy/domain";
 import { parseUsageTimestampMs } from "@features/monitor-widgets/monitor-utils";
-import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
+import {
+  SearchableCheckboxMultiSelect,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@code-proxy/ui";
+import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
 import { PaginationBar } from "@code-proxy/ui";
 import { ModelTag } from "@features/model-tags";
 
 export type TimeRange = 1 | 7 | 14 | 30;
+export type StatusFilterValue = "success" | "failed";
+export type MultiSelectFilterState<T extends string = string> = T[] | null;
+
+export function isStatusFilterValue(value: string): value is StatusFilterValue {
+  return value === "success" || value === "failed";
+}
+
+export function toStatusFilterValues(values: string[]): StatusFilterValue[] {
+  return values.filter(isStatusFilterValue);
+}
 
 export type RequestLogsRow = {
   id: string;
@@ -59,7 +76,9 @@ const computeOutputTokensPerSecond = (row: RequestLogsRow): number | null => {
   const totalSeconds = parseLatencyTextToSeconds(row.latencyText);
   if (totalSeconds === null || totalSeconds <= 0) return null;
 
-  const firstSeconds = row.streaming ? (parseLatencyTextToSeconds(row.firstTokenText) ?? 0) : 0;
+  const firstSeconds = row.streaming
+    ? (parseLatencyTextToSeconds(row.firstTokenText) ?? 0)
+    : 0;
   const generationSeconds = Math.max(0, totalSeconds - firstSeconds);
   if (generationSeconds <= 0) return null;
 
@@ -68,7 +87,8 @@ const computeOutputTokensPerSecond = (row: RequestLogsRow): number | null => {
 };
 
 const formatTokensPerSecond = (value: number | null): string => {
-  if (!Number.isFinite(value ?? Number.NaN) || !value || value <= 0) return "--";
+  if (!Number.isFinite(value ?? Number.NaN) || !value || value <= 0)
+    return "--";
   if (value >= 100) return `${Math.round(value)} t/s`;
   if (value >= 10) return `${value.toFixed(1)} t/s`;
   return `${value.toFixed(2)} t/s`;
@@ -116,7 +136,13 @@ function RequestLogMetricChip({
   );
 }
 
-function RequestLogModeChip({ label, streaming }: { label: string; streaming: boolean }) {
+function RequestLogModeChip({
+  label,
+  streaming,
+}: {
+  label: string;
+  streaming: boolean;
+}) {
   return (
     <span
       className={
@@ -167,7 +193,11 @@ export function RequestLogUsageMetricValue({
       placement="top"
       className={useCompact ? "cursor-help" : undefined}
     >
-      <span className={["block min-w-0 truncate", className].filter(Boolean).join(" ")}>
+      <span
+        className={["block min-w-0 truncate", className]
+          .filter(Boolean)
+          .join(" ")}
+      >
         {display}
       </span>
     </HoverTooltip>
@@ -188,8 +218,169 @@ export interface RequestLogsTableColumn<T> {
 
 export const DEFAULT_REQUEST_LOG_PAGE_SIZE = 50;
 export const REQUEST_LOG_PAGE_SIZE_OPTIONS = [20, 50, 100];
-export const REQUEST_LOG_TIME_RANGES: readonly TimeRange[] = [1, 7, 14, 30] as const;
+export const REQUEST_LOG_TIME_RANGES: readonly TimeRange[] = [
+  1, 7, 14, 30,
+] as const;
 export const SYSTEM_REQUEST_LOG_FILTER_VALUE = "__system__";
+
+export function normalizeFilterSelection<T extends string>(
+  selected: MultiSelectFilterState<T>,
+  allowedValues: T[],
+): MultiSelectFilterState<T> {
+  if (selected === null) return null;
+  if (allowedValues.length === 0) return [];
+  const allowed = new Set(allowedValues);
+  const normalized = selected.filter(
+    (item, index) => allowed.has(item) && selected.indexOf(item) === index,
+  );
+  if (normalized.length === allowedValues.length) return null;
+  return normalized;
+}
+
+export function toFilterParam<T extends string>(
+  selected: MultiSelectFilterState<T>,
+  allowedValues: T[],
+): { values?: T[]; matchesNone: boolean } {
+  const normalized = normalizeFilterSelection(selected, allowedValues);
+  if (normalized === null) return { values: undefined, matchesNone: false };
+  if (normalized.length === 0) return { values: undefined, matchesNone: true };
+  return { values: normalized, matchesNone: false };
+}
+
+export function hasActiveFilterSelection<T extends string>(
+  selected: MultiSelectFilterState<T>,
+  allowedValues: T[],
+): boolean {
+  const normalized = normalizeFilterSelection(selected, allowedValues);
+  return normalized !== null;
+}
+
+export function RequestLogFacetFilters({
+  modelOptions,
+  channelOptions,
+  statusOptions,
+  selectedModels,
+  selectedChannels,
+  selectedStatuses,
+  onModelsChange,
+  onChannelsChange,
+  onStatusesChange,
+  onModelsClear,
+  onChannelsClear,
+  onStatusesClear,
+}: {
+  modelOptions: SearchableCheckboxMultiSelectOption[];
+  channelOptions: SearchableCheckboxMultiSelectOption[];
+  statusOptions: SearchableCheckboxMultiSelectOption[];
+  selectedModels: MultiSelectFilterState<string>;
+  selectedChannels: MultiSelectFilterState<string>;
+  selectedStatuses: MultiSelectFilterState<StatusFilterValue>;
+  onModelsChange: (value: string[]) => void;
+  onChannelsChange: (value: string[]) => void;
+  onStatusesChange: (value: StatusFilterValue[]) => void;
+  onModelsClear: () => void;
+  onChannelsClear: () => void;
+  onStatusesClear: () => void;
+}) {
+  const { t } = useTranslation();
+  const statusChangeAdapter = useMemo(
+    () => (value: string[]) => onStatusesChange(toStatusFilterValues(value)),
+    [onStatusesChange],
+  );
+  const statusClearAdapter = useCallback(() => {
+    onStatusesClear();
+  }, [onStatusesClear]);
+
+  return (
+    <>
+      <div className="w-full min-[480px]:w-auto sm:w-[200px]">
+        <SearchableCheckboxMultiSelect
+          value={selectedModels ?? []}
+          onChange={onModelsChange}
+          options={modelOptions}
+          placeholder={t("request_logs.all_models_placeholder")}
+          searchPlaceholder={t("request_logs.search_models")}
+          selectFilteredLabel={t("request_logs.select_filtered")}
+          deselectFilteredLabel={t("request_logs.deselect_filtered")}
+          selectedCountLabel={(count: number) =>
+            t("request_logs.selected_count", { count })
+          }
+          noResultsLabel={t("request_logs.no_filter_results")}
+          aria-label={t("request_logs.filter_model")}
+          clearLabel={t("request_logs.clear_model_filter")}
+          onClear={onModelsClear}
+          showClearButton
+          size="sm"
+          emptyValueMeansAllSelected
+          emptyValueRepresentsAllSelected={selectedModels === null}
+          showFilteredToggleWithoutQuery={false}
+          applyMode="manual"
+          applyLabel={t("request_logs.apply_filters")}
+          cancelLabel={t("common.cancel")}
+          selectAllLabel={t("request_logs.select_all")}
+          deselectAllLabel={t("request_logs.deselect_all")}
+          emptySelectionLabel={t("request_logs.none_selected")}
+        />
+      </div>
+      <div className="w-full min-[480px]:w-auto sm:w-[180px]">
+        <SearchableCheckboxMultiSelect
+          value={selectedChannels ?? []}
+          onChange={onChannelsChange}
+          options={channelOptions}
+          placeholder={t("request_logs.all_channels_placeholder")}
+          searchPlaceholder={t("request_logs.search_channels")}
+          selectFilteredLabel={t("request_logs.select_filtered")}
+          deselectFilteredLabel={t("request_logs.deselect_filtered")}
+          selectedCountLabel={(count: number) =>
+            t("request_logs.selected_count", { count })
+          }
+          noResultsLabel={t("request_logs.no_filter_results")}
+          aria-label={t("request_logs.filter_channel")}
+          clearLabel={t("request_logs.clear_channel_filter")}
+          onClear={onChannelsClear}
+          showClearButton
+          size="sm"
+          emptyValueMeansAllSelected
+          emptyValueRepresentsAllSelected={selectedChannels === null}
+          showFilteredToggleWithoutQuery={false}
+          applyMode="manual"
+          applyLabel={t("request_logs.apply_filters")}
+          cancelLabel={t("common.cancel")}
+          selectAllLabel={t("request_logs.select_all")}
+          deselectAllLabel={t("request_logs.deselect_all")}
+          emptySelectionLabel={t("request_logs.none_selected")}
+        />
+      </div>
+      <div className="w-full min-[480px]:w-auto sm:w-[150px]">
+        <SearchableCheckboxMultiSelect
+          value={selectedStatuses ?? []}
+          onChange={statusChangeAdapter}
+          options={statusOptions}
+          placeholder={t("request_logs.all_status")}
+          searchPlaceholder=""
+          selectFilteredLabel={t("request_logs.select_filtered")}
+          deselectFilteredLabel={t("request_logs.deselect_filtered")}
+          selectedCountLabel={(count: number) => `${count}`}
+          noResultsLabel={t("request_logs.no_filter_results")}
+          aria-label={t("request_logs.filter_status")}
+          clearLabel={t("request_logs.clear_status_filter")}
+          onClear={statusClearAdapter}
+          showClearButton
+          size="sm"
+          emptyValueMeansAllSelected
+          emptyValueRepresentsAllSelected={selectedStatuses === null}
+          showFilteredToggleWithoutQuery={false}
+          applyMode="manual"
+          applyLabel={t("request_logs.apply_filters")}
+          cancelLabel={t("common.cancel")}
+          selectAllLabel={t("request_logs.select_all")}
+          deselectAllLabel={t("request_logs.deselect_all")}
+          emptySelectionLabel={t("request_logs.none_selected")}
+        />
+      </div>
+    </>
+  );
+}
 
 export type RequestLogKeyOption = {
   value: string;
@@ -200,7 +391,8 @@ export type RequestLogKeyOption = {
 export const maskRequestLogApiKey = (value: string): string => {
   const trimmed = value.trim();
   if (!trimmed) return "--";
-  if (trimmed.length <= 10) return `${trimmed.slice(0, 2)}***${trimmed.slice(-2)}`;
+  if (trimmed.length <= 10)
+    return `${trimmed.slice(0, 2)}***${trimmed.slice(-2)}`;
   return `${trimmed.slice(0, 6)}***${trimmed.slice(-4)}`;
 };
 
@@ -252,11 +444,17 @@ export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
   };
 };
 
-export const isSystemRequestLogKey = (apiKey: string, apiKeyName?: string): boolean => {
+export const isSystemRequestLogKey = (
+  apiKey: string,
+  apiKeyName?: string,
+): boolean => {
   if (String(apiKeyName || "").trim()) return false;
   const trimmed = String(apiKey || "").trim();
   if (!trimmed) return true;
-  return /^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+\//i.test(trimmed) || trimmed.startsWith("/");
+  return (
+    /^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)\s+\//i.test(trimmed) ||
+    trimmed.startsWith("/")
+  );
 };
 
 export const buildRequestLogKeyOptions = (
@@ -301,11 +499,16 @@ export function RequestLogsTimeRangeSelector({
 }) {
   const { t } = useTranslation();
   return (
-    <Tabs value={String(value)} onValueChange={(next) => onChange(Number(next) as TimeRange)}>
+    <Tabs
+      value={String(value)}
+      onValueChange={(next) => onChange(Number(next) as TimeRange)}
+    >
       <TabsList>
         {REQUEST_LOG_TIME_RANGES.map((range) => {
           const label =
-            range === 1 ? t("request_logs.today") : t("request_logs.n_days", { count: range });
+            range === 1
+              ? t("request_logs.today")
+              : t("request_logs.n_days", { count: range });
           return (
             <TabsTrigger key={range} value={String(range)}>
               {label}
@@ -328,7 +531,8 @@ export function buildRequestLogsColumns(
       label: t("request_logs.col_id"),
       width: "w-20",
       headerClassName: "text-left",
-      cellClassName: "text-left font-mono text-xs tabular-nums text-slate-500 dark:text-white/50",
+      cellClassName:
+        "text-left font-mono text-xs tabular-nums text-slate-500 dark:text-white/50",
       render: (row) => (
         <OverflowTooltip content={`#${row.id}`} className="block min-w-0">
           <span className="block min-w-0 truncate">#{row.id}</span>
@@ -347,7 +551,9 @@ export function buildRequestLogsColumns(
           content={formatRequestLogTimestamp(row.timestamp)}
           className="block min-w-0"
         >
-          <span className="block min-w-0 truncate">{formatRequestLogTimestamp(row.timestamp)}</span>
+          <span className="block min-w-0 truncate">
+            {formatRequestLogTimestamp(row.timestamp)}
+          </span>
         </OverflowTooltip>
       ),
     },
@@ -358,7 +564,10 @@ export function buildRequestLogsColumns(
       headerClassName: "text-center",
       cellClassName: "text-center",
       render: (row) => (
-        <OverflowTooltip content={row.channelName || "--"} className="block min-w-0">
+        <OverflowTooltip
+          content={row.channelName || "--"}
+          className="block min-w-0"
+        >
           <span
             className={`block min-w-0 truncate text-xs font-medium ${row.channelName ? "text-violet-600 dark:text-violet-400" : "text-slate-400 dark:text-white/30"}`}
           >
@@ -395,7 +604,8 @@ export function buildRequestLogsColumns(
       width: "w-64",
       minWidthPx: 240,
       headerClassName: "text-center",
-      cellClassName: "text-center text-xs tabular-nums text-slate-700 dark:text-slate-200",
+      cellClassName:
+        "text-center text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) => {
         const tps = computeOutputTokensPerSecond(row);
         const tpsText = formatTokensPerSecond(tps);
@@ -403,8 +613,12 @@ export function buildRequestLogsColumns(
         const hasFirstToken = hasRequestLogMetricText(row.firstTokenText);
         const hasTps = hasRequestLogMetricText(tpsText);
         const tooltipLines = [
-          hasLatency ? `${t("request_logs.col_duration")}: ${row.latencyText}` : null,
-          hasFirstToken ? `${t("request_logs.col_first_token")}: ${row.firstTokenText}` : null,
+          hasLatency
+            ? `${t("request_logs.col_duration")}: ${row.latencyText}`
+            : null,
+          hasFirstToken
+            ? `${t("request_logs.col_first_token")}: ${row.firstTokenText}`
+            : null,
           hasTps ? `${t("request_logs.tokens_per_second")}: ${tpsText}` : null,
         ].filter((line): line is string => Boolean(line));
 
@@ -513,7 +727,8 @@ export function buildRequestLogsColumns(
       label: t("request_logs.col_total_token"),
       width: "w-28",
       headerClassName: "text-center",
-      cellClassName: "text-center font-mono text-xs tabular-nums text-slate-900 dark:text-white",
+      cellClassName:
+        "text-center font-mono text-xs tabular-nums text-slate-900 dark:text-white",
       render: (row) => <RequestLogUsageMetricValue value={row.totalTokens} />,
     },
     {
@@ -523,7 +738,9 @@ export function buildRequestLogsColumns(
       headerClassName: "text-center",
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-400",
-      render: (row) => <RequestLogUsageMetricValue value={row.cost} variant="currency" />,
+      render: (row) => (
+        <RequestLogUsageMetricValue value={row.cost} variant="currency" />
+      ),
     },
     {
       key: "apiKeyName",
@@ -533,13 +750,19 @@ export function buildRequestLogsColumns(
       cellClassName: "text-center",
       render: (row) => (
         <OverflowTooltip
-          content={row.isSystemCall ? t("request_logs.system_call") : row.apiKeyName || "--"}
+          content={
+            row.isSystemCall
+              ? t("request_logs.system_call")
+              : row.apiKeyName || "--"
+          }
           className="block min-w-0"
         >
           <span
             className={`block min-w-0 truncate text-xs font-medium ${row.apiKeyName || row.isSystemCall ? "text-indigo-600 dark:text-indigo-400" : "text-slate-400 dark:text-white/30"}`}
           >
-            {row.isSystemCall ? t("request_logs.system_call") : row.apiKeyName || "--"}
+            {row.isSystemCall
+              ? t("request_logs.system_call")
+              : row.apiKeyName || "--"}
           </span>
         </OverflowTooltip>
       ),
@@ -567,7 +790,8 @@ export function buildRequestLogsColumns(
                 />
               </HoverTooltip>
             ) : null}
-            {row.visionFallbackModel && row.visionFallbackModel !== row.model ? (
+            {row.visionFallbackModel &&
+            row.visionFallbackModel !== row.model ? (
               <HoverTooltip
                 content={`${t("request_logs.vision_fallback_model_id")}\n${row.visionFallbackModel}`}
                 placement="top"
@@ -619,7 +843,8 @@ export function RequestLogsPaginationBar({
         nextPage: t("request_logs.next_page"),
         lastPage: t("request_logs.last_page"),
         rowsPerPage: t("request_logs.rows_per_page"),
-        pageInfo: ({ start, end, total }) => t("request_logs.page_info", { start, end, total }),
+        pageInfo: ({ start, end, total }) =>
+          t("request_logs.page_info", { start, end, total }),
       }}
     />
   );

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -9,8 +9,10 @@ import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Select, type SelectOption } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
+import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 import { LogContentModal } from "@features/log-content-viewer";
+import { ModelTag } from "@features/model-tags";
 import {
   fetchAvailableModels,
   fetchPublicChartData,
@@ -18,7 +20,10 @@ import {
   fetchPublicLogs,
 } from "./api";
 import { LookupEmptyState } from "./components/LookupEmptyState";
-import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
+import {
+  LookupResultsToolbar,
+  type ApiKeyLookupTab,
+} from "./components/LookupResultsToolbar";
 import { ModelsTabContent } from "./components/ModelsTabContent";
 import { PublicLogsSection } from "./components/PublicLogsSection";
 import { QuickImportTabContent } from "./components/QuickImportTabContent";
@@ -29,8 +34,13 @@ import {
   buildRequestLogsColumns,
   formatOptionalRequestLogLatencyMs,
   formatRequestLogLatencyMs,
+  normalizeFilterSelection,
+  toFilterParam,
+  toStatusFilterValues,
   maskRequestLogApiKey,
+  type MultiSelectFilterState,
   type RequestLogsRow,
+  type StatusFilterValue,
 } from "@features/request-log-viewer";
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -43,7 +53,10 @@ const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
 
 const readStoredLookupKey = (): string => {
   try {
-    return window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ?? "";
+    return (
+      window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ??
+      ""
+    );
   } catch {
     return "";
   }
@@ -87,13 +100,17 @@ const readStoredChartCache = (cacheKey: string): ChartDataResponse | null => {
   }
 };
 
-const writeStoredChartCache = (cacheKey: string, data: ChartDataResponse): void => {
+const writeStoredChartCache = (
+  cacheKey: string,
+  data: ChartDataResponse,
+): void => {
   try {
     const raw = window.sessionStorage.getItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
     const parsed: unknown = raw ? JSON.parse(raw) : {};
     const entries = isRecord(parsed)
-      ? Object.entries(parsed).filter((entry): entry is [string, ChartDataResponse] =>
-          isChartDataResponse(entry[1]),
+      ? Object.entries(parsed).filter(
+          (entry): entry is [string, ChartDataResponse] =>
+            isChartDataResponse(entry[1]),
         )
       : [];
     const next: Record<string, ChartDataResponse> = {};
@@ -102,7 +119,10 @@ const writeStoredChartCache = (cacheKey: string, data: ChartDataResponse): void 
     for (const [key, value] of [...keptEntries, cacheEntry].slice(-8)) {
       next[key] = value;
     }
-    window.sessionStorage.setItem(LOOKUP_CHART_CACHE_STORAGE_KEY, JSON.stringify(next));
+    window.sessionStorage.setItem(
+      LOOKUP_CHART_CACHE_STORAGE_KEY,
+      JSON.stringify(next),
+    );
   } catch {
     // ignore storage failures
   }
@@ -120,7 +140,8 @@ const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === "string");
 
 const sameStringArray = (left: string[], right: string[]): boolean =>
-  left.length === right.length && left.every((value, index) => value === right[index]);
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
 
 const readStoredModelsCache = (cacheKey: string): string[] | null => {
   try {
@@ -146,10 +167,16 @@ const writeStoredModelsCache = (cacheKey: string, models: string[]): void => {
       : [];
     const next: Record<string, string[]> = {};
     const keptEntries = entries.filter(([key]) => key !== cacheKey);
-    for (const [key, value] of [...keptEntries, [cacheKey, models] as const].slice(-8)) {
+    for (const [key, value] of [
+      ...keptEntries,
+      [cacheKey, models] as const,
+    ].slice(-8)) {
       next[key] = value;
     }
-    window.sessionStorage.setItem(LOOKUP_MODELS_CACHE_STORAGE_KEY, JSON.stringify(next));
+    window.sessionStorage.setItem(
+      LOOKUP_MODELS_CACHE_STORAGE_KEY,
+      JSON.stringify(next),
+    );
   } catch {
     // ignore storage failures
   }
@@ -207,7 +234,11 @@ const localizeLookupError = (
 const readLegacyLookupKeyFromUrl = (): string => {
   try {
     const url = new URL(window.location.href);
-    return (url.searchParams.get("api_key") || url.searchParams.get("key") || "").trim();
+    return (
+      url.searchParams.get("api_key") ||
+      url.searchParams.get("key") ||
+      ""
+    ).trim();
   } catch {
     return "";
   }
@@ -257,7 +288,10 @@ export function ApiKeyLookupPage() {
     return () => mq.removeEventListener("change", handler);
   }, []);
 
-  const initialLookupKey = useMemo(() => readLegacyLookupKeyFromUrl() || readStoredLookupKey(), []);
+  const initialLookupKey = useMemo(
+    () => readLegacyLookupKeyFromUrl() || readStoredLookupKey(),
+    [],
+  );
   const [apiKeyInput, setApiKeyInput] = useState(initialLookupKey);
   const [queriedKey, setQueriedKey] = useState(initialLookupKey);
   const [apiKeyName, setApiKeyName] = useState("");
@@ -265,14 +299,21 @@ export function ApiKeyLookupPage() {
 
   // ── Content modal state ──
   const [contentModalOpen, setContentModalOpen] = useState(false);
-  const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
-  const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
+  const [contentModalLogId, setContentModalLogId] = useState<number | null>(
+    null,
+  );
+  const [contentModalTab, setContentModalTab] = useState<"input" | "output">(
+    "input",
+  );
 
-  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
-    setContentModalLogId(logId);
-    setContentModalTab(tab);
-    setContentModalOpen(true);
-  }, []);
+  const handleContentClick = useCallback(
+    (logId: number, tab: "input" | "output") => {
+      setContentModalLogId(logId);
+      setContentModalTab(tab);
+      setContentModalOpen(true);
+    },
+    [],
+  );
 
   const logColumns = useMemo(
     () =>
@@ -281,27 +322,6 @@ export function ApiKeyLookupPage() {
       ),
     [t, handleContentClick],
   );
-  const statusOptions = useMemo(
-    () => [
-      {
-        value: "",
-        label: t("apikey_lookup.all_status"),
-        searchText: "all status",
-      },
-      {
-        value: "success",
-        label: t("request_logs.status_success"),
-        searchText: "success",
-      },
-      {
-        value: "failed",
-        label: t("request_logs.status_failed"),
-        searchText: "failed",
-      },
-    ],
-    [t],
-  );
-
   // ── Tab state ──
   const [activeTab, setActiveTab] = useState<ApiKeyLookupTab>("usage");
   const [quickImportReloadToken, setQuickImportReloadToken] = useState(0);
@@ -331,8 +351,12 @@ export function ApiKeyLookupPage() {
 
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
-  const [modelQuery, setModelQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
+  const [selectedModels, setSelectedModels] =
+    useState<MultiSelectFilterState<string>>(null);
+  const [selectedChannels, setSelectedChannels] =
+    useState<MultiSelectFilterState<string>>(null);
+  const [selectedStatuses, setSelectedStatuses] =
+    useState<MultiSelectFilterState<StatusFilterValue>>(null);
 
   // ── Backend stats + filter options ──
   const [stats, setStats] = useState<{
@@ -341,7 +365,92 @@ export function ApiKeyLookupPage() {
     total_tokens: number;
     total_cost: number;
   }>({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
-  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [filterOptions, setFilterOptions] = useState<{
+    models: string[];
+    channels: string[];
+    statuses: string[];
+  }>({ models: [], channels: [], statuses: ["success", "failed"] });
+
+  const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    return filterOptions.models.map((model) => ({
+      value: model,
+      label: <ModelTag id={model} size="sm" />,
+      searchText: model,
+    }));
+  }, [filterOptions.models]);
+
+  const channelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    return filterOptions.channels.map((channel) => ({
+      value: channel,
+      label: channel,
+      searchText: channel,
+    }));
+  }, [filterOptions.channels]);
+
+  const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    const statuses =
+      filterOptions.statuses.length > 0
+        ? filterOptions.statuses
+        : ["success", "failed"];
+    return statuses.map((status) => ({
+      value: status,
+      label:
+        status === "success"
+          ? t("request_logs.status_success")
+          : status === "failed"
+            ? t("request_logs.status_failed")
+            : status,
+      searchText: status,
+    }));
+  }, [filterOptions.statuses, t]);
+
+  const modelFilterValues = useMemo(
+    () => modelOptions.map((option) => option.value),
+    [modelOptions],
+  );
+  const channelFilterValues = useMemo(
+    () => channelOptions.map((option) => option.value),
+    [channelOptions],
+  );
+  const statusFilterValues = useMemo<StatusFilterValue[]>(
+    () => toStatusFilterValues(statusOptions.map((option) => option.value)),
+    [statusOptions],
+  );
+
+  const modelFilterParam = useMemo(
+    () => toFilterParam(selectedModels, modelFilterValues),
+    [modelFilterValues, selectedModels],
+  );
+  const channelFilterParam = useMemo(
+    () => toFilterParam(selectedChannels, channelFilterValues),
+    [channelFilterValues, selectedChannels],
+  );
+  const statusFilterParam = useMemo(
+    () => toFilterParam(selectedStatuses, statusFilterValues),
+    [selectedStatuses, statusFilterValues],
+  );
+
+  const handleModelsChange = useCallback(
+    (value: string[]) => {
+      setSelectedModels(normalizeFilterSelection(value, modelFilterValues));
+    },
+    [modelFilterValues],
+  );
+  const handleChannelsChange = useCallback(
+    (value: string[]) => {
+      setSelectedChannels(normalizeFilterSelection(value, channelFilterValues));
+    },
+    [channelFilterValues],
+  );
+  const handleStatusesChange = useCallback(
+    (value: StatusFilterValue[]) => {
+      setSelectedStatuses(normalizeFilterSelection(value, statusFilterValues));
+    },
+    [statusFilterValues],
+  );
+  const clearModelFilter = useCallback(() => setSelectedModels(null), []);
+  const clearChannelFilter = useCallback(() => setSelectedChannels(null), []);
+  const clearStatusFilter = useCallback(() => setSelectedStatuses(null), []);
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const fetchIdRef = useRef(0);
@@ -373,8 +482,12 @@ export function ApiKeyLookupPage() {
           page,
           size: size ?? pageSize,
           days: timeRange,
-          model: modelQuery || undefined,
-          status: statusFilter || undefined,
+          models: modelFilterParam.values,
+          channels: channelFilterParam.values,
+          statuses: statusFilterParam.values,
+          modelsEmpty: modelFilterParam.matchesNone,
+          channelsEmpty: channelFilterParam.matchesNone,
+          statusesEmpty: statusFilterParam.matchesNone,
           signal: controller.signal,
         });
 
@@ -391,7 +504,11 @@ export function ApiKeyLookupPage() {
             total_cost: 0,
           },
         );
-        setModelOptions(resp.filters?.models ?? []);
+        setFilterOptions({
+          models: resp.filters?.models ?? [],
+          channels: resp.filters?.channels ?? [],
+          statuses: resp.filters?.statuses ?? ["success", "failed"],
+        });
         setLastUpdatedAt(Date.now());
         setQueriedKey(key.trim());
         setApiKeyName(resp.api_key_name?.trim() ?? "");
@@ -401,7 +518,11 @@ export function ApiKeyLookupPage() {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (myFetchId !== fetchIdRef.current) return;
 
-        const message = localizeLookupError(t, err, "apikey_lookup.query_failed");
+        const message = localizeLookupError(
+          t,
+          err,
+          "apikey_lookup.query_failed",
+        );
         setError(message);
         setRawItems([]);
         setTotalCount(0);
@@ -413,7 +534,14 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [t, timeRange, modelQuery, statusFilter, pageSize],
+    [
+      channelFilterParam,
+      modelFilterParam,
+      pageSize,
+      statusFilterParam,
+      t,
+      timeRange,
+    ],
   );
 
   // ================================================================
@@ -452,7 +580,8 @@ export function ApiKeyLookupPage() {
           days,
           signal: controller.signal,
         });
-        if (myFetchId !== chartFetchIdRef.current || controller.signal.aborted) return;
+        if (myFetchId !== chartFetchIdRef.current || controller.signal.aborted)
+          return;
 
         chartCacheRef.current[cacheKey] = data;
         writeStoredChartCache(cacheKey, data);
@@ -463,7 +592,8 @@ export function ApiKeyLookupPage() {
         writeStoredLookupKey(trimmedKey);
         setLoginModalOpen(false);
       } catch (err) {
-        if (controller.signal.aborted || myFetchId !== chartFetchIdRef.current) return;
+        if (controller.signal.aborted || myFetchId !== chartFetchIdRef.current)
+          return;
         if (!cached) {
           setError(localizeLookupError(t, err, "apikey_lookup.query_failed"));
         }
@@ -471,7 +601,10 @@ export function ApiKeyLookupPage() {
         if (chartAbortControllerRef.current === controller) {
           chartAbortControllerRef.current = null;
         }
-        if (myFetchId === chartFetchIdRef.current && !controller.signal.aborted) {
+        if (
+          myFetchId === chartFetchIdRef.current &&
+          !controller.signal.aborted
+        ) {
           setChartLoading(false);
         }
       }
@@ -483,7 +616,10 @@ export function ApiKeyLookupPage() {
   //  Derived rows for VirtualTable
   // ================================================================
 
-  const rows = useMemo<RequestLogsRow[]>(() => rawItems.map((item) => toLogRow(item)), [rawItems]);
+  const rows = useMemo<RequestLogsRow[]>(
+    () => rawItems.map((item) => toLogRow(item)),
+    [rawItems],
+  );
 
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
@@ -515,7 +651,7 @@ export function ApiKeyLookupPage() {
         fetchLogs(queriedKey, 1);
       }
     }
-  }, [timeRange, modelQuery, statusFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [timeRange, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Models fetching ──
   const fetchModelsFn = useCallback(
@@ -525,10 +661,13 @@ export function ApiKeyLookupPage() {
 
       const cached = options?.force
         ? null
-        : modelsCacheRef.current[trimmedKey] || readStoredModelsCache(trimmedKey);
+        : modelsCacheRef.current[trimmedKey] ||
+          readStoredModelsCache(trimmedKey);
       if (cached) {
         modelsCacheRef.current[trimmedKey] = cached;
-        setAvailableModels((prev) => (sameStringArray(prev, cached) ? prev : cached));
+        setAvailableModels((prev) =>
+          sameStringArray(prev, cached) ? prev : cached,
+        );
       }
 
       setModelsLoading(true);
@@ -540,7 +679,9 @@ export function ApiKeyLookupPage() {
         setAvailableModels((prev) => (sameStringArray(prev, ids) ? prev : ids));
       } catch (err: unknown) {
         if (!cached) {
-          setModelsError(localizeLookupError(t, err, "apikey_lookup.load_models_failed"));
+          setModelsError(
+            localizeLookupError(t, err, "apikey_lookup.load_models_failed"),
+          );
         }
       } finally {
         setModelsLoading(false);
@@ -586,8 +727,14 @@ export function ApiKeyLookupPage() {
       event?.preventDefault();
       const val = apiKeyInput.trim();
       if (val) {
-        setModelQuery("");
-        setStatusFilter("");
+        setSelectedModels(null);
+        setSelectedChannels(null);
+        setSelectedStatuses(null);
+        setFilterOptions({
+          models: [],
+          channels: [],
+          statuses: ["success", "failed"],
+        });
         setRawItems([]);
         setCurrentPage(1);
         setApiKeyName("");
@@ -607,7 +754,15 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [apiKeyInput, queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn],
+    [
+      apiKeyInput,
+      queriedKey,
+      activeTab,
+      timeRange,
+      fetchLogs,
+      fetchChartDataFn,
+      fetchModelsFn,
+    ],
   );
 
   const handleApiKeyInputChange = useCallback((value: string) => {
@@ -636,9 +791,14 @@ export function ApiKeyLookupPage() {
     setCurrentPage(1);
     setLastUpdatedAt(null);
     setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
-    setModelOptions([]);
-    setModelQuery("");
-    setStatusFilter("");
+    setFilterOptions({
+      models: [],
+      channels: [],
+      statuses: ["success", "failed"],
+    });
+    setSelectedModels(null);
+    setSelectedChannels(null);
+    setSelectedStatuses(null);
 
     setQueriedKey("");
     setApiKeyName("");
@@ -662,7 +822,14 @@ export function ApiKeyLookupPage() {
         fetchLogs(queriedKey, 1);
       }
     }
-  }, [queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn]);
+  }, [
+    queriedKey,
+    activeTab,
+    timeRange,
+    fetchLogs,
+    fetchChartDataFn,
+    fetchModelsFn,
+  ]);
 
   // Strip legacy sensitive query params from the URL on mount.
   useEffect(() => {
@@ -708,19 +875,6 @@ export function ApiKeyLookupPage() {
     t,
   });
 
-  // ── Model filter options for SearchableSelect ──
-  const modelFilterOptions = useMemo(
-    () => [
-      {
-        value: "",
-        label: t("apikey_lookup.all_models"),
-        searchText: "all models",
-      },
-      ...modelOptions.map((m) => ({ value: m, label: m, searchText: m })),
-    ],
-    [modelOptions, t],
-  );
-
   const lastUpdatedText = useMemo(() => {
     if (!lastUpdatedAt) return "";
     const d = new Date(lastUpdatedAt);
@@ -728,7 +882,8 @@ export function ApiKeyLookupPage() {
     return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
   }, [lastUpdatedAt]);
 
-  const displayName = apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
+  const displayName =
+    apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
   const keyMenuOptions = useMemo<SelectOption[]>(
     () => [
       {
@@ -826,7 +981,9 @@ export function ApiKeyLookupPage() {
                 setModelMetric={setModelMetric}
                 heatmapSeries={heatmapSeries}
                 modelDistributionData={modelDistributionData}
-                modelDistributionOption={modelDistributionOption as Record<string, unknown>}
+                modelDistributionOption={
+                  modelDistributionOption as Record<string, unknown>
+                }
                 modelDistributionLegend={modelDistributionLegend}
                 dailySeries={dailySeries}
                 dailyTrendOption={dailyTrendOption as Record<string, unknown>}
@@ -839,13 +996,18 @@ export function ApiKeyLookupPage() {
             {activeTab === "logs" ? (
               <PublicLogsSection
                 t={t}
-                statusFilter={statusFilter}
-                setStatusFilter={setStatusFilter}
-                statusOptions={statusOptions}
                 modelOptions={modelOptions}
-                modelQuery={modelQuery}
-                setModelQuery={setModelQuery}
-                modelFilterOptions={modelFilterOptions}
+                channelOptions={channelOptions}
+                statusOptions={statusOptions}
+                selectedModels={selectedModels}
+                selectedChannels={selectedChannels}
+                selectedStatuses={selectedStatuses}
+                onModelsChange={handleModelsChange}
+                onChannelsChange={handleChannelsChange}
+                onStatusesChange={handleStatusesChange}
+                onModelsClear={clearModelFilter}
+                onChannelsClear={clearChannelFilter}
+                onStatusesClear={clearStatusFilter}
                 stats={stats}
                 lastUpdatedText={lastUpdatedText}
                 loading={loading}
@@ -874,7 +1036,10 @@ export function ApiKeyLookupPage() {
 
             {activeTab === "quickImport" ? (
               <Reveal>
-                <QuickImportTabContent apiKey={queriedKey} reloadToken={quickImportReloadToken} />
+                <QuickImportTabContent
+                  apiKey={queriedKey}
+                  reloadToken={quickImportReloadToken}
+                />
               </Reveal>
             ) : null}
           </>
@@ -930,7 +1095,11 @@ export function ApiKeyLookupPage() {
           </Button>
         }
       >
-        <form id="apikey-login-form" onSubmit={handleSubmit} className="space-y-2">
+        <form
+          id="apikey-login-form"
+          onSubmit={handleSubmit}
+          className="space-y-2"
+        >
           <label
             htmlFor="apikey-login-input"
             className="block text-sm font-medium text-slate-700 dark:text-white/80"
@@ -946,9 +1115,13 @@ export function ApiKeyLookupPage() {
             autoComplete="off"
             spellCheck={false}
             autoFocus
-            startAdornment={<Search size={16} className="text-slate-400 dark:text-white/40" />}
+            startAdornment={
+              <Search size={16} className="text-slate-400 dark:text-white/40" />
+            }
           />
-          {error ? <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p> : null}
+          {error ? (
+            <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p>
+          ) : null}
         </form>
       </Modal>
     </div>

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -20,10 +20,14 @@ const mocks = vi.hoisted(() => ({
       total_sessions: 0,
       total_cost: 0,
     },
-    filters: { models: [] },
+    filters: { models: [], channels: [], statuses: ["success", "failed"] },
   })),
   fetchPublicChartData: vi.fn(
-    async (_params?: { apiKey: string; days?: number; signal?: AbortSignal }) => ({
+    async (_params?: {
+      apiKey: string;
+      days?: number;
+      signal?: AbortSignal;
+    }) => ({
       daily_series: [],
       heatmap_series: [],
       model_distribution: [],
@@ -42,19 +46,22 @@ const mocks = vi.hoisted(() => ({
 
 type ChartResponse = Awaited<ReturnType<typeof mocks.fetchPublicChartData>>;
 
-const chartResponse = (total: number, apiKeyName = "Primary key"): ChartResponse => ({
-    daily_series: [],
-    heatmap_series: [],
-    model_distribution: [],
-    api_key_name: apiKeyName,
-    stats: {
-      total,
-      success_rate: 100,
-      total_tokens: total * 10,
-      total_sessions: 1,
-      total_cost: 0,
-    },
-  });
+const chartResponse = (
+  total: number,
+  apiKeyName = "Primary key",
+): ChartResponse => ({
+  daily_series: [],
+  heatmap_series: [],
+  model_distribution: [],
+  api_key_name: apiKeyName,
+  stats: {
+    total,
+    success_rate: 100,
+    total_tokens: total * 10,
+    total_sessions: 1,
+    total_cost: 0,
+  },
+});
 
 vi.mock("../api", () => ({
   fetchPublicLogs: mocks.fetchPublicLogs,
@@ -96,7 +103,9 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByRole("dialog", { name: /enter api key/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: /enter api key/i }),
+    ).toBeInTheDocument();
 
     await userEvent.type(
       screen.getByPlaceholderText(/enter api key to lookup usage/i),
@@ -113,7 +122,10 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("restores the last looked up API key after page refresh and shows its name", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
 
     render(
       <ThemeProvider>
@@ -129,12 +141,19 @@ describe("ApiKeyLookupPage", () => {
       );
     });
     expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
-    expect(await screen.findByRole("combobox", { name: /primary key/i })).toBeInTheDocument();
-    expect(screen.queryByRole("dialog", { name: /enter api key/i })).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("combobox", { name: /primary key/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: /enter api key/i }),
+    ).not.toBeInTheDocument();
   });
 
   test("loads public logs only after switching to the request logs tab", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
     const logItem: PublicLogItem = {
       id: 1,
       timestamp: new Date("2026-07-05T03:01:18Z").toISOString(),
@@ -164,7 +183,11 @@ describe("ApiKeyLookupPage", () => {
         total_sessions: 1,
         total_cost: 0.0688,
       },
-      filters: { models: ["gpt-5.5"] },
+      filters: {
+        models: ["gpt-5.5"],
+        channels: ["Codex 主渠道"],
+        statuses: ["success", "failed"],
+      },
     });
 
     render(
@@ -192,11 +215,103 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Codex 主渠道")).toBeInTheDocument();
     expect(screen.queryByText(/key name/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole("columnheader", { name: /^duration$/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: /^duration$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("uses the shared linked request-log filters on the public logs tab", async () => {
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
+    mocks.fetchPublicLogs
+      .mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        size: 50,
+        api_key_name: "Primary key",
+        stats: {
+          total: 0,
+          success_rate: 0,
+          total_tokens: 0,
+          total_sessions: 0,
+          total_cost: 0,
+        },
+        filters: {
+          models: ["gpt-5.5"],
+          channels: ["Codex 主渠道", "OpenCode"],
+          statuses: ["success", "failed"],
+        },
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        total: 0,
+        page: 1,
+        size: 50,
+        api_key_name: "Primary key",
+        stats: {
+          total: 0,
+          success_rate: 0,
+          total_tokens: 0,
+          total_sessions: 0,
+          total_cost: 0,
+        },
+        filters: {
+          models: ["gpt-5.5"],
+          channels: ["Codex 主渠道"],
+          statuses: ["success"],
+        },
+      });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("tab", { name: /request logs/i }),
+    );
+
+    expect(
+      await screen.findByRole("combobox", { name: /filter by model/i }),
+    ).toHaveTextContent(/all models/i);
+    const channelFilter = screen.getByRole("combobox", {
+      name: /filter by channel/i,
+    });
+    expect(channelFilter).toHaveTextContent(/all channels/i);
+    expect(
+      screen.getByRole("combobox", { name: /filter by status/i }),
+    ).toHaveTextContent(/all status/i);
+
+    await userEvent.click(channelFilter);
+    await userEvent.click(
+      await screen.findByRole("option", { name: "OpenCode" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /apply filters/i }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.fetchPublicLogs).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          apiKey: "sk-restored-key",
+          channels: ["Codex 主渠道"],
+          channelsEmpty: false,
+        }),
+      );
+    });
   });
 
   test("keeps cached models visible while refreshing the available models tab", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
     let resolveModelsRefresh: (value: string[]) => void = () => {};
     mocks.fetchAvailableModels
       .mockResolvedValueOnce(["gpt-5.3-codex", "claude-sonnet-4-5"])
@@ -230,7 +345,10 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("does not duplicate the current key in the header menu", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
 
     render(
       <ThemeProvider>
@@ -240,9 +358,13 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: /primary key/i }),
+    );
 
-    expect(screen.queryByRole("option", { name: /primary key/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /primary key/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /logout/i })).toHaveAttribute(
       "aria-selected",
       "false",
@@ -250,7 +372,10 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("logs out from the header menu and asks for the API key again", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
 
     render(
       <ThemeProvider>
@@ -260,15 +385,24 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: /primary key/i }),
+    );
     await userEvent.click(screen.getByRole("option", { name: /logout/i }));
 
-    expect(window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1")).toBeNull();
-    expect(screen.getByRole("dialog", { name: /enter api key/i })).toBeInTheDocument();
+    expect(
+      window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1"),
+    ).toBeNull();
+    expect(
+      screen.getByRole("dialog", { name: /enter api key/i }),
+    ).toBeInTheDocument();
   });
 
   test("shows cached usage data while refreshing chart data", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
     window.sessionStorage.setItem(
       "apiKeyLookup.chartCache.v1",
       JSON.stringify({
@@ -323,12 +457,19 @@ describe("ApiKeyLookupPage", () => {
       },
     });
 
-    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"));
-    expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v1")).toContain('"total":24');
+    await waitFor(() =>
+      expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"),
+    );
+    expect(
+      window.sessionStorage.getItem("apiKeyLookup.chartCache.v1"),
+    ).toContain('"total":24');
   });
 
   test("ignores stale chart responses after rapid time range changes", async () => {
-    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
     const pending: Array<{
       days: number;
       signal?: AbortSignal;
@@ -337,7 +478,11 @@ describe("ApiKeyLookupPage", () => {
     mocks.fetchPublicChartData.mockImplementation(
       (params?: { apiKey: string; days?: number; signal?: AbortSignal }) =>
         new Promise<ChartResponse>((resolve) => {
-          pending.push({ days: params?.days ?? 7, signal: params?.signal, resolve });
+          pending.push({
+            days: params?.days ?? 7,
+            signal: params?.signal,
+            resolve,
+          });
         }),
     );
 
@@ -359,16 +504,22 @@ describe("ApiKeyLookupPage", () => {
     if (!latest) throw new Error("missing latest chart request");
 
     latest.resolve(chartResponse(7, "Range 7"));
-    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("7"));
+    await waitFor(() =>
+      expect(screen.getByTestId("usage-tab")).toHaveTextContent("7"),
+    );
 
     for (const request of pending) {
       if (request !== latest) {
-        request.resolve(chartResponse(request.days * 100, `Range ${request.days}`));
+        request.resolve(
+          chartResponse(request.days * 100, `Range ${request.days}`),
+        );
       }
     }
 
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(screen.getByTestId("usage-tab")).toHaveTextContent("7");
-    expect(pending.some((request) => request.days === 30 && request.signal?.aborted)).toBe(true);
+    expect(
+      pending.some((request) => request.days === 30 && request.signal?.aborted),
+    ).toBe(true);
   });
 });

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -1,4 +1,7 @@
-import { detectApiBaseFromLocation, publicApiClient } from "@code-proxy/api-client";
+import {
+  detectApiBaseFromLocation,
+  publicApiClient,
+} from "@code-proxy/api-client";
 import type { ChartDataResponse, PublicLogsResponse } from "./types";
 
 type LogContentBodyPart = "input" | "output";
@@ -25,7 +28,9 @@ const extractModelIds = (payload: V1ModelsResponse): string[] => {
     new Set(
       data
         .map((item) =>
-          item && typeof item === "object" ? String((item as { id?: unknown }).id) : "",
+          item && typeof item === "object"
+            ? String((item as { id?: unknown }).id)
+            : "",
         )
         .map((value) => value.trim())
         .filter(Boolean),
@@ -38,8 +43,12 @@ export async function fetchPublicLogs(params: {
   page?: number;
   size?: number;
   days?: number;
-  model?: string;
-  status?: string;
+  models?: string[];
+  channels?: string[];
+  statuses?: string[];
+  modelsEmpty?: boolean;
+  channelsEmpty?: boolean;
+  statusesEmpty?: boolean;
   signal?: AbortSignal;
 }): Promise<PublicLogsResponse> {
   return publicApiClient.post<PublicLogsResponse>(
@@ -49,8 +58,12 @@ export async function fetchPublicLogs(params: {
       page: params.page,
       size: params.size,
       days: params.days,
-      model: params.model,
-      status: params.status,
+      models: params.models,
+      channels: params.channels,
+      statuses: params.statuses,
+      models_empty: params.modelsEmpty,
+      channels_empty: params.channelsEmpty,
+      statuses_empty: params.statusesEmpty,
     },
     { signal: params.signal },
   );

--- a/pages/api-key-lookup/components/PublicLogsSection.tsx
+++ b/pages/api-key-lookup/components/PublicLogsSection.tsx
@@ -1,19 +1,30 @@
 import { Filter } from "lucide-react";
 import { Card } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
-import { SearchableSelect } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
-import { RequestLogsPaginationBar, type RequestLogsRow } from "@features/request-log-viewer";
+import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
+import {
+  RequestLogFacetFilters,
+  RequestLogsPaginationBar,
+  type MultiSelectFilterState,
+  type RequestLogsRow,
+  type StatusFilterValue,
+} from "@features/request-log-viewer";
 
 export function PublicLogsSection({
   t,
-  statusFilter,
-  setStatusFilter,
   statusOptions,
   modelOptions,
-  modelQuery,
-  setModelQuery,
-  modelFilterOptions,
+  channelOptions,
+  selectedModels,
+  selectedChannels,
+  selectedStatuses,
+  onModelsChange,
+  onChannelsChange,
+  onStatusesChange,
+  onModelsClear,
+  onChannelsClear,
+  onStatusesClear,
   stats,
   lastUpdatedText,
   loading,
@@ -27,14 +38,24 @@ export function PublicLogsSection({
   onPageSizeChange,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
-  statusFilter: string;
-  setStatusFilter: (value: string) => void;
-  statusOptions: Array<{ value: string; label: string; searchText: string }>;
-  modelOptions: string[];
-  modelQuery: string;
-  setModelQuery: (value: string) => void;
-  modelFilterOptions: Array<{ value: string; label: string; searchText: string }>;
-  stats: { total: number; success_rate: number; total_tokens: number; total_cost: number };
+  modelOptions: SearchableCheckboxMultiSelectOption[];
+  channelOptions: SearchableCheckboxMultiSelectOption[];
+  statusOptions: SearchableCheckboxMultiSelectOption[];
+  selectedModels: MultiSelectFilterState<string>;
+  selectedChannels: MultiSelectFilterState<string>;
+  selectedStatuses: MultiSelectFilterState<StatusFilterValue>;
+  onModelsChange: (value: string[]) => void;
+  onChannelsChange: (value: string[]) => void;
+  onStatusesChange: (value: StatusFilterValue[]) => void;
+  onModelsClear: () => void;
+  onChannelsClear: () => void;
+  onStatusesClear: () => void;
+  stats: {
+    total: number;
+    success_rate: number;
+    total_tokens: number;
+    total_cost: number;
+  };
   lastUpdatedText: string;
   loading: boolean;
   logColumns: DataTableColumn<RequestLogsRow>[];
@@ -52,24 +73,20 @@ export function PublicLogsSection({
         <div className="border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60">
           <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-2">
             <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:gap-2">
-              <SearchableSelect
-                value={statusFilter}
-                onChange={setStatusFilter}
-                options={statusOptions}
-                placeholder={t("apikey_lookup.all_status")}
-                aria-label={t("apikey_lookup.status_filter")}
-                className="w-full sm:w-auto"
+              <RequestLogFacetFilters
+                modelOptions={modelOptions}
+                channelOptions={channelOptions}
+                statusOptions={statusOptions}
+                selectedModels={selectedModels}
+                selectedChannels={selectedChannels}
+                selectedStatuses={selectedStatuses}
+                onModelsChange={onModelsChange}
+                onChannelsChange={onChannelsChange}
+                onStatusesChange={onStatusesChange}
+                onModelsClear={onModelsClear}
+                onChannelsClear={onChannelsClear}
+                onStatusesClear={onStatusesClear}
               />
-              {modelOptions.length > 0 ? (
-                <SearchableSelect
-                  value={modelQuery}
-                  onChange={setModelQuery}
-                  options={modelFilterOptions}
-                  placeholder={t("request_logs.all_models_placeholder")}
-                  aria-label={t("apikey_lookup.model_filter")}
-                  className="w-full sm:w-auto"
-                />
-              ) : null}
             </div>
 
             <div className="hidden sm:block sm:flex-1" />
@@ -83,10 +100,15 @@ export function PublicLogsSection({
               </span>
               <span className="inline-flex items-center justify-end gap-1.5 whitespace-nowrap sm:justify-start">
                 {t("common.success_rate")}
-                <span className="font-mono tabular-nums">{stats.success_rate.toFixed(1)}%</span>
+                <span className="font-mono tabular-nums">
+                  {stats.success_rate.toFixed(1)}%
+                </span>
               </span>
               <span className="hidden sm:inline-flex items-center gap-1.5 whitespace-nowrap">
-                <span className="text-slate-300 dark:text-white/10" aria-hidden="true">
+                <span
+                  className="text-slate-300 dark:text-white/10"
+                  aria-hidden="true"
+                >
                   ·
                 </span>
                 {t("apikey_lookup.token")}
@@ -96,7 +118,10 @@ export function PublicLogsSection({
               </span>
               {lastUpdatedText ? (
                 <span className="hidden sm:inline-flex items-center gap-1.5 whitespace-nowrap">
-                  <span className="text-slate-300 dark:text-white/10" aria-hidden="true">
+                  <span
+                    className="text-slate-300 dark:text-white/10"
+                    aria-hidden="true"
+                  >
                     ·
                   </span>
                   <span className="text-slate-400 dark:text-white/40">

--- a/pages/api-key-lookup/types.ts
+++ b/pages/api-key-lookup/types.ts
@@ -34,6 +34,8 @@ export interface PublicLogsResponse {
   };
   filters: {
     models: string[];
+    channels: string[];
+    statuses: string[];
   };
 }
 

--- a/pages/request-logs/RequestLogsFilters.tsx
+++ b/pages/request-logs/RequestLogsFilters.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from "react-i18next";
-import { useCallback, useMemo } from "react";
 import { RotateCcw } from "lucide-react";
 import { SearchableCheckboxMultiSelect } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import { cn } from "@code-proxy/ui";
-
-type StatusFilterValue = "success" | "failed";
-type MultiSelectFilterState<T extends string = string> = T[] | null;
+import {
+  RequestLogFacetFilters,
+  type MultiSelectFilterState,
+  type StatusFilterValue,
+} from "@features/request-log-viewer";
 
 interface RequestLogsFiltersProps {
   keyOptions: SearchableCheckboxMultiSelectOption[];
@@ -51,14 +52,6 @@ export function RequestLogsFilters({
 }: RequestLogsFiltersProps) {
   const { t } = useTranslation();
 
-  const statusChangeAdapter = useMemo(
-    () => (value: string[]) => onStatusesChange(value as StatusFilterValue[]),
-    [onStatusesChange],
-  );
-  const statusClearAdapter = useCallback(() => {
-    onStatusesClear();
-  }, [onStatusesClear]);
-
   return (
     <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800/60">
       <div className="flex flex-wrap items-center gap-2">
@@ -71,7 +64,9 @@ export function RequestLogsFilters({
             searchPlaceholder={t("request_logs.search_keys")}
             selectFilteredLabel={t("request_logs.select_filtered")}
             deselectFilteredLabel={t("request_logs.deselect_filtered")}
-            selectedCountLabel={(count: number) => t("request_logs.selected_count", { count })}
+            selectedCountLabel={(count: number) =>
+              t("request_logs.selected_count", { count })
+            }
             noResultsLabel={t("request_logs.no_filter_results")}
             aria-label={t("request_logs.filter_key")}
             clearLabel={t("request_logs.clear_key_filter")}
@@ -89,87 +84,20 @@ export function RequestLogsFilters({
             emptySelectionLabel={t("request_logs.none_selected")}
           />
         </div>
-        <div className="w-full min-[480px]:w-auto sm:w-[200px]">
-          <SearchableCheckboxMultiSelect
-            value={selectedModels ?? []}
-            onChange={onModelsChange}
-            options={modelOptions}
-            placeholder={t("request_logs.all_models_placeholder")}
-            searchPlaceholder={t("request_logs.search_models")}
-            selectFilteredLabel={t("request_logs.select_filtered")}
-            deselectFilteredLabel={t("request_logs.deselect_filtered")}
-            selectedCountLabel={(count: number) => t("request_logs.selected_count", { count })}
-            noResultsLabel={t("request_logs.no_filter_results")}
-            aria-label={t("request_logs.filter_model")}
-            clearLabel={t("request_logs.clear_model_filter")}
-            onClear={onModelsClear}
-            showClearButton
-            size="sm"
-            emptyValueMeansAllSelected
-            emptyValueRepresentsAllSelected={selectedModels === null}
-            showFilteredToggleWithoutQuery={false}
-            applyMode="manual"
-            applyLabel={t("request_logs.apply_filters")}
-            cancelLabel={t("common.cancel")}
-            selectAllLabel={t("request_logs.select_all")}
-            deselectAllLabel={t("request_logs.deselect_all")}
-            emptySelectionLabel={t("request_logs.none_selected")}
-          />
-        </div>
-        <div className="w-full min-[480px]:w-auto sm:w-[180px]">
-          <SearchableCheckboxMultiSelect
-            value={selectedChannels ?? []}
-            onChange={onChannelsChange}
-            options={channelOptions}
-            placeholder={t("request_logs.all_channels_placeholder")}
-            searchPlaceholder={t("request_logs.search_channels")}
-            selectFilteredLabel={t("request_logs.select_filtered")}
-            deselectFilteredLabel={t("request_logs.deselect_filtered")}
-            selectedCountLabel={(count: number) => t("request_logs.selected_count", { count })}
-            noResultsLabel={t("request_logs.no_filter_results")}
-            aria-label={t("request_logs.filter_channel")}
-            clearLabel={t("request_logs.clear_channel_filter")}
-            onClear={onChannelsClear}
-            showClearButton
-            size="sm"
-            emptyValueMeansAllSelected
-            emptyValueRepresentsAllSelected={selectedChannels === null}
-            showFilteredToggleWithoutQuery={false}
-            applyMode="manual"
-            applyLabel={t("request_logs.apply_filters")}
-            cancelLabel={t("common.cancel")}
-            selectAllLabel={t("request_logs.select_all")}
-            deselectAllLabel={t("request_logs.deselect_all")}
-            emptySelectionLabel={t("request_logs.none_selected")}
-          />
-        </div>
-        <div className="w-full min-[480px]:w-auto sm:w-[150px]">
-          <SearchableCheckboxMultiSelect
-            value={selectedStatuses ?? []}
-            onChange={statusChangeAdapter}
-            options={statusOptions}
-            placeholder={t("request_logs.all_status")}
-            searchPlaceholder=""
-            selectFilteredLabel={t("request_logs.select_filtered")}
-            deselectFilteredLabel={t("request_logs.deselect_filtered")}
-            selectedCountLabel={(count: number) => `${count}`}
-            noResultsLabel={t("request_logs.no_filter_results")}
-            aria-label={t("request_logs.filter_status")}
-            clearLabel={t("request_logs.clear_status_filter")}
-            onClear={statusClearAdapter}
-            showClearButton
-            size="sm"
-            emptyValueMeansAllSelected
-            emptyValueRepresentsAllSelected={selectedStatuses === null}
-            showFilteredToggleWithoutQuery={false}
-            applyMode="manual"
-            applyLabel={t("request_logs.apply_filters")}
-            cancelLabel={t("common.cancel")}
-            selectAllLabel={t("request_logs.select_all")}
-            deselectAllLabel={t("request_logs.deselect_all")}
-            emptySelectionLabel={t("request_logs.none_selected")}
-          />
-        </div>
+        <RequestLogFacetFilters
+          modelOptions={modelOptions}
+          channelOptions={channelOptions}
+          statusOptions={statusOptions}
+          selectedModels={selectedModels}
+          selectedChannels={selectedChannels}
+          selectedStatuses={selectedStatuses}
+          onModelsChange={onModelsChange}
+          onChannelsChange={onChannelsChange}
+          onStatusesChange={onStatusesChange}
+          onModelsClear={onModelsClear}
+          onChannelsClear={onChannelsClear}
+          onStatusesClear={onStatusesClear}
+        />
 
         {/* Reset filters button */}
         {hasActiveFilters ? (

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -19,7 +19,10 @@ import { HoverTooltip } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { DataTable } from "@code-proxy/ui";
-import { ErrorDetailModal, LogContentModal } from "@features/log-content-viewer";
+import {
+  ErrorDetailModal,
+  LogContentModal,
+} from "@features/log-content-viewer";
 import { ModelTag } from "@features/model-tags";
 import { RequestLogsFilters } from "./RequestLogsFilters";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
@@ -27,15 +30,19 @@ import {
   buildRequestLogKeyOptions,
   buildRequestLogsColumns,
   DEFAULT_REQUEST_LOG_PAGE_SIZE,
+  hasActiveFilterSelection,
+  normalizeFilterSelection,
   RequestLogUsageMetricValue,
   RequestLogsPaginationBar,
   RequestLogsTimeRangeSelector,
+  toFilterParam,
   toRequestLogsRow,
+  toStatusFilterValues,
+  type MultiSelectFilterState,
+  type StatusFilterValue,
   type RequestLogsRow as LogRow,
   type TimeRange,
 } from "@features/request-log-viewer";
-type StatusFilterValue = "success" | "failed";
-type MultiSelectFilterState<T extends string = string> = T[] | null;
 
 const DEFAULT_LOG_STATS = {
   total: 0,
@@ -51,7 +58,8 @@ const DEFAULT_CLEAR_OPTIONS: ClearUsageLogsPayload = {
 };
 
 const isRequestCancelled = (err: unknown, signal?: AbortSignal) =>
-  signal?.aborted || (err instanceof Error && err.message === "Request was cancelled");
+  signal?.aborted ||
+  (err instanceof Error && err.message === "Request was cancelled");
 
 function RequestLogsRecordsCount({ count }: { count: number }) {
   const { t } = useTranslation();
@@ -73,38 +81,6 @@ function RequestLogsRecordsCount({ count }: { count: number }) {
   );
 }
 
-function normalizeFilterSelection<T extends string>(
-  selected: MultiSelectFilterState<T>,
-  allowedValues: T[],
-): MultiSelectFilterState<T> {
-  if (selected === null) return null;
-  if (allowedValues.length === 0) return [];
-  const allowed = new Set(allowedValues);
-  const normalized = selected.filter(
-    (item, index) => allowed.has(item) && selected.indexOf(item) === index,
-  );
-  if (normalized.length === allowedValues.length) return null;
-  return normalized;
-}
-
-function toFilterParam<T extends string>(
-  selected: MultiSelectFilterState<T>,
-  allowedValues: T[],
-): { values?: T[]; matchesNone: boolean } {
-  const normalized = normalizeFilterSelection(selected, allowedValues);
-  if (normalized === null) return { values: undefined, matchesNone: false };
-  if (normalized.length === 0) return { values: undefined, matchesNone: true };
-  return { values: normalized, matchesNone: false };
-}
-
-function hasActiveFilterSelection<T extends string>(
-  selected: MultiSelectFilterState<T>,
-  allowedValues: T[],
-): boolean {
-  const normalized = normalizeFilterSelection(selected, allowedValues);
-  return normalized !== null;
-}
-
 // ---------------------------------------------------------------------------
 // Main page
 // ---------------------------------------------------------------------------
@@ -115,14 +91,21 @@ export function RequestLogsPage() {
 
   // Content modal state
   const [contentModalOpen, setContentModalOpen] = useState(false);
-  const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
-  const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
+  const [contentModalLogId, setContentModalLogId] = useState<number | null>(
+    null,
+  );
+  const [contentModalTab, setContentModalTab] = useState<"input" | "output">(
+    "input",
+  );
 
-  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
-    setContentModalLogId(logId);
-    setContentModalTab(tab);
-    setContentModalOpen(true);
-  }, []);
+  const handleContentClick = useCallback(
+    (logId: number, tab: "input" | "output") => {
+      setContentModalLogId(logId);
+      setContentModalTab(tab);
+      setContentModalOpen(true);
+    },
+    [],
+  );
 
   // Error modal state
   const [errorModalOpen, setErrorModalOpen] = useState(false);
@@ -174,14 +157,19 @@ export function RequestLogsPage() {
 
   // Multi-value filters
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
-  const [selectedApiKeys, setSelectedApiKeys] = useState<MultiSelectFilterState<string>>(null);
-  const [selectedModels, setSelectedModels] = useState<MultiSelectFilterState<string>>(null);
-  const [selectedChannels, setSelectedChannels] = useState<MultiSelectFilterState<string>>(null);
+  const [selectedApiKeys, setSelectedApiKeys] =
+    useState<MultiSelectFilterState<string>>(null);
+  const [selectedModels, setSelectedModels] =
+    useState<MultiSelectFilterState<string>>(null);
+  const [selectedChannels, setSelectedChannels] =
+    useState<MultiSelectFilterState<string>>(null);
   const [selectedStatuses, setSelectedStatuses] =
     useState<MultiSelectFilterState<StatusFilterValue>>(null);
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
   const [clearingLogs, setClearingLogs] = useState(false);
-  const [clearOptions, setClearOptions] = useState<ClearUsageLogsPayload>(DEFAULT_CLEAR_OPTIONS);
+  const [clearOptions, setClearOptions] = useState<ClearUsageLogsPayload>(
+    DEFAULT_CLEAR_OPTIONS,
+  );
 
   const requestSeqRef = useRef(0);
   const requestAbortRef = useRef<AbortController | null>(null);
@@ -234,7 +222,10 @@ export function RequestLogsPage() {
     }));
   }, [filterOptions.statuses, t]);
 
-  const apiKeyFilterValues = useMemo(() => keyOptions.map((option) => option.value), [keyOptions]);
+  const apiKeyFilterValues = useMemo(
+    () => keyOptions.map((option) => option.value),
+    [keyOptions],
+  );
   const modelFilterValues = useMemo(
     () => modelOptions.map((option) => option.value),
     [modelOptions],
@@ -244,7 +235,7 @@ export function RequestLogsPage() {
     [channelOptions],
   );
   const statusFilterValues = useMemo<StatusFilterValue[]>(
-    () => statusOptions.map((option) => option.value as StatusFilterValue),
+    () => toStatusFilterValues(statusOptions.map((option) => option.value)),
     [statusOptions],
   );
 
@@ -360,12 +351,19 @@ export function RequestLogsPage() {
           ...resp.stats,
         });
       } catch (err) {
-        if (seq !== requestSeqRef.current || isRequestCancelled(err, controller.signal)) return;
-        const message = err instanceof Error ? err.message : t("request_logs.refresh_failed");
+        if (
+          seq !== requestSeqRef.current ||
+          isRequestCancelled(err, controller.signal)
+        )
+          return;
+        const message =
+          err instanceof Error ? err.message : t("request_logs.refresh_failed");
         notify({ type: "error", message });
       } finally {
-        if (requestAbortRef.current === controller) requestAbortRef.current = null;
-        if (seq === requestSeqRef.current && !controller.signal.aborted) setLoading(false);
+        if (requestAbortRef.current === controller)
+          requestAbortRef.current = null;
+        if (seq === requestSeqRef.current && !controller.signal.aborted)
+          setLoading(false);
       }
     },
     [
@@ -407,7 +405,13 @@ export function RequestLogsPage() {
   // Fetch page 1 when filters change
   useEffect(() => {
     fetchLogs(1, pageSize);
-  }, [timeRange, selectedApiKeys, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
+    timeRange,
+    selectedApiKeys,
+    selectedModels,
+    selectedChannels,
+    selectedStatuses,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleOpenClearDialog = useCallback(() => {
     setClearOptions(DEFAULT_CLEAR_OPTIONS);
@@ -466,7 +470,9 @@ export function RequestLogsPage() {
       setConfirmClearOpen(false);
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : t("request_logs.clear_database_logs_failed");
+        err instanceof Error
+          ? err.message
+          : t("request_logs.clear_database_logs_failed");
       notify({ type: "error", message });
     } finally {
       setClearingLogs(false);
@@ -483,7 +489,11 @@ export function RequestLogsPage() {
         <div className="flex flex-wrap items-center justify-between gap-3 px-5 pt-5 pb-3">
           <div className="flex flex-wrap items-center gap-3">
             <h2 className="flex items-center gap-2 text-base font-semibold text-slate-900 dark:text-white">
-              <ScrollText size={18} className="text-slate-900 dark:text-white" aria-hidden="true" />
+              <ScrollText
+                size={18}
+                className="text-slate-900 dark:text-white"
+                aria-hidden="true"
+              />
               {t("request_logs.heading")}
             </h2>
             <div className="hidden min-[640px]:flex items-center gap-2 text-xs text-slate-500 dark:text-white/50">
@@ -500,14 +510,21 @@ export function RequestLogsPage() {
               <span>
                 {t("request_logs.col_total_token")}{" "}
                 <span className="font-mono tabular-nums text-slate-900 dark:text-white">
-                  <RequestLogUsageMetricValue value={stats.total_tokens} compact />
+                  <RequestLogUsageMetricValue
+                    value={stats.total_tokens}
+                    compact
+                  />
                 </span>
               </span>
               <span className="text-slate-300 dark:text-white/15">|</span>
               <span>
                 {t("request_logs.col_cost")}{" "}
                 <span className="font-mono tabular-nums text-emerald-700 dark:text-emerald-400">
-                  <RequestLogUsageMetricValue value={stats.total_cost} variant="currency" compact />
+                  <RequestLogUsageMetricValue
+                    value={stats.total_cost}
+                    variant="currency"
+                    compact
+                  />
                 </span>
               </span>
               <span className="text-slate-300 dark:text-white/15">|</span>
@@ -520,7 +537,10 @@ export function RequestLogsPage() {
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <RequestLogsTimeRangeSelector value={timeRange} onChange={setTimeRange} />
+            <RequestLogsTimeRangeSelector
+              value={timeRange}
+              onChange={setTimeRange}
+            />
             <button
               type="button"
               onClick={handleOpenClearDialog}
@@ -542,7 +562,11 @@ export function RequestLogsPage() {
             >
               <RefreshCw
                 size={14}
-                className={loading ? "motion-reduce:animate-none motion-safe:animate-spin" : ""}
+                className={
+                  loading
+                    ? "motion-reduce:animate-none motion-safe:animate-spin"
+                    : ""
+                }
                 aria-hidden="true"
               />
             </button>


### PR DESCRIPTION
## Summary
- reuse the request log model/channel/status filter controls on API key lookup logs
- keep filter parameters and empty-selection behavior consistent across both pages
- add API key lookup coverage for shared filters and channel requests

## Validation
- rtk bun run --filter @code-proxy/admin-panel test:ci -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run build
- Playwright visual check: output/playwright/apikey-lookup-filters.png