### PR TITLE
fix: improve update migration progress feedback

### DIFF
--- a/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
+++ b/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
@@ -188,6 +188,15 @@ function translateProgressMessage(
   progress?: UpdateProgressResponse | null,
   fallbackStage?: string,
 ) {
+  const migrationPhase = progress?.migration?.phase?.trim();
+  if (migrationPhase) {
+    const migrationMessageKey =
+      MIGRATION_PROGRESS_MESSAGE_KEYS[migrationPhase] ??
+      (migrationPhase === "skipped"
+        ? sqliteSkipMessageKey(progress?.migration?.skip_reason)
+        : "");
+    if (migrationMessageKey) return t(migrationMessageKey);
+  }
   const raw = progress?.message?.trim() ?? "";
   if (!raw) return t("auto_update.progress_default_message");
   const key = UPDATE_PROGRESS_MESSAGE_KEYS[raw.toLowerCase()];
@@ -216,6 +225,29 @@ const MIGRATION_PHASE_LABEL_KEYS: Record<string, string> = {
   skipped: "auto_update.progress_migration_phase_skipped",
   finalizing: "auto_update.progress_migration_phase_finalizing",
 };
+
+const MIGRATION_PROGRESS_MESSAGE_KEYS: Record<string, string> = {
+  starting_runtime: "auto_update.progress_message_starting_runtime",
+  checking: "auto_update.progress_message_checking_sqlite",
+  preparing: "auto_update.progress_message_preparing_sqlite_import",
+  inventory: "auto_update.progress_message_sqlite_inventory",
+  dry_run: "auto_update.progress_message_postgres_dry_run",
+  applying: "auto_update.progress_message_applying_sqlite",
+  finalizing: "auto_update.progress_message_sqlite_complete",
+};
+
+function sqliteSkipMessageKey(reason?: string) {
+  switch (reason?.trim()) {
+    case "disabled":
+      return "auto_update.progress_message_sqlite_skipped_disabled";
+    case "no_legacy_sqlite":
+      return "auto_update.progress_message_sqlite_skipped_missing";
+    case "import_disabled":
+      return "auto_update.progress_message_sqlite_skipped_import_disabled";
+    default:
+      return "auto_update.progress_message_finishing_migration";
+  }
+}
 
 function formatCount(value?: number) {
   if (typeof value !== "number" || !Number.isFinite(value)) return "";
@@ -436,7 +468,6 @@ function UpdateProgressConsole({
   );
   const displayPercent = Math.round(animatedPercent);
   const progressPercentLabel = `${displayPercent}%`;
-  const progressMarkerLeft = `clamp(1.5rem, ${displayPercent}%, calc(100% - 1.5rem))`;
   const progressMessage = translateProgressMessage(t, progress, stage);
   const progressDetails = migrationProgressDetails(t, progress);
   const StatusIcon = isCompleted
@@ -534,27 +565,26 @@ function UpdateProgressConsole({
         </div>
 
         <div className="mt-4">
-          <div className="relative h-7">
+          <div className="mb-1 flex items-center justify-end">
             <span
               data-testid="update-progress-percent"
-              className="absolute top-0 z-10 -translate-x-1/2 font-mono text-sm font-semibold text-slate-900 dark:text-white"
-              style={{ left: progressMarkerLeft }}
+              className="font-mono text-sm font-semibold text-slate-900 dark:text-white"
             >
               {progressPercentLabel}
             </span>
-            <div className="absolute inset-x-0 bottom-0 h-2 overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
-              <div
-                data-testid="update-progress-fill"
-                className={[
-                  "relative h-full rounded-full transition-[width] duration-500 ease-out",
-                  progressBarClass,
-                ].join(" ")}
-                style={{ width: `${displayPercent}%` }}
-              >
-                {isRunning ? (
-                  <span className="absolute inset-y-0 right-0 w-16 bg-white/30 blur-md dark:bg-white/20" />
-                ) : null}
-              </div>
+          </div>
+          <div className="relative h-2 overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
+            <div
+              data-testid="update-progress-fill"
+              className={[
+                "relative h-full rounded-full transition-[width] duration-500 ease-out",
+                progressBarClass,
+              ].join(" ")}
+              style={{ width: `${displayPercent}%` }}
+            >
+              {isRunning ? (
+                <span className="absolute inset-y-0 right-0 w-16 bg-white/30 blur-md dark:bg-white/20" />
+              ) : null}
             </div>
           </div>
         </div>

--- a/apps/admin-panel/src/app/update/__tests__/UpdateDetailsModal.test.tsx
+++ b/apps/admin-panel/src/app/update/__tests__/UpdateDetailsModal.test.tsx
@@ -98,14 +98,11 @@ describe("UpdateDetailsModal", () => {
 
     expect(
       screen.getByText(
-        "Migrating legacy SQLite data before restarting the service.",
+        "Importing legacy SQLite data into PostgreSQL.",
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Data migration check")).toBeInTheDocument();
     expect(screen.getByText("86%")).toBeInTheDocument();
-    expect(screen.getByTestId("update-progress-percent")).toHaveStyle({
-      left: "clamp(1.5rem, 86%, calc(100% - 1.5rem))",
-    });
     expect(screen.getByTestId("update-progress-fill")).toHaveStyle({
       width: "86%",
     });

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4018,7 +4018,7 @@
     "progress_message_pulling_target_image": "Pulling the target image.",
     "progress_message_starting_runtime": "Starting PostgreSQL and Redis before the data migration check.",
     "progress_message_checking_sqlite": "Checking whether legacy SQLite data needs migration before restarting the service.",
-    "progress_message_migrating_sqlite": "Migrating legacy SQLite data before restarting the service.",
+    "progress_message_migrating_sqlite": "Checking legacy SQLite data before restart; importing only if needed.",
     "progress_message_preparing_sqlite_import": "Legacy SQLite data was found; preparing the PostgreSQL import.",
     "progress_message_sqlite_inventory": "Scanning the legacy SQLite database before import.",
     "progress_message_postgres_dry_run": "Running a PostgreSQL import dry-run.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3447,7 +3447,7 @@
     "progress_message_pulling_target_image": "正在拉取目标镜像。",
     "progress_message_starting_runtime": "正在启动 PostgreSQL 和 Redis，准备执行数据迁移检查。",
     "progress_message_checking_sqlite": "正在检查是否需要在重启服务前迁移历史 SQLite 数据。",
-    "progress_message_migrating_sqlite": "正在重启服务前迁移历史 SQLite 数据。",
+    "progress_message_migrating_sqlite": "正在重启前检查历史 SQLite 数据，仅在需要时导入。",
     "progress_message_preparing_sqlite_import": "已发现历史 SQLite 数据，正在准备导入 PostgreSQL。",
     "progress_message_sqlite_inventory": "正在扫描历史 SQLite 数据库，准备导入。",
     "progress_message_postgres_dry_run": "正在执行 PostgreSQL 导入预演。",


### PR DESCRIPTION
## Summary
- make migration phase drive the visible update message so applying/skipped/finalizing states do not show stale generic SQLite text
- move the percent label out of the progress bar marker so the label and fill always match
- keep the legacy migrating message as a check/import-if-needed fallback

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- src/app/update/__tests__/UpdateDetailsModal.test.tsx
- rtk bun run build
- rtk bun run --filter @code-proxy/admin-panel test:ci