### PR TITLE
fix(data-table): keep headers stable on hover

### DIFF
--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -254,6 +254,30 @@ test("Request Logs: centers every header except ID over its column content", asy
     expect(column.justifyContent, column.key ?? undefined).toBe("center");
     expect(column.centerDelta, column.key ?? undefined).toBeLessThanOrEqual(1);
   }
+
+  const channelHeader = page.locator('th[data-vt-column-key="channelName"]');
+  const channelLabel = channelHeader.locator("[data-vt-column-header-content] > span > span");
+  const centerBeforeHover = await channelLabel.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.left + rect.width / 2;
+  });
+
+  await channelHeader.hover();
+  await expect(channelHeader.locator("[data-vt-column-reorder-handle]")).toHaveCSS(
+    "opacity",
+    "1",
+  );
+
+  const hoverState = await channelLabel.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const content = element.closest<HTMLElement>("[data-vt-column-header-content]");
+    return {
+      center: rect.left + rect.width / 2,
+      paddingLeft: content ? getComputedStyle(content).paddingLeft : null,
+    };
+  });
+  expect(hoverState.paddingLeft).toBe("0px");
+  expect(Math.abs(hoverState.center - centerBeforeHover)).toBeLessThanOrEqual(1);
 });
 
 test("Request Logs: response metrics column resize clamps at its minimum width", async ({

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2872,14 +2872,7 @@ export function DataTable<T>({
                       ) : null}
                       <div
                         data-vt-column-header-content
-                        className={`min-w-0 max-w-full overflow-hidden ${
-                          canReorder
-                            ? "group-hover/column:pl-5 group-hover/column:transition-[padding] group-focus-within/column:pl-5 data-[vt-reorder-active=true]:pl-5"
-                            : ""
-                        }`}
-                        data-vt-reorder-active={
-                          activeReorderColumnKey === col.key ? "true" : undefined
-                        }
+                        className="min-w-0 max-w-full overflow-hidden"
                       >
                         {isRowReorderColumn ? (
                           <span className="flex items-center justify-center text-slate-400/70 dark:text-white/35">


### PR DESCRIPTION
## 修改内容

- 移除可拖拽列头在 hover、focus 和拖拽激活时动态增加的左侧内边距
- 保持拖拽图标为绝对定位覆盖显示，不再参与列名布局
- 扩展请求日志 E2E，验证图标出现后列名中心位置保持不变

## 根因

拖拽图标本身是绝对定位，但列头内容会在图标出现时额外增加 `padding-left: 1.25rem`，导致居中的列名向右移动。

## 验证

- `bun run e2e -- e2e/request-logs-column-reorder.spec.ts --grep "centers every header except ID" --workers=1`
- `bun run test:ci -- packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx`
- `bun run test:ci -- pages/monitor/__tests__/requestLogsShared.test.ts`
- `bun run lint`
- `bun run build`
