### PR TITLE
fix: render effective provider model access

### DIFF
--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
 import { Loader2, Plus, Zap } from "lucide-react";
-import type { ProviderSimpleConfig } from "@code-proxy/api-client";
+import type {
+  ProviderModel,
+  ProviderSimpleConfig,
+} from "@code-proxy/api-client";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { ProviderCard, ProviderCardSkeleton } from "./ProviderCard";
@@ -27,6 +30,7 @@ export function ProviderKeyListCard({
   onDelete,
   onToggleEnabled,
   renderExtra,
+  getDisplayModels,
 
   getStats,
   getStatusBar,
@@ -48,6 +52,10 @@ export function ProviderKeyListCard({
   onDelete: (index: number) => void;
   onToggleEnabled?: (index: number, enabled: boolean) => void;
   renderExtra?: (item: ProviderSimpleConfig, index: number) => ReactNode;
+  getDisplayModels?: (
+    item: ProviderSimpleConfig,
+    index: number,
+  ) => ProviderModel[];
   renderMetricsExtra?: (
     item: ProviderSimpleConfig,
     index: number,
@@ -55,7 +63,11 @@ export function ProviderKeyListCard({
   ) => ReactNode;
   getStats: (item: ProviderSimpleConfig) => KeyStatBucket;
   getStatusBar: (item: ProviderSimpleConfig) => StatusBarData;
-  getLatencyEntry?: (key: string) => { latencyMs: number | null; loading: boolean; error: boolean };
+  getLatencyEntry?: (key: string) => {
+    latencyMs: number | null;
+    loading: boolean;
+    error: boolean;
+  };
   checkLatency?: (key: string, baseUrl: string) => void;
   showBaseUrl?: boolean;
   selectedKeys?: Set<string>;
@@ -91,7 +103,10 @@ export function ProviderKeyListCard({
           style={
             naturalHeight
               ? undefined
-              : { gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))" }
+              : {
+                  gridTemplateColumns:
+                    "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))",
+                }
           }
         >
           {Array.from({ length: 6 }, (_, index) => (
@@ -99,7 +114,10 @@ export function ProviderKeyListCard({
           ))}
         </div>
       ) : items.length === 0 ? (
-        <EmptyState title={t("providers.no_config")} description={t("providers.no_config_desc")} />
+        <EmptyState
+          title={t("providers.no_config")}
+          description={t("providers.no_config_desc")}
+        />
       ) : (
         <div
           data-testid="providers-tab-scroll"
@@ -110,7 +128,10 @@ export function ProviderKeyListCard({
           style={
             naturalHeight
               ? undefined
-              : { gridTemplateColumns: "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))" }
+              : {
+                  gridTemplateColumns:
+                    "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))",
+                }
           }
         >
           {items.map((item, idx) => {
@@ -118,8 +139,12 @@ export function ProviderKeyListCard({
             const selected = selectedKeys?.has(selectionKey) ?? false;
             const disabled = hasDisableAllModelsRule(item.excludedModels);
             const headerEntries = Object.entries(item.headers || {});
-            const excludedModels = stripDisableAllModelsRule(item.excludedModels);
-            const models = item.models || [];
+            const excludedModels = stripDisableAllModelsRule(
+              item.excludedModels,
+            );
+            const models = getDisplayModels
+              ? getDisplayModels(item, idx)
+              : item.models || [];
             const stats = getStats(item);
             const statusData = getStatusBar(item);
 
@@ -131,14 +156,18 @@ export function ProviderKeyListCard({
                 enabled={!disabled}
                 dimmed={disabled}
                 naturalHeight={naturalHeight}
-                className={naturalHeight ? "w-full max-w-[22rem] flex-none" : undefined}
+                className={
+                  naturalHeight ? "w-full max-w-[22rem] flex-none" : undefined
+                }
                 onToggleSelected={
                   onToggleSelected
                     ? (checked) => onToggleSelected(selectionKey, checked)
                     : undefined
                 }
                 onToggleEnabled={
-                  onToggleEnabled ? (enabled) => onToggleEnabled(idx, enabled) : undefined
+                  onToggleEnabled
+                    ? (enabled) => onToggleEnabled(idx, enabled)
+                    : undefined
                 }
                 onEdit={() => onEdit(idx)}
                 onDelete={() => onDelete(idx)}
@@ -167,7 +196,8 @@ export function ProviderKeyListCard({
                             className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] tabular-nums font-medium transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 dark:hover:bg-white/10 dark:focus-visible:ring-white/20 ${entry.loading ? "text-slate-500" : entry.error ? "text-rose-500" : latencyColor}`}
                             onClick={(e) => {
                               e.stopPropagation();
-                              if (providerBaseUrl) checkLatency(latencyKey, providerBaseUrl);
+                              if (providerBaseUrl)
+                                checkLatency(latencyKey, providerBaseUrl);
                             }}
                             aria-label={
                               providerBaseUrl
@@ -231,14 +261,20 @@ export function ProviderKeyListCard({
                   ) : null}
                   <ProviderMetricChip
                     tone={stats.success > 0 ? "emerald" : "slate"}
-                    label={t("providers.success_stats", { count: stats.success })}
+                    label={t("providers.success_stats", {
+                      count: stats.success,
+                    })}
                   />
                   <ProviderMetricChip
                     tone={stats.failure > 0 ? "rose" : "slate"}
-                    label={t("providers.failed_stats", { count: stats.failure })}
+                    label={t("providers.failed_stats", {
+                      count: stats.failure,
+                    })}
                   />
                   {renderMetricsExtra ? (
-                    <div className="ml-auto">{renderMetricsExtra(item, idx, stats)}</div>
+                    <div className="ml-auto">
+                      {renderMetricsExtra(item, idx, stats)}
+                    </div>
                   ) : null}
                 </div>
 

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -15,7 +15,12 @@ type MockApiCallResult = {
 
 type MockOpenCodeGoUsageResponse = {
   workspace_id: string;
-  usage: { type: string; label: string; percentage: number; resets_in: string }[];
+  usage: {
+    type: string;
+    label: string;
+    percentage: number;
+    resets_in: string;
+  }[];
 };
 
 type MockEntityStatsResponse = {
@@ -34,7 +39,9 @@ const mocks = vi.hoisted(() => ({
   getOpenAIProviders: vi.fn(async (): Promise<unknown[]> => []),
   queryOpenCodeGoUsage: vi.fn(async () => ({
     workspace_id: "workspace-1",
-    usage: [{ type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" }],
+    usage: [
+      { type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" },
+    ],
   })),
   saveOpenCodeGoConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveClineConfigs: vi.fn(async (_configs: unknown[]) => ({})),
@@ -60,7 +67,9 @@ const mocks = vi.hoisted(() => ({
       },
     }),
   ),
-  getEntityStats: vi.fn(async (): Promise<MockEntityStatsResponse> => ({ source: [] })),
+  getEntityStats: vi.fn(async (): Promise<MockEntityStatsResponse> => ({
+    source: [],
+  })),
   apiKeyEntriesList: vi.fn(async (): Promise<unknown[]> => []),
   channelGroupsList: vi.fn(async (): Promise<unknown[]> => []),
   proxiesList: vi.fn(async (): Promise<any[]> => []),
@@ -133,7 +142,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
     mocks.getOpenAIProviders.mockImplementation(async () => []);
     mocks.queryOpenCodeGoUsage.mockImplementation(async () => ({
       workspace_id: "workspace-1",
-      usage: [{ type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" }],
+      usage: [
+        { type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" },
+      ],
     }));
     mocks.saveOpenCodeGoConfigs.mockImplementation(async () => ({}));
     mocks.saveClineConfigs.mockImplementation(async () => ({}));
@@ -164,7 +175,8 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
   test("shows usage loading instead of not queried before the first OpenCode Go usage result", async () => {
     localStorage.clear();
-    let resolveUsage: ((value: MockOpenCodeGoUsageResponse) => void) | undefined;
+    let resolveUsage:
+      ((value: MockOpenCodeGoUsageResponse) => void) | undefined;
     mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
       {
         name: "OpenCode Go",
@@ -195,8 +207,12 @@ describe("ProvidersPage OpenCode Go tab", () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(await screen.findByRole("tab", { name: /OpenCode Go/ }));
-    await waitFor(() => expect(screen.getAllByText("OpenCode Go").length).toBeGreaterThan(1));
+    await userEvent.click(
+      await screen.findByRole("tab", { name: /OpenCode Go/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getAllByText("OpenCode Go").length).toBeGreaterThan(1),
+    );
     expect(screen.getByText(/Success 9/i)).toBeInTheDocument();
     expect(screen.getByText(/Failed 1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Not queried/i)).not.toBeInTheDocument();
@@ -204,9 +220,43 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
     resolveUsage?.({
       workspace_id: "workspace-1",
-      usage: [{ type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" }],
+      usage: [
+        { type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" },
+      ],
     });
     expect(await screen.findByText(/Left 75%/i)).toBeInTheDocument();
+  });
+
+  test("shows effective OpenCode Go models instead of dirty legacy models", async () => {
+    const user = userEvent.setup();
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "OpenCode Go Dirty",
+        apiKey: "sk-opencode-go-dirty",
+        models: [{ name: "cline-pass/glm-5.2" }],
+        excludedModels: ["qwen3.5-plus"],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: /OpenCode Go/ }));
+    expect(await screen.findByText("OpenCode Go Dirty")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
+
+    expect(await screen.findByText("deepseek-v4-flash")).toBeInTheDocument();
+    expect(screen.queryByText("cline-pass/glm-5.2")).not.toBeInTheDocument();
+    expect(screen.queryByText("qwen3.5-plus")).not.toBeInTheDocument();
   });
 
   test("opens OpenCode Go route and saves a key without requiring Base URL", async () => {
@@ -337,7 +387,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Edit OpenCode Go configuration/i,
     });
-    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("tab", { name: /Models/i }),
+    ).toBeInTheDocument();
     await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
     expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
@@ -353,7 +405,10 @@ describe("ProvidersPage OpenCode Go tab", () => {
     const saved = mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0];
     expect(saved).not.toHaveProperty("models");
     expect(saved).toHaveProperty("visionFallbackModel", "qwen3.5-plus");
-    expect(saved).toHaveProperty("excludedModels", ["cline-pass/minimax-m3", "*"]);
+    expect(saved).toHaveProperty("excludedModels", [
+      "cline-pass/minimax-m3",
+      "*",
+    ]);
   });
 
   test("shows OpenCode Go dynamic model list without manual model inputs", async () => {
@@ -384,16 +439,25 @@ describe("ProvidersPage OpenCode Go tab", () => {
       within(dialog).getByRole("tab", { name: /Models/i }),
     ).toBeInTheDocument();
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("Models (optional)"),
+    ).not.toBeInTheDocument();
     await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
     expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
+    const modelsTable = within(dialog).getByRole("table", {
+      name: /OpenCode Go model access/i,
+    });
+    expect(modelsTable.closest(".table-scrollbar")).toBeInTheDocument();
+    expect(modelsTable.closest("[data-vt-scroll-content]")).toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
     const fallbackSelect = within(dialog).getByRole("combobox", {
       name: /Vision fallback model/i,
     });
     await user.click(fallbackSelect);
-    await user.click(await screen.findByRole("option", { name: /qwen3\.5-plus/ }));
+    await user.click(
+      await screen.findByRole("option", { name: /qwen3\.5-plus/ }),
+    );
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
     await user.type(
@@ -576,11 +640,84 @@ describe("ProvidersPage Cline tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Add ClinePass configuration/i,
     });
-    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
-    await userEvent.setup().click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
-    expect(within(dialog).getByText("cline-pass/mimo-v2.5-pro")).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("tab", { name: /Models/i }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
+    );
+    await userEvent
+      .setup()
+      .click(within(dialog).getByRole("tab", { name: /Models/i }));
+    expect(
+      within(dialog).queryByText("Models (optional)"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).getByText("cline-pass/mimo-v2.5-pro"),
+    ).toBeInTheDocument();
+  });
+
+  test("shows all hidden ClinePass card models in the +X tooltip", async () => {
+    const user = userEvent.setup();
+    mocks.getClineConfigs.mockImplementation(async () => [
+      {
+        name: "Cline Tooltip",
+        apiKey: "sk-cline-tooltip",
+      },
+    ]);
+    mocks.getModelDefinitions.mockImplementation(async (channel?: string) =>
+      channel === "cline"
+        ? [
+            { id: "cline-pass/glm-5.2", object: "model", owned_by: "cline" },
+            { id: "cline-pass/minimax-m3", object: "model", owned_by: "cline" },
+            {
+              id: "cline-pass/qwen3.7-max",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/mimo-v2.5-pro",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/qwen3-coder",
+              object: "model",
+              owned_by: "cline",
+            },
+            {
+              id: "cline-pass/deepseek-v4",
+              object: "model",
+              owned_by: "cline",
+            },
+            { id: "cline-pass/kimi-k2.6", object: "model", owned_by: "cline" },
+            { id: "cline-pass/gpt-5.2", object: "model", owned_by: "cline" },
+          ]
+        : [],
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: /ClinePass/ }));
+    expect(await screen.findByText("Cline Tooltip")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
+    );
+
+    await user.hover(screen.getByText("+2"));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("cline-pass/kimi-k2.6");
+    expect(tooltip).toHaveTextContent("cline-pass/gpt-5.2");
   });
 
   test("drops legacy ClinePass per-key model fields when saving", async () => {
@@ -611,8 +748,12 @@ describe("ProvidersPage Cline tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Edit ClinePass configuration/i,
     });
-    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
+    expect(
+      within(dialog).getByRole("tab", { name: /Models/i }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -626,7 +767,10 @@ describe("ProvidersPage Cline tab", () => {
     });
     const saved = mocks.saveClineConfigs.mock.calls[0][0][0];
     expect(saved).not.toHaveProperty("models");
-    expect(saved).toHaveProperty("visionFallbackModel", "cline-pass/mimo-v2.5-pro");
+    expect(saved).toHaveProperty(
+      "visionFallbackModel",
+      "cline-pass/mimo-v2.5-pro",
+    );
   });
 });
 
@@ -674,10 +818,18 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Add Ollama Cloud configuration/i,
     });
-    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
-    await userEvent.setup().click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("tab", { name: /Models/i }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
+    );
+    await userEvent
+      .setup()
+      .click(within(dialog).getByRole("tab", { name: /Models/i }));
+    expect(
+      within(dialog).queryByText("Models (optional)"),
+    ).not.toBeInTheDocument();
     expect(within(dialog).getByText("gpt-oss:120b")).toBeInTheDocument();
     expect(mocks.apiCallRequest).not.toHaveBeenCalled();
   });
@@ -709,8 +861,12 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Edit Ollama Cloud configuration/i,
     });
-    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
+    expect(
+      within(dialog).getByRole("tab", { name: /Models/i }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
+    );
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -8,12 +8,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
-import {
-  apiCallApi,
-  authFilesApi,
-  getApiCallErrorMessage,
-  modelsApi,
-} from "@code-proxy/api-client";
+import { modelsApi } from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
@@ -22,7 +17,6 @@ import type { ProviderKeyDraft } from "../providers-helpers";
 import {
   excludedModelsFromText,
   hasDisableAllModelsRule,
-  normalizeDiscoveredModels,
   stripDisableAllModelsRule,
 } from "../providers-helpers";
 import type { ModelEntryDraft } from "../ModelInputList";
@@ -30,10 +24,9 @@ import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
 import { ProviderKeyRequestTab } from "./ProviderKeyRequestTab";
 import { ProviderKeyModelsTab } from "./ProviderKeyModelsTab";
+import { fetchModelAccessCatalog } from "../provider-model-access";
 
 type ProviderKeyModalTab = "basic" | "request" | "models";
-
-const OPENCODE_GO_MODELS_URL = "https://opencode.ai/zen/go/v1/models";
 
 const isOpenCodeGoVisionModel = (modelId: string): boolean => {
   const normalized = modelId.trim().toLowerCase();
@@ -51,7 +44,8 @@ const isOpenCodeGoVisionModel = (modelId: string): boolean => {
     "mimo-v2.5",
     "mimo-v2.5-pro",
   ]);
-  if (candidates.some((candidate) => knownVisionModels.has(candidate))) return true;
+  if (candidates.some((candidate) => knownVisionModels.has(candidate)))
+    return true;
   if (
     candidates.some(
       (candidate) =>
@@ -116,9 +110,13 @@ export function ProviderKeyModal({
 }: ProviderKeyModalProps) {
   const { t } = useTranslation();
   const [modalTab, setModalTab] = useState<ProviderKeyModalTab>("basic");
-  const [openCodeModels, setOpenCodeModels] = useState<{ id: string; owned_by?: string }[]>([]);
+  const [openCodeModels, setOpenCodeModels] = useState<
+    { id: string; owned_by?: string }[]
+  >([]);
   const [openCodeModelsLoading, setOpenCodeModelsLoading] = useState(false);
-  const [openCodeModelsError, setOpenCodeModelsError] = useState<string | null>(null);
+  const [openCodeModelsError, setOpenCodeModelsError] = useState<string | null>(
+    null,
+  );
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
 
   const isBedrock = editKeyType === "bedrock";
@@ -128,7 +126,9 @@ export function ProviderKeyModal({
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
   const showModelsTab = true;
 
-  const [modelConfigs, setModelConfigs] = useState<{ id: string; owned_by: string }[]>([]);
+  const [modelConfigs, setModelConfigs] = useState<
+    { id: string; owned_by: string }[]
+  >([]);
   const [modelConfigsLoading, setModelConfigsLoading] = useState(false);
   const [selectedModelGroup, setSelectedModelGroup] = useState("");
 
@@ -144,11 +144,15 @@ export function ProviderKeyModal({
 
   const loadModelsFromGroup = useCallback(() => {
     if (!selectedModelGroup) return;
-    const models = modelConfigs.filter((m) => m.owned_by === selectedModelGroup);
+    const models = modelConfigs.filter(
+      (m) => m.owned_by === selectedModelGroup,
+    );
     if (!models.length) return;
 
     const existingNames = new Set(
-      keyDraft.modelEntries.map((e) => e.name.trim().toLowerCase()).filter(Boolean),
+      keyDraft.modelEntries
+        .map((e) => e.name.trim().toLowerCase())
+        .filter(Boolean),
     );
 
     const newEntries: ModelEntryDraft[] = [];
@@ -187,7 +191,9 @@ export function ProviderKeyModal({
       .getModelConfigs("library")
       .then((items) => {
         if (cancelled) return;
-        setModelConfigs(items.map((item) => ({ id: item.id, owned_by: item.owned_by })));
+        setModelConfigs(
+          items.map((item) => ({ id: item.id, owned_by: item.owned_by })),
+        );
       })
       .catch(() => {
         if (cancelled) return;
@@ -206,21 +212,11 @@ export function ProviderKeyModal({
     setOpenCodeModelsLoading(true);
     setOpenCodeModelsError(null);
     try {
-      if (isCline || isOllamaCloud) {
-        const items = await authFilesApi.getModelDefinitions(isCline ? "cline" : "ollama-cloud");
-        setOpenCodeModels(
-          normalizeDiscoveredModels({ data: items.map((item) => ({ ...item, object: "model" })) }),
-        );
-        return;
-      }
-      const result = await apiCallApi.request({
-        method: "GET",
-        url: OPENCODE_GO_MODELS_URL,
-      });
-      if (result.statusCode < 200 || result.statusCode >= 300) {
-        throw new Error(getApiCallErrorMessage(result));
-      }
-      setOpenCodeModels(normalizeDiscoveredModels(result.body ?? result.bodyText));
+      setOpenCodeModels(
+        await fetchModelAccessCatalog(
+          isCline ? "cline" : isOllamaCloud ? "ollama-cloud" : "opencode-go",
+        ),
+      );
     } catch (err: unknown) {
       setOpenCodeModelsError(
         err instanceof Error ? err.message : t("providers.fetch_models_failed"),
@@ -241,17 +237,31 @@ export function ProviderKeyModal({
   );
   const disableAllModels = hasDisableAllModelsRule(excludedModels);
   const excludedModelIds = useMemo(
-    () => new Set(stripDisableAllModelsRule(excludedModels).map((model) => model.toLowerCase())),
+    () =>
+      new Set(
+        stripDisableAllModelsRule(excludedModels).map((model) =>
+          model.toLowerCase(),
+        ),
+      ),
     [excludedModels],
   );
   const enabledOpenCodeModelIds = useMemo(
-    () => new Set(openCodeModels.map((model) => model.id.trim().toLowerCase()).filter(Boolean)),
+    () =>
+      new Set(
+        openCodeModels
+          .map((model) => model.id.trim().toLowerCase())
+          .filter(Boolean),
+      ),
     [openCodeModels],
   );
   const isOpenCodeModelAllowed = useCallback(
     (modelId: string) => {
       const normalized = modelId.trim().toLowerCase();
-      return normalized !== "" && !disableAllModels && !excludedModelIds.has(normalized);
+      return (
+        normalized !== "" &&
+        !disableAllModels &&
+        !excludedModelIds.has(normalized)
+      );
     },
     [disableAllModels, excludedModelIds],
   );
@@ -269,7 +279,11 @@ export function ProviderKeyModal({
   const openCodeVisionFallbackOptions = useMemo(() => {
     const optionMap = new Map<string, { value: string; label: string }>();
     for (const model of openCodeModels) {
-      if (!isOpenCodeGoVisionModel(model.id) || !isOpenCodeModelAllowed(model.id)) continue;
+      if (
+        !isOpenCodeGoVisionModel(model.id) ||
+        !isOpenCodeModelAllowed(model.id)
+      )
+        continue;
       optionMap.set(model.id.toLowerCase(), {
         value: model.id,
         label: model.owned_by ? `${model.id} · ${model.owned_by}` : model.id,
@@ -289,7 +303,9 @@ export function ProviderKeyModal({
     const currentFallback = keyDraft.visionFallbackModel.trim();
     const hasCurrentFallback =
       currentFallback !== "" &&
-      !modelOptions.some((model) => model.value.toLowerCase() === currentFallback.toLowerCase());
+      !modelOptions.some(
+        (model) => model.value.toLowerCase() === currentFallback.toLowerCase(),
+      );
     // Preserve existing configs even when "*" or a catalog refresh makes the model unavailable.
     const currentFallbackOption = hasCurrentFallback
       ? [
@@ -306,7 +322,13 @@ export function ProviderKeyModal({
       ...currentFallbackOption,
       ...modelOptions,
     ];
-  }, [isOpenCodeModelAllowed, keyDraft.visionFallbackModel, modelConfigs, openCodeModels, t]);
+  }, [
+    isOpenCodeModelAllowed,
+    keyDraft.visionFallbackModel,
+    modelConfigs,
+    openCodeModels,
+    t,
+  ]);
 
   const setOpenCodeModelAllowed = useCallback(
     (modelId: string, allowed: boolean) => {
@@ -321,7 +343,10 @@ export function ProviderKeyModal({
         );
         return {
           ...prev,
-          excludedModelsText: (allowed ? nextExcluded : [...nextExcluded, modelId]).join("\n"),
+          excludedModelsText: (allowed
+            ? nextExcluded
+            : [...nextExcluded, modelId]
+          ).join("\n"),
         };
       });
     },
@@ -330,7 +355,9 @@ export function ProviderKeyModal({
 
   const setAllFetchedOpenCodeModelsAllowed = useCallback(
     (allowed: boolean) => {
-      const fetchedIds = new Set(openCodeModels.map((model) => model.id.toLowerCase()));
+      const fetchedIds = new Set(
+        openCodeModels.map((model) => model.id.toLowerCase()),
+      );
       setKeyDraft((prev) => {
         const currentExcluded = stripDisableAllModelsRule(
           excludedModelsFromText(prev.excludedModelsText),
@@ -401,13 +428,22 @@ export function ProviderKeyModal({
         </div>
       }
     >
-      <Tabs value={modalTab} onValueChange={(next) => setModalTab(next as ProviderKeyModalTab)}>
+      <Tabs
+        value={modalTab}
+        onValueChange={(next) => setModalTab(next as ProviderKeyModalTab)}
+      >
         <div className="sticky top-0 z-20 border-b border-slate-200 bg-white/95 px-5 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/95">
           <TabsList>
-            <TabsTrigger value="basic">{t("providers.modal_tab_basic")}</TabsTrigger>
-            <TabsTrigger value="request">{t("providers.modal_tab_request")}</TabsTrigger>
+            <TabsTrigger value="basic">
+              {t("providers.modal_tab_basic")}
+            </TabsTrigger>
+            <TabsTrigger value="request">
+              {t("providers.modal_tab_request")}
+            </TabsTrigger>
             {showModelsTab ? (
-              <TabsTrigger value="models">{t("providers.modal_tab_models")}</TabsTrigger>
+              <TabsTrigger value="models">
+                {t("providers.modal_tab_models")}
+              </TabsTrigger>
             ) : null}
           </TabsList>
         </div>
@@ -442,33 +478,35 @@ export function ProviderKeyModal({
 
           {showModelsTab ? (
             <TabsContent value="models">
-            <ProviderKeyModelsTab
-              isOpenCodeGo={isOpenCodeGo}
-              isCline={isCline}
-              openCodeModels={openCodeModels}
-              openCodeModelsLoading={openCodeModelsLoading}
-              openCodeModelsError={openCodeModelsError}
-              openCodeModelQuery={openCodeModelQuery}
-              setOpenCodeModelQuery={setOpenCodeModelQuery}
-              filteredOpenCodeModels={filteredOpenCodeModels}
-              allowedOpenCodeCount={allowedOpenCodeCount}
-              excludeAll={disableAllModels}
-              excludedModelIds={excludedModelIds}
-              enabledOpenCodeModelIds={enabledOpenCodeModelIds}
-              fetchOpenCodeModels={fetchOpenCodeModels}
-              setAllFetchedOpenCodeModelsAllowed={setAllFetchedOpenCodeModelsAllowed}
-              setOpenCodeModelAllowed={setOpenCodeModelAllowed}
-              selectedModelGroup={selectedModelGroup}
-              setSelectedModelGroup={setSelectedModelGroup}
-              modelGroupOptions={modelGroupOptions}
-              modelConfigsLoading={modelConfigsLoading}
-              loadModelsFromGroup={loadModelsFromGroup}
-              editKeyType={editKeyType}
-              keyDraft={keyDraft}
-              setKeyDraft={setKeyDraft}
-              editKeyExcludedCount={editKeyExcludedCount}
-              editKeyEnabledToggle={editKeyEnabledToggle}
-            />
+              <ProviderKeyModelsTab
+                isOpenCodeGo={isOpenCodeGo}
+                isCline={isCline}
+                openCodeModels={openCodeModels}
+                openCodeModelsLoading={openCodeModelsLoading}
+                openCodeModelsError={openCodeModelsError}
+                openCodeModelQuery={openCodeModelQuery}
+                setOpenCodeModelQuery={setOpenCodeModelQuery}
+                filteredOpenCodeModels={filteredOpenCodeModels}
+                allowedOpenCodeCount={allowedOpenCodeCount}
+                excludeAll={disableAllModels}
+                excludedModelIds={excludedModelIds}
+                enabledOpenCodeModelIds={enabledOpenCodeModelIds}
+                fetchOpenCodeModels={fetchOpenCodeModels}
+                setAllFetchedOpenCodeModelsAllowed={
+                  setAllFetchedOpenCodeModelsAllowed
+                }
+                setOpenCodeModelAllowed={setOpenCodeModelAllowed}
+                selectedModelGroup={selectedModelGroup}
+                setSelectedModelGroup={setSelectedModelGroup}
+                modelGroupOptions={modelGroupOptions}
+                modelConfigsLoading={modelConfigsLoading}
+                loadModelsFromGroup={loadModelsFromGroup}
+                editKeyType={editKeyType}
+                keyDraft={keyDraft}
+                setKeyDraft={setKeyDraft}
+                editKeyExcludedCount={editKeyExcludedCount}
+                editKeyEnabledToggle={editKeyEnabledToggle}
+              />
             </TabsContent>
           ) : null}
         </div>

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
+import { DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { SearchableSelect } from "@code-proxy/ui";
 import {
@@ -11,8 +12,14 @@ import {
   stripDisableAllModelsRule,
   type ProviderKeyDraft,
 } from "../providers-helpers";
-import { createEmptyModelEntry, ModelInputList, type ModelEntryDraft } from "../ModelInputList";
+import {
+  createEmptyModelEntry,
+  ModelInputList,
+  type ModelEntryDraft,
+} from "../ModelInputList";
 import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
+
+type ModelAccessRow = { id: string; owned_by?: string };
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
   <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
@@ -97,25 +104,110 @@ export function ProviderKeyModelsTab({
     return out;
   }, [keyDraft.modelEntries]);
 
-  const setModelAlias = (modelId: string, alias: string) => {
-    const key = modelId.trim().toLowerCase();
-    if (!key) return;
-    setKeyDraft((prev) => {
-      const existing = prev.modelEntries.find((entry) => entry.name.trim().toLowerCase() === key);
-      if (existing) {
+  const setModelAlias = useCallback(
+    (modelId: string, alias: string) => {
+      const key = modelId.trim().toLowerCase();
+      if (!key) return;
+      setKeyDraft((prev) => {
+        const existing = prev.modelEntries.find(
+          (entry) => entry.name.trim().toLowerCase() === key,
+        );
+        if (existing) {
+          return {
+            ...prev,
+            modelEntries: prev.modelEntries.map((entry) =>
+              entry.id === existing.id ? { ...entry, alias } : entry,
+            ),
+          };
+        }
         return {
           ...prev,
-          modelEntries: prev.modelEntries.map((entry) =>
-            entry.id === existing.id ? { ...entry, alias } : entry,
-          ),
+          modelEntries: [
+            ...prev.modelEntries,
+            { ...createEmptyModelEntry(), name: modelId, alias },
+          ],
         };
-      }
-      return {
-        ...prev,
-        modelEntries: [...prev.modelEntries, { ...createEmptyModelEntry(), name: modelId, alias }],
-      };
-    });
-  };
+      });
+    },
+    [setKeyDraft],
+  );
+
+  const modelAccessColumns = useMemo<DataTableColumn<ModelAccessRow>[]>(
+    () => [
+      {
+        key: "model",
+        label: t("providers.real_model_id"),
+        minWidthPx: 280,
+        overflowTooltip: (model) =>
+          model.owned_by ? `${model.id}\n${model.owned_by}` : model.id,
+        render: (model) => (
+          <span className="min-w-0">
+            <span className="block truncate font-mono text-xs font-semibold text-slate-800 dark:text-white/85">
+              {model.id}
+            </span>
+            {model.owned_by ? (
+              <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
+                {model.owned_by}
+              </span>
+            ) : null}
+          </span>
+        ),
+      },
+      {
+        key: "alias",
+        label: t("providers.model_alias"),
+        minWidthPx: 220,
+        render: (model) => {
+          const entry = modelEntryByName.get(model.id.toLowerCase());
+          return (
+            <TextInput
+              value={entry?.alias ?? ""}
+              onChange={(event) =>
+                setModelAlias(model.id, event.currentTarget.value)
+              }
+              placeholder={t("common.model_alias_placeholder")}
+              className="h-8"
+            />
+          );
+        },
+      },
+      {
+        key: "enabled",
+        label: t("providers.model_enabled"),
+        width: "w-20",
+        minWidthPx: 80,
+        headerClassName: "text-center",
+        cellClassName: "text-center",
+        render: (model) => {
+          const normalized = model.id.toLowerCase();
+          const checked =
+            !excludeAll &&
+            enabledOpenCodeModelIds.has(normalized) &&
+            !excludedModelIds.has(normalized);
+          return (
+            <div className="flex justify-center">
+              <Checkbox
+                checked={checked}
+                onCheckedChange={(next) =>
+                  setOpenCodeModelAllowed(model.id, next)
+                }
+                aria-label={model.id}
+              />
+            </div>
+          );
+        },
+      },
+    ],
+    [
+      enabledOpenCodeModelIds,
+      excludeAll,
+      excludedModelIds,
+      modelEntryByName,
+      setModelAlias,
+      setOpenCodeModelAllowed,
+      t,
+    ],
+  );
 
   if (isModelAccessProvider) {
     return (
@@ -181,62 +273,23 @@ export function ProviderKeyModelsTab({
             </p>
           ) : null}
 
-          <div className="mt-3 max-h-80 overflow-y-auto rounded-xl bg-white dark:bg-neutral-950">
-            <div className="grid grid-cols-[minmax(0,1fr)_minmax(180px,260px)_72px] gap-3 px-3 py-2 text-xs font-semibold text-slate-500 dark:text-white/55">
-              <span>{t("providers.real_model_id")}</span>
-              <span>{t("providers.model_alias")}</span>
-              <span className="text-center">{t("providers.model_enabled")}</span>
-            </div>
-            {openCodeModelsLoading && openCodeModels.length === 0 ? (
-              <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-white/55">
-                {t("providers.models_loading")}
-              </div>
-            ) : filteredOpenCodeModels.length ? (
-              <div className="divide-y divide-slate-100 dark:divide-neutral-900">
-                {filteredOpenCodeModels.map((model) => {
-                  const normalized = model.id.toLowerCase();
-                  const checked =
-                    !excludeAll &&
-                    enabledOpenCodeModelIds.has(normalized) &&
-                    !excludedModelIds.has(normalized);
-                  const entry = modelEntryByName.get(normalized);
-                  return (
-                    <div
-                      key={model.id}
-                      className="grid grid-cols-[minmax(0,1fr)_minmax(180px,260px)_72px] items-center gap-3 px-3 py-2.5 transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
-                    >
-                      <span className="min-w-0">
-                        <span className="block truncate font-mono text-xs font-semibold text-slate-800 dark:text-white/85">
-                          {model.id}
-                        </span>
-                        {model.owned_by ? (
-                          <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
-                            {model.owned_by}
-                          </span>
-                        ) : null}
-                      </span>
-                      <TextInput
-                        value={entry?.alias ?? ""}
-                        onChange={(event) => setModelAlias(model.id, event.currentTarget.value)}
-                        placeholder={t("common.model_alias_placeholder")}
-                        className="h-8"
-                      />
-                      <div className="flex justify-center">
-                        <Checkbox
-                          checked={checked}
-                          onCheckedChange={(next) => setOpenCodeModelAllowed(model.id, next)}
-                          aria-label={model.id}
-                        />
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="px-3 py-6 text-center text-sm text-slate-500 dark:text-white/55">
-                {t("providers.no_discovered_models")}
-              </div>
-            )}
+          <div className="mt-3">
+            <DataTable<ModelAccessRow>
+              tableId={`provider-model-access-${editKeyType}`}
+              rows={filteredOpenCodeModels}
+              columns={modelAccessColumns}
+              rowKey={(model) => model.id}
+              loading={openCodeModelsLoading && openCodeModels.length === 0}
+              rowHeight={52}
+              caption={modelAccessTitle}
+              emptyText={t("providers.no_discovered_models")}
+              minWidth="min-w-[720px]"
+              height="h-80"
+              minHeight="min-h-0"
+              showAllLoadedMessage={false}
+              columnReorderable={false}
+              persistColumnOrder={false}
+            />
           </div>
         </SectionCard>
 

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -6,12 +6,7 @@ import { Checkbox } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { SearchableSelect } from "@code-proxy/ui";
-import {
-  excludedModelsFromText,
-  hasDisableAllModelsRule,
-  stripDisableAllModelsRule,
-  type ProviderKeyDraft,
-} from "../providers-helpers";
+import { type ProviderKeyDraft } from "../providers-helpers";
 import {
   createEmptyModelEntry,
   ModelInputList,

--- a/pages/providers/components/ProviderModelChips.tsx
+++ b/pages/providers/components/ProviderModelChips.tsx
@@ -1,4 +1,5 @@
 import type { ProviderModel } from "@code-proxy/api-client";
+import { HoverTooltip } from "@code-proxy/ui";
 
 interface ProviderModelChipsProps {
   models: ProviderModel[];
@@ -13,42 +14,47 @@ export function ProviderModelChips({
 }: ProviderModelChipsProps) {
   if (!models.length) {
     return emptyLabel ? (
-      <span className="text-xs text-slate-400 dark:text-white/40">{emptyLabel}</span>
+      <span className="text-xs text-slate-400 dark:text-white/40">
+        {emptyLabel}
+      </span>
     ) : null;
   }
 
   const visible = models.slice(0, maxVisible);
   const remaining = models.length - maxVisible;
+  const formatModelLabel = (model: ProviderModel, arrow: string) => {
+    const name = model.name ?? "";
+    return model.alias && model.alias !== name
+      ? `${name} ${arrow} ${model.alias}`
+      : name;
+  };
 
   return (
     <div className="flex flex-wrap gap-1">
       {visible.map((model) => {
-        const modelLabel =
-          model.alias && model.alias !== model.name ? `${model.name} → ${model.alias}` : model.name;
+        const modelLabel = formatModelLabel(model, "→");
         return (
           <span
             key={model.name}
             className="inline-flex max-w-full min-w-0 rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-            title={
-              model.alias && model.alias !== model.name
-                ? `${model.name} => ${model.alias}`
-                : model.name
-            }
+            title={formatModelLabel(model, "=>")}
           >
             <span className="min-w-0 truncate">{modelLabel}</span>
           </span>
         );
       })}
       {remaining > 0 ? (
-        <span
-          className="inline-flex max-w-full min-w-0 cursor-default rounded-full bg-slate-200 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-neutral-800 dark:text-white/55"
-          title={models
+        <HoverTooltip
+          content={models
             .slice(maxVisible)
-            .map((m) => m.name)
-            .join(", ")}
+            .map((model) => formatModelLabel(model, "=>"))
+            .join("\n")}
+          placement="top"
         >
-          +{remaining}
-        </span>
+          <span className="inline-flex max-w-full min-w-0 cursor-default rounded-full bg-slate-200 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-neutral-800 dark:text-white/55">
+            +{remaining}
+          </span>
+        </HoverTooltip>
       ) : null}
     </div>
   );

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1,8 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ampcodeApi, providersApi, usageApi } from "@code-proxy/api-client";
-import { proxiesApi, type ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
+import {
+  proxiesApi,
+  type ProxyPoolEntry,
+} from "@code-proxy/api-client/endpoints/proxies";
 import type {
   BedrockProviderConfig,
   OpenAIProvider,
@@ -30,13 +40,24 @@ import { useProviderLatency } from "../hooks/useProviderLatency";
 import { useProviderUsageSummary } from "../hooks/useProviderUsageSummary";
 import { normalizeUsageSourceId, type KeyStatBucket } from "@code-proxy/domain";
 import { getCachedData, setCachedData } from "../provider-cache";
-import { maskApiKey, readBool, readString, type AmpMappingEntry } from "../providers-helpers";
+import {
+  maskApiKey,
+  readBool,
+  readString,
+  type AmpMappingEntry,
+} from "../providers-helpers";
 import {
   createProviderExportText,
   prepareProviderImport,
   type ProviderImportDiff,
   type ProviderImportKind,
 } from "../provider-import-export";
+import {
+  fetchModelAccessCatalog,
+  getEffectiveProviderModels,
+  type DiscoveredProviderModel,
+  type ModelAccessProvider,
+} from "../provider-model-access";
 import { ProvidersToolbar } from "./ProvidersToolbar";
 import { ProviderTabsWithCounts } from "./ProviderTabsWithCounts";
 import type { ProviderTabId } from "./ProviderTabsWithCounts";
@@ -56,14 +77,17 @@ const PROVIDER_TAB_VALUES: ProviderTab[] = [
   "openai",
   "ampcode",
 ];
-const PROVIDER_LIST_TAB_VALUES: Exclude<ProviderTab, "ampcode">[] = PROVIDER_TAB_VALUES.filter(
-  (item) => item !== "ampcode",
-) as Exclude<ProviderTab, "ampcode">[];
+const PROVIDER_LIST_TAB_VALUES: Exclude<ProviderTab, "ampcode">[] =
+  PROVIDER_TAB_VALUES.filter((item) => item !== "ampcode") as Exclude<
+    ProviderTab,
+    "ampcode"
+  >[];
 
 function readSavedProviderTab(): ProviderTab {
   try {
     const saved = localStorage.getItem(PROVIDER_TAB_STORAGE_KEY);
-    if (saved && PROVIDER_TAB_VALUES.includes(saved as ProviderTab)) return saved as ProviderTab;
+    if (saved && PROVIDER_TAB_VALUES.includes(saved as ProviderTab))
+      return saved as ProviderTab;
   } catch {
     // ignore
   }
@@ -91,16 +115,43 @@ const getProviderSelectionKey = (
         .trim()
         .toLowerCase()}:${index}`;
 
-const getOpenCodeGoUsageCacheKey = (item: ProviderSimpleConfig, index: number) =>
-  [item.workspaceId?.trim() || "no-workspace", item.name?.trim() || `item-${index}`, index].join(
-    ":",
-  );
+const getOpenCodeGoUsageCacheKey = (
+  item: ProviderSimpleConfig,
+  index: number,
+) =>
+  [
+    item.workspaceId?.trim() || "no-workspace",
+    item.name?.trim() || `item-${index}`,
+    index,
+  ].join(":");
 
 const hasOpenCodeGoUsageQuery = (item: ProviderSimpleConfig) =>
   Boolean(item.workspaceId?.trim() && item.authCookie?.trim());
 
 type OpenCodeGoUsageState = Record<string, OpenCodeGoUsageCacheEntry>;
 type OpenCodeGoUsageLoadingState = Record<string, boolean>;
+type ModelAccessCatalogState = Record<
+  ModelAccessProvider,
+  DiscoveredProviderModel[]
+>;
+type ModelAccessCatalogLoadedState = Record<ModelAccessProvider, boolean>;
+
+const EMPTY_MODEL_ACCESS_CATALOGS: ModelAccessCatalogState = {
+  "opencode-go": [],
+  cline: [],
+  "ollama-cloud": [],
+};
+
+const EMPTY_MODEL_ACCESS_CATALOG_LOADED: ModelAccessCatalogLoadedState = {
+  "opencode-go": false,
+  cline: false,
+  "ollama-cloud": false,
+};
+
+const isModelAccessProvider = (
+  tabId: ProviderTab,
+): tabId is ModelAccessProvider =>
+  tabId === "opencode-go" || tabId === "cline" || tabId === "ollama-cloud";
 
 export function ProvidersPage() {
   const { t } = useTranslation();
@@ -117,16 +168,36 @@ export function ProvidersPage() {
   }, []);
   const [loading, setLoading] = useState(true);
 
-  const cachedUsageState = getCachedData<OpenCodeGoUsageState>("opencode-go-usage");
-  const [openCodeGoUsageState, setOpenCodeGoUsageState] = useState<OpenCodeGoUsageState>(
-    cachedUsageState ?? {},
-  );
+  const cachedUsageState =
+    getCachedData<OpenCodeGoUsageState>("opencode-go-usage");
+  const [openCodeGoUsageState, setOpenCodeGoUsageState] =
+    useState<OpenCodeGoUsageState>(cachedUsageState ?? {});
   const [openCodeGoUsageLoadingState, setOpenCodeGoUsageLoadingState] =
     useState<OpenCodeGoUsageLoadingState>({});
+  const [modelAccessCatalogs, setModelAccessCatalogs] =
+    useState<ModelAccessCatalogState>(EMPTY_MODEL_ACCESS_CATALOGS);
+  const [modelAccessCatalogLoaded, setModelAccessCatalogLoaded] =
+    useState<ModelAccessCatalogLoadedState>(EMPTY_MODEL_ACCESS_CATALOG_LOADED);
+
+  const loadModelAccessCatalog = useCallback(
+    async (provider: ModelAccessProvider) => {
+      try {
+        const catalog = await fetchModelAccessCatalog(provider);
+        setModelAccessCatalogs((prev) => ({ ...prev, [provider]: catalog }));
+      } catch {
+        setModelAccessCatalogs((prev) => ({ ...prev, [provider]: [] }));
+      } finally {
+        setModelAccessCatalogLoaded((prev) => ({ ...prev, [provider]: true }));
+      }
+    },
+    [],
+  );
 
   const refreshOpenCodeGoUsage = useCallback(
     async (item: ProviderSimpleConfig, index: number) => {
-      const hasQuery = Boolean(item.workspaceId?.trim() && item.authCookie?.trim());
+      const hasQuery = Boolean(
+        item.workspaceId?.trim() && item.authCookie?.trim(),
+      );
       if (!hasQuery) return;
 
       const cacheKey = getOpenCodeGoUsageCacheKey(item, index);
@@ -148,7 +219,10 @@ export function ProvidersPage() {
         };
         setOpenCodeGoUsageState((prev) => {
           const existing = prev[cacheKey];
-          const merged = mergeOpenCodeGoUsage(existing?.usage ?? [], entry.usage);
+          const merged = mergeOpenCodeGoUsage(
+            existing?.usage ?? [],
+            entry.usage,
+          );
           const next = {
             ...prev,
             [cacheKey]: {
@@ -160,7 +234,10 @@ export function ProvidersPage() {
           setCachedData("opencode-go-usage", next);
           return next;
         });
-        setOpenCodeGoUsageLoadingState((prev) => ({ ...prev, [cacheKey]: false }));
+        setOpenCodeGoUsageLoadingState((prev) => ({
+          ...prev,
+          [cacheKey]: false,
+        }));
       } catch (err: unknown) {
         setOpenCodeGoUsageState((prev) => {
           const existing = prev[cacheKey];
@@ -169,13 +246,18 @@ export function ProvidersPage() {
             usage: existing?.usage ?? [],
             updatedAt: Date.now(),
             error:
-              err instanceof Error ? err.message : t("providers.opencode_go_usage_query_failed"),
+              err instanceof Error
+                ? err.message
+                : t("providers.opencode_go_usage_query_failed"),
           };
           const next = { ...prev, [cacheKey]: entry };
           setCachedData("opencode-go-usage", next);
           return next;
         });
-        setOpenCodeGoUsageLoadingState((prev) => ({ ...prev, [cacheKey]: false }));
+        setOpenCodeGoUsageLoadingState((prev) => ({
+          ...prev,
+          [cacheKey]: false,
+        }));
       }
     },
     [t],
@@ -184,9 +266,13 @@ export function ProvidersPage() {
   const [geminiKeys, setGeminiKeys] = useState<ProviderSimpleConfig[]>([]);
   const [claudeKeys, setClaudeKeys] = useState<ProviderSimpleConfig[]>([]);
   const [codexKeys, setCodexKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>([]);
+  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>(
+    [],
+  );
   const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [ollamaCloudKeys, setOllamaCloudKeys] = useState<ProviderSimpleConfig[]>([]);
+  const [ollamaCloudKeys, setOllamaCloudKeys] = useState<
+    ProviderSimpleConfig[]
+  >([]);
   const [vertexKeys, setVertexKeys] = useState<ProviderSimpleConfig[]>([]);
   const [bedrockKeys, setBedrockKeys] = useState<BedrockProviderConfig[]>([]);
   const [openaiProviders, setOpenaiProviders] = useState<OpenAIProvider[]>([]);
@@ -202,12 +288,20 @@ export function ProvidersPage() {
     if (autoRefreshOpenCodeGoInFlightRef.current) return;
 
     const staleKeys = openCodeGoKeys
-      .map((item, idx) => ({ item, idx, key: getOpenCodeGoUsageCacheKey(item, idx) }))
-      .filter(({ item }) => Boolean(item.workspaceId?.trim() && item.authCookie?.trim()))
+      .map((item, idx) => ({
+        item,
+        idx,
+        key: getOpenCodeGoUsageCacheKey(item, idx),
+      }))
+      .filter(({ item }) =>
+        Boolean(item.workspaceId?.trim() && item.authCookie?.trim()),
+      )
       .filter(({ key }) => {
         if (openCodeGoUsageLoadingState[key]) return false;
         const entry = openCodeGoUsageState[key];
-        return !entry || Date.now() - entry.updatedAt > OPEN_CODE_GO_USAGE_STALE_MS;
+        return (
+          !entry || Date.now() - entry.updatedAt > OPEN_CODE_GO_USAGE_STALE_MS
+        );
       });
 
     if (staleKeys.length === 0) return;
@@ -217,7 +311,9 @@ export function ProvidersPage() {
     const refreshBatch = async () => {
       for (let i = 0; i < staleKeys.length; i += 2) {
         const batch = staleKeys.slice(i, i + 2);
-        await Promise.allSettled(batch.map(({ item, idx }) => refreshOpenCodeGoUsage(item, idx)));
+        await Promise.allSettled(
+          batch.map(({ item, idx }) => refreshOpenCodeGoUsage(item, idx)),
+        );
       }
       autoRefreshOpenCodeGoInFlightRef.current = false;
     };
@@ -232,9 +328,19 @@ export function ProvidersPage() {
     refreshOpenCodeGoUsage,
   ]);
 
-  const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>([]);
+  useEffect(() => {
+    if (!isModelAccessProvider(tab)) return;
+    if (modelAccessCatalogLoaded[tab]) return;
+    void loadModelAccessCatalog(tab);
+  }, [loadModelAccessCatalog, modelAccessCatalogLoaded, tab]);
 
-  const [usageStatsBySource, setUsageStatsBySource] = useState<Record<string, KeyStatBucket>>({});
+  const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>(
+    [],
+  );
+
+  const [usageStatsBySource, setUsageStatsBySource] = useState<
+    Record<string, KeyStatBucket>
+  >({});
 
   const [ampcode, setAmpcode] = useState<Record<string, unknown> | null>(null);
   const [ampUpstreamUrl, setAmpUpstreamUrl] = useState("");
@@ -263,7 +369,8 @@ export function ProvidersPage() {
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const [importPreview, setImportPreview] = useState<{
     kind: ProviderImportKind;
-    nextItems: ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[];
+    nextItems:
+      ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[];
     diff: ProviderImportDiff;
     filename: string;
   } | null>(null);
@@ -274,7 +381,9 @@ export function ProvidersPage() {
   useEffect(() => {
     setOpenCodeGoUsageState((prev) => {
       const validKeys = new Set(
-        openCodeGoKeys.map((item, idx) => getOpenCodeGoUsageCacheKey(item, idx)),
+        openCodeGoKeys.map((item, idx) =>
+          getOpenCodeGoUsageCacheKey(item, idx),
+        ),
       );
       const staleKeys = Object.keys(prev).filter((k) => !validKeys.has(k));
       if (staleKeys.length === 0) return prev;
@@ -370,7 +479,9 @@ export function ProvidersPage() {
             : {};
         setAmpcode(ampObj);
         setAmpUpstreamUrl(readString(ampObj, "upstreamUrl", "upstream-url"));
-        setAmpForceMappings(readBool(ampObj, "forceModelMappings", "force-model-mappings"));
+        setAmpForceMappings(
+          readBool(ampObj, "forceModelMappings", "force-model-mappings"),
+        );
 
         const mappings = Array.isArray(ampMap) ? ampMap : [];
         const entries: AmpMappingEntry[] = mappings
@@ -383,7 +494,11 @@ export function ProvidersPage() {
             return { id: `map-${idx}-${from}`, from, to };
           })
           .filter(Boolean) as AmpMappingEntry[];
-        setAmpMappings(entries.length ? entries : [{ id: `map-${Date.now()}`, from: "", to: "" }]);
+        setAmpMappings(
+          entries.length
+            ? entries
+            : [{ id: `map-${Date.now()}`, from: "", to: "" }],
+        );
         break;
       }
     }
@@ -397,7 +512,8 @@ export function ProvidersPage() {
       } catch (err: unknown) {
         notify({
           type: "error",
-          message: err instanceof Error ? err.message : t("providers.load_failed"),
+          message:
+            err instanceof Error ? err.message : t("providers.load_failed"),
         });
       } finally {
         setLoading(false);
@@ -408,7 +524,8 @@ export function ProvidersPage() {
 
   const loadUsage = useCallback(async () => {
     try {
-      const cachedUsage = getCachedData<Record<string, KeyStatBucket>>("usage-stats");
+      const cachedUsage =
+        getCachedData<Record<string, KeyStatBucket>>("usage-stats");
       if (cachedUsage) setUsageStatsBySource(cachedUsage);
       const usage = await usageApi.getEntityStats(30, "all").catch(() => null);
       if (usage?.source) {
@@ -450,7 +567,9 @@ export function ProvidersPage() {
   const refreshAll = useCallback(async () => {
     setLoading(true);
     const tabsToRefresh: ProviderTab[] =
-      tab === "ampcode" ? [...PROVIDER_LIST_TAB_VALUES, "ampcode"] : PROVIDER_LIST_TAB_VALUES;
+      tab === "ampcode"
+        ? [...PROVIDER_LIST_TAB_VALUES, "ampcode"]
+        : PROVIDER_LIST_TAB_VALUES;
     const results = await Promise.allSettled([
       ...tabsToRefresh.map((tabId) => loadProviderTab(tabId)),
       loadUsage(),
@@ -461,7 +580,9 @@ export function ProvidersPage() {
       notify({
         type: "error",
         message:
-          failed.reason instanceof Error ? failed.reason.message : t("providers.load_failed"),
+          failed.reason instanceof Error
+            ? failed.reason.message
+            : t("providers.load_failed"),
       });
     }
     setLoading(false);
@@ -639,7 +760,8 @@ export function ProvidersPage() {
     } catch (err: unknown) {
       notify({
         type: "error",
-        message: err instanceof Error ? err.message : t("providers.save_failed"),
+        message:
+          err instanceof Error ? err.message : t("providers.save_failed"),
       });
     }
   }, [
@@ -720,14 +842,18 @@ export function ProvidersPage() {
         ? currentTabItems.map((item, index) =>
             getProviderSelectionKey(
               currentImportKind,
-              item as ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
+              item as
+                ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
               index,
             ),
           )
         : [],
     [currentImportKind, currentTabItems],
   );
-  const selectedExportKeySet = useMemo(() => new Set(selectedExportKeys), [selectedExportKeys]);
+  const selectedExportKeySet = useMemo(
+    () => new Set(selectedExportKeys),
+    [selectedExportKeys],
+  );
   const selectedExportCount = selectedExportKeys.length;
   const allCurrentSelected =
     currentSelectableKeys.length > 0 &&
@@ -767,7 +893,8 @@ export function ProvidersPage() {
   const saveImportedItems = useCallback(
     async (
       kind: ProviderImportKind,
-      items: ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[],
+      items:
+        ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[],
     ) => {
       switch (kind) {
         case "gemini":
@@ -780,19 +907,25 @@ export function ProvidersPage() {
           await providersApi.saveCodexConfigs(items as ProviderSimpleConfig[]);
           return;
         case "opencode-go":
-          await providersApi.saveOpenCodeGoConfigs(items as ProviderSimpleConfig[]);
+          await providersApi.saveOpenCodeGoConfigs(
+            items as ProviderSimpleConfig[],
+          );
           return;
         case "cline":
           await providersApi.saveClineConfigs(items as ProviderSimpleConfig[]);
           return;
         case "ollama-cloud":
-          await providersApi.saveOllamaCloudConfigs(items as ProviderSimpleConfig[]);
+          await providersApi.saveOllamaCloudConfigs(
+            items as ProviderSimpleConfig[],
+          );
           return;
         case "vertex":
           await providersApi.saveVertexConfigs(items as ProviderSimpleConfig[]);
           return;
         case "bedrock":
-          await providersApi.saveBedrockConfigs(items as BedrockProviderConfig[]);
+          await providersApi.saveBedrockConfigs(
+            items as BedrockProviderConfig[],
+          );
           return;
         case "openai":
           await providersApi.saveOpenAIProviders(items as OpenAIProvider[]);
@@ -856,13 +989,21 @@ export function ProvidersPage() {
       createProviderExportText(kind, selectedItems as never),
       `${kind}-providers-selected.json`,
     );
-  }, [currentImportKind, currentTabItems, selectedExportCount, selectedExportKeySet]);
+  }, [
+    currentImportKind,
+    currentTabItems,
+    selectedExportCount,
+    selectedExportKeySet,
+  ]);
 
   const handleImportFile = useCallback(
     async (file: File | null) => {
       const kind = currentImportKind;
       if (!kind || !file) return;
-      if (!file.name.toLowerCase().endsWith(".json") && file.type !== "application/json") {
+      if (
+        !file.name.toLowerCase().endsWith(".json") &&
+        file.type !== "application/json"
+      ) {
         notify({ type: "error", message: t("upload_error_json") });
         return;
       }
@@ -899,19 +1040,29 @@ export function ProvidersPage() {
       await saveImportedItems(importPreview.kind, importPreview.nextItems);
       notify({
         type: "success",
-        message: t("providers.import_success", { filename: importPreview.filename }),
+        message: t("providers.import_success", {
+          filename: importPreview.filename,
+        }),
       });
       setImportPreview(null);
       startTransition(() => void refreshAll());
     } catch (error: unknown) {
       notify({
         type: "error",
-        message: error instanceof Error ? error.message : t("providers.save_failed"),
+        message:
+          error instanceof Error ? error.message : t("providers.save_failed"),
       });
     } finally {
       setImporting(false);
     }
-  }, [importPreview, notify, refreshAll, saveImportedItems, startTransition, t]);
+  }, [
+    importPreview,
+    notify,
+    refreshAll,
+    saveImportedItems,
+    startTransition,
+    t,
+  ]);
 
   return (
     <div
@@ -965,12 +1116,24 @@ export function ProvidersPage() {
             { id: "gemini", label: "Gemini", count: tabCounts.gemini },
             { id: "claude", label: "Claude", count: tabCounts.claude },
             { id: "codex", label: "Codex", count: tabCounts.codex },
-            { id: "opencode-go", label: "OpenCode Go", count: tabCounts["opencode-go"] },
+            {
+              id: "opencode-go",
+              label: "OpenCode Go",
+              count: tabCounts["opencode-go"],
+            },
             { id: "cline", label: "ClinePass", count: tabCounts.cline },
-            { id: "ollama-cloud", label: "Ollama Cloud", count: tabCounts["ollama-cloud"] },
+            {
+              id: "ollama-cloud",
+              label: "Ollama Cloud",
+              count: tabCounts["ollama-cloud"],
+            },
             { id: "vertex", label: "Vertex", count: tabCounts.vertex },
             { id: "bedrock", label: "Bedrock", count: tabCounts.bedrock },
-            { id: "openai", label: t("providers.openai_compatible"), count: tabCounts.openai },
+            {
+              id: "openai",
+              label: t("providers.openai_compatible"),
+              count: tabCounts.openai,
+            },
             { id: "ampcode", label: "Ampcode", count: tabCounts.ampcode },
           ]}
           value={tab}
@@ -982,8 +1145,12 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("gemini")}
               onAdd={() => openKeyEditor("gemini", null)}
               onEdit={(idx) => openKeyEditor("gemini", idx)}
-              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "gemini", index: idx })}
-              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("gemini", idx, enabled)}
+              onDelete={(idx) =>
+                setConfirm({ type: "deleteKey", keyType: "gemini", index: idx })
+              }
+              onToggleEnabled={(idx, enabled) =>
+                void toggleKeyEnabled("gemini", idx, enabled)
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -999,8 +1166,12 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("claude")}
               onAdd={() => openKeyEditor("claude", null)}
               onEdit={(idx) => openKeyEditor("claude", idx)}
-              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "claude", index: idx })}
-              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("claude", idx, enabled)}
+              onDelete={(idx) =>
+                setConfirm({ type: "deleteKey", keyType: "claude", index: idx })
+              }
+              onToggleEnabled={(idx, enabled) =>
+                void toggleKeyEnabled("claude", idx, enabled)
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1016,8 +1187,12 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("codex")}
               onAdd={() => openKeyEditor("codex", null)}
               onEdit={(idx) => openKeyEditor("codex", idx)}
-              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "codex", index: idx })}
-              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("codex", idx, enabled)}
+              onDelete={(idx) =>
+                setConfirm({ type: "deleteKey", keyType: "codex", index: idx })
+              }
+              onToggleEnabled={(idx, enabled) =>
+                void toggleKeyEnabled("codex", idx, enabled)
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1027,18 +1202,34 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="opencode-go" className="min-h-0 flex flex-1 flex-col">
+          <TabsContent
+            value="opencode-go"
+            className="min-h-0 flex flex-1 flex-col"
+          >
             <ProviderKeyListCard
               items={openCodeGoKeys}
               loading={isActiveTabListLoading("opencode-go")}
               onAdd={() => openKeyEditor("opencode-go", null)}
               onEdit={(idx) => openKeyEditor("opencode-go", idx)}
               onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "opencode-go", index: idx })
+                setConfirm({
+                  type: "deleteKey",
+                  keyType: "opencode-go",
+                  index: idx,
+                })
               }
-              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("opencode-go", idx, enabled)}
+              onToggleEnabled={(idx, enabled) =>
+                void toggleKeyEnabled("opencode-go", idx, enabled)
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
+              getDisplayModels={(item) =>
+                getEffectiveProviderModels(
+                  "opencode-go",
+                  item,
+                  modelAccessCatalogs["opencode-go"],
+                )
+              }
               showBaseUrl={false}
               naturalHeight
               showConnectionRows={false}
@@ -1053,13 +1244,16 @@ export function ProvidersPage() {
                     queryReady={queryReady}
                     usageEntry={queryReady ? usageEntry : undefined}
                     loading={
-                      queryReady ? (openCodeGoUsageLoadingState[cacheKey] ?? !usageEntry) : false
+                      queryReady
+                        ? (openCodeGoUsageLoadingState[cacheKey] ?? !usageEntry)
+                        : false
                     }
                   />
                 );
               }}
               renderMetricsExtra={(item, idx) => {
-                if (!(item.workspaceId?.trim() && item.authCookie?.trim())) return null;
+                if (!(item.workspaceId?.trim() && item.authCookie?.trim()))
+                  return null;
                 const cacheKey = getOpenCodeGoUsageCacheKey(item, idx);
                 const loading = openCodeGoUsageLoadingState[cacheKey] ?? false;
                 const hasError = Boolean(openCodeGoUsageState[cacheKey]?.error);
@@ -1112,10 +1306,21 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("cline")}
               onAdd={() => openKeyEditor("cline", null)}
               onEdit={(idx) => openKeyEditor("cline", idx)}
-              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "cline", index: idx })}
-              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("cline", idx, enabled)}
+              onDelete={(idx) =>
+                setConfirm({ type: "deleteKey", keyType: "cline", index: idx })
+              }
+              onToggleEnabled={(idx, enabled) =>
+                void toggleKeyEnabled("cline", idx, enabled)
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
+              getDisplayModels={(item) =>
+                getEffectiveProviderModels(
+                  "cline",
+                  item,
+                  modelAccessCatalogs.cline,
+                )
+              }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
               selectedKeys={selectedExportKeySet}
@@ -1123,20 +1328,34 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent value="ollama-cloud" className="min-h-0 flex flex-1 flex-col">
+          <TabsContent
+            value="ollama-cloud"
+            className="min-h-0 flex flex-1 flex-col"
+          >
             <ProviderKeyListCard
               items={ollamaCloudKeys}
               loading={isActiveTabListLoading("ollama-cloud")}
               onAdd={() => openKeyEditor("ollama-cloud", null)}
               onEdit={(idx) => openKeyEditor("ollama-cloud", idx)}
               onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "ollama-cloud", index: idx })
+                setConfirm({
+                  type: "deleteKey",
+                  keyType: "ollama-cloud",
+                  index: idx,
+                })
               }
               onToggleEnabled={(idx, enabled) =>
                 void toggleKeyEnabled("ollama-cloud", idx, enabled)
               }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
+              getDisplayModels={(item) =>
+                getEffectiveProviderModels(
+                  "ollama-cloud",
+                  item,
+                  modelAccessCatalogs["ollama-cloud"],
+                )
+              }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
               selectedKeys={selectedExportKeySet}
@@ -1150,7 +1369,9 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("vertex")}
               onAdd={() => openKeyEditor("vertex", null)}
               onEdit={(idx) => openKeyEditor("vertex", idx)}
-              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "vertex", index: idx })}
+              onDelete={(idx) =>
+                setConfirm({ type: "deleteKey", keyType: "vertex", index: idx })
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1166,8 +1387,16 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("bedrock")}
               onAdd={() => openKeyEditor("bedrock", null)}
               onEdit={(idx) => openKeyEditor("bedrock", idx)}
-              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "bedrock", index: idx })}
-              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("bedrock", idx, enabled)}
+              onDelete={(idx) =>
+                setConfirm({
+                  type: "deleteKey",
+                  keyType: "bedrock",
+                  index: idx,
+                })
+              }
+              onToggleEnabled={(idx, enabled) =>
+                void toggleKeyEnabled("bedrock", idx, enabled)
+              }
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1182,7 +1411,9 @@ export function ProvidersPage() {
               providers={openaiProviders}
               loading={isActiveTabListLoading("openai")}
               openOpenAIEditor={openOpenAIEditor}
-              confirmDelete={(index) => setConfirm({ type: "deleteOpenAI", index })}
+              confirmDelete={(index) =>
+                setConfirm({ type: "deleteOpenAI", index })
+              }
               maskApiKey={maskApiKey}
               getKeyEntryStats={getOpenAIKeyEntryStats}
               getProviderStats={getOpenAIProviderStats}
@@ -1191,7 +1422,11 @@ export function ProvidersPage() {
                 void toggleOpenAIProviderEnabled(providerIndex, enabled)
               }
               onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
-                void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
+                void toggleOpenAIKeyEntryEnabled(
+                  providerIndex,
+                  entryIndex,
+                  enabled,
+                )
               }
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
@@ -1287,7 +1522,9 @@ export function ProvidersPage() {
         title={t("providers.import_preview_title")}
         description={
           importPreview
-            ? t("providers.import_preview_desc", { filename: importPreview.filename })
+            ? t("providers.import_preview_desc", {
+                filename: importPreview.filename,
+              })
             : undefined
         }
         maxWidth="max-w-2xl"
@@ -1297,7 +1534,11 @@ export function ProvidersPage() {
         }}
         footer={
           <>
-            <Button variant="secondary" onClick={() => setImportPreview(null)} disabled={importing}>
+            <Button
+              variant="secondary"
+              onClick={() => setImportPreview(null)}
+              disabled={importing}
+            >
               {t("common.cancel")}
             </Button>
             <Button
@@ -1314,11 +1555,23 @@ export function ProvidersPage() {
           <div className="space-y-4 text-sm text-slate-700 dark:text-white/75">
             <div className="grid gap-2 sm:grid-cols-2">
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
-                <div>{t("providers.diff_added", { count: importPreview.diff.added })}</div>
-                <div>{t("providers.diff_updated", { count: importPreview.diff.changed })}</div>
+                <div>
+                  {t("providers.diff_added", {
+                    count: importPreview.diff.added,
+                  })}
+                </div>
+                <div>
+                  {t("providers.diff_updated", {
+                    count: importPreview.diff.changed,
+                  })}
+                </div>
               </div>
               <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
-                <div>{t("providers.diff_removed", { count: importPreview.diff.removed })}</div>
+                <div>
+                  {t("providers.diff_removed", {
+                    count: importPreview.diff.removed,
+                  })}
+                </div>
                 <div>
                   {t("providers.diff_duplicates_cleaned", {
                     count: importPreview.diff.duplicateEntriesRemoved,
@@ -1335,7 +1588,9 @@ export function ProvidersPage() {
 
             {importPreview.diff.addedLabels.length ? (
               <div>
-                <p className="font-semibold">{t("providers.diff_added_label")}</p>
+                <p className="font-semibold">
+                  {t("providers.diff_added_label")}
+                </p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {importPreview.diff.addedLabels.map((label) => (
                     <span
@@ -1351,7 +1606,9 @@ export function ProvidersPage() {
 
             {importPreview.diff.changedLabels.length ? (
               <div>
-                <p className="font-semibold">{t("providers.diff_updated_label")}</p>
+                <p className="font-semibold">
+                  {t("providers.diff_updated_label")}
+                </p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {importPreview.diff.changedLabels.map((label) => (
                     <span
@@ -1367,7 +1624,9 @@ export function ProvidersPage() {
 
             {importPreview.diff.removedLabels.length ? (
               <div>
-                <p className="font-semibold">{t("providers.diff_removed_label")}</p>
+                <p className="font-semibold">
+                  {t("providers.diff_removed_label")}
+                </p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {importPreview.diff.removedLabels.map((label) => (
                     <span

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -24,6 +24,10 @@ import {
   withoutDisableAllModelsRule,
   type ProviderKeyDraft,
 } from "../providers-helpers";
+import {
+  isModelAllowedForProvider,
+  type ModelAccessProvider,
+} from "../provider-model-access";
 
 export type ProviderKeyType =
   | "gemini"
@@ -175,6 +179,14 @@ export function useProviderKeyEditor({
       : undefined;
     const isOpenCodeGo = editKeyType === "opencode-go";
     const isCline = editKeyType === "cline";
+    const isOllamaCloud = editKeyType === "ollama-cloud";
+    const modelAccessProvider: ModelAccessProvider | null = isOpenCodeGo
+      ? "opencode-go"
+      : isCline
+        ? "cline"
+        : isOllamaCloud
+          ? "ollama-cloud"
+          : null;
     const excludedModels = rawExcludedModels;
 
     const requireAlias = editKeyType === "vertex";
@@ -187,6 +199,17 @@ export function useProviderKeyEditor({
       );
       return null;
     }
+    const models =
+      modelAccessProvider && modelCommit.models
+        ? modelCommit.models.filter((model) => {
+            const name = model.name?.trim() ?? "";
+            return (
+              name &&
+              model.alias?.trim() &&
+              isModelAllowedForProvider(modelAccessProvider, name)
+            );
+          })
+        : modelCommit.models;
     const result: ProviderSimpleConfig | BedrockProviderConfig = {
       apiKey:
         editKeyType === "bedrock" && keyDraft.authMode === "sigv4"
@@ -200,7 +223,7 @@ export function useProviderKeyEditor({
       ...(isCline && !keyDraft.baseUrl.trim()
         ? { baseUrl: "https://api.cline.bot/api/v1" }
         : {}),
-      ...(editKeyType === "ollama-cloud" && !keyDraft.baseUrl.trim()
+      ...(isOllamaCloud && !keyDraft.baseUrl.trim()
         ? { baseUrl: "https://ollama.com" }
         : {}),
       ...(keyDraft.proxyUrl.trim()
@@ -215,11 +238,10 @@ export function useProviderKeyEditor({
       ...(isOpenCodeGo && keyDraft.authCookie.trim()
         ? { authCookie: keyDraft.authCookie.trim() }
         : {}),
-      ...((isOpenCodeGo || isCline || editKeyType === "ollama-cloud") &&
-      keyDraft.visionFallbackModel.trim()
+      ...(modelAccessProvider && keyDraft.visionFallbackModel.trim()
         ? { visionFallbackModel: keyDraft.visionFallbackModel.trim() }
         : {}),
-      ...(modelCommit.models ? { models: modelCommit.models } : {}),
+      ...(models?.length ? { models } : {}),
       ...(editKeyType === "claude" && keyDraft.skipAnthropicProcessing
         ? { skipAnthropicProcessing: true }
         : {}),
@@ -407,7 +429,14 @@ export function useProviderKeyEditor({
 
   const toggleKeyEnabled = useCallback(
     async (
-      type: "gemini" | "claude" | "codex" | "opencode-go" | "cline" | "ollama-cloud" | "bedrock",
+      type:
+        | "gemini"
+        | "claude"
+        | "codex"
+        | "opencode-go"
+        | "cline"
+        | "ollama-cloud"
+        | "bedrock",
       index: number,
       enabled: boolean,
     ) => {

--- a/pages/providers/provider-import-export.ts
+++ b/pages/providers/provider-import-export.ts
@@ -162,7 +162,11 @@ const normalizeSimpleItem = (
   const apiKey = normalizeString(value["api-key"] ?? value.apiKey) ?? "";
   if (!apiKey) return { item: null, duplicateCount: 0 };
   const headers = sortRecord(normalizeHeaders(value.headers));
-  const { models, duplicateCount } = normalizeModelList(value.models);
+  const hasDynamicModelAccess =
+    kind === "opencode-go" || kind === "cline" || kind === "ollama-cloud";
+  const { models, duplicateCount } = hasDynamicModelAccess
+    ? { models: undefined, duplicateCount: 0 }
+    : normalizeModelList(value.models);
   const excludedModels = sortExcludedModels(value["excluded-models"] ?? value.excludedModels);
   const baseUrl =
     normalizeString(value["base-url"] ?? value.baseUrl) ??

--- a/pages/providers/provider-model-access.ts
+++ b/pages/providers/provider-model-access.ts
@@ -1,0 +1,76 @@
+import {
+  apiCallApi,
+  authFilesApi,
+  getApiCallErrorMessage,
+  type ProviderModel,
+  type ProviderSimpleConfig,
+} from "@code-proxy/api-client";
+import {
+  hasDisableAllModelsRule,
+  normalizeDiscoveredModels,
+  stripDisableAllModelsRule,
+} from "./providers-helpers";
+
+export type ModelAccessProvider = "opencode-go" | "cline" | "ollama-cloud";
+
+export type DiscoveredProviderModel = { id: string; owned_by?: string };
+
+export const OPENCODE_GO_MODELS_URL = "https://opencode.ai/zen/go/v1/models";
+
+export const isClinePassModelId = (modelId: string): boolean =>
+  modelId.trim().toLowerCase().startsWith("cline-pass/");
+
+export const isModelAllowedForProvider = (
+  provider: ModelAccessProvider,
+  modelId: string,
+): boolean =>
+  provider === "cline"
+    ? isClinePassModelId(modelId)
+    : !isClinePassModelId(modelId);
+
+export async function fetchModelAccessCatalog(
+  provider: ModelAccessProvider,
+): Promise<DiscoveredProviderModel[]> {
+  if (provider === "opencode-go") {
+    const result = await apiCallApi.request({
+      method: "GET",
+      url: OPENCODE_GO_MODELS_URL,
+    });
+    if (result.statusCode < 200 || result.statusCode >= 300) {
+      throw new Error(getApiCallErrorMessage(result));
+    }
+    return normalizeDiscoveredModels(result.body ?? result.bodyText);
+  }
+
+  const items = await authFilesApi.getModelDefinitions(provider);
+  return normalizeDiscoveredModels({
+    data: items.map((item) => ({ ...item, object: "model" })),
+  });
+}
+
+export function getEffectiveProviderModels(
+  provider: ModelAccessProvider,
+  item: ProviderSimpleConfig,
+  catalog: DiscoveredProviderModel[],
+): ProviderModel[] {
+  if (hasDisableAllModelsRule(item.excludedModels)) return [];
+
+  const excluded = new Set(
+    stripDisableAllModelsRule(item.excludedModels).map((model) =>
+      model.toLowerCase(),
+    ),
+  );
+  const configured = (item.models ?? []).filter((model) => {
+    const name = model.name?.trim() ?? "";
+    return name && isModelAllowedForProvider(provider, name);
+  });
+  const base =
+    configured.length > 0
+      ? configured
+      : catalog.map((model) => ({ name: model.id }));
+
+  return base.filter((model) => {
+    const name = model.name?.trim().toLowerCase() ?? "";
+    return name && !excluded.has(name);
+  });
+}


### PR DESCRIPTION
## Summary
- centralize model-access catalog loading for OpenCode Go, ClinePass, and Ollama Cloud without mixing their request paths
- render effective enabled models on provider cards, filtering stale legacy cross-channel models and honoring excluded models
- use the shared DataTable and table scrollbar for model permissions, and show hidden card models in the +X tooltip
- clean legacy per-key model fields for dynamic model-access providers on save

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build