### PR TITLE
fix: include pass provider channels in permissions

### DIFF
--- a/features/api-key-restrictions/useApiKeyPermissionOptions.tsx
+++ b/features/api-key-restrictions/useApiKeyPermissionOptions.tsx
@@ -129,6 +129,8 @@ export function useApiKeyPermissionOptions() {
         geminiKeys,
         claudeKeys,
         codexKeys,
+        openCodeGoKeys,
+        clineKeys,
         ollamaCloudKeys,
         vertexKeys,
         openaiProviders,
@@ -137,6 +139,8 @@ export function useApiKeyPermissionOptions() {
         providersApi.getGeminiKeys().catch(() => []),
         providersApi.getClaudeConfigs().catch(() => []),
         providersApi.getCodexConfigs().catch(() => []),
+        providersApi.getOpenCodeGoConfigs().catch(() => []),
+        providersApi.getClineConfigs().catch(() => []),
         providersApi.getOllamaCloudConfigs().catch(() => []),
         providersApi.getVertexConfigs().catch(() => []),
         providersApi.getOpenAIProviders().catch(() => []),
@@ -166,6 +170,8 @@ export function useApiKeyPermissionOptions() {
       geminiKeys.forEach((item) => push(item.name || "", "API", "gemini"));
       claudeKeys.forEach((item) => push(item.name || "", "API", "claude"));
       codexKeys.forEach((item) => push(item.name || "", "API", "codex"));
+      openCodeGoKeys.forEach((item) => push(item.name || "", "API", "opencode-go"));
+      clineKeys.forEach((item) => push(item.name || "", "API", "cline"));
       ollamaCloudKeys.forEach((item) => push(item.name || "", "API", "ollama-cloud"));
       vertexKeys.forEach((item) => push(item.name || "", "API", "vertex"));
       openaiProviders.forEach((item) => push(item.name || "", "API", "openai"));

--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -117,6 +117,7 @@ const PROVIDER_CHANNELS = [
   { key: "gemini", load: () => providersApi.getGeminiKeys() },
   { key: "claude", load: () => providersApi.getClaudeConfigs() },
   { key: "codex", load: () => providersApi.getCodexConfigs() },
+  { key: "cline", load: () => providersApi.getClineConfigs() },
   { key: "opencode-go", load: () => providersApi.getOpenCodeGoConfigs() },
   { key: "ollama-cloud", load: () => providersApi.getOllamaCloudConfigs() },
   { key: "vertex", load: () => providersApi.getVertexConfigs() },

--- a/pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
+++ b/pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
@@ -34,6 +34,8 @@ const mocks = vi.hoisted(() => ({
   getGeminiKeys: vi.fn(async (): Promise<unknown[]> => []),
   getClaudeConfigs: vi.fn(async (): Promise<unknown[]> => []),
   getCodexConfigs: vi.fn(async (): Promise<unknown[]> => []),
+  getOpenCodeGoConfigs: vi.fn(async (): Promise<unknown[]> => []),
+  getClineConfigs: vi.fn(async (): Promise<unknown[]> => []),
   getOllamaCloudConfigs: vi.fn(async (): Promise<unknown[]> => []),
   getVertexConfigs: vi.fn(async (): Promise<unknown[]> => []),
   getOpenAIProviders: vi.fn(async (): Promise<unknown[]> => []),
@@ -108,6 +110,8 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       getGeminiKeys: mocks.getGeminiKeys,
       getClaudeConfigs: mocks.getClaudeConfigs,
       getCodexConfigs: mocks.getCodexConfigs,
+      getOpenCodeGoConfigs: mocks.getOpenCodeGoConfigs,
+      getClineConfigs: mocks.getClineConfigs,
       getOllamaCloudConfigs: mocks.getOllamaCloudConfigs,
       getVertexConfigs: mocks.getVertexConfigs,
       getOpenAIProviders: mocks.getOpenAIProviders,
@@ -193,6 +197,9 @@ describe("ApiKeyPermissionsPage", () => {
       { name: "Claude备用" },
     ] as any);
     mocks.getCodexConfigs.mockResolvedValue(Array<unknown>());
+    mocks.getOpenCodeGoConfigs.mockResolvedValue(Array<unknown>());
+    mocks.getClineConfigs.mockResolvedValue(Array<unknown>());
+    mocks.getOllamaCloudConfigs.mockResolvedValue(Array<unknown>());
     mocks.getVertexConfigs.mockResolvedValue(Array<unknown>());
     mocks.getOpenAIProviders.mockResolvedValue(Array<unknown>());
     mocks.apiClientGet.mockClear();
@@ -274,6 +281,27 @@ describe("ApiKeyPermissionsPage", () => {
         ]),
       );
     });
+  });
+
+  test("loads provider channels from OpenCode Go, ClinePass and Ollama Cloud configs", async () => {
+    mocks.getOpenCodeGoConfigs.mockResolvedValue([{ name: "OpenCode Go 主渠道" }]);
+    mocks.getClineConfigs.mockResolvedValue([{ name: "ClinePass 主渠道" }]);
+    mocks.getOllamaCloudConfigs.mockResolvedValue([{ name: "Ollama Cloud 主渠道" }]);
+
+    renderPage();
+
+    expect(await screen.findByText("标准配置")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "新增配置" }));
+    const dialog = await screen.findByRole("dialog", { name: "新增权限配置" });
+    await userEvent.click(
+      within(dialog).getByRole("switch", { name: "精确渠道覆盖（高级）" }),
+    );
+    await userEvent.click(within(dialog).getByRole("button", { name: /^全部渠道$/i }));
+
+    expect(await screen.findByRole("button", { name: /OpenCode Go 主渠道/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /ClinePass 主渠道/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ollama Cloud 主渠道/i })).toBeInTheDocument();
   });
 
   test("refreshes stale API key entries before applying edited profile channels", async () => {

--- a/pages/system/__tests__/SystemPage.test.tsx
+++ b/pages/system/__tests__/SystemPage.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@code-proxy/api-client", () => ({
     getGeminiKeys: async () => [],
     getClaudeConfigs: async () => [],
     getCodexConfigs: async () => [],
+    getClineConfigs: () => normalizeProviderConfigs("/cline-api-key", "cline-api-key"),
     getOpenCodeGoConfigs: async () => [],
     getOllamaCloudConfigs: async () => [],
     getVertexConfigs: async () => [],
@@ -79,6 +80,24 @@ function extractList(payload: unknown, key: string): unknown[] {
   return Array.isArray(value) ? value : [];
 }
 
+async function normalizeProviderConfigs(path: string, key: string) {
+  const payload = await mocks.apiGet(path);
+  return extractList(payload, key).map((entry) => {
+    const item = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+    return {
+      apiKey: String(item["api-key"] ?? item.apiKey ?? ""),
+      name: typeof item.name === "string" ? item.name : undefined,
+      prefix: typeof item.prefix === "string" ? item.prefix : undefined,
+      models: Array.isArray(item.models) ? item.models : [],
+      excludedModels: Array.isArray(item["excluded-models"])
+        ? item["excluded-models"]
+        : Array.isArray(item.excludedModels)
+          ? item.excludedModels
+          : [],
+    };
+  });
+}
+
 function normalizeOpenAIProviders(payload: unknown) {
   return extractList(payload, "openai-compatibility").map((entry) => {
     const item = entry && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
@@ -121,6 +140,7 @@ describe("SystemPage", () => {
         path === "/gemini-api-key" ||
         path === "/claude-api-key" ||
         path === "/codex-api-key" ||
+        path === "/cline-api-key" ||
         path === "/vertex-api-key" ||
         path === "/openai-compatibility"
       ) {
@@ -403,6 +423,42 @@ describe("SystemPage", () => {
 
     expect(await screen.findByText(/ClinePass · cline/)).toBeInTheDocument();
     expect(screen.queryByText("Actual ID")).not.toBeInTheDocument();
+  });
+
+  test("falls back to ClinePass provider configs when configured availability is unavailable", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/models/configured-availability") return Promise.resolve({});
+      if (path === "/model-path-availability") return Promise.resolve({ data: [] });
+      if (path === "/model-configs?scope=library") return Promise.resolve({ data: [] });
+      if (path === "/auth-files") return Promise.resolve({ files: [] });
+      if (path === "/cline-api-key") {
+        return Promise.resolve({
+          "cline-api-key": [
+            {
+              name: "ClinePass",
+              "api-key": "sk-cline",
+              models: [{ name: "cline-pass/mimo-v2.5-pro" }],
+            },
+          ],
+        });
+      }
+      if (
+        path === "/gemini-api-key" ||
+        path === "/claude-api-key" ||
+        path === "/codex-api-key" ||
+        path === "/vertex-api-key" ||
+        path === "/openai-compatibility"
+      ) {
+        return Promise.resolve<unknown[]>([]);
+      }
+      if (path === "/system-stats") return Promise.resolve({ uptime: 10 });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("cline-pass/mimo-v2.5-pro")).toBeInTheDocument();
   });
 
   test("shows model sources in the model tag tooltip", async () => {


### PR DESCRIPTION
## Summary
- include ClinePass in configured model availability fallback aggregation
- include OpenCode Go and ClinePass in API key permission precise channel options
- add regression coverage for OpenCode Go, ClinePass, and Ollama Cloud channel visibility

## Tests
- rtk bun run test -- pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
- rtk bun run test -- pages/system/__tests__/SystemPage.test.tsx
- rtk bun run build
- rtk go test ./internal/app/service ./internal/api/handlers/management ./internal/management/modelcatalog ./internal/management/settings/providers