### PR TITLE
fix: save provider model permissions consistently

### DIFF
--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -1441,8 +1441,17 @@ export function RoutingConfigEditor({
     let cancelled = false;
     setModelsLoading(true);
     setModelsError("");
-    const modelLoader = editingSystemDefaultGroup
-      ? loadModelsForChannels(resolvedDraftChannelValues, SYSTEM_DEFAULT_GROUP_NAME)
+    const savedGroupName =
+      !editingSystemDefaultGroup && groupEditorId
+        ? values.routingChannelGroups.find((group) => group.id === groupEditorId)?.name.trim()
+        : "";
+    // Existing groups need their saved backend scope for model availability; new
+    // drafts do not exist server-side yet, so they stay channel-scoped only.
+    const modelGroupName = editingSystemDefaultGroup
+      ? SYSTEM_DEFAULT_GROUP_NAME
+      : savedGroupName || undefined;
+    const modelLoader = modelGroupName
+      ? loadModelsForChannels(resolvedDraftChannelValues, modelGroupName)
       : loadModelsForChannels(resolvedDraftChannelValues);
     modelLoader
       .then((models) => {
@@ -1486,9 +1495,11 @@ export function RoutingConfigEditor({
     groupEditorTab,
     editingSystemDefaultGroup,
     loadModelsForChannels,
+    groupEditorId,
     modelsSelectionTouched,
     resolvedDraftChannelKey,
     t,
+    values.routingChannelGroups,
   ]);
 
   return (

--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -305,7 +305,12 @@ export function ChannelGroupsPage() {
       const ids = Array.isArray(data?.data)
         ? data.data.map((model) => String(model.id ?? "").trim()).filter(Boolean)
         : [];
-      const availability = await loadConfiguredModelAvailability();
+      // Group editors must use the same scope as the channel group; default
+      // availability can be narrower and would drop owner-mapped catalog models.
+      const availability =
+        normalizedGroup && normalizedGroup !== "default"
+          ? await loadConfiguredModelAvailability({ allowedChannelGroups: [normalizedGroup] })
+          : await loadConfiguredModelAvailability();
       const detailsForGroup =
         (normalizedGroup ? availableChannelDetailsByGroup[normalizedGroup.toLowerCase()] : undefined) ??
         availableChannelDetails;

--- a/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -235,6 +235,41 @@ describe("RoutingConfigEditor", () => {
     expect(screen.getByTestId("allowed-models")).not.toHaveTextContent(/claude/);
   });
 
+  test("loads existing group models with the saved group scope", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const user = userEvent.setup();
+    const loadModelsForChannels = vi.fn(async () => ["gpt-5.6", "gpt-5.6-ultra"]);
+
+    render(
+      <Harness
+        initialValues={{
+          ...DEFAULT_VISUAL_VALUES,
+          routingChannelGroups: [
+            {
+              id: "group-codex",
+              name: "deepseekv4flash+chatgpt",
+              description: "",
+              strategy: "round-robin",
+              allowedModels: [],
+              channels: [{ id: "channel-main-codex", name: "Main Codex", priority: "" }],
+            },
+          ],
+        }}
+        loadModelsForChannels={loadModelsForChannels}
+      />,
+    );
+
+    const row = screen.getByRole("row", { name: /deepseekv4flash\+chatgpt/ });
+    await user.click(within(row).getByRole("button", { name: "编辑分组" }));
+    await user.click(screen.getByRole("tab", { name: "模型列表" }));
+
+    expect(await screen.findByLabelText("gpt-5.6")).toBeInTheDocument();
+    expect(loadModelsForChannels).toHaveBeenCalledWith(
+      ["Main Codex"],
+      "deepseekv4flash+chatgpt",
+    );
+  });
+
   test("renders channel-scoped models as a checkbox table with descriptions and prices", async () => {
     await i18n.changeLanguage("zh-CN");
     const user = userEvent.setup();

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -432,10 +432,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
       { name: "qwen3.7-max" },
     ]);
     expect(saved).toHaveProperty("visionFallbackModel", "qwen3.5-plus");
-    expect(saved).toHaveProperty("excludedModels", [
-      "cline-pass/minimax-m3",
-      "*",
-    ]);
+    expect(saved).toHaveProperty("excludedModels", ["*"]);
   });
 
   test("shows OpenCode Go dynamic model list without manual model inputs", async () => {
@@ -841,7 +838,6 @@ describe("ProvidersPage Cline tab", () => {
     const saved = mocks.patchClineConfig.mock.calls[0][1];
     expect(saved).toHaveProperty("models", [
       { name: "cline-pass/glm-5.2" },
-      { name: "cline-pass/minimax-m3" },
       { name: "cline-pass/qwen3.7-max" },
       { name: "cline-pass/mimo-v2.5-pro" },
     ]);
@@ -920,13 +916,17 @@ describe("ProvidersPage Ollama Cloud tab", () => {
 
   test("saves Ollama Cloud fetched model permissions when saving", async () => {
     const user = userEvent.setup();
+    mocks.getModelDefinitions.mockImplementation(async () => [
+      { id: "gpt-oss:120b", object: "model", owned_by: "ollama" },
+      { id: "gpt-oss:20b", object: "model", owned_by: "ollama" },
+    ]);
     mocks.getOllamaCloudConfigs.mockImplementation(async () => [
       {
         name: "Existing Ollama Cloud",
         apiKey: "sk-ollama",
         baseUrl: "https://ollama.com",
-        models: [{ name: "gpt-oss:120b" }],
-        excludedModels: ["gpt-oss:20b", "*"],
+        models: [{ name: "gpt-oss:120b" }, { name: "gpt-oss:20b" }],
+        excludedModels: ["gpt-oss:20b"],
       },
     ]);
 
@@ -960,7 +960,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
         expect.objectContaining({
           name: "Existing Ollama Cloud",
           apiKey: "",
-          excludedModels: ["gpt-oss:20b", "*"],
+          excludedModels: ["gpt-oss:20b"],
         }),
       );
     });

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -189,7 +189,19 @@ export function useProviderKeyEditor({
         : isOllamaCloud
           ? "ollama-cloud"
           : null;
-    const excludedModels = rawExcludedModels;
+    const excludedModels = rawExcludedModels?.filter((model) => {
+      const trimmed = model.trim();
+      return (
+        trimmed === "*" ||
+        !modelAccessProvider ||
+        isModelAllowedForProvider(modelAccessProvider, trimmed)
+      );
+    });
+    const excludedModelSet = new Set(
+      stripDisableAllModelsRule(excludedModels).map((model) =>
+        model.toLowerCase(),
+      ),
+    );
 
     const requireAlias = editKeyType === "vertex";
     const modelCommit = commitModelEntries(keyDraft.modelEntries, {
@@ -205,7 +217,11 @@ export function useProviderKeyEditor({
       modelAccessProvider && modelCommit.models
         ? modelCommit.models.filter((model) => {
             const name = model.name?.trim() ?? "";
-            return name && isModelAllowedForProvider(modelAccessProvider, name);
+            return (
+              name &&
+              isModelAllowedForProvider(modelAccessProvider, name) &&
+              !excludedModelSet.has(name.toLowerCase())
+            );
           })
         : modelCommit.models;
     const result: ProviderSimpleConfig | BedrockProviderConfig = {
@@ -229,7 +245,7 @@ export function useProviderKeyEditor({
         : {}),
       ...(keyDraft.proxyId.trim() ? { proxyId: keyDraft.proxyId.trim() } : {}),
       ...(headers ? { headers } : {}),
-      ...(excludedModels ? { excludedModels } : {}),
+      ...(excludedModels?.length ? { excludedModels } : {}),
       ...(isOpenCodeGo && keyDraft.workspaceId.trim()
         ? { workspaceId: keyDraft.workspaceId.trim() }
         : {}),


### PR DESCRIPTION
## Summary
- save OpenCode Go, ClinePass, and Ollama Cloud models without duplicating disabled models in the enabled model list
- filter stale cross-provider exclusions before save
- load model availability with the correct channel-group scope in group editors

## Tests
- bun run test:ci -- pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
- bun run test:ci -- pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx pages/system/__tests__/SystemPage.test.tsx
- bun run build