### PR TITLE
feat: show channel provider icons and split filter options

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/usage-logs.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/usage-logs.test.ts
@@ -39,6 +39,7 @@ describe("usage logs api", () => {
         api_key_names: {},
         models: [],
         channels: [],
+        channel_options: [],
       },
       stats: {
         total: 0,
@@ -49,6 +50,64 @@ describe("usage logs api", () => {
       },
     });
     expect(getMock).toHaveBeenCalledWith("/usage/logs?page=1&size=50");
+  });
+
+  test("normalizes channel_options and falls back to legacy channels", async () => {
+    const { usageApi, normalizeChannelOptions } = await import(
+      "@code-proxy/api-client/endpoints/usage"
+    );
+
+    expect(
+      normalizeChannelOptions(undefined, ["Codex", "Relay", "codex"]),
+    ).toEqual([
+      { value: "Codex", label: "Codex" },
+      { value: "Relay", label: "Relay" },
+    ]);
+
+    getMock.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      size: 50,
+      filters: {
+        channels: ["yuan@example.com"],
+        channel_options: [
+          {
+            value: "auth-codex",
+            label: "yuan@example.com",
+            provider: "codex",
+            auth_type: "oauth",
+            auth_index: "auth-codex",
+          },
+          {
+            value: "auth-xai",
+            label: "yuan@example.com",
+            provider: "xai",
+            auth_type: "oauth",
+            auth_index: "auth-xai",
+          },
+        ],
+      },
+      stats: {},
+    });
+
+    const result = await usageApi.getUsageLogs({ page: 1, size: 50 });
+    expect(result.filters.channel_options).toEqual([
+      {
+        value: "auth-codex",
+        label: "yuan@example.com",
+        provider: "codex",
+        auth_type: "oauth",
+        auth_index: "auth-codex",
+      },
+      {
+        value: "auth-xai",
+        label: "yuan@example.com",
+        provider: "xai",
+        auth_type: "oauth",
+        auth_index: "auth-xai",
+      },
+    ]);
   });
 
   test("passes abort signals through to the API client", async () => {

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -127,6 +127,69 @@ const isStringRecord = (value: unknown): value is Record<string, string> =>
   !Array.isArray(value) &&
   Object.values(value).every((entry) => typeof entry === "string");
 
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/** Normalize backend channel_options; fall back to legacy plain channel names. */
+export function normalizeChannelOptions(
+  rawOptions: unknown,
+  legacyChannels?: unknown,
+): UsageChannelFilterOption[] {
+  const options: UsageChannelFilterOption[] = [];
+  const seen = new Set<string>();
+
+  if (Array.isArray(rawOptions)) {
+    for (const entry of rawOptions) {
+      if (!entry || typeof entry !== "object") continue;
+      const record = entry as Record<string, unknown>;
+      const value =
+        asTrimmedString(record.value) ||
+        asTrimmedString(record.auth_index) ||
+        asTrimmedString(record.label);
+      const label =
+        asTrimmedString(record.label) ||
+        asTrimmedString(record.value) ||
+        value;
+      if (!value || !label) continue;
+      const dedupeKey = value.toLowerCase();
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      const authTypeRaw = asTrimmedString(record.auth_type).toLowerCase();
+      const authType =
+        authTypeRaw === "oauth"
+          ? "oauth"
+          : authTypeRaw === "api" ||
+              authTypeRaw === "api_key" ||
+              authTypeRaw === "apikey"
+            ? "api"
+            : authTypeRaw || undefined;
+      options.push({
+        value,
+        label,
+        provider: asTrimmedString(record.provider) || undefined,
+        auth_type: authType,
+        auth_index: asTrimmedString(record.auth_index) || undefined,
+      });
+    }
+  }
+
+  if (options.length > 0) return options;
+
+  if (Array.isArray(legacyChannels)) {
+    for (const channel of legacyChannels) {
+      const label = asTrimmedString(channel);
+      if (!label) continue;
+      const dedupeKey = label.toLowerCase();
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      options.push({ value: label, label });
+    }
+  }
+
+  return options;
+}
+
 export const usageApi = {
   async getUsage(): Promise<UsageData> {
     const response = await apiClient.get<
@@ -340,6 +403,7 @@ export const usageApi = {
         api_key_names: isStringRecord(filters?.api_key_names) ? filters.api_key_names : {},
         models: Array.isArray(filters?.models) ? filters.models : [],
         channels: Array.isArray(filters?.channels) ? filters.channels : [],
+        channel_options: normalizeChannelOptions(filters?.channel_options, filters?.channels),
         statuses: Array.isArray(filters?.statuses) ? filters.statuses : ["success", "failed"],
       },
       stats: {
@@ -351,6 +415,7 @@ export const usageApi = {
       },
     };
   },
+
 
   clearUsageLogs(
     payload: ClearUsageLogsPayload,
@@ -478,6 +543,14 @@ export interface DashboardThroughputPoint {
   tpm: number;
 }
 
+export interface UsageChannelFilterOption {
+  value: string;
+  label: string;
+  provider?: string;
+  auth_type?: "oauth" | "api" | string;
+  auth_index?: string;
+}
+
 export interface UsageLogItem {
   id: number;
   timestamp: string;
@@ -488,6 +561,8 @@ export interface UsageLogItem {
   vision_fallback_model?: string;
   source: string;
   channel_name: string;
+  provider?: string;
+  auth_type?: "oauth" | "api" | string;
   auth_index: string;
   failed: boolean;
   streaming?: boolean;
@@ -512,6 +587,7 @@ export interface UsageLogsResponse {
     api_key_names: Record<string, string>;
     models: string[];
     channels: string[];
+    channel_options: UsageChannelFilterOption[];
     statuses: string[];
   };
   stats: {
@@ -528,8 +604,10 @@ type UsageLogsFilterPayload = {
   api_key_names?: unknown;
   models?: unknown;
   channels?: unknown;
+  channel_options?: unknown;
   statuses?: unknown;
 };
+
 
 type UsageLogsPayload = {
   items?: UsageLogItem[] | null;

--- a/packages/assets/src/vendor-icons/VendorIcon.tsx
+++ b/packages/assets/src/vendor-icons/VendorIcon.tsx
@@ -24,11 +24,13 @@ import iconVertex from "@code-proxy/assets/icons/vertex.svg";
 const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
   amp: { light: iconAmp, dark: iconAmp },
   antigravity: { light: iconAntigravity, dark: iconAntigravity },
+  anthropic: { light: iconClaude, dark: iconClaude },
   claude: { light: iconClaude, dark: iconClaude },
   cline: { light: iconCline, dark: iconCline },
   codex: { light: iconCodex, dark: iconCodex },
   deepseek: { light: iconDeepseek, dark: iconDeepseek },
   gemini: { light: iconGemini, dark: iconGemini },
+  "gemini-cli": { light: iconGemini, dark: iconGemini },
   glm: { light: iconGlm, dark: iconGlm },
   gpt: { light: iconOpenaiLight, dark: iconOpenaiDark },
   grok: { light: iconGrok, dark: iconGrok },
@@ -45,11 +47,19 @@ const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
   openai: { light: iconOpenaiLight, dark: iconOpenaiDark },
   qwen: { light: iconQwen, dark: iconQwen },
   vertex: { light: iconVertex, dark: iconVertex },
+  xai: { light: iconGrok, dark: iconGrok },
 };
 
+/** Longer / more specific prefixes first so "gemini-cli" beats "gemini". */
+const VENDOR_PREFIXES = Object.keys(VENDOR_ICONS).sort(
+  (a, b) => b.length - a.length,
+);
+
 function getVendorPrefix(modelId: string): string {
-  const lower = modelId.toLowerCase();
-  for (const prefix of Object.keys(VENDOR_ICONS)) {
+  const lower = modelId.toLowerCase().trim();
+  if (!lower) return "";
+  if (VENDOR_ICONS[lower]) return lower;
+  for (const prefix of VENDOR_PREFIXES) {
     if (lower.startsWith(prefix)) return prefix;
   }
   return "";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2595,7 +2595,9 @@
     "clear_model_filter": "Clear model filter",
     "clear_channel_filter": "Clear channel filter",
     "clear_status_filter": "Clear status filter",
-    "cache_rate": "Cache Token Ratio"
+    "cache_rate": "Cache Token Ratio",
+    "auth_type_api": "API",
+    "auth_type_oauth": "OAuth"
   },
   "ccswitch": {
     "import_to_ccswitch": "Import to CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2890,7 +2890,9 @@
     "clear_key_filter": "清空密钥筛选",
     "clear_model_filter": "清空模型筛选",
     "clear_channel_filter": "清空渠道筛选",
-    "clear_status_filter": "清空状态筛选"
+    "clear_status_filter": "清空状态筛选",
+    "auth_type_api": "API",
+    "auth_type_oauth": "OAuth"
   },
   "ccswitch": {
     "import_to_ccswitch": "导入到 CC Switch",

--- a/packages/ui/src/primitives/SearchableSelect.tsx
+++ b/packages/ui/src/primitives/SearchableSelect.tsx
@@ -37,6 +37,13 @@ export interface SearchableSelectOption {
   triggerLabel?: ReactNode;
   /** searchable text (defaults to value if omitted) */
   searchText?: string;
+  /** Optional leading icon shown before the label in the list and trigger. */
+  icon?: ReactNode;
+  /**
+   * Optional trailing content (e.g. count pill) rendered immediately after the
+   * label text. The selection checkmark always stays at the far right.
+   */
+  trailing?: ReactNode;
   action?: {
     label: string;
     icon: ReactNode;
@@ -64,6 +71,33 @@ export interface SearchableSelectProps {
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
+
+function OptionContent({
+  icon,
+  label,
+  trailing,
+  selected,
+}: {
+  icon?: ReactNode;
+  label: ReactNode;
+  trailing?: ReactNode;
+  selected: boolean;
+}) {
+  return (
+    <>
+      {icon ? <span className="inline-flex shrink-0 items-center">{icon}</span> : null}
+      <span className="min-w-0 flex-1 truncate text-left">{label}</span>
+      {trailing ? <span className="inline-flex shrink-0 items-center">{trailing}</span> : null}
+      {selected ? (
+        <Check
+          size={14}
+          className="shrink-0 text-[#96969B] dark:text-[#9F9FA8]"
+          aria-hidden="true"
+        />
+      ) : null}
+    </>
+  );
+}
 
 export function SearchableSelect({
   value,
@@ -160,10 +194,26 @@ export function SearchableSelect({
     return () => document.removeEventListener("keydown", handler);
   }, [open]);
 
+  const selectedOption = useMemo(
+    () => options.find((o) => o.value === value) ?? null,
+    [options, value],
+  );
+
   const selectedLabel = useMemo(() => {
-    const match = options.find((o) => o.value === value);
-    return match ? (match.triggerLabel ?? match.label) : null;
-  }, [options, value]);
+    if (!selectedOption) return null;
+    if (selectedOption.triggerLabel != null) return selectedOption.triggerLabel;
+    return (
+      <span className="inline-flex min-w-0 items-center gap-2">
+        {selectedOption.icon ? (
+          <span className="inline-flex shrink-0 items-center">{selectedOption.icon}</span>
+        ) : null}
+        <span className="min-w-0 truncate">{selectedOption.label}</span>
+        {selectedOption.trailing ? (
+          <span className="inline-flex shrink-0 items-center">{selectedOption.trailing}</span>
+        ) : null}
+      </span>
+    );
+  }, [selectedOption]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -290,14 +340,12 @@ export function SearchableSelect({
                               onClick={() => handleSelect(opt.value)}
                               className="flex min-w-0 flex-1 items-center gap-2 text-left outline-none"
                             >
-                              <span className="min-w-0 flex-1">{opt.label}</span>
-                              {selected ? (
-                                <Check
-                                  size={14}
-                                  className="shrink-0 text-[#96969B] dark:text-[#9F9FA8]"
-                                  aria-hidden="true"
-                                />
-                              ) : null}
+                              <OptionContent
+                                icon={opt.icon}
+                                label={opt.label}
+                                trailing={opt.trailing}
+                                selected={selected}
+                              />
                             </button>
                             <button
                               type="button"
@@ -326,14 +374,12 @@ export function SearchableSelect({
                           onClick={() => handleSelect(opt.value)}
                           className={optionClassName}
                         >
-                          <span className="min-w-0 flex-1">{opt.label}</span>
-                          {selected ? (
-                            <Check
-                              size={14}
-                              className="shrink-0 text-[#96969B] dark:text-[#9F9FA8]"
-                              aria-hidden="true"
-                            />
-                          ) : null}
+                          <OptionContent
+                            icon={opt.icon}
+                            label={opt.label}
+                            trailing={opt.trailing}
+                            selected={selected}
+                          />
                         </button>
                       );
                     })}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -20,6 +20,7 @@ import {
   Upload,
 } from "lucide-react";
 import type { AuthFileItem } from "@code-proxy/api-client";
+import { VendorIcon } from "@code-proxy/assets";
 import { Button, buttonClassName } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
@@ -720,17 +721,28 @@ export function AuthFilesFilesTab({
         const count =
           key === "all" ? filterCounts.total : (filterCounts.counts[normalizedKey] ?? 0);
         const label = key === "all" ? t("auth_files.all") : key;
+        const countPill = (
+          <span className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-[10px] font-semibold tabular-nums text-slate-700 dark:bg-white/10 dark:text-white/70">
+            {count}
+          </span>
+        );
         return {
           value: key,
-          label: (
-            <span className="flex min-w-0 items-center gap-2">
+          label,
+          icon:
+            key === "all" ? undefined : (
+              <VendorIcon modelId={normalizedKey || key} size={14} />
+            ),
+          trailing: countPill,
+          triggerLabel: (
+            <span className="inline-flex min-w-0 items-center gap-2">
+              {key === "all" ? null : (
+                <VendorIcon modelId={normalizedKey || key} size={14} />
+              )}
               <span className="min-w-0 truncate">{label}</span>
-              <span className="ml-auto inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-[10px] font-semibold tabular-nums text-slate-700 dark:bg-white/10 dark:text-white/70">
-                {count}
-              </span>
+              {countPill}
             </span>
           ),
-          triggerLabel: `${label} (${count})`,
           searchText: `${key} ${label}`,
         };
       }),

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -4,9 +4,11 @@ import { LoaderCircle, RefreshCw, ScrollText, Trash2 } from "lucide-react";
 import { usageApi } from "@code-proxy/api-client";
 import type {
   ClearUsageLogsPayload,
+  UsageChannelFilterOption,
   UsageLogItem,
   UsageLogsResponse,
 } from "@code-proxy/api-client/endpoints/usage";
+import { VendorIcon } from "@code-proxy/assets";
 import {
   formatUsageMetricNumber,
   formatUsageMetricRate,
@@ -60,6 +62,52 @@ const DEFAULT_CLEAR_OPTIONS: ClearUsageLogsPayload = {
 const isRequestCancelled = (err: unknown, signal?: AbortSignal) =>
   signal?.aborted ||
   (err instanceof Error && err.message === "Request was cancelled");
+
+function authTypeBadgeClass(authType?: string): string {
+  if (authType === "api") {
+    return "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-200";
+  }
+  if (authType === "oauth") {
+    return "bg-violet-50 text-violet-700 dark:bg-violet-500/15 dark:text-violet-200";
+  }
+  return "bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/65";
+}
+
+function ChannelFilterOptionLabel({
+  option,
+  apiLabel,
+  oauthLabel,
+}: {
+  option: UsageChannelFilterOption;
+  apiLabel: string;
+  oauthLabel: string;
+}) {
+  const authType = String(option.auth_type ?? "").toLowerCase();
+  const badgeLabel =
+    authType === "api" ? apiLabel : authType === "oauth" ? oauthLabel : "";
+  const provider = String(option.provider ?? "").trim();
+
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      {provider ? (
+        <span className="inline-flex shrink-0 items-center" aria-hidden="true">
+          <VendorIcon modelId={provider} size={14} />
+        </span>
+      ) : null}
+      <span className="min-w-0 truncate">{option.label}</span>
+      {badgeLabel ? (
+        <span
+          className={[
+            "inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none",
+            authTypeBadgeClass(authType),
+          ].join(" ")}
+        >
+          {badgeLabel}
+        </span>
+      ) : null}
+    </span>
+  );
+}
 
 function RequestLogsRecordsCount({ count }: { count: number }) {
   const { t } = useTranslation();
@@ -139,12 +187,14 @@ export function RequestLogsPage() {
     api_key_names: Record<string, string>;
     models: string[];
     channels: string[];
+    channel_options: UsageChannelFilterOption[];
     statuses: string[];
   }>({
     api_keys: [],
     api_key_names: {},
     models: [],
     channels: [],
+    channel_options: [],
     statuses: ["success", "failed"],
   });
   const [stats, setStats] = useState<{
@@ -202,12 +252,33 @@ export function RequestLogsPage() {
   }, [filterOptions.models]);
 
   const channelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
-    return filterOptions.channels.map((ch) => ({
-      value: ch,
-      label: ch,
-      searchText: ch,
-    }));
-  }, [filterOptions.channels]);
+    const source: UsageChannelFilterOption[] =
+      filterOptions.channel_options.length > 0
+        ? filterOptions.channel_options
+        : filterOptions.channels.map((ch) => ({
+            value: ch,
+            label: ch,
+          }));
+    const apiLabel = t("request_logs.auth_type_api");
+    const oauthLabel = t("request_logs.auth_type_oauth");
+    return source.map((option) => {
+      const provider = String(option.provider ?? "").trim();
+      const authType = String(option.auth_type ?? "").trim();
+      return {
+        value: option.value,
+        label: (
+          <ChannelFilterOptionLabel
+            option={option}
+            apiLabel={apiLabel}
+            oauthLabel={oauthLabel}
+          />
+        ),
+        searchText: [option.label, provider, authType, option.value]
+          .filter(Boolean)
+          .join(" "),
+      };
+    });
+  }, [filterOptions.channel_options, filterOptions.channels, t]);
 
   const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return (filterOptions.statuses ?? ["success", "failed"]).map((status) => ({
@@ -345,7 +416,14 @@ export function RequestLogsPage() {
         setRawItems(resp.items ?? []);
         setTotalCount(resp.total ?? 0);
         setCurrentPage(page);
-        setFilterOptions(resp.filters);
+        setFilterOptions({
+          api_keys: resp.filters?.api_keys ?? [],
+          api_key_names: resp.filters?.api_key_names ?? {},
+          models: resp.filters?.models ?? [],
+          channels: resp.filters?.channels ?? [],
+          channel_options: resp.filters?.channel_options ?? [],
+          statuses: resp.filters?.statuses ?? ["success", "failed"],
+        });
         setStats({
           ...DEFAULT_LOG_STATS,
           ...resp.stats,

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -27,6 +27,7 @@ const emptyLogsResponse = {
     api_key_names: {},
     models: [],
     channels: [],
+    channel_options: [],
     statuses: [],
   },
   stats: {
@@ -50,6 +51,22 @@ const responseWithFilterOptions = {
     },
     models: ["gpt-5.4", "gpt-4.1"],
     channels: ["Codex", "Relay"],
+    channel_options: [
+      {
+        value: "auth-codex",
+        label: "Codex",
+        provider: "codex",
+        auth_type: "oauth",
+        auth_index: "auth-codex",
+      },
+      {
+        value: "auth-relay",
+        label: "Relay",
+        provider: "openai",
+        auth_type: "api",
+        auth_index: "auth-relay",
+      },
+    ],
     statuses: ["success", "failed"],
   },
   stats: {


### PR DESCRIPTION
## Summary
- Consume `channel_options` in request-log filters with vendor icons and colored API/OAuth badges.
- Extend `SearchableSelect` with `icon`/`trailing` so auth-files group options render icon + label + count with checkmark on the far right.
- Expand VendorIcon aliases for xai/gemini-cli/anthropic.

## Test plan
- [x] vitest: usage-logs + RequestLogsPage (19 tests)
- [x] `tsc --noEmit` in admin-panel
- [ ] Manual: request-log channel dropdown icons/badges; auth-files file group dropdown layout