### PR TITLE
fix(update): back off SSE progress reconnects

### DIFF
--- a/apps/admin-panel/src/app/update/__tests__/updateShared.test.ts
+++ b/apps/admin-panel/src/app/update/__tests__/updateShared.test.ts
@@ -3,6 +3,7 @@ import {
   applyUpdateFlow,
   formatUpdateStatusMessage,
   selectLocalizedReleaseNotes,
+  subscribeUpdateProgress,
 } from "@app/update/updateShared";
 
 const mocks = vi.hoisted(() => ({
@@ -141,5 +142,29 @@ describe("applyUpdateFlow", () => {
       "completed",
     ]);
     expect(notify).toHaveBeenCalledWith({ type: "success", message: "auto_update.success" });
+  });
+});
+
+describe("subscribeUpdateProgress", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.events.mockReset();
+  });
+
+  test("backs off failed SSE reconnects instead of retrying every second", async () => {
+    vi.useFakeTimers();
+    mocks.events.mockRejectedValue(new Error("updater unavailable"));
+
+    const unsubscribe = subscribeUpdateProgress(vi.fn());
+    await vi.waitFor(() => expect(mocks.events).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(mocks.events).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => expect(mocks.events).toHaveBeenCalledTimes(2));
+
+    unsubscribe();
+    vi.useRealTimers();
   });
 });

--- a/apps/admin-panel/src/app/update/updateShared.ts
+++ b/apps/admin-panel/src/app/update/updateShared.ts
@@ -7,6 +7,8 @@ import {
 
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 1000;
 export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 180000;
+const PROGRESS_STREAM_RECONNECT_INITIAL_MS = 5000;
+const PROGRESS_STREAM_RECONNECT_MAX_MS = 60000;
 
 const normalizedProgressStatus = (progress?: UpdateProgressResponse | null) =>
   progress?.status?.trim().toLowerCase() ?? "";
@@ -231,20 +233,35 @@ const publishProgress = (progress: UpdateProgressResponse) => {
   progressListeners.forEach((listener) => listener(progress));
 };
 
+const progressStreamReconnectDelay = (attempts: number) =>
+  Math.min(
+    PROGRESS_STREAM_RECONNECT_MAX_MS,
+    PROGRESS_STREAM_RECONNECT_INITIAL_MS * 2 ** Math.max(0, attempts - 1),
+  );
+
 const ensureProgressStream = () => {
   if (progressStreamTask || progressListeners.size === 0) return;
   const controller = new AbortController();
   progressStreamController = controller;
   progressStreamTask = (async () => {
+    let reconnectAttempts = 0;
     while (!controller.signal.aborted && progressListeners.size > 0) {
+      let receivedEvent = false;
       try {
-        await updateApi.events(publishProgress, { signal: controller.signal });
+        await updateApi.events(
+          (progress) => {
+            receivedEvent = true;
+            publishProgress(progress);
+          },
+          { signal: controller.signal },
+        );
       } catch {
         // The API container restarts during an update. Reconnect and let the updater
         // replay its latest persisted snapshot instead of manufacturing UI progress.
       }
       if (!controller.signal.aborted && progressListeners.size > 0) {
-        await delay(DEFAULT_HEARTBEAT_INTERVAL_MS, controller.signal);
+        reconnectAttempts = receivedEvent ? 1 : reconnectAttempts + 1;
+        await delay(progressStreamReconnectDelay(reconnectAttempts), controller.signal);
       }
     }
   })().finally(() => {


### PR DESCRIPTION
## Summary
- replace fixed 1s updater SSE reconnects with exponential backoff
- cap failed progress stream retries at 60s while preserving normal updater replay behavior
- add regression coverage for failed stream reconnect pacing

## Root cause
The admin panel subscribed to /update/events and retried every second after failures. During updater restarts or backend 502s this produced sustained high-frequency requests and amplified server load.

## Verification
- rtk bun run --filter @code-proxy/admin-panel test -- src/app/update/__tests__/updateShared.test.ts
- rtk bun run build