### PR TITLE
feat: gate oauth model owner override

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -820,6 +820,8 @@
     "failed_get_models": "Failed to get model definitions",
     "failed_get_model_owners": "Failed to get model owner groups",
     "model_owner_group": "Model owner group",
+    "model_owner_group_enabled": "Enable owner group override",
+    "model_owner_group_enabled_desc": "When off, OAuth accounts in this group use their own discovered model list. Turn it on to reuse the selected owner group.",
     "auth_file_models_option": "Not set",
     "model_owner_group_search_placeholder": "Search owner groups…",
     "model_owner_group_source_desc": "{{count}} models from {{owner}}.",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -756,6 +756,8 @@
     "filters": "Фильтры",
     "failed_get_model_owners": "Не удалось получить группы владельцев моделей",
     "model_owner_group": "Группа владельца моделей",
+    "model_owner_group_enabled": "Включить переопределение группы",
+    "model_owner_group_enabled_desc": "Если выключено, OAuth-аккаунты в этой группе используют собственный обнаруженный список моделей. Включите, чтобы использовать выбранную группу владельца.",
     "auth_file_models_option": "Не задано",
     "model_owner_group_search_placeholder": "Поиск групп владельцев…",
     "model_owner_group_source_desc": "{{count}} моделей из {{owner}}.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -834,6 +834,8 @@
     "failed_get_models": "获取模型定义失败",
     "failed_get_model_owners": "获取模型归属分组失败",
     "model_owner_group": "模型归属分组",
+    "model_owner_group_enabled": "启用归属分组覆盖",
+    "model_owner_group_enabled_desc": "关闭时，该分组下的 OAuth 账号使用自身可探测的模型列表；开启后才复用所选归属分组。",
     "auth_file_models_option": "未设置",
     "model_owner_group_search_placeholder": "搜索归属分组…",
     "model_owner_group_source_desc": "正在复用 {{owner}} 归属下的 {{count}} 个模型。",

--- a/packages/ui/src/primitives/SearchableSelect.tsx
+++ b/packages/ui/src/primitives/SearchableSelect.tsx
@@ -65,6 +65,7 @@ export interface SearchableSelectProps {
   "aria-label"?: string;
   name?: string;
   className?: string;
+  disabled?: boolean;
   size?: ControlSize;
 }
 
@@ -112,6 +113,7 @@ export function SearchableSelect({
   "aria-label": ariaLabel,
   name,
   className,
+  disabled = false,
   size = "default",
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
@@ -163,6 +165,10 @@ export function SearchableSelect({
       window.removeEventListener("resize", reposition);
     };
   }, [open, reposition]);
+
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
 
   // Focus search input on open
   useEffect(() => {
@@ -267,8 +273,14 @@ export function SearchableSelect({
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={ariaLabel}
+        disabled={disabled}
         onClick={() => setOpen((prev) => !prev)}
-        className={cn(getSelectTriggerBase(size), open && selectTriggerOpen, className)}
+        className={cn(
+          getSelectTriggerBase(size),
+          open && selectTriggerOpen,
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          className,
+        )}
       >
         <span className="min-w-0 flex-1 truncate text-left">{selectedLabel ?? placeholder}</span>
         <ChevronDown
@@ -280,7 +292,7 @@ export function SearchableSelect({
 
       {createPortal(
         <AnimatePresence>
-          {open ? (
+          {open && !disabled ? (
             <motion.div
               ref={listRef}
               role="listbox"

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -6,7 +6,11 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ToastProvider } from "@code-proxy/ui";
 import { ThemeProvider } from "@code-proxy/ui";
 import { AuthFilesPage } from "@pages/auth-files/AuthFilesPage";
-import type { AuthFileItem, AuthFileTrendResponse, EntityStatsResponse } from "@code-proxy/api-client";
+import type {
+  AuthFileItem,
+  AuthFileTrendResponse,
+  EntityStatsResponse,
+} from "@code-proxy/api-client";
 import {
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
@@ -30,20 +34,22 @@ const mocks = vi.hoisted(() => ({
     source: [],
     auth_index: [],
   })),
-  getAuthFileTrend: vi.fn(async (authIndex: string): Promise<AuthFileTrendResponse> => ({
-    auth_index: authIndex,
-    days: 7,
-    hours: 5,
-    request_total: 3,
-    cycle_request_total: 2,
-    cycle_cost_total: 1.2345,
-    weekly_quota_used_percent: 8,
-    cycle_known: true,
-    cycle_start: "2026-04-27T16:01:21Z",
-    daily_usage: [{ date: "2026-04-30", requests: 2, cost: 0.0123 }],
-    hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1, cost: 0.0045 }],
-    quota_series: [],
-  })),
+  getAuthFileTrend: vi.fn(
+    async (authIndex: string): Promise<AuthFileTrendResponse> => ({
+      auth_index: authIndex,
+      days: 7,
+      hours: 5,
+      request_total: 3,
+      cycle_request_total: 2,
+      cycle_cost_total: 1.2345,
+      weekly_quota_used_percent: 8,
+      cycle_known: true,
+      cycle_start: "2026-04-27T16:01:21Z",
+      daily_usage: [{ date: "2026-04-30", requests: 2, cost: 0.0123 }],
+      hourly_usage: [{ hour: "2026-04-30 16:00", requests: 1, cost: 0.0045 }],
+      quota_series: [],
+    }),
+  ),
   getUsageLogs: vi.fn(async () => ({ items: [], total: 0, page: 1, size: 200 })),
   getAuthFileGroupTrend: vi.fn(async () => ({
     days: 7,
@@ -2948,7 +2954,7 @@ describe("AuthFilesPage files table", () => {
     expect(mocks.getAuthFileTrend).toHaveBeenCalledWith("auth-1", { days: 7, hours: 5 });
   });
 
-  test("sets model owner group from an icon modal after confirmation", async () => {
+  test("sets model owner group from an icon modal after enabling override", async () => {
     mocks.list.mockImplementation(async () => ({
       files: [
         {
@@ -2990,6 +2996,13 @@ describe("AuthFilesPage files table", () => {
 
     fireEvent.click(settingsButton);
     const settingsDialog = await screen.findByRole("dialog", { name: "Model owner group" });
+    const overrideSwitch = within(settingsDialog).getByRole("switch", {
+      name: "Enable owner group override",
+    });
+    expect(overrideSwitch).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(overrideSwitch);
+    expect(overrideSwitch).toHaveAttribute("aria-checked", "true");
+
     const ownerSelect = within(settingsDialog).getByRole("combobox", {
       name: "Model owner group",
     });

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -656,6 +656,9 @@ export function AuthFilesFilesTab({
   const { t } = useTranslation();
   const [modelOwnerDialogOpen, setModelOwnerDialogOpen] = useState(false);
   const [draftModelOwner, setDraftModelOwner] = useState(selectedModelOwner);
+  const [draftModelOwnerEnabled, setDraftModelOwnerEnabled] = useState(
+    selectedModelOwner.trim() !== "",
+  );
   const [jsonImportOpen, setJsonImportOpen] = useState(false);
   const [jsonImportText, setJsonImportText] = useState("");
   const [jsonImportError, setJsonImportError] = useState("");
@@ -665,6 +668,11 @@ export function AuthFilesFilesTab({
   const normalizedFilter = normalizeProviderKey(filter);
   const normalizedTagFilter = normalizeTagValue(tagFilter);
   const canSetModelOwnerGroup = normalizedFilter !== "all";
+  const defaultDraftModelOwner =
+    normalizedFilter === "codex" && modelOwnerGroups.some((group) => group.value === "codex")
+      ? "codex"
+      : "";
+  const currentDraftModelOwner = selectedModelOwner || defaultDraftModelOwner;
   const activeFilterCount = [
     normalizedFilter !== "all",
     normalizedTagFilter !== "",
@@ -673,7 +681,7 @@ export function AuthFilesFilesTab({
     canSetModelOwnerGroup && selectedModelOwner.trim() !== "",
   ].filter(Boolean).length;
   const draftModelOwnerGroup =
-    draftModelOwner === ""
+    !draftModelOwnerEnabled || draftModelOwner === ""
       ? null
       : (modelOwnerGroups.find((group) => group.value === draftModelOwner) ?? null);
   const selectedModelOwnerGroup =
@@ -729,16 +737,11 @@ export function AuthFilesFilesTab({
         return {
           value: key,
           label,
-          icon:
-            key === "all" ? undefined : (
-              <VendorIcon modelId={normalizedKey || key} size={14} />
-            ),
+          icon: key === "all" ? undefined : <VendorIcon modelId={normalizedKey || key} size={14} />,
           trailing: countPill,
           triggerLabel: (
             <span className="inline-flex min-w-0 items-center gap-2">
-              {key === "all" ? null : (
-                <VendorIcon modelId={normalizedKey || key} size={14} />
-              )}
+              {key === "all" ? null : <VendorIcon modelId={normalizedKey || key} size={14} />}
               <span className="min-w-0 truncate">{label}</span>
               {countPill}
             </span>
@@ -810,9 +813,10 @@ export function AuthFilesFilesTab({
 
   useEffect(() => {
     if (!modelOwnerDialogOpen) {
-      setDraftModelOwner(selectedModelOwner);
+      setDraftModelOwner(currentDraftModelOwner);
+      setDraftModelOwnerEnabled(selectedModelOwner.trim() !== "");
     }
-  }, [modelOwnerDialogOpen, selectedModelOwner]);
+  }, [currentDraftModelOwner, modelOwnerDialogOpen, selectedModelOwner]);
 
   useEffect(() => {
     if (!uploading || !jsonImportOpen) return;
@@ -952,7 +956,8 @@ export function AuthFilesFilesTab({
             : "",
         ].join(" ")}
         onClick={() => {
-          setDraftModelOwner(selectedModelOwner);
+          setDraftModelOwner(currentDraftModelOwner);
+          setDraftModelOwnerEnabled(selectedModelOwner.trim() !== "");
           setModelOwnerDialogOpen(true);
         }}
         aria-label={t("auth_files.model_owner_group")}
@@ -1837,7 +1842,7 @@ export function AuthFilesFilesTab({
               onClick={async () => {
                 setModelOwnerDialogSaving(true);
                 try {
-                  await setSelectedModelOwner(draftModelOwner);
+                  await setSelectedModelOwner(draftModelOwnerEnabled ? draftModelOwner : "");
                   setModelOwnerDialogOpen(false);
                 } catch {
                   // Save failures are surfaced via toast by the parent hook.
@@ -1845,7 +1850,7 @@ export function AuthFilesFilesTab({
                   setModelOwnerDialogSaving(false);
                 }
               }}
-              disabled={modelOwnerDialogSaving}
+              disabled={modelOwnerDialogSaving || (draftModelOwnerEnabled && !draftModelOwner)}
             >
               {t("common.save")}
             </Button>
@@ -1853,6 +1858,16 @@ export function AuthFilesFilesTab({
         }
       >
         <div className="space-y-4">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-white/[0.04]">
+            <ToggleSwitch
+              checked={draftModelOwnerEnabled}
+              onCheckedChange={setDraftModelOwnerEnabled}
+              label={t("auth_files.model_owner_group_enabled")}
+              description={t("auth_files.model_owner_group_enabled_desc")}
+              disabled={modelOwnerDialogSaving}
+            />
+          </div>
+
           <div className="grid gap-3 sm:grid-cols-[minmax(0,18rem)_minmax(0,1fr)]">
             <div className="min-w-0 space-y-1.5">
               <label className="block text-sm font-medium text-slate-700 dark:text-white/80">
@@ -1865,6 +1880,7 @@ export function AuthFilesFilesTab({
                 placeholder={t("auth_files.auth_file_models_option")}
                 searchPlaceholder={t("auth_files.model_owner_group_search_placeholder")}
                 aria-label={t("auth_files.model_owner_group")}
+                disabled={!draftModelOwnerEnabled || modelOwnerDialogSaving}
               />
             </div>
 


### PR DESCRIPTION
## Summary
- add an enable switch before OAuth model owner group override is applied
- default Codex owner override to off while preserving the owner picker
- add disabled support to SearchableSelect for this flow

## Tests
- rtk bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
- rtk bun run build