### PR TITLE
fix(providers): render cached OpenCode Go usage first

### DIFF
--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -160,9 +160,12 @@ export function ProviderKeyListCard({
                 enabled={!disabled}
                 dimmed={disabled}
                 naturalHeight={naturalHeight}
-                className={
-                  naturalHeight ? "w-full max-w-[22rem] flex-none" : undefined
-                }
+                className={[
+                  "motion-safe:animate-[fadeInUp_0.22s_ease-out]",
+                  naturalHeight ? "w-full max-w-[22rem] flex-none" : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 onToggleSelected={
                   onToggleSelected
                     ? (checked) => onToggleSelected(selectionKey, checked)

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -190,6 +190,78 @@ describe("ProvidersPage OpenCode Go tab", () => {
     mocks.proxiesList.mockImplementation(async () => []);
   });
 
+  test("renders cached OpenCode Go usage without falling back to skeleton or placeholders", async () => {
+    localStorage.clear();
+    localStorage.setItem("providers-page:tab", "opencode-go");
+    localStorage.setItem(
+      "providers-page:cache:opencode-go",
+      JSON.stringify({
+        data: [
+          {
+            name: "OpenCode Go Cached",
+            apiKey: "sk-opencode-go",
+            workspaceId: "workspace-1",
+            authCookie: "session=abc",
+          },
+        ],
+        timestamp: Date.now(),
+      }),
+    );
+    localStorage.setItem(
+      "providers-page:cache:opencode-go-usage",
+      JSON.stringify({
+        data: {
+          "workspace-1:OpenCode Go Cached:0": {
+            workspaceId: "workspace-1",
+            usage: [
+              { type: "rolling", label: "Rolling", percentage: 1, resets_in: "30m" },
+              { type: "weekly", label: "Weekly", percentage: 5, resets_in: "5d" },
+              { type: "monthly", label: "Monthly", percentage: 23, resets_in: "20d" },
+            ],
+            updatedAt: Date.now(),
+          },
+        },
+        timestamp: Date.now(),
+      }),
+    );
+    mocks.getOpenCodeGoConfigs.mockImplementation(async () => [
+      {
+        name: "OpenCode Go Cached",
+        apiKey: "sk-opencode-go",
+        workspaceId: "workspace-1",
+        authCookie: "session=abc",
+      },
+      {
+        name: "OpenCode Go Fresh",
+        apiKey: "sk-opencode-go-fresh",
+        workspaceId: "workspace-2",
+        authCookie: "session=def",
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument();
+    const cachedTitle = await screen.findByText("OpenCode Go Cached");
+    const cachedCard = cachedTitle.closest(".group");
+    expect(cachedCard).toBeInTheDocument();
+    expect(within(cachedCard as HTMLElement).getByText(/Left 99%/i)).toBeInTheDocument();
+    expect(within(cachedCard as HTMLElement).getByText(/Left 95%/i)).toBeInTheDocument();
+    expect(within(cachedCard as HTMLElement).getByText(/Left 77%/i)).toBeInTheDocument();
+    expect(within(cachedCard as HTMLElement).queryByText(/Left --/i)).not.toBeInTheDocument();
+    expect(await screen.findByText("OpenCode Go Fresh")).toBeInTheDocument();
+  });
+
   test("shows usage loading instead of not queried before the first OpenCode Go usage result", async () => {
     localStorage.clear();
     let resolveUsage: ((value: MockOpenCodeGoUsageResponse) => void) | undefined;

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -214,7 +214,9 @@ export function ProvidersPage() {
   const [geminiKeys, setGeminiKeys] = useState<ProviderSimpleConfig[]>([]);
   const [claudeKeys, setClaudeKeys] = useState<ProviderSimpleConfig[]>([]);
   const [codexKeys, setCodexKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>([]);
+  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>(
+    () => getCachedData<ProviderSimpleConfig[]>("opencode-go") ?? [],
+  );
   const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>([]);
   const [ollamaCloudKeys, setOllamaCloudKeys] = useState<ProviderSimpleConfig[]>([]);
   const [vertexKeys, setVertexKeys] = useState<ProviderSimpleConfig[]>([]);
@@ -268,7 +270,9 @@ export function ProvidersPage() {
 
   const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>([]);
 
-  const [usageStatsBySource, setUsageStatsBySource] = useState<Record<string, KeyStatBucket>>({});
+  const [usageStatsBySource, setUsageStatsBySource] = useState<Record<string, KeyStatBucket>>(
+    () => getCachedData<Record<string, KeyStatBucket>>("usage-stats") ?? {},
+  );
 
   const [ampcode, setAmpcode] = useState<Record<string, unknown> | null>(null);
   const [ampUpstreamUrl, setAmpUpstreamUrl] = useState("");
@@ -338,9 +342,11 @@ export function ProvidersPage() {
         break;
       }
       case "opencode-go": {
-        removeCachedData("opencode-go");
+        const cachedO = getCachedData<ProviderSimpleConfig[]>("opencode-go");
+        if (cachedO) setOpenCodeGoKeys(cachedO);
         const freshO = await providersApi.getOpenCodeGoConfigs();
         setOpenCodeGoKeys(freshO);
+        setCachedData("opencode-go", freshO);
         break;
       }
       case "cline": {


### PR DESCRIPTION
## Summary
- initialize OpenCode Go provider cards from cached provider data
- preserve cached usage and stats on first paint so existing cards do not fall back to skeleton or Left -- placeholders
- add a light appear animation for newly fetched cards
- cover cached OpenCode Go usage first-paint behavior in tests

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build
- rtk bun run lint
- rtk git diff --check