### PR TITLE
fix: hide quick import copy action until hover

### DIFF
--- a/e2e/api-key-lookup.spec.ts
+++ b/e2e/api-key-lookup.spec.ts
@@ -284,8 +284,12 @@ test("API Key Lookup: Quick Import copy button surfaces the ccswitch link via cl
   // tooltip/title string. The card body's accessible name is the provider
   // name, so the copy button is uniquely identified by the copy label.
   const copyButton = page.getByRole("button", { name: /Copy import link|复制导入链接/i });
-  await expect(copyButton).toBeVisible();
-  await copyButton.first().click();
+  const firstCopyButton = copyButton.first();
+  const firstCopyAction = firstCopyButton.locator("xpath=..");
+  await expect(firstCopyAction).toHaveCSS("opacity", "0");
+  await cardButton.hover();
+  await expect(firstCopyAction).toHaveCSS("opacity", "1");
+  await firstCopyButton.click();
 
   // The copy button flips to a "copied" state immediately, then resets after
   // ~1.8s. We assert the pressed-state visual: the title becomes

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -252,7 +252,7 @@ function QuickImportCard({
           </span>
         </span>
       </button>
-      <div className="relative z-10 flex items-start gap-1 p-3 pl-0 opacity-70 transition-opacity group-hover/card:opacity-100 focus-within:opacity-100">
+      <div className="pointer-events-none relative z-10 flex items-start gap-1 p-3 pl-0 opacity-0 transition-opacity group-hover/card:pointer-events-auto group-hover/card:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
         <Button
           variant="ghost"
           size="xs"


### PR DESCRIPTION
## Summary
- hide the Quick Import copy action until its card is hovered or focused
- keep the copy action disabled while visually hidden
- cover the hover-only behavior in the API key lookup e2e test

## Verification
- bun run --filter @code-proxy/admin-panel test -- pages/api-key-lookup/components/__tests__/QuickImportTabContent.test.tsx
- bunx playwright test e2e/api-key-lookup.spec.ts -g "Quick Import copy button"
- bun run build