### PR TITLE
fix: hide denied provider models

### DIFF
--- a/pages/providers/__tests__/provider-model-access.test.ts
+++ b/pages/providers/__tests__/provider-model-access.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { getEffectiveProviderModels } from "@pages/providers/provider-model-access";
+
+describe("getEffectiveProviderModels", () => {
+  const catalog = [
+    { id: "qwen3.7-max", owned_by: "opencode" },
+    { id: "kimi-k2.7-code", owned_by: "opencode" },
+  ];
+
+  test("does not fallback to catalog for disabled or no-access configs", () => {
+    expect(
+      getEffectiveProviderModels(
+        "opencode-go",
+        { apiKey: "sk", disabled: true },
+        catalog,
+      ),
+    ).toEqual([]);
+    expect(
+      getEffectiveProviderModels(
+        "opencode-go",
+        { apiKey: "sk", excludedModels: ["*"] },
+        catalog,
+      ),
+    ).toEqual([]);
+  });
+
+  test("uses catalog only when no explicit allowlist or deny-all marker exists", () => {
+    expect(
+      getEffectiveProviderModels("opencode-go", { apiKey: "sk" }, catalog),
+    ).toEqual([{ name: "qwen3.7-max" }, { name: "kimi-k2.7-code" }]);
+  });
+});

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -178,7 +178,8 @@ export function ProviderKeyModelsTab({
         headerClassName: "text-center",
         cellClassName: "text-center",
         headerRender: () => (
-          <div className="flex items-center justify-center gap-2">
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+            <span aria-hidden="true" />
             <Checkbox
               checked={allOpenCodeModelsAllowed}
               indeterminate={someOpenCodeModelsAllowed}
@@ -186,7 +187,9 @@ export function ProviderKeyModelsTab({
               disabled={openCodeModels.length === 0}
               aria-label={t("providers.model_enabled")}
             />
-            <span>{t("providers.model_enabled")}</span>
+            <span className="justify-self-start">
+              {t("providers.model_enabled")}
+            </span>
           </div>
         ),
         render: (model) => {

--- a/pages/providers/provider-model-access.ts
+++ b/pages/providers/provider-model-access.ts
@@ -52,6 +52,7 @@ export function getEffectiveProviderModels(
   item: ProviderSimpleConfig,
   catalog: DiscoveredProviderModel[],
 ): ProviderModel[] {
+  if (item.disabled === true) return [];
   if (hasDisableAllModelsRule(item.excludedModels)) return [];
 
   const configured = (item.models ?? []).filter((model) => {


### PR DESCRIPTION
## Summary
- stop model-access provider cards from falling back to catalog models when disabled
- align the model table header checkbox with row checkboxes
- add provider model access display regression coverage

## Tests
- rtk bun run test:ci
- rtk bun run build
