### PR TITLE
fix: use dynamic ollama cloud models

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
@@ -19,7 +19,7 @@ describe("providersApi Ollama Cloud", () => {
     deleteMock.mockReset();
   });
 
-  test("normalizes Ollama Cloud configs with default Base URL", async () => {
+  test("normalizes Ollama Cloud configs with default Base URL and ignores legacy models", async () => {
     const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
     getMock.mockResolvedValue({
       "ollama-cloud-api-key": [
@@ -38,14 +38,13 @@ describe("providersApi Ollama Cloud", () => {
         name: "Ollama",
         apiKey: "sk-ollama",
         baseUrl: "https://ollama.com",
-        models: [{ name: "gpt-oss:120b" }],
         excludedModels: ["gpt-oss:20b", "*"],
       },
     ]);
     expect(getMock).toHaveBeenCalledWith("/ollama-cloud-api-key");
   });
 
-  test("serializes and deletes Ollama Cloud configs", async () => {
+  test("serializes Ollama Cloud configs without legacy models and deletes them", async () => {
     const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.saveOllamaCloudConfigs([
@@ -63,7 +62,6 @@ describe("providersApi Ollama Cloud", () => {
         name: "Ollama",
         "api-key": "sk-ollama",
         "base-url": "https://ollama.com",
-        models: [{ name: "gpt-oss:120b" }],
         "excluded-models": ["gpt-oss:20b", "*"],
       },
     ]);

--- a/packages/api-client/src/endpoints/helpers.ts
+++ b/packages/api-client/src/endpoints/helpers.ts
@@ -187,8 +187,6 @@ export const serializeOllamaCloudKey = (config: ProviderSimpleConfig) => {
   if (proxyId) payload["proxy-id"] = proxyId;
   const headers = serializeHeaders(config.headers);
   if (headers) payload.headers = headers;
-  const models = serializeModels(config.models);
-  if (models && models.length) payload.models = models;
   if (config.excludedModels && config.excludedModels.length) {
     payload["excluded-models"] = config.excludedModels;
   }

--- a/packages/api-client/src/endpoints/providers.ts
+++ b/packages/api-client/src/endpoints/providers.ts
@@ -221,7 +221,6 @@ export const providersApi = {
         const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
         const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
-        const models = normalizeModels(item.models);
         const excludedModels = normalizeExcludedModels(
           item["excluded-models"] ?? item.excludedModels,
         );
@@ -233,7 +232,6 @@ export const providersApi = {
           ...(proxyUrl ? { proxyUrl } : {}),
           ...(proxyId ? { proxyId } : {}),
           ...(headers ? { headers } : {}),
-          ...(models ? { models } : {}),
           ...(excludedModels ? { excludedModels } : {}),
         };
       })

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3426,6 +3426,8 @@
     "opencode_go_models_hint": "Models are loaded from the official OpenCode Go /models endpoint. Checked models are allowed; unchecked models are written to the blocked list.",
     "cline_models_title": "ClinePass model access",
     "cline_models_hint": "Models are loaded from the relay's ClinePass definitions. Checked models are allowed; unchecked models are written to the blocked list.",
+    "ollama_cloud_models_title": "Ollama Cloud model access",
+    "ollama_cloud_models_hint": "Models are loaded from the relay's Ollama Cloud definitions. Checked models are allowed; unchecked models are written to the blocked list.",
     "cline_real_model_id": "ClinePass real model ID",
     "cline_public_model_name": "Public model name",
     "model_enabled": "Enabled",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2712,6 +2712,8 @@
     "opencode_go_models_hint": "模型从官方 OpenCode Go /models 端点自动获取。勾选表示允许使用，取消勾选会写入屏蔽列表。",
     "cline_models_title": "ClinePass 模型权限",
     "cline_models_hint": "模型从 relay 内置的 ClinePass 定义加载。勾选表示允许使用，取消勾选会写入屏蔽列表。",
+    "ollama_cloud_models_title": "Ollama Cloud 模型权限",
+    "ollama_cloud_models_hint": "模型从 relay 内置的 Ollama Cloud 定义加载。勾选表示允许使用，取消勾选会写入屏蔽列表。",
     "cline_real_model_id": "ClinePass 真实模型 ID",
     "cline_public_model_name": "对外模型名",
     "model_enabled": "是否启用",

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -651,7 +651,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     mocks.proxiesList.mockImplementation(async () => []);
   });
 
-  test("shows Ollama Cloud manual model configuration", async () => {
+  test("shows Ollama Cloud dynamic model list without manual model inputs", async () => {
     render(
       <MemoryRouter initialEntries={["/ai-providers/ollama-cloud/new"]}>
         <ThemeProvider>
@@ -668,14 +668,14 @@ describe("ProvidersPage Ollama Cloud tab", () => {
       name: /Add Ollama Cloud configuration/i,
     });
     expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
     await userEvent.setup().click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(within(dialog).getByText("Models (optional)")).toBeInTheDocument();
-    expect(within(dialog).queryByText("gpt-oss:120b")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
+    expect(within(dialog).getByText("gpt-oss:120b")).toBeInTheDocument();
     expect(mocks.apiCallRequest).not.toHaveBeenCalled();
-    expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
   });
 
-  test("preserves Ollama Cloud per-key model fields when saving", async () => {
+  test("drops legacy Ollama Cloud per-key model fields when saving", async () => {
     const user = userEvent.setup();
     mocks.getOllamaCloudConfigs.mockImplementation(async () => [
       {
@@ -703,7 +703,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
       name: /Edit Ollama Cloud configuration/i,
     });
     expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
-    expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -711,13 +711,12 @@ describe("ProvidersPage Ollama Cloud tab", () => {
         expect.objectContaining({
           name: "Existing Ollama Cloud",
           apiKey: "sk-ollama",
-          models: [{ name: "gpt-oss:120b" }],
           excludedModels: ["gpt-oss:20b", "*"],
         }),
       ]);
     });
     const saved = mocks.saveOllamaCloudConfigs.mock.calls[0][0][0];
-    expect(saved).toHaveProperty("models", [{ name: "gpt-oss:120b" }]);
+    expect(saved).not.toHaveProperty("models");
   });
 });
 

--- a/pages/providers/__tests__/provider-import-export.test.ts
+++ b/pages/providers/__tests__/provider-import-export.test.ts
@@ -98,6 +98,56 @@ describe("provider import/export helpers", () => {
     ]);
   });
 
+  test("preserves Ollama Cloud provider fields without per-key model fields", () => {
+    const text = createProviderExportText("ollama-cloud", [
+      {
+        apiKey: " ollama-key ",
+        name: "Ollama Cloud",
+        baseUrl: "https://ollama.com",
+        models: [{ name: "gpt-oss:120b" }],
+        excludedModels: [" gpt-oss:20b ", "*"],
+      },
+    ] satisfies ProviderSimpleConfig[]);
+
+    expect(JSON.parse(text)).toEqual({
+      provider: "ollama-cloud",
+      version: 1,
+      items: [
+        {
+          "api-key": "ollama-key",
+          "base-url": "https://ollama.com",
+          "excluded-models": ["*", "gpt-oss:20b"],
+          name: "Ollama Cloud",
+        },
+      ],
+    });
+
+    const preview = prepareProviderImport(
+      "ollama-cloud",
+      JSON.stringify({
+        provider: "ollama-cloud",
+        items: [
+          {
+            "api-key": " ollama-key ",
+            name: "Ollama Cloud",
+            models: [{ name: "gpt-oss:120b" }],
+            "excluded-models": ["gpt-oss:20b", "*"],
+          },
+        ],
+      }),
+      [],
+    );
+
+    expect(preview.nextItems).toEqual([
+      {
+        apiKey: "ollama-key",
+        name: "Ollama Cloud",
+        baseUrl: "https://ollama.com",
+        excludedModels: ["*", "gpt-oss:20b"],
+      },
+    ]);
+  });
+
   test("normalizes imports, reports diff counts, and removes duplicate OpenAI nested entries", () => {
     const current: OpenAIProvider[] = [
       {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -93,7 +93,7 @@ export function ProviderKeyModal({
   const isOpenCodeGo = editKeyType === "opencode-go";
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
-  const isModelAccessProvider = isOpenCodeGo || isCline;
+  const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
   const showModelsTab = true;
 
   const [modelConfigs, setModelConfigs] = useState<{ id: string; owned_by: string }[]>([]);
@@ -174,8 +174,8 @@ export function ProviderKeyModal({
     setOpenCodeModelsLoading(true);
     setOpenCodeModelsError(null);
     try {
-      if (isCline) {
-        const items = await authFilesApi.getModelDefinitions("cline");
+      if (isCline || isOllamaCloud) {
+        const items = await authFilesApi.getModelDefinitions(isCline ? "cline" : "ollama-cloud");
         setOpenCodeModels(
           normalizeDiscoveredModels({ data: items.map((item) => ({ ...item, object: "model" })) }),
         );
@@ -196,7 +196,7 @@ export function ProviderKeyModal({
     } finally {
       setOpenCodeModelsLoading(false);
     }
-  }, [isCline, isModelAccessProvider, t]);
+  }, [isCline, isModelAccessProvider, isOllamaCloud, t]);
 
   useEffect(() => {
     if (!open || !isModelAccessProvider) return;

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -82,7 +82,18 @@ export function ProviderKeyModelsTab({
   editKeyEnabledToggle,
 }: ProviderKeyModelsTabProps) {
   const { t } = useTranslation();
-  const isModelAccessProvider = isOpenCodeGo || isCline;
+  const isOllamaCloud = editKeyType === "ollama-cloud";
+  const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
+  const modelAccessTitle = isCline
+    ? t("providers.cline_models_title")
+    : isOllamaCloud
+      ? t("providers.ollama_cloud_models_title")
+      : t("providers.opencode_go_models_title");
+  const modelAccessHint = isCline
+    ? t("providers.cline_models_hint")
+    : isOllamaCloud
+      ? t("providers.ollama_cloud_models_hint")
+      : t("providers.opencode_go_models_hint");
   const clineRows = useMemo<ClineModelRow[]>(() => {
     if (!isCline) return [];
     return filteredOpenCodeModels.map((model) => {
@@ -144,14 +155,10 @@ export function ProviderKeyModelsTab({
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
               <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                {isCline
-                  ? t("providers.cline_models_title")
-                  : t("providers.opencode_go_models_title")}
+                {modelAccessTitle}
               </p>
               <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-                {isCline
-                  ? t("providers.cline_models_hint")
-                  : t("providers.opencode_go_models_hint")}
+                {modelAccessHint}
               </p>
             </div>
             <Button

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -175,7 +175,7 @@ export function useProviderKeyEditor({
       : undefined;
     const isOpenCodeGo = editKeyType === "opencode-go";
     const isCline = editKeyType === "cline";
-    const usesDynamicModelCatalog = isOpenCodeGo || isCline;
+    const usesDynamicModelCatalog = isOpenCodeGo || isCline || editKeyType === "ollama-cloud";
     const excludedModels = rawExcludedModels;
 
     const requireAlias = editKeyType === "vertex";

--- a/pages/providers/provider-import-export.ts
+++ b/pages/providers/provider-import-export.ts
@@ -163,7 +163,8 @@ const normalizeSimpleItem = (
   if (!apiKey) return { item: null, duplicateCount: 0 };
   const headers = sortRecord(normalizeHeaders(value.headers));
   const { models, duplicateCount } = normalizeModelList(value.models);
-  const usesDynamicModelCatalog = kind === "opencode-go" || kind === "cline";
+  const usesDynamicModelCatalog =
+    kind === "opencode-go" || kind === "cline" || kind === "ollama-cloud";
   const excludedModels = sortExcludedModels(value["excluded-models"] ?? value.excludedModels);
   const baseUrl =
     normalizeString(value["base-url"] ?? value.baseUrl) ??


### PR DESCRIPTION
## Summary
- load Ollama Cloud models through the dynamic model definitions path
- stop reading, saving, importing, or exporting legacy per-key Ollama Cloud models
- update provider modal labels and coverage for Ollama Cloud model access

## Tests
- rtk bun run --filter @code-proxy/admin-panel test packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/provider-import-export.test.ts
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build
- rtk git diff --check