### PR TITLE
fix(update): show runtime dependency startup progress

### DIFF
--- a/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
+++ b/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
@@ -82,6 +82,8 @@ const UPDATE_STAGE_LABEL_KEYS: Record<string, string> = {
 const UPDATE_PROGRESS_MESSAGE_KEYS: Record<string, string> = {
   "preparing update": "auto_update.progress_message_preparing_update",
   "pulling target image": "auto_update.progress_message_pulling_target_image",
+  "starting runtime dependencies":
+    "auto_update.progress_message_starting_runtime_dependencies",
   "starting postgresql/redis before data migration check":
     "auto_update.progress_message_starting_runtime",
   "starting postgresql/redis before sqlite migration":

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4022,6 +4022,7 @@
     "progress_default_message": "Waiting for updater progress…",
     "progress_message_preparing_update": "Preparing the update workflow.",
     "progress_message_pulling_target_image": "Pulling the target image.",
+    "progress_message_starting_runtime_dependencies": "Starting PostgreSQL and Redis.",
     "progress_message_starting_runtime": "Starting PostgreSQL and Redis before the data migration check.",
     "progress_message_checking_runtime_data": "Checking runtime data migration before restarting the service.",
     "progress_message_checking_sqlite": "Checking whether legacy SQLite data needs migration before restarting the service.",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2269,6 +2269,7 @@
     "progress_default_message": "Waiting for updater progress…",
     "progress_message_preparing_update": "Preparing the update workflow.",
     "progress_message_pulling_target_image": "Pulling the target image.",
+    "progress_message_starting_runtime_dependencies": "Starting PostgreSQL and Redis.",
     "progress_message_starting_runtime": "Starting PostgreSQL and Redis before the data migration check.",
     "progress_message_checking_runtime_data": "Checking runtime data migration before restarting the service.",
     "progress_message_checking_sqlite": "Checking whether legacy SQLite data needs migration before restarting the service.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3451,6 +3451,7 @@
     "progress_default_message": "正在等待 updater 返回进度…",
     "progress_message_preparing_update": "正在准备更新流程。",
     "progress_message_pulling_target_image": "正在拉取目标镜像。",
+    "progress_message_starting_runtime_dependencies": "正在启动 PostgreSQL 和 Redis。",
     "progress_message_starting_runtime": "正在启动 PostgreSQL 和 Redis，准备执行数据迁移检查。",
     "progress_message_checking_runtime_data": "正在检查运行时数据迁移，完成后将重启服务。",
     "progress_message_checking_sqlite": "正在检查是否需要在重启服务前迁移历史 SQLite 数据。",


### PR DESCRIPTION
## Summary
- localize the updater message for starting PostgreSQL and Redis
- avoid showing this normal runtime startup as a data migration step

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- UpdateDetailsModal
- rtk bun run build