### PR TITLE
feat: add xai billing quota cards

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -25,6 +25,7 @@ import {
   fetchQuota,
   resolveQuotaProvider,
 } from "@features/quota-preview/quota-fetch";
+import type { AuthFileItem } from "@code-proxy/api-client";
 
 beforeEach(() => {
   mocks.request.mockReset();
@@ -54,6 +55,14 @@ const buildSyntheticCodexIdToken = (accountId: string): string =>
 describe("resolveQuotaProvider", () => {
   test("supports kimi auth files", () => {
     expect(resolveQuotaProvider({ name: "kimi.json", provider: "kimi" } as any)).toBe("kimi");
+  });
+
+  test("supports xAI and Grok auth files", () => {
+    expect(resolveQuotaProvider({ name: "xai.json", provider: "xai" } as AuthFileItem)).toBe("xai");
+    expect(resolveQuotaProvider({ name: "grok.json", provider: "grok" } as AuthFileItem)).toBe(
+      "xai",
+    );
+    expect(resolveQuotaProvider({ name: "x-ai.json", type: "x-ai" } as AuthFileItem)).toBe("xai");
   });
 
   test("supports Anthropic OAuth auth files as Claude quota files", () => {
@@ -524,6 +533,107 @@ describe("fetchQuota for kimi", () => {
         percent: 0,
         resetAtMs: Date.parse("2026-04-22T01:24:38.060611Z"),
         windowSeconds: 604800,
+      },
+    ]);
+  });
+});
+
+describe("fetchQuota for xai", () => {
+  test("requests weekly and monthly Grok billing and returns quota items", async () => {
+    mocks.request
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        header: {},
+        bodyText: "",
+        body: JSON.stringify({
+          config: {
+            currentPeriod: {
+              type: "weekly",
+              start: "2026-07-06T00:00:00Z",
+              end: "2026-07-13T00:00:00Z",
+            },
+            creditUsagePercent: 25,
+            productUsage: [{ product: "Grok 4", usagePercent: 40 }],
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        header: {},
+        bodyText: "",
+        body: JSON.stringify({
+          config: {
+            monthlyLimit: { val: 15000 },
+            used: { val: 2000 },
+            onDemandCap: { val: 5000 },
+            onDemandUsed: { val: 1000 },
+            billingPeriodEnd: "2026-08-01T00:00:00Z",
+          },
+        }),
+      });
+
+    const result = await fetchQuota("xai", {
+      name: "xai-user.json",
+      provider: "grok",
+      auth_index: "xai-auth",
+      metadata: { oauth: { sub: "user-123" } },
+    } as AuthFileItem);
+
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    expect(mocks.request).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        authIndex: "xai-auth",
+        method: "GET",
+        url: "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+        header: expect.objectContaining({
+          Authorization: "Bearer $TOKEN$",
+          "x-xai-token-auth": "xai-grok-cli",
+          "x-grok-client-version": "0.2.91",
+          accept: "*/*",
+          "user-agent": "grok-pager/0.2.91 grok-shell/0.2.91 (macos; aarch64)",
+          "x-userid": "user-123",
+        }),
+      }),
+    );
+    expect(mocks.request).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        authIndex: "xai-auth",
+        method: "GET",
+        url: "https://cli-chat-proxy.grok.com/v1/billing",
+      }),
+    );
+    expect(result.planType).toBe("supergrok");
+    expect(result.items).toEqual([
+      {
+        key: "weekly_limit",
+        label: "xai_quota.weekly_limit",
+        percent: 75,
+        value: "xai_quota.used_percent::25%",
+        resetAtMs: Date.parse("2026-07-13T00:00:00Z"),
+        meta: expect.any(String),
+      },
+      {
+        key: "product:Grok 4",
+        label: "xai_quota.product_usage_named::Grok 4",
+        percent: 60,
+        value: "xai_quota.used_percent::40%",
+      },
+      {
+        key: "pay_as_you_go",
+        label: "xai_quota.pay_as_you_go_label",
+        percent: 80,
+        value: "80%",
+        meta: "$40.00 / $50.00",
+      },
+      {
+        key: "monthly_credits",
+        label: "xai_quota.monthly_credits",
+        percent: 87,
+        value: "87%",
+        resetAtMs: Date.parse("2026-08-01T00:00:00Z"),
+        meta: "$130.00 / $150.00",
       },
     ]);
   });

--- a/features/quota-preview/quota-fetch.ts
+++ b/features/quota-preview/quota-fetch.ts
@@ -17,14 +17,20 @@ import {
   KIRO_QUOTA_URL,
   KIRO_REQUEST_BODY,
   KIRO_REQUEST_HEADERS,
+  XAI_BILLING_MONTHLY_URL,
+  XAI_BILLING_WEEKLY_URL,
+  XAI_REQUEST_HEADERS,
   buildAntigravityItems,
   buildClaudeItems,
   buildCodexItems,
   buildGeminiCliBuckets,
   buildKimiItems,
   buildKiroItems,
+  buildXaiBillingSummary,
+  buildXaiItems,
   clampPercent,
   isRecord,
+  mergeXaiBillingSummaries,
   normalizeAuthIndexValue,
   normalizeGeminiCliModelId,
   normalizeNumberValue,
@@ -36,16 +42,27 @@ import {
   parseGeminiCliQuotaPayload,
   parseKimiUsagePayload,
   parseKiroQuotaPayload,
+  parseXaiBillingPayload,
   parseResetTimeToMs,
   resolveAuthProvider,
   resolveCodexChatgptAccountId,
   resolveCodexResetCreditExpirations,
   resolveCodexResetCreditCount,
+  resolveXaiPlanType,
   resolveGeminiCliProjectId,
+  resolveXaiUserId,
+  type XaiBillingSummary,
   type QuotaItem,
 } from "@features/quota-preview/quota-helpers";
 
-export type QuotaProvider = "antigravity" | "claude" | "codex" | "gemini-cli" | "kimi" | "kiro";
+export type QuotaProvider =
+  | "antigravity"
+  | "claude"
+  | "codex"
+  | "gemini-cli"
+  | "kimi"
+  | "kiro"
+  | "xai";
 export type QuotaFetchResult = {
   items: QuotaItem[];
   planType?: string | null;
@@ -77,6 +94,13 @@ const buildCodexRequestHeaders = (file: AuthFileItem): Record<string, string> =>
   return requestHeader;
 };
 
+const buildXaiRequestHeaders = (file: AuthFileItem): Record<string, string> => {
+  const headers: Record<string, string> = { ...XAI_REQUEST_HEADERS };
+  const userId = resolveXaiUserId(file);
+  if (userId) headers["x-userid"] = userId;
+  return headers;
+};
+
 export const resolveQuotaProvider = (file: AuthFileItem): QuotaProvider | null => {
   const provider = resolveAuthProvider(file);
   if (provider === "antigravity") return "antigravity";
@@ -86,6 +110,7 @@ export const resolveQuotaProvider = (file: AuthFileItem): QuotaProvider | null =
   if (provider === "gemini-cli") return "gemini-cli";
   if (provider === "kimi") return "kimi";
   if (provider === "kiro") return "kiro";
+  if (provider === "xai") return "xai";
   return null;
 };
 
@@ -135,6 +160,23 @@ const isClaudeOAuthLikeFile = (file: AuthFileItem): boolean => {
     return false;
   }
   return true;
+};
+
+const requestXaiBilling = async (
+  authIndex: string,
+  url: string,
+  header: Record<string, string>,
+): Promise<XaiBillingSummary | null> => {
+  const result = await apiCallApi.request({
+    authIndex,
+    method: "GET",
+    url,
+    header,
+  });
+  if (result.statusCode < 200 || result.statusCode >= 300)
+    throw new Error(getApiCallErrorMessage(result));
+  const payload = parseXaiBillingPayload(result.body ?? result.bodyText);
+  return buildXaiBillingSummary(payload?.config);
 };
 
 export const fetchQuota = async (
@@ -298,6 +340,27 @@ export const fetchQuota = async (
     const payload = parseKimiUsagePayload(result.body ?? result.bodyText);
     if (!payload) throw new Error("parse_kimi_failed");
     return { items: buildKimiItems(payload) };
+  }
+
+  if (type === "xai") {
+    const header = buildXaiRequestHeaders(file);
+    const [weeklyResult, monthlyResult] = await Promise.allSettled([
+      requestXaiBilling(authIndex, XAI_BILLING_WEEKLY_URL, header),
+      requestXaiBilling(authIndex, XAI_BILLING_MONTHLY_URL, header),
+    ]);
+    const weeklySummary = weeklyResult.status === "fulfilled" ? weeklyResult.value : null;
+    const monthlySummary = monthlyResult.status === "fulfilled" ? monthlyResult.value : null;
+    const summary = mergeXaiBillingSummaries(weeklySummary, monthlySummary);
+    if (!summary) {
+      if (weeklyResult.status === "rejected" && monthlyResult.status === "rejected") {
+        throw weeklyResult.reason;
+      }
+      throw new Error("empty_data");
+    }
+    return {
+      items: buildXaiItems(summary),
+      planType: resolveXaiPlanType(summary.monthlyLimitCents),
+    };
   }
 
   const result = await apiCallApi.request({

--- a/features/quota-preview/quota-helpers.ts
+++ b/features/quota-preview/quota-helpers.ts
@@ -30,6 +30,15 @@ export { type KiroQuotaPayload } from "@features/quota-preview/quota-kiro";
 export { buildKiroItems, parseKiroQuotaPayload } from "@features/quota-preview/quota-kiro";
 export { type KimiUsagePayload } from "@features/quota-preview/quota-kimi";
 export { buildKimiItems, parseKimiUsagePayload } from "@features/quota-preview/quota-kimi";
+export { type XaiBillingPayload, type XaiBillingSummary } from "@features/quota-preview/quota-xai";
+export {
+  buildXaiBillingSummary,
+  buildXaiItems,
+  mergeXaiBillingSummaries,
+  parseXaiBillingPayload,
+  resolveXaiPlanType,
+  resolveXaiUserId,
+} from "@features/quota-preview/quota-xai";
 export {
   clampPercent,
   formatRelativeResetLabel,
@@ -102,9 +111,21 @@ export const KIMI_REQUEST_HEADERS = {
   Authorization: "Bearer $TOKEN$",
 };
 
+export const XAI_BILLING_WEEKLY_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+export const XAI_BILLING_MONTHLY_URL = "https://cli-chat-proxy.grok.com/v1/billing";
+export const XAI_REQUEST_HEADERS = {
+  Authorization: "Bearer $TOKEN$",
+  "x-xai-token-auth": "xai-grok-cli",
+  "x-grok-client-version": "0.2.91",
+  accept: "*/*",
+  "user-agent": "grok-pager/0.2.91 grok-shell/0.2.91 (macos; aarch64)",
+};
+
 export const resolveAuthProvider = (file: AuthFileItem): string => {
   const raw = (file.provider ?? file.type ?? "") as unknown;
-  return String(raw).trim().toLowerCase();
+  const key = String(raw).trim().toLowerCase().replace(/_/g, "-");
+  if (key === "x-ai" || key === "grok") return "xai";
+  return key;
 };
 
 export const isDisabledAuthFile = (file: AuthFileItem): boolean => {

--- a/features/quota-preview/quota-xai.ts
+++ b/features/quota-preview/quota-xai.ts
@@ -1,0 +1,383 @@
+import type { AuthFileItem } from "@code-proxy/api-client";
+import type { QuotaItem } from "@features/quota-preview/quota-types";
+import {
+  clampPercent,
+  isRecord,
+  normalizeNumberValue,
+  normalizeStringValue,
+  parseResetTimeToMs,
+} from "@features/quota-preview/quota-normalizers";
+
+type XaiBillingCent = { val?: number | string };
+
+type XaiBillingPeriod = {
+  type?: string;
+  start?: string;
+  end?: string;
+};
+
+type XaiBillingProductUsage = {
+  product?: string;
+  usagePercent?: number | string | null;
+  usage_percent?: number | string | null;
+};
+
+export type XaiBillingConfig = {
+  currentPeriod?: XaiBillingPeriod | null;
+  current_period?: XaiBillingPeriod | null;
+  creditUsagePercent?: number | string | null;
+  credit_usage_percent?: number | string | null;
+  productUsage?: XaiBillingProductUsage[] | null;
+  product_usage?: XaiBillingProductUsage[] | null;
+  monthlyLimit?: XaiBillingCent | number | string | null;
+  monthly_limit?: XaiBillingCent | number | string | null;
+  used?: XaiBillingCent | number | string | null;
+  onDemandCap?: XaiBillingCent | number | string | null;
+  on_demand_cap?: XaiBillingCent | number | string | null;
+  onDemandUsed?: XaiBillingCent | number | string | null;
+  on_demand_used?: XaiBillingCent | number | string | null;
+  billingPeriodStart?: string;
+  billing_period_start?: string;
+  billingPeriodEnd?: string;
+  billing_period_end?: string;
+};
+
+export type XaiBillingPayload = {
+  config?: XaiBillingConfig | null;
+};
+
+type XaiBillingPeriodType = "weekly" | "monthly" | "unknown";
+
+type XaiProductUsageSummary = {
+  product: string;
+  usagePercent: number | null;
+};
+
+export type XaiBillingSummary = {
+  periodType: XaiBillingPeriodType;
+  usagePercent: number | null;
+  periodStart?: string;
+  periodEnd?: string;
+  productUsage: XaiProductUsageSummary[];
+  monthlyLimitCents: number | null;
+  usedCents: number | null;
+  includedUsedCents: number | null;
+  onDemandCapCents: number | null;
+  onDemandUsedCents: number | null;
+  onDemandUsedPercent: number | null;
+  billingPeriodStart?: string;
+  billingPeriodEnd?: string;
+  usedPercent: number | null;
+};
+
+export const parseXaiBillingPayload = (payload: unknown): XaiBillingPayload | null => {
+  if (payload === undefined || payload === null) return null;
+  if (typeof payload === "string") {
+    const trimmed = payload.trim();
+    if (!trimmed) return null;
+    try {
+      return JSON.parse(trimmed) as XaiBillingPayload;
+    } catch {
+      return null;
+    }
+  }
+  return typeof payload === "object" ? (payload as XaiBillingPayload) : null;
+};
+
+const normalizeXaiCentValue = (
+  value: XaiBillingCent | number | string | null | undefined,
+): number | null => {
+  if (value === undefined || value === null) return null;
+  if (isRecord(value)) return normalizeNumberValue(value.val);
+  return normalizeNumberValue(value);
+};
+
+const resolveXaiPeriodType = (period?: XaiBillingPeriod | null): XaiBillingPeriodType => {
+  const rawType = normalizeStringValue(period?.type)?.toLowerCase() ?? "";
+  if (rawType.includes("weekly")) return "weekly";
+  if (rawType.includes("monthly")) return "monthly";
+  return "unknown";
+};
+
+const normalizeXaiProductUsage = (
+  productUsage: XaiBillingProductUsage[] | null | undefined,
+): XaiProductUsageSummary[] => {
+  if (!Array.isArray(productUsage)) return [];
+  return productUsage
+    .map((item, index): XaiProductUsageSummary | null => {
+      if (!item || typeof item !== "object") return null;
+      const product = normalizeStringValue(item.product) ?? `Product ${index + 1}`;
+      const usagePercent = normalizeNumberValue(item.usagePercent ?? item.usage_percent);
+      return { product, usagePercent };
+    })
+    .filter((item): item is XaiProductUsageSummary => item !== null);
+};
+
+const emptyXaiBillingSummary = (): XaiBillingSummary => ({
+  periodType: "unknown",
+  usagePercent: null,
+  productUsage: [],
+  monthlyLimitCents: null,
+  usedCents: null,
+  includedUsedCents: null,
+  onDemandCapCents: null,
+  onDemandUsedCents: null,
+  onDemandUsedPercent: null,
+  usedPercent: null,
+});
+
+export const buildXaiBillingSummary = (
+  config: XaiBillingConfig | null | undefined,
+): XaiBillingSummary | null => {
+  if (!config || typeof config !== "object") return null;
+
+  const summary = emptyXaiBillingSummary();
+  const currentPeriod = config.currentPeriod ?? config.current_period ?? null;
+  const periodType = resolveXaiPeriodType(currentPeriod);
+  const creditUsagePercent = normalizeNumberValue(
+    config.creditUsagePercent ?? config.credit_usage_percent,
+  );
+  const periodStart =
+    normalizeStringValue(currentPeriod?.start) ??
+    normalizeStringValue(config.billingPeriodStart ?? config.billing_period_start) ??
+    undefined;
+  const periodEnd =
+    normalizeStringValue(currentPeriod?.end) ??
+    normalizeStringValue(config.billingPeriodEnd ?? config.billing_period_end) ??
+    undefined;
+  const productUsage = normalizeXaiProductUsage(config.productUsage ?? config.product_usage);
+
+  const monthlyLimitCents = normalizeXaiCentValue(config.monthlyLimit ?? config.monthly_limit);
+  const usedCents = normalizeXaiCentValue(config.used);
+  const onDemandCapCents = normalizeXaiCentValue(config.onDemandCap ?? config.on_demand_cap);
+  const explicitOnDemandUsedCents = normalizeXaiCentValue(
+    config.onDemandUsed ?? config.on_demand_used,
+  );
+  const billingPeriodStart =
+    normalizeStringValue(config.billingPeriodStart ?? config.billing_period_start) ?? undefined;
+  const billingPeriodEnd =
+    normalizeStringValue(config.billingPeriodEnd ?? config.billing_period_end) ?? undefined;
+
+  const includedUsedCents =
+    usedCents === null
+      ? null
+      : monthlyLimitCents !== null && monthlyLimitCents > 0
+        ? Math.min(usedCents, monthlyLimitCents)
+        : usedCents;
+  const derivedOnDemandUsedCents =
+    usedCents !== null && monthlyLimitCents !== null
+      ? Math.max(0, usedCents - monthlyLimitCents)
+      : null;
+  const onDemandUsedCents = explicitOnDemandUsedCents ?? derivedOnDemandUsedCents;
+  const usedPercent =
+    monthlyLimitCents !== null && monthlyLimitCents > 0 && includedUsedCents !== null
+      ? (includedUsedCents / monthlyLimitCents) * 100
+      : null;
+  const onDemandUsedPercent =
+    onDemandCapCents !== null && onDemandCapCents > 0 && onDemandUsedCents !== null
+      ? (onDemandUsedCents / onDemandCapCents) * 100
+      : null;
+
+  const hasWeeklyData =
+    creditUsagePercent !== null || periodType === "weekly" || productUsage.length > 0;
+  const hasMonthlyData =
+    monthlyLimitCents !== null ||
+    usedCents !== null ||
+    (!hasWeeklyData && (onDemandCapCents !== null || Boolean(billingPeriodEnd)));
+
+  if (!hasWeeklyData && !hasMonthlyData) return null;
+
+  summary.periodType = hasWeeklyData
+    ? periodType === "unknown"
+      ? "weekly"
+      : periodType
+    : "monthly";
+  summary.usagePercent = hasWeeklyData ? creditUsagePercent : usedPercent;
+  summary.periodStart = hasWeeklyData ? periodStart : billingPeriodStart;
+  summary.periodEnd = hasWeeklyData ? periodEnd : billingPeriodEnd;
+  summary.productUsage = productUsage;
+  summary.monthlyLimitCents = monthlyLimitCents;
+  summary.usedCents = usedCents;
+  summary.includedUsedCents = includedUsedCents;
+  summary.onDemandCapCents = onDemandCapCents;
+  summary.onDemandUsedCents = onDemandUsedCents;
+  summary.onDemandUsedPercent = onDemandUsedPercent;
+  summary.billingPeriodStart = hasMonthlyData ? billingPeriodStart : undefined;
+  summary.billingPeriodEnd = hasMonthlyData ? billingPeriodEnd : undefined;
+  summary.usedPercent = usedPercent;
+
+  return summary;
+};
+
+export const mergeXaiBillingSummaries = (
+  primary: XaiBillingSummary | null,
+  fallback: XaiBillingSummary | null,
+): XaiBillingSummary | null => {
+  if (!primary) return fallback;
+  if (!fallback) return primary;
+  return {
+    periodType: primary.periodType !== "unknown" ? primary.periodType : fallback.periodType,
+    usagePercent: primary.usagePercent ?? fallback.usagePercent,
+    periodStart: primary.periodStart ?? fallback.periodStart,
+    periodEnd: primary.periodEnd ?? fallback.periodEnd,
+    productUsage: primary.productUsage.length > 0 ? primary.productUsage : fallback.productUsage,
+    monthlyLimitCents: primary.monthlyLimitCents ?? fallback.monthlyLimitCents,
+    usedCents: primary.usedCents ?? fallback.usedCents,
+    includedUsedCents: primary.includedUsedCents ?? fallback.includedUsedCents,
+    onDemandCapCents: primary.onDemandCapCents ?? fallback.onDemandCapCents,
+    onDemandUsedCents: primary.onDemandUsedCents ?? fallback.onDemandUsedCents,
+    onDemandUsedPercent: primary.onDemandUsedPercent ?? fallback.onDemandUsedPercent,
+    billingPeriodStart: primary.billingPeriodStart ?? fallback.billingPeriodStart,
+    billingPeriodEnd: primary.billingPeriodEnd ?? fallback.billingPeriodEnd,
+    usedPercent: primary.usedPercent ?? fallback.usedPercent,
+  };
+};
+
+export const resolveXaiUserId = (file: AuthFileItem): string | null => {
+  const metadata = isRecord(file.metadata) ? file.metadata : null;
+  const attributes = isRecord(file.attributes) ? file.attributes : null;
+  const oauth = isRecord(file.oauth)
+    ? file.oauth
+    : isRecord(metadata?.oauth)
+      ? metadata.oauth
+      : isRecord(attributes?.oauth)
+        ? attributes.oauth
+        : null;
+  const user = isRecord(file.user)
+    ? file.user
+    : isRecord(metadata?.user)
+      ? metadata.user
+      : isRecord(attributes?.user)
+        ? attributes.user
+        : null;
+  const candidates = [
+    file.sub,
+    file.subject,
+    file.user_id,
+    file.userId,
+    metadata?.sub,
+    metadata?.subject,
+    metadata?.user_id,
+    metadata?.userId,
+    attributes?.sub,
+    attributes?.subject,
+    attributes?.user_id,
+    attributes?.userId,
+    oauth?.sub,
+    oauth?.subject,
+    user?.sub,
+    user?.id,
+  ];
+  for (const candidate of candidates) {
+    const userId = normalizeStringValue(candidate);
+    if (userId) return userId;
+  }
+  return null;
+};
+
+const formatUsdFromCents = (cents: number | null): string => {
+  if (cents === null) return "--";
+  return new Intl.NumberFormat(undefined, { style: "currency", currency: "USD" }).format(
+    cents / 100,
+  );
+};
+
+const remainingPercent = (usedPercent: number | null): number | null =>
+  usedPercent === null ? null : Math.round(clampPercent(100 - usedPercent));
+
+const formatUsedPercent = (usedPercent: number | null): string =>
+  usedPercent === null ? "--" : `xai_quota.used_percent::${Math.round(clampPercent(usedPercent))}%`;
+
+const formatPercent = (percent: number | null): string =>
+  percent === null ? "--" : `${Math.round(clampPercent(percent))}%`;
+
+const formatPeriodRange = (start?: string, end?: string): string | undefined => {
+  const startMs = parseResetTimeToMs(start);
+  const endMs = parseResetTimeToMs(end);
+  const startLabel = startMs ? new Date(startMs).toLocaleDateString() : null;
+  const endLabel = endMs ? new Date(endMs).toLocaleDateString() : null;
+  if (startLabel && endLabel) return `${startLabel} - ${endLabel}`;
+  return endLabel ?? startLabel ?? undefined;
+};
+
+export const resolveXaiPlanType = (monthlyLimitCents: number | null): string | null => {
+  if (monthlyLimitCents === 15_000) return "supergrok";
+  if (monthlyLimitCents === 150_000) return "supergrok-heavy";
+  return null;
+};
+
+export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
+  const items: QuotaItem[] = [];
+  const weeklyUsed =
+    billing.periodType === "weekly" && billing.usagePercent !== null
+      ? clampPercent(billing.usagePercent)
+      : null;
+  if (
+    billing.periodType === "weekly" &&
+    (weeklyUsed !== null || Boolean(billing.periodEnd) || billing.productUsage.length > 0)
+  ) {
+    items.push({
+      key: "weekly_limit",
+      label: "xai_quota.weekly_limit",
+      percent: remainingPercent(weeklyUsed),
+      value: formatUsedPercent(weeklyUsed),
+      resetAtMs: parseResetTimeToMs(billing.periodEnd),
+      meta: formatPeriodRange(billing.periodStart, billing.periodEnd),
+    });
+  }
+
+  billing.productUsage.forEach((item) => {
+    const used = item.usagePercent === null ? null : clampPercent(item.usagePercent);
+    items.push({
+      key: `product:${item.product}`,
+      label: `xai_quota.product_usage_named::${item.product}`,
+      percent: remainingPercent(used),
+      value: formatUsedPercent(used),
+    });
+  });
+
+  if ((billing.onDemandCapCents ?? 0) > 0) {
+    const onDemandUsed =
+      billing.onDemandUsedPercent === null ? null : clampPercent(billing.onDemandUsedPercent);
+    const remainingCents =
+      billing.onDemandCapCents !== null && billing.onDemandUsedCents !== null
+        ? Math.max(0, billing.onDemandCapCents - billing.onDemandUsedCents)
+        : null;
+    items.push({
+      key: "pay_as_you_go",
+      label: "xai_quota.pay_as_you_go_label",
+      percent: remainingPercent(onDemandUsed),
+      value: formatPercent(remainingPercent(onDemandUsed)),
+      meta: `${formatUsdFromCents(remainingCents)} / ${formatUsdFromCents(billing.onDemandCapCents)}`,
+    });
+  } else {
+    items.push({
+      key: "pay_as_you_go",
+      label: "xai_quota.pay_as_you_go_label",
+      percent: null,
+      value: "xai_quota.pay_as_you_go_disabled",
+    });
+  }
+
+  if (
+    billing.monthlyLimitCents !== null ||
+    billing.usedCents !== null ||
+    Boolean(billing.billingPeriodEnd)
+  ) {
+    const monthlyUsed = billing.usedPercent === null ? null : clampPercent(billing.usedPercent);
+    const remainingCents =
+      billing.monthlyLimitCents !== null && billing.includedUsedCents !== null
+        ? Math.max(0, billing.monthlyLimitCents - billing.includedUsedCents)
+        : null;
+    items.push({
+      key: "monthly_credits",
+      label: "xai_quota.monthly_credits",
+      percent: remainingPercent(monthlyUsed),
+      value: formatPercent(remainingPercent(monthlyUsed)),
+      resetAtMs: parseResetTimeToMs(billing.billingPeriodEnd),
+      meta: `${formatUsdFromCents(remainingCents)} / ${formatUsdFromCents(billing.monthlyLimitCents)}`,
+    });
+  }
+
+  return items;
+};

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -1504,38 +1504,6 @@ export const resolveAuthFileStats = (file: AuthFileItem, index: UsageIndex): Key
   return bucket;
 };
 
-export const isXAIAuthFile = (file: AuthFileItem): boolean =>
-  normalizeProviderKey(resolveFileType(file)) === "xai";
-
-export const buildAuthFileLocalUsageQuotaItems = (
-  file: AuthFileItem,
-  index: UsageIndex,
-): QuotaItem[] => {
-  const stats = resolveAuthFileStats(file, index);
-  const total = stats.success + stats.failure;
-  const successRate = total > 0 ? (stats.success / total) * 100 : null;
-  return [
-    {
-      key: "local_success_rate",
-      label: "common.success_rate",
-      percent: successRate,
-      value: successRate === null ? "--" : `${successRate.toFixed(1)}%`,
-    },
-    {
-      key: "local_requests",
-      label: "auth_files.local_usage_requests",
-      percent: null,
-      value: String(total),
-    },
-    {
-      key: "local_failures",
-      label: "common.failure",
-      percent: null,
-      value: String(stats.failure),
-    },
-  ];
-};
-
 export const resolveAuthFileStatusBar = (file: AuthFileItem, index: UsageIndex): StatusBarData => {
   const stats = resolveAuthFileStats(file, index);
   if (stats.success === 0 && stats.failure === 0) {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -740,7 +740,6 @@
     "valid_mappings": "Valid mappings: {{count}}",
     "fork": "fork",
     "calls_count": "{{count}} calls",
-    "local_usage_requests": "Requests",
     "success_count": "Success {{count}}",
     "failed_count": "Failed {{count}}",
     "total_page": "Total {{total}} · Page {{page}} / {{pages}}",
@@ -969,6 +968,19 @@
     "plan_plus": "Plus",
     "plan_team": "Team",
     "plan_free": "Free"
+  },
+  "xai_quota": {
+    "title": "Grok Quota",
+    "weekly_limit": "Weekly limit",
+    "product_usage": "Product usage",
+    "product_usage_named": "{{product}} usage",
+    "used_percent": "Used {{percent}}",
+    "reset_at": "Resets {{time}}",
+    "pay_as_you_go_label": "Pay as you go",
+    "pay_as_you_go_disabled": "Not enabled",
+    "monthly_credits": "Monthly credits",
+    "plan_supergrok": "SuperGrok",
+    "plan_supergrok_heavy": "SuperGrok Heavy"
   },
   "gemini_cli_quota": {
     "title": "Gemini CLI Quota",
@@ -2404,6 +2416,8 @@
     "request_failed": "Request failed",
     "missing_account_id": "Missing Chatgpt-Account-Id",
     "parse_codex_failed": "Failed to parse Codex quota",
+    "parse_xai_failed": "Failed to parse Grok quota",
+    "empty_data": "No quota data available",
     "missing_project_id": "Missing Gemini CLI Project ID",
     "parse_kiro_failed": "Failed to parse Kiro quota",
     "load_auth_failed": "Failed to load auth files",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -754,7 +754,6 @@
     "valid_mappings": "有效映射：{{count}}",
     "fork": "分叉",
     "calls_count": "已调用 {{count}} 次",
-    "local_usage_requests": "请求数",
     "success_count": "成功 {{count}}",
     "failed_count": "失败 {{count}}",
     "total_page": "共 {{total}} 条 · 第 {{page}} / {{pages}} 页",
@@ -977,6 +976,19 @@
     "plan_plus": "Plus",
     "plan_team": "Team",
     "plan_free": "Free"
+  },
+  "xai_quota": {
+    "title": "Grok 额度",
+    "weekly_limit": "周限额",
+    "product_usage": "产品使用",
+    "product_usage_named": "{{product}} 使用",
+    "used_percent": "已用 {{percent}}",
+    "reset_at": "重置 {{time}}",
+    "pay_as_you_go_label": "按量付费",
+    "pay_as_you_go_disabled": "未启用",
+    "monthly_credits": "月度积分",
+    "plan_supergrok": "SuperGrok",
+    "plan_supergrok_heavy": "SuperGrok Heavy"
   },
   "gemini_cli_quota": {
     "title": "Gemini CLI 额度",
@@ -2421,6 +2433,8 @@
     "request_failed": "请求失败",
     "missing_account_id": "缺少 Chatgpt-Account-Id",
     "parse_codex_failed": "解析 Codex 配额失败",
+    "parse_xai_failed": "解析 Grok 额度失败",
+    "empty_data": "暂无额度数据",
     "missing_project_id": "缺少 Gemini CLI Project ID",
     "parse_kiro_failed": "解析 Kiro 配额失败",
     "load_auth_failed": "加载认证文件失败",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1274,7 +1274,7 @@ describe("AuthFilesPage files table", () => {
     });
   });
 
-  test("cards view shows xAI local usage in the quota panel", async () => {
+  test("cards view shows xAI billing quota instead of local usage", async () => {
     const now = Date.now();
     const xaiFile: AuthFileItem = {
       name: "xai-user.json",
@@ -1290,6 +1290,40 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     mocks.list.mockImplementation(async () => ({ files: [xaiFile] }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [
+        {
+          key: "weekly_limit",
+          label: "xai_quota.weekly_limit",
+          percent: 75,
+          value: "xai_quota.used_percent::25%",
+          resetAtMs: now + 7 * 24 * 60 * 60 * 1000,
+          meta: "07/06/2026 - 07/13/2026",
+        },
+        {
+          key: "product:Grok 4",
+          label: "xai_quota.product_usage_named::Grok 4",
+          percent: 60,
+          value: "xai_quota.used_percent::40%",
+        },
+        {
+          key: "pay_as_you_go",
+          label: "xai_quota.pay_as_you_go_label",
+          percent: 80,
+          value: "80%",
+          meta: "$40.00 / $50.00",
+        },
+        {
+          key: "monthly_credits",
+          label: "xai_quota.monthly_credits",
+          percent: 87,
+          value: "87%",
+          resetAtMs: now + 23 * 24 * 60 * 60 * 1000,
+          meta: "$130.00 / $150.00",
+        },
+      ],
+      planType: "supergrok",
+    });
     mocks.getEntityStats.mockImplementation(async () => ({
       source: [],
       auth_index: [
@@ -1321,14 +1355,21 @@ describe("AuthFilesPage files table", () => {
     const quota = within(card as HTMLElement).getByTestId("auth-file-card-quota");
 
     await waitFor(() => {
-      expect(quota).toHaveTextContent("Success Rate");
-      expect(quota).toHaveTextContent("90.0%");
-      expect(quota).toHaveTextContent("Requests");
-      expect(quota).toHaveTextContent("20");
-      expect(quota).toHaveTextContent("Failure");
-      expect(quota).toHaveTextContent("2");
+      expect(mocks.fetchQuota).toHaveBeenCalledWith(
+        "xai",
+        expect.objectContaining({ name: "xai-user.json" }),
+      );
+      expect(quota).toHaveTextContent("Weekly limit");
+      expect(quota).toHaveTextContent("Used 25%");
+      expect(quota).toHaveTextContent("Grok 4 usage");
+      expect(quota).toHaveTextContent("Pay as you go");
+      expect(quota).toHaveTextContent("$40.00 / $50.00");
+      expect(quota).toHaveTextContent("Monthly credits");
+      expect(quota).toHaveTextContent("$130.00 / $150.00");
+      expect(card as HTMLElement).toHaveTextContent("Plan SuperGrok");
     });
-    expect(mocks.fetchQuota).not.toHaveBeenCalled();
+    expect(quota).not.toHaveTextContent("Requests");
+    expect(quota).not.toHaveTextContent("Failure");
   });
 
   test("shows a skeleton table while first loading", async () => {

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -45,9 +45,7 @@ import {
   AUTH_FILES_PAGE_SIZE,
   AUTH_FILE_STATUS_FILTERS,
   TYPE_BADGE_CLASSES,
-  buildAuthFileLocalUsageQuotaItems,
   isRuntimeOnlyAuthFile,
-  isXAIAuthFile,
   normalizeAuthIndexValue,
   normalizeProviderKey,
   normalizeTagValue,
@@ -1346,17 +1344,7 @@ export function AuthFilesFilesTab({
                           : "text-rose-700 dark:text-rose-200";
 
                   const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
-                  const localUsageItems =
-                    !provider && isXAIAuthFile(file)
-                      ? buildAuthFileLocalUsageQuotaItems(file, usageIndex)
-                      : [];
-                  const slots = provider
-                    ? resolveQuotaCardSlots(provider, items)
-                    : localUsageItems.map((item) => ({
-                        id: item.key ?? item.label,
-                        label: item.label,
-                        item,
-                      }));
+                  const slots = provider ? resolveQuotaCardSlots(provider, items) : [];
 
                   const quotaRefreshing = provider
                     ? quotaByFileName[file.name]?.status === "loading"

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -22,7 +22,6 @@ import { ToggleSwitch } from "@code-proxy/ui";
 import type { DataTableColumn } from "@code-proxy/ui";
 import {
   pickQuotaPreviewItem,
-  buildAuthFileLocalUsageQuotaItems,
   type FilesViewMode,
   type QuotaPreviewMode,
   type UsageIndex,
@@ -41,7 +40,6 @@ import {
   resolveAuthFileStatusBar,
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
-  isXAIAuthFile,
   shouldShowAuthFileDisplayTag,
 } from "@code-proxy/domain";
 import { resolveQuotaProvider, type QuotaProvider } from "@features/quota-preview/quota-fetch";
@@ -58,6 +56,8 @@ const KNOWN_QUOTA_TEXT_KEYS = new Set([
   "request_failed",
   "missing_account_id",
   "parse_codex_failed",
+  "parse_xai_failed",
+  "empty_data",
   "missing_project_id",
   "parse_kiro_failed",
 ]);
@@ -190,6 +190,15 @@ export function useAuthFilesFilesPresentation({
   const translateQuotaText = useCallback(
     (text: string) => {
       if (!text) return text;
+      if (text.startsWith("xai_quota.")) {
+        const separatorIndex = text.indexOf("::");
+        const key = separatorIndex >= 0 ? text.slice(0, separatorIndex) : text;
+        const value = separatorIndex >= 0 ? text.slice(separatorIndex + 2) : "";
+        if (key === "xai_quota.product_usage_named" && value) return t(key, { product: value });
+        if (key === "xai_quota.used_percent" && value) return t(key, { percent: value });
+        if (key === "xai_quota.reset_at" && value) return t(key, { time: value });
+        return t(key);
+      }
       if (text.startsWith("m_quota.")) return t(text);
       if (text.startsWith("auth_files.")) return t(text);
       if (text.startsWith("common.")) return t(text);
@@ -213,6 +222,14 @@ export function useAuthFilesFilesPresentation({
       if (!normalized) return "";
       if (normalized === "plus" || normalized === "team" || normalized === "free") {
         return t(`codex_quota.plan_${normalized}`);
+      }
+      if (normalized === "supergrok") return t("xai_quota.plan_supergrok");
+      if (
+        normalized === "supergrok-heavy" ||
+        normalized === "supergrok_heavy" ||
+        normalized === "supergrokheavy"
+      ) {
+        return t("xai_quota.plan_supergrok_heavy");
       }
       return normalized.charAt(0).toUpperCase() + normalized.slice(1);
     },
@@ -473,6 +490,20 @@ export function useAuthFilesFilesPresentation({
     );
   }, []);
 
+  const formatQuotaItemDetailText = useCallback(
+    (item: QuotaItem | null | undefined) => {
+      const meta = item?.meta ? translateQuotaText(item.meta) : null;
+      const reset = formatQuotaResetTextCompact(item?.resetAtMs);
+      const resetLabel =
+        reset && item?.label.startsWith("xai_quota.")
+          ? t("xai_quota.reset_at", { time: reset })
+          : reset;
+      const parts = [meta, resetLabel].filter(Boolean);
+      return parts.length > 0 ? parts.join(" · ") : null;
+    },
+    [formatQuotaResetTextCompact, t, translateQuotaText],
+  );
+
   const renderQuotaHoverContent = useCallback(
     (state: QuotaState, options?: { suppressItemMeta?: boolean }) => {
       const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
@@ -491,10 +522,11 @@ export function useAuthFilesFilesPresentation({
               {items.map((item) => {
                 const tone = resolveQuotaVisualTone(item.percent);
                 const percentText =
-                  item.value ??
+                  (item.value ? translateQuotaText(item.value) : undefined) ??
                   (tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`);
-                const resetText = item.meta ?? formatQuotaResetTextCompact(item.resetAtMs);
-                const itemMeta = options?.suppressItemMeta ? undefined : item.meta;
+                const resetText = formatQuotaItemDetailText(item);
+                const itemMeta =
+                  options?.suppressItemMeta || resetText ? undefined : item.meta;
                 return (
                   <div key={item.label} className="contents">
                     <span className="min-w-0 truncate text-[10px] font-semibold text-slate-600 dark:text-white/70">
@@ -527,7 +559,7 @@ export function useAuthFilesFilesPresentation({
         </div>
       );
     },
-    [formatQuotaResetTextCompact, quotaProgressCircle, t, translateQuotaText],
+    [formatQuotaItemDetailText, quotaProgressCircle, t, translateQuotaText],
   );
 
   const renderQuotaBar = useCallback(
@@ -535,8 +567,9 @@ export function useAuthFilesFilesPresentation({
       const tone = resolveQuotaVisualTone(item?.percent);
       const normalized = tone.normalized;
       const percentText =
-        item?.value ?? (normalized === null ? "--" : `${Math.round(normalized)}%`);
-      const resetText = item?.meta ?? formatQuotaResetTextCompact(item?.resetAtMs) ?? "--";
+        (item?.value ? translateQuotaText(item.value) : undefined) ??
+        (normalized === null ? "--" : `${Math.round(normalized)}%`);
+      const detailText = formatQuotaItemDetailText(item) ?? "--";
 
       return (
         <div key={label} className="space-y-1">
@@ -561,12 +594,12 @@ export function useAuthFilesFilesPresentation({
             />
           </div>
           <div className="truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
-            {resetText}
+            {detailText}
           </div>
         </div>
       );
     },
-    [formatQuotaResetTextCompact, translateQuotaText],
+    [formatQuotaItemDetailText, translateQuotaText],
   );
 
   const fileColumns = useMemo<DataTableColumn<AuthFileItem>[]>(() => {
@@ -807,32 +840,23 @@ export function useAuthFilesFilesPresentation({
         ),
         render: (file) => {
           const provider = resolveQuotaProvider(file);
-          const localUsageItems =
-            !provider && isXAIAuthFile(file)
-              ? buildAuthFileLocalUsageQuotaItems(file, usageIndex)
-              : [];
-          if (!provider && localUsageItems.length === 0) {
+          if (!provider) {
             return <span className="text-xs text-slate-400 dark:text-white/40">--</span>;
           }
 
-          const state = provider
-            ? (quotaByFileName[file.name] ?? { status: "idle", items: [] })
-            : ({ status: "success", items: localUsageItems } satisfies QuotaState);
-          const rawItems = provider
-            ? Array.isArray(state.items)
-              ? (state.items as QuotaItem[])
-              : []
-            : localUsageItems;
+          const state = quotaByFileName[file.name] ?? { status: "idle", items: [] };
+          const rawItems = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
           const items =
             provider === "antigravity" ? filterAntigravityQuotaItems(rawItems) : rawItems;
           const displayState = items === rawItems ? state : { ...state, items };
-          const hasError = provider ? state.status === "error" : false;
+          const hasError = state.status === "error";
 
           const renderQuotaLinePreview = (item: QuotaItem) => {
             const tone = resolveQuotaVisualTone(item.percent);
             const percentText =
-              item.value ?? (tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`);
-            const resetText = item.meta ?? formatQuotaResetTextCompact(item.resetAtMs) ?? "--";
+              (item.value ? translateQuotaText(item.value) : undefined) ??
+              (tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`);
+            const detailText = formatQuotaItemDetailText(item) ?? "--";
             return (
               <div
                 key={item.label}
@@ -851,7 +875,7 @@ export function useAuthFilesFilesPresentation({
                   {percentText}
                 </span>
                 <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
-                  {resetText}
+                  {detailText}
                 </span>
               </div>
             );
@@ -1015,8 +1039,8 @@ export function useAuthFilesFilesPresentation({
     checkAuthFileConnectivity,
     connectivityState,
     downloadAuthFile,
+    formatQuotaItemDetailText,
     formatPlanTypeLabel,
-    formatQuotaResetTextCompact,
     openDetail,
     openTagsEditor,
     quotaByFileName,

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -129,6 +129,22 @@ export function useAuthFilesQuotaState({
 
   const resolveQuotaCardSlots = useCallback(
     (provider: QuotaProvider, items: QuotaItem[]) => {
+      const translateXaiQuotaText = (text: string) => {
+        const separatorIndex = text.indexOf("::");
+        const key = separatorIndex >= 0 ? text.slice(0, separatorIndex) : text;
+        const value = separatorIndex >= 0 ? text.slice(separatorIndex + 2) : "";
+        if (key === "xai_quota.product_usage_named" && value) {
+          return t(key, { product: value });
+        }
+        if (key === "xai_quota.used_percent" && value) {
+          return t(key, { percent: value });
+        }
+        if (key === "xai_quota.reset_at" && value) {
+          return t(key, { time: value });
+        }
+        return t(text);
+      };
+
       const translateQuotaLabel = (text: string) => {
         if (!text) return text;
         if (text.startsWith("m_quota.")) return t(text);
@@ -140,6 +156,7 @@ export function useAuthFilesQuotaState({
         }
         if (text.startsWith("claude_quota.")) return t(text);
         if (text.startsWith("antigravity_quota.")) return t(text);
+        if (text.startsWith("xai_quota.")) return translateXaiQuotaText(text);
         return text;
       };
 
@@ -154,6 +171,14 @@ export function useAuthFilesQuotaState({
       if (provider === "antigravity") {
         return filterAntigravityQuotaItems(items).map((item, index) => ({
           id: item.key ?? item.label ?? `antigravity-${index + 1}`,
+          label: translateQuotaLabel(item.label),
+          item,
+        }));
+      }
+
+      if (provider === "xai") {
+        return items.map((item, index) => ({
+          id: item.key ?? item.label ?? `xai-${index + 1}`,
           label: translateQuotaLabel(item.label),
           item,
         }));


### PR DESCRIPTION
## Summary
- add Grok/xAI billing quota fetch and parsing for weekly/monthly billing
- show SuperGrok plan, weekly limit, product usage, pay-as-you-go, and monthly credits in existing auth-file quota cards
- localize xAI quota labels and remove local usage fallback from xAI quota panels

## Verification
- rtk bun run --filter @code-proxy/admin-panel test features/quota-preview/__tests__/quota-fetch.test.ts pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run build