### PR TITLE
fix: cache ClinePass and Ollama Cloud provider tabs

### DIFF
--- a/e2e/opencode-go-layout.spec.ts
+++ b/e2e/opencode-go-layout.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+test.describe.configure({ mode: "serial" });
+
 const opencodeGoKeys = [
   {
     "api-key": "sk-opencode-go-alpha-1234567890abcdef",
@@ -41,10 +43,32 @@ const opencodeGoKeys = [
   },
 ];
 
-const usageStats = opencodeGoKeys.map((item, index) => ({
+const clineKeys = [
+  {
+    "api-key": "sk-cline-secret-1234567890",
+    name: "Cline usage card",
+    prefix: "cline-one",
+    "base-url": "https://api.cline.bot/api/v1",
+    "auth-cookie": "auth=cline",
+  },
+];
+
+const ollamaCloudKeys = [
+  {
+    "api-key": "sk-ollama-secret-0987654321",
+    name: "Ollama usage card",
+    prefix: "ollama-one",
+    "base-url": "https://ollama.com",
+    "auth-cookie": "auth=ollama",
+  },
+];
+
+const providerUsageKeys = [...opencodeGoKeys, ...clineKeys, ...ollamaCloudKeys];
+
+const usageStats = providerUsageKeys.map((item, index) => ({
   entity_name: item["api-key"],
-  requests: [5524, 4872, 3105, 0, 3381, 0][index] ?? 0,
-  failed: [279, 209, 78, 0, 163, 0][index] ?? 0,
+  requests: [5524, 4872, 3105, 0, 3381, 0, 120, 96][index] ?? 0,
+  failed: [279, 209, 78, 0, 163, 0, 4, 2][index] ?? 0,
   avg_latency: 320,
   total_tokens: 1000,
 }));
@@ -54,6 +78,23 @@ const opencodeGoUsage = [
   { type: "weekly", label: "Weekly", percentage: 47, resets_in: "4 days" },
   { type: "monthly", label: "Monthly", percentage: 96.8, resets_in: "12 days" },
 ];
+
+const clineUsage = [
+  { type: "five_hour", label: "5h", percentage: 18, resets_in: "2 hours" },
+  { type: "weekly", label: "Weekly", percentage: 41, resets_in: "4 days" },
+  { type: "monthly", label: "Monthly", percentage: 62, resets_in: "12 days" },
+];
+
+const ollamaCloudUsage = [
+  { type: "rolling", label: "Rolling", percentage: 11, resets_in: "48 minutes" },
+  { type: "weekly", label: "Weekly", percentage: 34, resets_in: "5 days" },
+];
+
+const modelDefinitions = {
+  "opencode-go": [{ id: "opencode/gpt-5.2" }],
+  cline: [{ id: "cline-pass/deepseek-v4" }],
+  "ollama-cloud": [{ id: "gpt-oss:120b" }],
+} as const;
 
 const testedViewports = [
   { name: "desktop-narrow", width: 1280, height: 720 },
@@ -97,12 +138,39 @@ const mockManagementApi = async (page: Page) => {
     if (managementPath === "/opencode-go-api-key" && request.method() === "GET") {
       return fulfillJson({ "opencode-go-api-key": opencodeGoKeys });
     }
+    if (managementPath === "/cline-api-key" && request.method() === "GET") {
+      return fulfillJson({ "cline-api-key": clineKeys });
+    }
+    if (managementPath === "/ollama-cloud-api-key" && request.method() === "GET") {
+      return fulfillJson({ "ollama-cloud-api-key": ollamaCloudKeys });
+    }
     if (managementPath === "/opencode-go-api-key/usage" && request.method() === "POST") {
       return fulfillJson({ workspace_id: "wrk_test", usage: opencodeGoUsage });
+    }
+    if (managementPath === "/cline-api-key/usage" && request.method() === "POST") {
+      return fulfillJson({ usage: clineUsage });
+    }
+    if (managementPath === "/ollama-cloud-api-key/usage" && request.method() === "POST") {
+      return fulfillJson({ usage: ollamaCloudUsage });
+    }
+    if (managementPath.startsWith("/model-definitions/")) {
+      const channel = decodeURIComponent(managementPath.split("/").pop() ?? "");
+      return fulfillJson({
+        models: modelDefinitions[channel as keyof typeof modelDefinitions] ?? [],
+      });
     }
     return fulfillJson({});
   });
 };
+
+const getTitleLeftOffset = async (page: Page, title: string) =>
+  page.getByText(title, { exact: true }).evaluate((titleElement) => {
+    const card = titleElement.closest(".group");
+    if (!card) throw new Error(`No provider card found for ${title}`);
+    const cardRect = card.getBoundingClientRect();
+    const titleRect = titleElement.getBoundingClientRect();
+    return Math.round(titleRect.left - cardRect.left);
+  });
 
 test("AI Providers: OpenCode Go cards should not overlap on responsive layouts", async ({
   page,
@@ -117,7 +185,7 @@ test("AI Providers: OpenCode Go cards should not overlap on responsive layouts",
     const list = page.getByTestId("providers-tab-scroll");
     await expect(list).toBeVisible();
     await expect.poll(() => list.locator("> *").count()).toBe(opencodeGoKeys.length);
-    await expect.poll(() => list.textContent()).toContain("剩余 3.2%");
+    await expect.poll(() => list.textContent()).toContain("3.2%");
 
     const metrics = await list.evaluate((el) => {
       const cards = Array.from(el.children).map((child, index) => {
@@ -154,5 +222,55 @@ test("AI Providers: OpenCode Go cards should not overlap on responsive layouts",
     expect(metrics.overlaps, `${viewport.name} has overlapping provider cards`).toEqual([]);
     expect(metrics.listOverflowX, `${viewport.name} list overflows horizontally`).toBe(false);
     expect(metrics.bodyOverflowX, `${viewport.name} page overflows horizontally`).toBe(false);
+  }
+});
+
+test("AI Providers: dashboard provider cards stay compact and left aligned", async ({ page }) => {
+  await setAuthed(page);
+  await mockManagementApi(page);
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/#/ai-providers");
+
+  for (const provider of [
+    {
+      tab: "OpenCode Go",
+      title: "OC usage nearly full",
+      hiddenTexts: ["sk-opencode", "Models", "模型"],
+    },
+    {
+      tab: "ClinePass",
+      title: "Cline usage card",
+      hiddenTexts: [
+        "sk-cli***7890",
+        "https://api.cline.bot/api/v1",
+        "Models",
+        "模型",
+      ],
+    },
+    {
+      tab: "Ollama Cloud",
+      title: "Ollama usage card",
+      hiddenTexts: ["sk-oll***4321", "https://ollama.com", "Models", "模型"],
+    },
+  ]) {
+    await page.getByRole("tab", { name: provider.tab }).click();
+
+    const list = page.getByTestId("providers-tab-scroll");
+    await expect(list).toBeVisible();
+    await expect(page.getByText(provider.title, { exact: true })).toBeVisible();
+
+    for (const text of provider.hiddenTexts) {
+      await expect(list).not.toContainText(text);
+    }
+
+    const titleLeftOffset = await getTitleLeftOffset(page, provider.title);
+    expect(
+      titleLeftOffset,
+      `${provider.tab} title should align to card padding`,
+    ).toBeGreaterThanOrEqual(15);
+    expect(
+      titleLeftOffset,
+      `${provider.tab} title should align to card padding`,
+    ).toBeLessThanOrEqual(19);
   }
 });

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -74,16 +74,14 @@ export function ProviderCard({
     >
       {/* Header */}
       <div className="flex min-w-0 items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex min-w-0 items-center">
           {onToggleSelected ? (
             <div
               className={[
-                "flex shrink-0 items-center justify-center overflow-hidden transition-[width,opacity] duration-200 ease-out",
+                "flex shrink-0 items-center justify-center overflow-hidden transition-[width,opacity,margin] duration-200 ease-out",
                 selected
-                  ? "w-7 opacity-100"
-                  : naturalHeight
-                    ? "w-7 opacity-0 group-hover:opacity-100 max-md:opacity-100"
-                    : "w-0 opacity-0 group-hover:w-7 group-hover:opacity-100 max-md:w-7 max-md:opacity-100",
+                  ? "mr-2 w-7 opacity-100"
+                  : "mr-0 w-0 opacity-0 group-hover:mr-2 group-hover:w-7 group-hover:opacity-100 max-md:mr-2 max-md:w-7 max-md:opacity-100",
               ].join(" ")}
             >
               <input
@@ -102,7 +100,7 @@ export function ProviderCard({
             {title}
           </p>
           {hasHeaderExtra ? (
-            <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+            <div className="ml-2 flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
               {headerExtra}
             </div>
           ) : null}

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -738,6 +738,7 @@ describe("ProvidersPage OpenCode Go tab", () => {
 
 describe("ProvidersPage Cline tab", () => {
   beforeEach(() => {
+    localStorage.clear();
     Object.values(mocks).forEach((mock) => mock.mockReset());
     mocks.getGeminiKeys.mockImplementation(async () => []);
     mocks.getClaudeConfigs.mockImplementation(async () => []);
@@ -788,6 +789,59 @@ describe("ProvidersPage Cline tab", () => {
     mocks.apiKeyEntriesList.mockImplementation(async () => []);
     mocks.channelGroupsList.mockImplementation(async () => []);
     mocks.proxiesList.mockImplementation(async () => []);
+  });
+
+  test("renders cached ClinePass configs while refreshing the fresh list", async () => {
+    let resolveFresh: ((value: unknown[]) => void) | undefined;
+    localStorage.setItem("providers-page:tab", "cline");
+    localStorage.setItem(
+      "providers-page:cache:cline",
+      JSON.stringify({
+        data: [
+          {
+            name: "Cline Cached",
+            apiKey: "sk-cline-cached",
+            baseUrl: "https://api.cline.bot/api/v1",
+          },
+        ],
+        timestamp: Date.now(),
+      }),
+    );
+    mocks.getClineConfigs.mockImplementation(
+      async () =>
+        new Promise((resolve) => {
+          resolveFresh = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument();
+    expect(await screen.findByText("Cline Cached")).toBeInTheDocument();
+    expect(screen.queryByText("Cline Fresh")).not.toBeInTheDocument();
+
+    resolveFresh?.([
+      {
+        name: "Cline Fresh",
+        apiKey: "sk-cline-fresh",
+        baseUrl: "https://api.cline.bot/api/v1",
+      },
+    ]);
+
+    expect(await screen.findByText("Cline Fresh")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(localStorage.getItem("providers-page:cache:cline")).toContain("Cline Fresh"),
+    );
   });
 
   test("opens Cline route and saves default Base URL", async () => {
@@ -1038,6 +1092,7 @@ describe("ProvidersPage Cline tab", () => {
 
 describe("ProvidersPage Ollama Cloud tab", () => {
   beforeEach(() => {
+    localStorage.clear();
     Object.values(mocks).forEach((mock) => mock.mockReset());
     mocks.getGeminiKeys.mockImplementation(async () => []);
     mocks.getClaudeConfigs.mockImplementation(async () => []);
@@ -1068,6 +1123,61 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     mocks.apiKeyEntriesList.mockImplementation(async () => []);
     mocks.channelGroupsList.mockImplementation(async () => []);
     mocks.proxiesList.mockImplementation(async () => []);
+  });
+
+  test("renders cached Ollama Cloud configs while refreshing the fresh list", async () => {
+    let resolveFresh: ((value: unknown[]) => void) | undefined;
+    localStorage.setItem("providers-page:tab", "ollama-cloud");
+    localStorage.setItem(
+      "providers-page:cache:ollama-cloud",
+      JSON.stringify({
+        data: [
+          {
+            name: "Ollama Cached",
+            apiKey: "sk-ollama-cached",
+            baseUrl: "https://ollama.com",
+          },
+        ],
+        timestamp: Date.now(),
+      }),
+    );
+    mocks.getOllamaCloudConfigs.mockImplementation(
+      async () =>
+        new Promise((resolve) => {
+          resolveFresh = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument();
+    expect(await screen.findByText("Ollama Cached")).toBeInTheDocument();
+    expect(screen.queryByText("Ollama Fresh")).not.toBeInTheDocument();
+
+    resolveFresh?.([
+      {
+        name: "Ollama Fresh",
+        apiKey: "sk-ollama-fresh",
+        baseUrl: "https://ollama.com",
+      },
+    ]);
+
+    expect(await screen.findByText("Ollama Fresh")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(localStorage.getItem("providers-page:cache:ollama-cloud")).toContain(
+        "Ollama Fresh",
+      ),
+    );
   });
 
   test("shows Ollama Cloud dynamic model list without manual model inputs", async () => {

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -1018,6 +1018,7 @@ describe("ProvidersPage Cline tab", () => {
       {
         name: "Cline Hidden Excluded",
         apiKey: "sk-cline-hidden",
+        baseUrl: "https://api.cline.bot/api/v1",
         excludedModels: ["cline-pass/legacy-disabled-only"],
       },
     ]);
@@ -1036,6 +1037,10 @@ describe("ProvidersPage Cline tab", () => {
 
     await user.click(await screen.findByRole("tab", { name: /ClinePass/ }));
     expect(await screen.findByText("Cline Hidden Excluded")).toBeInTheDocument();
+    expect(screen.queryByText("sk-cline-hidden")).not.toBeInTheDocument();
+    expect(screen.queryByText("sk-cli***dden")).not.toBeInTheDocument();
+    expect(screen.queryByText("https://api.cline.bot/api/v1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Models")).not.toBeInTheDocument();
     expect(screen.queryByText("cline-pass/legacy-disabled-only")).not.toBeInTheDocument();
   });
 
@@ -1304,6 +1309,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
       {
         name: "Ollama Hidden Excluded",
         apiKey: "sk-ollama-hidden",
+        baseUrl: "https://ollama.com",
         excludedModels: ["gpt-oss:legacy-disabled-only"],
       },
     ]);
@@ -1322,6 +1328,10 @@ describe("ProvidersPage Ollama Cloud tab", () => {
 
     await user.click(await screen.findByRole("tab", { name: /Ollama Cloud/ }));
     expect(await screen.findByText("Ollama Hidden Excluded")).toBeInTheDocument();
+    expect(screen.queryByText("sk-ollama-hidden")).not.toBeInTheDocument();
+    expect(screen.queryByText("sk-oll***dden")).not.toBeInTheDocument();
+    expect(screen.queryByText("https://ollama.com")).not.toBeInTheDocument();
+    expect(screen.queryByText("Models")).not.toBeInTheDocument();
     expect(screen.queryByText("gpt-oss:legacy-disabled-only")).not.toBeInTheDocument();
   });
 });

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -32,7 +32,7 @@ import { useProviderKeyEditor } from "../hooks/useProviderKeyEditor";
 import { useProviderLatency } from "../hooks/useProviderLatency";
 import { useProviderUsageSummary } from "../hooks/useProviderUsageSummary";
 import { normalizeUsageSourceId, type KeyStatBucket } from "@code-proxy/domain";
-import { getCachedData, removeCachedData, setCachedData } from "../provider-cache";
+import { getCachedData, setCachedData } from "../provider-cache";
 import { maskApiKey, readBool, readString, type AmpMappingEntry } from "../providers-helpers";
 import {
   createProviderExportText,
@@ -265,8 +265,12 @@ export function ProvidersPage() {
   const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>(
     () => getCachedData<ProviderSimpleConfig[]>("opencode-go") ?? [],
   );
-  const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [ollamaCloudKeys, setOllamaCloudKeys] = useState<ProviderSimpleConfig[]>([]);
+  const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>(
+    () => getCachedData<ProviderSimpleConfig[]>("cline") ?? [],
+  );
+  const [ollamaCloudKeys, setOllamaCloudKeys] = useState<ProviderSimpleConfig[]>(
+    () => getCachedData<ProviderSimpleConfig[]>("ollama-cloud") ?? [],
+  );
   const [vertexKeys, setVertexKeys] = useState<ProviderSimpleConfig[]>([]);
   const [bedrockKeys, setBedrockKeys] = useState<BedrockProviderConfig[]>([]);
   const [openaiProviders, setOpenaiProviders] = useState<OpenAIProvider[]>([]);
@@ -420,15 +424,19 @@ export function ProvidersPage() {
         break;
       }
       case "cline": {
-        removeCachedData("cline");
+        const cachedCl = getCachedData<ProviderSimpleConfig[]>("cline");
+        if (cachedCl) setClineKeys(cachedCl);
         const freshCl = await providersApi.getClineConfigs();
         setClineKeys(freshCl);
+        setCachedData("cline", freshCl);
         break;
       }
       case "ollama-cloud": {
-        removeCachedData("ollama-cloud");
+        const cachedOl = getCachedData<ProviderSimpleConfig[]>("ollama-cloud");
+        if (cachedOl) setOllamaCloudKeys(cachedOl);
         const freshOl = await providersApi.getOllamaCloudConfigs();
         setOllamaCloudKeys(freshOl);
+        setCachedData("ollama-cloud", freshOl);
         break;
       }
       case "vertex": {

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1212,9 +1212,9 @@ export function ProvidersPage() {
               getDisplayModels={(item) =>
                 getEffectiveProviderModels("cline", item, modelAccessCatalogs.cline)
               }
-              getLatencyEntry={getLatencyEntry}
-              checkLatency={checkLatency}
               naturalHeight
+              showConnectionRows={false}
+              showModelMetric={false}
               showExcludedModels={false}
               renderExtra={(item, idx) => {
                 const queryReady = hasProviderUsageQuery("cline", item);
@@ -1270,9 +1270,9 @@ export function ProvidersPage() {
                   modelAccessCatalogs["ollama-cloud"],
                 )
               }
-              getLatencyEntry={getLatencyEntry}
-              checkLatency={checkLatency}
               naturalHeight
+              showConnectionRows={false}
+              showModelMetric={false}
               showExcludedModels={false}
               renderExtra={(item, idx) => {
                 const queryReady = hasProviderUsageQuery("ollama-cloud", item);


### PR DESCRIPTION
## Summary
- reuse the providers page local cache for ClinePass and Ollama Cloud tabs
- keep cached cards visible while fresh provider configs load
- add regression tests for cached ClinePass and Ollama Cloud refresh behavior

## Verification
- rtk bun run --filter @code-proxy/admin-panel test pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
- rtk bun run build