### PR TITLE
fix: use provider model permissions

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -6,7 +6,11 @@ import type {
   ProviderModel,
   ProviderSimpleConfig,
 } from "@code-proxy/api-client";
-import { matchesModelPattern, normalizeProviderKey, resolveFileType } from "@code-proxy/domain";
+import {
+  matchesModelPattern,
+  normalizeProviderKey,
+  resolveFileType,
+} from "@code-proxy/domain";
 import {
   getConfiguredAvailabilityCacheVersion,
   invalidateConfiguredModelAvailability,
@@ -123,7 +127,15 @@ const PROVIDER_CHANNELS = [
   { key: "vertex", load: () => providersApi.getVertexConfigs() },
 ] as const;
 
-const emptyAvailability = (usesMappedOwners = false): ConfiguredModelAvailability => ({
+const MODEL_ACCESS_PROVIDER_KEYS = new Set([
+  "cline",
+  "opencode-go",
+  "ollama-cloud",
+]);
+
+const emptyAvailability = (
+  usesMappedOwners = false,
+): ConfiguredModelAvailability => ({
   scoped: false,
   items: [],
   idSet: new Set(),
@@ -143,7 +155,9 @@ export const emptyModelPricing = (): ModelPricing => ({
 const normalizeOwnerValue = (value: string): string =>
   value.trim().replace(/\s+/g, "-").toLowerCase();
 
-const normalizeAuthGroupOwnerMappings = (payload: unknown): AuthGroupOwnerMappingMap => {
+const normalizeAuthGroupOwnerMappings = (
+  payload: unknown,
+): AuthGroupOwnerMappingMap => {
   const record = isRecord(payload) ? payload : {};
   const rawList = Array.isArray(record.items)
     ? record.items
@@ -156,21 +170,28 @@ const normalizeAuthGroupOwnerMappings = (payload: unknown): AuthGroupOwnerMappin
   const output: AuthGroupOwnerMappingMap = {};
   for (const item of rawList) {
     if (!isRecord(item)) continue;
-    const authGroup = normalizeProviderKey(String(item.auth_group ?? item.authGroup ?? ""));
-    const owner = normalizeOwnerValue(String(item.owner ?? item.owner_value ?? ""));
+    const authGroup = normalizeProviderKey(
+      String(item.auth_group ?? item.authGroup ?? ""),
+    );
+    const owner = normalizeOwnerValue(
+      String(item.owner ?? item.owner_value ?? ""),
+    );
     if (!authGroup || authGroup === "all" || !owner) continue;
     output[authGroup] = owner;
   }
   return output;
 };
 
-const loadAuthGroupOwnerMappingMap = async (): Promise<AuthGroupOwnerMappingMap> => {
-  try {
-    return normalizeAuthGroupOwnerMappings(await apiClient.get("/auth-group-model-owner-mappings"));
-  } catch {
-    return {};
-  }
-};
+const loadAuthGroupOwnerMappingMap =
+  async (): Promise<AuthGroupOwnerMappingMap> => {
+    try {
+      return normalizeAuthGroupOwnerMappings(
+        await apiClient.get("/auth-group-model-owner-mappings"),
+      );
+    } catch {
+      return {};
+    }
+  };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -180,17 +201,27 @@ const asNumber = (value: unknown): number => {
   return Number.isFinite(num) && num >= 0 ? num : 0;
 };
 
-export const normalizeModelPricing = (raw: Record<string, unknown>): ModelPricing => {
+export const normalizeModelPricing = (
+  raw: Record<string, unknown>,
+): ModelPricing => {
   const pricing = isRecord(raw.pricing) ? raw.pricing : {};
   const mode: ModelPricingMode =
     pricing.mode === "call" || raw.pricing_mode === "call" ? "call" : "token";
 
   return {
     mode,
-    inputPricePerMillion: asNumber(pricing.input_price_per_million ?? pricing.prompt),
-    outputPricePerMillion: asNumber(pricing.output_price_per_million ?? pricing.completion),
-    cachedPricePerMillion: asNumber(pricing.cached_price_per_million ?? pricing.cache),
-    cacheReadPricePerMillion: asNumber(pricing.cache_read_price_per_million ?? pricing.cacheRead),
+    inputPricePerMillion: asNumber(
+      pricing.input_price_per_million ?? pricing.prompt,
+    ),
+    outputPricePerMillion: asNumber(
+      pricing.output_price_per_million ?? pricing.completion,
+    ),
+    cachedPricePerMillion: asNumber(
+      pricing.cached_price_per_million ?? pricing.cache,
+    ),
+    cacheReadPricePerMillion: asNumber(
+      pricing.cache_read_price_per_million ?? pricing.cacheRead,
+    ),
     cacheWritePricePerMillion: asNumber(
       pricing.cache_write_price_per_million ?? pricing.cacheWrite,
     ),
@@ -243,11 +274,15 @@ const normalizeModelSupportsVision = (
   return inputModalities.includes("image");
 };
 
-export const normalizeModelConfigMetadata = (item: unknown): ModelConfigMetadataItem | null => {
+export const normalizeModelConfigMetadata = (
+  item: unknown,
+): ModelConfigMetadataItem | null => {
   if (!isRecord(item)) return null;
   const id = String(item.id ?? item.model_id ?? item.name ?? "").trim();
   if (!id) return null;
-  const inputModalities = normalizeModelModalities(item.input_modalities ?? item.inputModalities);
+  const inputModalities = normalizeModelModalities(
+    item.input_modalities ?? item.inputModalities,
+  );
   const outputModalities = normalizeModelModalities(
     item.output_modalities ?? item.outputModalities,
   );
@@ -264,7 +299,9 @@ export const normalizeModelConfigMetadata = (item: unknown): ModelConfigMetadata
   };
 };
 
-export const normalizeModelConfigMetadataRows = (payload: unknown): ModelConfigMetadataItem[] => {
+export const normalizeModelConfigMetadataRows = (
+  payload: unknown,
+): ModelConfigMetadataItem[] => {
   const record = isRecord(payload) ? payload : {};
   const rawList = Array.isArray(record.data)
     ? record.data
@@ -296,7 +333,9 @@ const normalizeModelPath = (item: unknown): ModelPathItem | null => {
   };
 };
 
-const normalizeModelPathCapability = (item: unknown): ModelPathRouteCapability | null => {
+const normalizeModelPathCapability = (
+  item: unknown,
+): ModelPathRouteCapability | null => {
   const normalized = normalizeModelPath(item);
   if (!normalized) return null;
   return {
@@ -307,7 +346,9 @@ const normalizeModelPathCapability = (item: unknown): ModelPathRouteCapability |
   };
 };
 
-const normalizeModelPathAvailabilityItem = (item: unknown): ModelPathAvailabilityItem | null => {
+const normalizeModelPathAvailabilityItem = (
+  item: unknown,
+): ModelPathAvailabilityItem | null => {
   if (!isRecord(item)) return null;
   const id = String(item.id ?? "").trim();
   if (!id) return null;
@@ -325,14 +366,18 @@ const normalizeModelPathAvailabilityItem = (item: unknown): ModelPathAvailabilit
   };
 };
 
-const normalizeModelPathRouteItem = (route: unknown): ModelPathRouteItem | null => {
+const normalizeModelPathRouteItem = (
+  route: unknown,
+): ModelPathRouteItem | null => {
   if (!isRecord(route)) return null;
   const path = String(route.path ?? "").trim();
   if (!path) return null;
   const capabilities = Array.isArray(route.capabilities)
     ? route.capabilities
         .map((capability) => normalizeModelPathCapability(capability))
-        .filter((capability): capability is ModelPathRouteCapability => Boolean(capability))
+        .filter((capability): capability is ModelPathRouteCapability =>
+          Boolean(capability),
+        )
     : [];
   return {
     label: String(route.label ?? ""),
@@ -344,9 +389,15 @@ const normalizeModelPathRouteItem = (route: unknown): ModelPathRouteItem | null 
   };
 };
 
-export const normalizeModelPathAvailability = (payload: unknown): ModelPathAvailability => {
+export const normalizeModelPathAvailability = (
+  payload: unknown,
+): ModelPathAvailability => {
   const record = isRecord(payload) ? payload : {};
-  const rawItems = Array.isArray(record.data) ? record.data : Array.isArray(payload) ? payload : [];
+  const rawItems = Array.isArray(record.data)
+    ? record.data
+    : Array.isArray(payload)
+      ? payload
+      : [];
   const items = rawItems
     .map((item) => normalizeModelPathAvailabilityItem(item))
     .filter((item): item is ModelPathAvailabilityItem => Boolean(item))
@@ -416,8 +467,11 @@ const providerModelId = (model: ProviderModel): string => {
 };
 
 const isExcluded = (modelId: string, excludedModels?: string[]) => {
-  if (!Array.isArray(excludedModels) || excludedModels.length === 0) return false;
-  return excludedModels.some((pattern) => matchesModelPattern(modelId, pattern));
+  if (!Array.isArray(excludedModels) || excludedModels.length === 0)
+    return false;
+  return excludedModels.some((pattern) =>
+    matchesModelPattern(modelId, pattern),
+  );
 };
 
 const addExplicitProviderModels = (
@@ -467,13 +521,24 @@ const hasCredential = (config: ProviderSimpleConfig): boolean =>
 
 const isOpenAIProviderServiceable = (provider: OpenAIProvider): boolean => {
   if (provider.disabled === true) return false;
-  if (!Array.isArray(provider.apiKeyEntries) || provider.apiKeyEntries.length === 0) return true;
+  if (
+    !Array.isArray(provider.apiKeyEntries) ||
+    provider.apiKeyEntries.length === 0
+  )
+    return true;
   return provider.apiKeyEntries.some(
-    (entry) => entry.disabled !== true && Boolean(String(entry.apiKey ?? "").trim()),
+    (entry) =>
+      entry.disabled !== true && Boolean(String(entry.apiKey ?? "").trim()),
   );
 };
 
-const loadStaticDefinitions = async (provider: string): Promise<ModelDefinition[]> => {
+const hasDisableAllModelsRule = (excludedModels?: string[]) =>
+  Array.isArray(excludedModels) &&
+  excludedModels.some((model) => String(model ?? "").trim() === "*");
+
+const loadStaticDefinitions = async (
+  provider: string,
+): Promise<ModelDefinition[]> => {
   try {
     return await authFilesApi.getModelDefinitions(provider);
   } catch {
@@ -493,30 +558,64 @@ const loadProviderModelItems = async (): Promise<ModelAvailabilityItem[]> => {
         configs = [];
       }
 
-      const needsStaticModels = configs.some(
-        (config) => !Array.isArray(config.models) || config.models.length === 0,
-      );
-      const staticModels = needsStaticModels ? await loadStaticDefinitions(key) : [];
+      const isModelAccessProvider = MODEL_ACCESS_PROVIDER_KEYS.has(key);
+      const needsStaticModels = configs.some((config) => {
+        if (
+          isModelAccessProvider &&
+          hasDisableAllModelsRule(config.excludedModels)
+        )
+          return false;
+        return !Array.isArray(config.models) || config.models.length === 0;
+      });
+      const staticModels = needsStaticModels
+        ? await loadStaticDefinitions(key)
+        : [];
 
       for (const config of configs) {
+        const disabled = hasDisableAllModelsRule(config.excludedModels);
+        const excludedModels = isModelAccessProvider
+          ? disabled
+            ? ["*"]
+            : undefined
+          : config.excludedModels;
+        if (disabled) continue;
         if (Array.isArray(config.models) && config.models.length > 0) {
-          addExplicitProviderModels(map, config.models, key, config.prefix, config.excludedModels);
+          addExplicitProviderModels(
+            map,
+            config.models,
+            key,
+            config.prefix,
+            excludedModels,
+          );
           continue;
         }
-        addStaticProviderModels(map, staticModels, key, config.prefix, config.excludedModels);
+        addStaticProviderModels(
+          map,
+          staticModels,
+          key,
+          config.prefix,
+          excludedModels,
+        );
       }
     }),
   );
 
   let openAIProviders: OpenAIProvider[] = [];
   try {
-    openAIProviders = (await providersApi.getOpenAIProviders()).filter(isOpenAIProviderServiceable);
+    openAIProviders = (await providersApi.getOpenAIProviders()).filter(
+      isOpenAIProviderServiceable,
+    );
   } catch {
     openAIProviders = [];
   }
 
   for (const provider of openAIProviders) {
-    addExplicitProviderModels(map, provider.models, provider.name, provider.prefix);
+    addExplicitProviderModels(
+      map,
+      provider.models,
+      provider.name,
+      provider.prefix,
+    );
   }
 
   return Array.from(map.values());
@@ -562,7 +661,10 @@ const loadAuthFileModelItems = async (
       if (owner) {
         scoped = true;
         for (const model of modelsByOwner.get(owner) ?? []) {
-          addModel(map, { ...model, source: model.source || "auth-file-owner" });
+          addModel(map, {
+            ...model,
+            source: model.source || "auth-file-owner",
+          });
         }
         return;
       }
@@ -632,7 +734,9 @@ const augmentPathAvailabilityWithMappedOwners = async (
     if (existing) {
       if (
         !existing.paths.some(
-          (path) => path.method === rootModelPath.method && path.path === rootModelPath.path,
+          (path) =>
+            path.method === rootModelPath.method &&
+            path.path === rootModelPath.path,
         )
       ) {
         existing.paths = [...existing.paths, rootModelPath];
@@ -651,7 +755,9 @@ const augmentPathAvailabilityWithMappedOwners = async (
     });
   }
 
-  const items = Array.from(itemMap.values()).sort((a, b) => a.id.localeCompare(b.id));
+  const items = Array.from(itemMap.values()).sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
   return {
     ...availability,
     items,
@@ -661,7 +767,9 @@ const augmentPathAvailabilityWithMappedOwners = async (
 
 /* ── New backend aggregation endpoint support ── */
 
-const normalizeAvailabilitySources = (value: unknown): ModelAvailabilitySource[] | undefined => {
+const normalizeAvailabilitySources = (
+  value: unknown,
+): ModelAvailabilitySource[] | undefined => {
   if (!Array.isArray(value)) return undefined;
   const seen = new Set<string>();
   const sources: ModelAvailabilitySource[] = [];
@@ -676,8 +784,18 @@ const normalizeAvailabilitySources = (value: unknown): ModelAvailabilitySource[]
     const clientId = String(item.client_id ?? item.clientId ?? "").trim();
     const source = String(item.source ?? "").trim();
     const modelId = String(item.model_id ?? item.modelId ?? "").trim();
-    const upstreamModelId = String(item.upstream_model_id ?? item.upstreamModelId ?? "").trim();
-    const key = [label, provider, channel, clientId, source, modelId, upstreamModelId]
+    const upstreamModelId = String(
+      item.upstream_model_id ?? item.upstreamModelId ?? "",
+    ).trim();
+    const key = [
+      label,
+      provider,
+      channel,
+      clientId,
+      source,
+      modelId,
+      upstreamModelId,
+    ]
       .join("\x00")
       .toLowerCase();
     if (seen.has(key)) continue;
@@ -695,7 +813,9 @@ const normalizeAvailabilitySources = (value: unknown): ModelAvailabilitySource[]
   return sources.length ? sources : undefined;
 };
 
-const normalizeAvailabilityItem = (raw: unknown): ModelAvailabilityItem | null => {
+const normalizeAvailabilityItem = (
+  raw: unknown,
+): ModelAvailabilityItem | null => {
   if (!raw || typeof raw !== "object") return null;
   const record = raw as Record<string, unknown>;
   const id = String(record.id ?? "").trim();
@@ -708,21 +828,28 @@ const normalizeAvailabilityItem = (raw: unknown): ModelAvailabilityItem | null =
   const pricing: ModelPricing = {
     mode: String(pricingRecord.mode ?? "token") === "call" ? "call" : "token",
     inputPricePerMillion: asNumber(
-      pricingRecord.input_price_per_million ?? pricingRecord.inputPricePerMillion,
+      pricingRecord.input_price_per_million ??
+        pricingRecord.inputPricePerMillion,
     ),
     outputPricePerMillion: asNumber(
-      pricingRecord.output_price_per_million ?? pricingRecord.outputPricePerMillion,
+      pricingRecord.output_price_per_million ??
+        pricingRecord.outputPricePerMillion,
     ),
     cachedPricePerMillion: asNumber(
-      pricingRecord.cached_price_per_million ?? pricingRecord.cachedPricePerMillion,
+      pricingRecord.cached_price_per_million ??
+        pricingRecord.cachedPricePerMillion,
     ),
     cacheReadPricePerMillion: asNumber(
-      pricingRecord.cache_read_price_per_million ?? pricingRecord.cacheReadPricePerMillion,
+      pricingRecord.cache_read_price_per_million ??
+        pricingRecord.cacheReadPricePerMillion,
     ),
     cacheWritePricePerMillion: asNumber(
-      pricingRecord.cache_write_price_per_million ?? pricingRecord.cacheWritePricePerMillion,
+      pricingRecord.cache_write_price_per_million ??
+        pricingRecord.cacheWritePricePerMillion,
     ),
-    pricePerCall: asNumber(pricingRecord.price_per_call ?? pricingRecord.pricePerCall),
+    pricePerCall: asNumber(
+      pricingRecord.price_per_call ?? pricingRecord.pricePerCall,
+    ),
   };
 
   const inputModalities = Array.isArray(record.input_modalities)
@@ -733,7 +860,9 @@ const normalizeAvailabilityItem = (raw: unknown): ModelAvailabilityItem | null =
     : [];
   const supportsVision =
     record.supports_vision === true ||
-    inputModalities.some((m: string) => ["image", "vision"].includes(m.toLowerCase()));
+    inputModalities.some((m: string) =>
+      ["image", "vision"].includes(m.toLowerCase()),
+    );
 
   return {
     id,
@@ -767,18 +896,22 @@ export const normalizeConfiguredModelAvailability = (
     .filter((item): item is NonNullable<typeof item> => item !== null)
     .sort((a, b) => a!.id.localeCompare(b!.id));
 
-  const rawMetadata = Array.isArray(record.active_metadata) ? record.active_metadata : [];
+  const rawMetadata = Array.isArray(record.active_metadata)
+    ? record.active_metadata
+    : [];
   const metadataItems = rawMetadata
     .map((item) => normalizeAvailabilityItem(item))
     .filter((item): item is NonNullable<typeof item> => item !== null)
     .sort((a, b) => a!.id.localeCompare(b!.id));
 
   return {
-    scoped: typeof record.scoped === "boolean" ? record.scoped : items.length > 0,
+    scoped:
+      typeof record.scoped === "boolean" ? record.scoped : items.length > 0,
     items,
     metadataItems,
     idSet: new Set(items.map((item) => item.id.toLowerCase())),
-    usesMappedOwners: record.uses_mapped_owners === true || record.usesMappedOwners === true,
+    usesMappedOwners:
+      record.uses_mapped_owners === true || record.usesMappedOwners === true,
   };
 };
 
@@ -833,14 +966,20 @@ export const loadConfiguredModelAvailability = async (options?: {
     .map((g) => String(g ?? "").trim())
     .filter(Boolean);
   const loadFallback = async () =>
-    loadConfiguredModelAvailabilityFallback(await loadAuthGroupOwnerMappingMap());
+    loadConfiguredModelAvailabilityFallback(
+      await loadAuthGroupOwnerMappingMap(),
+    );
 
   if (validGroups.length > 0) {
     const cacheKey = validGroups.join(",");
     const now = Date.now();
     const cacheVersion = getConfiguredAvailabilityCacheVersion();
     const cached = groupAvailabilityCache.get(cacheKey);
-    if (cached && cached.cacheVersion === cacheVersion && now < cached.expiresAt) {
+    if (
+      cached &&
+      cached.cacheVersion === cacheVersion &&
+      now < cached.expiresAt
+    ) {
       return cached.promise;
     }
     const promise = (async (): Promise<ConfiguredModelAvailability> => {
@@ -876,13 +1015,18 @@ export const loadConfiguredModelAvailability = async (options?: {
   ) {
     return configuredAvailabilityCache.value;
   }
-  if (configuredAvailabilityInFlight && configuredAvailabilityInFlight.version === cacheVersion) {
+  if (
+    configuredAvailabilityInFlight &&
+    configuredAvailabilityInFlight.version === cacheVersion
+  ) {
     return configuredAvailabilityInFlight.promise;
   }
 
   const promise = (async (): Promise<ConfiguredModelAvailability> => {
     try {
-      const result = await loadConfiguredAvailabilityEndpoint("/models/configured-availability");
+      const result = await loadConfiguredAvailabilityEndpoint(
+        "/models/configured-availability",
+      );
       if (!result) return loadFallback();
       configuredAvailabilityCache = {
         expiresAt: now + CONFIGURED_AVAILABILITY_TTL_MS,
@@ -925,13 +1069,16 @@ const loadConfiguredModelAvailabilityFallback = async (
 
   const map = new Map<string, ModelAvailabilityItem>();
   for (const item of authFileAvailability.items) addModel(map, item);
-  for (const item of providerItems) addModel(map, withLibraryModelMetadata(item, libraryIndex));
+  for (const item of providerItems)
+    addModel(map, withLibraryModelMetadata(item, libraryIndex));
 
   if (!authFileAvailability.scoped && providerItems.length === 0) {
     return emptyAvailability(usesMappedOwners);
   }
 
-  const items = Array.from(map.values()).sort((a, b) => a.id.localeCompare(b.id));
+  const items = Array.from(map.values()).sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
   return {
     scoped: true,
     items,
@@ -940,17 +1087,22 @@ const loadConfiguredModelAvailabilityFallback = async (
   };
 };
 
-export const loadModelPathAvailability = async (): Promise<ModelPathAvailability> =>
-  augmentPathAvailabilityWithMappedOwners(
-    normalizeModelPathAvailability(await apiClient.get("/model-path-availability")),
-  );
+export const loadModelPathAvailability =
+  async (): Promise<ModelPathAvailability> =>
+    augmentPathAvailabilityWithMappedOwners(
+      normalizeModelPathAvailability(
+        await apiClient.get("/model-path-availability"),
+      ),
+    );
 
 export const filterByConfiguredModelAvailability = <T extends { id: string }>(
   models: T[],
   availability: ConfiguredModelAvailability,
 ): T[] => {
   if (!availability.scoped) return models;
-  return models.filter((model) => availability.idSet.has(model.id.toLowerCase()));
+  return models.filter((model) =>
+    availability.idSet.has(model.id.toLowerCase()),
+  );
 };
 
 export const hasModelPricing = (pricing: ModelPricing): boolean => {
@@ -974,7 +1126,10 @@ export const formatModelPriceAmount = (value: number): string => {
   }).format(rounded);
 };
 
-export const formatModelPrice = (pricing: ModelPricing, notPricedLabel: string): string => {
+export const formatModelPrice = (
+  pricing: ModelPricing,
+  notPricedLabel: string,
+): string => {
   if (pricing.mode === "call") {
     return pricing.pricePerCall > 0
       ? `$${formatModelPriceAmount(pricing.pricePerCall)} / call`
@@ -987,12 +1142,16 @@ export const formatModelPrice = (pricing: ModelPricing, notPricedLabel: string):
     `$${formatModelPriceAmount(pricing.outputPricePerMillion)}`,
   ];
   if (pricing.cacheReadPricePerMillion > 0) {
-    parts.push(`Read $${formatModelPriceAmount(pricing.cacheReadPricePerMillion)}`);
+    parts.push(
+      `Read $${formatModelPriceAmount(pricing.cacheReadPricePerMillion)}`,
+    );
   } else if (pricing.cachedPricePerMillion > 0) {
     parts.push(`$${formatModelPriceAmount(pricing.cachedPricePerMillion)}`);
   }
   if (pricing.cacheWritePricePerMillion > 0) {
-    parts.push(`Write $${formatModelPriceAmount(pricing.cacheWritePricePerMillion)}`);
+    parts.push(
+      `Write $${formatModelPriceAmount(pricing.cacheWritePricePerMillion)}`,
+    );
   }
   return parts.join(" / ");
 };

--- a/packages/api-client/src/endpoints/__tests__/providers-cline.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-cline.test.ts
@@ -23,7 +23,8 @@ describe("providersApi Cline", () => {
   });
 
   test("normalizes Cline configs with default and trimmed Base URL", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     getMock.mockResolvedValue({
       "cline-api-key": [
         {
@@ -38,7 +39,7 @@ describe("providersApi Cline", () => {
           "proxy-url": "http://127.0.0.1:7890",
           headers: { "X-Test": "yes" },
           models: [{ name: "cline-pass/glm-5.2", alias: "cline-glm" }],
-          "excluded-models": ["cline-pass/minimax-m3", "*"],
+          "excluded-models": ["*"],
           "vision-fallback-model": "cline-pass/mimo-v2.5-pro",
         },
       ],
@@ -61,18 +62,23 @@ describe("providersApi Cline", () => {
         proxyUrl: "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
         models: [{ name: "cline-pass/glm-5.2", alias: "cline-glm" }],
-        excludedModels: ["cline-pass/minimax-m3", "*"],
+        excludedModels: ["*"],
         visionFallbackModel: "cline-pass/mimo-v2.5-pro",
       },
     ]);
   });
 
   test("ignores OAuth and runtime rows returned by the Cline config endpoint", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     getMock.mockResolvedValue({
       "cline-api-key": [
         { name: "Cline API key", "api-key": "sk-cline" },
-        { name: "OAuth backed", "api-key": "oauth-token", account_type: "oauth" },
+        {
+          name: "OAuth backed",
+          "api-key": "oauth-token",
+          account_type: "oauth",
+        },
         { name: "runtime", "api-key": "runtime-token", runtime_only: true },
       ],
     });
@@ -87,7 +93,8 @@ describe("providersApi Cline", () => {
   });
 
   test("serializes and deletes Cline configs", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     putMock.mockResolvedValue({ status: "ok" });
     deleteMock.mockResolvedValue({ status: "ok" });
 
@@ -101,7 +108,7 @@ describe("providersApi Cline", () => {
         proxyUrl: "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
         models: [{ name: "cline-pass/glm-5.2", alias: "cline-glm" }],
-        excludedModels: ["cline-pass/minimax-m3", "*"],
+        excludedModels: ["*"],
         visionFallbackModel: "cline-pass/mimo-v2.5-pro",
       },
     ]);
@@ -116,7 +123,7 @@ describe("providersApi Cline", () => {
         "proxy-url": "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
         models: [{ name: "cline-pass/glm-5.2", alias: "cline-glm" }],
-        "excluded-models": ["cline-pass/minimax-m3", "*"],
+        "excluded-models": ["*"],
         "vision-fallback-model": "cline-pass/mimo-v2.5-pro",
       },
     ]);
@@ -129,14 +136,15 @@ describe("providersApi Cline", () => {
   });
 
   test("patches Cline config and excluded models on the Cline endpoint", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.patchClineConfig(0, {
       name: "Cline",
       apiKey: "sk-cline",
       baseUrl: "https://api.cline.bot/api/v1",
       models: [{ name: "cline-pass/glm-5.2", alias: "glm" }],
-      excludedModels: ["cline-pass/minimax-m3", "*"],
+      excludedModels: ["*"],
       visionFallbackModel: "cline-pass/mimo-v2.5-pro",
     });
 
@@ -147,7 +155,7 @@ describe("providersApi Cline", () => {
         "api-key": "sk-cline",
         "base-url": "https://api.cline.bot/api/v1",
         models: [{ name: "cline-pass/glm-5.2", alias: "glm" }],
-        "excluded-models": ["cline-pass/minimax-m3", "*"],
+        "excluded-models": ["*"],
         "vision-fallback-model": "cline-pass/mimo-v2.5-pro",
       },
     });
@@ -161,7 +169,8 @@ describe("providersApi Cline", () => {
   });
 
   test("omits empty api-key when patching an existing Cline config", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.patchClineConfig(0, {
       name: "Cline",

--- a/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
@@ -23,14 +23,15 @@ describe("providersApi Ollama Cloud", () => {
   });
 
   test("normalizes Ollama Cloud configs with default Base URL and model aliases", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     getMock.mockResolvedValue({
       "ollama-cloud-api-key": [
         {
           name: "Ollama",
           "api-key": "sk-ollama",
           models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-          "excluded-models": ["gpt-oss:20b", "*"],
+          "excluded-models": ["*"],
         },
         { name: "Runtime", "api-key": "runtime-token", runtime_only: true },
       ],
@@ -42,14 +43,15 @@ describe("providersApi Ollama Cloud", () => {
         apiKey: "sk-ollama",
         baseUrl: "https://ollama.com",
         models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-        excludedModels: ["gpt-oss:20b", "*"],
+        excludedModels: ["*"],
       },
     ]);
     expect(getMock).toHaveBeenCalledWith("/ollama-cloud-api-key");
   });
 
   test("serializes Ollama Cloud configs with model aliases and deletes them", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.saveOllamaCloudConfigs([
       {
@@ -57,7 +59,7 @@ describe("providersApi Ollama Cloud", () => {
         apiKey: "sk-ollama",
         baseUrl: "https://ollama.com",
         models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-        excludedModels: ["gpt-oss:20b", "*"],
+        excludedModels: ["*"],
       },
     ]);
 
@@ -67,25 +69,30 @@ describe("providersApi Ollama Cloud", () => {
         "api-key": "sk-ollama",
         "base-url": "https://ollama.com",
         models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-        "excluded-models": ["gpt-oss:20b", "*"],
+        "excluded-models": ["*"],
       },
     ]);
 
     await providersApi.deleteOllamaCloudConfig("sk-ollama");
-    expect(deleteMock).toHaveBeenCalledWith("/ollama-cloud-api-key", undefined, {
-      params: { "api-key": "sk-ollama" },
-    });
+    expect(deleteMock).toHaveBeenCalledWith(
+      "/ollama-cloud-api-key",
+      undefined,
+      {
+        params: { "api-key": "sk-ollama" },
+      },
+    );
   });
 
   test("patches Ollama Cloud config and excluded models on the Ollama endpoint", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.patchOllamaCloudConfig(2, {
       name: "Ollama",
       apiKey: "sk-ollama",
       baseUrl: "https://ollama.com",
       models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-      excludedModels: ["gpt-oss:20b", "*"],
+      excludedModels: ["*"],
       visionFallbackModel: "gpt-oss:120b",
     });
 
@@ -96,7 +103,7 @@ describe("providersApi Ollama Cloud", () => {
         "api-key": "sk-ollama",
         "base-url": "https://ollama.com",
         models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-        "excluded-models": ["gpt-oss:20b", "*"],
+        "excluded-models": ["*"],
         "vision-fallback-model": "gpt-oss:120b",
       },
     });
@@ -110,7 +117,8 @@ describe("providersApi Ollama Cloud", () => {
   });
 
   test("omits empty api-key when patching an existing Ollama Cloud config", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.patchOllamaCloudConfig(0, {
       name: "Ollama",

--- a/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
@@ -26,7 +26,8 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("normalizes OpenCode Go configs without exposing Base URL", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     getMock.mockResolvedValue({
       "opencode-go-api-key": [
         {
@@ -38,7 +39,7 @@ describe("providersApi OpenCode Go", () => {
           "proxy-url": "http://127.0.0.1:7890",
           headers: { "X-Test": "yes" },
           models: [{ name: "upstream-model", alias: "go-alias" }],
-          "excluded-models": ["disabled-model", "*"],
+          "excluded-models": ["*"],
           "vision-fallback-model": "qwen3.5-plus",
           "workspace-id": "wrk_123",
           "auth-cookie": "auth-token",
@@ -58,7 +59,7 @@ describe("providersApi OpenCode Go", () => {
         proxyUrl: "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
         models: [{ name: "upstream-model", alias: "go-alias" }],
-        excludedModels: ["disabled-model", "*"],
+        excludedModels: ["*"],
         visionFallbackModel: "qwen3.5-plus",
         workspaceId: "wrk_123",
         authCookie: "auth-token",
@@ -67,7 +68,8 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("ignores OAuth auth-file rows returned by the OpenCode Go config endpoint", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     getMock.mockResolvedValue({
       "opencode-go-api-key": [
         {
@@ -92,7 +94,8 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("serializes and deletes OpenCode Go configs without Base URL", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     putMock.mockResolvedValue({ status: "ok" });
     deleteMock.mockResolvedValue({ status: "ok" });
 
@@ -106,7 +109,7 @@ describe("providersApi OpenCode Go", () => {
         proxyUrl: "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
         models: [{ name: "upstream-model", alias: "go-alias" }],
-        excludedModels: ["disabled-model", "*"],
+        excludedModels: ["*"],
         visionFallbackModel: "qwen3.5-plus",
         workspaceId: "wrk_123",
         authCookie: "auth-token",
@@ -122,7 +125,7 @@ describe("providersApi OpenCode Go", () => {
         "proxy-url": "http://127.0.0.1:7890",
         headers: { "X-Test": "yes" },
         models: [{ name: "upstream-model", alias: "go-alias" }],
-        "excluded-models": ["disabled-model", "*"],
+        "excluded-models": ["*"],
         "vision-fallback-model": "qwen3.5-plus",
         "workspace-id": "wrk_123",
         "auth-cookie": "auth-token",
@@ -137,10 +140,18 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("queries OpenCode Go usage with dashboard credentials", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     postMock.mockResolvedValue({
       workspace_id: "wrk_123",
-      usage: [{ type: "rolling", label: "Rolling", percentage: 3, resets_in: "31 minutes" }],
+      usage: [
+        {
+          type: "rolling",
+          label: "Rolling",
+          percentage: 3,
+          resets_in: "31 minutes",
+        },
+      ],
     });
 
     await expect(
@@ -151,7 +162,14 @@ describe("providersApi OpenCode Go", () => {
       }),
     ).resolves.toEqual({
       workspace_id: "wrk_123",
-      usage: [{ type: "rolling", label: "Rolling", percentage: 3, resets_in: "31 minutes" }],
+      usage: [
+        {
+          type: "rolling",
+          label: "Rolling",
+          percentage: 3,
+          resets_in: "31 minutes",
+        },
+      ],
     });
 
     expect(postMock).toHaveBeenCalledWith("/opencode-go-api-key/usage", {
@@ -162,7 +180,8 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("patches OpenCode Go config and excluded models without Base URL", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.patchOpenCodeGoConfig(1, {
       name: "OpenCode Go",
@@ -181,7 +200,7 @@ describe("providersApi OpenCode Go", () => {
         name: "OpenCode Go",
         "api-key": "sk-go",
         models: [{ name: "qwen3.5-plus", alias: "qwen-go" }],
-        "excluded-models": ["minimax-m2.5", "*"],
+        "excluded-models": ["*"],
         "vision-fallback-model": "qwen3.5-plus",
         "workspace-id": "wrk_123",
         "auth-cookie": "auth-token",
@@ -197,7 +216,8 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("omits empty api-key when patching an existing OpenCode Go config", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
 
     await providersApi.patchOpenCodeGoConfig(0, {
       name: "OpenCode Go",
@@ -217,7 +237,8 @@ describe("providersApi OpenCode Go", () => {
   });
 
   test("ignores OAuth auth-file rows from every provider config endpoint", async () => {
-    const { providersApi } = await import("@code-proxy/api-client/endpoints/providers");
+    const { providersApi } =
+      await import("@code-proxy/api-client/endpoints/providers");
     const oauthRow = {
       name: "yuan364299311@gmail.com",
       "api-key": "oauth-backed-token",
@@ -233,12 +254,18 @@ describe("providersApi OpenCode Go", () => {
     getMock.mockImplementation(async (path: string) => {
       if (path === "/gemini-api-key") {
         return {
-          "gemini-api-key": [{ name: "Gemini API", "api-key": "sk-gemini" }, oauthRow],
+          "gemini-api-key": [
+            { name: "Gemini API", "api-key": "sk-gemini" },
+            oauthRow,
+          ],
         };
       }
       if (path === "/codex-api-key") {
         return {
-          "codex-api-key": [{ name: "Codex API", "api-key": "sk-codex" }, oauthRow],
+          "codex-api-key": [
+            { name: "Codex API", "api-key": "sk-codex" },
+            oauthRow,
+          ],
         };
       }
       if (path === "/claude-api-key") {
@@ -252,13 +279,20 @@ describe("providersApi OpenCode Go", () => {
       }
       if (path === "/vertex-api-key") {
         return {
-          "vertex-api-key": [{ name: "Vertex API", "api-key": "sk-vertex" }, oauthRow],
+          "vertex-api-key": [
+            { name: "Vertex API", "api-key": "sk-vertex" },
+            oauthRow,
+          ],
         };
       }
       if (path === "/bedrock-api-key") {
         return {
           "bedrock-api-key": [
-            { name: "Bedrock API", "api-key": "sk-bedrock", "auth-mode": "api-key" },
+            {
+              name: "Bedrock API",
+              "api-key": "sk-bedrock",
+              "auth-mode": "api-key",
+            },
             oauthRow,
           ],
         };

--- a/packages/api-client/src/endpoints/helpers.ts
+++ b/packages/api-client/src/endpoints/helpers.ts
@@ -23,7 +23,9 @@ export const normalizeString = (value: unknown): string | null => {
   return trimmed ? trimmed : null;
 };
 
-export const normalizeHeaders = (value: unknown): Record<string, string> | undefined => {
+export const normalizeHeaders = (
+  value: unknown,
+): Record<string, string> | undefined => {
   if (!isRecord(value)) return undefined;
   const result: Record<string, string> = {};
   Object.entries(value).forEach(([key, raw]) => {
@@ -39,7 +41,9 @@ export const normalizeHeaders = (value: unknown): Record<string, string> | undef
   return Object.keys(result).length ? result : undefined;
 };
 
-export const normalizeModels = (value: unknown): ProviderModel[] | undefined => {
+export const normalizeModels = (
+  value: unknown,
+): ProviderModel[] | undefined => {
   if (!Array.isArray(value)) return undefined;
   const models = value
     .map((item) => {
@@ -49,8 +53,11 @@ export const normalizeModels = (value: unknown): ProviderModel[] | undefined => 
       const alias = normalizeString(item.alias);
       const priorityRaw = item.priority;
       const priority =
-        typeof priorityRaw === "number" && Number.isFinite(priorityRaw) ? priorityRaw : undefined;
-      const testModel = normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
+        typeof priorityRaw === "number" && Number.isFinite(priorityRaw)
+          ? priorityRaw
+          : undefined;
+      const testModel =
+        normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
       return {
         name,
         ...(alias ? { alias } : {}),
@@ -62,7 +69,9 @@ export const normalizeModels = (value: unknown): ProviderModel[] | undefined => 
   return models.length ? models : undefined;
 };
 
-export const normalizeExcludedModels = (value: unknown): string[] | undefined => {
+export const normalizeExcludedModels = (
+  value: unknown,
+): string[] | undefined => {
   if (!value) return undefined;
   const list = Array.isArray(value)
     ? value
@@ -94,7 +103,10 @@ export const serializeModels = (models?: ProviderModel[]) =>
           const payload: Record<string, unknown> = { name };
           const alias = normalizeString(model?.alias);
           if (alias && alias !== name) payload.alias = alias;
-          if (typeof model?.priority === "number" && Number.isFinite(model.priority)) {
+          if (
+            typeof model?.priority === "number" &&
+            Number.isFinite(model.priority)
+          ) {
             payload.priority = model.priority;
           }
           const testModel = normalizeString(model?.testModel);
@@ -107,6 +119,11 @@ export const serializeModels = (models?: ProviderModel[]) =>
 type SerializeProviderKeyOptions = {
   includeApiKey?: boolean;
 };
+
+const modelAccessExcludedModels = (models?: string[]) =>
+  models?.some((model) => String(model ?? "").trim() === "*")
+    ? ["*"]
+    : undefined;
 
 export const serializeProviderKey = (config: ProviderSimpleConfig) => {
   const payload: Record<string, unknown> = { "api-key": config.apiKey };
@@ -128,7 +145,8 @@ export const serializeProviderKey = (config: ProviderSimpleConfig) => {
     payload["excluded-models"] = config.excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);
-  if (visionFallbackModel) payload["vision-fallback-model"] = visionFallbackModel;
+  if (visionFallbackModel)
+    payload["vision-fallback-model"] = visionFallbackModel;
   if (config.skipAnthropicProcessing) {
     payload["skip-anthropic-processing"] = true;
   }
@@ -153,11 +171,13 @@ export const serializeOpenCodeGoKey = (
   if (headers) payload.headers = headers;
   const models = serializeModels(config.models);
   if (models && models.length) payload.models = models;
-  if (config.excludedModels && config.excludedModels.length) {
-    payload["excluded-models"] = config.excludedModels;
+  const excludedModels = modelAccessExcludedModels(config.excludedModels);
+  if (excludedModels) {
+    payload["excluded-models"] = excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);
-  if (visionFallbackModel) payload["vision-fallback-model"] = visionFallbackModel;
+  if (visionFallbackModel)
+    payload["vision-fallback-model"] = visionFallbackModel;
   const workspaceId = normalizeString(config.workspaceId);
   if (workspaceId) payload["workspace-id"] = workspaceId;
   const authCookie = normalizeString(config.authCookie);
@@ -185,11 +205,13 @@ export const serializeClineKey = (
   if (headers) payload.headers = headers;
   const models = serializeModels(config.models);
   if (models && models.length) payload.models = models;
-  if (config.excludedModels && config.excludedModels.length) {
-    payload["excluded-models"] = config.excludedModels;
+  const excludedModels = modelAccessExcludedModels(config.excludedModels);
+  if (excludedModels) {
+    payload["excluded-models"] = excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);
-  if (visionFallbackModel) payload["vision-fallback-model"] = visionFallbackModel;
+  if (visionFallbackModel)
+    payload["vision-fallback-model"] = visionFallbackModel;
   return payload;
 };
 
@@ -213,11 +235,13 @@ export const serializeOllamaCloudKey = (
   if (headers) payload.headers = headers;
   const models = serializeModels(config.models);
   if (models && models.length) payload.models = models;
-  if (config.excludedModels && config.excludedModels.length) {
-    payload["excluded-models"] = config.excludedModels;
+  const excludedModels = modelAccessExcludedModels(config.excludedModels);
+  if (excludedModels) {
+    payload["excluded-models"] = excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);
-  if (visionFallbackModel) payload["vision-fallback-model"] = visionFallbackModel;
+  if (visionFallbackModel)
+    payload["vision-fallback-model"] = visionFallbackModel;
   return payload;
 };
 
@@ -268,7 +292,8 @@ export const serializeBedrockKey = (config: BedrockProviderConfig) => {
   if (authMode === "api-key") {
     payload["api-key"] = config.apiKey;
   } else {
-    const accessKeyId = normalizeString(config.accessKeyId) ?? normalizeString(config.apiKey);
+    const accessKeyId =
+      normalizeString(config.accessKeyId) ?? normalizeString(config.apiKey);
     if (accessKeyId) payload["access-key-id"] = accessKeyId;
     const secretAccessKey = normalizeString(config.secretAccessKey);
     if (secretAccessKey) payload["secret-access-key"] = secretAccessKey;
@@ -291,7 +316,10 @@ export const serializeOpenAIProvider = (provider: OpenAIProvider) => {
   if (headers) payload.headers = headers;
   const models = serializeModels(provider.models);
   if (models && models.length) payload.models = models;
-  if (typeof provider.priority === "number" && Number.isFinite(provider.priority)) {
+  if (
+    typeof provider.priority === "number" &&
+    Number.isFinite(provider.priority)
+  ) {
     payload.priority = provider.priority;
   }
   const testModel = normalizeString(provider.testModel);
@@ -321,7 +349,9 @@ export const serializeOpenAIProvider = (provider: OpenAIProvider) => {
   return payload;
 };
 
-export const normalizeOauthExcludedModels = (payload: unknown): Record<string, string[]> => {
+export const normalizeOauthExcludedModels = (
+  payload: unknown,
+): Record<string, string[]> => {
   if (!isRecord(payload)) return {};
   const source = payload["oauth-excluded-models"] ?? payload.items ?? payload;
   if (!isRecord(source)) return {};
@@ -382,7 +412,9 @@ export const normalizeOauthModelAlias = (
   return result;
 };
 
-export const normalizeApiKeyEntries = (raw: unknown): ProviderApiKeyEntry[] | undefined => {
+export const normalizeApiKeyEntries = (
+  raw: unknown,
+): ProviderApiKeyEntry[] | undefined => {
   if (!Array.isArray(raw)) return undefined;
   const entries = raw
     .map((entry) => {
@@ -390,8 +422,10 @@ export const normalizeApiKeyEntries = (raw: unknown): ProviderApiKeyEntry[] | un
       const apiKey = normalizeString(entry["api-key"] ?? entry.apiKey) ?? "";
       if (!apiKey) return null;
       const disabled = entry.disabled === true;
-      const proxyUrl = normalizeString(entry["proxy-url"] ?? entry.proxyUrl) ?? undefined;
-      const proxyId = normalizeString(entry["proxy-id"] ?? entry.proxyId) ?? undefined;
+      const proxyUrl =
+        normalizeString(entry["proxy-url"] ?? entry.proxyUrl) ?? undefined;
+      const proxyId =
+        normalizeString(entry["proxy-id"] ?? entry.proxyId) ?? undefined;
       const entryHeaders = normalizeHeaders(entry.headers);
       return {
         apiKey,

--- a/packages/api-client/src/endpoints/providers.ts
+++ b/packages/api-client/src/endpoints/providers.ts
@@ -24,13 +24,16 @@ import {
 } from "./helpers";
 
 const isOauthBackedProviderRow = (item: Record<string, unknown>): boolean => {
-  const accountType = normalizeString(item.account_type ?? item.accountType)?.toLowerCase();
+  const accountType = normalizeString(
+    item.account_type ?? item.accountType,
+  )?.toLowerCase();
   if (accountType === "oauth") return true;
 
   const runtimeOnly = item.runtime_only ?? item.runtimeOnly;
   return (
     runtimeOnly === true ||
-    (typeof runtimeOnly === "string" && runtimeOnly.trim().toLowerCase() === "true")
+    (typeof runtimeOnly === "string" &&
+      runtimeOnly.trim().toLowerCase() === "true")
   );
 };
 
@@ -39,6 +42,13 @@ const normalizeClineBaseUrl = (value: unknown): string | undefined =>
 
 const normalizeOllamaCloudBaseUrl = (value: unknown): string =>
   normalizeString(value)?.replace(/\/+$/g, "") || "https://ollama.com";
+
+const normalizeModelAccessExcludedModels = (
+  value: unknown,
+): string[] | undefined =>
+  normalizeExcludedModels(value)?.some((model) => model.trim() === "*")
+    ? ["*"]
+    : undefined;
 
 export const providersApi = {
   async getGeminiKeys(): Promise<ProviderSimpleConfig[]> {
@@ -52,8 +62,10 @@ export const providersApi = {
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
-        const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const baseUrl =
+          normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
         const excludedModels = normalizeExcludedModels(
@@ -80,7 +92,9 @@ export const providersApi = {
     ),
 
   deleteGeminiKey: (apiKey: string) =>
-    apiClient.delete("/gemini-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/gemini-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   async getCodexConfigs(): Promise<ProviderSimpleConfig[]> {
     const data = await apiClient.get("/codex-api-key");
@@ -93,9 +107,12 @@ export const providersApi = {
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
-        const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const baseUrl =
+          normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
         const excludedModels = normalizeExcludedModels(
@@ -123,7 +140,9 @@ export const providersApi = {
     ),
 
   deleteCodexConfig: (apiKey: string) =>
-    apiClient.delete("/codex-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/codex-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   async getOpenCodeGoConfigs(): Promise<ProviderSimpleConfig[]> {
     const data = await apiClient.get("/opencode-go-api-key");
@@ -136,17 +155,24 @@ export const providersApi = {
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
-        const excludedModels = normalizeExcludedModels(
+        const excludedModels = normalizeModelAccessExcludedModels(
           item["excluded-models"] ?? item.excludedModels,
         );
         const visionFallbackModel =
-          normalizeString(item["vision-fallback-model"] ?? item.visionFallbackModel) ?? undefined;
-        const workspaceId = normalizeString(item["workspace-id"] ?? item.workspaceId) ?? undefined;
-        const authCookie = normalizeString(item["auth-cookie"] ?? item.authCookie) ?? undefined;
+          normalizeString(
+            item["vision-fallback-model"] ?? item.visionFallbackModel,
+          ) ?? undefined;
+        const workspaceId =
+          normalizeString(item["workspace-id"] ?? item.workspaceId) ??
+          undefined;
+        const authCookie =
+          normalizeString(item["auth-cookie"] ?? item.authCookie) ?? undefined;
         return {
           apiKey,
           ...(name ? { name } : {}),
@@ -185,7 +211,9 @@ export const providersApi = {
     }),
 
   deleteOpenCodeGoConfig: (apiKey: string) =>
-    apiClient.delete("/opencode-go-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/opencode-go-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   async getClineConfigs(): Promise<ProviderSimpleConfig[]> {
     const data = await apiClient.get("/cline-api-key");
@@ -199,16 +227,21 @@ export const providersApi = {
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
         const baseUrl =
-          normalizeClineBaseUrl(item["base-url"] ?? item.baseUrl) ?? "https://api.cline.bot/api/v1";
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+          normalizeClineBaseUrl(item["base-url"] ?? item.baseUrl) ??
+          "https://api.cline.bot/api/v1";
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
-        const excludedModels = normalizeExcludedModels(
+        const excludedModels = normalizeModelAccessExcludedModels(
           item["excluded-models"] ?? item.excludedModels,
         );
         const visionFallbackModel =
-          normalizeString(item["vision-fallback-model"] ?? item.visionFallbackModel) ?? undefined;
+          normalizeString(
+            item["vision-fallback-model"] ?? item.visionFallbackModel,
+          ) ?? undefined;
         return {
           apiKey,
           ...(name ? { name } : {}),
@@ -246,7 +279,9 @@ export const providersApi = {
     }),
 
   deleteClineConfig: (apiKey: string) =>
-    apiClient.delete("/cline-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/cline-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   async getOllamaCloudConfigs(): Promise<ProviderSimpleConfig[]> {
     const data = await apiClient.get("/ollama-cloud-api-key");
@@ -259,16 +294,22 @@ export const providersApi = {
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
-        const baseUrl = normalizeOllamaCloudBaseUrl(item["base-url"] ?? item.baseUrl);
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const baseUrl = normalizeOllamaCloudBaseUrl(
+          item["base-url"] ?? item.baseUrl,
+        );
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
-        const excludedModels = normalizeExcludedModels(
+        const excludedModels = normalizeModelAccessExcludedModels(
           item["excluded-models"] ?? item.excludedModels,
         );
         const visionFallbackModel =
-          normalizeString(item["vision-fallback-model"] ?? item.visionFallbackModel) ?? undefined;
+          normalizeString(
+            item["vision-fallback-model"] ?? item.visionFallbackModel,
+          ) ?? undefined;
         return {
           apiKey,
           ...(name ? { name } : {}),
@@ -306,7 +347,9 @@ export const providersApi = {
     }),
 
   deleteOllamaCloudConfig: (apiKey: string) =>
-    apiClient.delete("/ollama-cloud-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/ollama-cloud-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   queryOpenCodeGoUsage: (payload: {
     "workspace-id"?: string;
@@ -316,7 +359,11 @@ export const providersApi = {
     name?: string;
     "api-key"?: string;
     index?: number;
-  }) => apiClient.post<OpenCodeGoUsageResponse>("/opencode-go-api-key/usage", payload),
+  }) =>
+    apiClient.post<OpenCodeGoUsageResponse>(
+      "/opencode-go-api-key/usage",
+      payload,
+    ),
 
   async getClaudeConfigs(): Promise<ProviderSimpleConfig[]> {
     const data = await apiClient.get("/claude-api-key");
@@ -329,16 +376,20 @@ export const providersApi = {
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
-        const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const baseUrl =
+          normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
         const excludedModels = normalizeExcludedModels(
           item["excluded-models"] ?? item.excludedModels,
         );
         const skipAnthropicProcessing =
-          item["skip-anthropic-processing"] === true || item.skipAnthropicProcessing === true;
+          item["skip-anthropic-processing"] === true ||
+          item.skipAnthropicProcessing === true;
         return {
           apiKey,
           ...(name ? { name } : {}),
@@ -362,7 +413,9 @@ export const providersApi = {
     ),
 
   deleteClaudeConfig: (apiKey: string) =>
-    apiClient.delete("/claude-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/claude-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   async getBedrockConfigs(): Promise<BedrockProviderConfig[]> {
     const data = await apiClient.get("/bedrock-api-key");
@@ -371,26 +424,36 @@ export const providersApi = {
       .map((item) => {
         if (!isRecord(item)) return null;
         if (isOauthBackedProviderRow(item)) return null;
-        const rawMode = normalizeString(item["auth-mode"] ?? item.authMode) ?? "sigv4";
+        const rawMode =
+          normalizeString(item["auth-mode"] ?? item.authMode) ?? "sigv4";
         const authMode: BedrockAuthMode =
           rawMode === "apikey" || rawMode === "api_key" || rawMode === "api-key"
             ? "api-key"
             : "sigv4";
         const apiKey = normalizeString(item["api-key"] ?? item.apiKey) ?? "";
-        const accessKeyId = normalizeString(item["access-key-id"] ?? item.accessKeyId) ?? undefined;
+        const accessKeyId =
+          normalizeString(item["access-key-id"] ?? item.accessKeyId) ??
+          undefined;
         const secretAccessKey =
-          normalizeString(item["secret-access-key"] ?? item.secretAccessKey) ?? undefined;
+          normalizeString(item["secret-access-key"] ?? item.secretAccessKey) ??
+          undefined;
         const sessionToken =
-          normalizeString(item["session-token"] ?? item.sessionToken) ?? undefined;
-        const credential = authMode === "api-key" ? apiKey : (accessKeyId ?? "");
+          normalizeString(item["session-token"] ?? item.sessionToken) ??
+          undefined;
+        const credential =
+          authMode === "api-key" ? apiKey : (accessKeyId ?? "");
         if (!credential) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
         const region = normalizeString(item.region) ?? undefined;
-        const forceGlobal = item["force-global"] === true || item.forceGlobal === true;
-        const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const forceGlobal =
+          item["force-global"] === true || item.forceGlobal === true;
+        const baseUrl =
+          normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
         const excludedModels = normalizeExcludedModels(
@@ -402,7 +465,9 @@ export const providersApi = {
           ...(name ? { name } : {}),
           ...(prefix ? { prefix } : {}),
           ...(authMode === "sigv4" && accessKeyId ? { accessKeyId } : {}),
-          ...(authMode === "sigv4" && secretAccessKey ? { secretAccessKey } : {}),
+          ...(authMode === "sigv4" && secretAccessKey
+            ? { secretAccessKey }
+            : {}),
           ...(authMode === "sigv4" && sessionToken ? { sessionToken } : {}),
           ...(region ? { region } : {}),
           ...(forceGlobal ? { forceGlobal } : {}),
@@ -437,9 +502,12 @@ export const providersApi = {
         if (!apiKey) return null;
         const name = normalizeString(item.name) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
-        const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
-        const proxyUrl = normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
-        const proxyId = normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
+        const baseUrl =
+          normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
+        const proxyUrl =
+          normalizeString(item["proxy-url"] ?? item.proxyUrl) ?? undefined;
+        const proxyId =
+          normalizeString(item["proxy-id"] ?? item.proxyId) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
         return {
@@ -463,7 +531,9 @@ export const providersApi = {
     ),
 
   deleteVertexConfig: (apiKey: string) =>
-    apiClient.delete("/vertex-api-key", undefined, { params: { "api-key": apiKey } }),
+    apiClient.delete("/vertex-api-key", undefined, {
+      params: { "api-key": apiKey },
+    }),
 
   async getOpenAIProviders(): Promise<OpenAIProvider[]> {
     const data = await apiClient.get("/openai-compatibility");
@@ -475,15 +545,21 @@ export const providersApi = {
         const name = normalizeString(item.name) ?? "";
         if (!name) return null;
         const disabled = item.disabled === true;
-        const baseUrl = normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
+        const baseUrl =
+          normalizeString(item["base-url"] ?? item.baseUrl) ?? undefined;
         const prefix = normalizeString(item.prefix) ?? undefined;
         const headers = normalizeHeaders(item.headers);
         const models = normalizeModels(item.models);
-        const apiKeyEntries = normalizeApiKeyEntries(item["api-key-entries"] ?? item.apiKeyEntries);
+        const apiKeyEntries = normalizeApiKeyEntries(
+          item["api-key-entries"] ?? item.apiKeyEntries,
+        );
         const priorityRaw = item.priority;
         const priority =
-          typeof priorityRaw === "number" && Number.isFinite(priorityRaw) ? priorityRaw : undefined;
-        const testModel = normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
+          typeof priorityRaw === "number" && Number.isFinite(priorityRaw)
+            ? priorityRaw
+            : undefined;
+        const testModel =
+          normalizeString(item["test-model"] ?? item.testModel) ?? undefined;
         return {
           name,
           ...(disabled ? { disabled } : {}),

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -46,12 +46,22 @@ const mocks = vi.hoisted(() => ({
   saveOpenCodeGoConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveClineConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveOllamaCloudConfigs: vi.fn(async (_configs: unknown[]) => ({})),
-  patchOpenCodeGoConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
+  patchOpenCodeGoConfig: vi.fn(
+    async (_index: number, _config: unknown) => ({}),
+  ),
   patchClineConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
-  patchOllamaCloudConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
-  patchOpenCodeGoExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
-  patchClineExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
-  patchOllamaCloudExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
+  patchOllamaCloudConfig: vi.fn(
+    async (_index: number, _config: unknown) => ({}),
+  ),
+  patchOpenCodeGoExcludedModels: vi.fn(
+    async (_index: number, _models: string[]) => ({}),
+  ),
+  patchClineExcludedModels: vi.fn(
+    async (_index: number, _models: string[]) => ({}),
+  ),
+  patchOllamaCloudExcludedModels: vi.fn(
+    async (_index: number, _models: string[]) => ({}),
+  ),
   getModelDefinitions: vi.fn(async (_channel?: string) => [
     { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
     { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
@@ -275,7 +285,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
     expect(await screen.findByText("deepseek-v4-flash")).toBeInTheDocument();
     expect(screen.queryByText("cline-pass/glm-5.2")).not.toBeInTheDocument();
-    expect(screen.queryByText("qwen3.5-plus")).not.toBeInTheDocument();
+    expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
   });
 
   test("opens OpenCode Go route and saves a key without requiring Base URL", async () => {
@@ -386,7 +396,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
         name: "Existing OpenCode Go",
         apiKey: "sk-existing-opencode-go",
         models: [{ name: "cline-pass/glm-5.2" }],
-        excludedModels: ["cline-pass/minimax-m3", "*"],
+        excludedModels: ["*"],
         visionFallbackModel: "qwen3.5-plus",
       },
     ]);
@@ -795,7 +805,7 @@ describe("ProvidersPage Cline tab", () => {
         apiKey: "sk-cline",
         baseUrl: "https://api.cline.bot/api/v1",
         models: [{ name: "cline-pass/glm-5.2" }],
-        excludedModels: ["cline-pass/minimax-m3", "*"],
+        excludedModels: ["*"],
         visionFallbackModel: "cline-pass/mimo-v2.5-pro",
       },
     ]);
@@ -830,7 +840,7 @@ describe("ProvidersPage Cline tab", () => {
         expect.objectContaining({
           name: "Existing Cline",
           apiKey: "",
-          excludedModels: ["cline-pass/minimax-m3", "*"],
+          excludedModels: ["*"],
         }),
       );
     });
@@ -838,6 +848,7 @@ describe("ProvidersPage Cline tab", () => {
     const saved = mocks.patchClineConfig.mock.calls[0][1];
     expect(saved).toHaveProperty("models", [
       { name: "cline-pass/glm-5.2" },
+      { name: "cline-pass/minimax-m3" },
       { name: "cline-pass/qwen3.7-max" },
       { name: "cline-pass/mimo-v2.5-pro" },
     ]);
@@ -926,7 +937,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
         apiKey: "sk-ollama",
         baseUrl: "https://ollama.com",
         models: [{ name: "gpt-oss:120b" }, { name: "gpt-oss:20b" }],
-        excludedModels: ["gpt-oss:20b"],
+        excludedModels: ["*"],
       },
     ]);
 
@@ -960,13 +971,16 @@ describe("ProvidersPage Ollama Cloud tab", () => {
         expect.objectContaining({
           name: "Existing Ollama Cloud",
           apiKey: "",
-          excludedModels: ["gpt-oss:20b"],
+          excludedModels: ["*"],
         }),
       );
     });
     expect(mocks.saveOllamaCloudConfigs).not.toHaveBeenCalled();
     const saved = mocks.patchOllamaCloudConfig.mock.calls[0][1];
-    expect(saved).toHaveProperty("models", [{ name: "gpt-oss:120b" }]);
+    expect(saved).toHaveProperty("models", [
+      { name: "gpt-oss:120b" },
+      { name: "gpt-oss:20b" },
+    ]);
   });
 
   test("does not show legacy Ollama Cloud excluded models on provider cards", async () => {
@@ -991,9 +1005,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
       </MemoryRouter>,
     );
 
-    await user.click(
-      await screen.findByRole("tab", { name: /Ollama Cloud/ }),
-    );
+    await user.click(await screen.findByRole("tab", { name: /Ollama Cloud/ }));
     expect(
       await screen.findByText("Ollama Hidden Excluded"),
     ).toBeInTheDocument();

--- a/pages/providers/__tests__/provider-import-export.test.ts
+++ b/pages/providers/__tests__/provider-import-export.test.ts
@@ -60,7 +60,7 @@ describe("provider import/export helpers", () => {
       items: [
         {
           "api-key": "go-key",
-          "excluded-models": ["*", "deepseek-v4-pro"],
+          "excluded-models": ["*"],
           "auth-cookie": "auth-token",
           name: "OpenCode Go",
           "vision-fallback-model": "qwen3.5-plus",
@@ -92,7 +92,7 @@ describe("provider import/export helpers", () => {
       {
         apiKey: "go-key",
         name: "OpenCode Go",
-        excludedModels: ["*", "deepseek-v4-pro"],
+        excludedModels: ["*"],
         visionFallbackModel: "qwen3.5-plus",
         workspaceId: "wrk_123",
         authCookie: "auth-token",
@@ -118,7 +118,7 @@ describe("provider import/export helpers", () => {
         {
           "api-key": "ollama-key",
           "base-url": "https://ollama.com",
-          "excluded-models": ["*", "gpt-oss:20b"],
+          "excluded-models": ["*"],
           name: "Ollama Cloud",
         },
       ],
@@ -145,7 +145,7 @@ describe("provider import/export helpers", () => {
         apiKey: "ollama-key",
         name: "Ollama Cloud",
         baseUrl: "https://ollama.com",
-        excludedModels: ["*", "gpt-oss:20b"],
+        excludedModels: ["*"],
       },
     ]);
   });

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -17,7 +17,6 @@ import type { ProviderKeyDraft } from "../providers-helpers";
 import {
   excludedModelsFromText,
   hasDisableAllModelsRule,
-  stripDisableAllModelsRule,
 } from "../providers-helpers";
 import { createEmptyModelEntry, type ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
@@ -240,23 +239,15 @@ export function ProviderKeyModal({
     [keyDraft.excludedModelsText],
   );
   const disableAllModels = hasDisableAllModelsRule(excludedModels);
-  const excludedModelIds = useMemo(
-    () =>
-      new Set(
-        stripDisableAllModelsRule(excludedModels).map((model) =>
-          model.toLowerCase(),
-        ),
-      ),
-    [excludedModels],
-  );
+  const excludedModelIds = useMemo(() => new Set<string>(), []);
   const enabledOpenCodeModelIds = useMemo(
     () =>
       new Set(
-        openCodeModels
-          .map((model) => model.id.trim().toLowerCase())
+        keyDraft.modelEntries
+          .map((model) => model.name.trim().toLowerCase())
           .filter(Boolean),
       ),
-    [openCodeModels],
+    [keyDraft.modelEntries],
   );
   const isOpenCodeModelAllowed = useCallback(
     (modelId: string) => {
@@ -264,10 +255,10 @@ export function ProviderKeyModal({
       return (
         normalized !== "" &&
         !disableAllModels &&
-        !excludedModelIds.has(normalized)
+        enabledOpenCodeModelIds.has(normalized)
       );
     },
-    [disableAllModels, excludedModelIds],
+    [disableAllModels, enabledOpenCodeModelIds],
   );
   const filteredOpenCodeModels = useMemo(() => {
     const query = openCodeModelQuery.trim().toLowerCase();
@@ -339,18 +330,27 @@ export function ProviderKeyModal({
       const normalized = modelId.trim().toLowerCase();
       if (!normalized) return;
       setKeyDraft((prev) => {
-        const currentExcluded = stripDisableAllModelsRule(
-          excludedModelsFromText(prev.excludedModelsText),
+        const exists = prev.modelEntries.some(
+          (entry) => entry.name.trim().toLowerCase() === normalized,
         );
-        const nextExcluded = currentExcluded.filter(
-          (model) => model.trim().toLowerCase() !== normalized,
-        );
+        const currentExcluded = excludedModelsFromText(prev.excludedModelsText);
+        const nextExcluded = allowed
+          ? currentExcluded.filter((model) => model.trim() !== "*")
+          : currentExcluded;
+        const nextEntries = allowed
+          ? exists
+            ? prev.modelEntries
+            : [
+                ...prev.modelEntries,
+                { ...createEmptyModelEntry(), name: modelId },
+              ]
+          : prev.modelEntries.filter(
+              (entry) => entry.name.trim().toLowerCase() !== normalized,
+            );
         return {
           ...prev,
-          excludedModelsText: (allowed
-            ? nextExcluded
-            : [...nextExcluded, modelId]
-          ).join("\n"),
+          excludedModelsText: nextExcluded.join("\n"),
+          modelEntries: nextEntries,
         };
       });
     },
@@ -360,21 +360,28 @@ export function ProviderKeyModal({
   const setAllFetchedOpenCodeModelsAllowed = useCallback(
     (allowed: boolean) => {
       const fetchedIds = new Set(
-        openCodeModels.map((model) => model.id.toLowerCase()),
+        openCodeModels.map((model) => model.id.trim().toLowerCase()),
       );
       setKeyDraft((prev) => {
-        const currentExcluded = stripDisableAllModelsRule(
-          excludedModelsFromText(prev.excludedModelsText),
+        const currentExcluded = excludedModelsFromText(prev.excludedModelsText);
+        const existingNames = new Set(
+          prev.modelEntries
+            .map((entry) => entry.name.trim().toLowerCase())
+            .filter(Boolean),
         );
-        const unknownExcluded = currentExcluded.filter(
-          (model) => !fetchedIds.has(model.toLowerCase()),
-        );
+        const addedEntries = openCodeModels
+          .filter((model) => !existingNames.has(model.id.trim().toLowerCase()))
+          .map((model) => ({ ...createEmptyModelEntry(), name: model.id }));
         return {
           ...prev,
-          excludedModelsText: (allowed
-            ? unknownExcluded
-            : [...unknownExcluded, ...openCodeModels.map((model) => model.id)]
-          ).join("\n"),
+          excludedModelsText: allowed
+            ? currentExcluded.filter((model) => model.trim() !== "*").join("\n")
+            : prev.excludedModelsText,
+          modelEntries: allowed
+            ? [...prev.modelEntries, ...addedEntries]
+            : prev.modelEntries.filter(
+                (entry) => !fetchedIds.has(entry.name.trim().toLowerCase()),
+              ),
         };
       });
     },

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -287,15 +287,6 @@ export function ProviderKeyModelsTab({
             />
           </div>
         </SectionCard>
-
-        <SectionCard>
-          <ExcludedModelsEditor
-            count={editKeyExcludedCount}
-            editKeyEnabledToggle={editKeyEnabledToggle}
-            keyDraft={keyDraft}
-            setKeyDraft={setKeyDraft}
-          />
-        </SectionCard>
       </div>
     );
   }

--- a/pages/providers/components/ProviderKeyStatusBadges.tsx
+++ b/pages/providers/components/ProviderKeyStatusBadges.tsx
@@ -21,6 +21,11 @@ export function ProviderKeyStatusBadges({
 }: ProviderKeyStatusBadgesProps) {
   const { t } = useTranslation();
   const isBedrock = editKeyType === "bedrock";
+  const showExcludedBadge =
+    showModelBadges &&
+    editKeyType !== "opencode-go" &&
+    editKeyType !== "cline" &&
+    editKeyType !== "ollama-cloud";
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -41,12 +46,18 @@ export function ProviderKeyStatusBadges({
         <>
           <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75">
             {t("providers.models_label")}:{" "}
-            <span className="font-semibold tabular-nums">{editKeyModelCount}</span>
+            <span className="font-semibold tabular-nums">
+              {editKeyModelCount}
+            </span>
           </span>
-          <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75">
-            {t("providers.excluded_models_label")}:{" "}
-            <span className="font-semibold tabular-nums">{editKeyExcludedCount}</span>
-          </span>
+          {showExcludedBadge ? (
+            <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75">
+              {t("providers.excluded_models_label")}:{" "}
+              <span className="font-semibold tabular-nums">
+                {editKeyExcludedCount}
+              </span>
+            </span>
+          ) : null}
         </>
       ) : null}
       {editKeyType === "vertex" ? (

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -189,19 +189,13 @@ export function useProviderKeyEditor({
         : isOllamaCloud
           ? "ollama-cloud"
           : null;
-    const excludedModels = rawExcludedModels?.filter((model) => {
-      const trimmed = model.trim();
-      return (
-        trimmed === "*" ||
-        !modelAccessProvider ||
-        isModelAllowedForProvider(modelAccessProvider, trimmed)
-      );
-    });
-    const excludedModelSet = new Set(
-      stripDisableAllModelsRule(excludedModels).map((model) =>
-        model.toLowerCase(),
-      ),
-    );
+    const disableAllModelAccess =
+      modelAccessProvider && hasDisableAllModelsRule(rawExcludedModels);
+    const excludedModels = modelAccessProvider
+      ? disableAllModelAccess
+        ? ["*"]
+        : undefined
+      : rawExcludedModels;
 
     const requireAlias = editKeyType === "vertex";
     const modelCommit = commitModelEntries(keyDraft.modelEntries, {
@@ -217,13 +211,13 @@ export function useProviderKeyEditor({
       modelAccessProvider && modelCommit.models
         ? modelCommit.models.filter((model) => {
             const name = model.name?.trim() ?? "";
-            return (
-              name &&
-              isModelAllowedForProvider(modelAccessProvider, name) &&
-              !excludedModelSet.has(name.toLowerCase())
-            );
+            return name && isModelAllowedForProvider(modelAccessProvider, name);
           })
         : modelCommit.models;
+    const modelAccessExcludedModels =
+      modelAccessProvider && (!models?.length || disableAllModelAccess)
+        ? ["*"]
+        : undefined;
     const result: ProviderSimpleConfig | BedrockProviderConfig = {
       apiKey:
         editKeyType === "bedrock" && keyDraft.authMode === "sigv4"
@@ -245,7 +239,9 @@ export function useProviderKeyEditor({
         : {}),
       ...(keyDraft.proxyId.trim() ? { proxyId: keyDraft.proxyId.trim() } : {}),
       ...(headers ? { headers } : {}),
-      ...(excludedModels?.length ? { excludedModels } : {}),
+      ...((modelAccessExcludedModels ?? excludedModels)?.length
+        ? { excludedModels: modelAccessExcludedModels ?? excludedModels }
+        : {}),
       ...(isOpenCodeGo && keyDraft.workspaceId.trim()
         ? { workspaceId: keyDraft.workspaceId.trim() }
         : {}),
@@ -516,7 +512,10 @@ export function useProviderKeyEditor({
           await providersApi.patchClineExcludedModels(index, nextExcluded);
         } else if (type === "ollama-cloud") {
           setOllamaCloudKeys(nextList);
-          await providersApi.patchOllamaCloudExcludedModels(index, nextExcluded);
+          await providersApi.patchOllamaCloudExcludedModels(
+            index,
+            nextExcluded,
+          );
         } else {
           setBedrockKeys(nextList as BedrockProviderConfig[]);
           await providersApi.saveBedrockConfigs(

--- a/pages/providers/provider-import-export.ts
+++ b/pages/providers/provider-import-export.ts
@@ -75,6 +75,9 @@ const sortExcludedModels = (value: unknown) =>
     ?.slice()
     .sort((left, right) => left.localeCompare(right));
 
+const normalizeModelAccessExcludedModels = (value: unknown) =>
+  normalizeExcludedModels(value)?.some((model) => model === "*") ? ["*"] : undefined;
+
 const normalizeModelList = (
   value: unknown,
 ): { models?: ProviderModel[]; duplicateCount: number } => {
@@ -167,7 +170,9 @@ const normalizeSimpleItem = (
   const { models, duplicateCount } = hasDynamicModelAccess
     ? { models: undefined, duplicateCount: 0 }
     : normalizeModelList(value.models);
-  const excludedModels = sortExcludedModels(value["excluded-models"] ?? value.excludedModels);
+  const excludedModels = hasDynamicModelAccess
+    ? normalizeModelAccessExcludedModels(value["excluded-models"] ?? value.excludedModels)
+    : sortExcludedModels(value["excluded-models"] ?? value.excludedModels);
   const baseUrl =
     normalizeString(value["base-url"] ?? value.baseUrl) ??
     (kind === "ollama-cloud" ? "https://ollama.com" : undefined);

--- a/pages/providers/provider-model-access.ts
+++ b/pages/providers/provider-model-access.ts
@@ -8,7 +8,6 @@ import {
 import {
   hasDisableAllModelsRule,
   normalizeDiscoveredModels,
-  stripDisableAllModelsRule,
 } from "./providers-helpers";
 
 export type ModelAccessProvider = "opencode-go" | "cline" | "ollama-cloud";
@@ -55,22 +54,11 @@ export function getEffectiveProviderModels(
 ): ProviderModel[] {
   if (hasDisableAllModelsRule(item.excludedModels)) return [];
 
-  const excluded = new Set(
-    stripDisableAllModelsRule(item.excludedModels).map((model) =>
-      model.toLowerCase(),
-    ),
-  );
   const configured = (item.models ?? []).filter((model) => {
     const name = model.name?.trim() ?? "";
     return name && isModelAllowedForProvider(provider, name);
   });
-  const base =
-    configured.length > 0
-      ? configured
-      : catalog.map((model) => ({ name: model.id }));
-
-  return base.filter((model) => {
-    const name = model.name?.trim().toLowerCase() ?? "";
-    return name && !excluded.has(name);
-  });
+  return configured.length > 0
+    ? configured
+    : catalog.map((model) => ({ name: model.id }));
 }


### PR DESCRIPTION
## Summary
- make OpenCode Go, ClinePass, and Ollama Cloud checkbox permissions save through model allowlists
- drop the manual excluded-models editor for those providers and keep only the internal disable-all marker
- update configured model availability and API client normalization to ignore legacy single-model exclusions

## Tests
- bun run test:ci -- pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx pages/system/__tests__/SystemPage.test.tsx packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts packages/api-client/src/endpoints/__tests__/providers-cline.test.ts packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
- bun run build