### PR TITLE
fix: preserve provider model access edits

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/providers-cline.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-cline.test.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getMock = vi.fn();
 const putMock = vi.fn();
+const patchMock = vi.fn();
 const deleteMock = vi.fn();
 
 vi.mock("../../client/client", () => ({
   apiClient: {
     get: getMock,
     put: putMock,
+    patch: patchMock,
     delete: deleteMock,
   },
 }));
@@ -16,6 +18,7 @@ describe("providersApi Cline", () => {
   beforeEach(() => {
     getMock.mockReset();
     putMock.mockReset();
+    patchMock.mockReset();
     deleteMock.mockReset();
   });
 
@@ -122,6 +125,60 @@ describe("providersApi Cline", () => {
 
     expect(deleteMock).toHaveBeenCalledWith("/cline-api-key", undefined, {
       params: { "api-key": "sk-cline" },
+    });
+  });
+
+  test("patches Cline config and excluded models on the Cline endpoint", async () => {
+    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+
+    await providersApi.patchClineConfig(0, {
+      name: "Cline",
+      apiKey: "sk-cline",
+      baseUrl: "https://api.cline.bot/api/v1",
+      models: [{ name: "cline-pass/glm-5.2", alias: "glm" }],
+      excludedModels: ["cline-pass/minimax-m3", "*"],
+      visionFallbackModel: "cline-pass/mimo-v2.5-pro",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/cline-api-key", {
+      index: 0,
+      value: {
+        name: "Cline",
+        "api-key": "sk-cline",
+        "base-url": "https://api.cline.bot/api/v1",
+        models: [{ name: "cline-pass/glm-5.2", alias: "glm" }],
+        "excluded-models": ["cline-pass/minimax-m3", "*"],
+        "vision-fallback-model": "cline-pass/mimo-v2.5-pro",
+      },
+    });
+
+    await providersApi.patchClineExcludedModels(0, ["*"]);
+
+    expect(patchMock).toHaveBeenLastCalledWith("/cline-api-key", {
+      index: 0,
+      value: { "excluded-models": ["*"] },
+    });
+  });
+
+  test("omits empty api-key when patching an existing Cline config", async () => {
+    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+
+    await providersApi.patchClineConfig(0, {
+      name: "Cline",
+      apiKey: "",
+      baseUrl: "https://api.cline.bot/api/v1",
+      models: [{ name: "cline-pass/glm-5.2" }],
+      visionFallbackModel: "cline-pass/mimo-v2.5-pro",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/cline-api-key", {
+      index: 0,
+      value: {
+        name: "Cline",
+        "base-url": "https://api.cline.bot/api/v1",
+        models: [{ name: "cline-pass/glm-5.2" }],
+        "vision-fallback-model": "cline-pass/mimo-v2.5-pro",
+      },
     });
   });
 });

--- a/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getMock = vi.fn();
 const putMock = vi.fn();
+const patchMock = vi.fn();
 const deleteMock = vi.fn();
 
 vi.mock("../../client/client", () => ({
   apiClient: {
     get: getMock,
     put: putMock,
+    patch: patchMock,
     delete: deleteMock,
   },
 }));
@@ -16,6 +18,7 @@ describe("providersApi Ollama Cloud", () => {
   beforeEach(() => {
     getMock.mockReset();
     putMock.mockReset();
+    patchMock.mockReset();
     deleteMock.mockReset();
   });
 
@@ -71,6 +74,60 @@ describe("providersApi Ollama Cloud", () => {
     await providersApi.deleteOllamaCloudConfig("sk-ollama");
     expect(deleteMock).toHaveBeenCalledWith("/ollama-cloud-api-key", undefined, {
       params: { "api-key": "sk-ollama" },
+    });
+  });
+
+  test("patches Ollama Cloud config and excluded models on the Ollama endpoint", async () => {
+    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+
+    await providersApi.patchOllamaCloudConfig(2, {
+      name: "Ollama",
+      apiKey: "sk-ollama",
+      baseUrl: "https://ollama.com",
+      models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
+      excludedModels: ["gpt-oss:20b", "*"],
+      visionFallbackModel: "gpt-oss:120b",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/ollama-cloud-api-key", {
+      index: 2,
+      value: {
+        name: "Ollama",
+        "api-key": "sk-ollama",
+        "base-url": "https://ollama.com",
+        models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
+        "excluded-models": ["gpt-oss:20b", "*"],
+        "vision-fallback-model": "gpt-oss:120b",
+      },
+    });
+
+    await providersApi.patchOllamaCloudExcludedModels(2, ["*"]);
+
+    expect(patchMock).toHaveBeenLastCalledWith("/ollama-cloud-api-key", {
+      index: 2,
+      value: { "excluded-models": ["*"] },
+    });
+  });
+
+  test("omits empty api-key when patching an existing Ollama Cloud config", async () => {
+    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+
+    await providersApi.patchOllamaCloudConfig(0, {
+      name: "Ollama",
+      apiKey: "",
+      baseUrl: "https://ollama.com",
+      models: [{ name: "gpt-oss:120b" }],
+      visionFallbackModel: "gpt-oss:120b",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/ollama-cloud-api-key", {
+      index: 0,
+      value: {
+        name: "Ollama",
+        "base-url": "https://ollama.com",
+        models: [{ name: "gpt-oss:120b" }],
+        "vision-fallback-model": "gpt-oss:120b",
+      },
     });
   });
 });

--- a/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const getMock = vi.fn();
 const postMock = vi.fn();
 const putMock = vi.fn();
+const patchMock = vi.fn();
 const deleteMock = vi.fn();
 
 vi.mock("../../client/client", () => ({
@@ -10,6 +11,7 @@ vi.mock("../../client/client", () => ({
     get: getMock,
     post: postMock,
     put: putMock,
+    patch: patchMock,
     delete: deleteMock,
   },
 }));
@@ -19,6 +21,7 @@ describe("providersApi OpenCode Go", () => {
     getMock.mockReset();
     postMock.mockReset();
     putMock.mockReset();
+    patchMock.mockReset();
     deleteMock.mockReset();
   });
 
@@ -155,6 +158,61 @@ describe("providersApi OpenCode Go", () => {
       "workspace-id": "wrk_123",
       "auth-cookie": "auth-token",
       "proxy-id": "hk",
+    });
+  });
+
+  test("patches OpenCode Go config and excluded models without Base URL", async () => {
+    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+
+    await providersApi.patchOpenCodeGoConfig(1, {
+      name: "OpenCode Go",
+      apiKey: "sk-go",
+      baseUrl: "https://should-not-save.example",
+      models: [{ name: "qwen3.5-plus", alias: "qwen-go" }],
+      excludedModels: ["minimax-m2.5", "*"],
+      visionFallbackModel: "qwen3.5-plus",
+      workspaceId: "wrk_123",
+      authCookie: "auth-token",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/opencode-go-api-key", {
+      index: 1,
+      value: {
+        name: "OpenCode Go",
+        "api-key": "sk-go",
+        models: [{ name: "qwen3.5-plus", alias: "qwen-go" }],
+        "excluded-models": ["minimax-m2.5", "*"],
+        "vision-fallback-model": "qwen3.5-plus",
+        "workspace-id": "wrk_123",
+        "auth-cookie": "auth-token",
+      },
+    });
+
+    await providersApi.patchOpenCodeGoExcludedModels(1, ["*"]);
+
+    expect(patchMock).toHaveBeenLastCalledWith("/opencode-go-api-key", {
+      index: 1,
+      value: { "excluded-models": ["*"] },
+    });
+  });
+
+  test("omits empty api-key when patching an existing OpenCode Go config", async () => {
+    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+
+    await providersApi.patchOpenCodeGoConfig(0, {
+      name: "OpenCode Go",
+      apiKey: " ",
+      models: [{ name: "qwen3.5-plus" }],
+      visionFallbackModel: "qwen3.5-plus",
+    });
+
+    expect(patchMock).toHaveBeenCalledWith("/opencode-go-api-key", {
+      index: 0,
+      value: {
+        name: "OpenCode Go",
+        models: [{ name: "qwen3.5-plus" }],
+        "vision-fallback-model": "qwen3.5-plus",
+      },
     });
   });
 

--- a/packages/api-client/src/endpoints/helpers.ts
+++ b/packages/api-client/src/endpoints/helpers.ts
@@ -104,6 +104,10 @@ export const serializeModels = (models?: ProviderModel[]) =>
         .filter(Boolean)
     : undefined;
 
+type SerializeProviderKeyOptions = {
+  includeApiKey?: boolean;
+};
+
 export const serializeProviderKey = (config: ProviderSimpleConfig) => {
   const payload: Record<string, unknown> = { "api-key": config.apiKey };
   const name = normalizeString(config.name);
@@ -131,8 +135,12 @@ export const serializeProviderKey = (config: ProviderSimpleConfig) => {
   return payload;
 };
 
-export const serializeOpenCodeGoKey = (config: ProviderSimpleConfig) => {
-  const payload: Record<string, unknown> = { "api-key": config.apiKey };
+export const serializeOpenCodeGoKey = (
+  config: ProviderSimpleConfig,
+  options: SerializeProviderKeyOptions = {},
+) => {
+  const payload: Record<string, unknown> = {};
+  if (options.includeApiKey !== false) payload["api-key"] = config.apiKey;
   const name = normalizeString(config.name);
   if (name) payload.name = name;
   const prefix = normalizeString(config.prefix);
@@ -157,8 +165,12 @@ export const serializeOpenCodeGoKey = (config: ProviderSimpleConfig) => {
   return payload;
 };
 
-export const serializeClineKey = (config: ProviderSimpleConfig) => {
-  const payload: Record<string, unknown> = { "api-key": config.apiKey };
+export const serializeClineKey = (
+  config: ProviderSimpleConfig,
+  options: SerializeProviderKeyOptions = {},
+) => {
+  const payload: Record<string, unknown> = {};
+  if (options.includeApiKey !== false) payload["api-key"] = config.apiKey;
   const name = normalizeString(config.name);
   if (name) payload.name = name;
   const prefix = normalizeString(config.prefix);
@@ -181,8 +193,12 @@ export const serializeClineKey = (config: ProviderSimpleConfig) => {
   return payload;
 };
 
-export const serializeOllamaCloudKey = (config: ProviderSimpleConfig) => {
-  const payload: Record<string, unknown> = { "api-key": config.apiKey };
+export const serializeOllamaCloudKey = (
+  config: ProviderSimpleConfig,
+  options: SerializeProviderKeyOptions = {},
+) => {
+  const payload: Record<string, unknown> = {};
+  if (options.includeApiKey !== false) payload["api-key"] = config.apiKey;
   const name = normalizeString(config.name);
   if (name) payload.name = name;
   const prefix = normalizeString(config.prefix);

--- a/packages/api-client/src/endpoints/providers.ts
+++ b/packages/api-client/src/endpoints/providers.ts
@@ -170,6 +170,20 @@ export const providersApi = {
       configs.map((item) => serializeOpenCodeGoKey(item)),
     ),
 
+  patchOpenCodeGoConfig: (index: number, config: ProviderSimpleConfig) =>
+    apiClient.patch("/opencode-go-api-key", {
+      index,
+      value: serializeOpenCodeGoKey(config, {
+        includeApiKey: Boolean(config.apiKey.trim()),
+      }),
+    }),
+
+  patchOpenCodeGoExcludedModels: (index: number, excludedModels: string[]) =>
+    apiClient.patch("/opencode-go-api-key", {
+      index,
+      value: { "excluded-models": excludedModels },
+    }),
+
   deleteOpenCodeGoConfig: (apiKey: string) =>
     apiClient.delete("/opencode-go-api-key", undefined, { params: { "api-key": apiKey } }),
 
@@ -217,6 +231,20 @@ export const providersApi = {
       configs.map((item) => serializeClineKey(item)),
     ),
 
+  patchClineConfig: (index: number, config: ProviderSimpleConfig) =>
+    apiClient.patch("/cline-api-key", {
+      index,
+      value: serializeClineKey(config, {
+        includeApiKey: Boolean(config.apiKey.trim()),
+      }),
+    }),
+
+  patchClineExcludedModels: (index: number, excludedModels: string[]) =>
+    apiClient.patch("/cline-api-key", {
+      index,
+      value: { "excluded-models": excludedModels },
+    }),
+
   deleteClineConfig: (apiKey: string) =>
     apiClient.delete("/cline-api-key", undefined, { params: { "api-key": apiKey } }),
 
@@ -262,6 +290,20 @@ export const providersApi = {
       "/ollama-cloud-api-key",
       configs.map((item) => serializeOllamaCloudKey(item)),
     ),
+
+  patchOllamaCloudConfig: (index: number, config: ProviderSimpleConfig) =>
+    apiClient.patch("/ollama-cloud-api-key", {
+      index,
+      value: serializeOllamaCloudKey(config, {
+        includeApiKey: Boolean(config.apiKey.trim()),
+      }),
+    }),
+
+  patchOllamaCloudExcludedModels: (index: number, excludedModels: string[]) =>
+    apiClient.patch("/ollama-cloud-api-key", {
+      index,
+      value: { "excluded-models": excludedModels },
+    }),
 
   deleteOllamaCloudConfig: (apiKey: string) =>
     apiClient.delete("/ollama-cloud-api-key", undefined, { params: { "api-key": apiKey } }),

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -46,6 +46,12 @@ const mocks = vi.hoisted(() => ({
   saveOpenCodeGoConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveClineConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveOllamaCloudConfigs: vi.fn(async (_configs: unknown[]) => ({})),
+  patchOpenCodeGoConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
+  patchClineConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
+  patchOllamaCloudConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
+  patchOpenCodeGoExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
+  patchClineExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
+  patchOllamaCloudExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
   getModelDefinitions: vi.fn(async (_channel?: string) => [
     { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
     { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
@@ -94,6 +100,12 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       saveOpenCodeGoConfigs: mocks.saveOpenCodeGoConfigs,
       saveClineConfigs: mocks.saveClineConfigs,
       saveOllamaCloudConfigs: mocks.saveOllamaCloudConfigs,
+      patchOpenCodeGoConfig: mocks.patchOpenCodeGoConfig,
+      patchClineConfig: mocks.patchClineConfig,
+      patchOllamaCloudConfig: mocks.patchOllamaCloudConfig,
+      patchOpenCodeGoExcludedModels: mocks.patchOpenCodeGoExcludedModels,
+      patchClineExcludedModels: mocks.patchClineExcludedModels,
+      patchOllamaCloudExcludedModels: mocks.patchOllamaCloudExcludedModels,
     },
     usageApi: {
       ...mod.usageApi,
@@ -148,6 +160,13 @@ describe("ProvidersPage OpenCode Go tab", () => {
     }));
     mocks.saveOpenCodeGoConfigs.mockImplementation(async () => ({}));
     mocks.saveClineConfigs.mockImplementation(async () => ({}));
+    mocks.saveOllamaCloudConfigs.mockImplementation(async () => ({}));
+    mocks.patchOpenCodeGoConfig.mockImplementation(async () => ({}));
+    mocks.patchClineConfig.mockImplementation(async () => ({}));
+    mocks.patchOllamaCloudConfig.mockImplementation(async () => ({}));
+    mocks.patchOpenCodeGoExcludedModels.mockImplementation(async () => ({}));
+    mocks.patchClineExcludedModels.mockImplementation(async () => ({}));
+    mocks.patchOllamaCloudExcludedModels.mockImplementation(async () => ({}));
     mocks.getModelDefinitions.mockImplementation(async () => [
       { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
       { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
@@ -392,17 +411,20 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ).toBeInTheDocument();
     await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
     expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
+    await user.clear(within(dialog).getByPlaceholderText(/Paste API Key/i));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
-      expect(mocks.saveOpenCodeGoConfigs).toHaveBeenCalledWith([
+      expect(mocks.patchOpenCodeGoConfig).toHaveBeenCalledWith(
+        0,
         expect.objectContaining({
           name: "Existing OpenCode Go",
-          apiKey: "sk-existing-opencode-go",
+          apiKey: "",
         }),
-      ]);
+      );
     });
-    const saved = mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0];
+    expect(mocks.saveOpenCodeGoConfigs).not.toHaveBeenCalled();
+    const saved = mocks.patchOpenCodeGoConfig.mock.calls[0][1];
     expect(saved).toHaveProperty("models", [
       { name: "deepseek-v4-flash" },
       { name: "qwen3.5-plus" },
@@ -508,6 +530,13 @@ describe("ProvidersPage Cline tab", () => {
     mocks.getOpenAIProviders.mockImplementation(async () => []);
     mocks.saveOpenCodeGoConfigs.mockImplementation(async () => ({}));
     mocks.saveClineConfigs.mockImplementation(async () => ({}));
+    mocks.saveOllamaCloudConfigs.mockImplementation(async () => ({}));
+    mocks.patchOpenCodeGoConfig.mockImplementation(async () => ({}));
+    mocks.patchClineConfig.mockImplementation(async () => ({}));
+    mocks.patchOllamaCloudConfig.mockImplementation(async () => ({}));
+    mocks.patchOpenCodeGoExcludedModels.mockImplementation(async () => ({}));
+    mocks.patchClineExcludedModels.mockImplementation(async () => ({}));
+    mocks.patchOllamaCloudExcludedModels.mockImplementation(async () => ({}));
     mocks.getModelDefinitions.mockImplementation(async (channel?: string) =>
       channel === "cline"
         ? [
@@ -795,18 +824,21 @@ describe("ProvidersPage Cline tab", () => {
     await waitFor(() =>
       expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
     );
+    await user.clear(within(dialog).getByPlaceholderText(/Paste API Key/i));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
-      expect(mocks.saveClineConfigs).toHaveBeenCalledWith([
+      expect(mocks.patchClineConfig).toHaveBeenCalledWith(
+        0,
         expect.objectContaining({
           name: "Existing Cline",
-          apiKey: "sk-cline",
+          apiKey: "",
           excludedModels: ["cline-pass/minimax-m3", "*"],
         }),
-      ]);
+      );
     });
-    const saved = mocks.saveClineConfigs.mock.calls[0][0][0];
+    expect(mocks.saveClineConfigs).not.toHaveBeenCalled();
+    const saved = mocks.patchClineConfig.mock.calls[0][1];
     expect(saved).toHaveProperty("models", [
       { name: "cline-pass/glm-5.2" },
       { name: "cline-pass/minimax-m3" },
@@ -833,6 +865,12 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     mocks.getOllamaCloudConfigs.mockImplementation(async () => []);
     mocks.getOpenAIProviders.mockImplementation(async () => []);
     mocks.saveOllamaCloudConfigs.mockImplementation(async () => ({}));
+    mocks.patchOpenCodeGoConfig.mockImplementation(async () => ({}));
+    mocks.patchClineConfig.mockImplementation(async () => ({}));
+    mocks.patchOllamaCloudConfig.mockImplementation(async () => ({}));
+    mocks.patchOpenCodeGoExcludedModels.mockImplementation(async () => ({}));
+    mocks.patchClineExcludedModels.mockImplementation(async () => ({}));
+    mocks.patchOllamaCloudExcludedModels.mockImplementation(async () => ({}));
     mocks.getModelDefinitions.mockImplementation(async () => [
       { id: "gpt-oss:120b", object: "model", owned_by: "ollama" },
     ]);
@@ -913,18 +951,21 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     await waitFor(() =>
       expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
     );
+    await user.clear(within(dialog).getByPlaceholderText(/Paste API Key/i));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
-      expect(mocks.saveOllamaCloudConfigs).toHaveBeenCalledWith([
+      expect(mocks.patchOllamaCloudConfig).toHaveBeenCalledWith(
+        0,
         expect.objectContaining({
           name: "Existing Ollama Cloud",
-          apiKey: "sk-ollama",
+          apiKey: "",
           excludedModels: ["gpt-oss:20b", "*"],
         }),
-      ]);
+      );
     });
-    const saved = mocks.saveOllamaCloudConfigs.mock.calls[0][0][0];
+    expect(mocks.saveOllamaCloudConfigs).not.toHaveBeenCalled();
+    const saved = mocks.patchOllamaCloudConfig.mock.calls[0][1];
     expect(saved).toHaveProperty("models", [{ name: "gpt-oss:120b" }]);
   });
 

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -17,7 +17,7 @@ import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
 type ModelAccessRow = { id: string; owned_by?: string };
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-lg border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
     {children}
   </div>
 );
@@ -169,8 +169,8 @@ export function ProviderKeyModelsTab({
       {
         key: "enabled",
         label: t("providers.model_enabled"),
-        width: "w-28",
-        minWidthPx: 112,
+        width: "w-36",
+        minWidthPx: 144,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (model) => {
@@ -263,7 +263,7 @@ export function ProviderKeyModelsTab({
           </div>
 
           {openCodeModelsError ? (
-            <p className="mt-3 rounded-xl bg-rose-500/10 px-3 py-2 text-xs font-medium text-rose-700 dark:text-rose-200">
+            <p className="mt-3 rounded-lg bg-rose-500/10 px-3 py-2 text-xs font-medium text-rose-700 dark:text-rose-200">
               {openCodeModelsError}
             </p>
           ) : null}

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -39,7 +39,7 @@ import { useProviderKeyEditor } from "../hooks/useProviderKeyEditor";
 import { useProviderLatency } from "../hooks/useProviderLatency";
 import { useProviderUsageSummary } from "../hooks/useProviderUsageSummary";
 import { normalizeUsageSourceId, type KeyStatBucket } from "@code-proxy/domain";
-import { getCachedData, setCachedData } from "../provider-cache";
+import { getCachedData, removeCachedData, setCachedData } from "../provider-cache";
 import {
   maskApiKey,
   readBool,
@@ -421,27 +421,21 @@ export function ProvidersPage() {
         break;
       }
       case "opencode-go": {
-        const cachedO = getCachedData<ProviderSimpleConfig[]>("opencode-go");
-        if (cachedO) setOpenCodeGoKeys(cachedO);
+        removeCachedData("opencode-go");
         const freshO = await providersApi.getOpenCodeGoConfigs();
         setOpenCodeGoKeys(freshO);
-        setCachedData("opencode-go", freshO);
         break;
       }
       case "cline": {
-        const cachedCl = getCachedData<ProviderSimpleConfig[]>("cline");
-        if (cachedCl) setClineKeys(cachedCl);
+        removeCachedData("cline");
         const freshCl = await providersApi.getClineConfigs();
         setClineKeys(freshCl);
-        setCachedData("cline", freshCl);
         break;
       }
       case "ollama-cloud": {
-        const cachedOl = getCachedData<ProviderSimpleConfig[]>("ollama-cloud");
-        if (cachedOl) setOllamaCloudKeys(cachedOl);
+        removeCachedData("ollama-cloud");
         const freshOl = await providersApi.getOllamaCloudConfigs();
         setOllamaCloudKeys(freshOl);
-        setCachedData("ollama-cloud", freshOl);
         break;
       }
       case "vertex": {

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -156,6 +156,11 @@ export function useProviderKeyEditor({
     const apiKey = keyDraft.apiKey.trim();
     const bedrockAccessKeyId = keyDraft.accessKeyId.trim();
     const bedrockSecretAccessKey = keyDraft.secretAccessKey.trim();
+    const isOpenCodeGo = editKeyType === "opencode-go";
+    const isCline = editKeyType === "cline";
+    const isOllamaCloud = editKeyType === "ollama-cloud";
+    const canKeepExistingApiKey =
+      editKeyIndex !== null && (isOpenCodeGo || isCline || isOllamaCloud);
     if (editKeyType === "bedrock") {
       if (keyDraft.authMode === "api-key" && !apiKey) {
         setKeyDraftError(t("providers.api_key_error"));
@@ -168,7 +173,7 @@ export function useProviderKeyEditor({
         setKeyDraftError(t("providers.bedrock_sigv4_error"));
         return null;
       }
-    } else if (!apiKey) {
+    } else if (!apiKey && !canKeepExistingApiKey) {
       setKeyDraftError(t("providers.api_key_error"));
       return null;
     }
@@ -177,9 +182,6 @@ export function useProviderKeyEditor({
     const rawExcludedModels = keyDraft.excludedModelsText.trim()
       ? excludedModelsFromText(keyDraft.excludedModelsText)
       : undefined;
-    const isOpenCodeGo = editKeyType === "opencode-go";
-    const isCline = editKeyType === "cline";
-    const isOllamaCloud = editKeyType === "ollama-cloud";
     const modelAccessProvider: ModelAccessProvider | null = isOpenCodeGo
       ? "opencode-go"
       : isCline
@@ -274,7 +276,9 @@ export function useProviderKeyEditor({
     const apply = (list: ProviderSimpleConfig[]) => {
       if (index === null) return [...list, value];
       return list.map((item, itemIndex) =>
-        itemIndex === index ? value : item,
+        itemIndex === index
+          ? { ...value, apiKey: value.apiKey || item.apiKey }
+          : item,
       );
     };
 
@@ -293,15 +297,27 @@ export function useProviderKeyEditor({
         setCodexKeys(next);
       } else if (type === "opencode-go") {
         const next = apply(openCodeGoKeys);
-        await providersApi.saveOpenCodeGoConfigs(next);
+        if (index === null) {
+          await providersApi.saveOpenCodeGoConfigs(next);
+        } else {
+          await providersApi.patchOpenCodeGoConfig(index, value);
+        }
         setOpenCodeGoKeys(next);
       } else if (type === "cline") {
         const next = apply(clineKeys);
-        await providersApi.saveClineConfigs(next);
+        if (index === null) {
+          await providersApi.saveClineConfigs(next);
+        } else {
+          await providersApi.patchClineConfig(index, value);
+        }
         setClineKeys(next);
       } else if (type === "ollama-cloud") {
         const next = apply(ollamaCloudKeys);
-        await providersApi.saveOllamaCloudConfigs(next);
+        if (index === null) {
+          await providersApi.saveOllamaCloudConfigs(next);
+        } else {
+          await providersApi.patchOllamaCloudConfig(index, value);
+        }
         setOllamaCloudKeys(next);
       } else if (type === "vertex") {
         const next = apply(vertexKeys);
@@ -478,13 +494,13 @@ export function useProviderKeyEditor({
           await providersApi.saveCodexConfigs(nextList);
         } else if (type === "opencode-go") {
           setOpenCodeGoKeys(nextList);
-          await providersApi.saveOpenCodeGoConfigs(nextList);
+          await providersApi.patchOpenCodeGoExcludedModels(index, nextExcluded);
         } else if (type === "cline") {
           setClineKeys(nextList);
-          await providersApi.saveClineConfigs(nextList);
+          await providersApi.patchClineExcludedModels(index, nextExcluded);
         } else if (type === "ollama-cloud") {
           setOllamaCloudKeys(nextList);
-          await providersApi.saveOllamaCloudConfigs(nextList);
+          await providersApi.patchOllamaCloudExcludedModels(index, nextExcluded);
         } else {
           setBedrockKeys(nextList as BedrockProviderConfig[]);
           await providersApi.saveBedrockConfigs(

--- a/pages/providers/provider-cache.ts
+++ b/pages/providers/provider-cache.ts
@@ -28,3 +28,11 @@ export function setCachedData<T>(key: string, data: T): void {
     // localStorage full or unavailable
   }
 }
+
+export function removeCachedData(key: string): void {
+  try {
+    localStorage.removeItem(`providers-page:cache:${key}`);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary\n- use PATCH when editing existing OpenCode Go, ClinePass, and Ollama Cloud configs so blank masked keys do not overwrite saved keys\n- patch excluded models separately and clear stale provider-tab cache before reload\n- keep model access on the shared DataTable with wider enabled column\n\n## Tests\n- rtk bun run test:ci -- packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts packages/api-client/src/endpoints/__tests__/providers-cline.test.ts packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx pages/system/__tests__/SystemPage.test.tsx\n- rtk bun run build