### PR TITLE
fix(request-logs): center table headers

### DIFF
--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -224,6 +224,38 @@ const readResponseMetricsColumnState = async (page: Page) =>
     };
   });
 
+test("Request Logs: centers every header except ID over its column content", async ({ page }) => {
+  await setAuthed(page);
+  await mockRequestLogsApis(page);
+
+  await page.goto("/manage/#/monitor/request-logs");
+  await page.locator('th[data-vt-column-key="id"]').waitFor({ state: "visible" });
+
+  const alignment = await page.locator("th[data-vt-column-key]").evaluateAll((headers) =>
+    headers.map((header) => {
+      const key = header.getAttribute("data-vt-column-key");
+      const content = header.querySelector<HTMLElement>("[data-vt-column-header-content] > span");
+      if (!content) throw new Error(`Missing header content for ${key}`);
+
+      const headerRect = header.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      return {
+        key,
+        justifyContent: getComputedStyle(content).justifyContent,
+        centerDelta: Math.abs(
+          contentRect.left + contentRect.width / 2 - (headerRect.left + headerRect.width / 2),
+        ),
+      };
+    }),
+  );
+
+  expect(alignment.find(({ key }) => key === "id")?.justifyContent).toBe("normal");
+  for (const column of alignment.filter(({ key }) => key !== "id")) {
+    expect(column.justifyContent, column.key ?? undefined).toBe("center");
+    expect(column.centerDelta, column.key ?? undefined).toBeLessThanOrEqual(1);
+  }
+});
+
 test("Request Logs: response metrics column resize clamps at its minimum width", async ({
   page,
 }) => {

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -520,6 +520,9 @@ export function RequestLogsTimeRangeSelector({
   );
 }
 
+const CENTERED_REQUEST_LOG_HEADER_CLASS =
+  "text-center [&_[data-vt-column-header-content]>span]:justify-center";
+
 export function buildRequestLogsColumns(
   t: (key: string) => string,
   onContentClick?: (logId: number, tab: "input" | "output") => void,
@@ -543,7 +546,7 @@ export function buildRequestLogsColumns(
       key: "timestamp",
       label: t("request_logs.col_time"),
       width: "w-52",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) => (
@@ -561,7 +564,7 @@ export function buildRequestLogsColumns(
       key: "channelName",
       label: t("request_logs.col_channel"),
       width: "w-32",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
       render: (row) => (
         <OverflowTooltip
@@ -580,7 +583,7 @@ export function buildRequestLogsColumns(
       key: "status",
       label: t("request_logs.col_status"),
       width: "w-28",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
       render: (row) =>
         row.failed ? (
@@ -603,7 +606,7 @@ export function buildRequestLogsColumns(
       label: t("request_logs.col_response_metrics"),
       width: "w-64",
       minWidthPx: 240,
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName:
         "text-center text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) => {
@@ -661,7 +664,7 @@ export function buildRequestLogsColumns(
       key: "inputTokens",
       label: t("request_logs.col_input"),
       width: "w-32",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200 pl-6",
       render: (row) =>
@@ -685,7 +688,7 @@ export function buildRequestLogsColumns(
       key: "cachedTokens",
       label: t("request_logs.col_cache_read"),
       width: "w-24",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center font-mono text-xs tabular-nums",
       render: (row) => (
         <RequestLogUsageMetricValue
@@ -702,7 +705,7 @@ export function buildRequestLogsColumns(
       key: "outputTokens",
       label: t("request_logs.col_output"),
       width: "w-24",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
       render: (row) =>
@@ -726,7 +729,7 @@ export function buildRequestLogsColumns(
       key: "totalTokens",
       label: t("request_logs.col_total_token"),
       width: "w-28",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-slate-900 dark:text-white",
       render: (row) => <RequestLogUsageMetricValue value={row.totalTokens} />,
@@ -735,7 +738,7 @@ export function buildRequestLogsColumns(
       key: "cost",
       label: t("request_logs.col_cost"),
       width: "w-24",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName:
         "text-center font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-400",
       render: (row) => (
@@ -746,7 +749,7 @@ export function buildRequestLogsColumns(
       key: "apiKeyName",
       label: t("request_logs.col_key_name"),
       width: "w-28",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
       render: (row) => (
         <OverflowTooltip
@@ -771,7 +774,7 @@ export function buildRequestLogsColumns(
       key: "model",
       label: t("request_logs.col_model"),
       width: "w-44",
-      headerClassName: "text-center",
+      headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
       render: (row) =>
         row.model ? (


### PR DESCRIPTION
## 修改内容

- 将请求日志表格除 `ID` 外的列头水平居中，使其与对应列内容对齐
- 保持 `ID` 列左对齐不变
- 增加真实管理端页面 mock 路径的 E2E 几何回归测试

## 根因

`DataTable` 列头内部使用 flex 布局，原有 `text-center` 只设置文本对齐，未改变内部 flex 内容的主轴对齐方式。

## 验证

- `bun run e2e -- e2e/request-logs-column-reorder.spec.ts --grep "centers every header except ID" --workers=1`
- `bun run test:ci -- pages/monitor/__tests__/requestLogsShared.test.ts`
- `bun run lint`
- `bun run build`

补充：整份 `request-logs-column-reorder.spec.ts` 中 3 个既有拖拽测试在当前环境失败，其中横向滚动失败已在未修改的 `origin/dev` 上复现，与本改动无关。
