### PR TITLE
fix: unify xAI quota remaining display

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -610,7 +610,7 @@ describe("fetchQuota for xai", () => {
         key: "weekly_limit",
         label: "xai_quota.weekly_limit",
         percent: 75,
-        value: "xai_quota.used_percent::25%",
+        value: "75%",
         resetAtMs: Date.parse("2026-07-13T00:00:00Z"),
         meta: expect.any(String),
       },
@@ -618,14 +618,14 @@ describe("fetchQuota for xai", () => {
         key: "product:Grok 4",
         label: "xai_quota.product_usage_named::Grok 4",
         percent: 60,
-        value: "xai_quota.used_percent::40%",
+        value: "60%",
       },
       {
         key: "pay_as_you_go",
         label: "xai_quota.pay_as_you_go_label",
         percent: 80,
         value: "80%",
-        meta: "$40.00 / $50.00",
+        meta: expect.stringMatching(/40\.00.*50\.00/),
       },
       {
         key: "monthly_credits",
@@ -633,7 +633,7 @@ describe("fetchQuota for xai", () => {
         percent: 87,
         value: "87%",
         resetAtMs: Date.parse("2026-08-01T00:00:00Z"),
-        meta: "$130.00 / $150.00",
+        meta: expect.stringMatching(/130\.00.*150\.00/),
       },
     ]);
   });

--- a/features/quota-preview/quota-xai.ts
+++ b/features/quota-preview/quota-xai.ts
@@ -282,14 +282,12 @@ const formatUsdFromCents = (cents: number | null): string => {
   );
 };
 
-const remainingPercent = (usedPercent: number | null): number | null =>
-  usedPercent === null ? null : Math.round(clampPercent(100 - usedPercent));
+// Bar + label both mean "remaining". Null/unknown usage is treated as fully remaining (100%).
+const remainingPercent = (usedPercent: number | null): number =>
+  usedPercent === null ? 100 : Math.round(clampPercent(100 - usedPercent));
 
-const formatUsedPercent = (usedPercent: number | null): string =>
-  usedPercent === null ? "--" : `xai_quota.used_percent::${Math.round(clampPercent(usedPercent))}%`;
-
-const formatPercent = (percent: number | null): string =>
-  percent === null ? "--" : `${Math.round(clampPercent(percent))}%`;
+const formatRemainingPercent = (usedPercent: number | null): string =>
+  `${remainingPercent(usedPercent)}%`;
 
 const formatPeriodRange = (start?: string, end?: string): string | undefined => {
   const startMs = parseResetTimeToMs(start);
@@ -320,7 +318,7 @@ export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
       key: "weekly_limit",
       label: "xai_quota.weekly_limit",
       percent: remainingPercent(weeklyUsed),
-      value: formatUsedPercent(weeklyUsed),
+      value: formatRemainingPercent(weeklyUsed),
       resetAtMs: parseResetTimeToMs(billing.periodEnd),
       meta: formatPeriodRange(billing.periodStart, billing.periodEnd),
     });
@@ -332,7 +330,7 @@ export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
       key: `product:${item.product}`,
       label: `xai_quota.product_usage_named::${item.product}`,
       percent: remainingPercent(used),
-      value: formatUsedPercent(used),
+      value: formatRemainingPercent(used),
     });
   });
 
@@ -347,15 +345,16 @@ export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
       key: "pay_as_you_go",
       label: "xai_quota.pay_as_you_go_label",
       percent: remainingPercent(onDemandUsed),
-      value: formatPercent(remainingPercent(onDemandUsed)),
+      value: formatRemainingPercent(onDemandUsed),
       meta: `${formatUsdFromCents(remainingCents)} / ${formatUsdFromCents(billing.onDemandCapCents)}`,
     });
   } else {
+    // Not enabled: treat as full remaining (100% green bar), no "disabled" status text.
     items.push({
       key: "pay_as_you_go",
       label: "xai_quota.pay_as_you_go_label",
-      percent: null,
-      value: "xai_quota.pay_as_you_go_disabled",
+      percent: 100,
+      value: "100%",
     });
   }
 
@@ -373,7 +372,7 @@ export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
       key: "monthly_credits",
       label: "xai_quota.monthly_credits",
       percent: remainingPercent(monthlyUsed),
-      value: formatPercent(remainingPercent(monthlyUsed)),
+      value: formatRemainingPercent(monthlyUsed),
       resetAtMs: parseResetTimeToMs(billing.billingPeriodEnd),
       meta: `${formatUsdFromCents(remainingCents)} / ${formatUsdFromCents(billing.monthlyLimitCents)}`,
     });

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -975,6 +975,7 @@
     "product_usage": "Product usage",
     "product_usage_named": "{{product}} usage",
     "used_percent": "Used {{percent}}",
+    "remaining_percent": "Left {{percent}}",
     "reset_at": "Resets {{time}}",
     "pay_as_you_go_label": "Pay as you go",
     "pay_as_you_go_disabled": "Not enabled",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -983,6 +983,7 @@
     "product_usage": "产品使用",
     "product_usage_named": "{{product}} 使用",
     "used_percent": "已用 {{percent}}",
+    "remaining_percent": "剩余 {{percent}}",
     "reset_at": "重置 {{time}}",
     "pay_as_you_go_label": "按量付费",
     "pay_as_you_go_disabled": "未启用",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1296,7 +1296,7 @@ describe("AuthFilesPage files table", () => {
           key: "weekly_limit",
           label: "xai_quota.weekly_limit",
           percent: 75,
-          value: "xai_quota.used_percent::25%",
+          value: "75%",
           resetAtMs: now + 7 * 24 * 60 * 60 * 1000,
           meta: "07/06/2026 - 07/13/2026",
         },
@@ -1304,7 +1304,7 @@ describe("AuthFilesPage files table", () => {
           key: "product:Grok 4",
           label: "xai_quota.product_usage_named::Grok 4",
           percent: 60,
-          value: "xai_quota.used_percent::40%",
+          value: "60%",
         },
         {
           key: "pay_as_you_go",
@@ -1360,14 +1360,16 @@ describe("AuthFilesPage files table", () => {
         expect.objectContaining({ name: "xai-user.json" }),
       );
       expect(quota).toHaveTextContent("Weekly limit");
-      expect(quota).toHaveTextContent("Used 25%");
+      expect(quota).toHaveTextContent("75%");
       expect(quota).toHaveTextContent("Grok 4 usage");
+      expect(quota).toHaveTextContent("60%");
       expect(quota).toHaveTextContent("Pay as you go");
       expect(quota).toHaveTextContent("$40.00 / $50.00");
       expect(quota).toHaveTextContent("Monthly credits");
       expect(quota).toHaveTextContent("$130.00 / $150.00");
       expect(card as HTMLElement).toHaveTextContent("Plan SuperGrok");
     });
+    expect(quota).not.toHaveTextContent("Used");
     expect(quota).not.toHaveTextContent("Requests");
     expect(quota).not.toHaveTextContent("Failure");
   });

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -196,6 +196,7 @@ export function useAuthFilesFilesPresentation({
         const value = separatorIndex >= 0 ? text.slice(separatorIndex + 2) : "";
         if (key === "xai_quota.product_usage_named" && value) return t(key, { product: value });
         if (key === "xai_quota.used_percent" && value) return t(key, { percent: value });
+        if (key === "xai_quota.remaining_percent" && value) return t(key, { percent: value });
         if (key === "xai_quota.reset_at" && value) return t(key, { time: value });
         return t(key);
       }
@@ -569,7 +570,8 @@ export function useAuthFilesFilesPresentation({
       const percentText =
         (item?.value ? translateQuotaText(item.value) : undefined) ??
         (normalized === null ? "--" : `${Math.round(normalized)}%`);
-      const detailText = formatQuotaItemDetailText(item) ?? "--";
+      // Keep a fixed-height meta row so bars stay evenly spaced; hide "--" when empty.
+      const detailText = formatQuotaItemDetailText(item);
 
       return (
         <div key={label} className="space-y-1">
@@ -593,8 +595,8 @@ export function useAuthFilesFilesPresentation({
               aria-hidden="true"
             />
           </div>
-          <div className="truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
-            {detailText}
+          <div className="min-h-[14px] truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
+            {detailText ?? "\u00A0"}
           </div>
         </div>
       );

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -139,6 +139,9 @@ export function useAuthFilesQuotaState({
         if (key === "xai_quota.used_percent" && value) {
           return t(key, { percent: value });
         }
+        if (key === "xai_quota.remaining_percent" && value) {
+          return t(key, { percent: value });
+        }
         if (key === "xai_quota.reset_at" && value) {
           return t(key, { time: value });
         }


### PR DESCRIPTION
## Summary
- Unify xAI quota progress bars and labels on **remaining** percent (e.g. used 8% → `92%` + ~92% green bar) so refresh no longer flips to “已用 X%” while the bar still shows remaining.
- Pay-as-you-go when disabled shows full green `100%` instead of “未启用” / empty bar.
- Empty meta under quota bars no longer renders `--`, but keeps a fixed-height placeholder so row spacing stays even.

## Test plan
- [x] `bun run test -- features/quota-preview/__tests__/quota-fetch.test.ts`
- [x] `bun run test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx`
- [ ] Manual: open manage/account-security xAI card, confirm remaining labels, full green disabled pay-as-you-go, no `--` under empty meta; hard refresh and confirm same semantics.