### PR TITLE
fix: center provider tab count badges

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -172,8 +172,11 @@ describe("ProvidersPage openai tab", () => {
     const openCodeGoTab = screen.getByRole("tab", { name: /OpenCode Go/ });
     const geminiTab = screen.getByRole("tab", { name: /Gemini/ });
 
-    expect(within(codexTab).getByText("2")).toHaveClass("absolute");
-    expect(within(openCodeGoTab).getByText("1")).toHaveClass("absolute");
+    const codexBadge = within(codexTab).getByText("2");
+    const openCodeGoBadge = within(openCodeGoTab).getByText("1");
+
+    expect(codexBadge).toHaveClass("inline-flex", "items-center", "justify-center");
+    expect(openCodeGoBadge).toHaveClass("inline-flex", "items-center", "justify-center");
     expect(within(geminiTab).queryByText("0")).not.toBeInTheDocument();
   });
 

--- a/pages/providers/components/ProviderTabsWithCounts.tsx
+++ b/pages/providers/components/ProviderTabsWithCounts.tsx
@@ -79,18 +79,20 @@ export function ProviderTabsWithCounts({ tabs, value }: ProviderTabsWithCountsPr
           return (
             <TabsTrigger key={tab.id} value={tab.id}>
               {icon}
-              {tab.label}
-              {tab.count !== null && tab.count > 0 ? (
-                <span
-                  className={
-                    value === tab.id
-                      ? "absolute right-1 top-0.5 min-w-4 rounded-full bg-white/90 px-1 text-center text-[10px] font-medium leading-4 text-slate-700 dark:bg-white/15 dark:text-white"
-                      : "absolute right-1 top-0.5 min-w-4 rounded-full bg-slate-200/70 px-1 text-center text-[10px] font-medium leading-4 text-slate-500 dark:bg-white/10 dark:text-white/60"
-                  }
-                >
-                  {tab.count}
-                </span>
-              ) : null}
+              <span className="relative inline-flex items-center pr-4">
+                {tab.label}
+                {tab.count !== null && tab.count > 0 ? (
+                  <span
+                    className={
+                      value === tab.id
+                        ? "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[#18181B] px-1 text-[10px] font-semibold leading-none tabular-nums text-white shadow-sm ring-1 ring-black/10 dark:bg-white dark:text-[#18181B] dark:ring-white/15"
+                        : "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-100 px-1 text-[10px] font-semibold leading-none tabular-nums text-blue-700 shadow-sm ring-1 ring-blue-200/80 dark:bg-blue-500/25 dark:text-blue-100 dark:ring-blue-300/25"
+                    }
+                  >
+                    {tab.count}
+                  </span>
+                ) : null}
+              </span>
             </TabsTrigger>
           );
         })}


### PR DESCRIPTION
## Summary
- reserve a label slot for AI provider tab count badges
- style count badges with clearer selected and inactive states
- center badge numbers with flex alignment and tabular numerals

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.openai.test.tsx
- rtk bun run build
- mocked /manage/#/ai-providers visual check: count badges render centered and tab widths stay stable