### PR TITLE
fix: persist model access selections

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -560,6 +560,7 @@ const loadProviderModelItems = async (): Promise<ModelAvailabilityItem[]> => {
 
       const isModelAccessProvider = MODEL_ACCESS_PROVIDER_KEYS.has(key);
       const needsStaticModels = configs.some((config) => {
+        if (isModelAccessProvider && config.disabled === true) return false;
         if (
           isModelAccessProvider &&
           hasDisableAllModelsRule(config.excludedModels)
@@ -572,9 +573,11 @@ const loadProviderModelItems = async (): Promise<ModelAvailabilityItem[]> => {
         : [];
 
       for (const config of configs) {
-        const disabled = hasDisableAllModelsRule(config.excludedModels);
+        const disabled = isModelAccessProvider
+          ? config.disabled === true
+          : hasDisableAllModelsRule(config.excludedModels);
         const excludedModels = isModelAccessProvider
-          ? disabled
+          ? hasDisableAllModelsRule(config.excludedModels)
             ? ["*"]
             : undefined
           : config.excludedModels;

--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -266,6 +266,7 @@ export interface OpenAIProvider {
 
 export interface ProviderSimpleConfig {
   apiKey: string;
+  disabled?: boolean;
   name?: string;
   prefix?: string;
   baseUrl?: string;

--- a/packages/api-client/src/endpoints/__tests__/providers-cline.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-cline.test.ts
@@ -34,6 +34,7 @@ describe("providersApi Cline", () => {
         {
           name: "Cline Custom",
           "api-key": "sk-custom",
+          disabled: true,
           "base-url": " https://api.example.com/v1/ ",
           "proxy-id": "hk",
           "proxy-url": "http://127.0.0.1:7890",
@@ -57,6 +58,7 @@ describe("providersApi Cline", () => {
       {
         name: "Cline Custom",
         apiKey: "sk-custom",
+        disabled: true,
         baseUrl: "https://api.example.com/v1",
         proxyId: "hk",
         proxyUrl: "http://127.0.0.1:7890",
@@ -142,9 +144,10 @@ describe("providersApi Cline", () => {
     await providersApi.patchClineConfig(0, {
       name: "Cline",
       apiKey: "sk-cline",
+      disabled: true,
       baseUrl: "https://api.cline.bot/api/v1",
-      models: [{ name: "cline-pass/glm-5.2", alias: "glm" }],
-      excludedModels: ["*"],
+      models: [],
+      excludedModels: [],
       visionFallbackModel: "cline-pass/mimo-v2.5-pro",
     });
 
@@ -153,9 +156,10 @@ describe("providersApi Cline", () => {
       value: {
         name: "Cline",
         "api-key": "sk-cline",
+        disabled: true,
         "base-url": "https://api.cline.bot/api/v1",
-        models: [{ name: "cline-pass/glm-5.2", alias: "glm" }],
-        "excluded-models": ["*"],
+        models: [],
+        "excluded-models": [],
         "vision-fallback-model": "cline-pass/mimo-v2.5-pro",
       },
     });

--- a/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-ollama-cloud.test.ts
@@ -30,6 +30,7 @@ describe("providersApi Ollama Cloud", () => {
         {
           name: "Ollama",
           "api-key": "sk-ollama",
+          disabled: true,
           models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
           "excluded-models": ["*"],
         },
@@ -41,6 +42,7 @@ describe("providersApi Ollama Cloud", () => {
       {
         name: "Ollama",
         apiKey: "sk-ollama",
+        disabled: true,
         baseUrl: "https://ollama.com",
         models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
         excludedModels: ["*"],
@@ -90,9 +92,10 @@ describe("providersApi Ollama Cloud", () => {
     await providersApi.patchOllamaCloudConfig(2, {
       name: "Ollama",
       apiKey: "sk-ollama",
+      disabled: true,
       baseUrl: "https://ollama.com",
-      models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-      excludedModels: ["*"],
+      models: [],
+      excludedModels: [],
       visionFallbackModel: "gpt-oss:120b",
     });
 
@@ -101,9 +104,10 @@ describe("providersApi Ollama Cloud", () => {
       value: {
         name: "Ollama",
         "api-key": "sk-ollama",
+        disabled: true,
         "base-url": "https://ollama.com",
-        models: [{ name: "gpt-oss:120b", alias: "oss-large" }],
-        "excluded-models": ["*"],
+        models: [],
+        "excluded-models": [],
         "vision-fallback-model": "gpt-oss:120b",
       },
     });

--- a/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/providers-opencode-go.test.ts
@@ -33,6 +33,7 @@ describe("providersApi OpenCode Go", () => {
         {
           name: "OpenCode Go",
           "api-key": "sk-go",
+          disabled: true,
           prefix: "go",
           "base-url": "https://should-not-surface.example",
           "proxy-id": "hk",
@@ -54,6 +55,7 @@ describe("providersApi OpenCode Go", () => {
       {
         name: "OpenCode Go",
         apiKey: "sk-go",
+        disabled: true,
         prefix: "go",
         proxyId: "hk",
         proxyUrl: "http://127.0.0.1:7890",
@@ -186,9 +188,10 @@ describe("providersApi OpenCode Go", () => {
     await providersApi.patchOpenCodeGoConfig(1, {
       name: "OpenCode Go",
       apiKey: "sk-go",
+      disabled: true,
       baseUrl: "https://should-not-save.example",
-      models: [{ name: "qwen3.5-plus", alias: "qwen-go" }],
-      excludedModels: ["minimax-m2.5", "*"],
+      models: [],
+      excludedModels: [],
       visionFallbackModel: "qwen3.5-plus",
       workspaceId: "wrk_123",
       authCookie: "auth-token",
@@ -199,8 +202,9 @@ describe("providersApi OpenCode Go", () => {
       value: {
         name: "OpenCode Go",
         "api-key": "sk-go",
-        models: [{ name: "qwen3.5-plus", alias: "qwen-go" }],
-        "excluded-models": ["*"],
+        disabled: true,
+        models: [],
+        "excluded-models": [],
         "vision-fallback-model": "qwen3.5-plus",
         "workspace-id": "wrk_123",
         "auth-cookie": "auth-token",

--- a/packages/api-client/src/endpoints/helpers.ts
+++ b/packages/api-client/src/endpoints/helpers.ts
@@ -121,8 +121,10 @@ type SerializeProviderKeyOptions = {
 };
 
 const modelAccessExcludedModels = (models?: string[]) =>
-  models?.some((model) => String(model ?? "").trim() === "*")
-    ? ["*"]
+  Array.isArray(models)
+    ? models.some((model) => String(model ?? "").trim() === "*")
+      ? ["*"]
+      : []
     : undefined;
 
 export const serializeProviderKey = (config: ProviderSimpleConfig) => {
@@ -159,6 +161,7 @@ export const serializeOpenCodeGoKey = (
 ) => {
   const payload: Record<string, unknown> = {};
   if (options.includeApiKey !== false) payload["api-key"] = config.apiKey;
+  if (config.disabled !== undefined) payload.disabled = config.disabled;
   const name = normalizeString(config.name);
   if (name) payload.name = name;
   const prefix = normalizeString(config.prefix);
@@ -170,9 +173,9 @@ export const serializeOpenCodeGoKey = (
   const headers = serializeHeaders(config.headers);
   if (headers) payload.headers = headers;
   const models = serializeModels(config.models);
-  if (models && models.length) payload.models = models;
+  if (models) payload.models = models;
   const excludedModels = modelAccessExcludedModels(config.excludedModels);
-  if (excludedModels) {
+  if (excludedModels !== undefined) {
     payload["excluded-models"] = excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);
@@ -191,6 +194,7 @@ export const serializeClineKey = (
 ) => {
   const payload: Record<string, unknown> = {};
   if (options.includeApiKey !== false) payload["api-key"] = config.apiKey;
+  if (config.disabled !== undefined) payload.disabled = config.disabled;
   const name = normalizeString(config.name);
   if (name) payload.name = name;
   const prefix = normalizeString(config.prefix);
@@ -204,9 +208,9 @@ export const serializeClineKey = (
   const headers = serializeHeaders(config.headers);
   if (headers) payload.headers = headers;
   const models = serializeModels(config.models);
-  if (models && models.length) payload.models = models;
+  if (models) payload.models = models;
   const excludedModels = modelAccessExcludedModels(config.excludedModels);
-  if (excludedModels) {
+  if (excludedModels !== undefined) {
     payload["excluded-models"] = excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);
@@ -221,6 +225,7 @@ export const serializeOllamaCloudKey = (
 ) => {
   const payload: Record<string, unknown> = {};
   if (options.includeApiKey !== false) payload["api-key"] = config.apiKey;
+  if (config.disabled !== undefined) payload.disabled = config.disabled;
   const name = normalizeString(config.name);
   if (name) payload.name = name;
   const prefix = normalizeString(config.prefix);
@@ -234,9 +239,9 @@ export const serializeOllamaCloudKey = (
   const headers = serializeHeaders(config.headers);
   if (headers) payload.headers = headers;
   const models = serializeModels(config.models);
-  if (models && models.length) payload.models = models;
+  if (models) payload.models = models;
   const excludedModels = modelAccessExcludedModels(config.excludedModels);
-  if (excludedModels) {
+  if (excludedModels !== undefined) {
     payload["excluded-models"] = excludedModels;
   }
   const visionFallbackModel = normalizeString(config.visionFallbackModel);

--- a/packages/api-client/src/endpoints/providers.ts
+++ b/packages/api-client/src/endpoints/providers.ts
@@ -175,6 +175,7 @@ export const providersApi = {
           normalizeString(item["auth-cookie"] ?? item.authCookie) ?? undefined;
         return {
           apiKey,
+          ...(item.disabled === true ? { disabled: true } : {}),
           ...(name ? { name } : {}),
           ...(prefix ? { prefix } : {}),
           ...(proxyUrl ? { proxyUrl } : {}),
@@ -244,6 +245,7 @@ export const providersApi = {
           ) ?? undefined;
         return {
           apiKey,
+          ...(item.disabled === true ? { disabled: true } : {}),
           ...(name ? { name } : {}),
           ...(prefix ? { prefix } : {}),
           baseUrl,
@@ -312,6 +314,7 @@ export const providersApi = {
           ) ?? undefined;
         return {
           apiKey,
+          ...(item.disabled === true ? { disabled: true } : {}),
           ...(name ? { name } : {}),
           ...(prefix ? { prefix } : {}),
           baseUrl,

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -29,6 +29,7 @@ export function ProviderKeyListCard({
   onEdit,
   onDelete,
   onToggleEnabled,
+  isItemEnabled,
   renderExtra,
   getDisplayModels,
 
@@ -51,6 +52,7 @@ export function ProviderKeyListCard({
   onEdit: (index: number) => void;
   onDelete: (index: number) => void;
   onToggleEnabled?: (index: number, enabled: boolean) => void;
+  isItemEnabled?: (item: ProviderSimpleConfig) => boolean;
   renderExtra?: (item: ProviderSimpleConfig, index: number) => ReactNode;
   getDisplayModels?: (
     item: ProviderSimpleConfig,
@@ -137,7 +139,9 @@ export function ProviderKeyListCard({
           {items.map((item, idx) => {
             const selectionKey = `${item.apiKey.trim().toLowerCase()}:${idx}`;
             const selected = selectedKeys?.has(selectionKey) ?? false;
-            const disabled = hasDisableAllModelsRule(item.excludedModels);
+            const disabled = !(isItemEnabled
+              ? isItemEnabled(item)
+              : !hasDisableAllModelsRule(item.excludedModels));
             const headerEntries = Object.entries(item.headers || {});
             const excludedModels = stripDisableAllModelsRule(
               item.excludedModels,

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -435,14 +435,54 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
     expect(mocks.saveOpenCodeGoConfigs).not.toHaveBeenCalled();
     const saved = mocks.patchOpenCodeGoConfig.mock.calls[0][1];
-    expect(saved).toHaveProperty("models", [
-      { name: "deepseek-v4-flash" },
-      { name: "qwen3.5-plus" },
-      { name: "kimi-k2.6" },
-      { name: "qwen3.7-max" },
-    ]);
+    expect(saved).toHaveProperty("models", []);
     expect(saved).toHaveProperty("visionFallbackModel", "qwen3.5-plus");
     expect(saved).toHaveProperty("excludedModels", ["*"]);
+    expect(saved).toHaveProperty("disabled", false);
+  });
+
+  test("selects one OpenCode Go model from wildcard without restoring stale allowlist", async () => {
+    const user = userEvent.setup();
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "Existing OpenCode Go",
+        apiKey: "sk-existing-opencode-go",
+        models: [
+          { name: "deepseek-v4-flash" },
+          { name: "qwen3.5-plus" },
+          { name: "kimi-k2.6" },
+        ],
+        excludedModels: ["*"],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Edit OpenCode Go configuration/i,
+    });
+    await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
+    await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
+    await user.click(
+      within(dialog).getByRole("checkbox", { name: "qwen3.5-plus" }),
+    );
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => expect(mocks.patchOpenCodeGoConfig).toHaveBeenCalled());
+    const saved = mocks.patchOpenCodeGoConfig.mock.calls[0][1];
+    expect(saved).toHaveProperty("models", [{ name: "qwen3.5-plus" }]);
+    expect(saved).toHaveProperty("excludedModels", []);
+    expect(saved).toHaveProperty("disabled", false);
   });
 
   test("shows OpenCode Go dynamic model list without manual model inputs", async () => {
@@ -483,6 +523,15 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
     expect(modelsTable.closest(".table-scrollbar")).toBeInTheDocument();
     expect(modelsTable.closest("[data-vt-scroll-content]")).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("checkbox", { name: /Enabled/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole("button", { name: /Select all/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole("button", { name: /Select none/i }),
+    ).not.toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
     const fallbackSelect = within(dialog).getByRole("combobox", {
@@ -846,16 +895,12 @@ describe("ProvidersPage Cline tab", () => {
     });
     expect(mocks.saveClineConfigs).not.toHaveBeenCalled();
     const saved = mocks.patchClineConfig.mock.calls[0][1];
-    expect(saved).toHaveProperty("models", [
-      { name: "cline-pass/glm-5.2" },
-      { name: "cline-pass/minimax-m3" },
-      { name: "cline-pass/qwen3.7-max" },
-      { name: "cline-pass/mimo-v2.5-pro" },
-    ]);
+    expect(saved).toHaveProperty("models", []);
     expect(saved).toHaveProperty(
       "visionFallbackModel",
       "cline-pass/mimo-v2.5-pro",
     );
+    expect(saved).toHaveProperty("disabled", false);
   });
 });
 
@@ -977,10 +1022,52 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     });
     expect(mocks.saveOllamaCloudConfigs).not.toHaveBeenCalled();
     const saved = mocks.patchOllamaCloudConfig.mock.calls[0][1];
-    expect(saved).toHaveProperty("models", [
-      { name: "gpt-oss:120b" },
-      { name: "gpt-oss:20b" },
+    expect(saved).toHaveProperty("models", []);
+    expect(saved).toHaveProperty("disabled", false);
+  });
+
+  test("uses the Ollama Cloud header checkbox to save no model access", async () => {
+    const user = userEvent.setup();
+    mocks.getModelDefinitions.mockImplementation(async () => [
+      { id: "gpt-oss:120b", object: "model", owned_by: "ollama" },
+      { id: "gpt-oss:20b", object: "model", owned_by: "ollama" },
     ]);
+    mocks.getOllamaCloudConfigs.mockImplementation(async () => [
+      {
+        name: "Existing Ollama Cloud",
+        apiKey: "sk-ollama",
+        baseUrl: "https://ollama.com",
+        models: [{ name: "gpt-oss:120b" }, { name: "gpt-oss:20b" }],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/ollama-cloud/0"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Edit Ollama Cloud configuration/i,
+    });
+    await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
+    await waitFor(() =>
+      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
+    );
+    await user.click(within(dialog).getByRole("checkbox", { name: /Enabled/i }));
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => expect(mocks.patchOllamaCloudConfig).toHaveBeenCalled());
+    const saved = mocks.patchOllamaCloudConfig.mock.calls[0][1];
+    expect(saved).toHaveProperty("models", []);
+    expect(saved).toHaveProperty("excludedModels", ["*"]);
+    expect(saved).toHaveProperty("disabled", false);
   });
 
   test("does not show legacy Ollama Cloud excluded models on provider cards", async () => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -127,6 +127,13 @@ export function ProviderKeyModal({
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
+  const modelAccessProvider: ModelAccessProvider | null = isCline
+    ? "cline"
+    : isOllamaCloud
+      ? "ollama-cloud"
+      : isOpenCodeGo
+        ? "opencode-go"
+        : null;
   const showModelsTab = true;
 
   const [modelConfigs, setModelConfigs] = useState<
@@ -211,15 +218,11 @@ export function ProviderKeyModal({
   }, [open, showModelsTab]);
 
   const fetchOpenCodeModels = useCallback(async () => {
-    if (!isModelAccessProvider) return;
+    if (!modelAccessProvider) return;
     setOpenCodeModelsLoading(true);
     setOpenCodeModelsError(null);
     try {
-      setOpenCodeModels(
-        await fetchModelAccessCatalog(
-          isCline ? "cline" : isOllamaCloud ? "ollama-cloud" : "opencode-go",
-        ),
-      );
+      setOpenCodeModels(await fetchModelAccessCatalog(modelAccessProvider));
     } catch (err: unknown) {
       setOpenCodeModelsError(
         err instanceof Error ? err.message : t("providers.fetch_models_failed"),
@@ -227,7 +230,7 @@ export function ProviderKeyModal({
     } finally {
       setOpenCodeModelsLoading(false);
     }
-  }, [isCline, isModelAccessProvider, isOllamaCloud, t]);
+  }, [modelAccessProvider, t]);
 
   useEffect(() => {
     if (!open || !isModelAccessProvider) return;
@@ -271,6 +274,10 @@ export function ProviderKeyModal({
   const allowedOpenCodeCount = openCodeModels.filter((model) =>
     isOpenCodeModelAllowed(model.id),
   ).length;
+  const allOpenCodeModelsAllowed =
+    openCodeModels.length > 0 && allowedOpenCodeCount === openCodeModels.length;
+  const someOpenCodeModelsAllowed =
+    allowedOpenCodeCount > 0 && allowedOpenCodeCount < openCodeModels.length;
   const openCodeVisionFallbackOptions = useMemo(() => {
     const optionMap = new Map<string, { value: string; label: string }>();
     for (const model of openCodeModels) {
@@ -328,25 +335,43 @@ export function ProviderKeyModal({
   const setOpenCodeModelAllowed = useCallback(
     (modelId: string, allowed: boolean) => {
       const normalized = modelId.trim().toLowerCase();
-      if (!normalized) return;
+      if (!normalized || !modelAccessProvider) return;
       setKeyDraft((prev) => {
         const exists = prev.modelEntries.some(
           (entry) => entry.name.trim().toLowerCase() === normalized,
         );
         const currentExcluded = excludedModelsFromText(prev.excludedModelsText);
-        const nextExcluded = allowed
-          ? currentExcluded.filter((model) => model.trim() !== "*")
-          : currentExcluded;
+        const baseEntries =
+          allowed && hasDisableAllModelsRule(currentExcluded)
+            ? prev.modelEntries.filter(
+                (entry) =>
+                  !isModelAllowedForProvider(modelAccessProvider, entry.name),
+              )
+            : prev.modelEntries;
+        const existingEntry = prev.modelEntries.find(
+          (entry) => entry.name.trim().toLowerCase() === normalized,
+        );
         const nextEntries = allowed
-          ? exists
-            ? prev.modelEntries
+          ? exists &&
+            baseEntries.some(
+              (entry) => entry.name.trim().toLowerCase() === normalized,
+            )
+            ? baseEntries
             : [
-                ...prev.modelEntries,
-                { ...createEmptyModelEntry(), name: modelId },
+                ...baseEntries,
+                existingEntry ?? { ...createEmptyModelEntry(), name: modelId },
               ]
-          : prev.modelEntries.filter(
+          : baseEntries.filter(
               (entry) => entry.name.trim().toLowerCase() !== normalized,
             );
+        const hasAllowedEntry = nextEntries.some((entry) =>
+          isModelAllowedForProvider(modelAccessProvider, entry.name),
+        );
+        const nextExcluded = allowed
+          ? currentExcluded.filter((model) => model.trim() !== "*")
+          : hasAllowedEntry
+            ? currentExcluded
+            : ["*"];
         return {
           ...prev,
           excludedModelsText: nextExcluded.join("\n"),
@@ -354,7 +379,7 @@ export function ProviderKeyModal({
         };
       });
     },
-    [setKeyDraft],
+    [modelAccessProvider, setKeyDraft],
   );
 
   const setAllFetchedOpenCodeModelsAllowed = useCallback(
@@ -372,16 +397,19 @@ export function ProviderKeyModal({
         const addedEntries = openCodeModels
           .filter((model) => !existingNames.has(model.id.trim().toLowerCase()))
           .map((model) => ({ ...createEmptyModelEntry(), name: model.id }));
+        const nextEntries = allowed
+          ? [...prev.modelEntries, ...addedEntries]
+          : prev.modelEntries.filter(
+              (entry) => !fetchedIds.has(entry.name.trim().toLowerCase()),
+            );
         return {
           ...prev,
           excludedModelsText: allowed
             ? currentExcluded.filter((model) => model.trim() !== "*").join("\n")
-            : prev.excludedModelsText,
-          modelEntries: allowed
-            ? [...prev.modelEntries, ...addedEntries]
-            : prev.modelEntries.filter(
-                (entry) => !fetchedIds.has(entry.name.trim().toLowerCase()),
-              ),
+            : nextEntries.length
+              ? prev.excludedModelsText
+              : "*",
+          modelEntries: nextEntries,
         };
       });
     },
@@ -389,13 +417,10 @@ export function ProviderKeyModal({
   );
 
   useEffect(() => {
-    if (!open || !isModelAccessProvider || openCodeModels.length === 0) return;
-    const provider: ModelAccessProvider = isCline
-      ? "cline"
-      : isOllamaCloud
-        ? "ollama-cloud"
-        : "opencode-go";
+    if (!open || !modelAccessProvider || openCodeModels.length === 0) return;
     setKeyDraft((prev) => {
+      if (hasDisableAllModelsRule(excludedModelsFromText(prev.excludedModelsText)))
+        return prev;
       const existingNames = new Set(
         prev.modelEntries
           .map((entry) => entry.name.trim().toLowerCase())
@@ -406,7 +431,7 @@ export function ProviderKeyModal({
         const name = model.id.trim();
         const key = name.toLowerCase();
         if (!key || existingNames.has(key)) continue;
-        if (!isModelAllowedForProvider(provider, name)) continue;
+        if (!isModelAllowedForProvider(modelAccessProvider, name)) continue;
         existingNames.add(key);
         nextEntries.push({ ...createEmptyModelEntry(), name });
       }
@@ -415,9 +440,7 @@ export function ProviderKeyModal({
         : { ...prev, modelEntries: nextEntries };
     });
   }, [
-    isCline,
-    isModelAccessProvider,
-    isOllamaCloud,
+    modelAccessProvider,
     open,
     openCodeModels,
     setKeyDraft,
@@ -534,6 +557,8 @@ export function ProviderKeyModal({
                 setOpenCodeModelQuery={setOpenCodeModelQuery}
                 filteredOpenCodeModels={filteredOpenCodeModels}
                 allowedOpenCodeCount={allowedOpenCodeCount}
+                allOpenCodeModelsAllowed={allOpenCodeModelsAllowed}
+                someOpenCodeModelsAllowed={someOpenCodeModelsAllowed}
                 excludeAll={disableAllModels}
                 excludedModelIds={excludedModelIds}
                 enabledOpenCodeModelIds={enabledOpenCodeModelIds}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -32,6 +32,8 @@ interface ProviderKeyModelsTabProps {
   setOpenCodeModelQuery: (value: string) => void;
   filteredOpenCodeModels: { id: string; owned_by?: string }[];
   allowedOpenCodeCount: number;
+  allOpenCodeModelsAllowed: boolean;
+  someOpenCodeModelsAllowed: boolean;
   excludeAll: boolean;
   excludedModelIds: Set<string>;
   enabledOpenCodeModelIds: Set<string>;
@@ -60,6 +62,8 @@ export function ProviderKeyModelsTab({
   setOpenCodeModelQuery,
   filteredOpenCodeModels,
   allowedOpenCodeCount,
+  allOpenCodeModelsAllowed,
+  someOpenCodeModelsAllowed,
   excludeAll,
   excludedModelIds,
   enabledOpenCodeModelIds,
@@ -173,6 +177,18 @@ export function ProviderKeyModelsTab({
         minWidthPx: 144,
         headerClassName: "text-center",
         cellClassName: "text-center",
+        headerRender: () => (
+          <div className="flex items-center justify-center gap-2">
+            <Checkbox
+              checked={allOpenCodeModelsAllowed}
+              indeterminate={someOpenCodeModelsAllowed}
+              onCheckedChange={setAllFetchedOpenCodeModelsAllowed}
+              disabled={openCodeModels.length === 0}
+              aria-label={t("providers.model_enabled")}
+            />
+            <span>{t("providers.model_enabled")}</span>
+          </div>
+        ),
         render: (model) => {
           const normalized = model.id.toLowerCase();
           const checked =
@@ -197,9 +213,13 @@ export function ProviderKeyModelsTab({
       enabledOpenCodeModelIds,
       excludeAll,
       excludedModelIds,
+      allOpenCodeModelsAllowed,
       modelEntryByName,
+      openCodeModels.length,
+      setAllFetchedOpenCodeModelsAllowed,
       setModelAlias,
       setOpenCodeModelAllowed,
+      someOpenCodeModelsAllowed,
       t,
     ],
   );
@@ -238,22 +258,6 @@ export function ProviderKeyModelsTab({
               placeholder={t("providers.models_search_placeholder")}
               className="max-w-xs"
             />
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setAllFetchedOpenCodeModelsAllowed(true)}
-              disabled={openCodeModels.length === 0}
-            >
-              {t("providers.models_select_all")}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setAllFetchedOpenCodeModelsAllowed(false)}
-              disabled={openCodeModels.length === 0}
-            >
-              {t("providers.models_select_none")}
-            </Button>
             <span className="text-xs tabular-nums text-slate-500 dark:text-white/55">
               {t("providers.models_allowed_count", {
                 allowed: allowedOpenCodeCount,

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1215,6 +1215,7 @@ export function ProvidersPage() {
               onToggleEnabled={(idx, enabled) =>
                 void toggleKeyEnabled("opencode-go", idx, enabled)
               }
+              isItemEnabled={(item) => item.disabled !== true}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getDisplayModels={(item) =>
@@ -1306,6 +1307,7 @@ export function ProvidersPage() {
               onToggleEnabled={(idx, enabled) =>
                 void toggleKeyEnabled("cline", idx, enabled)
               }
+              isItemEnabled={(item) => item.disabled !== true}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getDisplayModels={(item) =>
@@ -1342,6 +1344,7 @@ export function ProvidersPage() {
               onToggleEnabled={(idx, enabled) =>
                 void toggleKeyEnabled("ollama-cloud", idx, enabled)
               }
+              isItemEnabled={(item) => item.disabled !== true}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getDisplayModels={(item) =>

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -189,8 +189,9 @@ export function useProviderKeyEditor({
         : isOllamaCloud
           ? "ollama-cloud"
           : null;
-    const disableAllModelAccess =
-      modelAccessProvider && hasDisableAllModelsRule(rawExcludedModels);
+    const disableAllModelAccess = Boolean(
+      modelAccessProvider && hasDisableAllModelsRule(rawExcludedModels),
+    );
     const excludedModels = modelAccessProvider
       ? disableAllModelAccess
         ? ["*"]
@@ -214,15 +215,23 @@ export function useProviderKeyEditor({
             return name && isModelAllowedForProvider(modelAccessProvider, name);
           })
         : modelCommit.models;
+    const modelAccessModels = modelAccessProvider
+      ? disableAllModelAccess
+        ? []
+        : (models ?? [])
+      : models;
     const modelAccessExcludedModels =
-      modelAccessProvider && (!models?.length || disableAllModelAccess)
+      modelAccessProvider && (!modelAccessModels?.length || disableAllModelAccess)
         ? ["*"]
-        : undefined;
+        : modelAccessProvider
+          ? []
+          : undefined;
     const result: ProviderSimpleConfig | BedrockProviderConfig = {
       apiKey:
         editKeyType === "bedrock" && keyDraft.authMode === "sigv4"
           ? bedrockAccessKeyId
           : apiKey,
+      ...(modelAccessProvider ? { disabled: keyDraft.disabled } : {}),
       name,
       ...(keyDraft.prefix.trim() ? { prefix: keyDraft.prefix.trim() } : {}),
       ...(!isOpenCodeGo && keyDraft.baseUrl.trim()
@@ -239,9 +248,11 @@ export function useProviderKeyEditor({
         : {}),
       ...(keyDraft.proxyId.trim() ? { proxyId: keyDraft.proxyId.trim() } : {}),
       ...(headers ? { headers } : {}),
-      ...((modelAccessExcludedModels ?? excludedModels)?.length
-        ? { excludedModels: modelAccessExcludedModels ?? excludedModels }
-        : {}),
+      ...(modelAccessExcludedModels !== undefined
+        ? { excludedModels: modelAccessExcludedModels }
+        : excludedModels?.length
+          ? { excludedModels }
+          : {}),
       ...(isOpenCodeGo && keyDraft.workspaceId.trim()
         ? { workspaceId: keyDraft.workspaceId.trim() }
         : {}),
@@ -251,7 +262,11 @@ export function useProviderKeyEditor({
       ...(modelAccessProvider && keyDraft.visionFallbackModel.trim()
         ? { visionFallbackModel: keyDraft.visionFallbackModel.trim() }
         : {}),
-      ...(models?.length ? { models } : {}),
+      ...(modelAccessProvider
+        ? { models: modelAccessModels }
+        : modelAccessModels?.length
+          ? { models: modelAccessModels }
+          : {}),
       ...(editKeyType === "claude" && keyDraft.skipAnthropicProcessing
         ? { skipAnthropicProcessing: true }
         : {}),
@@ -482,13 +497,19 @@ export function useProviderKeyEditor({
       if (!current) return;
       const prev = list;
 
-      const nextExcluded = enabled
-        ? withoutDisableAllModelsRule(current.excludedModels)
-        : withDisableAllModelsRule(current.excludedModels);
+      const usesExplicitDisabled =
+        type === "opencode-go" || type === "cline" || type === "ollama-cloud";
+
+      const nextExcluded = usesExplicitDisabled
+        ? current.excludedModels
+        : enabled
+          ? withoutDisableAllModelsRule(current.excludedModels)
+          : withDisableAllModelsRule(current.excludedModels);
 
       const nextItem: ProviderSimpleConfig = {
         ...current,
-        excludedModels: nextExcluded,
+        ...(usesExplicitDisabled ? { disabled: !enabled } : {}),
+        ...(nextExcluded ? { excludedModels: nextExcluded } : {}),
       };
       const nextList = prev.map((item, itemIndex) =>
         itemIndex === index ? nextItem : item,
@@ -506,16 +527,22 @@ export function useProviderKeyEditor({
           await providersApi.saveCodexConfigs(nextList);
         } else if (type === "opencode-go") {
           setOpenCodeGoKeys(nextList);
-          await providersApi.patchOpenCodeGoExcludedModels(index, nextExcluded);
+          await providersApi.patchOpenCodeGoConfig(index, {
+            apiKey: "",
+            disabled: !enabled,
+          });
         } else if (type === "cline") {
           setClineKeys(nextList);
-          await providersApi.patchClineExcludedModels(index, nextExcluded);
+          await providersApi.patchClineConfig(index, {
+            apiKey: "",
+            disabled: !enabled,
+          });
         } else if (type === "ollama-cloud") {
           setOllamaCloudKeys(nextList);
-          await providersApi.patchOllamaCloudExcludedModels(
-            index,
-            nextExcluded,
-          );
+          await providersApi.patchOllamaCloudConfig(index, {
+            apiKey: "",
+            disabled: !enabled,
+          });
         } else {
           setBedrockKeys(nextList as BedrockProviderConfig[]);
           await providersApi.saveBedrockConfigs(
@@ -584,19 +611,34 @@ export function useProviderKeyEditor({
                   : "Bedrock";
 
   const editKeyEnabled = useMemo(() => {
+    if (
+      editKeyType === "opencode-go" ||
+      editKeyType === "cline" ||
+      editKeyType === "ollama-cloud"
+    ) {
+      return !keyDraft.disabled;
+    }
     const list = excludedModelsFromText(keyDraft.excludedModelsText);
     return !hasDisableAllModelsRule(list);
-  }, [keyDraft.excludedModelsText]);
+  }, [editKeyType, keyDraft.disabled, keyDraft.excludedModelsText]);
 
   const editKeyEnabledToggle = useCallback(
     (enabled: boolean) => {
+      if (
+        editKeyType === "opencode-go" ||
+        editKeyType === "cline" ||
+        editKeyType === "ollama-cloud"
+      ) {
+        setKeyDraft((prev) => ({ ...prev, disabled: !enabled }));
+        return;
+      }
       const current = excludedModelsFromText(keyDraft.excludedModelsText);
       const next = enabled
         ? withoutDisableAllModelsRule(current)
         : withDisableAllModelsRule(current);
       setKeyDraft((prev) => ({ ...prev, excludedModelsText: next.join("\n") }));
     },
-    [keyDraft.excludedModelsText],
+    [editKeyType, keyDraft.excludedModelsText],
   );
 
   const editKeyExcludedCount = useMemo(() => {

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -112,6 +112,7 @@ export const normalizeDiscoveredModels = (
 export type ProviderKeyDraft = {
   name: string;
   apiKey: string;
+  disabled: boolean;
   authMode: BedrockAuthMode;
   accessKeyId: string;
   secretAccessKey: string;
@@ -196,6 +197,7 @@ export const buildProviderKeyDraft = (
   return {
     name: input?.name ?? "",
     apiKey: input?.apiKey ?? "",
+    disabled: input?.disabled === true,
     authMode: bedrockInput?.authMode ?? "api-key",
     accessKeyId:
       bedrockInput?.accessKeyId ?? (bedrockInput ? input?.apiKey : "") ?? "",


### PR DESCRIPTION
## Summary
- persist model access provider selections as explicit models/excluded-models changes
- use disabled for channel enablement instead of excluded-models wildcard
- replace select-all buttons with the models-table header checkbox

## Tests
- rtk bun run test:ci
- rtk bun run build