### PR TITLE
fix(providers): refresh OpenCode Go usage locally

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -39,29 +39,17 @@ const mocks = vi.hoisted(() => ({
   getOpenAIProviders: vi.fn(async (): Promise<unknown[]> => []),
   queryOpenCodeGoUsage: vi.fn(async () => ({
     workspace_id: "workspace-1",
-    usage: [
-      { type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" },
-    ],
+    usage: [{ type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" }],
   })),
   saveOpenCodeGoConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveClineConfigs: vi.fn(async (_configs: unknown[]) => ({})),
   saveOllamaCloudConfigs: vi.fn(async (_configs: unknown[]) => ({})),
-  patchOpenCodeGoConfig: vi.fn(
-    async (_index: number, _config: unknown) => ({}),
-  ),
+  patchOpenCodeGoConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
   patchClineConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
-  patchOllamaCloudConfig: vi.fn(
-    async (_index: number, _config: unknown) => ({}),
-  ),
-  patchOpenCodeGoExcludedModels: vi.fn(
-    async (_index: number, _models: string[]) => ({}),
-  ),
-  patchClineExcludedModels: vi.fn(
-    async (_index: number, _models: string[]) => ({}),
-  ),
-  patchOllamaCloudExcludedModels: vi.fn(
-    async (_index: number, _models: string[]) => ({}),
-  ),
+  patchOllamaCloudConfig: vi.fn(async (_index: number, _config: unknown) => ({})),
+  patchOpenCodeGoExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
+  patchClineExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
+  patchOllamaCloudExcludedModels: vi.fn(async (_index: number, _models: string[]) => ({})),
   getModelDefinitions: vi.fn(async (_channel?: string) => [
     { id: "deepseek-v4-flash", object: "model", owned_by: "opencode" },
     { id: "qwen3.5-plus", object: "model", owned_by: "opencode" },
@@ -83,9 +71,11 @@ const mocks = vi.hoisted(() => ({
       },
     }),
   ),
-  getEntityStats: vi.fn(async (): Promise<MockEntityStatsResponse> => ({
-    source: [],
-  })),
+  getEntityStats: vi.fn(
+    async (): Promise<MockEntityStatsResponse> => ({
+      source: [],
+    }),
+  ),
   apiKeyEntriesList: vi.fn(async (): Promise<unknown[]> => []),
   channelGroupsList: vi.fn(async (): Promise<unknown[]> => []),
   proxiesList: vi.fn(async (): Promise<any[]> => []),
@@ -164,9 +154,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
     mocks.getOpenAIProviders.mockImplementation(async () => []);
     mocks.queryOpenCodeGoUsage.mockImplementation(async () => ({
       workspace_id: "workspace-1",
-      usage: [
-        { type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" },
-      ],
+      usage: [{ type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" }],
     }));
     mocks.saveOpenCodeGoConfigs.mockImplementation(async () => ({}));
     mocks.saveClineConfigs.mockImplementation(async () => ({}));
@@ -204,8 +192,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
   test("shows usage loading instead of not queried before the first OpenCode Go usage result", async () => {
     localStorage.clear();
-    let resolveUsage:
-      ((value: MockOpenCodeGoUsageResponse) => void) | undefined;
+    let resolveUsage: ((value: MockOpenCodeGoUsageResponse) => void) | undefined;
     mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
       {
         name: "OpenCode Go",
@@ -236,12 +223,8 @@ describe("ProvidersPage OpenCode Go tab", () => {
       </MemoryRouter>,
     );
 
-    await userEvent.click(
-      await screen.findByRole("tab", { name: /OpenCode Go/ }),
-    );
-    await waitFor(() =>
-      expect(screen.getAllByText("OpenCode Go").length).toBeGreaterThan(1),
-    );
+    await userEvent.click(await screen.findByRole("tab", { name: /OpenCode Go/ }));
+    await waitFor(() => expect(screen.getAllByText("OpenCode Go").length).toBeGreaterThan(1));
     expect(screen.getByText(/Success 9/i)).toBeInTheDocument();
     expect(screen.getByText(/Failed 1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Not queried/i)).not.toBeInTheDocument();
@@ -249,11 +232,70 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
     resolveUsage?.({
       workspace_id: "workspace-1",
-      usage: [
-        { type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" },
-      ],
+      usage: [{ type: "rolling", label: "Rolling", percentage: 25, resets_in: "30m" }],
     });
     expect(await screen.findByText(/Left 75%/i)).toBeInTheDocument();
+  });
+
+  test("refreshes OpenCode Go usage without replacing existing usage values", async () => {
+    localStorage.clear();
+    const user = userEvent.setup();
+    let callCount = 0;
+    let resolveRefresh: ((value: MockOpenCodeGoUsageResponse) => void) | undefined;
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "OpenCode Go",
+        apiKey: "sk-opencode-go",
+        workspaceId: "workspace-1",
+        authCookie: "session=abc",
+      },
+    ]);
+    mocks.queryOpenCodeGoUsage.mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return {
+          workspace_id: "workspace-1",
+          usage: [
+            {
+              type: "rolling",
+              label: "Rolling",
+              percentage: 25,
+              resets_in: "30m",
+            },
+          ],
+        };
+      }
+      return new Promise((resolve) => {
+        resolveRefresh = resolve;
+      });
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: /OpenCode Go/ }));
+    expect(await screen.findByText(/Left 75%/i)).toBeInTheDocument();
+
+    const refreshButton = screen.getByRole("button", { name: /Refresh usage/i });
+    await user.click(refreshButton);
+    await waitFor(() => expect(refreshButton).toBeDisabled());
+    expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
+    expect(screen.getByText(/Left 75%/i)).toBeInTheDocument();
+
+    resolveRefresh?.({
+      workspace_id: "workspace-1",
+      usage: [{ type: "rolling", label: "Rolling", percentage: 40, resets_in: "20m" }],
+    });
+    expect(await screen.findByText(/Left 60%/i)).toBeInTheDocument();
   });
 
   test("shows effective OpenCode Go models instead of dirty legacy models", async () => {
@@ -303,26 +345,16 @@ describe("ProvidersPage OpenCode Go tab", () => {
       </MemoryRouter>,
     );
 
-    expect(
-      await screen.findByRole("tab", { name: /OpenCode Go/ }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("tab", { name: /OpenCode Go/ })).toBeInTheDocument();
     const dialog = await screen.findByRole("dialog", {
       name: /Add OpenCode Go configuration/i,
     });
 
     expect(within(dialog).queryByText("Base URL")).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByText("Models (optional)"),
-    ).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
 
-    await user.type(
-      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
-      "OpenCode Go",
-    );
-    await user.type(
-      within(dialog).getByPlaceholderText(/Paste API Key/i),
-      "sk-opencode-go",
-    );
+    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");
+    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-opencode-go");
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -333,9 +365,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
         }),
       ]);
     });
-    expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty(
-      "baseUrl",
-    );
+    expect(mocks.saveOpenCodeGoConfigs.mock.calls[0][0][0]).not.toHaveProperty("baseUrl");
   });
 
   test("keeps failed OpenCode Go saves out of the rendered provider list", async () => {
@@ -346,9 +376,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
         apiKey: "sk-existing-opencode-go",
       },
     ]);
-    mocks.saveOpenCodeGoConfigs.mockRejectedValue(
-      new Error("channel name already used"),
-    );
+    mocks.saveOpenCodeGoConfigs.mockRejectedValue(new Error("channel name already used"));
 
     render(
       <MemoryRouter initialEntries={["/ai-providers/opencode-go/new"]}>
@@ -367,14 +395,8 @@ describe("ProvidersPage OpenCode Go tab", () => {
       name: /Add OpenCode Go configuration/i,
     });
 
-    await user.type(
-      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
-      "New OpenCode Go",
-    );
-    await user.type(
-      within(dialog).getByPlaceholderText(/Paste API Key/i),
-      "sk-new-opencode-go",
-    );
+    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "New OpenCode Go");
+    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-new-opencode-go");
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -416,9 +438,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Edit OpenCode Go configuration/i,
     });
-    expect(
-      within(dialog).getByRole("tab", { name: /Models/i }),
-    ).toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
     await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
     expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
     await user.clear(within(dialog).getByPlaceholderText(/Paste API Key/i));
@@ -447,11 +467,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
       {
         name: "Existing OpenCode Go",
         apiKey: "sk-existing-opencode-go",
-        models: [
-          { name: "deepseek-v4-flash" },
-          { name: "qwen3.5-plus" },
-          { name: "kimi-k2.6" },
-        ],
+        models: [{ name: "deepseek-v4-flash" }, { name: "qwen3.5-plus" }, { name: "kimi-k2.6" }],
         excludedModels: ["*"],
       },
     ]);
@@ -473,9 +489,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
     await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
-    await user.click(
-      within(dialog).getByRole("checkbox", { name: "qwen3.5-plus" }),
-    );
+    await user.click(within(dialog).getByRole("checkbox", { name: "qwen3.5-plus" }));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => expect(mocks.patchOpenCodeGoConfig).toHaveBeenCalled());
@@ -580,19 +594,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Add OpenCode Go configuration/i,
     });
-    expect(
-      within(dialog).getByRole("tab", { name: /Basic/i }),
-    ).toBeInTheDocument();
-    expect(
-      within(dialog).getByRole("tab", { name: /Request/i }),
-    ).toBeInTheDocument();
-    expect(
-      within(dialog).getByRole("tab", { name: /Models/i }),
-    ).toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: /Basic/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: /Request/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(
-      within(dialog).queryByText("Models (optional)"),
-    ).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
     await waitFor(() => expect(mocks.apiCallRequest).toHaveBeenCalled());
     expect(mocks.getModelDefinitions).not.toHaveBeenCalled();
     const modelsTable = within(dialog).getByRole("table", {
@@ -600,34 +606,20 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
     expect(modelsTable.closest(".table-scrollbar")).toBeInTheDocument();
     expect(modelsTable.closest("[data-vt-scroll-content]")).toBeInTheDocument();
-    expect(
-      within(dialog).getByRole("checkbox", { name: /Enabled/i }),
-    ).toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole("button", { name: /Select all/i }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole("button", { name: /Select none/i }),
-    ).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("checkbox", { name: /Enabled/i })).toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: /Select all/i })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole("button", { name: /Select none/i })).not.toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
     const fallbackSelect = within(dialog).getByRole("combobox", {
       name: /Vision fallback model/i,
     });
     await user.click(fallbackSelect);
-    await user.click(
-      await screen.findByRole("option", { name: /qwen3\.5-plus/ }),
-    );
+    await user.click(await screen.findByRole("option", { name: /qwen3\.5-plus/ }));
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
-    await user.type(
-      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
-      "OpenCode Go",
-    );
-    await user.type(
-      within(dialog).getByPlaceholderText(/Paste API Key/i),
-      "sk-opencode-go",
-    );
+    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");
+    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-opencode-go");
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -718,30 +710,20 @@ describe("ProvidersPage Cline tab", () => {
       </MemoryRouter>,
     );
 
-    expect(
-      await screen.findByRole("tab", { name: /ClinePass/ }),
-    ).toBeInTheDocument();
+    expect(await screen.findByRole("tab", { name: /ClinePass/ })).toBeInTheDocument();
     const dialog = await screen.findByRole("dialog", {
       name: /Add ClinePass configuration/i,
     });
 
     await user.click(within(dialog).getByRole("tab", { name: /Request/i }));
-    expect(
-      within(dialog).getByDisplayValue("https://api.cline.bot/api/v1"),
-    ).toBeInTheDocument();
+    expect(within(dialog).getByDisplayValue("https://api.cline.bot/api/v1")).toBeInTheDocument();
     expect(
       within(dialog).getByText("https://api.cline.bot/api/v1/chat/completions"),
     ).toBeInTheDocument();
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
-    await user.type(
-      within(dialog).getByPlaceholderText("e.g. Gemini Primary"),
-      "Cline",
-    );
-    await user.type(
-      within(dialog).getByPlaceholderText(/Paste API Key/i),
-      "sk-cline",
-    );
+    await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "Cline");
+    await user.type(within(dialog).getByPlaceholderText(/Paste API Key/i), "sk-cline");
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
@@ -812,21 +794,11 @@ describe("ProvidersPage Cline tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Add ClinePass configuration/i,
     });
-    expect(
-      within(dialog).getByRole("tab", { name: /Models/i }),
-    ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
-    );
-    await userEvent
-      .setup()
-      .click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(
-      within(dialog).queryByText("Models (optional)"),
-    ).not.toBeInTheDocument();
-    expect(
-      within(dialog).getByText("cline-pass/mimo-v2.5-pro"),
-    ).toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
+    await userEvent.setup().click(within(dialog).getByRole("tab", { name: /Models/i }));
+    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
+    expect(within(dialog).getByText("cline-pass/mimo-v2.5-pro")).toBeInTheDocument();
   });
 
   test("shows all hidden ClinePass card models in the +X tooltip", async () => {
@@ -882,9 +854,7 @@ describe("ProvidersPage Cline tab", () => {
 
     await user.click(await screen.findByRole("tab", { name: /ClinePass/ }));
     expect(await screen.findByText("Cline Tooltip")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
-    );
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
 
     await user.hover(screen.getByText("+2"));
     const tooltip = await screen.findByRole("tooltip");
@@ -915,12 +885,8 @@ describe("ProvidersPage Cline tab", () => {
     );
 
     await user.click(await screen.findByRole("tab", { name: /ClinePass/ }));
-    expect(
-      await screen.findByText("Cline Hidden Excluded"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText("cline-pass/legacy-disabled-only"),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByText("Cline Hidden Excluded")).toBeInTheDocument();
+    expect(screen.queryByText("cline-pass/legacy-disabled-only")).not.toBeInTheDocument();
   });
 
   test("saves ClinePass fetched model permissions when saving", async () => {
@@ -951,12 +917,8 @@ describe("ProvidersPage Cline tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Edit ClinePass configuration/i,
     });
-    expect(
-      within(dialog).getByRole("tab", { name: /Models/i }),
-    ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"),
-    );
+    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
     await user.clear(within(dialog).getByPlaceholderText(/Paste API Key/i));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
@@ -973,10 +935,7 @@ describe("ProvidersPage Cline tab", () => {
     expect(mocks.saveClineConfigs).not.toHaveBeenCalled();
     const saved = mocks.patchClineConfig.mock.calls[0][1];
     expect(saved).toHaveProperty("models", []);
-    expect(saved).toHaveProperty(
-      "visionFallbackModel",
-      "cline-pass/mimo-v2.5-pro",
-    );
+    expect(saved).toHaveProperty("visionFallbackModel", "cline-pass/mimo-v2.5-pro");
     expect(saved).toHaveProperty("disabled", false);
   });
 });
@@ -1031,18 +990,10 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Add Ollama Cloud configuration/i,
     });
-    expect(
-      within(dialog).getByRole("tab", { name: /Models/i }),
-    ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
-    );
-    await userEvent
-      .setup()
-      .click(within(dialog).getByRole("tab", { name: /Models/i }));
-    expect(
-      within(dialog).queryByText("Models (optional)"),
-    ).not.toBeInTheDocument();
+    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
+    await userEvent.setup().click(within(dialog).getByRole("tab", { name: /Models/i }));
+    expect(within(dialog).queryByText("Models (optional)")).not.toBeInTheDocument();
     expect(within(dialog).getByText("gpt-oss:120b")).toBeInTheDocument();
     expect(mocks.apiCallRequest).not.toHaveBeenCalled();
   });
@@ -1078,12 +1029,8 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     const dialog = await screen.findByRole("dialog", {
       name: /Edit Ollama Cloud configuration/i,
     });
-    expect(
-      within(dialog).getByRole("tab", { name: /Models/i }),
-    ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
-    );
+    expect(within(dialog).getByRole("tab", { name: /Models/i })).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
     await user.clear(within(dialog).getByPlaceholderText(/Paste API Key/i));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
@@ -1134,9 +1081,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
       name: /Edit Ollama Cloud configuration/i,
     });
     await user.click(within(dialog).getByRole("tab", { name: /Models/i }));
-    await waitFor(() =>
-      expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"),
-    );
+    await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("ollama-cloud"));
     await user.click(within(dialog).getByRole("checkbox", { name: /Enabled/i }));
     await user.click(within(dialog).getByRole("button", { name: /Save/ }));
 
@@ -1170,12 +1115,8 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     );
 
     await user.click(await screen.findByRole("tab", { name: /Ollama Cloud/ }));
-    expect(
-      await screen.findByText("Ollama Hidden Excluded"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText("gpt-oss:legacy-disabled-only"),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByText("Ollama Hidden Excluded")).toBeInTheDocument();
+    expect(screen.queryByText("gpt-oss:legacy-disabled-only")).not.toBeInTheDocument();
   });
 });
 
@@ -1183,18 +1124,14 @@ describe("mergeOpenCodeGoUsage", () => {
   test("returns incoming when existing is empty", async () => {
     const { mergeOpenCodeGoUsage } =
       await import("@pages/providers/components/OpenCodeGoUsageCardSection");
-    const incoming = [
-      { type: "rolling", label: "Rolling", percentage: 50, resets_in: "30m" },
-    ];
+    const incoming = [{ type: "rolling", label: "Rolling", percentage: 50, resets_in: "30m" }];
     expect(mergeOpenCodeGoUsage([], incoming)).toEqual(incoming);
   });
 
   test("returns existing when incoming is empty", async () => {
     const { mergeOpenCodeGoUsage } =
       await import("@pages/providers/components/OpenCodeGoUsageCardSection");
-    const existing = [
-      { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
-    ];
+    const existing = [{ type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" }];
     expect(mergeOpenCodeGoUsage(existing, [])).toEqual(existing);
   });
 
@@ -1206,9 +1143,7 @@ describe("mergeOpenCodeGoUsage", () => {
       { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
       { type: "monthly", label: "Monthly", percentage: 10, resets_in: "20d" },
     ];
-    const incoming = [
-      { type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" },
-    ];
+    const incoming = [{ type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" }];
     const result = mergeOpenCodeGoUsage(existing, incoming);
 
     expect(result).toHaveLength(3);
@@ -1220,12 +1155,8 @@ describe("mergeOpenCodeGoUsage", () => {
   test("handles case-insensitive type matching", async () => {
     const { mergeOpenCodeGoUsage } =
       await import("@pages/providers/components/OpenCodeGoUsageCardSection");
-    const existing = [
-      { type: "Rolling", label: "Rolling", percentage: 50, resets_in: "30m" },
-    ];
-    const incoming = [
-      { type: "rolling", label: "Rolling", percentage: 75, resets_in: "25m" },
-    ];
+    const existing = [{ type: "Rolling", label: "Rolling", percentage: 50, resets_in: "30m" }];
+    const incoming = [{ type: "rolling", label: "Rolling", percentage: 75, resets_in: "25m" }];
     const result = mergeOpenCodeGoUsage(existing, incoming);
 
     expect(result).toHaveLength(1);
@@ -1239,14 +1170,35 @@ describe("mergeOpenCodeGoUsage", () => {
       { type: "monthly", label: "Monthly", percentage: 10, resets_in: "20d" },
       { type: "weekly", label: "Weekly", percentage: 30, resets_in: "3d" },
     ];
-    const incoming = [
-      { type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" },
-    ];
+    const incoming = [{ type: "rolling", label: "Rolling", percentage: 80, resets_in: "25m" }];
     const result = mergeOpenCodeGoUsage(existing, incoming);
 
     expect(result).toHaveLength(3);
     expect(result[0].type).toBe("rolling");
     expect(result[1].type).toBe("monthly");
     expect(result[2].type).toBe("weekly");
+  });
+});
+
+describe("createOpenCodeGoUsageStore", () => {
+  test("notifies only the changed usage key", async () => {
+    const { createOpenCodeGoUsageStore } =
+      await import("@pages/providers/components/OpenCodeGoUsageCardSection");
+    const onChange = vi.fn();
+    const store = createOpenCodeGoUsageStore({}, onChange);
+    const first = vi.fn();
+    const second = vi.fn();
+
+    store.subscribe("first", first);
+    store.subscribe("second", second);
+    store.setLoading("first", true);
+    store.updateEntry("first", () => ({
+      usage: [],
+      updatedAt: 1,
+    }));
+
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/pages/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/pages/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+import { RefreshCcw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { OpenCodeGoUsageItem } from "@code-proxy/api-client";
 
@@ -9,6 +11,94 @@ export interface OpenCodeGoUsageCacheEntry {
 }
 
 const clampPercent = (value: number): number => Math.max(0, Math.min(100, value));
+
+type OpenCodeGoUsageState = Record<string, OpenCodeGoUsageCacheEntry>;
+type OpenCodeGoUsageSnapshot = {
+  usageEntry?: OpenCodeGoUsageCacheEntry;
+  loading: boolean;
+};
+type OpenCodeGoUsageListener = () => void;
+
+export interface OpenCodeGoUsageStore {
+  getSnapshot: (cacheKey: string) => OpenCodeGoUsageSnapshot;
+  subscribe: (cacheKey: string, listener: OpenCodeGoUsageListener) => () => void;
+  setLoading: (cacheKey: string, loading: boolean) => void;
+  updateEntry: (
+    cacheKey: string,
+    updater: (existing: OpenCodeGoUsageCacheEntry | undefined) => OpenCodeGoUsageCacheEntry,
+  ) => void;
+  prune: (validKeys: Set<string>) => void;
+}
+
+export function createOpenCodeGoUsageStore(
+  initialEntries: OpenCodeGoUsageState,
+  onChange: (entries: OpenCodeGoUsageState) => void,
+): OpenCodeGoUsageStore {
+  let entries = initialEntries;
+  const loadingState: Record<string, boolean> = {};
+  const listeners = new Map<string, Set<OpenCodeGoUsageListener>>();
+
+  const emit = (cacheKey: string) => {
+    listeners.get(cacheKey)?.forEach((listener) => listener());
+  };
+
+  const setEntries = (next: OpenCodeGoUsageState, changedKeys: string[]) => {
+    entries = next;
+    onChange(entries);
+    changedKeys.forEach(emit);
+  };
+
+  return {
+    getSnapshot: (cacheKey) => ({
+      usageEntry: entries[cacheKey],
+      loading: loadingState[cacheKey] ?? false,
+    }),
+    subscribe: (cacheKey, listener) => {
+      const keyListeners = listeners.get(cacheKey) ?? new Set();
+      keyListeners.add(listener);
+      listeners.set(cacheKey, keyListeners);
+      return () => {
+        keyListeners.delete(listener);
+        if (keyListeners.size === 0) listeners.delete(cacheKey);
+      };
+    },
+    setLoading: (cacheKey, loading) => {
+      if ((loadingState[cacheKey] ?? false) === loading) return;
+      loadingState[cacheKey] = loading;
+      emit(cacheKey);
+    },
+    updateEntry: (cacheKey, updater) => {
+      const nextEntry = updater(entries[cacheKey]);
+      setEntries({ ...entries, [cacheKey]: nextEntry }, [cacheKey]);
+    },
+    prune: (validKeys) => {
+      const staleKeys = Object.keys(entries).filter((key) => !validKeys.has(key));
+      if (staleKeys.length === 0) return;
+      const next = { ...entries };
+      staleKeys.forEach((key) => {
+        delete next[key];
+        delete loadingState[key];
+      });
+      setEntries(next, staleKeys);
+    },
+  };
+}
+
+export function useOpenCodeGoUsageSnapshot(
+  store: OpenCodeGoUsageStore,
+  cacheKey: string,
+): OpenCodeGoUsageSnapshot {
+  const [snapshot, setSnapshot] = useState(() => store.getSnapshot(cacheKey));
+
+  useEffect(() => {
+    setSnapshot(store.getSnapshot(cacheKey));
+    return store.subscribe(cacheKey, () => {
+      setSnapshot(store.getSnapshot(cacheKey));
+    });
+  }, [cacheKey, store]);
+
+  return snapshot;
+}
 
 export function mergeOpenCodeGoUsage(
   existing: OpenCodeGoUsageItem[],
@@ -84,15 +174,20 @@ const TYPE_COMPACT_LABEL_KEYS: Record<(typeof TYPE_LABELS)[number], string> = {
 };
 
 export function OpenCodeGoUsageCardSection({
-  usageEntry,
+  cacheKey,
+  usageStore,
   loading,
   queryReady,
 }: {
-  usageEntry?: OpenCodeGoUsageCacheEntry;
-  loading: boolean;
+  cacheKey: string;
+  usageStore: OpenCodeGoUsageStore;
+  loading?: boolean;
   queryReady: boolean;
 }) {
   const { t } = useTranslation();
+  const snapshot = useOpenCodeGoUsageSnapshot(usageStore, cacheKey);
+  const usageEntry = queryReady ? snapshot.usageEntry : undefined;
+  const isLoading = queryReady ? (loading ?? (snapshot.loading || !snapshot.usageEntry)) : false;
   const remainingUnknownText = t("providers.opencode_go_usage_remaining_unknown");
 
   const usageByType = new Map(
@@ -118,9 +213,7 @@ export function OpenCodeGoUsageCardSection({
                 {t(TYPE_COMPACT_LABEL_KEYS[type])}
               </span>
               <div className="h-1.5 rounded-full bg-slate-200/70 dark:bg-white/8" />
-              <span className="text-right text-[11px] tabular-nums">
-                {remainingUnknownText}
-              </span>
+              <span className="text-right text-[11px] tabular-nums">{remainingUnknownText}</span>
             </div>
           ))}
         </div>
@@ -130,7 +223,7 @@ export function OpenCodeGoUsageCardSection({
 
   return (
     <div className="mt-3">
-      {loading && !hasUsage ? (
+      {isLoading && !hasUsage ? (
         <div className="space-y-2">
           {TYPE_LABELS.map((type) => (
             <div
@@ -189,7 +282,7 @@ export function OpenCodeGoUsageCardSection({
             );
           })}
         </div>
-      ) : !loading ? (
+      ) : !isLoading ? (
         <p className="text-xs text-slate-400 dark:text-white/45">
           {t("providers.opencode_go_usage_not_queried")}
         </p>
@@ -203,5 +296,42 @@ export function OpenCodeGoUsageCardSection({
         </p>
       ) : null}
     </div>
+  );
+}
+
+export function OpenCodeGoUsageRefreshButton({
+  cacheKey,
+  usageStore,
+  onRefresh,
+}: {
+  cacheKey: string;
+  usageStore: OpenCodeGoUsageStore;
+  onRefresh: () => void;
+}) {
+  const snapshot = useOpenCodeGoUsageSnapshot(usageStore, cacheKey);
+  const loading = snapshot.loading;
+  const hasError = Boolean(snapshot.usageEntry?.error);
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onRefresh();
+      }}
+      disabled={loading}
+      className={[
+        "inline-flex h-6 w-6 items-center justify-center rounded-lg transition-all duration-150",
+        "text-slate-400 hover:bg-slate-200/60 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25",
+        "dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/60 dark:focus-visible:ring-white/20",
+        loading || hasError
+          ? "opacity-100"
+          : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+      ].join(" ")}
+      aria-label="Refresh usage"
+      title="Refresh usage"
+    >
+      <RefreshCcw size={13} className={loading ? "animate-spin" : ""} />
+    </button>
   );
 }

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1,18 +1,8 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useTransition,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ampcodeApi, providersApi, usageApi } from "@code-proxy/api-client";
-import {
-  proxiesApi,
-  type ProxyPoolEntry,
-} from "@code-proxy/api-client/endpoints/proxies";
+import { proxiesApi, type ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import type {
   BedrockProviderConfig,
   OpenAIProvider,
@@ -31,21 +21,19 @@ import { ProviderKeyModal } from "./ProviderKeyModal";
 import { useOpenAIProviderEditor } from "../hooks/useOpenAIProviderEditor";
 import { ProviderKeyListCard } from "../ProviderKeyListCard";
 import {
+  OpenCodeGoUsageRefreshButton,
   OpenCodeGoUsageCardSection,
+  createOpenCodeGoUsageStore,
   mergeOpenCodeGoUsage,
   type OpenCodeGoUsageCacheEntry,
+  type OpenCodeGoUsageStore,
 } from "./OpenCodeGoUsageCardSection";
 import { useProviderKeyEditor } from "../hooks/useProviderKeyEditor";
 import { useProviderLatency } from "../hooks/useProviderLatency";
 import { useProviderUsageSummary } from "../hooks/useProviderUsageSummary";
 import { normalizeUsageSourceId, type KeyStatBucket } from "@code-proxy/domain";
 import { getCachedData, removeCachedData, setCachedData } from "../provider-cache";
-import {
-  maskApiKey,
-  readBool,
-  readString,
-  type AmpMappingEntry,
-} from "../providers-helpers";
+import { maskApiKey, readBool, readString, type AmpMappingEntry } from "../providers-helpers";
 import {
   createProviderExportText,
   prepareProviderImport,
@@ -77,17 +65,14 @@ const PROVIDER_TAB_VALUES: ProviderTab[] = [
   "openai",
   "ampcode",
 ];
-const PROVIDER_LIST_TAB_VALUES: Exclude<ProviderTab, "ampcode">[] =
-  PROVIDER_TAB_VALUES.filter((item) => item !== "ampcode") as Exclude<
-    ProviderTab,
-    "ampcode"
-  >[];
+const PROVIDER_LIST_TAB_VALUES: Exclude<ProviderTab, "ampcode">[] = PROVIDER_TAB_VALUES.filter(
+  (item) => item !== "ampcode",
+) as Exclude<ProviderTab, "ampcode">[];
 
 function readSavedProviderTab(): ProviderTab {
   try {
     const saved = localStorage.getItem(PROVIDER_TAB_STORAGE_KEY);
-    if (saved && PROVIDER_TAB_VALUES.includes(saved as ProviderTab))
-      return saved as ProviderTab;
+    if (saved && PROVIDER_TAB_VALUES.includes(saved as ProviderTab)) return saved as ProviderTab;
   } catch {
     // ignore
   }
@@ -115,25 +100,16 @@ const getProviderSelectionKey = (
         .trim()
         .toLowerCase()}:${index}`;
 
-const getOpenCodeGoUsageCacheKey = (
-  item: ProviderSimpleConfig,
-  index: number,
-) =>
-  [
-    item.workspaceId?.trim() || "no-workspace",
-    item.name?.trim() || `item-${index}`,
-    index,
-  ].join(":");
+const getOpenCodeGoUsageCacheKey = (item: ProviderSimpleConfig, index: number) =>
+  [item.workspaceId?.trim() || "no-workspace", item.name?.trim() || `item-${index}`, index].join(
+    ":",
+  );
 
 const hasOpenCodeGoUsageQuery = (item: ProviderSimpleConfig) =>
   Boolean(item.workspaceId?.trim() && item.authCookie?.trim());
 
 type OpenCodeGoUsageState = Record<string, OpenCodeGoUsageCacheEntry>;
-type OpenCodeGoUsageLoadingState = Record<string, boolean>;
-type ModelAccessCatalogState = Record<
-  ModelAccessProvider,
-  DiscoveredProviderModel[]
->;
+type ModelAccessCatalogState = Record<ModelAccessProvider, DiscoveredProviderModel[]>;
 type ModelAccessCatalogLoadedState = Record<ModelAccessProvider, boolean>;
 
 const EMPTY_MODEL_ACCESS_CATALOGS: ModelAccessCatalogState = {
@@ -148,9 +124,7 @@ const EMPTY_MODEL_ACCESS_CATALOG_LOADED: ModelAccessCatalogLoadedState = {
   "ollama-cloud": false,
 };
 
-const isModelAccessProvider = (
-  tabId: ProviderTab,
-): tabId is ModelAccessProvider =>
+const isModelAccessProvider = (tabId: ProviderTab): tabId is ModelAccessProvider =>
   tabId === "opencode-go" || tabId === "cline" || tabId === "ollama-cloud";
 
 export function ProvidersPage() {
@@ -168,40 +142,38 @@ export function ProvidersPage() {
   }, []);
   const [loading, setLoading] = useState(true);
 
-  const cachedUsageState =
-    getCachedData<OpenCodeGoUsageState>("opencode-go-usage");
-  const [openCodeGoUsageState, setOpenCodeGoUsageState] =
-    useState<OpenCodeGoUsageState>(cachedUsageState ?? {});
-  const [openCodeGoUsageLoadingState, setOpenCodeGoUsageLoadingState] =
-    useState<OpenCodeGoUsageLoadingState>({});
-  const [modelAccessCatalogs, setModelAccessCatalogs] =
-    useState<ModelAccessCatalogState>(EMPTY_MODEL_ACCESS_CATALOGS);
+  const openCodeGoUsageStoreRef = useRef<OpenCodeGoUsageStore | null>(null);
+  if (!openCodeGoUsageStoreRef.current) {
+    openCodeGoUsageStoreRef.current = createOpenCodeGoUsageStore(
+      getCachedData<OpenCodeGoUsageState>("opencode-go-usage") ?? {},
+      (next) => setCachedData("opencode-go-usage", next),
+    );
+  }
+  const openCodeGoUsageStore = openCodeGoUsageStoreRef.current;
+  const [modelAccessCatalogs, setModelAccessCatalogs] = useState<ModelAccessCatalogState>(
+    EMPTY_MODEL_ACCESS_CATALOGS,
+  );
   const [modelAccessCatalogLoaded, setModelAccessCatalogLoaded] =
     useState<ModelAccessCatalogLoadedState>(EMPTY_MODEL_ACCESS_CATALOG_LOADED);
 
-  const loadModelAccessCatalog = useCallback(
-    async (provider: ModelAccessProvider) => {
-      try {
-        const catalog = await fetchModelAccessCatalog(provider);
-        setModelAccessCatalogs((prev) => ({ ...prev, [provider]: catalog }));
-      } catch {
-        setModelAccessCatalogs((prev) => ({ ...prev, [provider]: [] }));
-      } finally {
-        setModelAccessCatalogLoaded((prev) => ({ ...prev, [provider]: true }));
-      }
-    },
-    [],
-  );
+  const loadModelAccessCatalog = useCallback(async (provider: ModelAccessProvider) => {
+    try {
+      const catalog = await fetchModelAccessCatalog(provider);
+      setModelAccessCatalogs((prev) => ({ ...prev, [provider]: catalog }));
+    } catch {
+      setModelAccessCatalogs((prev) => ({ ...prev, [provider]: [] }));
+    } finally {
+      setModelAccessCatalogLoaded((prev) => ({ ...prev, [provider]: true }));
+    }
+  }, []);
 
   const refreshOpenCodeGoUsage = useCallback(
     async (item: ProviderSimpleConfig, index: number) => {
-      const hasQuery = Boolean(
-        item.workspaceId?.trim() && item.authCookie?.trim(),
-      );
+      const hasQuery = Boolean(item.workspaceId?.trim() && item.authCookie?.trim());
       if (!hasQuery) return;
 
       const cacheKey = getOpenCodeGoUsageCacheKey(item, index);
-      setOpenCodeGoUsageLoadingState((prev) => ({ ...prev, [cacheKey]: true }));
+      openCodeGoUsageStore.setLoading(cacheKey, true);
       try {
         const result = await providersApi.queryOpenCodeGoUsage({
           "workspace-id": item.workspaceId?.trim(),
@@ -217,62 +189,34 @@ export function ProvidersPage() {
           usage: result.usage,
           updatedAt: Date.now(),
         };
-        setOpenCodeGoUsageState((prev) => {
-          const existing = prev[cacheKey];
-          const merged = mergeOpenCodeGoUsage(
-            existing?.usage ?? [],
-            entry.usage,
-          );
-          const next = {
-            ...prev,
-            [cacheKey]: {
-              ...entry,
-              usage: merged,
-              workspaceId: entry.workspaceId ?? existing?.workspaceId,
-            },
+        openCodeGoUsageStore.updateEntry(cacheKey, (existing) => {
+          const merged = mergeOpenCodeGoUsage(existing?.usage ?? [], entry.usage);
+          return {
+            ...entry,
+            usage: merged,
+            workspaceId: entry.workspaceId ?? existing?.workspaceId,
           };
-          setCachedData("opencode-go-usage", next);
-          return next;
         });
-        setOpenCodeGoUsageLoadingState((prev) => ({
-          ...prev,
-          [cacheKey]: false,
-        }));
+        openCodeGoUsageStore.setLoading(cacheKey, false);
       } catch (err: unknown) {
-        setOpenCodeGoUsageState((prev) => {
-          const existing = prev[cacheKey];
-          const entry: OpenCodeGoUsageCacheEntry = {
-            workspaceId: existing?.workspaceId,
-            usage: existing?.usage ?? [],
-            updatedAt: Date.now(),
-            error:
-              err instanceof Error
-                ? err.message
-                : t("providers.opencode_go_usage_query_failed"),
-          };
-          const next = { ...prev, [cacheKey]: entry };
-          setCachedData("opencode-go-usage", next);
-          return next;
-        });
-        setOpenCodeGoUsageLoadingState((prev) => ({
-          ...prev,
-          [cacheKey]: false,
+        openCodeGoUsageStore.updateEntry(cacheKey, (existing) => ({
+          workspaceId: existing?.workspaceId,
+          usage: existing?.usage ?? [],
+          updatedAt: Date.now(),
+          error: err instanceof Error ? err.message : t("providers.opencode_go_usage_query_failed"),
         }));
+        openCodeGoUsageStore.setLoading(cacheKey, false);
       }
     },
-    [t],
+    [openCodeGoUsageStore, t],
   );
 
   const [geminiKeys, setGeminiKeys] = useState<ProviderSimpleConfig[]>([]);
   const [claudeKeys, setClaudeKeys] = useState<ProviderSimpleConfig[]>([]);
   const [codexKeys, setCodexKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>(
-    [],
-  );
+  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>([]);
   const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [ollamaCloudKeys, setOllamaCloudKeys] = useState<
-    ProviderSimpleConfig[]
-  >([]);
+  const [ollamaCloudKeys, setOllamaCloudKeys] = useState<ProviderSimpleConfig[]>([]);
   const [vertexKeys, setVertexKeys] = useState<ProviderSimpleConfig[]>([]);
   const [bedrockKeys, setBedrockKeys] = useState<BedrockProviderConfig[]>([]);
   const [openaiProviders, setOpenaiProviders] = useState<OpenAIProvider[]>([]);
@@ -293,15 +237,12 @@ export function ProvidersPage() {
         idx,
         key: getOpenCodeGoUsageCacheKey(item, idx),
       }))
-      .filter(({ item }) =>
-        Boolean(item.workspaceId?.trim() && item.authCookie?.trim()),
-      )
+      .filter(({ item }) => Boolean(item.workspaceId?.trim() && item.authCookie?.trim()))
       .filter(({ key }) => {
-        if (openCodeGoUsageLoadingState[key]) return false;
-        const entry = openCodeGoUsageState[key];
-        return (
-          !entry || Date.now() - entry.updatedAt > OPEN_CODE_GO_USAGE_STALE_MS
-        );
+        const snapshot = openCodeGoUsageStore.getSnapshot(key);
+        if (snapshot.loading) return false;
+        const entry = snapshot.usageEntry;
+        return !entry || Date.now() - entry.updatedAt > OPEN_CODE_GO_USAGE_STALE_MS;
       });
 
     if (staleKeys.length === 0) return;
@@ -311,22 +252,13 @@ export function ProvidersPage() {
     const refreshBatch = async () => {
       for (let i = 0; i < staleKeys.length; i += 2) {
         const batch = staleKeys.slice(i, i + 2);
-        await Promise.allSettled(
-          batch.map(({ item, idx }) => refreshOpenCodeGoUsage(item, idx)),
-        );
+        await Promise.allSettled(batch.map(({ item, idx }) => refreshOpenCodeGoUsage(item, idx)));
       }
       autoRefreshOpenCodeGoInFlightRef.current = false;
     };
 
     void refreshBatch();
-  }, [
-    tab,
-    loading,
-    openCodeGoKeys,
-    openCodeGoUsageState,
-    openCodeGoUsageLoadingState,
-    refreshOpenCodeGoUsage,
-  ]);
+  }, [tab, loading, openCodeGoKeys, openCodeGoUsageStore, refreshOpenCodeGoUsage]);
 
   useEffect(() => {
     if (!isModelAccessProvider(tab)) return;
@@ -334,13 +266,9 @@ export function ProvidersPage() {
     void loadModelAccessCatalog(tab);
   }, [loadModelAccessCatalog, modelAccessCatalogLoaded, tab]);
 
-  const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>(
-    [],
-  );
+  const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>([]);
 
-  const [usageStatsBySource, setUsageStatsBySource] = useState<
-    Record<string, KeyStatBucket>
-  >({});
+  const [usageStatsBySource, setUsageStatsBySource] = useState<Record<string, KeyStatBucket>>({});
 
   const [ampcode, setAmpcode] = useState<Record<string, unknown> | null>(null);
   const [ampUpstreamUrl, setAmpUpstreamUrl] = useState("");
@@ -369,8 +297,7 @@ export function ProvidersPage() {
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const [importPreview, setImportPreview] = useState<{
     kind: ProviderImportKind;
-    nextItems:
-      ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[];
+    nextItems: ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[];
     diff: ProviderImportDiff;
     filename: string;
   } | null>(null);
@@ -379,20 +306,10 @@ export function ProvidersPage() {
 
   // Clean up stale usage cache entries when config list changes
   useEffect(() => {
-    setOpenCodeGoUsageState((prev) => {
-      const validKeys = new Set(
-        openCodeGoKeys.map((item, idx) =>
-          getOpenCodeGoUsageCacheKey(item, idx),
-        ),
-      );
-      const staleKeys = Object.keys(prev).filter((k) => !validKeys.has(k));
-      if (staleKeys.length === 0) return prev;
-      const next = { ...prev };
-      staleKeys.forEach((k) => delete next[k]);
-      setCachedData("opencode-go-usage", next);
-      return next;
-    });
-  }, [openCodeGoKeys]);
+    openCodeGoUsageStore.prune(
+      new Set(openCodeGoKeys.map((item, idx) => getOpenCodeGoUsageCacheKey(item, idx))),
+    );
+  }, [openCodeGoKeys, openCodeGoUsageStore]);
 
   const loadProviderTab = useCallback(async (tabId: ProviderTab) => {
     switch (tabId) {
@@ -473,9 +390,7 @@ export function ProvidersPage() {
             : {};
         setAmpcode(ampObj);
         setAmpUpstreamUrl(readString(ampObj, "upstreamUrl", "upstream-url"));
-        setAmpForceMappings(
-          readBool(ampObj, "forceModelMappings", "force-model-mappings"),
-        );
+        setAmpForceMappings(readBool(ampObj, "forceModelMappings", "force-model-mappings"));
 
         const mappings = Array.isArray(ampMap) ? ampMap : [];
         const entries: AmpMappingEntry[] = mappings
@@ -488,11 +403,7 @@ export function ProvidersPage() {
             return { id: `map-${idx}-${from}`, from, to };
           })
           .filter(Boolean) as AmpMappingEntry[];
-        setAmpMappings(
-          entries.length
-            ? entries
-            : [{ id: `map-${Date.now()}`, from: "", to: "" }],
-        );
+        setAmpMappings(entries.length ? entries : [{ id: `map-${Date.now()}`, from: "", to: "" }]);
         break;
       }
     }
@@ -506,8 +417,7 @@ export function ProvidersPage() {
       } catch (err: unknown) {
         notify({
           type: "error",
-          message:
-            err instanceof Error ? err.message : t("providers.load_failed"),
+          message: err instanceof Error ? err.message : t("providers.load_failed"),
         });
       } finally {
         setLoading(false);
@@ -518,8 +428,7 @@ export function ProvidersPage() {
 
   const loadUsage = useCallback(async () => {
     try {
-      const cachedUsage =
-        getCachedData<Record<string, KeyStatBucket>>("usage-stats");
+      const cachedUsage = getCachedData<Record<string, KeyStatBucket>>("usage-stats");
       if (cachedUsage) setUsageStatsBySource(cachedUsage);
       const usage = await usageApi.getEntityStats(30, "all").catch(() => null);
       if (usage?.source) {
@@ -561,9 +470,7 @@ export function ProvidersPage() {
   const refreshAll = useCallback(async () => {
     setLoading(true);
     const tabsToRefresh: ProviderTab[] =
-      tab === "ampcode"
-        ? [...PROVIDER_LIST_TAB_VALUES, "ampcode"]
-        : PROVIDER_LIST_TAB_VALUES;
+      tab === "ampcode" ? [...PROVIDER_LIST_TAB_VALUES, "ampcode"] : PROVIDER_LIST_TAB_VALUES;
     const results = await Promise.allSettled([
       ...tabsToRefresh.map((tabId) => loadProviderTab(tabId)),
       loadUsage(),
@@ -574,9 +481,7 @@ export function ProvidersPage() {
       notify({
         type: "error",
         message:
-          failed.reason instanceof Error
-            ? failed.reason.message
-            : t("providers.load_failed"),
+          failed.reason instanceof Error ? failed.reason.message : t("providers.load_failed"),
       });
     }
     setLoading(false);
@@ -754,8 +659,7 @@ export function ProvidersPage() {
     } catch (err: unknown) {
       notify({
         type: "error",
-        message:
-          err instanceof Error ? err.message : t("providers.save_failed"),
+        message: err instanceof Error ? err.message : t("providers.save_failed"),
       });
     }
   }, [
@@ -836,18 +740,14 @@ export function ProvidersPage() {
         ? currentTabItems.map((item, index) =>
             getProviderSelectionKey(
               currentImportKind,
-              item as
-                ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
+              item as ProviderSimpleConfig | BedrockProviderConfig | OpenAIProvider,
               index,
             ),
           )
         : [],
     [currentImportKind, currentTabItems],
   );
-  const selectedExportKeySet = useMemo(
-    () => new Set(selectedExportKeys),
-    [selectedExportKeys],
-  );
+  const selectedExportKeySet = useMemo(() => new Set(selectedExportKeys), [selectedExportKeys]);
   const selectedExportCount = selectedExportKeys.length;
   const allCurrentSelected =
     currentSelectableKeys.length > 0 &&
@@ -887,8 +787,7 @@ export function ProvidersPage() {
   const saveImportedItems = useCallback(
     async (
       kind: ProviderImportKind,
-      items:
-        ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[],
+      items: ProviderSimpleConfig[] | BedrockProviderConfig[] | OpenAIProvider[],
     ) => {
       switch (kind) {
         case "gemini":
@@ -901,25 +800,19 @@ export function ProvidersPage() {
           await providersApi.saveCodexConfigs(items as ProviderSimpleConfig[]);
           return;
         case "opencode-go":
-          await providersApi.saveOpenCodeGoConfigs(
-            items as ProviderSimpleConfig[],
-          );
+          await providersApi.saveOpenCodeGoConfigs(items as ProviderSimpleConfig[]);
           return;
         case "cline":
           await providersApi.saveClineConfigs(items as ProviderSimpleConfig[]);
           return;
         case "ollama-cloud":
-          await providersApi.saveOllamaCloudConfigs(
-            items as ProviderSimpleConfig[],
-          );
+          await providersApi.saveOllamaCloudConfigs(items as ProviderSimpleConfig[]);
           return;
         case "vertex":
           await providersApi.saveVertexConfigs(items as ProviderSimpleConfig[]);
           return;
         case "bedrock":
-          await providersApi.saveBedrockConfigs(
-            items as BedrockProviderConfig[],
-          );
+          await providersApi.saveBedrockConfigs(items as BedrockProviderConfig[]);
           return;
         case "openai":
           await providersApi.saveOpenAIProviders(items as OpenAIProvider[]);
@@ -983,21 +876,13 @@ export function ProvidersPage() {
       createProviderExportText(kind, selectedItems as never),
       `${kind}-providers-selected.json`,
     );
-  }, [
-    currentImportKind,
-    currentTabItems,
-    selectedExportCount,
-    selectedExportKeySet,
-  ]);
+  }, [currentImportKind, currentTabItems, selectedExportCount, selectedExportKeySet]);
 
   const handleImportFile = useCallback(
     async (file: File | null) => {
       const kind = currentImportKind;
       if (!kind || !file) return;
-      if (
-        !file.name.toLowerCase().endsWith(".json") &&
-        file.type !== "application/json"
-      ) {
+      if (!file.name.toLowerCase().endsWith(".json") && file.type !== "application/json") {
         notify({ type: "error", message: t("upload_error_json") });
         return;
       }
@@ -1043,20 +928,12 @@ export function ProvidersPage() {
     } catch (error: unknown) {
       notify({
         type: "error",
-        message:
-          error instanceof Error ? error.message : t("providers.save_failed"),
+        message: error instanceof Error ? error.message : t("providers.save_failed"),
       });
     } finally {
       setImporting(false);
     }
-  }, [
-    importPreview,
-    notify,
-    refreshAll,
-    saveImportedItems,
-    startTransition,
-    t,
-  ]);
+  }, [importPreview, notify, refreshAll, saveImportedItems, startTransition, t]);
 
   return (
     <div
@@ -1139,12 +1016,8 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("gemini")}
               onAdd={() => openKeyEditor("gemini", null)}
               onEdit={(idx) => openKeyEditor("gemini", idx)}
-              onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "gemini", index: idx })
-              }
-              onToggleEnabled={(idx, enabled) =>
-                void toggleKeyEnabled("gemini", idx, enabled)
-              }
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "gemini", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("gemini", idx, enabled)}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1160,12 +1033,8 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("claude")}
               onAdd={() => openKeyEditor("claude", null)}
               onEdit={(idx) => openKeyEditor("claude", idx)}
-              onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "claude", index: idx })
-              }
-              onToggleEnabled={(idx, enabled) =>
-                void toggleKeyEnabled("claude", idx, enabled)
-              }
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "claude", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("claude", idx, enabled)}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1181,12 +1050,8 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("codex")}
               onAdd={() => openKeyEditor("codex", null)}
               onEdit={(idx) => openKeyEditor("codex", idx)}
-              onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "codex", index: idx })
-              }
-              onToggleEnabled={(idx, enabled) =>
-                void toggleKeyEnabled("codex", idx, enabled)
-              }
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "codex", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("codex", idx, enabled)}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1196,10 +1061,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent
-            value="opencode-go"
-            className="min-h-0 flex flex-1 flex-col"
-          >
+          <TabsContent value="opencode-go" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               items={openCodeGoKeys}
               loading={isActiveTabListLoading("opencode-go")}
@@ -1212,18 +1074,12 @@ export function ProvidersPage() {
                   index: idx,
                 })
               }
-              onToggleEnabled={(idx, enabled) =>
-                void toggleKeyEnabled("opencode-go", idx, enabled)
-              }
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("opencode-go", idx, enabled)}
               isItemEnabled={(item) => item.disabled !== true}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getDisplayModels={(item) =>
-                getEffectiveProviderModels(
-                  "opencode-go",
-                  item,
-                  modelAccessCatalogs["opencode-go"],
-                )
+                getEffectiveProviderModels("opencode-go", item, modelAccessCatalogs["opencode-go"])
               }
               showBaseUrl={false}
               naturalHeight
@@ -1233,61 +1089,23 @@ export function ProvidersPage() {
               renderExtra={(item, idx) => {
                 const queryReady = hasOpenCodeGoUsageQuery(item);
                 const cacheKey = getOpenCodeGoUsageCacheKey(item, idx);
-                const usageEntry = openCodeGoUsageState[cacheKey];
                 return (
                   <OpenCodeGoUsageCardSection
+                    cacheKey={cacheKey}
                     queryReady={queryReady}
-                    usageEntry={queryReady ? usageEntry : undefined}
-                    loading={
-                      queryReady
-                        ? (openCodeGoUsageLoadingState[cacheKey] ?? !usageEntry)
-                        : false
-                    }
+                    usageStore={openCodeGoUsageStore}
                   />
                 );
               }}
               renderMetricsExtra={(item, idx) => {
-                if (!(item.workspaceId?.trim() && item.authCookie?.trim()))
-                  return null;
+                if (!(item.workspaceId?.trim() && item.authCookie?.trim())) return null;
                 const cacheKey = getOpenCodeGoUsageCacheKey(item, idx);
-                const loading = openCodeGoUsageLoadingState[cacheKey] ?? false;
-                const hasError = Boolean(openCodeGoUsageState[cacheKey]?.error);
                 return (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void refreshOpenCodeGoUsage(item, idx);
-                    }}
-                    disabled={loading}
-                    className={[
-                      "inline-flex h-6 w-6 items-center justify-center rounded-lg transition-all duration-150",
-                      "text-slate-400 hover:bg-slate-200/60 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25",
-                      "dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/60 dark:focus-visible:ring-white/20",
-                      loading || hasError
-                        ? "opacity-100"
-                        : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
-                    ].join(" ")}
-                    aria-label="Refresh usage"
-                    title="Refresh usage"
-                  >
-                    <svg
-                      width="13"
-                      height="13"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      className={loading ? "animate-spin" : ""}
-                    >
-                      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
-                      <path d="M21 3v5h-5" />
-                      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
-                      <path d="M3 21v-5h5" />
-                    </svg>
-                  </button>
+                  <OpenCodeGoUsageRefreshButton
+                    cacheKey={cacheKey}
+                    usageStore={openCodeGoUsageStore}
+                    onRefresh={() => void refreshOpenCodeGoUsage(item, idx)}
+                  />
                 );
               }}
               selectedKeys={selectedExportKeySet}
@@ -1301,21 +1119,13 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("cline")}
               onAdd={() => openKeyEditor("cline", null)}
               onEdit={(idx) => openKeyEditor("cline", idx)}
-              onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "cline", index: idx })
-              }
-              onToggleEnabled={(idx, enabled) =>
-                void toggleKeyEnabled("cline", idx, enabled)
-              }
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "cline", index: idx })}
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("cline", idx, enabled)}
               isItemEnabled={(item) => item.disabled !== true}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getDisplayModels={(item) =>
-                getEffectiveProviderModels(
-                  "cline",
-                  item,
-                  modelAccessCatalogs.cline,
-                )
+                getEffectiveProviderModels("cline", item, modelAccessCatalogs.cline)
               }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
@@ -1325,10 +1135,7 @@ export function ProvidersPage() {
             />
           </TabsContent>
 
-          <TabsContent
-            value="ollama-cloud"
-            className="min-h-0 flex flex-1 flex-col"
-          >
+          <TabsContent value="ollama-cloud" className="min-h-0 flex flex-1 flex-col">
             <ProviderKeyListCard
               items={ollamaCloudKeys}
               loading={isActiveTabListLoading("ollama-cloud")}
@@ -1368,9 +1175,7 @@ export function ProvidersPage() {
               loading={isActiveTabListLoading("vertex")}
               onAdd={() => openKeyEditor("vertex", null)}
               onEdit={(idx) => openKeyEditor("vertex", idx)}
-              onDelete={(idx) =>
-                setConfirm({ type: "deleteKey", keyType: "vertex", index: idx })
-              }
+              onDelete={(idx) => setConfirm({ type: "deleteKey", keyType: "vertex", index: idx })}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1393,9 +1198,7 @@ export function ProvidersPage() {
                   index: idx,
                 })
               }
-              onToggleEnabled={(idx, enabled) =>
-                void toggleKeyEnabled("bedrock", idx, enabled)
-              }
+              onToggleEnabled={(idx, enabled) => void toggleKeyEnabled("bedrock", idx, enabled)}
               getStats={getSimpleStats}
               getStatusBar={getSimpleStatusBar}
               getLatencyEntry={getLatencyEntry}
@@ -1410,9 +1213,7 @@ export function ProvidersPage() {
               providers={openaiProviders}
               loading={isActiveTabListLoading("openai")}
               openOpenAIEditor={openOpenAIEditor}
-              confirmDelete={(index) =>
-                setConfirm({ type: "deleteOpenAI", index })
-              }
+              confirmDelete={(index) => setConfirm({ type: "deleteOpenAI", index })}
               maskApiKey={maskApiKey}
               getKeyEntryStats={getOpenAIKeyEntryStats}
               getProviderStats={getOpenAIProviderStats}
@@ -1421,11 +1222,7 @@ export function ProvidersPage() {
                 void toggleOpenAIProviderEnabled(providerIndex, enabled)
               }
               onToggleKeyEntryEnabled={(providerIndex, entryIndex, enabled) =>
-                void toggleOpenAIKeyEntryEnabled(
-                  providerIndex,
-                  entryIndex,
-                  enabled,
-                )
+                void toggleOpenAIKeyEntryEnabled(providerIndex, entryIndex, enabled)
               }
               selectedKeys={selectedExportKeySet}
               onToggleSelected={toggleExportSelection}
@@ -1533,11 +1330,7 @@ export function ProvidersPage() {
         }}
         footer={
           <>
-            <Button
-              variant="secondary"
-              onClick={() => setImportPreview(null)}
-              disabled={importing}
-            >
+            <Button variant="secondary" onClick={() => setImportPreview(null)} disabled={importing}>
               {t("common.cancel")}
             </Button>
             <Button
@@ -1587,9 +1380,7 @@ export function ProvidersPage() {
 
             {importPreview.diff.addedLabels.length ? (
               <div>
-                <p className="font-semibold">
-                  {t("providers.diff_added_label")}
-                </p>
+                <p className="font-semibold">{t("providers.diff_added_label")}</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {importPreview.diff.addedLabels.map((label) => (
                     <span
@@ -1605,9 +1396,7 @@ export function ProvidersPage() {
 
             {importPreview.diff.changedLabels.length ? (
               <div>
-                <p className="font-semibold">
-                  {t("providers.diff_updated_label")}
-                </p>
+                <p className="font-semibold">{t("providers.diff_updated_label")}</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {importPreview.diff.changedLabels.map((label) => (
                     <span
@@ -1623,9 +1412,7 @@ export function ProvidersPage() {
 
             {importPreview.diff.removedLabels.length ? (
               <div>
-                <p className="font-semibold">
-                  {t("providers.diff_removed_label")}
-                </p>
+                <p className="font-semibold">{t("providers.diff_removed_label")}</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {importPreview.diff.removedLabels.map((label) => (
                     <span


### PR DESCRIPTION
## Summary
- keep OpenCode Go usage/loading in a per-card usage store keyed by provider
- update only the usage rows and refresh button when a card refreshes
- cover manual refresh and per-key notifications in OpenCode Go provider tests

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build
- rtk git diff --check