### PR TITLE
feat: preserve GPT-5.6 Codex catalog capabilities

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -16,7 +16,6 @@ import {
   CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
   buildCcSwitchCodexModelCatalog,
   getCcSwitchClientConfig,
-  type CcSwitchCodexCatalogModel,
   type CcSwitchClientType,
 } from "@code-proxy/domain/ccswitch/ccswitchImport";
 import {
@@ -327,7 +326,16 @@ function buildDraftCodexModelCatalog(
   draft: ConfigDraft,
 ): CcSwitchImportCodexModelCatalog | undefined {
   if (draft.clientType !== "codex") return undefined;
-  const models: CcSwitchCodexCatalogModel[] = [];
+
+  const existingByModel = new Map<string, Record<string, unknown>>();
+  for (const entry of draft.codexModelCatalog?.models ?? []) {
+    const modelId = String(entry.slug ?? entry.model ?? "")
+      .trim()
+      .toLowerCase();
+    if (modelId) existingByModel.set(modelId, entry);
+  }
+
+  const models: Array<{ model: string; contextWindow?: number }> = [];
   const addModel = (model: string, contextWindow?: number) => {
     const normalized = model.trim();
     if (normalized) models.push({ model: normalized, contextWindow });
@@ -341,8 +349,32 @@ function buildDraftCodexModelCatalog(
   }
   addModel(draft.defaultModel);
   if (models.length === 0) return undefined;
-  const catalog = buildCcSwitchCodexModelCatalog(models);
-  return { models: catalog.models.map((model) => ({ ...model })) };
+
+  const seen = new Set<string>();
+  const entries: Array<Record<string, unknown>> = [];
+  for (const model of models) {
+    const key = model.model.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const existing = existingByModel.get(key);
+    if (!existing) {
+      const generated = buildCcSwitchCodexModelCatalog([model]).models[0];
+      if (generated) entries.push({ ...generated, priority: 1000 + entries.length });
+      continue;
+    }
+
+    const entry = { ...existing };
+    if (model.contextWindow) {
+      entry.context_window = model.contextWindow;
+      const messages = asRecord(entry.model_messages);
+      if (messages) {
+        entry.model_messages = { ...messages, context_window: model.contextWindow };
+      }
+    }
+    entries.push(entry);
+  }
+  return entries.length > 0 ? { models: entries } : undefined;
 }
 
 function prepareDraftForSave(draft: ConfigDraft): ConfigDraft {

--- a/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts
@@ -174,4 +174,43 @@ describe("ccSwitchImportConfigsApi", () => {
       },
     });
   });
+
+  test("normalizes camelCase Codex catalog context and reasoning fields", () => {
+    const configs = normalizeCcSwitchImportConfigs([
+      {
+        id: "codex-gpt56",
+        "client-type": "codex",
+        "provider-name": "GPT-5.6",
+        "default-model": "gpt-5.6-sol",
+        "model-mappings": [{ "request-model": "gpt-5.6-sol", "target-model": "gpt-5.6-sol" }],
+        "codex-model-catalog": {
+          models: [
+            {
+              slug: "gpt-5.6-sol",
+              model: "gpt-5.6-sol",
+              contextWindow: 1050000,
+              maxContextWindow: 1050000,
+              defaultReasoningLevel: "medium",
+              supportedReasoningLevels: [
+                { effort: "max", description: "Maximum" },
+                { effort: "ultra", description: "Delegated" },
+              ],
+              modelMessages: { contextWindow: 1050000, maxContextWindow: 1050000 },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(configs[0]?.codexModelCatalog?.models[0]).toMatchObject({
+      context_window: 1050000,
+      max_context_window: 1050000,
+      default_reasoning_level: "medium",
+      supported_reasoning_levels: [
+        { effort: "max", description: "Maximum" },
+        { effort: "ultra", description: "Delegated" },
+      ],
+      model_messages: { context_window: 1050000, max_context_window: 1050000 },
+    });
+  });
 });

--- a/packages/api-client/src/endpoints/ccswitch-import-configs.ts
+++ b/packages/api-client/src/endpoints/ccswitch-import-configs.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "../client/client";
+import { normalizeCcSwitchCodexInlineModelCatalog } from "@code-proxy/domain/ccswitch/ccswitchImport";
 import {
   createCcSwitchImportConfig,
   type CcSwitchImportCodexModelCatalog,
@@ -66,18 +67,8 @@ const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
     .filter((item): item is CcSwitchModelMapping => Boolean(item));
 };
 
-const normalizeCodexModelCatalog = (
-  value: unknown,
-): CcSwitchImportCodexModelCatalog | undefined => {
-  const record = asRecord(value);
-  if (!record || !Array.isArray(record.models)) return undefined;
-
-  const models = record.models.filter(
-    (entry): entry is Record<string, unknown> => asRecord(entry) !== null,
-  );
-  const hasSlug = models.some((entry) => normalizeString(entry.slug));
-  return hasSlug ? { models: models.map((entry) => ({ ...entry })) } : undefined;
-};
+const normalizeCodexModelCatalog = (value: unknown): CcSwitchImportCodexModelCatalog | undefined =>
+  normalizeCcSwitchCodexInlineModelCatalog(value);
 
 export function normalizeCcSwitchImportConfigs(raw: unknown): CcSwitchImportConfigListItem[] {
   if (!Array.isArray(raw)) return [];

--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -21,6 +21,7 @@ export interface CcSwitchCodexCatalogModel {
   model: string;
   displayName?: string;
   contextWindow?: number;
+  maxContextWindow?: number;
   defaultReasoningLevel?: string;
   supportedReasoningLevels?: Array<
     | string
@@ -270,13 +271,64 @@ const normalizeUsageScriptLanguage = (language: string | undefined): CcSwitchUsa
 
 const DEFAULT_CODEX_CONTEXT_WINDOW = 128_000;
 const CODEX_BASE_INSTRUCTIONS = "You are Codex, a coding agent.";
-const CODEX_SUPPORTED_REASONING_LEVELS: CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"] =
+const CODEX_FALLBACK_REASONING_LEVELS: CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"] =
   [
     { effort: "low", description: "Fast responses with lighter reasoning" },
     { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
     { effort: "high", description: "Greater reasoning depth for complex problems" },
     { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
   ];
+const CODEX_GPT56_REASONING_LEVELS: CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"] = [
+  ...CODEX_FALLBACK_REASONING_LEVELS,
+  { effort: "max", description: "Maximum reasoning depth for the hardest problems" },
+  { effort: "ultra", description: "Maximum reasoning with automatic task delegation" },
+];
+
+type CodexCatalogFallbackCapability = {
+  displayName: string;
+  contextWindow: number;
+  maxContextWindow: number;
+  defaultReasoningLevel: string;
+  supportedReasoningLevels: CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"];
+};
+
+const CODEX_CATALOG_FALLBACK_CAPABILITIES: Record<string, CodexCatalogFallbackCapability> = {
+  "gpt-5.6": {
+    displayName: "GPT-5.6",
+    contextWindow: 1_050_000,
+    maxContextWindow: 1_050_000,
+    defaultReasoningLevel: "medium",
+    supportedReasoningLevels: CODEX_GPT56_REASONING_LEVELS,
+  },
+  "gpt-5.6-sol": {
+    displayName: "GPT-5.6 Sol",
+    contextWindow: 1_050_000,
+    maxContextWindow: 1_050_000,
+    defaultReasoningLevel: "medium",
+    supportedReasoningLevels: CODEX_GPT56_REASONING_LEVELS,
+  },
+  "gpt-5.6-terra": {
+    displayName: "GPT-5.6 Terra",
+    contextWindow: 1_050_000,
+    maxContextWindow: 1_050_000,
+    defaultReasoningLevel: "medium",
+    supportedReasoningLevels: CODEX_GPT56_REASONING_LEVELS,
+  },
+  "gpt-5.6-luna": {
+    displayName: "GPT-5.6 Luna",
+    contextWindow: 1_050_000,
+    maxContextWindow: 1_050_000,
+    defaultReasoningLevel: "medium",
+    supportedReasoningLevels: CODEX_GPT56_REASONING_LEVELS,
+  },
+  "gpt-5.6-ultra": {
+    displayName: "GPT-5.6 Sol (Ultra compatibility alias)",
+    contextWindow: 1_050_000,
+    maxContextWindow: 1_050_000,
+    defaultReasoningLevel: "ultra",
+    supportedReasoningLevels: CODEX_GPT56_REASONING_LEVELS,
+  },
+};
 
 const normalizeCodexContextWindow = (value: number | undefined): number => {
   if (!Number.isFinite(value) || !value || value <= 0) return DEFAULT_CODEX_CONTEXT_WINDOW;
@@ -286,20 +338,20 @@ const normalizeCodexContextWindow = (value: number | undefined): number => {
 const normalizeCodexReasoningLevels = (
   levels: CcSwitchCodexCatalogModel["supportedReasoningLevels"],
 ): CcSwitchCodexModelCatalogEntry["supported_reasoning_levels"] => {
-  if (!Array.isArray(levels) || levels.length === 0) return CODEX_SUPPORTED_REASONING_LEVELS;
+  if (!Array.isArray(levels) || levels.length === 0) return CODEX_FALLBACK_REASONING_LEVELS;
 
   const normalized = levels
     .map((level) => {
       if (typeof level === "string") {
         const effort = level.trim();
         if (!effort) return null;
-        const builtIn = CODEX_SUPPORTED_REASONING_LEVELS.find((item) => item.effort === effort);
+        const builtIn = CODEX_GPT56_REASONING_LEVELS.find((item) => item.effort === effort);
         return builtIn ?? { effort, description: effort };
       }
 
       const effort = String(level.effort ?? "").trim();
       if (!effort) return null;
-      const builtIn = CODEX_SUPPORTED_REASONING_LEVELS.find((item) => item.effort === effort);
+      const builtIn = CODEX_GPT56_REASONING_LEVELS.find((item) => item.effort === effort);
       return {
         effort,
         description: String(level.description ?? builtIn?.description ?? effort),
@@ -310,7 +362,7 @@ const normalizeCodexReasoningLevels = (
         Boolean(level),
     );
 
-  return normalized.length > 0 ? normalized : CODEX_SUPPORTED_REASONING_LEVELS;
+  return normalized.length > 0 ? normalized : CODEX_FALLBACK_REASONING_LEVELS;
 };
 
 const buildCodexCatalogEntry = (
@@ -318,10 +370,20 @@ const buildCodexCatalogEntry = (
   priority: number,
 ): CcSwitchCodexModelCatalogEntry => {
   const slug = model.model.trim();
-  const displayName = model.displayName?.trim() || slug;
-  const contextWindow = normalizeCodexContextWindow(model.contextWindow);
-  const defaultReasoningLevel = model.defaultReasoningLevel?.trim() || "medium";
-  const supportedReasoningLevels = normalizeCodexReasoningLevels(model.supportedReasoningLevels);
+  const capability = CODEX_CATALOG_FALLBACK_CAPABILITIES[slug.toLowerCase()];
+  const displayName = model.displayName?.trim() || capability?.displayName || slug;
+  const maxContextWindow = normalizeCodexContextWindow(
+    model.maxContextWindow ?? capability?.maxContextWindow ?? model.contextWindow,
+  );
+  const requestedContextWindow = normalizeCodexContextWindow(
+    model.contextWindow ?? capability?.contextWindow,
+  );
+  const contextWindow = Math.min(requestedContextWindow, maxContextWindow);
+  const defaultReasoningLevel =
+    model.defaultReasoningLevel?.trim() || capability?.defaultReasoningLevel || "medium";
+  const supportedReasoningLevels = normalizeCodexReasoningLevels(
+    model.supportedReasoningLevels ?? capability?.supportedReasoningLevels,
+  );
 
   return {
     slug,
@@ -352,7 +414,7 @@ const buildCodexCatalogEntry = (
       supports_parallel_tool_calls: true,
       supports_image_detail_original: true,
       context_window: contextWindow,
-      max_context_window: contextWindow,
+      max_context_window: maxContextWindow,
       effective_context_window_percent: 95,
       experimental_supported_tools: [],
       input_modalities: ["text", "image"],
@@ -369,7 +431,7 @@ const buildCodexCatalogEntry = (
     supports_parallel_tool_calls: true,
     supports_image_detail_original: true,
     context_window: contextWindow,
-    max_context_window: contextWindow,
+    max_context_window: maxContextWindow,
     effective_context_window_percent: 95,
     experimental_supported_tools: [],
     input_modalities: ["text", "image"],
@@ -377,6 +439,61 @@ const buildCodexCatalogEntry = (
     use_responses_lite: false,
   };
 };
+
+const copyCatalogRecord = (value: unknown): Record<string, unknown> | null => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return { ...value };
+};
+
+const setSnakeCaseCatalogField = (
+  target: Record<string, unknown>,
+  snakeCase: string,
+  camelCase: string,
+): void => {
+  if (target[snakeCase] === undefined && target[camelCase] !== undefined) {
+    target[snakeCase] = target[camelCase];
+  }
+  delete target[camelCase];
+};
+
+export function normalizeCcSwitchCodexInlineModelCatalog(
+  value: unknown,
+): CcSwitchCodexInlineModelCatalog | undefined {
+  const catalog = copyCatalogRecord(value);
+  if (!catalog || !Array.isArray(catalog.models)) return undefined;
+
+  const models = catalog.models
+    .map((entry) => {
+      const normalized = copyCatalogRecord(entry);
+      if (!normalized) return null;
+      setSnakeCaseCatalogField(normalized, "display_name", "displayName");
+      setSnakeCaseCatalogField(normalized, "default_reasoning_level", "defaultReasoningLevel");
+      setSnakeCaseCatalogField(
+        normalized,
+        "supported_reasoning_levels",
+        "supportedReasoningLevels",
+      );
+      setSnakeCaseCatalogField(normalized, "context_window", "contextWindow");
+      setSnakeCaseCatalogField(normalized, "max_context_window", "maxContextWindow");
+      setSnakeCaseCatalogField(normalized, "model_messages", "modelMessages");
+
+      const modelMessages = copyCatalogRecord(normalized.model_messages);
+      if (modelMessages) {
+        setSnakeCaseCatalogField(modelMessages, "context_window", "contextWindow");
+        setSnakeCaseCatalogField(modelMessages, "max_context_window", "maxContextWindow");
+        normalized.model_messages = modelMessages;
+      }
+      return normalized;
+    })
+    .filter((entry): entry is Record<string, unknown> => entry !== null);
+
+  const hasModelID = models.some((entry) => {
+    const slug = typeof entry.slug === "string" ? entry.slug.trim() : "";
+    const model = typeof entry.model === "string" ? entry.model.trim() : "";
+    return Boolean(slug || model);
+  });
+  return hasModelID ? { models } : undefined;
+}
 
 export const buildCcSwitchCodexModelCatalog = (
   models: readonly CcSwitchCodexCatalogModel[],
@@ -440,19 +557,28 @@ const buildCodexConfig = (input: {
     const key = normalized.toLowerCase();
     if (!normalized || seen.has(key)) return;
     seen.add(key);
+    const capability = CODEX_CATALOG_FALLBACK_CAPABILITIES[key];
     const modelEntry: Record<string, unknown> = {
       model: normalized,
-      defaultReasoningLevel: "medium",
-      supportedReasoningLevels: CODEX_SUPPORTED_REASONING_LEVELS,
+      defaultReasoningLevel: capability?.defaultReasoningLevel ?? "medium",
+      supportedReasoningLevels:
+        capability?.supportedReasoningLevels ?? CODEX_FALLBACK_REASONING_LEVELS,
     };
-    if (contextWindow && contextWindow > 0) {
-      modelEntry.contextWindow = contextWindow;
+    const resolvedContextWindow = contextWindow ?? capability?.contextWindow;
+    if (resolvedContextWindow && resolvedContextWindow > 0) {
+      modelEntry.contextWindow = Math.min(
+        resolvedContextWindow,
+        capability?.maxContextWindow ?? resolvedContextWindow,
+      );
+      modelEntry.maxContextWindow = capability?.maxContextWindow ?? resolvedContextWindow;
     }
     catalogModels.push(modelEntry);
   };
 
-  for (const entry of input.codexModelCatalog?.models ?? []) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+  const normalizedExplicitCatalog = normalizeCcSwitchCodexInlineModelCatalog(
+    input.codexModelCatalog,
+  );
+  for (const entry of normalizedExplicitCatalog?.models ?? []) {
     addCatalogEntry(entry);
   }
   for (const mapping of input.modelMappings) {

--- a/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
+++ b/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
@@ -1,5 +1,6 @@
 import {
   getCcSwitchClientConfig,
+  normalizeCcSwitchCodexInlineModelCatalog,
   type CcSwitchClaudeModelRole,
   type CcSwitchClientType,
 } from "./ccswitchImport";
@@ -125,25 +126,8 @@ const normalizeUsageAutoInterval = (value: unknown, fallback: number) => {
   return Math.round(parsed);
 };
 
-const normalizeCodexModelCatalog = (
-  value: unknown,
-): CcSwitchImportCodexModelCatalog | undefined => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-  if (!("models" in value)) return undefined;
-  const { models } = value;
-  if (!Array.isArray(models)) return undefined;
-
-  const entries = models.filter(
-    (entry): entry is Record<string, unknown> =>
-      entry !== null && typeof entry === "object" && !Array.isArray(entry),
-  );
-  const hasModelId = entries.some((entry) => {
-    const slug = typeof entry.slug === "string" ? entry.slug.trim() : "";
-    const model = typeof entry.model === "string" ? entry.model.trim() : "";
-    return slug || model;
-  });
-  return hasModelId ? { models: entries.map((entry) => ({ ...entry })) } : undefined;
-};
+const normalizeCodexModelCatalog = (value: unknown): CcSwitchImportCodexModelCatalog | undefined =>
+  normalizeCcSwitchCodexInlineModelCatalog(value);
 
 const createConfigId = () => {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -794,6 +794,78 @@ describe("CcSwitchImportSettingsPage", () => {
     );
   });
 
+  test("preserves explicit Codex reasoning and max context metadata when saving", async () => {
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "pro",
+        description: "Pro route",
+        "path-routes": ["/pro"],
+        "allowed-models": ["gpt-5.6-sol"],
+      },
+    ]);
+    listConfigs.mockResolvedValue([
+      {
+        id: "cfg-gpt56",
+        clientType: "codex",
+        providerName: "Relay GPT-5.6",
+        note: "explicit catalog",
+        defaultModel: "gpt-5.6-sol",
+        allowedChannelGroups: ["pro"],
+        routePath: "/pro/cs_gpt56",
+        endpointPath: "/v1",
+        usageAutoInterval: 30,
+        modelMappings: [{ requestModel: "gpt-5.6-sol", targetModel: "gpt-5.6-sol" }],
+        codexModelCatalogFilename: "cc-switch-model-catalog.json",
+        codexModelCatalog: {
+          models: [
+            {
+              slug: "gpt-5.6-sol",
+              model: "gpt-5.6-sol",
+              context_window: 900000,
+              max_context_window: 1050000,
+              default_reasoning_level: "medium",
+              supported_reasoning_levels: [
+                { effort: "low", description: "Low" },
+                { effort: "max", description: "Maximum" },
+                { effort: "ultra", description: "Delegated" },
+              ],
+              model_messages: {
+                context_window: 900000,
+                max_context_window: 1050000,
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(await screen.findByText("Relay GPT-5.6")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /edit config/i }));
+    const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
+    expect(within(dialog).getByLabelText(/context window for mapping 1/i)).toHaveValue(900000);
+    await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const saved = replaceConfigs.mock.calls[0]?.[0]?.[0];
+      expect(saved?.codexModelCatalog?.models[0]).toMatchObject({
+        context_window: 900000,
+        max_context_window: 1050000,
+        default_reasoning_level: "medium",
+        supported_reasoning_levels: [
+          { effort: "low", description: "Low" },
+          { effort: "max", description: "Maximum" },
+          { effort: "ultra", description: "Delegated" },
+        ],
+        model_messages: {
+          context_window: 900000,
+          max_context_window: 1050000,
+        },
+      });
+    });
+  });
+
   test("shows saved model mappings immediately while edited config models refresh", async () => {
     const modelsDeferred = createDeferred<{ id: string }[]>();
     listChannelGroups.mockResolvedValue([

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -5,6 +5,7 @@ import {
   buildCcSwitchImportUrl,
   CC_SWITCH_CODEX_API_FORMAT,
   CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME,
+  normalizeCcSwitchCodexInlineModelCatalog,
   openCcSwitchImportUrl,
   pickCcSwitchDefaultModel,
   resolveCcSwitchImportConfig,
@@ -279,7 +280,10 @@ describe("ccswitchImport", () => {
         defaultReasoningLevel: "medium",
         supportedReasoningLevels: [
           { effort: "low", description: "Fast responses with lighter reasoning" },
-          { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+          {
+            effort: "medium",
+            description: "Balances speed and reasoning depth for everyday tasks",
+          },
           { effort: "high", description: "Greater reasoning depth for complex problems" },
           { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
         ],
@@ -354,7 +358,10 @@ describe("ccswitchImport", () => {
             defaultReasoningLevel: "medium",
             supportedReasoningLevels: [
               { effort: "low", description: "Fast responses with lighter reasoning" },
-              { effort: "medium", description: "Balances speed and reasoning depth for everyday tasks" },
+              {
+                effort: "medium",
+                description: "Balances speed and reasoning depth for everyday tasks",
+              },
               { effort: "high", description: "Greater reasoning depth for complex problems" },
               { effort: "xhigh", description: "Extra high reasoning depth for complex problems" },
             ],
@@ -407,6 +414,62 @@ describe("ccswitchImport", () => {
         input_modalities: ["text", "image"],
       },
     });
+  });
+
+  test("uses GPT-5.6 capabilities without widening unknown model reasoning", () => {
+    const catalog = buildCcSwitchCodexModelCatalog([
+      { model: "gpt-5.6-sol" },
+      { model: "gpt-5.6-terra", contextWindow: 400000 },
+      { model: "gpt-5.6-luna", contextWindow: 2000000 },
+      { model: "deepseek-v4-flash" },
+    ]);
+
+    for (const model of catalog.models.slice(0, 3)) {
+      expect(model.max_context_window).toBe(1050000);
+      expect(model.supported_reasoning_levels.map((level) => level.effort)).toEqual([
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+      ]);
+    }
+    expect(catalog.models[0]?.context_window).toBe(1050000);
+    expect(catalog.models[1]?.context_window).toBe(400000);
+    expect(catalog.models[2]?.context_window).toBe(1050000);
+    expect(catalog.models[3]?.supported_reasoning_levels.map((level) => level.effort)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  test("normalizes camelCase explicit catalog fields for deep-link round trips", () => {
+    const catalog = normalizeCcSwitchCodexInlineModelCatalog({
+      models: [
+        {
+          slug: "gpt-5.6-sol",
+          model: "gpt-5.6-sol",
+          contextWindow: 900000,
+          maxContextWindow: 1050000,
+          defaultReasoningLevel: "ultra",
+          supportedReasoningLevels: ["max", "ultra"],
+          modelMessages: { contextWindow: 900000, maxContextWindow: 1050000 },
+        },
+      ],
+    });
+
+    expect(catalog?.models[0]).toMatchObject({
+      context_window: 900000,
+      max_context_window: 1050000,
+      default_reasoning_level: "ultra",
+      supported_reasoning_levels: ["max", "ultra"],
+      model_messages: { context_window: 900000, max_context_window: 1050000 },
+    });
+    expect(catalog?.models[0]).not.toHaveProperty("contextWindow");
+    expect(catalog?.models[0]).not.toHaveProperty("maxContextWindow");
   });
 
   test("serializes a Codex model catalog JSON that preserves all model IDs", () => {
@@ -545,6 +608,44 @@ describe("ccswitchImport", () => {
     expect(decodeConfig(url).config).toContain(`model_reasoning_effort = "low"`);
   });
 
+  test("exports normalized GPT-5.6 catalog metadata through the CC Switch deep link", () => {
+    const url = buildCcSwitchImportUrl({
+      apiKey: "sk-test",
+      baseUrl: "https://relay.example.com",
+      clientType: "codex",
+      enabled: true,
+      providerName: "Relay GPT-5.6",
+      model: "gpt-5.6-sol",
+      codexModelCatalog: {
+        models: [
+          {
+            slug: "gpt-5.6-sol",
+            model: "gpt-5.6-sol",
+            contextWindow: 1050000,
+            maxContextWindow: 1050000,
+            defaultReasoningLevel: "ultra",
+            supportedReasoningLevels: [
+              { effort: "max", description: "Maximum" },
+              { effort: "ultra", description: "Delegated" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const decoded = decodeConfig(url);
+    expect(decoded.config).toContain(`model_reasoning_effort = "ultra"`);
+    expect(decoded.modelCatalog.models[0]).toMatchObject({
+      context_window: 1050000,
+      max_context_window: 1050000,
+      default_reasoning_level: "ultra",
+      supported_reasoning_levels: [
+        { effort: "max", description: "Maximum" },
+        { effort: "ultra", description: "Delegated" },
+      ],
+    });
+  });
+
   test("falls back to model_reasoning_effort = high when no matching catalog entry exists", () => {
     const url = buildCcSwitchImportUrl({
       apiKey: "sk-test-key",
@@ -581,6 +682,8 @@ describe("ccswitchImport", () => {
     // into the catalog (so the catalog pointer is present) but the effort
     // falls back to the legacy "high" default to preserve prior behavior.
     expect(decodeConfig(url).config).toContain(`model_reasoning_effort = "high"`);
-    expect(decodeConfig(url).config).toContain(`model_catalog_json = "${CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME}"`);
+    expect(decodeConfig(url).config).toContain(
+      `model_catalog_json = "${CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME}"`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- preserve explicit Codex reasoning and context metadata across API and UI flows
- normalize camelCase and snake_case catalog fields
- add GPT-5.6 max/ultra fallback capabilities without widening unknown models
- preserve CC Switch deep-link round trips and modal saves

## Verification
- `rtk bun run lint`
- `rtk bun run test:ci`
- `rtk bun run build`
- `rtk git diff --check`