### PR TITLE
fix(providers): keep usage values during refresh

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -262,6 +262,18 @@ describe("ProvidersPage OpenCode Go tab", () => {
               percentage: 25,
               resets_in: "30m",
             },
+            {
+              type: "weekly",
+              label: "Weekly",
+              percentage: 5,
+              resets_in: "5d",
+            },
+            {
+              type: "monthly",
+              label: "Monthly",
+              percentage: 23,
+              resets_in: "20d",
+            },
           ],
         };
       }
@@ -290,6 +302,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
     await waitFor(() => expect(refreshButton).toBeDisabled());
     expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
     expect(screen.getByText(/Left 75%/i)).toBeInTheDocument();
+    expect(screen.getByText(/Left 95%/i)).toBeInTheDocument();
+    expect(screen.getByText(/Left 77%/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Left --/i)).not.toBeInTheDocument();
 
     resolveRefresh?.({
       workspace_id: "workspace-1",

--- a/pages/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/pages/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -87,15 +87,28 @@ export function createOpenCodeGoUsageStore(
 export function useOpenCodeGoUsageSnapshot(
   store: OpenCodeGoUsageStore,
   cacheKey: string,
+  includeLoading = true,
 ): OpenCodeGoUsageSnapshot {
-  const [snapshot, setSnapshot] = useState(() => store.getSnapshot(cacheKey));
+  const readSnapshot = () => {
+    const snapshot = store.getSnapshot(cacheKey);
+    return includeLoading ? snapshot : { ...snapshot, loading: false };
+  };
+  const [snapshot, setSnapshot] = useState(readSnapshot);
 
   useEffect(() => {
-    setSnapshot(store.getSnapshot(cacheKey));
+    const updateSnapshot = () => {
+      setSnapshot((previous) => {
+        const next = readSnapshot();
+        return previous.usageEntry === next.usageEntry && previous.loading === next.loading
+          ? previous
+          : next;
+      });
+    };
+    updateSnapshot();
     return store.subscribe(cacheKey, () => {
-      setSnapshot(store.getSnapshot(cacheKey));
+      updateSnapshot();
     });
-  }, [cacheKey, store]);
+  }, [cacheKey, includeLoading, store]);
 
   return snapshot;
 }
@@ -185,7 +198,7 @@ export function OpenCodeGoUsageCardSection({
   queryReady: boolean;
 }) {
   const { t } = useTranslation();
-  const snapshot = useOpenCodeGoUsageSnapshot(usageStore, cacheKey);
+  const snapshot = useOpenCodeGoUsageSnapshot(usageStore, cacheKey, false);
   const usageEntry = queryReady ? snapshot.usageEntry : undefined;
   const isLoading = queryReady ? (loading ?? (snapshot.loading || !snapshot.usageEntry)) : false;
   const remainingUnknownText = t("providers.opencode_go_usage_remaining_unknown");


### PR DESCRIPTION
## Summary
- stop usage rows from subscribing to loading-only updates
- keep existing rolling/weekly/monthly values and bars visible while refresh is pending
- expand OpenCode Go refresh regression coverage to catch fallback grey placeholders

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build
- rtk bun run lint
- rtk git diff --check