### PR TITLE
fix: reset oauth dialog state

### DIFF
--- a/features/oauth-login/components/OAuthLoginDialog.tsx
+++ b/features/oauth-login/components/OAuthLoginDialog.tsx
@@ -122,14 +122,16 @@ export function OAuthLoginDialog({
   const { t } = useTranslation();
   const { notify } = useToast();
   const timers = useRef<Record<string, number>>({});
+  const pollRuns = useRef<Record<string, number>>({});
+  const completedStates = useRef<Record<string, string>>({});
 
   const [tab, setTab] = useState<TabValue>(defaultTab);
   const [selectedProxyID, setSelectedProxyID] = useState("");
   const proxyCheckState = useProxyPoolChecks(proxyPoolEntries, open);
 
-  const [states, setStates] = useState<Record<OAuthProvider, ProviderState>>(
-    {} as Record<OAuthProvider, ProviderState>,
-  );
+  const [states, setStates] = useState<
+    Partial<Record<OAuthProvider, ProviderState>>
+  >({});
 
   const [iflowCookie, setIflowCookie] = useState("");
   const [iflowLoading, setIflowLoading] = useState(false);
@@ -156,16 +158,25 @@ export function OAuthLoginDialog({
   useEffect(() => {
     if (!open) {
       clearTimers();
+      pollRuns.current = {};
+      completedStates.current = {};
       return;
     }
-    return () => clearTimers();
-  }, [clearTimers, open]);
-
-  useEffect(() => {
-    if (!open) return;
+    clearTimers();
+    pollRuns.current = {};
+    completedStates.current = {};
     setTab(defaultTab);
     setSelectedProxyID("");
-  }, [defaultTab, open]);
+    setStates({});
+    setIflowCookie("");
+    setIflowLoading(false);
+    setIflowResult(null);
+    setVertexFileName("");
+    setVertexLocation("");
+    setVertexLoading(false);
+    setVertexResult(null);
+    return () => clearTimers();
+  }, [clearTimers, defaultTab, open]);
 
   const getProviderTitle = useCallback(
     (provider: OAuthProvider) =>
@@ -206,7 +217,9 @@ export function OAuthLoginDialog({
   );
 
   const completeAuthorization = useCallback(
-    async (provider: OAuthProvider) => {
+    async (provider: OAuthProvider, state: string) => {
+      if (completedStates.current[provider] === state) return;
+      completedStates.current[provider] = state;
       clearProviderTimer(provider);
       updateProviderState(provider, {
         status: "success",
@@ -236,11 +249,16 @@ export function OAuthLoginDialog({
   const startPolling = useCallback(
     (provider: OAuthProvider, state: string) => {
       clearProviderTimer(provider);
+      const run = (pollRuns.current[provider] ?? 0) + 1;
+      pollRuns.current[provider] = run;
+      const isCurrentRun = () => pollRuns.current[provider] === run;
+
       const pollOnce = async () => {
         try {
           const res = await oauthApi.getAuthStatus(state);
+          if (!isCurrentRun()) return;
           if (res.status === "ok") {
-            await completeAuthorization(provider);
+            await completeAuthorization(provider, state);
           } else if (res.status === "error") {
             clearProviderTimer(provider);
             updateProviderState(provider, {
@@ -258,6 +276,7 @@ export function OAuthLoginDialog({
             });
           }
         } catch (err: unknown) {
+          if (!isCurrentRun()) return;
           clearProviderTimer(provider);
           updateProviderState(provider, {
             status: "error",
@@ -291,12 +310,17 @@ export function OAuthLoginDialog({
         provider === "gemini-cli"
           ? (states[provider]?.projectId || "").trim()
           : undefined;
+      pollRuns.current[provider] = (pollRuns.current[provider] ?? 0) + 1;
+      delete completedStates.current[provider];
+      clearProviderTimer(provider);
       updateProviderState(provider, {
         status: "waiting",
         polling: true,
         error: undefined,
         url: "",
         state: "",
+        callbackUrl: "",
+        callbackSubmitting: false,
         callbackStatus: undefined,
         callbackError: undefined,
       });
@@ -338,6 +362,7 @@ export function OAuthLoginDialog({
       startPolling,
       states,
       t,
+      clearProviderTimer,
       updateProviderState,
     ],
   );
@@ -403,13 +428,13 @@ export function OAuthLoginDialog({
           status: callbackState ? "waiting" : "success",
           polling: Boolean(callbackState),
         });
-        notify({
-          type: "success",
-          message: t("oauth.callback_submit_success"),
-        });
         if (callbackState) {
           startPolling(provider, callbackState);
         } else {
+          notify({
+            type: "success",
+            message: t("oauth.callback_submit_success"),
+          });
           await onAuthorized?.();
           updateProviderState(provider, { callbackSubmitting: false });
           onClose();

--- a/features/oauth-login/components/OAuthPage.tsx
+++ b/features/oauth-login/components/OAuthPage.tsx
@@ -89,10 +89,12 @@ export function OAuthPage() {
   const { t } = useTranslation();
   const { notify } = useToast();
   const timers = useRef<Record<string, number>>({});
+  const pollRuns = useRef<Record<string, number>>({});
+  const completedStates = useRef<Record<string, string>>({});
 
-  const [states, setStates] = useState<Record<OAuthProvider, ProviderState>>(
-    {} as Record<OAuthProvider, ProviderState>,
-  );
+  const [states, setStates] = useState<
+    Partial<Record<OAuthProvider, ProviderState>>
+  >({});
   const [iflowCookie, setIflowCookie] = useState("");
   const [iflowLoading, setIflowLoading] = useState(false);
   const [iflowResult, setIflowResult] =
@@ -113,6 +115,8 @@ export function OAuthPage() {
       window.clearInterval(timer),
     );
     timers.current = {};
+    pollRuns.current = {};
+    completedStates.current = {};
   }, []);
 
   const getProviderTitle = useCallback(
@@ -155,10 +159,17 @@ export function OAuthPage() {
       if (timers.current[provider]) {
         window.clearInterval(timers.current[provider]);
       }
+      const run = (pollRuns.current[provider] ?? 0) + 1;
+      pollRuns.current[provider] = run;
+      const isCurrentRun = () => pollRuns.current[provider] === run;
+
       const timer = window.setInterval(async () => {
         try {
           const res = await oauthApi.getAuthStatus(state);
+          if (!isCurrentRun()) return;
           if (res.status === "ok") {
+            if (completedStates.current[provider] === state) return;
+            completedStates.current[provider] = state;
             updateProviderState(provider, {
               status: "success",
               polling: false,
@@ -188,6 +199,7 @@ export function OAuthPage() {
             delete timers.current[provider];
           }
         } catch (err: unknown) {
+          if (!isCurrentRun()) return;
           updateProviderState(provider, {
             status: "error",
             error: getErrorMessage(err),
@@ -208,12 +220,20 @@ export function OAuthPage() {
         provider === "gemini-cli"
           ? (states[provider]?.projectId || "").trim()
           : undefined;
+      if (timers.current[provider]) {
+        window.clearInterval(timers.current[provider]);
+        delete timers.current[provider];
+      }
+      pollRuns.current[provider] = (pollRuns.current[provider] ?? 0) + 1;
+      delete completedStates.current[provider];
       updateProviderState(provider, {
         status: "waiting",
         polling: true,
         error: undefined,
         url: "",
         state: "",
+        callbackUrl: "",
+        callbackSubmitting: false,
         callbackStatus: undefined,
         callbackError: undefined,
       });
@@ -304,14 +324,19 @@ export function OAuthPage() {
             ? { code: callbackInput, state: currentState }
             : callbackInput,
         );
+        const callbackState = manualCodeProvider(provider)
+          ? currentState
+          : states[provider]?.state || "";
         updateProviderState(provider, {
           callbackSubmitting: false,
           callbackStatus: "success",
         });
-        notify({
-          type: "success",
-          message: t("oauth.callback_submit_success"),
-        });
+        if (!callbackState) {
+          notify({
+            type: "success",
+            message: t("oauth.callback_submit_success"),
+          });
+        }
       } catch (err: unknown) {
         const message =
           getErrorMessage(err) || t("oauth.callback_submit_failed");

--- a/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -31,6 +31,18 @@ const mocks = vi.hoisted(() => ({
   })),
 }));
 
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+}));
+
+vi.mock("goey-toast", () => ({
+  GoeyToaster: () => null,
+  goeyToast: toastMocks,
+}));
+
 vi.mock("@code-proxy/api-client", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@code-proxy/api-client")>();
   return {
@@ -61,16 +73,33 @@ vi.mock("@code-proxy/api-client/endpoints/proxies", () => ({
   },
 }));
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
 beforeEach(() => {
   window.localStorage.clear();
   window.sessionStorage.clear();
-  mocks.list.mockClear();
-  mocks.getEntityStats.mockClear();
-  mocks.startAuth.mockClear();
-  mocks.getAuthStatus.mockClear();
-  mocks.submitCallback.mockClear();
-  mocks.iflowCookieAuth.mockClear();
-  mocks.importCredential.mockClear();
+  mocks.list.mockReset();
+  mocks.list.mockResolvedValue({ files: [] });
+  mocks.getEntityStats.mockReset();
+  mocks.getEntityStats.mockResolvedValue({ source: [], auth_index: [] });
+  mocks.startAuth.mockReset();
+  mocks.startAuth.mockResolvedValue({ url: "", state: "" });
+  mocks.getAuthStatus.mockReset();
+  mocks.getAuthStatus.mockResolvedValue({ status: "waiting" });
+  mocks.submitCallback.mockReset();
+  mocks.submitCallback.mockResolvedValue({});
+  mocks.iflowCookieAuth.mockReset();
+  mocks.iflowCookieAuth.mockResolvedValue({ status: "ok" });
+  mocks.importCredential.mockReset();
+  mocks.importCredential.mockResolvedValue({});
   mocks.getModelConfigs.mockReset();
   mocks.getModelConfigs.mockResolvedValue(Array<unknown>());
   mocks.getModelOwnerPresets.mockReset();
@@ -81,6 +110,10 @@ beforeEach(() => {
   mocks.proxiesCheck.mockReset();
   mocks.proxiesList.mockResolvedValue(Array<ProxyPoolEntry>());
   mocks.proxiesCheck.mockResolvedValue({ ok: true, latencyMs: 88 });
+  toastMocks.success.mockReset();
+  toastMocks.error.mockReset();
+  toastMocks.info.mockReset();
+  toastMocks.warning.mockReset();
 });
 
 describe("AuthFilesPage OAuth login dialog", () => {
@@ -295,6 +328,135 @@ describe("AuthFilesPage OAuth login dialog", () => {
         {},
       );
     });
+  });
+
+  test("clears OAuth dialog state when reopened", async () => {
+    const user = userEvent.setup();
+    mocks.startAuth.mockResolvedValueOnce({
+      url: "https://example.com/oauth",
+      state: "oauth-state",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add OAuth Login" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    const scoped = within(dialog);
+    await user.click(
+      scoped.getByRole("button", { name: "Start authorization" }),
+    );
+    expect(await scoped.findByText("https://example.com/oauth")).toBeInTheDocument();
+
+    const callbackInput = scoped.getByPlaceholderText(
+      "Paste the full callback URL from browser",
+    );
+    await user.type(
+      callbackInput,
+      "http://localhost:1455/auth/callback?code=test-code&state=oauth-state",
+    );
+    expect(callbackInput).toHaveValue(
+      "http://localhost:1455/auth/callback?code=test-code&state=oauth-state",
+    );
+
+    await user.click(scoped.getByRole("button", { name: "Close" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add OAuth Login" }));
+    const reopened = within(await screen.findByRole("dialog"));
+
+    expect(reopened.queryByText("https://example.com/oauth")).not.toBeInTheDocument();
+    expect(
+      reopened.getByPlaceholderText("Paste the full callback URL from browser"),
+    ).toHaveValue("");
+  });
+
+  test("shows one OAuth success toast when an old poll resolves after restart", async () => {
+    const user = userEvent.setup();
+    const firstPoll = deferred<{ status: "ok" }>();
+    const secondPoll = deferred<{ status: "ok" }>();
+    mocks.list
+      .mockResolvedValueOnce({ files: [] })
+      .mockResolvedValue({
+        files: [
+          {
+            name: "xai-new.json",
+            type: "xai",
+            size: 2048,
+            modified: Date.now(),
+            disabled: false,
+          },
+        ],
+      });
+    mocks.startAuth.mockResolvedValueOnce({
+      url: "https://accounts.x.ai/oauth2/consent",
+      state: "xai-state",
+    });
+    mocks.getAuthStatus
+      .mockImplementationOnce(() => firstPoll.promise)
+      .mockImplementationOnce(() => secondPoll.promise);
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add OAuth Login" }),
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    const scoped = within(dialog);
+    await user.click(scoped.getByRole("tab", { name: "xAI / Grok OAuth" }));
+    await user.click(
+      scoped.getByRole("button", { name: "Start authorization" }),
+    );
+    await waitFor(() => expect(mocks.getAuthStatus).toHaveBeenCalledTimes(1));
+
+    await user.type(
+      scoped.getByPlaceholderText("Paste the code shown by xAI / Grok"),
+      "manual-code",
+    );
+    await user.click(scoped.getByRole("button", { name: "Submit callback" }));
+    await waitFor(() => expect(mocks.getAuthStatus).toHaveBeenCalledTimes(2));
+
+    secondPoll.resolve({ status: "ok" });
+    await waitFor(() =>
+      expect(
+        toastMocks.success.mock.calls.filter(
+          ([title]) => title === "xAI / Grok OAuth authorization succeeded",
+        ),
+      ).toHaveLength(1),
+    );
+
+    firstPoll.resolve({ status: "ok" });
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(
+      toastMocks.success.mock.calls.filter(
+        ([title]) => title === "xAI / Grok OAuth authorization succeeded",
+      ),
+    ).toHaveLength(1);
   });
 
   test("keeps the dialog open until OAuth completes and the new auth file is listed", async () => {


### PR DESCRIPTION
## Summary
- reset OAuth dialog provider/iFlow/Vertex state every time the dialog opens
- ignore stale OAuth polling responses and make success handling idempotent by provider/state
- avoid showing both callback-submitted and authorization-success success toasts for pending OAuth flows

## Tests
- rtk bun run --filter @code-proxy/admin-panel test pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx --no-file-parallelism --maxWorkers=1
- rtk bun run --filter @code-proxy/admin-panel test ../../packages/api-client/src/endpoints/__tests__/oauth-proxy-id.test.ts --no-file-parallelism --maxWorkers=1
- rtk bun run build
- rtk bun run e2e --grep "OAuth dialog should submit callback url"
- rtk git -C codeProxy diff --check