### PR TITLE
feat: add system model vendor tabs

### DIFF
--- a/features/model-tags/index.tsx
+++ b/features/model-tags/index.tsx
@@ -416,24 +416,47 @@ export function ModelVendorStatBadge({
   vendorKey,
   label,
   count,
+  active = false,
+  onClick,
 }: {
   vendorKey: ModelVendorKey;
   label: string;
   count: number;
+  active?: boolean;
+  onClick?: () => void;
 }) {
   const tone = getModelVendorColor(vendorKey);
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-semibold",
-        tone.bg,
-        tone.text,
-        tone.border,
-      )}
-    >
+  const className = cn(
+    "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-semibold",
+    tone.bg,
+    active ? "ring-2 ring-indigo-500/35 ring-offset-1 ring-offset-white dark:ring-indigo-300/40 dark:ring-offset-neutral-950" : "",
+    onClick ? "cursor-pointer transition hover:shadow-sm" : "",
+    tone.text,
+    tone.border,
+  );
+  const content = (
+    <>
       <VendorIcon modelId={vendorKey} size={12} />
       {label}
       <span className="tabular-nums">{count}</span>
-    </span>
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        aria-label={`${label} ${count}`}
+        aria-pressed={active}
+        onClick={onClick}
+        className={className}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span className={className}>{content}</span>
   );
 }

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -18,6 +18,7 @@ import {
 import { useAuth } from "@app/providers/AuthProvider";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
+import { ScrollArea } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { UpdateDetailsCard } from "@app/update/UpdateDetailsCard";
@@ -29,7 +30,9 @@ import {
 import {
   buildModelVendorStats,
   CopyableModelTag,
+  getModelVendorKey,
   ModelVendorStatBadge,
+  type ModelVendorKey,
 } from "@features/model-tags";
 import { HoverTooltip } from "@code-proxy/ui";
 
@@ -130,6 +133,8 @@ type SystemModelEntry = {
   sources?: ModelAvailabilitySource[];
 };
 
+type ModelVendorFilter = "all" | ModelVendorKey;
+
 const formatSourceLabel = (source: ModelAvailabilitySource): string => {
   const label = source.label.trim();
   const provider = source.provider?.trim();
@@ -200,6 +205,7 @@ export function SystemPage({
   const [modelsError, setModelsError] = useState<string | null>(null);
   const [models, setModels] = useState<SystemModelEntry[]>([]);
   const [modelFilter, setModelFilter] = useState("");
+  const [selectedModelVendor, setSelectedModelVendor] = useState<ModelVendorFilter>("all");
 
   const loadModels = useCallback(async () => {
     setModelsLoading(true);
@@ -251,9 +257,13 @@ export function SystemPage({
 
   const filteredModels = useMemo(() => {
     const needle = modelFilter.trim().toLowerCase();
-    if (!needle) return models;
-    return models.filter((model) => model.id.toLowerCase().includes(needle));
-  }, [modelFilter, models]);
+    return models.filter((model) => {
+      if (selectedModelVendor !== "all" && getModelVendorKey(model.id) !== selectedModelVendor) {
+        return false;
+      }
+      return !needle || model.id.toLowerCase().includes(needle);
+    });
+  }, [modelFilter, models, selectedModelVendor]);
 
   const vendorStats = useMemo(() => {
     return buildModelVendorStats(
@@ -381,13 +391,36 @@ export function SystemPage({
 
         {/* Vendor stats bar */}
         {vendorStats.length > 0 && !modelsLoading && (
-          <div className="flex flex-wrap items-center gap-2 border-b border-slate-100 px-5 py-2.5 dark:border-neutral-800/60">
+          <div
+            className="flex flex-wrap items-center gap-2 border-b border-slate-100 px-5 py-2.5 dark:border-neutral-800/60"
+            aria-label={t("system_page.available_models")}
+          >
+            <button
+              type="button"
+              aria-label={`${t("common.all", { defaultValue: "All" })} ${models.length}`}
+              aria-pressed={selectedModelVendor === "all"}
+              onClick={() => setSelectedModelVendor("all")}
+              className={[
+                "inline-flex items-center gap-1.5 rounded-md border border-slate-200/70 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-600 transition hover:shadow-sm dark:border-neutral-700/60 dark:bg-neutral-900 dark:text-white/70",
+                selectedModelVendor === "all"
+                  ? "ring-2 ring-indigo-500/35 ring-offset-1 ring-offset-white dark:ring-indigo-300/40 dark:ring-offset-neutral-950"
+                  : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              <Layers size={12} aria-hidden="true" />
+              {t("common.all", { defaultValue: "All" })}
+              <span className="tabular-nums">{models.length}</span>
+            </button>
             {vendorStats.map((stat) => (
               <ModelVendorStatBadge
                 key={stat.key}
                 vendorKey={stat.key}
                 label={stat.label}
                 count={stat.count}
+                active={selectedModelVendor === stat.key}
+                onClick={() => setSelectedModelVendor(stat.key)}
               />
             ))}
           </div>
@@ -401,7 +434,14 @@ export function SystemPage({
         )}
 
         {/* Model tags */}
-        <div className="max-h-[480px] overflow-y-auto px-5 py-4 md:max-h-none md:min-h-0 md:flex-1">
+        <ScrollArea
+          className="md:min-h-0 md:flex-1 [&_[data-scroll-area-scrollbar='y']]:right-1"
+          viewportClassName="max-h-[480px] md:max-h-none md:!h-full"
+          contentClassName="px-5 py-4 pr-8"
+          scrollbarVisibility="track-hover"
+          scrollbarTrackInset={4}
+          data-testid="system-models-scroll-area"
+        >
           {modelsLoading && models.length === 0 ? (
             <div className="flex items-center justify-center py-12 text-sm text-slate-500 dark:text-white/50">
               <RefreshCw size={14} className="animate-spin mr-2" />
@@ -460,7 +500,7 @@ export function SystemPage({
               </p>
             </div>
           )}
-        </div>
+        </ScrollArea>
       </Card>
     </div>
   );

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -278,6 +278,64 @@ describe("SystemPage", () => {
     expect(mocks.apiGet).toHaveBeenCalledWith("/model-path-availability");
   });
 
+  test("filters available models by vendor tab and uses the shared scroll area", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "gpt-5.4",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+            {
+              id: "qwen3.5-plus",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+            {
+              id: "deepseek-chat",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve<unknown[]>([]);
+      }
+      return Promise.resolve({});
+    });
+
+    const { container } = renderPage();
+
+    expect(await screen.findByText("gpt-5.4")).toBeInTheDocument();
+    expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
+    expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
+
+    const viewport = container.querySelector(
+      '[data-testid="system-models-scroll-area"] [data-scroll-area-viewport]',
+    );
+    expect(viewport).toHaveAttribute("data-scrollbar-visibility", "track-hover");
+
+    await userEvent.click(screen.getByRole("button", { name: /^qwen 1$/i }));
+
+    expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-5.4")).not.toBeInTheDocument();
+    expect(screen.queryByText("deepseek-chat")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /^All 3$/i }));
+
+    expect(screen.getByText("gpt-5.4")).toBeInTheDocument();
+    expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
+    expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
+  });
+
   test("keeps configured Cline models when root v1 discovery has other models", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });


### PR DESCRIPTION
## Summary
- add an All chip and clickable vendor chips for filtering Available Models
- render the System Available Models list through the shared ScrollArea component
- cover vendor filtering and ScrollArea usage in SystemPage tests

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/system/__tests__/SystemPage.test.tsx
- rtk bun run build