### PR TITLE
fix: hide sidebar scrollbar until track hover

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -256,7 +256,7 @@ function ShellSidebar({
         </div>
         <ScrollArea
           className="flex-1 [&_[data-scroll-area-scrollbar='y']]:right-1"
-          scrollbarVisibility="always"
+          scrollbarVisibility="track-hover"
           scrollbarTrackInset={16}
         >
           <nav className="space-y-1 px-3 pb-4 pt-4">

--- a/packages/ui/src/primitives/ScrollArea.tsx
+++ b/packages/ui/src/primitives/ScrollArea.tsx
@@ -10,7 +10,7 @@ import {
   type PropsWithChildren,
 } from "react";
 
-type ScrollbarVisibility = "hover" | "always";
+type ScrollbarVisibility = "hover" | "track-hover" | "always";
 
 type ScrollMetrics = {
   clientHeight: number;
@@ -161,6 +161,8 @@ export function ScrollArea({
   const visibilityClasses =
     scrollbarVisibility === "always"
       ? "opacity-100"
+      : scrollbarVisibility === "track-hover"
+        ? "opacity-0 transition-opacity hover:opacity-100 group-focus-within:opacity-100"
       : "opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100";
 
   return (


### PR DESCRIPTION
## Summary
- add a track-hover scrollbar visibility mode to the shared ScrollArea
- use it for the admin sidebar so the scrollbar does not show while hovering menu items

## Verification
- rtk bun run --filter @code-proxy/admin-panel test src/app/layout/AppShell.test.tsx
- rtk bun run build
- Playwright local render check: sidebar scrollbar opacity stays 0 away/on menu item and becomes 1 on scrollbar track