### PR TITLE
fix: persist provider model access

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -360,7 +360,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ).toBeInTheDocument();
   });
 
-  test("drops legacy OpenCode Go per-key model fields when saving", async () => {
+  test("saves OpenCode Go fetched model permissions and drops dirty legacy models", async () => {
     const user = userEvent.setup();
     mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
       {
@@ -403,7 +403,12 @@ describe("ProvidersPage OpenCode Go tab", () => {
       ]);
     });
     const saved = mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0];
-    expect(saved).not.toHaveProperty("models");
+    expect(saved).toHaveProperty("models", [
+      { name: "deepseek-v4-flash" },
+      { name: "qwen3.5-plus" },
+      { name: "kimi-k2.6" },
+      { name: "qwen3.7-max" },
+    ]);
     expect(saved).toHaveProperty("visionFallbackModel", "qwen3.5-plus");
     expect(saved).toHaveProperty("excludedModels", [
       "cline-pass/minimax-m3",
@@ -479,7 +484,12 @@ describe("ProvidersPage OpenCode Go tab", () => {
       ]);
     });
     const saved = mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0];
-    expect(saved).not.toHaveProperty("models");
+    expect(saved).toHaveProperty("models", [
+      { name: "deepseek-v4-flash" },
+      { name: "qwen3.5-plus" },
+      { name: "kimi-k2.6" },
+      { name: "qwen3.7-max" },
+    ]);
     expect(saved).toHaveProperty("visionFallbackModel", "qwen3.5-plus");
   });
 });
@@ -751,7 +761,7 @@ describe("ProvidersPage Cline tab", () => {
     ).not.toBeInTheDocument();
   });
 
-  test("drops legacy ClinePass per-key model fields when saving", async () => {
+  test("saves ClinePass fetched model permissions when saving", async () => {
     const user = userEvent.setup();
     mocks.getClineConfigs.mockImplementation(async () => [
       {
@@ -797,7 +807,12 @@ describe("ProvidersPage Cline tab", () => {
       ]);
     });
     const saved = mocks.saveClineConfigs.mock.calls[0][0][0];
-    expect(saved).not.toHaveProperty("models");
+    expect(saved).toHaveProperty("models", [
+      { name: "cline-pass/glm-5.2" },
+      { name: "cline-pass/minimax-m3" },
+      { name: "cline-pass/qwen3.7-max" },
+      { name: "cline-pass/mimo-v2.5-pro" },
+    ]);
     expect(saved).toHaveProperty(
       "visionFallbackModel",
       "cline-pass/mimo-v2.5-pro",
@@ -865,7 +880,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     expect(mocks.apiCallRequest).not.toHaveBeenCalled();
   });
 
-  test("drops legacy Ollama Cloud per-key model fields when saving", async () => {
+  test("saves Ollama Cloud fetched model permissions when saving", async () => {
     const user = userEvent.setup();
     mocks.getOllamaCloudConfigs.mockImplementation(async () => [
       {
@@ -910,7 +925,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
       ]);
     });
     const saved = mocks.saveOllamaCloudConfigs.mock.calls[0][0][0];
-    expect(saved).not.toHaveProperty("models");
+    expect(saved).toHaveProperty("models", [{ name: "gpt-oss:120b" }]);
   });
 
   test("does not show legacy Ollama Cloud excluded models on provider cards", async () => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -19,12 +19,16 @@ import {
   hasDisableAllModelsRule,
   stripDisableAllModelsRule,
 } from "../providers-helpers";
-import type { ModelEntryDraft } from "../ModelInputList";
+import { createEmptyModelEntry, type ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
 import { ProviderKeyRequestTab } from "./ProviderKeyRequestTab";
 import { ProviderKeyModelsTab } from "./ProviderKeyModelsTab";
-import { fetchModelAccessCatalog } from "../provider-model-access";
+import {
+  fetchModelAccessCatalog,
+  isModelAllowedForProvider,
+  type ModelAccessProvider,
+} from "../provider-model-access";
 
 type ProviderKeyModalTab = "basic" | "request" | "models";
 
@@ -376,6 +380,41 @@ export function ProviderKeyModal({
     },
     [openCodeModels, setKeyDraft],
   );
+
+  useEffect(() => {
+    if (!open || !isModelAccessProvider || openCodeModels.length === 0) return;
+    const provider: ModelAccessProvider = isCline
+      ? "cline"
+      : isOllamaCloud
+        ? "ollama-cloud"
+        : "opencode-go";
+    setKeyDraft((prev) => {
+      const existingNames = new Set(
+        prev.modelEntries
+          .map((entry) => entry.name.trim().toLowerCase())
+          .filter(Boolean),
+      );
+      const nextEntries = [...prev.modelEntries];
+      for (const model of openCodeModels) {
+        const name = model.id.trim();
+        const key = name.toLowerCase();
+        if (!key || existingNames.has(key)) continue;
+        if (!isModelAllowedForProvider(provider, name)) continue;
+        existingNames.add(key);
+        nextEntries.push({ ...createEmptyModelEntry(), name });
+      }
+      return nextEntries.length === prev.modelEntries.length
+        ? prev
+        : { ...prev, modelEntries: nextEntries };
+    });
+  }, [
+    isCline,
+    isModelAccessProvider,
+    isOllamaCloud,
+    open,
+    openCodeModels,
+    setKeyDraft,
+  ]);
   const statusBadges = (
     <ProviderKeyStatusBadges
       editKeyEnabled={editKeyEnabled}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -169,8 +169,8 @@ export function ProviderKeyModelsTab({
       {
         key: "enabled",
         label: t("providers.model_enabled"),
-        width: "w-20",
-        minWidthPx: 80,
+        width: "w-28",
+        minWidthPx: 112,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (model) => {

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -203,11 +203,7 @@ export function useProviderKeyEditor({
       modelAccessProvider && modelCommit.models
         ? modelCommit.models.filter((model) => {
             const name = model.name?.trim() ?? "";
-            return (
-              name &&
-              model.alias?.trim() &&
-              isModelAllowedForProvider(modelAccessProvider, name)
-            );
+            return name && isModelAllowedForProvider(modelAccessProvider, name);
           })
         : modelCommit.models;
     const result: ProviderSimpleConfig | BedrockProviderConfig = {


### PR DESCRIPTION
## Summary
- persist fetched model access rows for OpenCode Go, ClinePass, and Ollama Cloud even when alias is empty
- auto-populate provider model entries from each provider catalog while keeping provider-specific catalog routing separate
- widen the enabled column in the model access table and keep the existing DataTable scrollbar path

## Tests
- bun run --filter @code-proxy/admin-panel test -- pages/providers/__tests__/provider-access.test.ts pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts packages/api-client/src/endpoints/__tests__/providers-cline.test.ts packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
- bun run test:ci
- bun run build
- bun run lint (warnings only in unrelated existing files)