### PR TITLE
fix: hide disabled model chips for pass providers

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -720,6 +720,37 @@ describe("ProvidersPage Cline tab", () => {
     expect(tooltip).toHaveTextContent("cline-pass/gpt-5.2");
   });
 
+  test("does not show legacy ClinePass excluded models on provider cards", async () => {
+    const user = userEvent.setup();
+    mocks.getClineConfigs.mockImplementation(async () => [
+      {
+        name: "Cline Hidden Excluded",
+        apiKey: "sk-cline-hidden",
+        excludedModels: ["cline-pass/legacy-disabled-only"],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: /ClinePass/ }));
+    expect(
+      await screen.findByText("Cline Hidden Excluded"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("cline-pass/legacy-disabled-only"),
+    ).not.toBeInTheDocument();
+  });
+
   test("drops legacy ClinePass per-key model fields when saving", async () => {
     const user = userEvent.setup();
     mocks.getClineConfigs.mockImplementation(async () => [
@@ -880,6 +911,39 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     });
     const saved = mocks.saveOllamaCloudConfigs.mock.calls[0][0][0];
     expect(saved).not.toHaveProperty("models");
+  });
+
+  test("does not show legacy Ollama Cloud excluded models on provider cards", async () => {
+    const user = userEvent.setup();
+    mocks.getOllamaCloudConfigs.mockImplementation(async () => [
+      {
+        name: "Ollama Hidden Excluded",
+        apiKey: "sk-ollama-hidden",
+        excludedModels: ["gpt-oss:legacy-disabled-only"],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(
+      await screen.findByRole("tab", { name: /Ollama Cloud/ }),
+    );
+    expect(
+      await screen.findByText("Ollama Hidden Excluded"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("gpt-oss:legacy-disabled-only"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1323,6 +1323,7 @@ export function ProvidersPage() {
               }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              showExcludedModels={false}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />
@@ -1358,6 +1359,7 @@ export function ProvidersPage() {
               }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              showExcludedModels={false}
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
             />


### PR DESCRIPTION
## Summary
- hide legacy excluded model chips on ClinePass and Ollama Cloud provider cards, matching OpenCode Go
- keep effective enabled model display and +X tooltip behavior intact
- add regression coverage for ClinePass and Ollama Cloud legacy excludedModels data

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build
- rtk git diff --check