### PR TITLE
fix: pin provider tab count badges

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -172,8 +172,8 @@ describe("ProvidersPage openai tab", () => {
     const openCodeGoTab = screen.getByRole("tab", { name: /OpenCode Go/ });
     const geminiTab = screen.getByRole("tab", { name: /Gemini/ });
 
-    expect(within(codexTab).getByText("2")).toBeInTheDocument();
-    expect(within(openCodeGoTab).getByText("1")).toBeInTheDocument();
+    expect(within(codexTab).getByText("2")).toHaveClass("absolute");
+    expect(within(openCodeGoTab).getByText("1")).toHaveClass("absolute");
     expect(within(geminiTab).queryByText("0")).not.toBeInTheDocument();
   });
 

--- a/pages/providers/components/ProviderTabsWithCounts.tsx
+++ b/pages/providers/components/ProviderTabsWithCounts.tsx
@@ -84,8 +84,8 @@ export function ProviderTabsWithCounts({ tabs, value }: ProviderTabsWithCountsPr
                 <span
                   className={
                     value === tab.id
-                      ? "ml-0.5 rounded-full bg-white/90 px-1.5 text-[10px] font-medium text-slate-700 dark:bg-white/15 dark:text-white"
-                      : "ml-0.5 rounded-full bg-slate-200/70 px-1.5 text-[10px] font-medium text-slate-500 dark:bg-white/10 dark:text-white/60"
+                      ? "absolute right-1 top-0.5 min-w-4 rounded-full bg-white/90 px-1 text-center text-[10px] font-medium leading-4 text-slate-700 dark:bg-white/15 dark:text-white"
+                      : "absolute right-1 top-0.5 min-w-4 rounded-full bg-slate-200/70 px-1 text-center text-[10px] font-medium leading-4 text-slate-500 dark:bg-white/10 dark:text-white/60"
                   }
                 >
                   {tab.count}


### PR DESCRIPTION
## Summary
- render AI provider tab counts as absolute top-right badges
- keep count badges out of tab layout flow to prevent tab position jumps
- update provider page test to assert count badges stay absolute

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.openai.test.tsx
- rtk bun run build
- mocked /manage/#/ai-providers visual check: hiding badges kept tab widths stable