### PR TITLE
feat: add per-model CC Switch context windows

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -165,18 +165,23 @@ function reconcileGenericMappings(
 ): CcSwitchModelMapping[] {
   const currentNonRole = currentMappings.filter((mapping) => !mapping.role);
   if (currentNonRole.length > 0) {
-    return currentNonRole;
+    return currentNonRole.map((mapping) => ({
+      ...mapping,
+      contextWindow: normalizeContextWindow(mapping.contextWindow),
+    }));
   }
 
   const autoMappings = dedupeModels(models).map((targetModel) => ({
     requestModel: targetModel,
     targetModel,
+    contextWindow: DEFAULT_CODEX_CONTEXT_WINDOW,
   }));
   if (autoMappings.length > 0) return autoMappings;
 
   return dedupeModels([fallbackModel]).map((targetModel) => ({
     requestModel: targetModel,
     targetModel,
+    contextWindow: DEFAULT_CODEX_CONTEXT_WINDOW,
   }));
 }
 
@@ -274,46 +279,73 @@ const asRecord = (value: unknown): Record<string, unknown> | null =>
     ? (value as Record<string, unknown>)
     : null;
 
-const normalizeContextWindow = (value: unknown): number => {
+const normalizeOptionalContextWindow = (value: unknown): number | undefined => {
   const parsed = typeof value === "number" ? value : Number(String(value ?? ""));
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CODEX_CONTEXT_WINDOW;
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
   return Math.round(parsed);
 };
 
-function getDraftCodexContextWindow(draft: ConfigDraft): number {
+const normalizeContextWindow = (value: unknown): number =>
+  normalizeOptionalContextWindow(value) ?? DEFAULT_CODEX_CONTEXT_WINDOW;
+
+function getCodexCatalogContextWindow(draft: ConfigDraft, modelId: string): number | undefined {
+  const normalizedModelId = modelId.trim().toLowerCase();
+  if (!normalizedModelId) return undefined;
   for (const model of draft.codexModelCatalog?.models ?? []) {
-    const topLevel = normalizeContextWindow(model.context_window ?? model.contextWindow);
-    if (topLevel !== DEFAULT_CODEX_CONTEXT_WINDOW) return topLevel;
+    const id = String(model.slug ?? model.model ?? "")
+      .trim()
+      .toLowerCase();
+    if (id !== normalizedModelId) continue;
+    const topLevel = normalizeOptionalContextWindow(model.context_window ?? model.contextWindow);
+    if (topLevel) return topLevel;
     const messages = asRecord(model.model_messages);
     if (messages) {
-      const nested = normalizeContextWindow(messages.context_window ?? messages.contextWindow);
-      if (nested !== DEFAULT_CODEX_CONTEXT_WINDOW) return nested;
+      const nested = normalizeOptionalContextWindow(
+        messages.context_window ?? messages.contextWindow,
+      );
+      if (nested) return nested;
     }
   }
-  return DEFAULT_CODEX_CONTEXT_WINDOW;
+  return undefined;
+}
+
+function withCodexMappingContextWindows(draft: ConfigDraft): CcSwitchModelMapping[] {
+  if (draft.clientType !== "codex") return draft.modelMappings;
+  return draft.modelMappings.map((mapping) => {
+    if (mapping.role) return mapping;
+    return {
+      ...mapping,
+      contextWindow: normalizeContextWindow(
+        mapping.contextWindow ??
+          getCodexCatalogContextWindow(draft, mapping.requestModel || mapping.targetModel),
+      ),
+    };
+  });
 }
 
 function buildDraftCodexModelCatalog(
   draft: ConfigDraft,
-  contextWindow: number,
 ): CcSwitchImportCodexModelCatalog | undefined {
   if (draft.clientType !== "codex") return undefined;
   const models: CcSwitchCodexCatalogModel[] = [];
-  const addModel = (model: string) => {
+  const addModel = (model: string, contextWindow?: number) => {
     const normalized = model.trim();
     if (normalized) models.push({ model: normalized, contextWindow });
   };
-  addModel(draft.defaultModel);
   for (const mapping of draft.modelMappings) {
     if (mapping.role) continue;
-    addModel(mapping.requestModel || mapping.targetModel);
+    addModel(
+      mapping.requestModel || mapping.targetModel,
+      normalizeContextWindow(mapping.contextWindow),
+    );
   }
+  addModel(draft.defaultModel);
   if (models.length === 0) return undefined;
   const catalog = buildCcSwitchCodexModelCatalog(models);
   return { models: catalog.models.map((model) => ({ ...model })) };
 }
 
-function prepareDraftForSave(draft: ConfigDraft, codexContextWindow: unknown): ConfigDraft {
+function prepareDraftForSave(draft: ConfigDraft): ConfigDraft {
   const endpointPath = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[draft.clientType].endpointPath;
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
   const routePath = ensureCcSwitchRoutePath(draft.routePath, selectedGroup, draft.id);
@@ -325,6 +357,7 @@ function prepareDraftForSave(draft: ConfigDraft, codexContextWindow: unknown): C
         ...(mapping.role ? { role: mapping.role } : {}),
         requestModel,
         targetModel,
+        ...(!mapping.role ? { contextWindow: normalizeContextWindow(mapping.contextWindow) } : {}),
       };
     })
     .filter((mapping) => mapping.targetModel && (mapping.role || mapping.requestModel));
@@ -337,10 +370,7 @@ function prepareDraftForSave(draft: ConfigDraft, codexContextWindow: unknown): C
     defaultModel,
     modelMappings: normalizedMappings,
   };
-  const codexModelCatalog = buildDraftCodexModelCatalog(
-    normalizedDraft,
-    normalizeContextWindow(codexContextWindow),
-  );
+  const codexModelCatalog = buildDraftCodexModelCatalog(normalizedDraft);
 
   return {
     ...normalizedDraft,
@@ -378,21 +408,18 @@ export function CcSwitchImportConfigModal({
   const [draft, setDraft] = useState<ConfigDraft>(value);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
-  const [codexContextWindow, setCodexContextWindow] = useState(
-    String(DEFAULT_CODEX_CONTEXT_WINDOW),
-  );
 
   useEffect(() => {
     if (!open) return;
     setDraft({
       ...value,
+      modelMappings: withCodexMappingContextWindows(value),
       endpointPath:
         value.endpointPath || DEFAULT_CC_SWITCH_IMPORT_SETTINGS[value.clientType].endpointPath,
     });
     setAvailableModels(
       dedupeModels(value.modelMappings.map((mapping) => mapping.targetModel).filter(Boolean)),
     );
-    setCodexContextWindow(String(getDraftCodexContextWindow(value)));
   }, [open, value]);
 
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
@@ -597,7 +624,7 @@ export function CcSwitchImportConfigModal({
       ]),
     [availableModels, draft.modelMappings],
   );
-  const preparedDraft = prepareDraftForSave(draft, codexContextWindow);
+  const preparedDraft = prepareDraftForSave(draft);
   const hasRenderableMappings = draft.modelMappings.length > 0;
   const modelMappingsLoading = Boolean(selectedGroup && modelsLoading && !hasRenderableMappings);
   const duplicateRequestModels = getDuplicateGenericRequestModels(draft.modelMappings);
@@ -694,6 +721,22 @@ export function CcSwitchImportConfigModal({
     });
   };
 
+  const updateGenericContextWindow = (index: number, contextWindow: string) => {
+    setDraft((current) => {
+      const parsed = Number(contextWindow);
+      const nextContextWindow =
+        contextWindow.trim() && Number.isFinite(parsed) && parsed > 0
+          ? Math.round(parsed)
+          : undefined;
+      const modelMappings = current.modelMappings.map((mapping, mappingIndex) =>
+        !mapping.role && mappingIndex === index
+          ? { ...mapping, contextWindow: nextContextWindow }
+          : mapping,
+      );
+      return { ...current, modelMappings };
+    });
+  };
+
   const updateClaudeRoleModel = (role: CcSwitchClaudeModelRole, targetModel: string) => {
     setDraft((current) => {
       const modelMappings = current.modelMappings.map((mapping) =>
@@ -731,7 +774,7 @@ export function CcSwitchImportConfigModal({
           </Button>
           <Button
             variant="primary"
-            onClick={() => onSave(prepareDraftForSave(draft, codexContextWindow))}
+            onClick={() => onSave(prepareDraftForSave(draft))}
             disabled={isSaveDisabled}
           >
             {t("common.save")}
@@ -869,22 +912,6 @@ export function CcSwitchImportConfigModal({
               className={controlClassName}
             />
           </label>
-
-          {draft.clientType === "codex" ? (
-            <label className={fieldClassName}>
-              <span className={labelClassName}>{t("ccswitch.config_codex_context_window")}</span>
-              <TextInput
-                type="number"
-                min={1}
-                inputMode="numeric"
-                value={codexContextWindow}
-                onChange={(event) => setCodexContextWindow(event.currentTarget.value)}
-                placeholder={String(DEFAULT_CODEX_CONTEXT_WINDOW)}
-                aria-label={t("ccswitch.config_codex_context_window")}
-                className={controlClassName}
-              />
-            </label>
-          ) : null}
         </section>
 
         <section className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white shadow-[0_18px_44px_rgb(15_23_42_/_0.05)] dark:border-neutral-800 dark:bg-neutral-950/80">
@@ -1019,7 +1046,7 @@ export function CcSwitchImportConfigModal({
                   </tbody>
                 </table>
               ) : (
-                <table className="min-w-[720px] w-full text-left text-sm">
+                <table className="min-w-[900px] w-full text-left text-sm">
                   <thead className="bg-slate-50 text-[11px] uppercase tracking-wide text-slate-500 dark:bg-neutral-900/60 dark:text-white/45">
                     <tr>
                       <th className="px-4 py-2.5 font-semibold">
@@ -1027,6 +1054,9 @@ export function CcSwitchImportConfigModal({
                       </th>
                       <th className="px-4 py-2.5 font-semibold">
                         {t("ccswitch.config_request_model_name")}
+                      </th>
+                      <th className="w-44 px-4 py-2.5 font-semibold">
+                        {t("ccswitch.config_codex_context_window")}
                       </th>
                       <th className="w-16 px-4 py-2.5 text-right font-semibold">
                         {t("ccswitch.config_table_actions")}
@@ -1059,6 +1089,26 @@ export function CcSwitchImportConfigModal({
                               updateGenericRequestModel(index, requestModel);
                             }}
                             aria-label={t("ccswitch.config_request_model_for_mapping", {
+                              index: index + 1,
+                            })}
+                            className={controlClassName}
+                          />
+                        </td>
+                        <td className="px-4 py-3">
+                          <TextInput
+                            type="number"
+                            min={1}
+                            inputMode="numeric"
+                            value={
+                              mapping.contextWindow === undefined
+                                ? ""
+                                : String(mapping.contextWindow)
+                            }
+                            onChange={(event) =>
+                              updateGenericContextWindow(index, event.currentTarget.value)
+                            }
+                            placeholder={String(DEFAULT_CODEX_CONTEXT_WINDOW)}
+                            aria-label={t("ccswitch.config_context_window_for_mapping", {
                               index: index + 1,
                             })}
                             className={controlClassName}

--- a/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
@@ -70,7 +70,7 @@ describe("ccSwitchImportConfigsApi", () => {
         endpointPath: "/v1",
         usageAutoInterval: 30,
         modelMappings: [
-          { requestModel: "gpt-5.5", targetModel: "gpt-5.5" },
+          { requestModel: "gpt-5.5", targetModel: "gpt-5.5", contextWindow: 272000 },
           { requestModel: "deepseek-v4-flash", targetModel: "deepseek-chat" },
         ],
         codexModelCatalogFilename: "cc-switch-model-catalog.json",
@@ -97,6 +97,14 @@ describe("ccSwitchImportConfigsApi", () => {
       expect.objectContaining({
         id: "codex-deepseek",
         "client-type": "codex",
+        "model-mappings": [
+          {
+            "request-model": "gpt-5.5",
+            "target-model": "gpt-5.5",
+            "context-window": 272000,
+          },
+          { "request-model": "deepseek-v4-flash", "target-model": "deepseek-chat" },
+        ],
         "codex-model-catalog-filename": "cc-switch-model-catalog.json",
         "codex-model-catalog": expect.objectContaining({
           models: expect.arrayContaining([
@@ -125,7 +133,7 @@ describe("ccSwitchImportConfigsApi", () => {
         "provider-name": "Pro pool + DeepSeek",
         "default-model": "gpt-5.5",
         "model-mappings": [
-          { "request-model": "gpt-5.5", "target-model": "gpt-5.5" },
+          { "request-model": "gpt-5.5", "target-model": "gpt-5.5", "context-window": 272000 },
           { "request-model": "deepseek-v4-flash", "target-model": "deepseek-chat" },
         ],
         "allowed-channel-groups": ["pro"],
@@ -150,6 +158,10 @@ describe("ccSwitchImportConfigsApi", () => {
     expect(configs).toHaveLength(1);
     expect(configs[0]).toMatchObject({
       codexModelCatalogFilename: "cc-switch-model-catalog.json",
+      modelMappings: [
+        { requestModel: "gpt-5.5", targetModel: "gpt-5.5", contextWindow: 272000 },
+        { requestModel: "deepseek-v4-flash", targetModel: "deepseek-chat" },
+      ],
       codexModelCatalog: {
         models: [
           {

--- a/packages/api-client/src/endpoints/ccswitch-import-configs.ts
+++ b/packages/api-client/src/endpoints/ccswitch-import-configs.ts
@@ -21,6 +21,11 @@ const normalizeNumber = (value: unknown): number | undefined => {
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
+const normalizePositiveNumber = (value: unknown): number | undefined => {
+  const parsed = normalizeNumber(value);
+  return parsed !== undefined && parsed > 0 ? Math.round(parsed) : undefined;
+};
+
 const normalizeStringList = (value: unknown): string[] => {
   if (!Array.isArray(value)) return [];
   return value.map((item) => (typeof item === "string" ? item.trim() : "")).filter(Boolean);
@@ -49,6 +54,13 @@ const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
         ...(normalizedRole ? { role: normalizedRole } : {}),
         requestModel,
         targetModel,
+        ...(normalizePositiveNumber(record["context-window"] ?? record.contextWindow) !== undefined
+          ? {
+              contextWindow: normalizePositiveNumber(
+                record["context-window"] ?? record.contextWindow,
+              ),
+            }
+          : {}),
       };
     })
     .filter((item): item is CcSwitchModelMapping => Boolean(item));
@@ -119,6 +131,7 @@ const serializeCcSwitchImportConfig = (config: CcSwitchImportConfigListItem) => 
     ...(mapping.role ? { role: mapping.role } : {}),
     "request-model": mapping.requestModel,
     "target-model": mapping.targetModel,
+    ...(mapping.contextWindow ? { "context-window": mapping.contextWindow } : {}),
   })),
   "allowed-channel-groups": [...config.allowedChannelGroups],
   "route-path": config.routePath,

--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -12,6 +12,7 @@ export interface CcSwitchModelMappingInput {
   requestModel: string;
   targetModel: string;
   role?: CcSwitchClaudeModelRole;
+  contextWindow?: number;
 }
 
 export const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME = "cc-switch-model-catalog.json";
@@ -223,6 +224,9 @@ const normalizeModelMappings = (
         ...(role ? { role } : {}),
         requestModel: requestModel || targetModel,
         targetModel,
+        ...(normalizeCodexContextWindow(mapping.contextWindow) !== DEFAULT_CODEX_CONTEXT_WINDOW
+          ? { contextWindow: normalizeCodexContextWindow(mapping.contextWindow) }
+          : {}),
       };
     })
     .filter((mapping): mapping is CcSwitchModelMappingInput => Boolean(mapping));
@@ -301,8 +305,9 @@ const normalizeCodexReasoningLevels = (
         description: String(level.description ?? builtIn?.description ?? effort),
       };
     })
-    .filter((level): level is CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"][number] =>
-      Boolean(level),
+    .filter(
+      (level): level is CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"][number] =>
+        Boolean(level),
     );
 
   return normalized.length > 0 ? normalized : CODEX_SUPPORTED_REASONING_LEVELS;
@@ -430,27 +435,31 @@ const buildCodexConfig = (input: {
     catalogModels.push(normalizedEntry);
     explicitCatalogModels.push(normalizedEntry);
   };
-  const addCatalogModel = (value: string) => {
+  const addCatalogModel = (value: string, contextWindow?: number) => {
     const normalized = value.trim();
     const key = normalized.toLowerCase();
     if (!normalized || seen.has(key)) return;
     seen.add(key);
-    catalogModels.push({
+    const modelEntry: Record<string, unknown> = {
       model: normalized,
       defaultReasoningLevel: "medium",
       supportedReasoningLevels: CODEX_SUPPORTED_REASONING_LEVELS,
-    });
+    };
+    if (contextWindow && contextWindow > 0) {
+      modelEntry.contextWindow = contextWindow;
+    }
+    catalogModels.push(modelEntry);
   };
 
   for (const entry of input.codexModelCatalog?.models ?? []) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
     addCatalogEntry(entry);
   }
-  addCatalogModel(model);
   for (const mapping of input.modelMappings) {
     if (mapping.role) continue;
-    addCatalogModel(mapping.requestModel);
+    addCatalogModel(mapping.requestModel, mapping.contextWindow);
   }
+  addCatalogModel(model);
 
   // Derive the default reasoning effort from the explicit catalog entry for
   // the selected model so the generated config.toml stays consistent with

--- a/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
+++ b/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
@@ -15,6 +15,7 @@ export interface CcSwitchModelMapping {
   requestModel: string;
   targetModel: string;
   role?: CcSwitchClaudeModelRole;
+  contextWindow?: number;
 }
 
 export interface CcSwitchImportCodexModelCatalog {
@@ -71,6 +72,12 @@ const normalizeClaudeRole = (value: unknown): CcSwitchClaudeModelRole | undefine
     : undefined;
 };
 
+const normalizeContextWindow = (value: unknown): number | undefined => {
+  const parsed = typeof value === "number" ? value : Number(String(value ?? ""));
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.round(parsed);
+};
+
 const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
   if (!Array.isArray(value)) return [];
   const seen = new Set<string>();
@@ -101,6 +108,11 @@ const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
       ...(role ? { role } : {}),
       requestModel,
       targetModel,
+      ...(normalizeContextWindow(record["context-window"] ?? record.contextWindow) !== undefined
+        ? {
+            contextWindow: normalizeContextWindow(record["context-window"] ?? record.contextWindow),
+          }
+        : {}),
     });
   });
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2673,6 +2673,7 @@
     "config_request_model_name": "CC Switch request model",
     "config_request_model_for": "CC Switch request model for {{model}}",
     "config_request_model_for_mapping": "CC Switch request model for mapping {{index}}",
+    "config_context_window_for_mapping": "Context window for mapping {{index}}",
     "config_claude_request_model_for": "{{role}} request model",
     "config_claude_model_role": "Claude Code setting",
     "config_claude_role_main": "Main model",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2962,6 +2962,7 @@
     "config_request_model_name": "CC Switch 请求模型",
     "config_request_model_for": "{{model}} 对应的 CC Switch 请求模型",
     "config_request_model_for_mapping": "第 {{index}} 条 CC Switch 请求模型",
+    "config_context_window_for_mapping": "第 {{index}} 条上下文窗口",
     "config_claude_request_model_for": "{{role}} 请求模型",
     "config_claude_model_role": "Claude Code 设置",
     "config_claude_role_main": "主模型",

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -65,6 +65,7 @@ function serializeQuickImportConfig(config: CcSwitchImportConfigListItem): Recor
       ...(mapping.role ? { role: mapping.role } : {}),
       "request-model": mapping.requestModel,
       "target-model": mapping.targetModel,
+      ...(mapping.contextWindow ? { "context-window": mapping.contextWindow } : {}),
     })),
     "allowed-channel-groups": [...config.allowedChannelGroups],
     "route-path": config.routePath,

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -184,7 +184,7 @@ describe("CcSwitchImportSettingsPage", () => {
     );
     await user.clear(requestModelInput);
     await user.type(requestModelInput, "gpt-5.5");
-    const contextWindowInput = within(dialog).getByLabelText(/codex context window/i);
+    const contextWindowInput = within(dialog).getByLabelText(/context window for mapping 1/i);
     expect(contextWindowInput).toHaveValue(128000);
     await user.clear(contextWindowInput);
     await user.type(contextWindowInput, "272000");
@@ -208,6 +208,7 @@ describe("CcSwitchImportSettingsPage", () => {
             {
               requestModel: "gpt-5.5",
               targetModel: "deepseek-v4-flash",
+              contextWindow: 272000,
             },
           ]),
           codexModelCatalog: {
@@ -223,7 +224,7 @@ describe("CcSwitchImportSettingsPage", () => {
               }),
               expect.objectContaining({
                 slug: "kimi-k2",
-                context_window: 272000,
+                context_window: 128000,
               }),
             ],
           },
@@ -305,6 +306,7 @@ describe("CcSwitchImportSettingsPage", () => {
           defaultModel: "gpt-5.5",
           modelMappings: [
             {
+              contextWindow: 128000,
               requestModel: "gpt-5.5",
               targetModel: "deepseek-v4-flash",
             },
@@ -777,10 +779,12 @@ describe("CcSwitchImportSettingsPage", () => {
           allowedChannelGroups: ["kimicode"],
           modelMappings: [
             {
+              contextWindow: 128000,
               requestModel: "gpt-5.5",
               targetModel: "gpt-5.5",
             },
             {
+              contextWindow: 128000,
               requestModel: "gpt-5.4-mini",
               targetModel: "gpt-5.5",
             },
@@ -912,6 +916,7 @@ describe("CcSwitchImportSettingsPage", () => {
           allowedChannelGroups: ["deepseekv4flash+chatgpt"],
           modelMappings: [
             {
+              contextWindow: 128000,
               requestModel: "gpt-5.4",
               targetModel: "deepseek-v4-flash",
             },


### PR DESCRIPTION
## Summary
- move Codex context window editing into each CC Switch model mapping row
- persist context-window through API serialization and quick import
- generate Codex model catalog entries from per-mapping context windows

## Tests
- bun run --filter @code-proxy/admin-panel test -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
- bun run build