### PR TITLE
fix(auth-files): show subscriptions under one day

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -901,6 +901,7 @@
     "subscription_period_yearly": "Yearly",
     "subscription_expires_at_title": "{{period}} - started {{start}} - expires {{date}}",
     "subscription_remaining_short": "{{days}}d left",
+    "subscription_remaining_less_than_day": "<1d left",
     "subscription_expired_short": "Expired {{days}}d",
     "quota_preview_5h": "5h",
     "quota_preview_week": "Week",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -573,6 +573,7 @@
     "subscription_period_yearly": "Ежегодно",
     "subscription_expires_at_title": "{{period}} - начало {{start}} - истекает {{date}}",
     "subscription_remaining_short": "Осталось {{days}} д",
+    "subscription_remaining_less_than_day": "Осталось менее дня",
     "subscription_expired_short": "Истекла {{days}} д назад",
     "restriction_duration_day": "д",
     "restriction_duration_hour": "ч",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -909,6 +909,7 @@
     "subscription_period_yearly": "年订阅",
     "subscription_expires_at_title": "{{period}} · 开始于 {{start}} · 到期于 {{date}}",
     "subscription_remaining_short": "剩余 {{days}} 天",
+    "subscription_remaining_less_than_day": "不足一天",
     "subscription_expired_short": "已过期 {{days}} 天",
     "quota_preview_5h": "5小时",
     "quota_preview_week": "周",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2695,6 +2695,9 @@ describe("AuthFilesPage files table", () => {
     const expiresAt = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
     const startedAt = new Date(expiresAt);
     startedAt.setFullYear(startedAt.getFullYear() - 1);
+    const expiresSoonAt = new Date(Date.now() + 60 * 60 * 1000);
+    const startedSoonAt = new Date(expiresSoonAt);
+    startedSoonAt.setFullYear(startedSoonAt.getFullYear() - 1);
     mocks.list.mockImplementation(async () => ({
       files: [
         {
@@ -2706,6 +2709,17 @@ describe("AuthFilesPage files table", () => {
           modified: Date.now(),
           disabled: false,
           subscription_started_at: startedAt.toISOString(),
+          subscription_period: "yearly",
+        },
+        {
+          name: "codex-subscription-expiring-soon.json",
+          label: "Codex Subscriber Expiring Soon",
+          account_type: "oauth",
+          type: "codex",
+          size: 1024,
+          modified: Date.now(),
+          disabled: false,
+          subscription_started_at: startedSoonAt.toISOString(),
           subscription_period: "yearly",
         },
       ],
@@ -2726,6 +2740,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("Codex Subscriber")).toBeInTheDocument();
     expect(screen.getByText("Subscription")).toBeInTheDocument();
     expect(screen.getByText(/5d left/)).toBeInTheDocument();
+    expect(screen.getByText("<1d left")).toBeInTheDocument();
 
     cleanup();
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
@@ -2743,6 +2758,7 @@ describe("AuthFilesPage files table", () => {
 
     expect(await screen.findByTestId("auth-files-cards")).toBeInTheDocument();
     expect(screen.getByText(/5d left/)).toBeInTheDocument();
+    expect(screen.getByText("<1d left")).toBeInTheDocument();
   });
 
   test("saves subscription start and period from the auth fields editor", async () => {

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -392,7 +392,9 @@ export function useAuthFilesFilesPresentation({
       const days = Math.max(0, Math.abs(status.remainingDays));
       const label = status.expired
         ? t("auth_files.subscription_expired_short", { days })
-        : t("auth_files.subscription_remaining_short", { days });
+        : status.expiresAtMs - nowMs < 24 * 60 * 60 * 1000
+          ? t("auth_files.subscription_remaining_less_than_day")
+          : t("auth_files.subscription_remaining_short", { days });
       const title = t("auth_files.subscription_expires_at_title", {
         start: status.startedAtText,
         date: status.expiresAtText,


### PR DESCRIPTION
## 修改内容

- 订阅剩余时间不足 24 小时时显示“​​不足一天”，不再向上取整显示“剩余 1 天”
- 补充中、英、俄三种语言文案
- 覆盖表格与卡片视图的回归测试

## 根因

订阅徽标直接展示按 `Math.ceil` 计算的剩余天数，因此任何大于 0 且小于 24 小时的剩余时间都会显示为 1 天。

## 验证

- `bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx`（79 tests passed）
- `bunx oxlint pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx`
- `bun run build`
