### PR TITLE
fix: preserve provider model permissions

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -485,6 +485,83 @@ describe("ProvidersPage OpenCode Go tab", () => {
     expect(saved).toHaveProperty("disabled", false);
   });
 
+  test("keeps a partial OpenCode Go allowlist when reopening the editor", async () => {
+    const user = userEvent.setup();
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "Existing OpenCode Go",
+        apiKey: "sk-existing-opencode-go",
+        models: [{ name: "qwen3.5-plus" }],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Edit OpenCode Go configuration/i,
+    });
+    await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => expect(mocks.patchOpenCodeGoConfig).toHaveBeenCalled());
+    const saved = mocks.patchOpenCodeGoConfig.mock.calls[0][1];
+    expect(saved).toHaveProperty("models", [{ name: "qwen3.5-plus" }]);
+    expect(saved).not.toHaveProperty("excludedModels", ["*"]);
+  });
+
+  test("header uncheck saves no OpenCode Go access even with stale hidden models", async () => {
+    const user = userEvent.setup();
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "Existing OpenCode Go",
+        apiKey: "sk-existing-opencode-go",
+        models: [
+          { name: "deepseek-v4-flash" },
+          { name: "qwen3.5-plus" },
+          { name: "kimi-k2.6" },
+          { name: "qwen3.7-max" },
+          { name: "stale-model-not-in-catalog" },
+        ],
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Edit OpenCode Go configuration/i,
+    });
+    await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
+    await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
+    await user.click(within(dialog).getByRole("checkbox", { name: /Enabled/i }));
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => expect(mocks.patchOpenCodeGoConfig).toHaveBeenCalled());
+    const saved = mocks.patchOpenCodeGoConfig.mock.calls[0][1];
+    expect(saved).toHaveProperty("models", []);
+    expect(saved).toHaveProperty("excludedModels", ["*"]);
+    expect(saved).toHaveProperty("disabled", false);
+  });
+
   test("shows OpenCode Go dynamic model list without manual model inputs", async () => {
     const user = userEvent.setup();
 

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -252,6 +252,15 @@ export function ProviderKeyModal({
       ),
     [keyDraft.modelEntries],
   );
+  const openCodeModelIds = useMemo(
+    () =>
+      new Set(
+        openCodeModels
+          .map((model) => model.id.trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    [openCodeModels],
+  );
   const isOpenCodeModelAllowed = useCallback(
     (modelId: string) => {
       const normalized = modelId.trim().toLowerCase();
@@ -364,9 +373,14 @@ export function ProviderKeyModal({
           : baseEntries.filter(
               (entry) => entry.name.trim().toLowerCase() !== normalized,
             );
-        const hasAllowedEntry = nextEntries.some((entry) =>
-          isModelAllowedForProvider(modelAccessProvider, entry.name),
-        );
+        const hasAllowedEntry = nextEntries.some((entry) => {
+          const key = entry.name.trim().toLowerCase();
+          return (
+            key !== "" &&
+            openCodeModelIds.has(key) &&
+            isModelAllowedForProvider(modelAccessProvider, entry.name)
+          );
+        });
         const nextExcluded = allowed
           ? currentExcluded.filter((model) => model.trim() !== "*")
           : hasAllowedEntry
@@ -379,41 +393,50 @@ export function ProviderKeyModal({
         };
       });
     },
-    [modelAccessProvider, setKeyDraft],
+    [modelAccessProvider, openCodeModelIds, setKeyDraft],
   );
 
   const setAllFetchedOpenCodeModelsAllowed = useCallback(
     (allowed: boolean) => {
-      const fetchedIds = new Set(
-        openCodeModels.map((model) => model.id.trim().toLowerCase()),
-      );
+      if (!modelAccessProvider) return;
       setKeyDraft((prev) => {
         const currentExcluded = excludedModelsFromText(prev.excludedModelsText);
-        const existingNames = new Set(
+        const existingByName = new Map(
           prev.modelEntries
-            .map((entry) => entry.name.trim().toLowerCase())
-            .filter(Boolean),
+            .map((entry) => [entry.name.trim().toLowerCase(), entry] as const)
+            .filter(([name]) => name !== ""),
         );
-        const addedEntries = openCodeModels
-          .filter((model) => !existingNames.has(model.id.trim().toLowerCase()))
-          .map((model) => ({ ...createEmptyModelEntry(), name: model.id }));
+        const preservedEntries = prev.modelEntries.filter(
+          (entry) => !isModelAllowedForProvider(modelAccessProvider, entry.name),
+        );
         const nextEntries = allowed
-          ? [...prev.modelEntries, ...addedEntries]
-          : prev.modelEntries.filter(
-              (entry) => !fetchedIds.has(entry.name.trim().toLowerCase()),
-            );
+          ? [
+              ...preservedEntries,
+              ...openCodeModels
+                .filter((model) =>
+                  isModelAllowedForProvider(modelAccessProvider, model.id),
+                )
+                .map((model) => {
+                  const key = model.id.trim().toLowerCase();
+                  return (
+                    existingByName.get(key) ?? {
+                      ...createEmptyModelEntry(),
+                      name: model.id,
+                    }
+                  );
+                }),
+            ]
+          : preservedEntries;
         return {
           ...prev,
           excludedModelsText: allowed
             ? currentExcluded.filter((model) => model.trim() !== "*").join("\n")
-            : nextEntries.length
-              ? prev.excludedModelsText
-              : "*",
+            : "*",
           modelEntries: nextEntries,
         };
       });
     },
-    [openCodeModels, setKeyDraft],
+    [modelAccessProvider, openCodeModels, setKeyDraft],
   );
 
   useEffect(() => {
@@ -421,6 +444,13 @@ export function ProviderKeyModal({
     setKeyDraft((prev) => {
       if (hasDisableAllModelsRule(excludedModelsFromText(prev.excludedModelsText)))
         return prev;
+      if (
+        prev.modelEntries.some((entry) =>
+          isModelAllowedForProvider(modelAccessProvider, entry.name),
+        )
+      ) {
+        return prev;
+      }
       const existingNames = new Set(
         prev.modelEntries
           .map((entry) => entry.name.trim().toLowerCase())

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -178,8 +178,7 @@ export function ProviderKeyModelsTab({
         headerClassName: "text-center",
         cellClassName: "text-center",
         headerRender: () => (
-          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
-            <span aria-hidden="true" />
+          <div className="flex justify-center">
             <Checkbox
               checked={allOpenCodeModelsAllowed}
               indeterminate={someOpenCodeModelsAllowed}
@@ -187,9 +186,6 @@ export function ProviderKeyModelsTab({
               disabled={openCodeModels.length === 0}
               aria-label={t("providers.model_enabled")}
             />
-            <span className="justify-self-start">
-              {t("providers.model_enabled")}
-            </span>
           </div>
         ),
         render: (model) => {


### PR DESCRIPTION
## Summary
- keep existing partial OpenCode Go/Cline/Ollama Cloud model allowlists when reopening the editor
- make header checkbox clear all provider models, including stale hidden entries
- center the model permission header checkbox with row checkboxes

## Tests
- bun run test -- ProvidersPage.opencode-go.test.tsx provider-model-access.test.ts
- bun run test:ci
- bun run build
- bun run lint (existing warnings only)
- one-off Playwright geometry check: headerCenter == rowCenter