### PR TITLE
fix: wait for request storage cleanup

### DIFF
--- a/packages/api-client/src/endpoints/config.ts
+++ b/packages/api-client/src/endpoints/config.ts
@@ -50,10 +50,14 @@ export const configApi = {
     return data.enabled === true;
   },
   updateRequestLogBodyStorage: (enabled: boolean, clearExisting = false) =>
-    apiClient.put<RequestLogBodyStorageResponse>("/request-log-storage/store-content", {
-      value: enabled,
-      clear_existing: clearExisting,
-    }),
+    apiClient.put<RequestLogBodyStorageResponse>(
+      "/request-log-storage/store-content",
+      {
+        value: enabled,
+        clear_existing: clearExisting,
+      },
+      { timeoutMs: 10 * 60_000 },
+    ),
   updateLoggingToFile: (enabled: boolean) => apiClient.put("/logging-to-file", { value: enabled }),
   getLogsMaxTotalSizeMb: async (): Promise<number> => {
     const data = await apiClient.get<Record<string, unknown>>("/logs-max-total-size-mb");

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4005,7 +4005,7 @@
     "request_body_storage": "Store request and response bodies",
     "request_body_storage_desc": "Store full inputs and model outputs for log replay. Disabled by default; request details remain available.",
     "request_body_storage_disable_title": "Disable and clear request bodies",
-    "request_body_storage_disable_desc": "Disabling immediately stops storing new request inputs and model outputs, and permanently clears all stored input and output bodies. Request details, request records, token usage, and cost statistics are preserved.",
+    "request_body_storage_disable_desc": "Disabling immediately stops storing new request inputs and model outputs, removes historical inputs, outputs, and bodies embedded in request details, then reclaims PostgreSQL disk space. Request-detail metadata, request records, token usage, and cost statistics are preserved. Large databases may take several minutes; keep this page open.",
     "request_body_storage_disable_confirm": "Disable and clear",
     "request_body_storage_disabling": "Disabling and clearing…",
     "request_body_storage_enabled_toast": "Request and response body storage enabled",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3423,7 +3423,7 @@
     "request_body_storage": "保存请求与响应正文",
     "request_body_storage_desc": "保存完整输入和模型输出，用于日志回放。默认关闭，请求详情仍会保留。",
     "request_body_storage_disable_title": "关闭并清理请求正文",
-    "request_body_storage_disable_desc": "关闭后将立即停止保存新的请求输入和模型输出，并清除数据库中已保存的全部输入与输出正文。请求详情、请求记录、Token 和费用统计会保留。此操作不可撤销。",
+    "request_body_storage_disable_desc": "关闭后将立即停止保存新的请求输入和模型输出，清除历史输入、输出及请求详情中嵌入的正文，并回收 PostgreSQL 物理空间。请求详情元数据、请求记录、Token 和费用统计会保留。数据量较大时可能需要几分钟，请勿关闭页面。此操作不可撤销。",
     "request_body_storage_disable_confirm": "确认关闭并清理",
     "request_body_storage_disabling": "正在关闭并清理…",
     "request_body_storage_enabled_toast": "已开启请求与响应正文存储",

--- a/pages/config/__tests__/RuntimeConfigPanel.test.tsx
+++ b/pages/config/__tests__/RuntimeConfigPanel.test.tsx
@@ -130,7 +130,7 @@ describe("RuntimeConfigPanel", () => {
       name: /store request and response bodies/i,
     });
     await userEvent.click(toggle);
-    expect(screen.getByText(/permanently clears all stored input and output bodies/i)).toBeInTheDocument();
+    expect(screen.getByText(/reclaims PostgreSQL disk space/i)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /disable and clear/i }));
     expect(screen.getByText(/disabling and clearing/i)).toBeInTheDocument();
@@ -139,7 +139,7 @@ describe("RuntimeConfigPanel", () => {
     pending.resolve();
     await waitFor(() => {
       expect(
-        screen.queryByText(/permanently clears all stored input and output bodies/i),
+        screen.queryByText(/reclaims PostgreSQL disk space/i),
       ).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## 修改内容

- 将关闭正文存储接口超时延长到 10 分钟，允许后端完成历史详情清理和 PostgreSQL 物理空间回收
- 二次确认中明确说明会清除请求详情中嵌入的正文并回收 PostgreSQL 空间
- 提示大数据库可能需要几分钟，清理期间不要关闭页面

## 验证

- 配置面板测试通过
- `rtk bun run build`
- `rtk bun run lint`，0 errors，2 个已有无关 warnings
- `rtk git diff --check`
