### PR TITLE
fix: refine sidebar scrollbar visibility

### DIFF
--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -75,6 +75,7 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   page,
 }) => {
   await setAuthed(page);
+  await page.setViewportSize({ width: 1280, height: 520 });
 
   await page.route("**/v0/management/config", async (route) => {
     await route.fulfill({
@@ -100,10 +101,26 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   const linkWhiteSpace = await dashboardLink.evaluate((el) => getComputedStyle(el).whiteSpace);
   expect(linkWhiteSpace).toBe("nowrap");
 
+  const aside = page.locator("aside");
+  const sidebarScrollbar = aside.locator("[data-scroll-area-scrollbar='y']");
+  await expect(sidebarScrollbar).toHaveCount(1);
+  await expect
+    .poll(async () => Number(await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity)))
+    .toBeLessThan(0.05);
+
+  await dashboardLink.hover();
+  await expect
+    .poll(async () => Number(await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity)))
+    .toBeGreaterThan(0.95);
+
+  await page.mouse.move(760, 120);
+  await expect
+    .poll(async () => Number(await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity)))
+    .toBeLessThan(0.05);
+
   await page.getByRole("button", { name: /Collapse Sidebar|收起侧边栏/i }).click();
   await expect(page.getByRole("button", { name: /Expand Sidebar|展开侧边栏/i })).toBeVisible();
 
-  const aside = page.locator("aside");
   await expect
     .poll(async () => {
       return await aside.evaluate((el) => el.getBoundingClientRect().width);
@@ -194,7 +211,7 @@ test("API Keys: table should scroll vertically when many keys are listed", async
 
   await page.goto("/#/api-keys");
 
-  const tableScroller = page.locator(".table-scrollbar");
+  const tableScroller = page.locator("[data-vt-scroll-content]").locator("xpath=..");
   await expect(tableScroller).toBeVisible();
 
   await expect

--- a/packages/ui/src/primitives/ScrollArea.tsx
+++ b/packages/ui/src/primitives/ScrollArea.tsx
@@ -38,6 +38,7 @@ export function ScrollArea({
   contentClassName,
   scrollbarVisibility = "hover",
   scrollbarTrackInset = 8,
+  onPointerLeave,
   ...divProps
 }: PropsWithChildren<
   {
@@ -58,6 +59,13 @@ export function ScrollArea({
     scrollHeight: 0,
     scrollTop: 0,
   });
+
+  const clearScrollHideTimer = useCallback(() => {
+    if (scrollHideTimerRef.current !== null) {
+      window.clearTimeout(scrollHideTimerRef.current);
+      scrollHideTimerRef.current = null;
+    }
+  }, []);
 
   const measure = useCallback(() => {
     const viewport = viewportRef.current;
@@ -93,12 +101,8 @@ export function ScrollArea({
   }, [children, measure]);
 
   useEffect(() => {
-    return () => {
-      if (scrollHideTimerRef.current !== null) {
-        window.clearTimeout(scrollHideTimerRef.current);
-      }
-    };
-  }, []);
+    return clearScrollHideTimer;
+  }, [clearScrollHideTimer]);
 
   const thumb = useMemo(() => {
     const trackInset = Math.max(0, scrollbarTrackInset);
@@ -128,14 +132,19 @@ export function ScrollArea({
     measure();
     if (scrollbarVisibility !== "track-hover") return;
     setScrollbarActive(true);
-    if (scrollHideTimerRef.current !== null) {
-      window.clearTimeout(scrollHideTimerRef.current);
-    }
+    clearScrollHideTimer();
     scrollHideTimerRef.current = window.setTimeout(() => {
       setScrollbarActive(false);
       scrollHideTimerRef.current = null;
     }, 900);
-  }, [measure, scrollbarVisibility]);
+  }, [clearScrollHideTimer, measure, scrollbarVisibility]);
+
+  const handleRootPointerLeave = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    onPointerLeave?.(event);
+    if (scrollbarVisibility !== "track-hover" || dragStateRef.current) return;
+    clearScrollHideTimer();
+    setScrollbarActive(false);
+  }, [clearScrollHideTimer, onPointerLeave, scrollbarVisibility]);
 
   const handleThumbPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -145,6 +154,7 @@ export function ScrollArea({
 
       event.preventDefault();
       event.currentTarget.setPointerCapture?.(event.pointerId);
+      setScrollbarActive(true);
       dragStateRef.current = {
         pointerId: event.pointerId,
         startY: event.clientY,
@@ -175,21 +185,25 @@ export function ScrollArea({
     if (dragStateRef.current?.pointerId !== event.pointerId) return;
     event.currentTarget.releasePointerCapture?.(event.pointerId);
     dragStateRef.current = null;
-  }, []);
+    if (scrollbarVisibility === "track-hover") {
+      setScrollbarActive(false);
+    }
+  }, [scrollbarVisibility]);
 
   const visibilityClasses =
     scrollbarVisibility === "always"
       ? "opacity-100"
       : scrollbarVisibility === "track-hover"
         ? scrollbarActive
-          ? "opacity-100 transition-opacity hover:opacity-100 group-focus-within:opacity-100"
-          : "opacity-0 transition-opacity hover:opacity-100 group-focus-within:opacity-100"
+          ? "opacity-100 transition-opacity group-hover:opacity-100"
+          : "opacity-0 transition-opacity group-hover:opacity-100"
       : "opacity-0 transition-opacity hover:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100";
 
   return (
     <div
       {...divProps}
       data-scroll-area-root
+      onPointerLeave={handleRootPointerLeave}
       className={cn("group relative isolate min-h-0 min-w-0", className)}
     >
       <div

--- a/packages/ui/src/primitives/__tests__/ScrollArea.test.tsx
+++ b/packages/ui/src/primitives/__tests__/ScrollArea.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { ScrollArea } from "../ScrollArea";
+
+function setScrollMetrics(element: HTMLElement) {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: 100 },
+    scrollHeight: { configurable: true, value: 300 },
+    scrollTop: { configurable: true, value: 20, writable: true },
+  });
+}
+
+describe("ScrollArea", () => {
+  test("shows track-hover scrollbars for the whole area and hides on pointer leave", () => {
+    render(
+      <ScrollArea scrollbarVisibility="track-hover">
+        <div>content</div>
+      </ScrollArea>,
+    );
+
+    const root = document.querySelector<HTMLElement>("[data-scroll-area-root]");
+    const viewport = document.querySelector<HTMLElement>("[data-scroll-area-viewport]");
+    expect(root).not.toBeNull();
+    expect(viewport).not.toBeNull();
+
+    setScrollMetrics(viewport!);
+    fireEvent.scroll(viewport!);
+
+    const scrollbar = document.querySelector<HTMLElement>("[data-scroll-area-scrollbar='y']");
+    expect(scrollbar).not.toBeNull();
+    expect(scrollbar!).toHaveClass("opacity-100", "group-hover:opacity-100");
+    expect(scrollbar!).not.toHaveClass("group-focus-within:opacity-100");
+
+    fireEvent.pointerLeave(root!);
+
+    expect(scrollbar!).toHaveClass("opacity-0", "group-hover:opacity-100");
+    expect(scrollbar!).not.toHaveClass("group-focus-within:opacity-100");
+  });
+});


### PR DESCRIPTION
## Summary
- show track-hover scrollbars when hovering the whole ScrollArea instead of only the rail
- hide the sidebar scrollbar immediately after leaving the menu area
- add component and E2E coverage for the sidebar scrollbar behavior

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- packages/ui/src/primitives/__tests__/ScrollArea.test.tsx
- rtk bunx playwright test e2e/config-editor-and-sidebar.spec.ts
- rtk bun run --filter @code-proxy/admin-panel build