### PR TITLE
fix: keep auth file provider filter valid

### DIFF
--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -62,27 +62,43 @@ const wait = (ms: number) =>
     window.setTimeout(resolve, ms);
   });
 
+const buildAuthFileSignature = (file: AuthFileItem): string =>
+  [
+    file.name,
+    file.type,
+    file.provider,
+    file.label,
+    file.email,
+    file.account_type,
+    file.size,
+    file.modified,
+    file.modtime,
+    file.authIndex,
+    file.auth_index,
+  ]
+    .map((value) => String(value ?? ""))
+    .join("|");
+
 const buildAuthFilesSignature = (items: AuthFileItem[]): string =>
   items
-    .map((file) =>
-      [
-        file.name,
-        file.type,
-        file.provider,
-        file.label,
-        file.email,
-        file.account_type,
-        file.size,
-        file.modified,
-        file.modtime,
-        file.authIndex,
-        file.auth_index,
-      ]
-        .map((value) => String(value ?? ""))
-        .join("|"),
-    )
+    .map(buildAuthFileSignature)
     .sort()
     .join("\n");
+
+const findChangedAuthFile = (
+  previousFiles: AuthFileItem[],
+  nextFiles: AuthFileItem[],
+): AuthFileItem | null => {
+  const previousSignatures = new Map(
+    previousFiles.map((file) => [String(file.name ?? ""), buildAuthFileSignature(file)]),
+  );
+  return (
+    nextFiles.find((file) => {
+      const name = String(file.name ?? "");
+      return previousSignatures.get(name) !== buildAuthFileSignature(file);
+    }) ?? null
+  );
+};
 
 export function AuthFilesPage() {
   const { t } = useTranslation();
@@ -162,6 +178,7 @@ export function AuthFilesPage() {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const filesRef = useRef<AuthFileItem[]>(files);
+  const oauthBaselineFilesRef = useRef<AuthFileItem[]>([]);
   const oauthBaselineSignatureRef = useRef("");
   const previousConfigModalTabRef = useRef<AuthFilesConfigModalTab | null>(null);
 
@@ -177,6 +194,7 @@ export function AuthFilesPage() {
 
   const setOAuthDialogOpenWithBaseline = useCallback((open: boolean) => {
     if (open) {
+      oauthBaselineFilesRef.current = filesRef.current;
       oauthBaselineSignatureRef.current = buildAuthFilesSignature(filesRef.current);
     }
     setOauthDialogOpen(open);
@@ -364,6 +382,18 @@ export function AuthFilesPage() {
     setSelectedFileNames,
   });
 
+  useEffect(() => {
+    const normalizedFilter = normalizeProviderKey(filter);
+    if (!normalizedFilter || normalizedFilter === "all" || loading || refreshingAll) return;
+    const filterExists = providerOptions.some(
+      (provider) => normalizeProviderKey(provider) === normalizedFilter,
+    );
+    if (!filterExists) {
+      setFilter("all");
+      setPage(1);
+    }
+  }, [filter, loading, providerOptions, refreshingAll]);
+
   const {
     connectivityState,
     quotaByFileName,
@@ -431,7 +461,17 @@ export function AuthFilesPage() {
   );
 
   const refreshAfterOAuthAuthorized = useCallback(async () => {
-    await waitForAuthFilesChanged();
+    const result = await waitForAuthFilesChanged();
+    const changedFile = findChangedAuthFile(oauthBaselineFilesRef.current, result.files);
+    if (!changedFile) return;
+
+    const provider = normalizeProviderKey(resolveFileType(changedFile));
+    if (!provider || provider === "all" || provider === "unknown") return;
+    setFilter(provider);
+    setTagFilter("");
+    setStatusFilter("all");
+    setSearch("");
+    setPage(1);
   }, [waitForAuthFilesChanged]);
 
   const handleUploadAndRefreshQuota = useCallback(

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@code-proxy/ui";
 import { ThemeProvider } from "@code-proxy/ui";
 import { AuthFilesPage } from "@pages/auth-files/AuthFilesPage";
+import type { AuthFileItem } from "@code-proxy/api-client";
 import {
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
@@ -14,7 +15,7 @@ import {
 import i18n from "@code-proxy/i18n";
 
 const mocks = vi.hoisted(() => ({
-  list: vi.fn(async () => ({
+  list: vi.fn<() => Promise<{ files: AuthFileItem[] }>>(async () => ({
     files: [
       {
         name: "qwen.json",
@@ -1221,6 +1222,52 @@ describe("AuthFilesPage files table", () => {
     await waitFor(() => {
       expect(mocks.deleteFile).toHaveBeenCalledWith("qwen.json");
       expect(screen.queryByText("qwen.json")).not.toBeInTheDocument();
+    });
+  });
+
+  test("resets the file group when deleting the last file for the selected provider", async () => {
+    const now = Date.now();
+    const xaiFile: AuthFileItem = {
+      name: "xai-user.json",
+      type: "xai",
+      provider: "xai",
+      account_type: "oauth",
+      email: "user@example.com",
+      auth_index: "xai-auth",
+      size: 2048,
+      modified: now,
+      disabled: false,
+    };
+
+    window.localStorage.setItem(
+      AUTH_FILES_UI_STATE_KEY,
+      JSON.stringify({ tab: "files", filter: "xai", search: "", page: 1 }),
+    );
+    mocks.list.mockImplementation(async () => ({ files: [xaiFile] }));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("user@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "File group" })).toHaveTextContent("xai (1)");
+
+    fireEvent.click(screen.getByLabelText("Select user@example.com"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete selected (1)" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteFile).toHaveBeenCalledWith("xai-user.json");
+      expect(screen.queryByText("user@example.com")).not.toBeInTheDocument();
+      expect(screen.getByRole("combobox", { name: "File group" })).toHaveTextContent("All (0)");
     });
   });
 

--- a/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -6,6 +6,7 @@ import { ToastProvider } from "@code-proxy/ui";
 import { ThemeProvider } from "@code-proxy/ui";
 import { AuthFilesPage } from "@pages/auth-files/AuthFilesPage";
 import type { AuthFileItem } from "@code-proxy/api-client";
+import { AUTH_FILES_UI_STATE_KEY } from "@code-proxy/domain";
 import type {
   ProxyCheckResult,
   ProxyPoolEntry,
@@ -457,6 +458,81 @@ describe("AuthFilesPage OAuth login dialog", () => {
         ([title]) => title === "xAI / Grok OAuth authorization succeeded",
       ),
     ).toHaveLength(1);
+  });
+
+  test("switches to the newly authorized xAI file group", async () => {
+    const user = userEvent.setup();
+    const now = Date.now();
+    const initialFile: AuthFileItem = {
+      name: "qwen.json",
+      type: "qwen",
+      size: 1024,
+      modified: now,
+      disabled: false,
+    };
+    const xaiFile: AuthFileItem = {
+      name: "xai-user.json",
+      type: "xai",
+      provider: "xai",
+      account_type: "oauth",
+      email: "user@example.com",
+      auth_index: "xai-auth",
+      size: 2048,
+      modified: now + 1,
+      disabled: false,
+    };
+    const firstPoll = deferred<{ status: "waiting" }>();
+    const secondPoll = deferred<{ status: "ok" }>();
+
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    window.localStorage.setItem(
+      AUTH_FILES_UI_STATE_KEY,
+      JSON.stringify({ tab: "files", filter: "qwen", search: "qwen", page: 1 }),
+    );
+    mocks.list
+      .mockResolvedValueOnce({ files: [initialFile] })
+      .mockResolvedValue({ files: [initialFile, xaiFile] });
+    mocks.startAuth.mockResolvedValueOnce({
+      url: "https://accounts.x.ai/oauth2/consent",
+      state: "xai-state",
+    });
+    mocks.getAuthStatus
+      .mockImplementationOnce(() => firstPoll.promise)
+      .mockImplementationOnce(() => secondPoll.promise);
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Add OAuth Login" }));
+
+    const dialog = await screen.findByRole("dialog");
+    const scoped = within(dialog);
+    await user.click(scoped.getByRole("tab", { name: "xAI / Grok OAuth" }));
+    await user.click(scoped.getByRole("button", { name: "Start authorization" }));
+    await waitFor(() => expect(mocks.getAuthStatus).toHaveBeenCalledTimes(1));
+
+    await user.type(scoped.getByPlaceholderText("Paste the code shown by xAI / Grok"), "code");
+    await user.click(scoped.getByRole("button", { name: "Submit callback" }));
+    await waitFor(() => expect(mocks.getAuthStatus).toHaveBeenCalledTimes(2));
+
+    secondPoll.resolve({ status: "ok" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    expect(screen.getByRole("combobox", { name: "File group" })).toHaveTextContent("xai (1)");
+    expect(await screen.findByText("user@example.com")).toBeInTheDocument();
+    expect(screen.queryByText("qwen.json")).not.toBeInTheDocument();
+
+    firstPoll.resolve({ status: "waiting" });
   });
 
   test("keeps the dialog open until OAuth completes and the new auth file is listed", async () => {


### PR DESCRIPTION
## Summary
- switch Auth Files to the newly authorized provider after OAuth success
- reset stale provider filters when the last file for that provider is removed
- add regression coverage for xAI OAuth auto-selection and stale provider cleanup

## Tests
- rtk bun run --filter @code-proxy/admin-panel test pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx --no-file-parallelism --maxWorkers=1
- rtk bun run build