### PR TITLE
fix: show postgres database status

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3620,6 +3620,7 @@
     "idle": "Idle",
     "started": "Started {{time}}",
     "heap": "Heap {{size}}",
+    "postgresql": "PostgreSQL",
     "sqlite_wal": "SQLite + WAL",
     "sqlite_wal_shm": "SQLite + WAL + SHM",
     "request_log_content": "request_log_content body data",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3812,6 +3812,7 @@
     "idle": "空闲",
     "started": "启动于 {{time}}",
     "heap": "堆内存 {{size}}",
+    "postgresql": "PostgreSQL",
     "sqlite_wal": "SQLite + WAL",
     "sqlite_wal_shm": "SQLite + WAL + SHM",
     "request_log_content": "request_log_content 正文数据",

--- a/pages/dashboard/SystemMonitorSection.tsx
+++ b/pages/dashboard/SystemMonitorSection.tsx
@@ -502,6 +502,14 @@ export function SystemMonitorSection({
     latencyWeight > 0
       ? channelLatency.reduce((acc, item) => acc + item.avg_ms * item.count, 0) / latencyWeight
       : 0;
+  const rawDBEngine = stats.db_engine?.trim();
+  const dbEngine = (rawDBEngine || "sqlite").toLowerCase();
+  const dbSublabel =
+    dbEngine === "postgres"
+      ? t("system_monitor.postgresql")
+      : dbEngine === "sqlite"
+        ? t("system_monitor.sqlite_wal_shm")
+        : rawDBEngine;
 
   return (
     <Card
@@ -541,7 +549,7 @@ export function SystemMonitorSection({
               label={t("system_monitor.database")}
               value={formatBytes(stats.db_size_bytes)}
               icon={Database}
-              sublabel={t("system_monitor.sqlite_wal_shm")}
+              sublabel={dbSublabel}
             />
             <MiniKpi
               label={t("system_monitor.log_storage")}

--- a/pages/dashboard/__tests__/SystemMonitorSection.test.tsx
+++ b/pages/dashboard/__tests__/SystemMonitorSection.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { SystemMonitorSection } from "../SystemMonitorSection";
+import type { SystemStats } from "../useSystemStats";
+
+const stats = {
+  db_size_bytes: 8192,
+  db_engine: "postgres",
+  log_content_store_bytes: 1024,
+  log_dir_size_bytes: 2048,
+  log_size_bytes: 2048,
+  process_mem_bytes: 64 * 1024 * 1024,
+  process_mem_pct: 3,
+  process_cpu_pct: 2,
+  go_routines: 12,
+  go_heap_bytes: 16 * 1024 * 1024,
+  system_cpu_pct: 10,
+  system_mem_total: 2 * 1024 * 1024 * 1024,
+  system_mem_used: 512 * 1024 * 1024,
+  system_mem_pct: 25,
+  net_bytes_sent: 1000,
+  net_bytes_recv: 2000,
+  net_send_rate: 10,
+  net_recv_rate: 20,
+  disk_total: 100 * 1024 * 1024 * 1024,
+  disk_used: 40 * 1024 * 1024 * 1024,
+  disk_free: 60 * 1024 * 1024 * 1024,
+  disk_pct: 40,
+  uptime_seconds: 3600,
+  start_time: "2026-07-09T12:00:00Z",
+  channel_latency: [],
+  active_concurrency: null,
+  total_in_flight: 0,
+  total_rpm: 0,
+  total_tpm: 0,
+} satisfies SystemStats;
+
+describe("SystemMonitorSection", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  test("shows PostgreSQL for postgres runtime database stats", () => {
+    render(<SystemMonitorSection stats={stats} connected apiKeyCount={1} />);
+
+    expect(screen.getByText("PostgreSQL")).toBeInTheDocument();
+    expect(screen.queryByText("SQLite + WAL + SHM")).toBeNull();
+  });
+});

--- a/pages/dashboard/useSystemStats.ts
+++ b/pages/dashboard/useSystemStats.ts
@@ -5,6 +5,7 @@ import { apiClient } from "@code-proxy/api-client";
 
 export interface SystemStats {
   db_size_bytes: number;
+  db_engine?: string;
   log_content_store_bytes: number;
   log_dir_size_bytes: number;
   log_size_bytes: number;


### PR DESCRIPTION
## Summary
- consume db_engine from system stats
- show PostgreSQL on dashboard database card
- keep SQLite fallback label for older responses

## Tests
- rtk bun run --filter @code-proxy/admin-panel test -- pages/dashboard/__tests__/SystemMonitorSection.test.tsx
- rtk bun run build