### PR TITLE
perf(deploy): prioritize frontend rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,15 +3,27 @@ name: Deploy Frontend
 on:
   push:
     branches: [dev]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
+
+concurrency:
+  group: deploy-relay-frontend
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PANEL_RELEASE: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -29,17 +41,7 @@ jobs:
         run: |
           printf '%s\n' "${VITE_APP_VERSION}" > dist/version.txt
 
-      - name: Clean old static files
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          port: ${{ secrets.SERVER_PORT }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            rm -rf /home/web/html/relay-panel/*
-
-      - name: Deploy static assets to server
+      - name: Upload static assets to release directory
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -47,25 +49,67 @@ jobs:
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: "dist/*"
-          target: "/home/web/html/relay-panel/"
+          target: "/home/web/html/relay-panel-releases/${{ env.PANEL_RELEASE }}/"
           strip_components: 1
           overwrite: true
 
-      - name: Verify deployment
+      - name: Activate and verify frontend release
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SERVER_HOST }}
           port: ${{ secrets.SERVER_PORT }}
           username: root
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: PANEL_RELEASE,VITE_APP_VERSION
           script: |
-            ls -la /home/web/html/relay-panel/
-            test -f /home/web/html/relay-panel/manage.html
-            test -f /home/web/html/relay-panel/version.txt
-            echo "UI version:"
-            cat /home/web/html/relay-panel/version.txt
-            if ! grep -R --include='*.js' -q "/channel-groups" /home/web/html/relay-panel/assets; then
-              echo "channel-groups route was not found in deployed frontend assets"
+            set -euo pipefail
+            releases_dir="/home/web/html/relay-panel-releases"
+            release_dir="${releases_dir}/${PANEL_RELEASE}"
+            live_path="/home/web/html/relay-panel"
+            candidate_link="/home/web/html/.relay-panel-${PANEL_RELEASE}"
+
+            test -f "${release_dir}/manage.html"
+            test -f "${release_dir}/version.txt"
+            test "$(cat "${release_dir}/version.txt")" = "${VITE_APP_VERSION}"
+            if ! grep -R --include='*.js' -q "/channel-groups" "${release_dir}/assets"; then
+              echo "channel-groups route was not found in uploaded frontend assets"
               exit 1
             fi
-            echo "Frontend deployed successfully"
+
+            rm -f "${candidate_link}"
+            ln -s "relay-panel-releases/${PANEL_RELEASE}" "${candidate_link}"
+            if [ -L "${live_path}" ]; then
+              mv -Tf "${candidate_link}" "${live_path}"
+            elif [ -d "${live_path}" ]; then
+              legacy_path="${live_path}.legacy-$(date +%s)"
+              mv "${live_path}" "${legacy_path}"
+              if ! mv -T "${candidate_link}" "${live_path}"; then
+                mv "${legacy_path}" "${live_path}"
+                exit 1
+              fi
+              rm -rf "${legacy_path}"
+            elif [ ! -e "${live_path}" ]; then
+              mv -T "${candidate_link}" "${live_path}"
+            else
+              echo "Unsupported frontend live path: ${live_path}"
+              exit 1
+            fi
+
+            test "$(docker exec nginx cat /var/www/html/relay-panel/version.txt)" = "${VITE_APP_VERSION}"
+            docker exec nginx test -f /var/www/html/relay-panel/manage.html
+            find "${releases_dir}" -mindepth 1 -maxdepth 1 -type d ! -path "${release_dir}" -mtime +7 -exec rm -rf -- {} +
+            echo "Frontend ${VITE_APP_VERSION} deployed successfully from ${release_dir}."
+
+      - name: Trigger CliRelay Docker image build
+        env:
+          GH_TOKEN: ${{ secrets.CLIRELAY_WORKFLOW_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "CLIRELAY_WORKFLOW_TOKEN secret is required to trigger CliRelay Docker builds." >&2
+            exit 1
+          fi
+          gh workflow run docker-publish.yml \
+            --repo kittors/CliRelay \
+            --ref dev
+          echo "Triggered Docker image build after frontend deployment completed."

--- a/.github/workflows/rebuild-clirelay.yml
+++ b/.github/workflows/rebuild-clirelay.yml
@@ -2,7 +2,7 @@ name: Rebuild CliRelay Image
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 修改内容

- 前端构建产物先上传到独立 release 目录，校验成功后再切换线上软链接
- 删除部署前清空 `/home/web/html/relay-panel` 的空窗流程
- 从 nginx 容器内部验证实际生效版本
- 仅在前端部署成功后异步触发 CliRelay dev Docker 镜像构建
- 增加部署 concurrency、文档路径过滤并固定 Bun 版本
- `Rebuild CliRelay Image` 的 dev 提前触发被移除，main 行为保持不变

## 根因

前端部署和 Docker 多架构构建同时触发，可能竞争 GitHub Runner；旧流程还会先删除线上静态文件再上传，上传变慢时会产生不可用窗口。

## 影响

- 最新前端优先部署到 `relay.07230805.xyz`
- 前端切换接近瞬时，并保留已验证的 release 目录
- Docker 镜像在前端部署完成后独立运行，不阻塞体验最新版本

## 验证

- `bun run build` 通过
- `actionlint`：修改的 workflows 通过
- `git diff --check`
- BWG 临时目录原子软链接切换模拟通过，未修改线上服务或配置
