### PR TITLE
fix: polish provider usage cards

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3384,6 +3384,8 @@
     "opencode_go_usage_compact_rolling": "Rolling",
     "opencode_go_usage_compact_weekly": "Weekly",
     "opencode_go_usage_compact_monthly": "Monthly",
+    "opencode_go_usage_compact_five_hour": "5 hours",
+    "opencode_go_usage_compact_session": "Rolling",
     "opencode_go_usage_remaining_unknown": "Left --",
     "opencode_go_usage_remaining_percent": "Left {{percent}}%",
     "opencode_go_usage_resets_in": "Resets in {{time}}",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2206,9 +2206,11 @@
   "providers": {
     "opencode_go_usage_query_failed": "Failed to check OpenCode Go usage",
     "opencode_go_usage_not_queried": "Not queried",
-    "opencode_go_usage_compact_rolling": "Rolling",
-    "opencode_go_usage_compact_weekly": "Weekly",
-    "opencode_go_usage_compact_monthly": "Monthly",
+    "opencode_go_usage_compact_rolling": "Скользящее",
+    "opencode_go_usage_compact_weekly": "Неделя",
+    "opencode_go_usage_compact_monthly": "Месяц",
+    "opencode_go_usage_compact_five_hour": "5 часов",
+    "opencode_go_usage_compact_session": "Скользящее",
     "opencode_go_usage_remaining_unknown": "Left --",
     "opencode_go_usage_remaining_percent": "Left {{percent}}%"
   },

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2668,6 +2668,8 @@
     "opencode_go_usage_compact_rolling": "滚动",
     "opencode_go_usage_compact_weekly": "每周",
     "opencode_go_usage_compact_monthly": "每月",
+    "opencode_go_usage_compact_five_hour": "5 小时",
+    "opencode_go_usage_compact_session": "滚动",
     "opencode_go_usage_remaining_unknown": "剩余 --",
     "opencode_go_usage_remaining_percent": "剩余 {{percent}}%",
     "opencode_go_usage_resets_in": "重置于 {{time}} 后",

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -951,8 +951,9 @@ describe("ProvidersPage Cline tab", () => {
     expect(await screen.findByText("Cline Tooltip")).toBeInTheDocument();
     await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
 
-    await user.hover(screen.getByText("+2"));
+    await user.hover(screen.getByText("+3"));
     const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("cline-pass/deepseek-v4");
     expect(tooltip).toHaveTextContent("cline-pass/kimi-k2.6");
     expect(tooltip).toHaveTextContent("cline-pass/gpt-5.2");
   });

--- a/pages/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/pages/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -181,10 +181,12 @@ const resolveRemainingTone = (
 
 const DEFAULT_TYPE_LABELS = ["rolling", "weekly", "monthly"] as const;
 
-const TYPE_COMPACT_LABEL_KEYS: Record<(typeof DEFAULT_TYPE_LABELS)[number], string> = {
+const TYPE_COMPACT_LABEL_KEYS: Record<string, string> = {
   rolling: "providers.opencode_go_usage_compact_rolling",
   weekly: "providers.opencode_go_usage_compact_weekly",
   monthly: "providers.opencode_go_usage_compact_monthly",
+  five_hour: "providers.opencode_go_usage_compact_five_hour",
+  session: "providers.opencode_go_usage_compact_session",
 };
 
 const getCompactUsageLabel = (
@@ -193,12 +195,30 @@ const getCompactUsageLabel = (
   t: (key: string) => string,
 ): string => {
   const normalized = type.toLowerCase();
-  if (normalized === "rolling" || normalized === "weekly" || normalized === "monthly") {
+  if (
+    normalized === "rolling" ||
+    normalized === "weekly" ||
+    normalized === "monthly" ||
+    normalized === "five_hour" ||
+    normalized === "session"
+  ) {
     return t(TYPE_COMPACT_LABEL_KEYS[normalized]);
   }
-  if (normalized === "five_hour") return "5h";
-  if (normalized === "session") return "Sess";
   return usageByType.get(normalized)?.label || type;
+};
+
+const getUsageItemForType = (
+  type: string,
+  usageByType: Map<string, OpenCodeGoUsageItem>,
+): OpenCodeGoUsageItem | undefined => {
+  const normalized = type.toLowerCase();
+  if (normalized === "rolling") {
+    return usageByType.get("rolling") ?? usageByType.get("session");
+  }
+  if (normalized === "session") {
+    return usageByType.get("session") ?? usageByType.get("rolling");
+  }
+  return usageByType.get(normalized);
 };
 
 export function OpenCodeGoUsageCardSection({
@@ -252,7 +272,7 @@ export function OpenCodeGoUsageCardSection({
   }
 
   return (
-    <div className="mt-3">
+    <div className="mt-3 min-h-[3.375rem]">
       {isLoading && !hasUsage ? (
         <div className="space-y-2">
           {windowTypes.map((type) => (
@@ -275,7 +295,7 @@ export function OpenCodeGoUsageCardSection({
       ) : hasUsage ? (
         <div className="mx-auto w-full max-w-[20rem] space-y-1.5">
           {windowTypes.map((type) => {
-            const item = usageByType.get(type.toLowerCase());
+            const item = getUsageItemForType(type, usageByType);
             const remaining = resolveRemainingPercent(item?.percentage);
             const tone = resolveRemainingTone(remaining);
             const remainingText =

--- a/pages/providers/components/ProviderModelChips.tsx
+++ b/pages/providers/components/ProviderModelChips.tsx
@@ -14,44 +14,45 @@ export function ProviderModelChips({
 }: ProviderModelChipsProps) {
   if (!models.length) {
     return emptyLabel ? (
-      <span className="text-xs text-slate-400 dark:text-white/40">
-        {emptyLabel}
-      </span>
+      <span className="text-xs text-slate-400 dark:text-white/40">{emptyLabel}</span>
     ) : null;
   }
 
-  const visible = models.slice(0, maxVisible);
-  const remaining = models.length - maxVisible;
+  const visibleLimit = models.length > maxVisible ? Math.max(1, maxVisible - 1) : maxVisible;
+  const visible = models.slice(0, visibleLimit);
+  const remaining = models.length - visibleLimit;
   const formatModelLabel = (model: ProviderModel, arrow: string) => {
     const name = model.name ?? "";
-    return model.alias && model.alias !== name
-      ? `${name} ${arrow} ${model.alias}`
-      : name;
+    return model.alias && model.alias !== name ? `${name} ${arrow} ${model.alias}` : name;
   };
 
   return (
-    <div className="flex flex-wrap gap-1">
+    <div className="grid max-h-[3.25rem] grid-cols-3 gap-1 overflow-hidden">
       {visible.map((model) => {
         const modelLabel = formatModelLabel(model, "→");
         return (
-          <span
+          <HoverTooltip
             key={model.name}
-            className="inline-flex max-w-full min-w-0 rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950"
-            title={formatModelLabel(model, "=>")}
+            content={formatModelLabel(model, "=>")}
+            placement="top"
+            className="min-w-0"
           >
-            <span className="min-w-0 truncate">{modelLabel}</span>
-          </span>
+            <span className="inline-flex w-full min-w-0 cursor-default rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950">
+              <span className="min-w-0 truncate">{modelLabel}</span>
+            </span>
+          </HoverTooltip>
         );
       })}
       {remaining > 0 ? (
         <HoverTooltip
           content={models
-            .slice(maxVisible)
+            .slice(visibleLimit)
             .map((model) => formatModelLabel(model, "=>"))
             .join("\n")}
           placement="top"
+          className="min-w-0"
         >
-          <span className="inline-flex max-w-full min-w-0 cursor-default rounded-full bg-slate-200 px-2 py-0.5 text-[11px] text-slate-500 dark:bg-neutral-800 dark:text-white/55">
+          <span className="inline-flex min-w-0 cursor-default justify-center rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold tabular-nums text-slate-500 dark:bg-neutral-800 dark:text-white/55">
             +{remaining}
           </span>
         </HoverTooltip>

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -108,7 +108,7 @@ type ProviderUsageProvider = "opencode-go" | "cline" | "ollama-cloud";
 const PROVIDER_USAGE_WINDOWS: Record<ProviderUsageProvider, readonly string[]> = {
   "opencode-go": ["rolling", "weekly", "monthly"],
   cline: ["five_hour", "weekly", "monthly"],
-  "ollama-cloud": ["session", "weekly"],
+  "ollama-cloud": ["rolling", "weekly"],
 };
 
 const getProviderUsageCacheKey = (
@@ -1206,6 +1206,7 @@ export function ProvidersPage() {
               }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              naturalHeight
               showExcludedModels={false}
               renderExtra={(item, idx) => {
                 const queryReady = hasProviderUsageQuery("cline", item);
@@ -1263,6 +1264,7 @@ export function ProvidersPage() {
               }
               getLatencyEntry={getLatencyEntry}
               checkLatency={checkLatency}
+              naturalHeight
               showExcludedModels={false}
               renderExtra={(item, idx) => {
                 const queryReady = hasProviderUsageQuery("ollama-cloud", item);

--- a/pages/providers/components/__tests__/OpenCodeGoUsageCardSection.test.tsx
+++ b/pages/providers/components/__tests__/OpenCodeGoUsageCardSection.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+import i18n from "@code-proxy/i18n";
+import {
+  OpenCodeGoUsageCardSection,
+  createOpenCodeGoUsageStore,
+} from "../OpenCodeGoUsageCardSection";
+
+describe("OpenCodeGoUsageCardSection", () => {
+  afterEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  test("localizes compact Cline usage labels", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const store = createOpenCodeGoUsageStore(
+      {
+        cline: {
+          usage: [{ type: "five_hour", label: "5-Hour", percentage: 25, resets_in: "1h" }],
+          updatedAt: 1,
+        },
+      },
+      () => undefined,
+    );
+
+    render(
+      <OpenCodeGoUsageCardSection
+        cacheKey="cline"
+        queryReady
+        usageStore={store}
+        windowTypes={["five_hour", "weekly", "monthly"]}
+      />,
+    );
+
+    expect(screen.getByText("5 小时")).toBeInTheDocument();
+    expect(screen.queryByText("5h")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sess")).not.toBeInTheDocument();
+  });
+
+  test("shows Ollama Cloud session usage as rolling usage", async () => {
+    await i18n.changeLanguage("zh-CN");
+    const store = createOpenCodeGoUsageStore(
+      {
+        ollama: {
+          usage: [
+            { type: "session", label: "Session", percentage: 20, resets_in: "1h" },
+            { type: "weekly", label: "Weekly", percentage: 40, resets_in: "4d" },
+          ],
+          updatedAt: 1,
+        },
+      },
+      () => undefined,
+    );
+
+    render(
+      <OpenCodeGoUsageCardSection
+        cacheKey="ollama"
+        queryReady
+        usageStore={store}
+        windowTypes={["rolling", "weekly"]}
+      />,
+    );
+
+    expect(screen.getByText("滚动")).toBeInTheDocument();
+    expect(screen.getByText("每周")).toBeInTheDocument();
+    expect(screen.getByText("剩余 80%")).toBeInTheDocument();
+    expect(screen.queryByText("Sess")).not.toBeInTheDocument();
+  });
+});

--- a/pages/providers/components/__tests__/ProviderModelChips.test.tsx
+++ b/pages/providers/components/__tests__/ProviderModelChips.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { ProviderModelChips } from "../ProviderModelChips";
+
+describe("ProviderModelChips", () => {
+  test("keeps overflow models behind the final summary chip", async () => {
+    const user = userEvent.setup();
+    const models = [
+      { name: "model-1" },
+      { name: "model-2" },
+      { name: "model-3" },
+      { name: "model-4" },
+      { name: "model-5" },
+      { name: "model-6" },
+      { name: "model-7", alias: "mapped-7" },
+      { name: "model-8" },
+    ];
+
+    render(<ProviderModelChips models={models} maxVisible={6} />);
+
+    expect(screen.getByText("model-5")).toBeInTheDocument();
+    expect(screen.getByText("+3")).toBeInTheDocument();
+    expect(screen.queryByText("model-6")).not.toBeInTheDocument();
+    expect(screen.queryByText("model-7 → mapped-7")).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText("+3"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("model-6");
+    expect(tooltip).toHaveTextContent("model-7 => mapped-7");
+    expect(tooltip).toHaveTextContent("model-8");
+  });
+
+  test("shows the full model mapping for visible truncated chips", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ProviderModelChips
+        models={[{ name: "very-long-upstream-model-name", alias: "very-long-downstream-alias" }]}
+      />,
+    );
+
+    await user.hover(screen.getByText("very-long-upstream-model-name → very-long-downstream-alias"));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "very-long-upstream-model-name => very-long-downstream-alias",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep provider model chips to two rows with +N overflow tooltip
- show full tooltip text for visible truncated model and mapping chips
- localize ClinePass/Ollama Cloud usage labels and show Ollama Cloud rolling + weekly usage

## Verification
- bun run --filter @code-proxy/admin-panel test:ci -- pages/providers/components/__tests__/ProviderModelChips.test.tsx pages/providers/components/__tests__/OpenCodeGoUsageCardSection.test.tsx pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- bun run build