### PR TITLE
fix: stabilize xAI auth-file cycle, plan badge, and identity UI

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -612,6 +612,7 @@ describe("fetchQuota for xai", () => {
         percent: 75,
         value: "75%",
         resetAtMs: Date.parse("2026-07-13T00:00:00Z"),
+        windowSeconds: 604800,
         meta: expect.any(String),
       },
       {

--- a/features/quota-preview/quota-xai.ts
+++ b/features/quota-preview/quota-xai.ts
@@ -70,6 +70,9 @@ export type XaiBillingSummary = {
   usedPercent: number | null;
 };
 
+/** xAI weekly billing window length used for cycle tracking snapshots. */
+export const XAI_WEEKLY_WINDOW_SECONDS = 604_800;
+
 export const parseXaiBillingPayload = (payload: unknown): XaiBillingPayload | null => {
   if (payload === undefined || payload === null) return null;
   if (typeof payload === "string") {
@@ -320,6 +323,8 @@ export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
       percent: remainingPercent(weeklyUsed),
       value: formatRemainingPercent(weeklyUsed),
       resetAtMs: parseResetTimeToMs(billing.periodEnd),
+      // Required so backend can record weekly cycle start and power cycle call totals.
+      windowSeconds: XAI_WEEKLY_WINDOW_SECONDS,
       meta: formatPeriodRange(billing.periodStart, billing.periodEnd),
     });
   }

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -1352,6 +1352,24 @@ export const resolveAuthFilePlanType = (
   readCodexFilenamePlanType(String(file.name || "")) ??
   normalizePlanType(quotaState?.planType);
 
+/**
+ * Plan badges may come from auth-file tags (Codex plus/pro) or quota state (xAI SuperGrok).
+ * Only enforce display_tags visibility when the plan is part of the file's default tags;
+ * quota-derived plans are always shown when resolved.
+ */
+export const shouldShowAuthFilePlanBadge = (
+  file: AuthFileItem,
+  planType: string | null | undefined,
+): boolean => {
+  const normalized = normalizeTagValue(planType);
+  if (!normalized) return false;
+  const defaultTags = readAuthFileDefaultTags(file);
+  if (defaultTags.includes(normalized)) {
+    return shouldShowAuthFileDisplayTag(file, normalized);
+  }
+  return true;
+};
+
 export const resolveAuthFileSupplementalTags = (
   file: AuthFileItem,
   quotaState?: QuotaState | null,

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -914,6 +914,7 @@ export function AuthFilesPage() {
         mappedModelOwnerGroup={detailModelOwnerGroup}
         mappedModelOwnerValue={detailModelOwnerValue}
         excluded={excluded}
+        quotaState={detailFile ? (quotaByFileName[detailFile.name] ?? null) : null}
         prefixProxyEditor={prefixProxyEditor}
         setPrefixProxyEditor={setPrefixProxyEditor}
         prefixProxyDirty={prefixProxyDirty}

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -372,6 +372,132 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByText(/resets/)).not.toBeInTheDocument();
   });
 
+  test("shows SuperGrok plan badge and falls back cycle totals for xAI when cycle is unknown", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "xai-user.json",
+        label: "xAI Grok",
+        type: "xai",
+        provider: "xai",
+        size: 256,
+      },
+      modelsFileType: "xai",
+      quotaState: {
+        status: "success",
+        planType: "supergrok",
+        items: [],
+        updatedAt: Date.now(),
+      },
+      detailTrend: {
+        auth_index: "xai-auth",
+        days: 7,
+        hours: 5,
+        request_total: 116,
+        cycle_request_total: 0,
+        cycle_cost_total: 0,
+        weekly_quota_used_percent: null,
+        cycle_known: false,
+        cycle_start: "",
+        daily_usage: [{ date: "2026-07-08", requests: 116, cost: 0.12 }],
+        hourly_usage: [],
+        quota_series: [
+          {
+            quota_key: "weekly_limit",
+            quota_label: "xai_quota.weekly_limit",
+            window_seconds: 604800,
+            points: [{ timestamp: "2026-07-08T12:00:00Z", percent: 75 }],
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("SuperGrok")).toBeInTheDocument();
+    expectSummaryCard("Last 7 days requests", "116");
+    // When cycle_known is false, fall back to request_total instead of showing 0.
+    expectSummaryCard("Current weekly cycle", "116");
+    // Remaining snapshot percent 75% => used 25%.
+    expectSummaryCard("Weekly quota used", "25%");
+    expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
+  });
+
+  test("hides empty identity fingerprint field rows", () => {
+    renderDetailModal({
+      detailTab: "identity",
+      detailFile: {
+        name: "xai-user.json",
+        label: "xAI Grok",
+        type: "xai",
+        provider: "xai",
+        size: 256,
+        identity_fingerprint_summary: {
+          provider: "xai",
+          account_key: "xai-account",
+          enabled: true,
+          primary_source: "learned",
+          learned: true,
+          learned_fields: 1,
+          effective_fields: 2,
+          source_counts: { learned: 1 },
+          client_product: "grok-cli",
+          version: "0.3.1",
+        },
+      },
+      identityFingerprintDetail: {
+        summary: {
+          provider: "xai",
+          account_key: "xai-account",
+          enabled: true,
+          primary_source: "learned",
+          learned: true,
+          learned_fields: 1,
+          effective_fields: 2,
+          source_counts: { learned: 1 },
+          client_product: "grok-cli",
+          version: "0.3.1",
+        },
+        effective: {
+          provider: "xai",
+          account_key: "xai-account",
+          enabled: true,
+          client_product: "grok-cli",
+          version: "0.3.1",
+          fields: {
+            "user-agent": { value: "grok-cli/0.3.1", source: "learned" },
+            "x-empty-header": { value: "", source: "preset" },
+            "x-blank-header": { value: "   ", source: "builtin_default" },
+          },
+        },
+        learned: {
+          provider: "xai",
+          account_key: "xai-account",
+          client_product: "grok-cli",
+          version: "0.3.1",
+          fields: {
+            "user-agent": "grok-cli/0.3.1",
+            "x-empty-learned": "",
+          },
+          observed_headers: {
+            "user-agent": "grok-cli/0.3.1",
+            "x-empty-observed": "  ",
+          },
+          created_at: "2026-07-01T00:00:00Z",
+          updated_at: "2026-07-08T00:00:00Z",
+          last_seen_at: "2026-07-08T01:00:00Z",
+        },
+        preset: {},
+        builtin_default: {},
+      },
+    });
+
+    const fields = screen.getByTestId("auth-file-identity-fields");
+    expect(within(fields).getAllByText("user-agent").length).toBeGreaterThanOrEqual(1);
+    expect(within(fields).getAllByText("grok-cli/0.3.1").length).toBeGreaterThanOrEqual(1);
+    expect(within(fields).queryByText("x-empty-header")).not.toBeInTheDocument();
+    expect(within(fields).queryByText("x-blank-header")).not.toBeInTheDocument();
+    expect(within(fields).queryByText("x-empty-learned")).not.toBeInTheDocument();
+    expect(within(fields).queryByText("x-empty-observed")).not.toBeInTheDocument();
+  });
+
   test("renders account identity fingerprint sources and learned request headers in mobile flow", () => {
     renderDetailModal({
       detailTab: "identity",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1298,6 +1298,7 @@ describe("AuthFilesPage files table", () => {
           percent: 75,
           value: "75%",
           resetAtMs: now + 7 * 24 * 60 * 60 * 1000,
+          windowSeconds: 604800,
           meta: "07/06/2026 - 07/13/2026",
         },
         {
@@ -1747,6 +1748,80 @@ describe("AuthFilesPage files table", () => {
     expect(await within(card as HTMLElement).findByText("7 calls")).toBeInTheDocument();
     expect(within(card as HTMLElement).queryByText("99 calls")).not.toBeInTheDocument();
     expect(mocks.getAuthFileTrend).toHaveBeenCalledWith("77", { days: 7, hours: 5 });
+  });
+
+  test("cards view falls back to request_total when xAI weekly cycle is unknown", async () => {
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    mocks.list.mockImplementation(async () => ({
+      files: [
+        {
+          name: "xai-user.json",
+          type: "xai",
+          provider: "xai",
+          account_type: "oauth",
+          email: "user@example.com",
+          auth_index: "xai-auth",
+          size: 2048,
+          modified: Date.now(),
+          disabled: false,
+        },
+      ],
+    }));
+    mocks.getEntityStats.mockImplementation(
+      async () =>
+        ({
+          source: [],
+          auth_index: [
+            { entity_name: "xai-auth", requests: 116, failed: 0, avg_latency: 0, total_tokens: 0 },
+          ],
+        }) as any,
+    );
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) => ({
+      auth_index: authIndex,
+      days: 7,
+      hours: 5,
+      request_total: 116,
+      cycle_request_total: 0,
+      cycle_cost_total: 0,
+      weekly_quota_used_percent: null,
+      cycle_known: false,
+      cycle_start: "",
+      daily_usage: [{ date: "2026-07-08", requests: 116, cost: 0.12 }],
+      hourly_usage: [],
+      quota_series: [],
+    }));
+    mocks.fetchQuota.mockResolvedValue({
+      items: [
+        {
+          key: "weekly_limit",
+          label: "xai_quota.weekly_limit",
+          percent: 75,
+          value: "75%",
+          windowSeconds: 604800,
+        },
+      ],
+      planType: "supergrok",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("user@example.com");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    // Prefer request_total over a misleading cycle_request_total of 0 when cycle_known is false.
+    expect(await within(card as HTMLElement).findByText("116 calls")).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText("Plan SuperGrok")).toBeInTheDocument();
+    expect(mocks.getAuthFileTrend).toHaveBeenCalledWith("xai-auth", { days: 7, hours: 5 });
   });
 
   test("filters auth files by custom tag options", async () => {

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@code-proxy/ui";
 import { ThemeProvider } from "@code-proxy/ui";
 import { AuthFilesPage } from "@pages/auth-files/AuthFilesPage";
-import type { AuthFileItem, EntityStatsResponse } from "@code-proxy/api-client";
+import type { AuthFileItem, AuthFileTrendResponse, EntityStatsResponse } from "@code-proxy/api-client";
 import {
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
     source: [],
     auth_index: [],
   })),
-  getAuthFileTrend: vi.fn(async (authIndex: string) => ({
+  getAuthFileTrend: vi.fn(async (authIndex: string): Promise<AuthFileTrendResponse> => ({
     auth_index: authIndex,
     days: 7,
     hours: 5,

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -22,6 +22,7 @@ import {
   resolveAuthFileStats,
   sanitizeAuthFilesForCache,
   shouldShowAuthFileDisplayTag,
+  shouldShowAuthFilePlanBadge,
   writeAuthFilesDataCache,
   writeAuthFilesUiState,
 } from "@code-proxy/domain";
@@ -423,6 +424,54 @@ describe("Auth Files helper coverage", () => {
         "codex",
       ),
     ).toBe(true);
+  });
+
+  test("always shows quota-derived plan badges even when display tags omit them", () => {
+    // xAI SuperGrok is resolved from monthly credits, not auth-file default tags.
+    expect(
+      shouldShowAuthFilePlanBadge(
+        {
+          name: "xai.json",
+          type: "xai",
+          default_tags: ["xai"],
+          display_tags: ["xai"],
+        } as AuthFileItem,
+        "supergrok",
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowAuthFilePlanBadge(
+        {
+          name: "xai.json",
+          type: "xai",
+          default_tags: ["xai"],
+          display_tags: [],
+        } as AuthFileItem,
+        "supergrok-heavy",
+      ),
+    ).toBe(true);
+    // Codex plan tags still respect display_tags / hidden defaults.
+    expect(
+      shouldShowAuthFilePlanBadge(
+        {
+          name: "codex.json",
+          default_tags: ["codex", "pro"],
+          display_tags: ["codex"],
+        } as AuthFileItem,
+        "pro",
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowAuthFilePlanBadge(
+        {
+          name: "codex.json",
+          default_tags: ["codex", "pro"],
+          display_tags: ["codex", "pro"],
+        } as AuthFileItem,
+        "pro",
+      ),
+    ).toBe(true);
+    expect(shouldShowAuthFilePlanBadge({ name: "xai.json" } as AuthFileItem, null)).toBe(false);
   });
 
   test("drops stale display tags that no longer match current default or custom tags", () => {

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -49,6 +49,7 @@ import {
   type CodexOAuthAdmissionEditorState,
   type PrefixProxyEditorState,
 } from "@code-proxy/domain";
+import type { QuotaState } from "@features/quota-preview/quota-helpers";
 
 type DetailTab = "usage" | "identity" | "fields" | "models";
 type DetailTrendWindow = "5h" | "week";
@@ -192,6 +193,7 @@ interface AuthFileDetailModalProps {
   mappedModelOwnerGroup: AuthFileModelOwnerGroup | null;
   mappedModelOwnerValue: string;
   excluded: Record<string, string[]>;
+  quotaState?: QuotaState | null;
   prefixProxyEditor: PrefixProxyEditorState;
   setPrefixProxyEditor: Dispatch<SetStateAction<PrefixProxyEditorState>>;
   prefixProxyDirty: boolean;
@@ -233,6 +235,7 @@ export function AuthFileDetailModal({
   mappedModelOwnerGroup,
   mappedModelOwnerValue,
   excluded,
+  quotaState = null,
   prefixProxyEditor,
   setPrefixProxyEditor,
   prefixProxyDirty,
@@ -268,7 +271,7 @@ export function AuthFileDetailModal({
     ? resolveAuthFileDisplayName(detailFile) || String(detailFile.name || "")
     : t("auth_files.view_auth_file");
   const claudeOAuthHealth = detailFile ? resolveClaudeOAuthHealth(detailFile) : null;
-  const detailPlanType = detailFile ? resolveAuthFilePlanType(detailFile) : null;
+  const detailPlanType = detailFile ? resolveAuthFilePlanType(detailFile, quotaState) : null;
   const detailPlanLabel = useMemo(() => {
     if (!detailPlanType) return "";
     const normalized = detailPlanType.trim().toLowerCase();
@@ -276,7 +279,15 @@ export function AuthFileDetailModal({
     if (normalized === "plus" || normalized === "team" || normalized === "free") {
       return t(`codex_quota.plan_${normalized}`);
     }
-    return normalized;
+    if (normalized === "supergrok") return t("xai_quota.plan_supergrok");
+    if (
+      normalized === "supergrok-heavy" ||
+      normalized === "supergrok_heavy" ||
+      normalized === "supergrokheavy"
+    ) {
+      return t("xai_quota.plan_supergrok_heavy");
+    }
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
   }, [detailPlanType, t]);
   const excludedModels = excluded[providerKey] ?? [];
   const canRenameChannel = detailFile ? canRenameAuthFileChannel(detailFile) : false;
@@ -703,6 +714,8 @@ export function AuthFileDetailModal({
 
     const clientLabel =
       [summary.client_product, summary.client_variant].filter(Boolean).join(" / ") || "--";
+    const hasMeaningfulValue = (value: unknown): boolean =>
+      typeof value === "string" ? value.trim().length > 0 : value != null && value !== "";
     const effectiveRows = Object.entries(identityFingerprintDetail?.effective.fields ?? {})
       .map(
         ([key, field]): IdentityFingerprintFieldRow => ({
@@ -713,6 +726,7 @@ export function AuthFileDetailModal({
           source: field.source,
         }),
       )
+      .filter((row) => hasMeaningfulValue(row.value))
       .sort((left, right) => left.field.localeCompare(right.field));
     const learnedRows = Object.entries(identityFingerprintDetail?.learned?.fields ?? {})
       .map(
@@ -724,6 +738,7 @@ export function AuthFileDetailModal({
           source: "learned",
         }),
       )
+      .filter((row) => hasMeaningfulValue(row.value))
       .sort((left, right) => left.field.localeCompare(right.field));
     const observedHeaderRows = Object.entries(
       identityFingerprintDetail?.learned?.observed_headers ?? {},
@@ -737,6 +752,7 @@ export function AuthFileDetailModal({
           source: "learned",
         }),
       )
+      .filter((row) => hasMeaningfulValue(row.value))
       .sort((left, right) => left.field.localeCompare(right.field));
     const identityFieldRows = [...effectiveRows, ...learnedRows, ...observedHeaderRows];
 
@@ -924,10 +940,21 @@ export function AuthFileDetailModal({
 
     const formatCount = (value: number) =>
       Number.isFinite(value) ? Math.round(value).toLocaleString() : "0";
+    // Prefer cycle totals when the backend knows the weekly cycle start; otherwise fall back
+    // so xAI cards do not show a misleading 0 before weekly_limit snapshots exist.
+    const displayCycleRequestTotal =
+      detailTrend.cycle_known === true
+        ? detailTrend.cycle_request_total
+        : detailTrend.cycle_request_total > 0
+          ? detailTrend.cycle_request_total
+          : detailTrend.request_total;
+    const displayCycleCostTotal =
+      detailTrend.cycle_known === true
+        ? detailTrend.cycle_cost_total
+        : detailTrend.cycle_cost_total;
     const cycleStart = detailTrend.cycle_start
       ? new Date(detailTrend.cycle_start).toLocaleString()
       : "--";
-    const weeklyQuotaUsed = formatPercent(detailTrend.weekly_quota_used_percent);
     const fiveHourQuotaUsedPercent = isCodexDetail
       ? latestQuotaUsedPercent(
           detailTrend.quota_series,
@@ -943,13 +970,21 @@ export function AuthFileDetailModal({
             "code_week",
             (windowSeconds) => windowSeconds >= WEEK_WINDOW_SECONDS,
           )
-        : null);
+        : detailProviderKey === "xai"
+          ? latestQuotaUsedPercent(
+              detailTrend.quota_series,
+              "weekly_limit",
+              (windowSeconds) => windowSeconds >= WEEK_WINDOW_SECONDS,
+            )
+          : null);
+    // Prefer the backend weekly used percent; fall back to the latest weekly_limit snapshot for xAI.
+    const weeklyQuotaUsed = formatPercent(weeklyQuotaUsedPercent);
     const estimatedFiveHourQuota = estimateQuotaBudget(
       sumUsageCost(detailTrend.hourly_usage),
       fiveHourQuotaUsedPercent,
     );
     const estimatedWeeklyQuota = estimateQuotaBudget(
-      detailTrend.cycle_cost_total,
+      displayCycleCostTotal,
       weeklyQuotaUsedPercent,
     );
 
@@ -967,13 +1002,13 @@ export function AuthFileDetailModal({
           <div className={SUMMARY_CARD_CLASS_NAME}>
             <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_weekly_cycle")}</p>
             <p className={SUMMARY_VALUE_CLASS_NAME}>
-              {formatCount(detailTrend.cycle_request_total)}
+              {formatCount(displayCycleRequestTotal)}
             </p>
           </div>
           <div className={SUMMARY_CARD_CLASS_NAME}>
             <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_cycle_cost")}</p>
             <p className={SUMMARY_VALUE_CLASS_NAME}>
-              {formatCurrency(detailTrend.cycle_cost_total)}
+              {formatCurrency(displayCycleCostTotal)}
             </p>
           </div>
           {isCodexDetail ? (

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -54,6 +54,7 @@ import {
   resolveAuthFileSupplementalTags,
   resolveFileType,
   shouldShowAuthFileDisplayTag,
+  shouldShowAuthFilePlanBadge,
 } from "@code-proxy/domain";
 import {
   parseIdTokenPayload,
@@ -1322,9 +1323,7 @@ export function AuthFilesFilesTab({
                   const planType = resolveAuthFilePlanType(file, state);
                   const displayTags = resolveAuthFileSupplementalTags(file, state);
                   const showTypeBadge = shouldShowAuthFileDisplayTag(file, typeKey);
-                  const showPlanBadge = planType
-                    ? shouldShowAuthFileDisplayTag(file, planType)
-                    : false;
+                  const showPlanBadge = shouldShowAuthFilePlanBadge(file, planType);
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const usageTotalCalls = stats.success + stats.failure;

--- a/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
+++ b/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
@@ -16,6 +16,33 @@ const resolveCycleUsageAuthIndex = (file: AuthFileItem): string | null => {
   return normalizeAuthIndexValue(file.auth_index ?? file.authIndex);
 };
 
+/**
+ * Prefer cycle_request_total when the backend knows the weekly cycle start.
+ * When cycle_known is false, fall back to request_total so cards do not jump
+ * from entity-stats totals (e.g. 116) to a misleading 0.
+ */
+const resolveDisplayCycleCount = (trend: {
+  cycle_known?: boolean;
+  cycle_request_total?: number;
+  request_total?: number;
+}): number | null => {
+  const cycleKnown = trend.cycle_known === true;
+  const cycleTotal = trend.cycle_request_total;
+  if (cycleKnown && typeof cycleTotal === "number" && Number.isFinite(cycleTotal)) {
+    return Math.max(0, Math.round(cycleTotal));
+  }
+
+  const requestTotal = trend.request_total;
+  if (typeof requestTotal === "number" && Number.isFinite(requestTotal)) {
+    return Math.max(0, Math.round(requestTotal));
+  }
+
+  if (typeof cycleTotal === "number" && Number.isFinite(cycleTotal)) {
+    return Math.max(0, Math.round(cycleTotal));
+  }
+  return null;
+};
+
 export function useAuthFilesCycleUsageState() {
   const mountedRef = useRef(true);
   const inFlightRef = useRef<Map<string, Promise<number | null>>>(new Map());
@@ -40,10 +67,9 @@ export function useAuthFilesCycleUsageState() {
     request = usageApi
       .getAuthFileTrend(authIndex, { days: 7, hours: 5 })
       .then((trend) => {
-        const rawCount = trend.cycle_request_total;
-        if (typeof rawCount !== "number" || !Number.isFinite(rawCount)) return null;
+        const nextCount = resolveDisplayCycleCount(trend);
+        if (nextCount === null) return null;
 
-        const nextCount = Math.max(0, Math.round(rawCount));
         if (mountedRef.current) {
           setCallsByAuthIndex((prev) =>
             prev[authIndex] === nextCount ? prev : { ...prev, [authIndex]: nextCount },

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -41,6 +41,7 @@ import {
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
   shouldShowAuthFileDisplayTag,
+  shouldShowAuthFilePlanBadge,
 } from "@code-proxy/domain";
 import { resolveQuotaProvider, type QuotaProvider } from "@features/quota-preview/quota-fetch";
 import {
@@ -693,7 +694,7 @@ export function useAuthFilesFilesPresentation({
           const planType = resolveAuthFilePlanType(file, quotaByFileName[file.name]);
           const runtimeOnly = isRuntimeOnlyAuthFile(file);
           const showTypeBadge = shouldShowAuthFileDisplayTag(file, typeKey);
-          const showPlanBadge = planType ? shouldShowAuthFileDisplayTag(file, planType) : false;
+          const showPlanBadge = shouldShowAuthFilePlanBadge(file, planType);
 
           return (
             <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- Prefer `request_total` when weekly cycle is unknown so xAI cards do not jump from real call counts to 0.
- Always show quota-derived SuperGrok / SuperGrok Heavy plan badges (not gated by `display_tags`).
- Attach `windowSeconds: 604800` on xAI `weekly_limit` snapshots and fall back weekly used% / cycle metrics in the detail modal.
- Hide empty identity fingerprint field rows.

## Test plan
- [x] `bun run test` helpers / DetailModal / quota-fetch / files-table (xAI cases)
- [x] `bun run build`
- [ ] Deploy Frontend on `dev` after merge