### PR TITLE
feat: add sortable CC Switch model mappings

### DIFF
--- a/apps/admin-panel/vite.config.ts
+++ b/apps/admin-panel/vite.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
           "vendor-animation": ["framer-motion", "gsap"],
           "vendor-charts": ["chart.js", "react-chartjs-2"],
           "vendor-markdown": ["react-markdown", "react-syntax-highlighter", "remark-gfm"],
+          "vendor-radix-dropdown": ["@radix-ui/react-dropdown-menu"],
         },
       },
     },

--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -6,6 +6,7 @@ import iconCodex from "@code-proxy/assets/icons/codex.svg";
 import iconGemini from "@code-proxy/assets/icons/gemini.svg";
 import { modelsApi } from "@code-proxy/api-client";
 import { Button } from "@code-proxy/ui";
+import { DataTable, type DataTableColumn, type DataTableSortState } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { SearchableSelect, type SearchableSelectOption } from "@code-proxy/ui";
@@ -192,8 +193,20 @@ function reconcileClaudeMappings(
   const currentByRole = new Map(
     currentMappings.filter((mapping) => mapping.role).map((mapping) => [mapping.role, mapping]),
   );
+  const seenRoles = new Set<CcSwitchClaudeModelRole>();
+  const orderedRoles: CcSwitchClaudeModelRole[] = [];
+  for (const mapping of currentMappings) {
+    if (!mapping.role || seenRoles.has(mapping.role)) continue;
+    seenRoles.add(mapping.role);
+    orderedRoles.push(mapping.role);
+  }
+  for (const role of CLAUDE_ROLE_ORDER) {
+    if (seenRoles.has(role)) continue;
+    seenRoles.add(role);
+    orderedRoles.push(role);
+  }
 
-  return CLAUDE_ROLE_ORDER.map((role) => {
+  return orderedRoles.map((role) => {
     const existing = currentByRole.get(role);
     const targetModel =
       existing?.targetModel.trim() ||
@@ -440,6 +453,7 @@ export function CcSwitchImportConfigModal({
   const [draft, setDraft] = useState<ConfigDraft>(value);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelMappingSort, setModelMappingSort] = useState<DataTableSortState | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -452,6 +466,7 @@ export function CcSwitchImportConfigModal({
     setAvailableModels(
       dedupeModels(value.modelMappings.map((mapping) => mapping.targetModel).filter(Boolean)),
     );
+    setModelMappingSort(null);
   }, [open, value]);
 
   const selectedGroup = draft.allowedChannelGroups[0] ?? "";
@@ -668,6 +683,7 @@ export function CcSwitchImportConfigModal({
     duplicateRequestModels.length > 0;
 
   const setClientType = (clientType: CcSwitchClientType) => {
+    setModelMappingSort(null);
     const defaults = DEFAULT_CC_SWITCH_IMPORT_SETTINGS[clientType];
     setDraft((current) =>
       reconcileModelMappings(
@@ -697,6 +713,7 @@ export function CcSwitchImportConfigModal({
   };
 
   const addGenericModelMapping = () => {
+    setModelMappingSort(null);
     setDraft((current) => ({
       ...current,
       modelMappings: [
@@ -711,6 +728,7 @@ export function CcSwitchImportConfigModal({
   };
 
   const removeGenericModelMapping = (index: number) => {
+    setModelMappingSort(null);
     setDraft((current) => {
       const modelMappings = current.modelMappings.filter((mapping, mappingIndex) => {
         if (mapping.role) return false;
@@ -725,6 +743,7 @@ export function CcSwitchImportConfigModal({
   };
 
   const updateGenericTargetModel = (index: number, targetModel: string) => {
+    setModelMappingSort(null);
     setDraft((current) => {
       const modelMappings = current.modelMappings.map((mapping, mappingIndex) =>
         !mapping.role && mappingIndex === index ? { ...mapping, targetModel } : mapping,
@@ -738,6 +757,7 @@ export function CcSwitchImportConfigModal({
   };
 
   const updateGenericRequestModel = (index: number, requestModel: string) => {
+    setModelMappingSort(null);
     setDraft((current) => {
       const modelMappings = current.modelMappings.map((mapping, mappingIndex) =>
         !mapping.role && mappingIndex === index ? { ...mapping, requestModel } : mapping,
@@ -770,6 +790,7 @@ export function CcSwitchImportConfigModal({
   };
 
   const updateClaudeRoleModel = (role: CcSwitchClaudeModelRole, targetModel: string) => {
+    setModelMappingSort(null);
     setDraft((current) => {
       const modelMappings = current.modelMappings.map((mapping) =>
         mapping.role === role ? { ...mapping, targetModel } : mapping,
@@ -779,6 +800,7 @@ export function CcSwitchImportConfigModal({
   };
 
   const updateClaudeRequestModel = (role: CcSwitchClaudeModelRole, requestModel: string) => {
+    setModelMappingSort(null);
     setDraft((current) => {
       const modelMappings = current.modelMappings.map((mapping) =>
         mapping.role === role ? { ...mapping, requestModel } : mapping,
@@ -790,12 +812,167 @@ export function CcSwitchImportConfigModal({
     });
   };
 
+  const replaceModelMappingRows = (modelMappings: CcSwitchModelMapping[]) => {
+    setDraft((current) => ({
+      ...current,
+      modelMappings,
+      defaultModel:
+        current.clientType === "claude"
+          ? modelMappings.find((mapping) => mapping.role === "main")?.targetModel || ""
+          : resolveGenericDefaultModel(modelMappings, current.defaultModel),
+    }));
+  };
+
+  const mappingCellClassName = "border-b border-slate-200/70 dark:border-neutral-800";
+  const modelMappingColumns: DataTableColumn<CcSwitchModelMapping>[] =
+    draft.clientType === "claude"
+      ? [
+          {
+            key: "role",
+            label: t("ccswitch.config_claude_model_role"),
+            width: "w-44",
+            cellClassName: `${mappingCellClassName} font-medium text-slate-800 dark:text-white/80`,
+            render: (mapping) =>
+              mapping.role ? t(`ccswitch.config_claude_role_${mapping.role}`) : "",
+          },
+          {
+            key: "requestModel",
+            label: t("ccswitch.config_request_model_name"),
+            width: "w-72",
+            cellClassName: mappingCellClassName,
+            sort: { getValue: (mapping) => mapping.requestModel },
+            render: (mapping) => {
+              const role = mapping.role;
+              const label = role ? t(`ccswitch.config_claude_role_${role}`) : "";
+              return (
+                <TextInput
+                  value={mapping.requestModel}
+                  onChange={(event) => {
+                    if (role) updateClaudeRequestModel(role, event.currentTarget.value);
+                  }}
+                  aria-label={t("ccswitch.config_claude_request_model_for", { role: label })}
+                  className={controlClassName}
+                />
+              );
+            },
+          },
+          {
+            key: "targetModel",
+            label: t("ccswitch.config_actual_channel_model"),
+            width: "w-80",
+            cellClassName: mappingCellClassName,
+            sort: { getValue: (mapping) => mapping.targetModel },
+            render: (mapping) => {
+              const role = mapping.role;
+              const label = role ? t(`ccswitch.config_claude_role_${role}`) : "";
+              return (
+                <SearchableSelect
+                  value={mapping.targetModel}
+                  onChange={(next) => {
+                    if (role) updateClaudeRoleModel(role, next);
+                  }}
+                  options={currentModelOptions}
+                  allowCreate
+                  createLabel={(value) => t("ccswitch.model_use_custom", { value })}
+                  placeholder={t("ccswitch.import_model_placeholder")}
+                  searchPlaceholder={t("ccswitch.config_model_search_placeholder")}
+                  aria-label={label}
+                  className={`${controlClassName} w-full`}
+                />
+              );
+            },
+          },
+        ]
+      : [
+          {
+            key: "targetModel",
+            label: t("ccswitch.config_actual_channel_model"),
+            width: "w-80",
+            cellClassName: mappingCellClassName,
+            sort: { getValue: (mapping) => mapping.targetModel },
+            render: (mapping, index) => (
+              <SearchableSelect
+                value={mapping.targetModel}
+                onChange={(next) => updateGenericTargetModel(index, next)}
+                options={currentModelOptions}
+                allowCreate
+                createLabel={(value) => t("ccswitch.model_use_custom", { value })}
+                placeholder={t("ccswitch.import_model_placeholder")}
+                searchPlaceholder={t("ccswitch.config_model_search_placeholder")}
+                aria-label={t("ccswitch.config_actual_channel_model_for_mapping", {
+                  index: index + 1,
+                })}
+                className={`${controlClassName} w-full`}
+              />
+            ),
+          },
+          {
+            key: "requestModel",
+            label: t("ccswitch.config_request_model_name"),
+            width: "w-72",
+            cellClassName: mappingCellClassName,
+            sort: { getValue: (mapping) => mapping.requestModel },
+            render: (mapping, index) => (
+              <TextInput
+                value={mapping.requestModel}
+                onChange={(event) => updateGenericRequestModel(index, event.currentTarget.value)}
+                aria-label={t("ccswitch.config_request_model_for_mapping", {
+                  index: index + 1,
+                })}
+                className={controlClassName}
+              />
+            ),
+          },
+          {
+            key: "contextWindow",
+            label: t("ccswitch.config_codex_context_window"),
+            width: "w-44",
+            cellClassName: mappingCellClassName,
+            render: (mapping, index) => (
+              <TextInput
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={mapping.contextWindow === undefined ? "" : String(mapping.contextWindow)}
+                onChange={(event) => updateGenericContextWindow(index, event.currentTarget.value)}
+                placeholder={String(DEFAULT_CODEX_CONTEXT_WINDOW)}
+                aria-label={t("ccswitch.config_context_window_for_mapping", {
+                  index: index + 1,
+                })}
+                className={controlClassName}
+              />
+            ),
+          },
+          {
+            key: "actions",
+            label: t("ccswitch.config_table_actions"),
+            width: "w-20",
+            lockOrder: "end",
+            resizable: false,
+            reorderable: false,
+            headerClassName: "text-right",
+            cellClassName: `${mappingCellClassName} text-right`,
+            render: (_mapping, index) => (
+              <Button
+                size="xs"
+                variant="ghost"
+                aria-label={t("ccswitch.config_delete_model_mapping", {
+                  index: index + 1,
+                })}
+                onClick={() => removeGenericModelMapping(index)}
+              >
+                <Trash2 size={14} />
+              </Button>
+            ),
+          },
+        ];
+
   return (
     <Modal
       open={open}
       title={t(mode === "create" ? "ccswitch.config_modal_create" : "ccswitch.config_modal_edit")}
       description={t("ccswitch.config_modal_description")}
-      maxWidth="max-w-[820px]"
+      maxWidth="max-w-[1180px]"
       bodyHeightClassName="max-h-[78vh]"
       bodyClassName="bg-slate-50/45 dark:bg-neutral-950/45"
       onClose={onClose}
@@ -820,15 +997,16 @@ export function CcSwitchImportConfigModal({
             <span className={labelClassName}>{t("ccswitch.config_select_channel_group")}</span>
             <SearchableSelect
               value={selectedGroup}
-              onChange={(next) =>
+              onChange={(next) => {
+                setModelMappingSort(null);
                 setDraft((current) => ({
                   ...current,
                   allowedChannelGroups: next ? [next] : [],
                   routePath: next ? ensureCcSwitchRoutePath("", next, current.id) : "",
                   modelMappings: [],
                   defaultModel: "",
-                }))
-              }
+                }));
+              }}
               options={groupSelectOptions}
               placeholder={
                 channelGroupsLoading
@@ -1021,150 +1199,26 @@ export function CcSwitchImportConfigModal({
                 : t("ccswitch.config_model_mapping_select_group_first")}
             </div>
           ) : (
-            <div className="overflow-x-auto">
-              {draft.clientType === "claude" ? (
-                <table className="min-w-[760px] w-full text-left text-sm">
-                  <thead className="bg-slate-50 text-[11px] uppercase tracking-wide text-slate-500 dark:bg-neutral-900/60 dark:text-white/45">
-                    <tr>
-                      <th className="px-4 py-2.5 font-semibold">
-                        {t("ccswitch.config_claude_model_role")}
-                      </th>
-                      <th className="px-4 py-2.5 font-semibold">
-                        {t("ccswitch.config_request_model_name")}
-                      </th>
-                      <th className="px-4 py-2.5 font-semibold">
-                        {t("ccswitch.config_actual_channel_model")}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-200/70 dark:divide-neutral-800">
-                    {CLAUDE_ROLE_ORDER.map((role) => {
-                      const mapping = draft.modelMappings.find((item) => item.role === role);
-                      const label = t(`ccswitch.config_claude_role_${role}`);
-                      return (
-                        <tr key={role}>
-                          <td className="px-4 py-3 font-medium text-slate-800 dark:text-white/80">
-                            {label}
-                          </td>
-                          <td className="px-4 py-3">
-                            <TextInput
-                              value={mapping?.requestModel ?? ""}
-                              onChange={(event) => {
-                                const requestModel = event.currentTarget.value;
-                                updateClaudeRequestModel(role, requestModel);
-                              }}
-                              aria-label={t("ccswitch.config_claude_request_model_for", {
-                                role: label,
-                              })}
-                              className={controlClassName}
-                            />
-                          </td>
-                          <td className="px-4 py-3">
-                            <SearchableSelect
-                              value={mapping?.targetModel ?? ""}
-                              onChange={(next) => updateClaudeRoleModel(role, next)}
-                              options={currentModelOptions}
-                              allowCreate
-                              createLabel={(value) => t("ccswitch.model_use_custom", { value })}
-                              placeholder={t("ccswitch.import_model_placeholder")}
-                              searchPlaceholder={t("ccswitch.config_model_search_placeholder")}
-                              aria-label={label}
-                              className={`${controlClassName} w-full`}
-                            />
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              ) : (
-                <table className="min-w-[900px] w-full text-left text-sm">
-                  <thead className="bg-slate-50 text-[11px] uppercase tracking-wide text-slate-500 dark:bg-neutral-900/60 dark:text-white/45">
-                    <tr>
-                      <th className="px-4 py-2.5 font-semibold">
-                        {t("ccswitch.config_actual_channel_model")}
-                      </th>
-                      <th className="px-4 py-2.5 font-semibold">
-                        {t("ccswitch.config_request_model_name")}
-                      </th>
-                      <th className="w-44 px-4 py-2.5 font-semibold">
-                        {t("ccswitch.config_codex_context_window")}
-                      </th>
-                      <th className="w-16 px-4 py-2.5 text-right font-semibold">
-                        {t("ccswitch.config_table_actions")}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-slate-200/70 dark:divide-neutral-800">
-                    {draft.modelMappings.map((mapping, index) => (
-                      <tr key={index}>
-                        <td className="px-4 py-3">
-                          <SearchableSelect
-                            value={mapping.targetModel}
-                            onChange={(next) => updateGenericTargetModel(index, next)}
-                            options={currentModelOptions}
-                            allowCreate
-                            createLabel={(value) => t("ccswitch.model_use_custom", { value })}
-                            placeholder={t("ccswitch.import_model_placeholder")}
-                            searchPlaceholder={t("ccswitch.config_model_search_placeholder")}
-                            aria-label={t("ccswitch.config_actual_channel_model_for_mapping", {
-                              index: index + 1,
-                            })}
-                            className={`${controlClassName} w-full`}
-                          />
-                        </td>
-                        <td className="px-4 py-3">
-                          <TextInput
-                            value={mapping.requestModel}
-                            onChange={(event) => {
-                              const requestModel = event.currentTarget.value;
-                              updateGenericRequestModel(index, requestModel);
-                            }}
-                            aria-label={t("ccswitch.config_request_model_for_mapping", {
-                              index: index + 1,
-                            })}
-                            className={controlClassName}
-                          />
-                        </td>
-                        <td className="px-4 py-3">
-                          <TextInput
-                            type="number"
-                            min={1}
-                            inputMode="numeric"
-                            value={
-                              mapping.contextWindow === undefined
-                                ? ""
-                                : String(mapping.contextWindow)
-                            }
-                            onChange={(event) =>
-                              updateGenericContextWindow(index, event.currentTarget.value)
-                            }
-                            placeholder={String(DEFAULT_CODEX_CONTEXT_WINDOW)}
-                            aria-label={t("ccswitch.config_context_window_for_mapping", {
-                              index: index + 1,
-                            })}
-                            className={controlClassName}
-                          />
-                        </td>
-                        <td className="px-4 py-3 text-right">
-                          <Button
-                            size="xs"
-                            variant="ghost"
-                            aria-label={t("ccswitch.config_delete_model_mapping", {
-                              index: index + 1,
-                            })}
-                            onClick={() => removeGenericModelMapping(index)}
-                          >
-                            <Trash2 size={14} />
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
+            <div data-testid="ccswitch-model-mapping-table" className="px-4 pt-3 pb-4">
+              <DataTable<CcSwitchModelMapping>
+                rows={draft.modelMappings}
+                columns={modelMappingColumns}
+                rowKey={(mapping, index) => mapping.role ?? `mapping-${index}`}
+                rowReorderable
+                onRowsChange={(rows) => replaceModelMappingRows(rows)}
+                sortState={modelMappingSort}
+                onSortStateChange={setModelMappingSort}
+                height="h-[320px]"
+                minHeight="min-h-[320px]"
+                minWidth={draft.clientType === "claude" ? "min-w-[800px]" : "min-w-[980px]"}
+                caption={t("ccswitch.config_model_mapping_title")}
+                showAllLoadedMessage={false}
+                allowWheelPropagationAtBoundary
+                columnReorderable={false}
+                persistColumnOrder={false}
+              />
               {duplicateRequestModels.length > 0 ? (
-                <div className="border-t border-rose-100 bg-rose-50 px-4 py-2 text-xs font-medium text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">
+                <div className="mt-3 rounded-xl bg-rose-50 px-4 py-2 text-xs font-medium text-rose-700 dark:bg-rose-500/10 dark:text-rose-200">
                   {t("ccswitch.config_request_model_duplicate", {
                     model: duplicateRequestModels.join(", "),
                   })}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -79,7 +79,12 @@
     "resize_column": "Drag to resize {{column}} column",
     "column_width_px": "Width: {{width}} px",
     "reorder_column": "Drag to reorder {{column}} column",
-    "column_reorder_target": "Move to column {{index}}"
+    "column_reorder_target": "Move to column {{index}}",
+    "row_order": "Row order",
+    "reorder_row": "Drag to reorder row {{index}}",
+    "sort_column": "Sort {{column}}",
+    "sort_ascending": "Ascending",
+    "sort_descending": "Descending"
   },
   "title": {
     "main": "Code Proxy Admin Dashboard",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -59,7 +59,12 @@
     "resize_column": "Перетащите, чтобы изменить ширину столбца {{column}}",
     "column_width_px": "Ширина: {{width}} px",
     "reorder_column": "Перетащите, чтобы изменить порядок столбца {{column}}",
-    "column_reorder_target": "Переместить в столбец {{index}}"
+    "column_reorder_target": "Переместить в столбец {{index}}",
+    "row_order": "Порядок строк",
+    "reorder_row": "Перетащите, чтобы изменить порядок строки {{index}}",
+    "sort_column": "Сортировать {{column}}",
+    "sort_ascending": "По возрастанию",
+    "sort_descending": "По убыванию"
   },
   "ccswitch": {
     "import_to_ccswitch": "Импорт в CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -81,7 +81,12 @@
     "resize_column": "拖拽调整 {{column}} 列宽",
     "column_width_px": "宽：{{width}} 像素",
     "reorder_column": "拖拽调整 {{column}} 列位置",
-    "column_reorder_target": "移动到第 {{index}} 列"
+    "column_reorder_target": "移动到第 {{index}} 列",
+    "row_order": "行顺序",
+    "reorder_row": "拖拽调整第 {{index}} 行位置",
+    "sort_column": "排序 {{column}}",
+    "sort_ascending": "升序",
+    "sort_descending": "降序"
   },
   "title": {
     "main": "Code Proxy 管理后台",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -7,103 +7,29 @@ import {
   useState,
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
-  type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { GripVertical } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Check, GripVertical } from "lucide-react";
+import { DropdownMenu } from "../primitives/DropdownMenu";
 import { TableCellOverflowTooltip } from "./TableCellOverflowTooltip";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** Column definition for DataTable */
-export interface DataTableColumn<T> {
-  /** Unique key for this column */
-  key: string;
-  /** Header label */
-  label: string;
-  /** Fixed width class (Tailwind), e.g. "w-52" */
-  width?: string;
-  /** Whether users can drag this column's right edge to resize it. */
-  resizable?: boolean;
-  /** Whether users can reorder this column by dragging its handle. */
-  reorderable?: boolean;
-  /** Pin this column to the start or end of the table, preventing it from being reordered. */
-  lockOrder?: "start" | "end";
-  /** Minimum drag-resize width in px. */
-  minWidthPx?: number;
-  /** Maximum drag-resize width in px. */
-  maxWidthPx?: number;
-  /** Extra header class (e.g. "text-right") */
-  headerClassName?: string;
-  /** Extra cell class */
-  cellClassName?: string;
-  /** Overflow tooltip text for a truncated cell. Primitive render output is used by default. */
-  overflowTooltip?: boolean | ((row: T, index: number) => string | null | undefined);
-  /** Custom header render function (overrides label) */
-  headerRender?: () => ReactNode;
-  /** Render function for cell content */
-  render: (row: T, index: number) => ReactNode;
-}
-
-export interface DataTableProps<T> {
-  /** Stable id used to keep each table's column widths isolated in localStorage. */
-  tableId?: string;
-  /** Row data array */
-  rows: readonly T[];
-  /** Column definitions */
-  columns: DataTableColumn<T>[];
-  /** Unique key extractor for each row */
-  rowKey: (row: T, index: number) => string;
-  /** Whether the initial data is loading */
-  loading?: boolean;
-  /** Whether more data is available for infinite scroll */
-  hasMore?: boolean;
-  /** Whether a next-page load is in progress */
-  loadingMore?: boolean;
-  /** Callback when scrolled near bottom (triggers next page load) */
-  onScrollBottom?: () => void;
-  /** Legacy row windowing mode. Most management tables keep this disabled for finite row sets. */
-  virtualize?: boolean;
-  /** Row height in px (default 44) */
-  rowHeight?: number;
-  /** Overscan rows above/below viewport (default 12) */
-  overscan?: number;
-  /** Distance from bottom to trigger onScrollBottom (default 100) */
-  scrollThreshold?: number;
-  /** Debounce ms before triggering onScrollBottom (default 120) */
-  bottomDebounceMs?: number;
-  /** Minimum table width class (default "min-w-[1320px]") */
-  minWidth?: string;
-  /** Container height class (default "h-[calc(100dvh-260px)]") */
-  height?: string;
-  /** Container minimum height class (default "min-h-[360px]") */
-  minHeight?: string;
-  /** Screen-reader caption */
-  caption?: string;
-  /** Empty state message */
-  emptyText?: string;
-  /** Show the "all records loaded" footer when there is no next page. */
-  showAllLoadedMessage?: boolean;
-  /** Extra row className */
-  rowClassName?: string | ((row: T, index: number) => string);
-  /** Optional row click handler. When set, rows become keyboard-focusable selection targets. */
-  onRowClick?: (row: T, index: number) => void;
-  /** Optional selected state for row interaction semantics. */
-  rowAriaSelected?: (row: T, index: number) => boolean;
-  /** Let parent scroll containers handle wheel/touch scroll chaining when this table is already at an edge. */
-  allowWheelPropagationAtBoundary?: boolean;
-  /** Render the table in normal document flow without any internal table scrollbars. */
-  naturalFlow?: boolean;
-  /** Extra class for the content wrapper inside the scroll viewport (e.g. "pr-5" for right padding). */
-  scrollContentClassName?: string;
-  /** Whether column reorder by dragging the header handle is allowed (default true when tableId is set). */
-  columnReorderable?: boolean;
-  /** Whether column order is persisted to localStorage (default true). */
-  persistColumnOrder?: boolean;
-}
+export type {
+  DataTableColumn,
+  DataTableColumnSort,
+  DataTableProps,
+  DataTableRowsChangeAction,
+  DataTableSortDirection,
+  DataTableSortState,
+  DataTableSortValue,
+} from "./DataTable.types";
+import type {
+  DataTableColumn,
+  DataTableProps,
+  DataTableSortDirection,
+  DataTableSortState,
+  DataTableSortValue,
+} from "./DataTable.types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -141,6 +67,11 @@ const COLUMN_REORDER_SETTLE_CLEANUP_MS = 110;
 const COLUMN_REORDER_SETTLE_FEEDBACK_MS = 900;
 const NON_REORDERABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
 
+const ROW_REORDER_COLUMN_KEY = "__data-table-row-reorder__";
+const ROW_REORDER_MIN_DRAG_DISTANCE_PX = 4;
+const ROW_REORDER_AUTOSCROLL_EDGE_PX = 56;
+const ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME = 18;
+
 type ColumnOrder = string[];
 
 interface ColumnReorderGeometry {
@@ -170,6 +101,16 @@ interface ColumnReorderState {
   allowedMaxIndex: number;
   columns: ColumnReorderGeometry[];
   draggedWidth: number;
+}
+
+interface RowReorderState {
+  pointerId: number;
+  fromIndex: number;
+  insertionIndex: number;
+  startClientY: number;
+  lastClientY: number;
+  activated: boolean;
+  scrollContainer: HTMLElement | null;
 }
 
 type ColumnWidthMap = Record<string, number>;
@@ -465,6 +406,48 @@ function safeSetPointerCapture(element: Element, pointerId: number) {
   }
 }
 
+function isEmptySortValue(value: DataTableSortValue) {
+  return value === null || value === undefined || (typeof value === "string" && !value.trim());
+}
+
+function compareSortValues(
+  left: DataTableSortValue,
+  right: DataTableSortValue,
+  collator: Intl.Collator,
+) {
+  const leftEmpty = isEmptySortValue(left);
+  const rightEmpty = isEmptySortValue(right);
+  if (leftEmpty || rightEmpty) {
+    if (leftEmpty && rightEmpty) return 0;
+    return leftEmpty ? 1 : -1;
+  }
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+  return collator.compare(String(left), String(right));
+}
+
+function moveRow<T>(rows: readonly T[], fromIndex: number, toIndex: number): T[] {
+  const next = Array.from(rows);
+  const [moved] = next.splice(fromIndex, 1);
+  if (moved === undefined) return next;
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+function findVerticalScrollContainer(element: HTMLElement | null): HTMLElement | null {
+  let current = element?.parentElement ?? null;
+  while (current) {
+    const overflowY = window.getComputedStyle(current).overflowY;
+    if (/(auto|scroll)/.test(overflowY) && current.scrollHeight > current.clientHeight) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  const scrollingElement = document.scrollingElement;
+  return scrollingElement instanceof HTMLElement ? scrollingElement : null;
+}
+
 // ---------------------------------------------------------------------------
 // Column Order Helpers
 // ---------------------------------------------------------------------------
@@ -670,7 +653,7 @@ function scheduleColumnReorderSettleCleanup(element: HTMLElement) {
 export function DataTable<T>({
   tableId,
   rows,
-  columns,
+  columns: providedColumns,
   rowKey,
   loading = false,
   hasMore = false,
@@ -695,8 +678,34 @@ export function DataTable<T>({
   scrollContentClassName,
   columnReorderable = true,
   persistColumnOrder = true,
+  sortState,
+  defaultSortState = null,
+  onSortStateChange,
+  rowReorderable = false,
+  onRowsChange,
 }: DataTableProps<T>) {
   const { t } = useTranslation();
+  const columns = useMemo<DataTableColumn<T>[]>(() => {
+    if (!rowReorderable) return providedColumns;
+    const stickyClassName = naturalFlow ? "" : "sticky";
+    return [
+      {
+        key: ROW_REORDER_COLUMN_KEY,
+        label: t("common.row_order"),
+        width: "w-12",
+        minWidthPx: 48,
+        maxWidthPx: 48,
+        resizable: false,
+        reorderable: false,
+        lockOrder: "start",
+        headerClassName: stickyClassName,
+        cellClassName: stickyClassName,
+        overflowTooltip: false,
+        render: () => null,
+      },
+      ...providedColumns,
+    ];
+  }, [naturalFlow, providedColumns, rowReorderable, t]);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const tableRef = useRef<HTMLTableElement | null>(null);
@@ -768,6 +777,14 @@ export function DataTable<T>({
   const columnReorderAutoScrollRafRef = useRef<number | null>(null);
   const columnReorderSettleTimeoutRef = useRef<number | null>(null);
   const hoveredRowRef = useRef<HTMLTableRowElement | null>(null);
+  const [internalSortState, setInternalSortState] = useState<DataTableSortState | null>(
+    defaultSortState,
+  );
+  const activeSortState = sortState === undefined ? internalSortState : sortState;
+  const rowReorderRef = useRef<RowReorderState | null>(null);
+  const rowReorderAutoScrollRafRef = useRef<number | null>(null);
+  const [activeRowReorderIndex, setActiveRowReorderIndex] = useState<number | null>(null);
+  const [rowReorderInsertionIndex, setRowReorderInsertionIndex] = useState<number | null>(null);
 
   const orderedColumns = useMemo(() => {
     if (!canUseColumnOrder) return columns;
@@ -823,6 +840,274 @@ export function DataTable<T>({
     });
   }, [columns]);
 
+  const sortCollator = useMemo(
+    () => new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }),
+    [],
+  );
+
+  const updateSortState = useCallback(
+    (nextSortState: DataTableSortState | null) => {
+      if (sortState === undefined) setInternalSortState(nextSortState);
+      onSortStateChange?.(nextSortState);
+    },
+    [onSortStateChange, sortState],
+  );
+
+  const handleColumnSort = useCallback(
+    (column: DataTableColumn<T>, direction: DataTableSortDirection) => {
+      if (!column.sort || !onRowsChange) return;
+      const nextSortState = { columnKey: column.key, direction };
+      const indexedRows = rows.map((row, index) => ({ row, index }));
+      indexedRows.sort((left, right) => {
+        let compared: number;
+        if (column.sort?.compare) {
+          compared = column.sort.compare(left.row, right.row);
+          if (!Number.isFinite(compared)) compared = 0;
+          compared = direction === "asc" ? compared : -compared;
+        } else {
+          const leftValue = column.sort?.getValue(left.row, left.index);
+          const rightValue = column.sort?.getValue(right.row, right.index);
+          const leftEmpty = isEmptySortValue(leftValue);
+          const rightEmpty = isEmptySortValue(rightValue);
+          if (leftEmpty || rightEmpty) {
+            compared = leftEmpty === rightEmpty ? 0 : leftEmpty ? 1 : -1;
+          } else {
+            compared = compareSortValues(leftValue, rightValue, sortCollator);
+            compared = direction === "asc" ? compared : -compared;
+          }
+        }
+        return compared || left.index - right.index;
+      });
+      updateSortState(nextSortState);
+      onRowsChange(
+        indexedRows.map((item) => item.row),
+        { type: "sort", sort: nextSortState },
+      );
+    },
+    [onRowsChange, rows, sortCollator, updateSortState],
+  );
+
+  const resolveRowInsertionIndex = useCallback((clientY: number) => {
+    const rowElements = Array.from(
+      tableRef.current?.querySelectorAll<HTMLTableRowElement>("tbody tr[data-vt-row-index]") ?? [],
+    );
+    if (rowElements.length === 0) return 0;
+
+    for (const rowElement of rowElements) {
+      const rowIndex = Number(rowElement.dataset.vtRowIndex);
+      if (!Number.isInteger(rowIndex)) continue;
+      const rect = rowElement.getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return rowIndex;
+    }
+
+    const lastRowIndex = Number(rowElements.at(-1)?.dataset.vtRowIndex);
+    return Number.isInteger(lastRowIndex) ? lastRowIndex + 1 : 0;
+  }, []);
+
+  const stopRowReorderAutoScroll = useCallback(() => {
+    if (rowReorderAutoScrollRafRef.current !== null) {
+      window.cancelAnimationFrame(rowReorderAutoScrollRafRef.current);
+      rowReorderAutoScrollRafRef.current = null;
+    }
+  }, []);
+
+  const updateRowReorderTarget = useCallback(
+    (clientY: number) => {
+      const active = rowReorderRef.current;
+      if (!active?.activated) return;
+      const insertionIndex = Math.max(0, Math.min(rows.length, resolveRowInsertionIndex(clientY)));
+      if (insertionIndex === active.insertionIndex) return;
+      active.insertionIndex = insertionIndex;
+      setRowReorderInsertionIndex(insertionIndex);
+    },
+    [resolveRowInsertionIndex, rows.length],
+  );
+
+  const runRowReorderAutoScroll = useCallback(() => {
+    rowReorderAutoScrollRafRef.current = null;
+    const active = rowReorderRef.current;
+    const scrollContainer = active?.scrollContainer;
+    if (!active?.activated || !scrollContainer) return;
+
+    const rect = scrollContainer.getBoundingClientRect();
+    const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+    if (maxScrollTop <= 0) return;
+
+    const topIntensity = Math.max(
+      0,
+      Math.min(
+        1,
+        (ROW_REORDER_AUTOSCROLL_EDGE_PX - (active.lastClientY - rect.top)) /
+          ROW_REORDER_AUTOSCROLL_EDGE_PX,
+      ),
+    );
+    const bottomIntensity = Math.max(
+      0,
+      Math.min(
+        1,
+        (ROW_REORDER_AUTOSCROLL_EDGE_PX - (rect.bottom - active.lastClientY)) /
+          ROW_REORDER_AUTOSCROLL_EDGE_PX,
+      ),
+    );
+    const direction =
+      topIntensity > 0 && scrollContainer.scrollTop > 0
+        ? -1
+        : bottomIntensity > 0 && scrollContainer.scrollTop < maxScrollTop
+          ? 1
+          : 0;
+    if (direction === 0) return;
+
+    const intensity = direction < 0 ? topIntensity : bottomIntensity;
+    const delta =
+      direction *
+      Math.max(1, Math.round(ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME * intensity * intensity));
+    const nextScrollTop = Math.max(0, Math.min(maxScrollTop, scrollContainer.scrollTop + delta));
+    if (nextScrollTop !== scrollContainer.scrollTop) {
+      scrollContainer.scrollTop = nextScrollTop;
+      updateRowReorderTarget(active.lastClientY);
+    }
+    rowReorderAutoScrollRafRef.current = window.requestAnimationFrame(runRowReorderAutoScroll);
+  }, [updateRowReorderTarget]);
+
+  const ensureRowReorderAutoScroll = useCallback(() => {
+    if (rowReorderAutoScrollRafRef.current !== null) return;
+    rowReorderAutoScrollRafRef.current = window.requestAnimationFrame(runRowReorderAutoScroll);
+  }, [runRowReorderAutoScroll]);
+
+  const clearRowReorder = useCallback(() => {
+    stopRowReorderAutoScroll();
+    rowReorderRef.current = null;
+    setActiveRowReorderIndex(null);
+    setRowReorderInsertionIndex(null);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    document.documentElement.style.cursor = "";
+  }, [stopRowReorderAutoScroll]);
+
+  const cancelRowReorder = useCallback(() => {
+    clearRowReorder();
+  }, [clearRowReorder]);
+
+  const finishRowReorder = useCallback(
+    (event?: PointerEvent) => {
+      const active = rowReorderRef.current;
+      if (!active || (event && event.pointerId !== active.pointerId)) return;
+      const shouldCommit = active.activated;
+      const fromIndex = active.fromIndex;
+      const insertionIndex = active.insertionIndex;
+      clearRowReorder();
+      if (!shouldCommit || !onRowsChange || rows.length < 2) return;
+
+      const toIndex = Math.max(
+        0,
+        Math.min(rows.length - 1, insertionIndex > fromIndex ? insertionIndex - 1 : insertionIndex),
+      );
+      if (toIndex === fromIndex) return;
+      if (activeSortState) updateSortState(null);
+      onRowsChange(moveRow(rows, fromIndex, toIndex), {
+        type: "row-reorder",
+        fromIndex,
+        toIndex,
+      });
+    },
+    [activeSortState, clearRowReorder, onRowsChange, rows, updateSortState],
+  );
+
+  const activateRowReorder = useCallback((active: RowReorderState) => {
+    if (active.activated) return;
+    active.activated = true;
+    setActiveRowReorderIndex(active.fromIndex);
+    setRowReorderInsertionIndex(active.insertionIndex);
+    document.body.style.cursor = "grabbing";
+    document.body.style.userSelect = "none";
+    document.documentElement.style.cursor = "grabbing";
+  }, []);
+
+  const handleRowReorderPointerDown = useCallback(
+    (rowIndex: number, event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0 || !rowReorderable || !onRowsChange || rows.length < 2 || loading) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      safeSetPointerCapture(event.currentTarget, event.pointerId);
+      rowReorderRef.current = {
+        pointerId: event.pointerId,
+        fromIndex: rowIndex,
+        insertionIndex: rowIndex,
+        startClientY: event.clientY,
+        lastClientY: event.clientY,
+        activated: false,
+        scrollContainer:
+          !naturalFlow && containerRef.current
+            ? containerRef.current
+            : findVerticalScrollContainer(rootRef.current),
+      };
+    },
+    [loading, naturalFlow, onRowsChange, rowReorderable, rows.length],
+  );
+
+  const handleRowReorderKeyDown = useCallback(
+    (rowIndex: number, event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!onRowsChange || rows.length < 2) return;
+      const toIndex =
+        event.key === "ArrowUp"
+          ? Math.max(0, rowIndex - 1)
+          : event.key === "ArrowDown"
+            ? Math.min(rows.length - 1, rowIndex + 1)
+            : rowIndex;
+      if (toIndex === rowIndex) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (activeSortState) updateSortState(null);
+      onRowsChange(moveRow(rows, rowIndex, toIndex), {
+        type: "row-reorder",
+        fromIndex: rowIndex,
+        toIndex,
+      });
+    },
+    [activeSortState, onRowsChange, rows, updateSortState],
+  );
+
+  useEffect(() => {
+    if (!rowReorderable) return;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const active = rowReorderRef.current;
+      if (!active || active.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      active.lastClientY = event.clientY;
+      if (
+        !active.activated &&
+        Math.abs(event.clientY - active.startClientY) >= ROW_REORDER_MIN_DRAG_DISTANCE_PX
+      ) {
+        activateRowReorder(active);
+      }
+      if (!active.activated) return;
+      updateRowReorderTarget(event.clientY);
+      ensureRowReorderAutoScroll();
+    };
+    const handleWindowBlur = () => cancelRowReorder();
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", finishRowReorder);
+    window.addEventListener("pointercancel", cancelRowReorder);
+    window.addEventListener("blur", handleWindowBlur);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", finishRowReorder);
+      window.removeEventListener("pointercancel", cancelRowReorder);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [
+    activateRowReorder,
+    cancelRowReorder,
+    ensureRowReorderAutoScroll,
+    finishRowReorder,
+    rowReorderable,
+    updateRowReorderTarget,
+  ]);
+
   const syncScrollbarThumbs = useCallback(
     (metrics: ScrollMetrics, measuredHeaderHeight = headerHeightRef.current) => {
       const { vThumb: nextVThumb, hThumb: nextHThumb } = calculateScrollbarThumbs(
@@ -841,7 +1126,6 @@ export function DataTable<T>({
         horizontalThumb.style.left = `${nextHThumb.left}px`;
         horizontalThumb.style.width = `${nextHThumb.width}px`;
       }
-
     },
     [],
   );
@@ -2054,6 +2338,11 @@ export function DataTable<T>({
         window.clearTimeout(columnReorderSettleTimeoutRef.current);
         columnReorderSettleTimeoutRef.current = null;
       }
+      if (rowReorderAutoScrollRafRef.current) {
+        window.cancelAnimationFrame(rowReorderAutoScrollRafRef.current);
+        rowReorderAutoScrollRafRef.current = null;
+      }
+      rowReorderRef.current = null;
       pendingColumnResizePointerRef.current = null;
     };
   }, []);
@@ -2293,8 +2582,12 @@ export function DataTable<T>({
             >
               <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-white/55">
                 {orderedColumns.map((col, colIndex) => {
+                  const isRowReorderColumn = col.key === ROW_REORDER_COLUMN_KEY;
                   const canResize = shouldAllowColumnResize(col, colIndex, orderedColumns);
                   const canReorder = canUseColumnOrder && shouldAllowColumnReorder(col);
+                  const canSort = Boolean(col.sort && onRowsChange);
+                  const sortDirection =
+                    activeSortState?.columnKey === col.key ? activeSortState.direction : null;
                   const isResizingThisColumn = activeResizeColumnKey === col.key;
                   const isSettledReorderColumn = settledReorderColumnKey === col.key;
                   const stickyPlacement = naturalFlow ? undefined : stickyColumnPlacements[col.key];
@@ -2350,7 +2643,7 @@ export function DataTable<T>({
                       ) : null}
                       <div
                         data-vt-column-header-content
-                        className={`min-w-0 max-w-full overflow-hidden truncate ${
+                        className={`min-w-0 max-w-full overflow-hidden ${
                           canReorder
                             ? "group-hover/column:pl-5 group-hover/column:transition-[padding] group-focus-within/column:pl-5 data-[vt-reorder-active=true]:pl-5"
                             : ""
@@ -2359,7 +2652,67 @@ export function DataTable<T>({
                           activeReorderColumnKey === col.key ? "true" : undefined
                         }
                       >
-                        {col.headerRender ? col.headerRender() : col.label}
+                        {isRowReorderColumn ? (
+                          <span className="flex items-center justify-center text-slate-400/70 dark:text-white/35">
+                            <GripVertical size={14} aria-hidden="true" />
+                            <span className="sr-only">{col.label}</span>
+                          </span>
+                        ) : (
+                          <span className="flex min-w-0 items-center gap-1.5">
+                            <span className="min-w-0 truncate">
+                              {col.headerRender ? col.headerRender() : col.label}
+                            </span>
+                            {canSort ? (
+                              <DropdownMenu.Root size="sm">
+                                <DropdownMenu.Trigger asChild>
+                                  <button
+                                    type="button"
+                                    data-vt-sort-trigger={col.key}
+                                    data-vt-sort-direction={sortDirection ?? "none"}
+                                    aria-label={t("common.sort_column", { column: col.label })}
+                                    title={t("common.sort_column", { column: col.label })}
+                                    className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-slate-200/75 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:hover:bg-white/10 dark:focus-visible:ring-white/15 ${
+                                      sortDirection
+                                        ? "text-slate-900 dark:text-white"
+                                        : "text-slate-400 dark:text-white/35"
+                                    }`}
+                                    onPointerDown={(event) => event.stopPropagation()}
+                                  >
+                                    {sortDirection === "asc" ? (
+                                      <ArrowUp size={14} aria-hidden="true" />
+                                    ) : sortDirection === "desc" ? (
+                                      <ArrowDown size={14} aria-hidden="true" />
+                                    ) : (
+                                      <ArrowUpDown size={14} aria-hidden="true" />
+                                    )}
+                                  </button>
+                                </DropdownMenu.Trigger>
+                                <DropdownMenu.Portal>
+                                  <DropdownMenu.Content align="start">
+                                    <DropdownMenu.Item
+                                      onSelect={() => handleColumnSort(col, "asc")}
+                                    >
+                                      <ArrowUp size={13} aria-hidden="true" />
+                                      <span>{t("common.sort_ascending")}</span>
+                                      {sortDirection === "asc" ? (
+                                        <Check className="ml-auto" size={13} aria-hidden="true" />
+                                      ) : null}
+                                    </DropdownMenu.Item>
+                                    <DropdownMenu.Item
+                                      onSelect={() => handleColumnSort(col, "desc")}
+                                    >
+                                      <ArrowDown size={13} aria-hidden="true" />
+                                      <span>{t("common.sort_descending")}</span>
+                                      {sortDirection === "desc" ? (
+                                        <Check className="ml-auto" size={13} aria-hidden="true" />
+                                      ) : null}
+                                    </DropdownMenu.Item>
+                                  </DropdownMenu.Content>
+                                </DropdownMenu.Portal>
+                              </DropdownMenu.Root>
+                            ) : null}
+                          </span>
+                        )}
                       </div>
                       {canResize ? (
                         <button
@@ -2442,15 +2795,24 @@ export function DataTable<T>({
                         : (rowClassName ?? "");
                     const rowSelected = rowAriaSelected?.(row, globalIdx);
                     const rowInteractive = Boolean(onRowClick);
+                    const isActiveRowReorder = activeRowReorderIndex === globalIdx;
+                    const showDropBefore = rowReorderInsertionIndex === globalIdx;
+                    const showDropAfter =
+                      rowReorderInsertionIndex === rows.length && globalIdx === rows.length - 1;
                     return (
                       <tr
                         key={key}
+                        data-vt-row-index={globalIdx}
+                        data-vt-row-key={key}
+                        data-vt-row-reorder-active={isActiveRowReorder ? true : undefined}
                         tabIndex={rowInteractive ? 0 : undefined}
                         aria-selected={rowSelected}
-                        className={`group/row relative z-0 text-sm transition-colors ${
+                        className={`group/row relative z-0 text-sm transition-[opacity,background-color] ${
                           rowInteractive ? "cursor-pointer outline-none" : ""
-                        } ${
-                          naturalFlow ? "hover:bg-slate-50 dark:hover:bg-white/[0.04]" : ""
+                        } ${naturalFlow ? "hover:bg-slate-50 dark:hover:bg-white/[0.04]" : ""} ${
+                          isActiveRowReorder
+                            ? "z-20 bg-slate-100/90 opacity-75 dark:bg-white/10"
+                            : ""
                         } ${extraCls}`}
                         style={virtualize ? { height: rowHeight } : undefined}
                         onClick={
@@ -2479,6 +2841,7 @@ export function DataTable<T>({
                         {orderedColumns.map((col, colIdx) => {
                           const isFirst = colIdx === 0;
                           const isLast = colIdx === orderedColumns.length - 1;
+                          const isRowReorderColumn = col.key === ROW_REORDER_COLUMN_KEY;
                           const isSettledReorderColumn = settledReorderColumnKey === col.key;
                           const stickyPlacement = naturalFlow
                             ? undefined
@@ -2496,6 +2859,11 @@ export function DataTable<T>({
                             : stickyPlacement
                               ? "group-hover/row:bg-slate-50 dark:group-hover/row:bg-neutral-900"
                               : "group-hover/row:bg-slate-50 dark:group-hover/row:bg-white/[0.04]";
+                          const dropIndicatorClass = showDropBefore
+                            ? "border-t-2 border-t-blue-500"
+                            : showDropAfter
+                              ? "border-b-2 border-b-blue-500"
+                              : "";
                           return (
                             <td
                               key={col.key}
@@ -2504,7 +2872,9 @@ export function DataTable<T>({
                                 isSettledReorderColumn ? true : undefined
                               }
                               style={resolveColumnStyle(col, "cell")}
-                              className={`overflow-hidden px-4 py-2.5 align-middle ${
+                              className={`overflow-hidden align-middle ${
+                                isRowReorderColumn ? "px-1 py-2.5 text-center" : "px-4 py-2.5"
+                              } ${
                                 stickyPlacement?.edge === "start"
                                   ? "md:left-[var(--vt-sticky-left)]"
                                   : ""
@@ -2514,19 +2884,40 @@ export function DataTable<T>({
                                   : ""
                               } ${
                                 hoverChromeClass
-                              } ${col.cellClassName ?? ""} ${roundCls}`}
+                              } ${dropIndicatorClass} ${col.cellClassName ?? ""} ${roundCls}`}
                             >
-                              <div
-                                data-vt-cell-content-clip
-                                className="min-w-0 max-w-full overflow-hidden"
-                              >
-                                <TableCellOverflowTooltip
-                                  tooltipContent={overflowTooltip}
-                                  className={col.cellClassName}
+                              {isRowReorderColumn ? (
+                                <button
+                                  type="button"
+                                  data-vt-row-reorder-handle
+                                  aria-label={t("common.reorder_row", { index: globalIdx + 1 })}
+                                  title={t("common.reorder_row", { index: globalIdx + 1 })}
+                                  disabled={!onRowsChange || rows.length < 2 || loading}
+                                  className={`inline-flex h-7 w-7 touch-none items-center justify-center rounded-lg text-slate-400 outline-none transition-colors hover:bg-slate-200/80 hover:text-slate-700 focus-visible:ring-2 focus-visible:ring-slate-400/35 disabled:cursor-default disabled:opacity-35 dark:text-white/35 dark:hover:bg-white/10 dark:hover:text-white/75 dark:focus-visible:ring-white/15 ${
+                                    isActiveRowReorder
+                                      ? "cursor-grabbing bg-slate-200 text-slate-800 dark:bg-white/15 dark:text-white"
+                                      : "cursor-grab"
+                                  }`}
+                                  onPointerDown={(event) =>
+                                    handleRowReorderPointerDown(globalIdx, event)
+                                  }
+                                  onKeyDown={(event) => handleRowReorderKeyDown(globalIdx, event)}
                                 >
-                                  {content}
-                                </TableCellOverflowTooltip>
-                              </div>
+                                  <GripVertical size={15} aria-hidden="true" />
+                                </button>
+                              ) : (
+                                <div
+                                  data-vt-cell-content-clip
+                                  className="min-w-0 max-w-full overflow-hidden"
+                                >
+                                  <TableCellOverflowTooltip
+                                    tooltipContent={overflowTooltip}
+                                    className={col.cellClassName}
+                                  >
+                                    {content}
+                                  </TableCellOverflowTooltip>
+                                </div>
+                              )}
                             </td>
                           );
                         })}

--- a/packages/ui/src/data-table/DataTable.types.ts
+++ b/packages/ui/src/data-table/DataTable.types.ts
@@ -1,8 +1,31 @@
 import { type ReactNode } from "react";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+export type DataTableSortDirection = "asc" | "desc";
+
+export interface DataTableSortState {
+  columnKey: string;
+  direction: DataTableSortDirection;
+}
+
+export type DataTableSortValue = string | number | null | undefined;
+
+export interface DataTableColumnSort<T> {
+  /** Value used by the built-in stable sorter. */
+  getValue: (row: T, index: number) => DataTableSortValue;
+  /** Optional row comparator. The table applies the active direction. */
+  compare?: (left: T, right: T) => number;
+}
+
+export type DataTableRowsChangeAction =
+  | {
+      type: "sort";
+      sort: DataTableSortState;
+    }
+  | {
+      type: "row-reorder";
+      fromIndex: number;
+      toIndex: number;
+    };
 
 /** Column definition for DataTable */
 export interface DataTableColumn<T> {
@@ -28,6 +51,8 @@ export interface DataTableColumn<T> {
   cellClassName?: string;
   /** Overflow tooltip text for a truncated cell. Primitive render output is used by default. */
   overflowTooltip?: boolean | ((row: T, index: number) => string | null | undefined);
+  /** Built-in sort menu configuration. Omit to keep the column unsortable. */
+  sort?: DataTableColumnSort<T>;
   /** Custom header render function (overrides label) */
   headerRender?: () => ReactNode;
   /** Render function for cell content */
@@ -75,6 +100,10 @@ export interface DataTableProps<T> {
   showAllLoadedMessage?: boolean;
   /** Extra row className */
   rowClassName?: string | ((row: T, index: number) => string);
+  /** Optional row click handler. When set, rows become keyboard-focusable selection targets. */
+  onRowClick?: (row: T, index: number) => void;
+  /** Optional selected state for row interaction semantics. */
+  rowAriaSelected?: (row: T, index: number) => boolean;
   /** Let parent scroll containers handle wheel/touch scroll chaining when this table is already at an edge. */
   allowWheelPropagationAtBoundary?: boolean;
   /** Render the table in normal document flow without any internal table scrollbars. */
@@ -85,4 +114,14 @@ export interface DataTableProps<T> {
   columnReorderable?: boolean;
   /** Whether column order is persisted to localStorage (default true). */
   persistColumnOrder?: boolean;
+  /** Controlled active sort state. Omit to let DataTable manage the icon state. */
+  sortState?: DataTableSortState | null;
+  /** Initial sort state for an uncontrolled table. */
+  defaultSortState?: DataTableSortState | null;
+  /** Called whenever a column sort is selected or row dragging clears the current sort. */
+  onSortStateChange?: (sort: DataTableSortState | null) => void;
+  /** Enable the built-in row drag handle. Requires onRowsChange to persist the new order. */
+  rowReorderable?: boolean;
+  /** Receives rows in their new order after sorting or row dragging. */
+  onRowsChange?: (rows: T[], action: DataTableRowsChangeAction) => void;
 }

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { DataTable } from "../DataTable";
+import type { DataTableColumn, DataTableSortState } from "../DataTable.types";
+
+type TestRow = {
+  id: string;
+  name: string;
+};
+
+const initialRows: TestRow[] = [
+  { id: "charlie", name: "charlie" },
+  { id: "alpha", name: "alpha" },
+  { id: "bravo", name: "bravo" },
+];
+
+const columns: DataTableColumn<TestRow>[] = [
+  {
+    key: "name",
+    label: "Name",
+    sort: { getValue: (row) => row.name },
+    render: (row) => <span data-testid="row-name">{row.name}</span>,
+  },
+];
+
+function DataTableHarness() {
+  const [rows, setRows] = useState(initialRows);
+  const [sortState, setSortState] = useState<DataTableSortState | null>(null);
+  return (
+    <DataTable
+      rows={rows}
+      columns={columns}
+      rowKey={(row) => row.id}
+      rowReorderable
+      onRowsChange={(nextRows) => setRows(nextRows)}
+      sortState={sortState}
+      onSortStateChange={setSortState}
+      naturalFlow
+      height="h-auto"
+      minHeight="min-h-0"
+      minWidth="min-w-[320px]"
+      showAllLoadedMessage={false}
+    />
+  );
+}
+
+function visibleRowNames() {
+  return screen.getAllByTestId("row-name").map((element) => element.textContent);
+}
+
+describe("DataTable sorting and row reordering", () => {
+  test("uses the small dropdown menu and updates the sort icon and row order", async () => {
+    const user = userEvent.setup();
+    render(<DataTableHarness />);
+
+    const sortTrigger = screen.getByRole("button", { name: "Sort Name" });
+    expect(sortTrigger).toHaveAttribute("data-vt-sort-direction", "none");
+
+    await user.click(sortTrigger);
+    const menu = screen.getByRole("menu");
+    expect(menu).toHaveClass("min-w-28");
+    expect(screen.getByRole("menuitem", { name: "Ascending" })).toHaveClass("text-xs");
+    await user.click(screen.getByRole("menuitem", { name: "Ascending" }));
+
+    expect(visibleRowNames()).toEqual(["alpha", "bravo", "charlie"]);
+    expect(sortTrigger).toHaveAttribute("data-vt-sort-direction", "asc");
+
+    await user.click(sortTrigger);
+    await user.click(screen.getByRole("menuitem", { name: "Descending" }));
+
+    expect(visibleRowNames()).toEqual(["charlie", "bravo", "alpha"]);
+    expect(sortTrigger).toHaveAttribute("data-vt-sort-direction", "desc");
+  });
+
+  test("dragging a row persists the manual order and resets the active sort icon", async () => {
+    const user = userEvent.setup();
+    render(<DataTableHarness />);
+
+    const sortTrigger = screen.getByRole("button", { name: "Sort Name" });
+    await user.click(sortTrigger);
+    await user.click(screen.getByRole("menuitem", { name: "Ascending" }));
+    expect(visibleRowNames()).toEqual(["alpha", "bravo", "charlie"]);
+
+    const tableRows = Array.from(
+      document.querySelectorAll<HTMLTableRowElement>("tr[data-vt-row-index]"),
+    );
+    tableRows.forEach((row, index) => {
+      row.getBoundingClientRect = () =>
+        ({
+          x: 0,
+          y: index * 40,
+          top: index * 40,
+          right: 320,
+          bottom: index * 40 + 40,
+          left: 0,
+          width: 320,
+          height: 40,
+          toJSON: () => ({}),
+        }) as DOMRect;
+    });
+
+    const firstHandle = screen.getByRole("button", { name: "Drag to reorder row 1" });
+    fireEvent.pointerDown(firstHandle, { button: 0, pointerId: 7, clientY: 20 });
+    fireEvent.pointerMove(window, { pointerId: 7, clientY: 115 });
+    fireEvent.pointerUp(window, { pointerId: 7, clientY: 115 });
+
+    await waitFor(() => expect(visibleRowNames()).toEqual(["bravo", "charlie", "alpha"]));
+    expect(sortTrigger).toHaveAttribute("data-vt-sort-direction", "none");
+  });
+});

--- a/packages/ui/src/data-table/index.ts
+++ b/packages/ui/src/data-table/index.ts
@@ -1,3 +1,10 @@
 export { DataTable } from "./DataTable";
-export type { DataTableColumn, DataTableProps } from "./DataTable.types";
-export { TableCellOverflowTooltip, extractTableCellTextContent } from "./TableCellOverflowTooltip";
+export type {
+  DataTableColumn,
+  DataTableColumnSort,
+  DataTableProps,
+  DataTableRowsChangeAction,
+  DataTableSortDirection,
+  DataTableSortState,
+  DataTableSortValue,
+} from "./DataTable.types";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,7 +6,15 @@ export { Reveal } from "./feedback/Reveal";
 export { ToastProvider, useToast } from "./feedback/ToastProvider";
 
 export { DataTable } from "./data-table/DataTable";
-export type { DataTableColumn, DataTableProps } from "./data-table/DataTable.types";
+export type {
+  DataTableColumn,
+  DataTableColumnSort,
+  DataTableProps,
+  DataTableRowsChangeAction,
+  DataTableSortDirection,
+  DataTableSortState,
+  DataTableSortValue,
+} from "./data-table/DataTable.types";
 export {
   TableCellOverflowTooltip,
   extractTableCellTextContent,
@@ -43,6 +51,8 @@ export { Button, buttonClassName } from "./primitives/Button";
 export { Card } from "./primitives/Card";
 export { Checkbox } from "./primitives/Checkbox";
 export { DateTimePicker } from "./primitives/DateTimePicker";
+export { DropdownMenu } from "./primitives/DropdownMenu";
+export type { DropdownMenuRootProps } from "./primitives/DropdownMenu";
 export { Fieldset } from "./primitives/Fieldset";
 export { TextInput } from "./primitives/Input";
 export { MultiSelect } from "./primitives/MultiSelect";

--- a/packages/ui/src/primitives/DropdownMenu.tsx
+++ b/packages/ui/src/primitives/DropdownMenu.tsx
@@ -1,0 +1,105 @@
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "../utils/selectStyles";
+import type { ControlSize } from "../utils/controlStyles";
+
+const DropdownMenuSizeContext = createContext<ControlSize>("default");
+
+export interface DropdownMenuRootProps extends ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.Root
+> {
+  /** Shared visual size for menu content and items. */
+  size?: ControlSize;
+}
+
+function Root({ size = "default", children, ...props }: DropdownMenuRootProps) {
+  return (
+    <DropdownMenuSizeContext.Provider value={size}>
+      <DropdownMenuPrimitive.Root {...props}>{children}</DropdownMenuPrimitive.Root>
+    </DropdownMenuSizeContext.Provider>
+  );
+}
+
+const Trigger = DropdownMenuPrimitive.Trigger;
+const Portal = DropdownMenuPrimitive.Portal;
+const Group = DropdownMenuPrimitive.Group;
+const ItemIndicator = DropdownMenuPrimitive.ItemIndicator;
+
+const CONTENT_CLASS_BY_SIZE: Record<ControlSize, string> = {
+  sm: "min-w-28 rounded-xl p-1",
+  default: "min-w-36 rounded-2xl p-1.5",
+  lg: "min-w-40 rounded-2xl p-2",
+};
+
+const ITEM_CLASS_BY_SIZE: Record<ControlSize, string> = {
+  sm: "gap-1.5 rounded-lg px-2 py-1.5 text-xs",
+  default: "gap-2 rounded-xl px-3 py-2 text-sm",
+  lg: "gap-2.5 rounded-xl px-3.5 py-2.5 text-sm",
+};
+
+const Content = forwardRef<
+  ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(function DropdownMenuContent({ className, sideOffset = 6, ...props }, ref) {
+  const size = useContext(DropdownMenuSizeContext);
+  return (
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[9999] border border-slate-200 bg-white shadow-xl shadow-slate-900/10 outline-none dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35",
+        CONTENT_CLASS_BY_SIZE[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+const Item = forwardRef<
+  ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(function DropdownMenuItem({ className, ...props }, ref) {
+  const size = useContext(DropdownMenuSizeContext);
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        "flex w-full cursor-default select-none items-center font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10",
+        ITEM_CLASS_BY_SIZE[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+const Separator = forwardRef<
+  ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(function DropdownMenuSeparator({ className, ...props }, ref) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      ref={ref}
+      className={cn("my-1 h-px bg-slate-200 dark:bg-white/10", className)}
+      {...props}
+    />
+  );
+});
+
+export const DropdownMenu = {
+  Root,
+  Trigger,
+  Portal,
+  Content,
+  Group,
+  Item,
+  ItemIndicator,
+  Separator,
+};

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -1088,6 +1088,151 @@ describe("CcSwitchImportSettingsPage", () => {
     );
   });
 
+  test("sorts Codex mappings from the shared table menu and saves the visible order", async () => {
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "pro",
+        description: "Pro route",
+        "path-routes": ["/pro"],
+        "allowed-models": ["model-1", "model-2", "model-3"],
+      },
+    ]);
+    listConfigs.mockResolvedValue([
+      {
+        id: "cfg-sort-codex",
+        clientType: "codex",
+        providerName: "Sorted Codex",
+        note: "",
+        defaultModel: "request-c",
+        allowedChannelGroups: ["pro"],
+        endpointPath: "/v1",
+        usageAutoInterval: 30,
+        modelMappings: [
+          { requestModel: "request-c", targetModel: "model-3", contextWindow: 300000 },
+          { requestModel: "request-a", targetModel: "model-1", contextWindow: 100000 },
+          { requestModel: "request-b", targetModel: "model-2", contextWindow: 200000 },
+        ],
+      },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(await screen.findByText("Sorted Codex")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /edit config/i }));
+    const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
+
+    const mappingTable = within(dialog).getByTestId("ccswitch-model-mapping-table");
+    const tableViewport = mappingTable.querySelector<HTMLElement>(
+      "[data-scrollbar-visibility='hover']",
+    );
+    expect(mappingTable).toHaveClass("px-4", "pt-3", "pb-4");
+    expect(tableViewport).toHaveClass("h-full", "overflow-auto");
+    expect(tableViewport?.parentElement).toHaveClass("h-[320px]", "min-h-[320px]");
+    expect(tableViewport?.querySelector("thead")).toHaveClass("sticky", "top-0");
+
+    const requestSort = within(dialog).getByRole("button", {
+      name: /sort cc switch request model/i,
+    });
+    const targetSort = within(dialog).getByRole("button", {
+      name: /sort actual channel model/i,
+    });
+    await user.click(requestSort);
+    await user.click(screen.getByRole("menuitem", { name: /ascending/i }));
+
+    expect(
+      within(dialog)
+        .getAllByLabelText(/cc switch request model for mapping/i)
+        .map((input) => (input as HTMLInputElement).value),
+    ).toEqual(["request-a", "request-b", "request-c"]);
+    expect(requestSort).toHaveAttribute("data-vt-sort-direction", "asc");
+    expect(targetSort).toHaveAttribute("data-vt-sort-direction", "none");
+
+    await user.click(targetSort);
+    await user.click(screen.getByRole("menuitem", { name: /descending/i }));
+
+    expect(
+      within(dialog)
+        .getAllByLabelText(/cc switch request model for mapping/i)
+        .map((input) => (input as HTMLInputElement).value),
+    ).toEqual(["request-c", "request-b", "request-a"]);
+    expect(requestSort).toHaveAttribute("data-vt-sort-direction", "none");
+    expect(targetSort).toHaveAttribute("data-vt-sort-direction", "desc");
+
+    await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
+    await waitFor(() =>
+      expect(replaceConfigs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: "cfg-sort-codex",
+          modelMappings: [
+            { requestModel: "request-c", targetModel: "model-3", contextWindow: 300000 },
+            { requestModel: "request-b", targetModel: "model-2", contextWindow: 200000 },
+            { requestModel: "request-a", targetModel: "model-1", contextWindow: 100000 },
+          ],
+        }),
+      ]),
+    );
+  });
+
+  test("sorts and persists Claude Code mappings without restoring the fixed role order", async () => {
+    listChannelGroups.mockResolvedValue([
+      {
+        name: "pro",
+        description: "Pro route",
+        "path-routes": ["/pro"],
+        "allowed-models": ["target-main", "target-haiku", "target-sonnet", "target-opus"],
+      },
+    ]);
+    listConfigs.mockResolvedValue([
+      {
+        id: "cfg-sort-claude",
+        clientType: "claude",
+        providerName: "Sorted Claude",
+        note: "",
+        defaultModel: "target-main",
+        allowedChannelGroups: ["pro"],
+        endpointPath: "",
+        usageAutoInterval: 30,
+        apiKeyField: "ANTHROPIC_API_KEY",
+        modelMappings: [
+          { role: "main", requestModel: "z-main", targetModel: "target-main" },
+          { role: "haiku", requestModel: "a-haiku", targetModel: "target-haiku" },
+          { role: "sonnet", requestModel: "m-sonnet", targetModel: "target-sonnet" },
+          { role: "opus", requestModel: "b-opus", targetModel: "target-opus" },
+        ],
+      },
+    ]);
+    renderPage();
+    const user = userEvent.setup();
+
+    expect(await screen.findByText("Sorted Claude")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /edit config/i }));
+    const dialog = await screen.findByRole("dialog", { name: /edit cc switch config/i });
+
+    await user.click(within(dialog).getByRole("button", { name: /sort cc switch request model/i }));
+    await user.click(screen.getByRole("menuitem", { name: /ascending/i }));
+
+    const orderedRequestModels = Array.from(
+      dialog.querySelectorAll<HTMLTableRowElement>("tr[data-vt-row-index]"),
+    ).map((row) => row.querySelector<HTMLInputElement>("input")?.value);
+    expect(orderedRequestModels).toEqual(["a-haiku", "b-opus", "m-sonnet", "z-main"]);
+
+    await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
+    await waitFor(() =>
+      expect(replaceConfigs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          id: "cfg-sort-claude",
+          defaultModel: "target-main",
+          modelMappings: [
+            { role: "haiku", requestModel: "a-haiku", targetModel: "target-haiku" },
+            { role: "opus", requestModel: "b-opus", targetModel: "target-opus" },
+            { role: "sonnet", requestModel: "m-sonnet", targetModel: "target-sonnet" },
+            { role: "main", requestModel: "z-main", targetModel: "target-main" },
+          ],
+        }),
+      ]),
+    );
+  });
+
   test("deletes a saved config row through the API", async () => {
     listConfigs.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

- Extend the shared `DataTable` with configurable stable column sorting and pointer/keyboard row reordering.
- Add the shared Radix dropdown menu primitive with the small control size used by table sort actions.
- Use the shared table for Codex and Claude Code model mappings, preserving the displayed order when saving.
- Reset the active sort icon after manual row reordering and auto-scroll the fixed table viewport near drag edges.
- Give the model mapping table a fixed 320px internal scroll viewport, sticky header, and padded borderless table layout.
- Add English, Simplified Chinese, and Russian sorting/reordering translations.
- Isolate the shared Radix dropdown dependency in a vendor chunk so the main entry remains within the bundle delta budget.

## Verification

- `rtk bun run check` — passed; lint reports 3 pre-existing warnings and 0 errors, and bundle diff passes.
- `rtk bun run test:ci` — 78 files / 601 tests passed.
- `rtk git diff --check` — passed.

## Visual and interaction QA

Verified through the real local admin application route with Playwright route mocks:

- fixed-height vertical scrolling and sticky table header;
- compact ascending/descending sort menu and icon states;
- drag-edge auto-scroll in the fixed viewport;
- manual reorder clearing the active sort state;
- Codex and Claude Code mapping layouts.
