### PR TITLE
fix: align admin headers and scrollbars

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -30,7 +30,7 @@ import {
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
-import { LanguageSelector, PageBackground, ThemeToggleButton } from "@code-proxy/ui";
+import { LanguageSelector, PageBackground, ScrollArea, ThemeToggleButton } from "@code-proxy/ui";
 import { preloadPageRoute } from "@pages/registry";
 
 interface ShellContextState {
@@ -254,34 +254,40 @@ function ShellSidebar({
             </span>
           </span>
         </div>
-        <nav className="flex-1 space-y-1 overflow-y-auto px-3 pb-4 pt-4">
-          {NAV_ITEMS.map((item) => {
-            const Icon = item.icon;
-            const active = activeTo === item.to;
-            return (
-              <Link
-                key={item.to}
-                to={item.to}
-                viewTransition
-                onClick={(event) => handleNavClick(event, item.to)}
-                onMouseEnter={() => warmPageRoute(item.to)}
-                onFocus={() => warmPageRoute(item.to)}
-                className={
-                  "flex min-w-0 items-center gap-3 rounded-[14px] px-3.5 py-2.5 text-[13px] transition-colors duration-200 ease-out whitespace-nowrap " +
-                  (active
-                    ? "bg-gradient-to-r from-blue-600 to-blue-500 font-semibold text-white shadow-[0_12px_24px_rgba(37,99,235,0.22)]"
-                    : "font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white")
-                }
-              >
-                <Icon
-                  size={15}
-                  className="shrink-0 opacity-90 transition-colors duration-200 ease-out"
-                />
-                <span className="min-w-0 truncate">{t(item.i18nKey)}</span>
-              </Link>
-            );
-          })}
-        </nav>
+        <ScrollArea
+          className="flex-1 [&_[data-scroll-area-scrollbar='y']]:right-1"
+          scrollbarVisibility="always"
+          scrollbarTrackInset={16}
+        >
+          <nav className="space-y-1 px-3 pb-4 pt-4">
+            {NAV_ITEMS.map((item) => {
+              const Icon = item.icon;
+              const active = activeTo === item.to;
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  viewTransition
+                  onClick={(event) => handleNavClick(event, item.to)}
+                  onMouseEnter={() => warmPageRoute(item.to)}
+                  onFocus={() => warmPageRoute(item.to)}
+                  className={
+                    "flex min-w-0 items-center gap-3 rounded-[14px] px-3.5 py-2.5 text-[13px] transition-colors duration-200 ease-out whitespace-nowrap " +
+                    (active
+                      ? "bg-gradient-to-r from-blue-600 to-blue-500 font-semibold text-white shadow-[0_12px_24px_rgba(37,99,235,0.22)]"
+                      : "font-medium text-slate-700 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white")
+                  }
+                >
+                  <Icon
+                    size={15}
+                    className="shrink-0 opacity-90 transition-colors duration-200 ease-out"
+                  />
+                  <span className="min-w-0 truncate">{t(item.i18nKey)}</span>
+                </Link>
+              );
+            })}
+          </nav>
+        </ScrollArea>
         <div className="space-y-3 px-3 pb-4">
           <div className="flex items-center gap-3 rounded-[18px] bg-slate-50/80 p-3 dark:bg-white/[0.04]">
             <div className="grid h-10 w-10 place-items-center rounded-[14px] bg-gradient-to-br from-blue-600 to-sky-500 text-white shadow-[0_10px_22px_rgba(37,99,235,0.2)]">
@@ -333,7 +339,7 @@ function ShellHeader({
   return (
     <header className="z-20 shrink-0 border-b border-slate-200 bg-white/75 backdrop-blur-xl motion-reduce:transition-none motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:border-neutral-800 dark:bg-neutral-950/60">
       <h1 className="sr-only">{t(titleKey)}</h1>
-      <div className="flex h-16 items-center justify-between gap-3 px-3 sm:px-6">
+      <div className="flex h-14 items-center justify-between gap-3 px-3 sm:px-6">
         <div className="flex min-w-0 items-center gap-2 sm:gap-3">
           <button
             type="button"

--- a/packages/ui/src/primitives/ScrollArea.tsx
+++ b/packages/ui/src/primitives/ScrollArea.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type HTMLAttributes,
+  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type PropsWithChildren,
 } from "react";
@@ -33,6 +34,7 @@ export function ScrollArea({
   children,
   className,
   viewportClassName,
+  viewportStyle,
   contentClassName,
   scrollbarVisibility = "hover",
   scrollbarTrackInset = 8,
@@ -40,6 +42,7 @@ export function ScrollArea({
 }: PropsWithChildren<
   {
     viewportClassName?: string;
+    viewportStyle?: CSSProperties;
     contentClassName?: string;
     scrollbarVisibility?: ScrollbarVisibility;
     scrollbarTrackInset?: number;
@@ -172,6 +175,7 @@ export function ScrollArea({
         data-scroll-area-viewport
         data-scrollbar-visibility={scrollbarVisibility}
         onScroll={handleScroll}
+        style={viewportStyle}
         className={cn(
           "h-full min-h-0 table-scrollbar overflow-auto overscroll-contain",
           viewportClassName,

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -27,6 +27,7 @@ import {
   selectTriggerDisabled,
 } from "../utils/selectStyles";
 import type { ControlSize } from "../utils/controlStyles";
+import { ScrollArea } from "./ScrollArea";
 
 export interface SearchableCheckboxMultiSelectOption {
   value: string;
@@ -109,6 +110,7 @@ export function SearchableCheckboxMultiSelect({
   const searchRef = useRef<HTMLInputElement | null>(null);
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
   const [dropdownPlacement, setDropdownPlacement] = useState<"bottom" | "top">("bottom");
+  const [listMaxHeight, setListMaxHeight] = useState(224);
 
   const manualApply = applyMode === "manual";
   const committedEmptyMeansAllSelected =
@@ -196,6 +198,11 @@ export function SearchableCheckboxMultiSelect({
     const rect = trigger.getBoundingClientRect();
     const gap = 6;
     const maxHeight = 360;
+    const listChromeHeight = manualApply ? 132 : 84;
+    const setPanelMaxHeight = (height: number) => {
+      setListMaxHeight(Math.max(96, height - listChromeHeight));
+      return height;
+    };
 
     const isNarrow = window.innerWidth < mobileBreakpoint;
     if (isNarrow) {
@@ -205,25 +212,27 @@ export function SearchableCheckboxMultiSelect({
       const openAbove = spaceBelow < maxHeightMobile && spaceAbove > spaceBelow;
 
       if (openAbove) {
+        const panelMaxHeight = setPanelMaxHeight(Math.min(maxHeightMobile, spaceAbove));
         setDropdownPlacement("top");
         setDropdownStyle({
           position: "fixed",
           left: 12,
           right: 12,
           width: "auto",
-          maxHeight: Math.min(maxHeightMobile, spaceAbove),
+          maxHeight: panelMaxHeight,
           bottom: window.innerHeight - rect.top + gap,
           zIndex: 99999,
         });
         return;
       }
+      const panelMaxHeight = setPanelMaxHeight(Math.min(maxHeightMobile, spaceBelow));
       setDropdownPlacement("bottom");
       setDropdownStyle({
         position: "fixed",
         left: 12,
         right: 12,
         width: "auto",
-        maxHeight: Math.min(maxHeightMobile, spaceBelow),
+        maxHeight: panelMaxHeight,
         top: Math.min(rect.bottom + gap, window.innerHeight - maxHeightMobile - 12),
         zIndex: 99999,
       });
@@ -235,28 +244,30 @@ export function SearchableCheckboxMultiSelect({
     const openAbove = spaceBelow < maxHeight && spaceAbove > spaceBelow;
 
     if (openAbove) {
+      const panelMaxHeight = setPanelMaxHeight(Math.min(maxHeight, spaceAbove));
       setDropdownPlacement("top");
       setDropdownStyle({
         position: "fixed",
         bottom: window.innerHeight - rect.top + gap,
         left: rect.left,
         width: Math.max(rect.width, 260),
-        maxHeight: Math.min(maxHeight, spaceAbove),
+        maxHeight: panelMaxHeight,
         zIndex: 99999,
       });
       return;
     }
 
+    const panelMaxHeight = setPanelMaxHeight(Math.min(maxHeight, spaceBelow));
     setDropdownPlacement("bottom");
     setDropdownStyle({
       position: "fixed",
       top: rect.bottom + gap,
       left: rect.left,
       width: Math.max(rect.width, 260),
-      maxHeight: Math.min(maxHeight, spaceBelow),
+      maxHeight: panelMaxHeight,
       zIndex: 99999,
     });
-  }, [mobileBreakpoint]);
+  }, [manualApply, mobileBreakpoint]);
 
   useEffect(() => {
     if (!open) return;
@@ -545,10 +556,15 @@ export function SearchableCheckboxMultiSelect({
                   </div>
                 </div>
               ) : null}
-              <div
+              <ScrollArea
                 role="listbox"
                 aria-label={ariaLabel}
-                className="min-h-0 flex-1 overflow-y-auto p-1"
+                className="min-h-0 flex-1 [&_[data-scroll-area-scrollbar='y']]:right-1"
+                viewportClassName="!h-auto"
+                viewportStyle={{ maxHeight: listMaxHeight }}
+                contentClassName="p-1"
+                scrollbarVisibility="always"
+                scrollbarTrackInset={4}
               >
                 {filteredOptions.length === 0 ? (
                   <div className={selectEmptyState}>{noResultsLabel}</div>
@@ -583,7 +599,7 @@ export function SearchableCheckboxMultiSelect({
                     );
                   })
                 )}
-              </div>
+              </ScrollArea>
               {manualApply ? (
                 <div className="flex items-center justify-end gap-2 border-t border-slate-100 px-3 py-2 dark:border-neutral-800">
                   <button

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -913,9 +913,9 @@ export function ApiKeyLookupPage() {
   // ================================================================
 
   return (
-    <div className="relative min-h-dvh bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
+    <div className="relative min-h-dvh bg-gradient-to-br from-slate-50 via-white to-slate-100 pt-14 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
       {/* Header */}
-      <header className="sticky top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70">
+      <header className="fixed inset-x-0 top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70">
         <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-4 sm:px-6">
           <div className="flex items-center gap-2.5">
             <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-slate-900 shadow-sm dark:bg-white">


### PR DESCRIPTION
## Summary
- fix the public API key lookup header to stay pinned at the top
- align the admin shell header height with the API key lookup header
- use the shared custom scroll area for request-log side/filter overflow scrolling

## Verification
- rtk bun run --filter @code-proxy/admin-panel test src/app/layout/AppShell.test.tsx ../../pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx ../../pages/request-logs/__tests__/RequestLogsPage.test.tsx
- rtk bun run build
- Playwright local render check for apikey lookup fixed header and request logs scrollbars