### PR TITLE
feat: unify sidebar and floating menu interactions

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -1,5 +1,7 @@
 import {
   createContext,
+  type FocusEvent,
+  type KeyboardEvent,
   type MouseEvent,
   type PropsWithChildren,
   use,
@@ -31,7 +33,14 @@ import {
   Sparkles,
   type LucideIcon,
 } from "lucide-react";
-import { LanguageSelector, PageBackground, ScrollArea, ThemeToggleButton } from "@code-proxy/ui";
+import {
+  DropdownMenu,
+  LanguageSelector,
+  floatingPanelSurface,
+  PageBackground,
+  ScrollArea,
+  ThemeToggleButton,
+} from "@code-proxy/ui";
 import { preloadPageRoute } from "@pages/registry";
 
 interface ShellContextState {
@@ -75,7 +84,11 @@ const NAV_GROUPS = [
     icon: Activity,
     items: [
       { to: "/monitor", i18nKey: "shell.nav_monitor", icon: Activity },
-      { to: "/monitor/request-logs", i18nKey: "shell.nav_request_logs", icon: ScrollText },
+      {
+        to: "/monitor/request-logs",
+        i18nKey: "shell.nav_request_logs",
+        icon: ScrollText,
+      },
       { to: "/logs", i18nKey: "shell.nav_logs", icon: FileText },
       { to: "/system", i18nKey: "shell.nav_system", icon: Info },
     ],
@@ -100,8 +113,16 @@ const NAV_GROUPS = [
     icon: Layers,
     items: [
       { to: "/models", i18nKey: "shell.nav_models", icon: Cpu },
-      { to: "/image-generation", i18nKey: "shell.nav_image_generation", icon: Image },
-      { to: "/channel-groups", i18nKey: "shell.nav_channel_groups", icon: Layers },
+      {
+        to: "/image-generation",
+        i18nKey: "shell.nav_image_generation",
+        icon: Image,
+      },
+      {
+        to: "/channel-groups",
+        i18nKey: "shell.nav_channel_groups",
+        icon: Layers,
+      },
       { to: "/proxies", i18nKey: "shell.nav_proxies", icon: Network },
     ],
   },
@@ -110,7 +131,11 @@ const NAV_GROUPS = [
     i18nKey: "shell.nav_group_system",
     icon: Settings,
     items: [
-      { to: "/account-security", i18nKey: "shell.nav_account_security", icon: ShieldCheck },
+      {
+        to: "/account-security",
+        i18nKey: "shell.nav_account_security",
+        icon: ShieldCheck,
+      },
       {
         to: "/api-key-permissions",
         i18nKey: "shell.nav_api_key_permissions",
@@ -128,10 +153,14 @@ const NAV_ITEMS: readonly SidebarNavItem[] = [
 
 const getPageTitleKey = (pathname: string): string => {
   if (pathname.startsWith("/dashboard")) return "shell.nav_dashboard";
-  if (pathname.startsWith("/monitor/request-logs")) return "shell.nav_request_logs";
+  if (pathname.startsWith("/monitor/request-logs"))
+    return "shell.nav_request_logs";
   if (pathname.startsWith("/monitor")) return "shell.nav_monitor";
   if (pathname.startsWith("/ai-providers")) return "shell.nav_ai_providers";
-  if (pathname.startsWith("/account-security") || pathname.startsWith("/auth-files"))
+  if (
+    pathname.startsWith("/account-security") ||
+    pathname.startsWith("/auth-files")
+  )
     return "shell.nav_account_security";
   if (pathname.startsWith("/api-keys")) return "shell.page_api_keys";
   if (
@@ -144,8 +173,10 @@ const getPageTitleKey = (pathname: string): string => {
     pathname.startsWith("/manage/ccswitch-import-settings")
   )
     return "shell.nav_ccswitch_import_settings";
-  if (pathname.startsWith("/image-generation")) return "shell.nav_image_generation";
-  if (pathname.startsWith("/channel-groups")) return "shell.page_channel_groups";
+  if (pathname.startsWith("/image-generation"))
+    return "shell.nav_image_generation";
+  if (pathname.startsWith("/channel-groups"))
+    return "shell.page_channel_groups";
   if (
     pathname.startsWith("/identity-fingerprint") ||
     pathname.startsWith("/manage/identity-fingerprint")
@@ -182,6 +213,7 @@ function SidebarChildLink({
   onWarm,
   tabIndex,
   role,
+  onSelect,
 }: {
   item: SidebarNavItem;
   active: boolean;
@@ -190,6 +222,7 @@ function SidebarChildLink({
   onWarm: (to: string) => void;
   tabIndex?: number;
   role?: "menuitem";
+  onSelect?: () => void;
 }) {
   const Icon = item.icon;
   return (
@@ -199,7 +232,10 @@ function SidebarChildLink({
       tabIndex={tabIndex}
       role={role}
       aria-current={active ? "page" : undefined}
-      onClick={(event) => onClick(event, item.to)}
+      onClick={(event) => {
+        onSelect?.();
+        onClick(event, item.to);
+      }}
       onMouseEnter={() => onWarm(item.to)}
       onFocus={() => onWarm(item.to)}
       className={
@@ -245,19 +281,21 @@ function SidebarPrimaryLink({
       onMouseEnter={() => onWarm(item.to)}
       onFocus={() => onWarm(item.to)}
       className={
-        "flex h-10 w-full items-center overflow-hidden rounded-xl whitespace-nowrap transition-colors duration-150 " +
+        "mx-2 flex h-10 w-[calc(100%-1rem)] items-center overflow-hidden rounded-xl whitespace-nowrap transition-colors duration-150 " +
         (active
           ? "bg-slate-100 font-semibold text-slate-950 dark:bg-white/10 dark:text-white"
           : "font-medium text-slate-600 hover:bg-slate-100/80 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/[0.06] dark:hover:text-white")
       }
     >
-      <span className="grid h-10 w-16 shrink-0 place-items-center">
+      <span className="grid h-10 w-12 shrink-0 place-items-center">
         <Icon size={16} className="opacity-80" />
       </span>
       <span
         className={
-          "min-w-0 truncate pr-3 text-[13px] transition-opacity duration-150 " +
-          (labelVisible ? "opacity-100" : "opacity-0")
+          "min-w-0 truncate pl-2 pr-3 text-[13px] transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+          (labelVisible
+            ? "translate-x-0 opacity-100 delay-100"
+            : "-translate-x-1 opacity-0 delay-0")
         }
       >
         {label}
@@ -269,11 +307,11 @@ function SidebarPrimaryLink({
 function SidebarToggle({
   label,
   onToggle,
-  visible,
+  alwaysVisible,
 }: {
   label: string;
   onToggle: () => void;
-  visible: boolean;
+  alwaysVisible: boolean;
 }) {
   return (
     <button
@@ -281,9 +319,10 @@ function SidebarToggle({
       onClick={onToggle}
       aria-label={label}
       data-tooltip-managed="true"
+      data-sidebar-toggle="true"
       className={
-        "absolute -right-3.5 top-3.5 z-50 inline-flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 shadow-sm transition-[background-color,color,opacity] duration-150 hover:bg-slate-100 hover:text-slate-950 focus-visible:bg-slate-100 focus-visible:text-slate-950 focus-visible:outline-none dark:border-neutral-700 dark:bg-neutral-900 dark:text-slate-400 dark:hover:bg-neutral-800 dark:hover:text-white " +
-        (visible
+        "absolute right-[15px] top-3 z-50 inline-flex h-8 w-8 items-center justify-center rounded-xl bg-transparent text-slate-500 transition-[background-color,color,opacity] duration-120 hover:bg-slate-100 hover:text-slate-950 focus-visible:bg-slate-100 focus-visible:text-slate-950 focus-visible:outline-none dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-white " +
+        (alwaysVisible
           ? "opacity-100"
           : "opacity-0 group-hover/sidebar:opacity-100 focus-visible:opacity-100")
       }
@@ -297,20 +336,33 @@ function SidebarGroupFlyout({
   group,
   activeTo,
   label,
+  open,
   onClick,
   onWarm,
+  onSelect,
 }: {
   group: SidebarNavGroup;
   activeTo: string | null;
   label: string;
+  open: boolean;
   onClick: (event: MouseEvent<HTMLAnchorElement>, to: string) => void;
   onWarm: (to: string) => void;
+  onSelect: () => void;
 }) {
   const { t } = useTranslation();
   return (
     <div
       role="menu"
-      className="invisible absolute left-[calc(100%+8px)] top-0 z-50 w-52 translate-x-1 rounded-2xl border border-slate-200 bg-white p-2 opacity-0 shadow-[0_16px_48px_rgba(15,23,42,0.14)] transition-[opacity,transform,visibility] duration-180 ease-out before:absolute before:-left-3 before:top-0 before:h-full before:w-3 group-hover/flyout:visible group-hover/flyout:translate-x-0 group-hover/flyout:opacity-100 group-focus-within/flyout:visible group-focus-within/flyout:translate-x-0 group-focus-within/flyout:opacity-100 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/40"
+      aria-hidden={!open}
+      data-sidebar-flyout={group.id}
+      data-open={open ? "true" : "false"}
+      className={
+        floatingPanelSurface +
+        " absolute left-[calc(100%+8px)] top-0 z-50 w-52 origin-top-left p-2 transition-[opacity,transform,visibility] duration-[160ms] ease-[cubic-bezier(0.22,1,0.36,1)] before:absolute before:-left-3 before:top-0 before:h-full before:w-3 " +
+        (open
+          ? "visible pointer-events-auto translate-x-0 scale-100 opacity-100"
+          : "invisible pointer-events-none -translate-x-1 scale-[0.98] opacity-0")
+      }
     >
       <div className="px-3 pb-1.5 pt-1 text-[11px] font-semibold tracking-wide text-slate-400">
         {label}
@@ -324,10 +376,197 @@ function SidebarGroupFlyout({
             label={t(item.i18nKey)}
             onClick={onClick}
             onWarm={onWarm}
+            onSelect={onSelect}
+            tabIndex={open ? undefined : -1}
             role="menuitem"
           />
         ))}
       </div>
+    </div>
+  );
+}
+
+function SidebarMenuGroup({
+  group,
+  activeTo,
+  active,
+  inlineOpen,
+  railCollapsed,
+  visualRailCollapsed,
+  labelsVisible,
+  mode,
+  onToggle,
+  onClick,
+  onWarm,
+}: {
+  group: SidebarNavGroup;
+  activeTo: string | null;
+  active: boolean;
+  inlineOpen: boolean;
+  railCollapsed: boolean;
+  visualRailCollapsed: boolean;
+  labelsVisible: boolean;
+  mode: "desktop" | "mobile";
+  onToggle: () => void;
+  onClick: (event: MouseEvent<HTMLAnchorElement>, to: string) => void;
+  onWarm: (to: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [flyoutOpen, setFlyoutOpen] = useState(false);
+  const suppressUntilPointerLeave = useRef(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const GroupIcon = group.icon;
+  const groupLabel = t(group.i18nKey);
+  const contentId = `sidebar-${mode}-${group.id}`;
+  const showInlineItems = inlineOpen && labelsVisible && !visualRailCollapsed;
+
+  useEffect(() => {
+    if (visualRailCollapsed) return;
+    setFlyoutOpen(false);
+    suppressUntilPointerLeave.current = false;
+  }, [visualRailCollapsed]);
+
+  const closeAndSuppress = useCallback(() => {
+    suppressUntilPointerLeave.current = true;
+    setFlyoutOpen(false);
+  }, []);
+
+  const handlePointerEnter = useCallback(() => {
+    if (visualRailCollapsed && !suppressUntilPointerLeave.current)
+      setFlyoutOpen(true);
+  }, [visualRailCollapsed]);
+
+  const handlePointerLeave = useCallback(() => {
+    setFlyoutOpen(false);
+    suppressUntilPointerLeave.current = false;
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    if (visualRailCollapsed && !suppressUntilPointerLeave.current)
+      setFlyoutOpen(true);
+  }, [visualRailCollapsed]);
+
+  const handleBlur = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget))
+      return;
+    setFlyoutOpen(false);
+    suppressUntilPointerLeave.current = false;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Escape" || !flyoutOpen) return;
+      event.preventDefault();
+      suppressUntilPointerLeave.current = true;
+      setFlyoutOpen(false);
+      triggerRef.current?.focus({ preventScroll: true });
+      queueMicrotask(() => {
+        suppressUntilPointerLeave.current = false;
+      });
+    },
+    [flyoutOpen],
+  );
+
+  const handleTriggerClick = useCallback(() => {
+    if (!visualRailCollapsed) {
+      onToggle();
+      return;
+    }
+    if (flyoutOpen) closeAndSuppress();
+    else {
+      suppressUntilPointerLeave.current = false;
+      setFlyoutOpen(true);
+    }
+  }, [closeAndSuppress, flyoutOpen, onToggle, visualRailCollapsed]);
+
+  return (
+    <div
+      className="relative"
+      data-tooltip-managed="true"
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      onFocusCapture={handleFocus}
+      onBlurCapture={handleBlur}
+      onKeyDown={handleKeyDown}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={railCollapsed ? groupLabel : undefined}
+        aria-expanded={visualRailCollapsed ? flyoutOpen : inlineOpen}
+        aria-controls={visualRailCollapsed ? undefined : contentId}
+        aria-haspopup={visualRailCollapsed ? "menu" : undefined}
+        onClick={handleTriggerClick}
+        className={
+          "mx-2 flex h-10 w-[calc(100%-1rem)] items-center overflow-hidden rounded-xl text-left whitespace-nowrap transition-colors duration-150 " +
+          (active
+            ? "text-slate-950 dark:text-white"
+            : "text-slate-500 hover:bg-slate-100/80 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/[0.06] dark:hover:text-slate-200")
+        }
+      >
+        <span className="grid h-10 w-12 shrink-0 place-items-center">
+          <GroupIcon size={16} className="opacity-80" />
+        </span>
+        <span
+          className={
+            "min-w-0 flex-1 truncate pl-2 text-[13px] font-semibold transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+            (labelsVisible
+              ? "translate-x-0 opacity-100 delay-100"
+              : "-translate-x-1 opacity-0 delay-0")
+          }
+        >
+          {groupLabel}
+        </span>
+        <ChevronDown
+          size={14}
+          className={
+            "mr-3 shrink-0 transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+            (labelsVisible ? "opacity-55 delay-100" : "opacity-0 delay-0") +
+            (inlineOpen ? " rotate-0" : " -rotate-90")
+          }
+        />
+      </button>
+      <div
+        id={contentId}
+        aria-hidden={!showInlineItems}
+        className={
+          "grid transition-[grid-template-rows] duration-[220ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+          (showInlineItems ? "grid-rows-[1fr]" : "grid-rows-[0fr]")
+        }
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div
+            className={
+              "space-y-0.5 pb-1 pl-8 pr-3 pt-0.5 transition-[opacity,transform] duration-[160ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+              (showInlineItems
+                ? "translate-y-0 opacity-100 delay-75"
+                : "-translate-y-1 opacity-0 delay-0")
+            }
+          >
+            {group.items.map((item) => (
+              <SidebarChildLink
+                key={item.to}
+                item={item}
+                active={activeTo === item.to}
+                label={t(item.i18nKey)}
+                onClick={onClick}
+                onWarm={onWarm}
+                tabIndex={showInlineItems ? undefined : -1}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <SidebarGroupFlyout
+        group={group}
+        activeTo={activeTo}
+        label={groupLabel}
+        open={visualRailCollapsed && flyoutOpen}
+        onClick={onClick}
+        onWarm={onWarm}
+        onSelect={closeAndSuppress}
+      />
     </div>
   );
 }
@@ -365,7 +604,9 @@ function ShellSidebar({
   const resolveActiveTo = useCallback((pathname: string) => {
     const sorted = [...NAV_ITEMS].sort((a, b) => b.to.length - a.to.length);
     return (
-      sorted.find((item) => pathname === item.to || pathname.startsWith(`${item.to}/`))?.to ?? null
+      sorted.find(
+        (item) => pathname === item.to || pathname.startsWith(`${item.to}/`),
+      )?.to ?? null
     );
   }, []);
 
@@ -374,10 +615,15 @@ function ShellSidebar({
     [pendingTo, location.pathname, resolveActiveTo],
   );
   const activeGroupId = useMemo(
-    () => NAV_GROUPS.find((group) => group.items.some((item) => item.to === activeTo))?.id,
+    () =>
+      NAV_GROUPS.find((group) =>
+        group.items.some((item) => item.to === activeTo),
+      )?.id,
     [activeTo],
   );
-  const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set(["runtime"]));
+  const [openGroups, setOpenGroups] = useState<Set<string>>(
+    () => new Set(["runtime"]),
+  );
 
   useEffect(() => {
     if (!activeGroupId) return;
@@ -399,13 +645,20 @@ function ShellSidebar({
   const isMobile = mode === "mobile";
   const railCollapsed = !isMobile && collapsed;
   const [visualRailCollapsed, setVisualRailCollapsed] = useState(railCollapsed);
-  const [sidebarLabelsVisible, setSidebarLabelsVisible] = useState(!railCollapsed);
-  const sidebarTransitionTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [sidebarLabelsVisible, setSidebarLabelsVisible] =
+    useState(!railCollapsed);
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const sidebarTransitionTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const accountLogoutLabel = t("shell.logout_button");
-  const sidebarLabel = collapsed ? t("shell.expand_sidebar") : t("shell.collapse_sidebar");
+  const sidebarLabel = collapsed
+    ? t("shell.expand_sidebar")
+    : t("shell.collapse_sidebar");
 
   useEffect(() => {
-    if (sidebarTransitionTimer.current) clearTimeout(sidebarTransitionTimer.current);
+    if (sidebarTransitionTimer.current)
+      clearTimeout(sidebarTransitionTimer.current);
 
     if (railCollapsed) {
       setSidebarLabelsVisible(false);
@@ -422,7 +675,8 @@ function ShellSidebar({
     }
 
     return () => {
-      if (sidebarTransitionTimer.current) clearTimeout(sidebarTransitionTimer.current);
+      if (sidebarTransitionTimer.current)
+        clearTimeout(sidebarTransitionTimer.current);
     };
   }, [railCollapsed]);
 
@@ -450,12 +704,18 @@ function ShellSidebar({
       setPendingTo(to);
 
       const minimumProgress = new Promise<void>((resolve) => {
-        const delay = Math.max(0, ROUTE_PROGRESS_MIN_MS - (Date.now() - progressStartedAt.current));
+        const delay = Math.max(
+          0,
+          ROUTE_PROGRESS_MIN_MS - (Date.now() - progressStartedAt.current),
+        );
         const timer = setTimeout(resolve, delay);
         progressTimers.current.push(timer);
       });
 
-      void Promise.all([preloadPageRoute(to).catch(() => undefined), minimumProgress]).then(() => {
+      void Promise.all([
+        preloadPageRoute(to).catch(() => undefined),
+        minimumProgress,
+      ]).then(() => {
         if (navigationRequestId.current !== requestId) return;
         setProgressDone(true);
 
@@ -505,28 +765,49 @@ function ShellSidebar({
         ].join(" ")}
         aria-hidden={isMobile && collapsed}
       >
-        <SidebarToggle label={sidebarLabel} onToggle={onToggleSidebar} visible={isMobile} />
+        <SidebarToggle
+          label={sidebarLabel}
+          onToggle={onToggleSidebar}
+          alwaysVisible={isMobile}
+        />
         <div className="flex h-full w-full flex-col">
-          <div className="flex h-14 shrink-0 items-center overflow-hidden border-b border-slate-200/80 text-slate-900 whitespace-nowrap dark:border-neutral-800 dark:text-white">
-            <span className="grid h-14 w-16 shrink-0 place-items-center">
-              <span className="grid h-8 w-8 place-items-center rounded-xl bg-blue-600 text-white shadow-[0_8px_18px_rgba(37,99,235,0.2)]">
+          <div className="flex h-14 shrink-0 items-center overflow-hidden text-slate-900 whitespace-nowrap dark:text-white">
+            <span
+              className={
+                "grid h-14 w-16 shrink-0 place-items-center transition-opacity duration-120 " +
+                (visualRailCollapsed
+                  ? "opacity-100 group-hover/sidebar:opacity-0"
+                  : "opacity-100")
+              }
+            >
+              <span
+                data-sidebar-logo="true"
+                className="grid h-8 w-8 place-items-center rounded-xl bg-blue-600 text-white"
+              >
                 <LayoutDashboard size={17} />
               </span>
             </span>
             <span
               className={
-                "min-w-0 flex-1 overflow-hidden leading-tight transition-opacity duration-150 " +
-                (sidebarLabelsVisible ? "opacity-100" : "opacity-0")
+                "min-w-0 flex-1 overflow-hidden leading-tight transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+                (sidebarLabelsVisible
+                  ? "translate-x-0 opacity-100 delay-100"
+                  : "-translate-x-1 opacity-0 delay-0")
               }
             >
               <span className="block truncate text-[15px] font-semibold tracking-tight">
                 {t("shell.console")}
               </span>
-              <span className="block text-[10px] font-medium text-slate-400">CLI Proxy</span>
+              <span className="block text-[10px] font-medium text-slate-400">
+                CLI Proxy
+              </span>
             </span>
           </div>
           <ScrollArea
             className="min-h-0 flex-1 [&_[data-scroll-area-scrollbar='y']]:right-1 [&_[data-scroll-area-scrollbar='y']]:w-5"
+            viewportClassName={
+              visualRailCollapsed ? "overflow-visible" : undefined
+            }
             scrollbarVisibility="track-hover"
             scrollbarTrackInset={16}
           >
@@ -541,140 +822,130 @@ function ShellSidebar({
                 onWarm={warmPageRoute}
               />
               <div className="space-y-1 pt-1">
-                {NAV_GROUPS.map((group) => {
-                  const GroupIcon = group.icon;
-                  const open = openGroups.has(group.id);
-                  const groupActive = group.id === activeGroupId;
-                  const contentId = `sidebar-${mode}-${group.id}`;
-                  const groupLabel = t(group.i18nKey);
-                  return (
-                    <div
+                {NAV_GROUPS.map((group) => (
+                  <SidebarMenuGroup
                       key={group.id}
-                      className="group/flyout relative"
-                      data-tooltip-managed="true"
-                    >
-                      <button
-                        type="button"
-                        aria-label={railCollapsed ? groupLabel : undefined}
-                        aria-expanded={railCollapsed ? undefined : open}
-                        aria-controls={railCollapsed ? undefined : contentId}
-                        aria-haspopup={railCollapsed ? "menu" : undefined}
-                        onClick={() => {
-                          if (!railCollapsed) toggleGroup(group.id);
-                        }}
-                        className={
-                          "flex h-10 w-full items-center overflow-hidden rounded-xl text-left whitespace-nowrap transition-colors duration-150 " +
-                          (groupActive
-                            ? "text-slate-950 dark:text-white"
-                            : "text-slate-500 hover:bg-slate-100/80 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/[0.06] dark:hover:text-slate-200")
-                        }
-                      >
-                        <span className="grid h-10 w-16 shrink-0 place-items-center">
-                          <GroupIcon size={16} className="opacity-80" />
-                        </span>
-                        <span
-                          className={
-                            "min-w-0 flex-1 truncate text-[13px] font-semibold transition-opacity duration-150 " +
-                            (sidebarLabelsVisible ? "opacity-100" : "opacity-0")
-                          }
-                        >
-                          {groupLabel}
-                        </span>
-                        <ChevronDown
-                          size={14}
-                          className={
-                            "mr-3 shrink-0 opacity-55 transition-[opacity,transform] duration-200 ease-out " +
-                            (sidebarLabelsVisible ? "opacity-55" : "opacity-0") +
-                            (open ? " rotate-0" : " -rotate-90")
-                          }
-                        />
-                      </button>
-                      <div
-                        id={contentId}
-                        aria-hidden={!open || railCollapsed}
-                        className={
-                          "grid transition-[grid-template-rows] duration-220 ease-[cubic-bezier(0.22,1,0.36,1)] " +
-                          (open ? "grid-rows-[1fr]" : "grid-rows-[0fr]")
-                        }
-                      >
-                        <div className="min-h-0 overflow-hidden">
-                          <div
-                            className={
-                              "space-y-0.5 pb-1 pl-8 pr-3 pt-0.5 transition-opacity duration-150 " +
-                              (sidebarLabelsVisible ? "opacity-100" : "opacity-0")
-                            }
-                          >
-                            {group.items.map((item) => (
-                              <SidebarChildLink
-                                key={item.to}
-                                item={item}
-                                active={activeTo === item.to}
-                                label={t(item.i18nKey)}
-                                onClick={handleNavClick}
-                                onWarm={warmPageRoute}
-                                tabIndex={open && !railCollapsed ? undefined : -1}
-                              />
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                      {visualRailCollapsed ? (
-                        <SidebarGroupFlyout
                           group={group}
                           activeTo={activeTo}
-                          label={groupLabel}
+                    active={group.id === activeGroupId}
+                    inlineOpen={openGroups.has(group.id)}
+                    railCollapsed={railCollapsed}
+                    visualRailCollapsed={visualRailCollapsed}
+                    labelsVisible={sidebarLabelsVisible}
+                    mode={mode}
+                    onToggle={() => toggleGroup(group.id)}
                           onClick={handleNavClick}
                           onWarm={warmPageRoute}
                         />
-                      ) : null}
-                    </div>
-                  );
-                })}
+                ))}
               </div>
             </nav>
           </ScrollArea>
-          <div className="shrink-0 overflow-visible border-t border-slate-200/80 dark:border-neutral-800">
+          <div className="shrink-0 overflow-visible px-0 pb-2 pt-1">
             <div
-              className="group/account relative flex h-[68px] w-full items-center overflow-visible"
+              className="group/account relative h-[60px] overflow-visible"
               data-tooltip-managed="true"
             >
-              <button
-                type="button"
-                aria-label="Admin"
-                className="grid h-[68px] w-16 shrink-0 place-items-center focus-visible:outline-none"
-              >
-                <span className="relative grid h-9 w-9 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white shadow-[0_7px_16px_rgba(37,99,235,0.18)]">
-                  AD
-                  <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full border-2 border-white bg-emerald-500 dark:border-neutral-950" />
-                </span>
-              </button>
-              <div
-                className={
-                  "min-w-0 flex-1 overflow-hidden leading-tight transition-opacity duration-150 " +
-                  (sidebarLabelsVisible ? "opacity-100" : "opacity-0")
+              <DropdownMenu.Root
+                open={!visualRailCollapsed && accountMenuOpen}
+                onOpenChange={(open) =>
+                  setAccountMenuOpen(visualRailCollapsed ? false : open)
                 }
               >
-                <div className="truncate text-[13px] font-semibold text-slate-950 dark:text-white">
-                  Admin
-                </div>
-                <div className="mt-0.5 truncate text-[10px] text-slate-400">
-                  {t("shell.sidebar_account_role")}
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={handleLogout}
-                aria-label={accountLogoutLabel}
-                tabIndex={visualRailCollapsed ? -1 : undefined}
-                className={
-                  "mr-3 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-slate-400 transition-[background-color,color,opacity] duration-150 hover:bg-rose-50 hover:text-rose-600 focus-visible:bg-rose-50 focus-visible:text-rose-600 focus-visible:outline-none dark:text-slate-500 dark:hover:bg-rose-400/10 dark:hover:text-rose-300 " +
-                  (sidebarLabelsVisible ? "opacity-100" : "opacity-0")
-                }
-              >
-                <LogOut size={15} />
-              </button>
+                <DropdownMenu.Trigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Admin"
+                    className={
+                      "mx-2 flex h-14 w-[calc(100%-1rem)] items-center overflow-hidden rounded-2xl text-left transition-[background-color,box-shadow] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:outline-none " +
+                      (visualRailCollapsed
+                        ? "hover:bg-slate-100/80 dark:hover:bg-white/[0.06]"
+                        : "hover:bg-slate-100/85 hover:shadow-[0_8px_24px_rgba(15,23,42,0.10)] data-[state=open]:bg-slate-100/85 data-[state=open]:shadow-[0_8px_24px_rgba(15,23,42,0.10)] dark:hover:bg-white/[0.08] dark:hover:shadow-black/30 dark:data-[state=open]:bg-white/[0.08] dark:data-[state=open]:shadow-black/30")
+                    }
+                  >
+                    <span className="grid h-14 w-12 shrink-0 place-items-center">
+                      <span
+                        data-sidebar-account-avatar="true"
+                        className="relative grid h-9 w-9 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white"
+                      >
+                        AD
+                        <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full border-2 border-white bg-emerald-500 dark:border-neutral-950" />
+                      </span>
+                    </span>
+                    <span
+                      className={
+                        "min-w-0 flex-1 overflow-hidden pl-2 pr-3 leading-tight transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+                        (sidebarLabelsVisible
+                          ? "translate-x-0 opacity-100 delay-100"
+                          : "-translate-x-1 opacity-0 delay-0")
+                      }
+                    >
+                      <span className="block truncate text-[13px] font-semibold text-slate-950 dark:text-white">
+                        Admin
+                      </span>
+                      <span className="mt-0.5 block truncate text-[10px] text-slate-400">
+                        {t("shell.sidebar_account_role")}
+                      </span>
+                    </span>
+                  </button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content
+                    data-sidebar-account-menu="true"
+                    side="top"
+                    align="start"
+                    sideOffset={8}
+                    collisionPadding={8}
+                    className="w-[var(--radix-dropdown-menu-trigger-width)] p-2"
+                  >
+                    <div className="flex items-center gap-3 px-2 py-2">
+                      <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white">
+                        AD
+                      </div>
+                      <div className="min-w-0 flex-1 leading-tight">
+                        <div className="truncate text-[13px] font-semibold text-slate-950 dark:text-white">
+                          Admin
+                        </div>
+                        <div className="mt-0.5 truncate text-[10px] text-slate-400">
+                          {t("shell.sidebar_account_role")}
+                        </div>
+                      </div>
+                    </div>
+                    <DropdownMenu.Separator />
+                    <DropdownMenu.Item
+                      onSelect={() =>
+                        navigate("/account-security", { viewTransition: true })
+                      }
+                      className="py-2.5"
+                    >
+                      <ShieldCheck size={16} />
+                      {t("shell.nav_account_security")}
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      onSelect={() => navigate("/config", { viewTransition: true })}
+                      className="py-2.5"
+                    >
+                      <Settings size={16} />
+                      {t("shell.nav_config")}
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator />
+                    <DropdownMenu.Item
+                      onSelect={handleLogout}
+                      className="py-2.5 text-rose-600 focus:text-rose-700 dark:text-rose-300"
+                    >
+                      <LogOut size={16} />
+                      {accountLogoutLabel}
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Root>
               {visualRailCollapsed ? (
-                <div className="invisible absolute bottom-2 left-[calc(100%+8px)] z-50 w-52 translate-x-1 rounded-2xl border border-slate-200 bg-white p-2 opacity-0 shadow-[0_16px_48px_rgba(15,23,42,0.14)] transition-[opacity,transform,visibility] duration-180 ease-out before:absolute before:-left-3 before:top-0 before:h-full before:w-3 group-hover/account:visible group-hover/account:translate-x-0 group-hover/account:opacity-100 group-focus-within/account:visible group-focus-within/account:translate-x-0 group-focus-within/account:opacity-100 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/40">
+                <div
+                  className={
+                    floatingPanelSurface +
+                    " invisible absolute bottom-1 left-[calc(100%+8px)] z-50 w-52 translate-x-1 p-2 opacity-0 transition-[opacity,transform,visibility] duration-180 ease-out before:absolute before:-left-3 before:top-0 before:h-full before:w-3 group-hover/account:visible group-hover/account:translate-x-0 group-hover/account:opacity-100 group-focus-within/account:visible group-focus-within/account:translate-x-0 group-focus-within/account:opacity-100"
+                  }
+                >
                   <div className="flex items-center gap-3 px-2 py-2">
                     <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white">
                       AD
@@ -719,7 +990,9 @@ function ShellHeader({
   const {
     state: { titleKey },
   } = useShell();
-  const sidebarLabel = sidebarCollapsed ? t("shell.expand_sidebar") : t("shell.collapse_sidebar");
+  const sidebarLabel = sidebarCollapsed
+    ? t("shell.expand_sidebar")
+    : t("shell.collapse_sidebar");
 
   return (
     <header className="z-20 shrink-0 border-b border-slate-200 bg-white/75 backdrop-blur-xl motion-reduce:transition-none motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:border-neutral-800 dark:bg-neutral-950/60">
@@ -758,14 +1031,18 @@ function ShellMain({ children }: PropsWithChildren) {
   );
 }
 
-export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: () => void }>) {
+export function AppShell({
+  children,
+  onLogout,
+}: PropsWithChildren<{ onLogout?: () => void }>) {
   const location = useLocation();
   const { t } = useTranslation();
   const logout = onLogout ?? (() => {});
 
   const [isMobile, setIsMobile] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState<boolean>(() => {
+  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] =
+    useState<boolean>(() => {
     try {
       return localStorage.getItem(STORAGE_KEY_SIDEBAR_COLLAPSED) === "1";
     } catch {
@@ -815,7 +1092,10 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
 
   useEffect(() => {
     try {
-      localStorage.setItem(STORAGE_KEY_SIDEBAR_COLLAPSED, desktopSidebarCollapsed ? "1" : "0");
+      localStorage.setItem(
+        STORAGE_KEY_SIDEBAR_COLLAPSED,
+        desktopSidebarCollapsed ? "1" : "0",
+      );
     } catch {
       // 忽略持久化失败
     }
@@ -841,7 +1121,9 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
     [location.pathname, logout],
   );
 
-  const sidebarCollapsed = isMobile ? !mobileSidebarOpen : desktopSidebarCollapsed;
+  const sidebarCollapsed = isMobile
+    ? !mobileSidebarOpen
+    : desktopSidebarCollapsed;
 
   return (
     <ShellContext value={value}>
@@ -865,7 +1147,9 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
             collapsed={sidebarCollapsed}
             mode={isMobile ? "mobile" : "desktop"}
             onToggleSidebar={toggleSidebar}
-            onNavigate={isMobile ? () => setMobileSidebarOpen(false) : undefined}
+            onNavigate={
+              isMobile ? () => setMobileSidebarOpen(false) : undefined
+            }
           />
           <div className="flex min-w-0 flex-1 flex-col">
             <ShellHeader

--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -44,6 +44,11 @@ interface AuthContextState {
 
 const AuthContext = createContext<AuthContextState | null>(null);
 
+const isLocalPreviewMode = () =>
+  import.meta.env.DEV &&
+  ["127.0.0.1", "localhost", "::1"].includes(window.location.hostname) &&
+  new URLSearchParams(window.location.search).get("preview") === "1";
+
 export function AuthProvider({ children }: PropsWithChildren) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);
@@ -76,6 +81,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
       return;
     }
 
+    if (isLocalPreviewMode()) {
+      setIsAuthenticated(true);
+      setIsRestoring(false);
+      return;
+    }
+
     try {
       await configApi.getConfig();
       setIsAuthenticated(true);
@@ -93,6 +104,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     const handleUnauthorized = () => {
+      if (isLocalPreviewMode()) return;
       setIsAuthenticated(false);
       clearPersistedAuthSnapshot();
     };
@@ -125,7 +137,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
         managementKey: trimmedKey,
       });
 
-      await configApi.getConfig();
+      if (!isLocalPreviewMode()) await configApi.getConfig();
 
       setApiBase(normalizedBase);
       setManagementKey(trimmedKey);

--- a/docs/internal-review/bundle-baseline.md
+++ b/docs/internal-review/bundle-baseline.md
@@ -1,6 +1,6 @@
 # codeProxy Bundle Baseline
 
-更新时间：2026-07-10 17:10:00 +0800
+更新时间：2026-07-11 16:42:00 +0800
 
 ## 当前构建命令
 
@@ -17,7 +17,7 @@ bun run build
 | `vendor-markdown`    |  761.13 kB | 261.12 kB | Markdown + syntax highlighter 组合                                          |
 | `vendor-animation`   |  126.13 kB |  41.83 kB | 动画依赖独立 vendor chunk                                                   |
 | `vendor-charts`      |    0.07 kB |   0.08 kB | Chart.js 入口当前几乎未进入业务路径                                         |
-| `index`              |  283.68 kB |  88.17 kB | 入口基础包接受本轮窗口顶部进度条变化，后续仍需持续往下压                    |
+| `index`              |  304.11 kB |  93.99 kB | 接受本轮侧边栏稳定交互与全局浮层规范；后续仍需持续往下压                  |
 | `ConfigPage`         |  118.44 kB |  32.93 kB | 页面 chunk 低于预算                                                         |
 | `AuthFilesPage`      |  221.86 kB |  59.92 kB | 身份多档案与出站策略交互加入后仍低于页面 gzip 预算                          |
 | `ProvidersPage`      |  113.50 kB |  28.33 kB | 已低于 `< 80 kB gzip` 页面预算                                              |

--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -5,7 +5,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const readAllowedClients = (value: unknown): string[] => {
   if (!isRecord(value) || !Array.isArray(value.allowed_clients)) return [];
-  return value.allowed_clients.filter((item): item is string => typeof item === "string");
+  return value.allowed_clients.filter(
+    (item): item is string => typeof item === "string",
+  );
 };
 
 const setAuthed = async (page: Page) => {
@@ -21,6 +23,15 @@ const setAuthed = async (page: Page) => {
     );
   });
 };
+
+test("Local preview: accepts any non-empty management key without a backend", async ({
+  page,
+}) => {
+  await page.goto("/manage/?preview=1#/login");
+  await page.locator('input[type="password"]').fill("anything");
+  await page.getByRole("button", { name: /Login|登录/i }).click();
+  await expect(page.locator("aside")).toBeVisible();
+});
 
 test("Config: page should not horizontally scroll; editor should allow horizontal scroll", async ({
   page,
@@ -101,7 +112,9 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   const systemGroup = page.getByRole("button", { name: /System|系统管理/i });
   await expect(systemGroup).toHaveAttribute("aria-expanded", "true");
 
-  const requestLogsLink = page.getByRole("link", { name: /Request Logs|请求日志/i });
+  const requestLogsLink = page.getByRole("link", {
+    name: /Request Logs|请求日志/i,
+  });
   await expect(requestLogsLink).toBeVisible();
   await expect(requestLogsLink).toHaveCSS("font-size", "13px");
 
@@ -110,13 +123,22 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   await expect(configLink).toHaveClass(/bg-slate-100/);
   await expect(configLink).not.toHaveClass(/from-blue-600/);
 
-  const modelsGroup = page.getByRole("button", { name: /Models & Routing|模型与路由/i });
+  const modelsGroup = page.getByRole("button", {
+    name: /Models & Routing|模型与路由/i,
+  });
   await expect(modelsGroup).toHaveAttribute("aria-expanded", "false");
   await modelsGroup.click();
-  await expect(page.getByRole("link", { name: /^Models|模型管理$/i })).toBeVisible();
-  const modelsIconBeforeCollapse = await modelsGroup.locator("svg").first().boundingBox();
+  await expect(
+    page.getByRole("link", { name: /^Models|模型管理$/i }),
+  ).toBeVisible();
+  const modelsIconBeforeCollapse = await modelsGroup
+    .locator("svg")
+    .first()
+    .boundingBox();
 
-  const linkWhiteSpace = await dashboardLink.evaluate((el) => getComputedStyle(el).whiteSpace);
+  const linkWhiteSpace = await dashboardLink.evaluate(
+    (el) => getComputedStyle(el).whiteSpace,
+  );
   expect(linkWhiteSpace).toBe("nowrap");
 
   const aside = page.locator("aside");
@@ -124,30 +146,104 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   await expect(sidebarScrollbar).toHaveCount(1);
   await page.mouse.move(760, 120);
   await expect
-    .poll(async () => Number(await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity)))
+    .poll(async () =>
+      Number(
+        await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity),
+      ),
+    )
     .toBeLessThan(0.05);
 
   await dashboardLink.hover();
   await expect
-    .poll(async () => Number(await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity)))
+    .poll(async () =>
+      Number(
+        await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity),
+      ),
+    )
     .toBeGreaterThan(0.95);
 
   await page.mouse.move(760, 120);
   await expect
-    .poll(async () => Number(await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity)))
+    .poll(async () =>
+      Number(
+        await sidebarScrollbar.evaluate((el) => getComputedStyle(el).opacity),
+      ),
+    )
     .toBeLessThan(0.05);
 
   await aside.hover();
   const collapseButton = page.getByRole("button", {
     name: /Collapse Sidebar|收起侧边栏/i,
   });
-  const toggleIconClass = await collapseButton.locator("svg").getAttribute("class");
+  const toggleIconClass = await collapseButton
+    .locator("svg")
+    .getAttribute("class");
   await collapseButton.click();
 
-  const expandButton = page.getByRole("button", { name: /Expand Sidebar|展开侧边栏/i });
+  const expandButton = page.getByRole("button", {
+    name: /Expand Sidebar|展开侧边栏/i,
+  });
+  const sidebarLogo = aside.locator("[data-sidebar-logo='true']");
+  const sidebarToggle = aside.locator("[data-sidebar-toggle='true']");
+  await expect(sidebarLogo).toHaveCSS("box-shadow", "none");
+  await page.mouse.move(760, 120);
+  await expect
+    .poll(async () =>
+      Number(
+        await sidebarLogo.evaluate(
+          (el) => getComputedStyle(el.parentElement!).opacity,
+        ),
+      ),
+    )
+    .toBeGreaterThan(0.95);
+  await expect
+    .poll(async () =>
+      Number(
+        await sidebarToggle.evaluate((el) => getComputedStyle(el).opacity),
+      ),
+    )
+    .toBeLessThan(0.05);
   await aside.hover();
   await expect(expandButton).toBeVisible();
-  await expect(expandButton.locator("svg")).toHaveAttribute("class", toggleIconClass ?? "");
+  await expect
+    .poll(async () =>
+      Number(
+        await sidebarLogo.evaluate(
+          (el) => getComputedStyle(el.parentElement!).opacity,
+        ),
+      ),
+    )
+    .toBeLessThan(0.05);
+  await expect
+    .poll(async () =>
+      Number(
+        await sidebarToggle.evaluate((el) => getComputedStyle(el).opacity),
+      ),
+    )
+    .toBeGreaterThan(0.95);
+  expect(await sidebarToggle.boundingBox()).toEqual(
+    await sidebarLogo.boundingBox(),
+  );
+  await expect(sidebarToggle).toHaveCSS("border-top-width", "0px");
+  const toggleBox = await sidebarToggle.boundingBox();
+  const accountButtonBox = await aside
+    .locator("[data-sidebar-account-avatar='true']")
+    .boundingBox();
+  const collapsedDashboardBox = await page
+    .getByRole("link", { name: /Dashboard|仪表盘/i })
+    .locator("svg")
+    .boundingBox();
+  const toggleCenter = (toggleBox?.x ?? 0) + (toggleBox?.width ?? 0) / 2;
+  expect((accountButtonBox?.x ?? 0) + (accountButtonBox?.width ?? 0) / 2).toBe(
+    toggleCenter,
+  );
+  expect(
+    (collapsedDashboardBox?.x ?? 0) + (collapsedDashboardBox?.width ?? 0) / 2,
+  ).toBe(toggleCenter);
+  await expect(expandButton.locator("svg")).toHaveAttribute(
+    "class",
+    toggleIconClass ?? "",
+  );
 
   await expect
     .poll(async () => {
@@ -165,26 +261,170 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   });
   const railPositionBefore = await collapsedModelsGroup.boundingBox();
   await collapsedModelsGroup.hover();
-  await expect(page.getByRole("menuitem", { name: /^Models$|^模型管理$/i })).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: /^Models$|^模型管理$/i }),
+  ).toBeVisible();
+  const modelsFlyout = aside.locator("[data-sidebar-flyout='models']");
+  await expect(modelsFlyout).toHaveAttribute("data-open", "true");
+  await expect
+    .poll(async () =>
+      Number(await modelsFlyout.evaluate((el) => getComputedStyle(el).opacity)),
+    )
+    .toBeGreaterThan(0.95);
   const railPositionAfter = await collapsedModelsGroup.boundingBox();
-  const modelsIconAfterCollapse = await collapsedModelsGroup.locator("svg").first().boundingBox();
+  const modelsIconAfterCollapse = await collapsedModelsGroup
+    .locator("svg")
+    .first()
+    .boundingBox();
   expect(railPositionAfter?.x).toBe(railPositionBefore?.x);
   expect(railPositionAfter?.y).toBe(railPositionBefore?.y);
-  expect(modelsIconAfterCollapse).toEqual(modelsIconBeforeCollapse);
+  expect(modelsIconAfterCollapse?.x).toBe(modelsIconBeforeCollapse?.x);
+  expect(modelsIconAfterCollapse?.width).toBe(modelsIconBeforeCollapse?.width);
+  expect(modelsIconAfterCollapse?.height).toBe(
+    modelsIconBeforeCollapse?.height,
+  );
   await expect(page.getByRole("button", { name: "Admin" })).toBeVisible();
+
+  const collapsedSystemGroup = page.getByRole("button", {
+    name: /System|系统管理/i,
+  });
+  const systemFlyout = aside.locator("[data-sidebar-flyout='system']");
+  await collapsedSystemGroup.hover();
+  await expect(systemFlyout).toHaveAttribute("data-open", "true");
+  const flyoutConfigLink = page.getByRole("menuitem", {
+    name: /^Config|配置面板$/i,
+  });
+  await flyoutConfigLink.click();
+  await expect(systemFlyout).toHaveAttribute("data-open", "false");
+  await expect
+    .poll(async () =>
+      Number(await systemFlyout.evaluate((el) => getComputedStyle(el).opacity)),
+    )
+    .toBeLessThan(0.05);
+  await page.waitForTimeout(220);
+  await expect(systemFlyout).toHaveAttribute("data-open", "false");
+
+  await page.mouse.move(760, 120);
+  await collapsedSystemGroup.focus();
+  await expect(systemFlyout).toHaveAttribute("data-open", "true");
+  await page.keyboard.press("Escape");
+  await expect(systemFlyout).toHaveAttribute("data-open", "false");
+  await expect(collapsedSystemGroup).toBeFocused();
+
+  await page.mouse.move(760, 120);
+  await collapsedSystemGroup.hover();
+  await expect(systemFlyout).toHaveAttribute("data-open", "true");
+  await page.mouse.move(760, 120);
+  await expect(systemFlyout).toHaveAttribute("data-open", "false");
+
+  const asideBox = await aside.boundingBox();
+  const expandButtonBox = await expandButton.boundingBox();
+  expect(expandButtonBox?.x).toBeGreaterThanOrEqual(asideBox?.x ?? 0);
+  expect(
+    (expandButtonBox?.x ?? 0) + (expandButtonBox?.width ?? 0),
+  ).toBeLessThanOrEqual((asideBox?.x ?? 0) + (asideBox?.width ?? 0));
+
+  const collapsedDashboard = page.getByRole("link", {
+    name: /Dashboard|仪表盘/i,
+  });
+  const dashboardBox = await collapsedDashboard.boundingBox();
+  expect(dashboardBox?.x).toBeGreaterThan(asideBox?.x ?? 0);
+  expect(dashboardBox?.width).toBeLessThan(
+    asideBox?.width ?? Number.POSITIVE_INFINITY,
+  );
+
+  const collapsedGroupBoxes = await Promise.all(
+    [
+      /Operations|运行监控/i,
+      /Access|接入管理/i,
+      /Models & Routing|模型与路由/i,
+      /System|系统管理/i,
+    ].map(async (name) => page.getByRole("button", { name }).boundingBox()),
+  );
+  for (let index = 1; index < collapsedGroupBoxes.length; index += 1) {
+    expect(
+      (collapsedGroupBoxes[index]?.y ?? 0) -
+        (collapsedGroupBoxes[index - 1]?.y ?? 0),
+    ).toBeLessThan(60);
+  }
 
   await aside.hover();
   await expandButton.click();
   await aside.hover();
-  await expect(page.getByRole("button", { name: /Collapse Sidebar|收起侧边栏/i })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Collapse Sidebar|收起侧边栏/i }),
+  ).toBeVisible();
   await expect
     .poll(async () => {
       return await aside.evaluate((el) => el.getBoundingClientRect().width);
     })
     .toBeGreaterThan(220);
+
+  const accountTrigger = page.getByRole("button", { name: "Admin" });
+  await expect(accountTrigger.locator("svg")).toHaveCount(0);
+  await accountTrigger.hover();
+  await expect
+    .poll(async () =>
+      accountTrigger.evaluate((el) => getComputedStyle(el).boxShadow),
+    )
+    .not.toBe("none");
+  await expect(
+    page.getByRole("button", { name: /Logout|退出登录/i }),
+  ).toHaveCount(0);
+  const accountTriggerBox = await accountTrigger.boundingBox();
+  await accountTrigger.click();
+  const accountMenu = page.locator("[data-sidebar-account-menu='true']");
+  await expect(accountMenu).toBeVisible();
+  await expect(accountMenu).toHaveClass(/code-proxy-floating-surface/);
+  await expect(accountMenu).toHaveCSS("border-radius", "12px");
+  await expect(
+    page.getByRole("menuitem", { name: /Account & Security|账号与安全/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: /^Config|配置面板$/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("menuitem", { name: /Logout|退出登录/i }),
+  ).toBeVisible();
+  await page.waitForTimeout(220);
+  const accountMenuBox = await accountMenu.boundingBox();
+  const accountSurfaceStyle = await accountMenu.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return {
+      borderColor: style.borderTopColor,
+      borderRadius: style.borderRadius,
+      borderWidth: style.borderTopWidth,
+      boxShadow: style.boxShadow,
+    };
+  });
+  expect(Math.abs((accountMenuBox?.width ?? 0) - (accountTriggerBox?.width ?? 0))).toBeLessThan(1);
+  expect((accountMenuBox?.y ?? 0) + (accountMenuBox?.height ?? 0)).toBeLessThan(
+    accountTriggerBox?.y ?? 0,
+  );
+  await page.keyboard.press("Escape");
+  await expect(accountMenu).toBeHidden();
+
+  const languageTrigger = page.locator("header button[aria-haspopup='listbox']");
+  await languageTrigger.click();
+  const languageMenu = page.locator("[role='listbox'].code-proxy-floating-surface");
+  await expect(languageMenu).toBeVisible();
+  const languageSurfaceStyle = await languageMenu.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return {
+      borderColor: style.borderTopColor,
+      borderRadius: style.borderRadius,
+      borderWidth: style.borderTopWidth,
+      boxShadow: style.boxShadow,
+    };
+  });
+  expect(languageSurfaceStyle).toEqual(accountSurfaceStyle);
+  await page.keyboard.press("Escape");
+  await expect(languageMenu).toBeHidden();
 });
 
-test("API Keys: table should scroll vertically when many keys are listed", async ({ page }) => {
+test("API Keys: table should scroll vertically when many keys are listed", async ({
+  page,
+}) => {
   await setAuthed(page);
 
   const entries = Array.from({ length: 80 }, (_, index) => ({
@@ -259,12 +499,16 @@ test("API Keys: table should scroll vertically when many keys are listed", async
 
   await page.goto("/#/api-keys");
 
-  const tableScroller = page.locator("[data-vt-scroll-content]").locator("xpath=..");
+  const tableScroller = page
+    .locator("[data-vt-scroll-content]")
+    .locator("xpath=..");
   await expect(tableScroller).toBeVisible();
 
   await expect
     .poll(async () => {
-      return await tableScroller.evaluate((el) => el.scrollHeight - el.clientHeight);
+      return await tableScroller.evaluate(
+        (el) => el.scrollHeight - el.clientHeight,
+      );
     })
     .toBeGreaterThan(100);
 

--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -224,6 +224,23 @@ const readResponseMetricsColumnState = async (page: Page) =>
     };
   });
 
+test("Request Logs: filter dropdown uses the shared floating surface", async ({ page }) => {
+  await setAuthed(page);
+  await mockRequestLogsApis(page);
+
+  await page.goto("/manage/#/monitor/request-logs");
+  await page.locator('th[data-vt-column-key="id"]').waitFor({ state: "visible" });
+  await page.getByRole("combobox").first().click();
+
+  const filterPanel = page.locator(".code-proxy-floating-surface").last();
+  await expect(filterPanel).toBeVisible();
+  await expect(filterPanel).toHaveCSS("border-radius", "12px");
+  await expect(filterPanel).toHaveCSS("border-top-width", "1px");
+  await expect
+    .poll(async () => filterPanel.evaluate((el) => getComputedStyle(el).boxShadow))
+    .not.toBe("none");
+});
+
 test("Request Logs: centers every header except ID over its column content", async ({ page }) => {
   await setAuthed(page);
   await mockRequestLogsApis(page);

--- a/features/api-key-restrictions/RestrictionMultiSelect.tsx
+++ b/features/api-key-restrictions/RestrictionMultiSelect.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown } from "lucide-react";
-import type { MultiSelectOption } from "@code-proxy/ui";
+import { floatingPanelSurface, type MultiSelectOption } from "@code-proxy/ui";
 
 interface RestrictionMultiSelectProps {
   options: MultiSelectOption[];
@@ -59,6 +59,7 @@ export function RestrictionMultiSelect({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
+  const [dropdownPlacement, setDropdownPlacement] = useState<"bottom" | "top">("bottom");
 
   const selectedValues = useMemo(() => normalizeSelection(options, value), [options, value]);
   const selectedSet = useMemo(() => new Set(selectedValues), [selectedValues]);
@@ -73,6 +74,7 @@ export function RestrictionMultiSelect({
     const openAbove = spaceBelow < dropdownMaxH && spaceAbove > spaceBelow;
 
     if (openAbove) {
+      setDropdownPlacement("top");
       setDropdownStyle({
         position: "fixed",
         bottom: window.innerHeight - rect.top + gap,
@@ -84,6 +86,7 @@ export function RestrictionMultiSelect({
       return;
     }
 
+    setDropdownPlacement("bottom");
     setDropdownStyle({
       position: "fixed",
       top: rect.bottom + gap,
@@ -199,7 +202,9 @@ export function RestrictionMultiSelect({
         <div
           ref={dropdownRef}
           style={dropdownStyle}
-          className="flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xl shadow-black/10 dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-black/30"
+          data-state="open"
+          data-side={dropdownPlacement}
+          className={`flex flex-col overflow-hidden ${floatingPanelSurface}`}
         >
           <div className="border-b border-slate-100 px-3 py-2 dark:border-neutral-800">
             <input

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -87,6 +87,7 @@ export {
 } from "./utils/controlStyles";
 export {
   cn,
+  floatingPanelSurface,
   getSelectTriggerBase,
   selectTriggerBase,
   selectTriggerOpen,

--- a/packages/ui/src/primitives/DateTimePicker.tsx
+++ b/packages/ui/src/primitives/DateTimePicker.tsx
@@ -319,6 +319,7 @@ export function DateTimePicker({
               role="dialog"
               aria-label={labels.picker}
               data-placement={placement}
+              data-side={placement}
               className={cn(selectPanel, "p-3 text-[#18181B] dark:text-white")}
               style={panelStyle}
               {...getSelectDropdownMotion(placement)}

--- a/packages/ui/src/primitives/DropdownMenu.tsx
+++ b/packages/ui/src/primitives/DropdownMenu.tsx
@@ -6,7 +6,7 @@ import {
   type ComponentRef,
 } from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { cn } from "../utils/selectStyles";
+import { cn, floatingPanelSurface } from "../utils/selectStyles";
 import type { ControlSize } from "../utils/controlStyles";
 
 const DropdownMenuSizeContext = createContext<ControlSize>("default");
@@ -32,15 +32,15 @@ const Group = DropdownMenuPrimitive.Group;
 const ItemIndicator = DropdownMenuPrimitive.ItemIndicator;
 
 const CONTENT_CLASS_BY_SIZE: Record<ControlSize, string> = {
-  sm: "min-w-28 rounded-xl p-1",
-  default: "min-w-36 rounded-2xl p-1.5",
-  lg: "min-w-40 rounded-2xl p-2",
+  sm: "min-w-28 p-1",
+  default: "min-w-36 p-1.5",
+  lg: "min-w-40 p-2",
 };
 
 const ITEM_CLASS_BY_SIZE: Record<ControlSize, string> = {
-  sm: "gap-1.5 rounded-lg px-2 py-1.5 text-xs",
-  default: "gap-2 rounded-xl px-3 py-2 text-sm",
-  lg: "gap-2.5 rounded-xl px-3.5 py-2.5 text-sm",
+  sm: "gap-1.5 rounded-md px-2 py-1.5 text-xs",
+  default: "gap-2 rounded-lg px-3 py-2 text-sm",
+  lg: "gap-2.5 rounded-lg px-3.5 py-2.5 text-sm",
 };
 
 const Content = forwardRef<
@@ -53,7 +53,8 @@ const Content = forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[9999] border border-slate-200 bg-white shadow-xl shadow-slate-900/10 outline-none dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35",
+        "z-[9999] overflow-hidden outline-none",
+        floatingPanelSurface,
         CONTENT_CLASS_BY_SIZE[size],
         className,
       )}
@@ -71,7 +72,7 @@ const Item = forwardRef<
     <DropdownMenuPrimitive.Item
       ref={ref}
       className={cn(
-        "flex w-full cursor-default select-none items-center font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10",
+        "flex w-full cursor-default select-none items-center font-medium text-slate-700 outline-none transition-colors duration-150 focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10",
         ITEM_CLASS_BY_SIZE[size],
         className,
       )}

--- a/packages/ui/src/primitives/MultiSelect.tsx
+++ b/packages/ui/src/primitives/MultiSelect.tsx
@@ -184,6 +184,7 @@ export function MultiSelect({
       {open ? (
         <motion.div
           ref={dropdownRef}
+              data-side={dropdownPlacement}
           style={dropdownStyle}
           className={cn(searchableSelectPanel, "flex flex-col")}
           {...getSelectDropdownMotion(dropdownPlacement)}

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -493,6 +493,7 @@ export function SearchableCheckboxMultiSelect({
           {open ? (
             <motion.div
               ref={dropdownRef}
+              data-side={dropdownPlacement}
               style={dropdownStyle}
               className={cn(searchableSelectPanel, "flex flex-col")}
               {...getSelectDropdownMotion(dropdownPlacement)}

--- a/packages/ui/src/primitives/SearchableSelect.tsx
+++ b/packages/ui/src/primitives/SearchableSelect.tsx
@@ -296,6 +296,7 @@ export function SearchableSelect({
             <motion.div
               ref={listRef}
               role="listbox"
+              data-side={pos.placement}
               aria-label={ariaLabel}
               className={searchableSelectPanel}
               {...getSelectDropdownMotion(pos.placement)}

--- a/packages/ui/src/primitives/Select.tsx
+++ b/packages/ui/src/primitives/Select.tsx
@@ -188,6 +188,7 @@ export function Select({
             <motion.div
               ref={listRef}
               role="listbox"
+              data-side={pos.placement}
               aria-label={ariaLabel}
               className={selectPanel}
               {...getSelectDropdownMotion(pos.placement)}

--- a/packages/ui/src/theme/LanguageSelector.tsx
+++ b/packages/ui/src/theme/LanguageSelector.tsx
@@ -138,6 +138,8 @@ export function LanguageSelector({ className }: { className?: string }) {
             <div
               ref={listRef}
               role="listbox"
+              data-state="open"
+              data-side="bottom"
               aria-label={label}
               className={cn(selectPanel, "w-[170px]")}
               style={{ top: pos.top, left: pos.left }}

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -283,6 +283,8 @@ export function ThemeToggleButton({ className, label }: { className?: string; la
             <div
               ref={menuRef}
               role="menu"
+              data-state="open"
+              data-side="bottom"
               aria-label={buttonLabel}
               className={cn(selectPanel, "w-[220px]")}
               style={{ top: pos.top, left: pos.left }}

--- a/packages/ui/src/utils/FloatingPanel.css
+++ b/packages/ui/src/utils/FloatingPanel.css
@@ -1,0 +1,66 @@
+.code-proxy-floating-surface {
+  --dropdown-menu-offset-x: 0px;
+  --dropdown-menu-offset-y: 0px;
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+  will-change: transform, opacity;
+}
+
+.code-proxy-floating-surface[data-side="top"] {
+  --dropdown-menu-offset-y: 6px;
+}
+
+.code-proxy-floating-surface[data-side="bottom"] {
+  --dropdown-menu-offset-y: -6px;
+}
+
+.code-proxy-floating-surface[data-side="left"] {
+  --dropdown-menu-offset-x: 6px;
+}
+
+.code-proxy-floating-surface[data-side="right"] {
+  --dropdown-menu-offset-x: -6px;
+}
+
+.code-proxy-floating-surface[data-state="open"] {
+  animation: code-proxy-floating-surface-in 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.code-proxy-floating-surface[data-state="closed"] {
+  animation: code-proxy-floating-surface-out 130ms ease-in forwards;
+}
+
+@keyframes code-proxy-floating-surface-in {
+  from {
+    opacity: 0;
+    transform: translate(
+        var(--dropdown-menu-offset-x),
+        var(--dropdown-menu-offset-y)
+      )
+      scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+@keyframes code-proxy-floating-surface-out {
+  from {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translate(
+        var(--dropdown-menu-offset-x),
+        var(--dropdown-menu-offset-y)
+      )
+      scale(0.985);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-proxy-floating-surface {
+    animation: none !important;
+  }
+}

--- a/packages/ui/src/utils/selectStyles.ts
+++ b/packages/ui/src/utils/selectStyles.ts
@@ -27,7 +27,7 @@ export const selectTriggerDisabled =
   "cursor-not-allowed bg-white/70 text-[#A1A1AA] opacity-70 shadow-none dark:bg-[#27272A]/70 dark:text-[#71717A]";
 
 export const selectTriggerChip =
-  "inline-flex h-7 items-center justify-center gap-1.5 rounded-xl border-0 bg-white px-2.5 text-[11px] font-semibold text-[#71717A] shadow-[0_2px_8px_rgb(0_0_0_/_0.10)] outline-none transition-colors hover:bg-white hover:text-[#18181B] focus-visible:ring-2 focus-visible:ring-black/[0.08] dark:bg-[#27272A] dark:text-[#A1A1AA] dark:shadow-[0_6px_18px_rgb(0_0_0_/_0.22)] dark:hover:bg-[#303036] dark:hover:text-white dark:focus-visible:ring-white/10";
+  "inline-flex h-7 items-center justify-center gap-1.5 rounded-xl border-0 bg-white px-2.5 text-xs font-semibold text-[#71717A] shadow-[0_2px_8px_rgb(0_0_0_/_0.10)] outline-none transition-colors hover:bg-white hover:text-[#18181B] focus-visible:ring-2 focus-visible:ring-black/[0.08] dark:bg-[#27272A] dark:text-[#A1A1AA] dark:shadow-[0_6px_18px_rgb(0_0_0_/_0.22)] dark:hover:bg-[#303036] dark:hover:text-white dark:focus-visible:ring-white/10";
 
 export const selectChevron =
   "ml-auto shrink-0 text-[#71717A] transition-transform duration-200 dark:text-[#A1A1AA]";
@@ -61,7 +61,7 @@ export const getSelectDropdownMotion = (placement: "bottom" | "top" = "bottom") 
   const offset = placement === "top" ? 6 : -6;
 
   return {
-    initial: { opacity: 0, scale: 0.98, y: offset },
+    initial: { opacity: 1, scale: 0.98, y: offset },
     animate: { opacity: 1, scale: 1, y: 0 },
     exit: { opacity: 0, scale: 0.985, y: offset },
   } as const;

--- a/packages/ui/src/utils/selectStyles.ts
+++ b/packages/ui/src/utils/selectStyles.ts
@@ -1,3 +1,4 @@
+import "./FloatingPanel.css";
 import {
   controlHeightBySize,
   controlPaddingBySize,
@@ -31,11 +32,14 @@ export const selectTriggerChip =
 export const selectChevron =
   "ml-auto shrink-0 text-[#71717A] transition-transform duration-200 dark:text-[#A1A1AA]";
 
+export const floatingPanelSurface =
+  "code-proxy-floating-surface rounded-xl border border-slate-200 bg-white shadow-[0_16px_40px_rgba(15,23,42,0.14)] dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-[0_16px_40px_rgba(0,0,0,0.38)]";
+
 export const selectPanel =
-  "fixed z-[9999] overflow-hidden rounded-2xl border-0 bg-white p-1 shadow-[0_8px_28px_rgb(0_0_0_/_0.16)] dark:bg-[#27272A] dark:shadow-[0_14px_36px_rgb(0_0_0_/_0.38)]";
+  `fixed z-[9999] overflow-hidden p-1 ${floatingPanelSurface}`;
 
 export const searchableSelectPanel =
-  "fixed z-[9999] flex flex-col overflow-hidden rounded-2xl border-0 bg-white shadow-[0_8px_28px_rgb(0_0_0_/_0.16)] dark:bg-[#27272A] dark:shadow-[0_14px_36px_rgb(0_0_0_/_0.38)]";
+  `fixed z-[9999] flex flex-col overflow-hidden ${floatingPanelSurface}`;
 
 export const selectSearchRow =
   "flex items-center gap-2 border-b border-black/[0.06] px-3 py-2 dark:border-white/10";
@@ -44,7 +48,7 @@ export const selectSearchInput =
   "h-6 w-full bg-transparent text-sm text-[#18181B] outline-none placeholder:text-[#96969B] dark:text-white dark:placeholder:text-[#9F9FA8]";
 
 export const selectOptionBase =
-  "flex w-full items-center gap-2 rounded-xl px-2.5 py-2 text-left text-sm outline-none transition-colors hover:bg-[#EBEBEC] hover:text-[#18181B] dark:hover:bg-[#46464C] dark:hover:text-white";
+  "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm outline-none transition-colors hover:bg-[#EBEBEC] hover:text-[#18181B] dark:hover:bg-[#46464C] dark:hover:text-white";
 
 export const selectOptionSelected = "font-medium text-[#18181B] dark:text-white";
 
@@ -54,16 +58,16 @@ export const selectEmptyState =
   "px-2.5 py-3 text-center text-xs text-[#96969B] dark:text-[#9F9FA8]";
 
 export const getSelectDropdownMotion = (placement: "bottom" | "top" = "bottom") => {
-  const exitOffset = placement === "top" ? 2 : -2;
+  const offset = placement === "top" ? 6 : -6;
 
   return {
-    initial: { opacity: 1, scale: 1, y: 0 },
+    initial: { opacity: 0, scale: 0.98, y: offset },
     animate: { opacity: 1, scale: 1, y: 0 },
-    exit: { opacity: 0, scale: 0.98, y: exitOffset },
+    exit: { opacity: 0, scale: 0.985, y: offset },
   } as const;
 };
 
 export const selectDropdownTransition = {
-  duration: 0.14,
-  ease: [0.4, 0, 0.2, 1],
+  duration: 0.18,
+  ease: [0.22, 1, 0.36, 1],
 } as const;

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState, type RefObject, type ReactNode } from "react";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useTranslation } from "react-i18next";
 import {
   BarChart3,
@@ -21,7 +20,7 @@ import {
 } from "lucide-react";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { VendorIcon } from "@code-proxy/assets";
-import { Button, buttonClassName } from "@code-proxy/ui";
+import { Button, DropdownMenu, buttonClassName } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
@@ -65,10 +64,6 @@ import {
 import type { QuotaProvider } from "@features/quota-preview/quota-fetch";
 
 const MAX_FILENAME_PART_LENGTH = 72;
-const ACTION_MENU_CONTENT_CLASS =
-  "z-[220] min-w-44 rounded-2xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
-const ACTION_MENU_ITEM_CLASS =
-  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
 const FILTER_LABEL_CLASS =
   "truncate text-[11px] font-semibold uppercase tracking-[0.02em] text-slate-600 dark:text-white/65";
 const FILTER_FIELD_CLASS = "min-w-0 space-y-2";
@@ -872,9 +867,9 @@ export function AuthFilesFilesTab({
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
-        <DropdownMenu.Content align="end" sideOffset={8} className={ACTION_MENU_CONTENT_CLASS}>
+        <DropdownMenu.Content align="end" sideOffset={8} className="min-w-44">
           <DropdownMenu.Item
-            className={ACTION_MENU_ITEM_CLASS}
+
             disabled={selectablePageNames.length === 0}
             onSelect={() => selectCurrentPage(!allPageSelected)}
           >
@@ -886,7 +881,7 @@ export function AuthFilesFilesTab({
             </span>
           </DropdownMenu.Item>
           <DropdownMenu.Item
-            className={ACTION_MENU_ITEM_CLASS}
+
             disabled={selectableFilteredFiles.length === 0}
             onSelect={() => selectFilteredFiles(!allFilteredSelected)}
           >
@@ -1622,17 +1617,17 @@ export function AuthFilesFilesTab({
                               <DropdownMenu.Content
                                 align="end"
                                 sideOffset={8}
-                                className={ACTION_MENU_CONTENT_CLASS}
+                                className="min-w-44"
                               >
                                 <DropdownMenu.Item
-                                  className={ACTION_MENU_ITEM_CLASS}
+
                                   onSelect={() => openTagsEditor(file)}
                                 >
                                   <Tags size={15} />
                                   <span>{t("auth_files.edit_tags")}</span>
                                 </DropdownMenu.Item>
                                 <DropdownMenu.Item
-                                  className={ACTION_MENU_ITEM_CLASS}
+
                                   disabled={clearStatusDisabled}
                                   onSelect={() => void clearAuthFileStatus(file)}
                                 >
@@ -1644,7 +1639,7 @@ export function AuthFilesFilesTab({
                                   <span>{t("auth_files.clear_status")}</span>
                                 </DropdownMenu.Item>
                                 <DropdownMenu.Item
-                                  className={ACTION_MENU_ITEM_CLASS}
+
                                   onSelect={() => void downloadAuthFile(file)}
                                 >
                                   <Download size={15} />

--- a/pages/auth-files/helpers/authFilesTabUtils.ts
+++ b/pages/auth-files/helpers/authFilesTabUtils.ts
@@ -1,9 +1,4 @@
 export const MAX_FILENAME_PART_LENGTH = 72;
-export const ACTION_MENU_CONTENT_CLASS =
-  "z-[220] min-w-44 rounded-2xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
-export const ACTION_MENU_ITEM_CLASS =
-  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
-
 export const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 

--- a/pages/models/components/ModelFormModal.tsx
+++ b/pages/models/components/ModelFormModal.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import {
   Button,
   Modal,
+  floatingPanelSurface,
   SearchableSelect,
   Select,
   TextInput,
@@ -104,7 +105,9 @@ export function ModelFormModal({
                   <div
                     id="model-config-id-reuse-options"
                     role="listbox"
-                    className="absolute left-0 right-0 top-full z-30 mt-2 max-h-64 overflow-y-auto rounded-2xl bg-white p-1 shadow-[0_8px_28px_rgb(0_0_0_/_0.16)] dark:bg-[#27272A] dark:shadow-[0_14px_36px_rgb(0_0_0_/_0.38)]"
+                    data-state="open"
+                    data-side="bottom"
+                    className={`absolute left-0 right-0 top-full z-30 mt-2 max-h-64 overflow-y-auto p-1 ${floatingPanelSurface}`}
                   >
                     {reusableModelCandidates.map((model) => (
                       <button
@@ -114,7 +117,7 @@ export function ModelFormModal({
                         aria-selected={form.id === model.id}
                         onMouseDown={(event) => event.preventDefault()}
                         onClick={() => onApplyReusableModel(model)}
-                        className="flex w-full min-w-0 items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:bg-[#F4F4F5] dark:hover:bg-white/[0.06]"
+                        className="flex w-full min-w-0 items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-[#F4F4F5] dark:hover:bg-white/[0.06]"
                       >
                         <span className="min-w-0">
                           <span className="block truncate font-medium text-[#18181B] dark:text-white">

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -1,14 +1,7 @@
 import { useState, type ReactNode } from "react";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { DropdownMenu } from "@code-proxy/ui";
 import { EllipsisVertical, Power, Settings2, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-
-const ACTION_MENU_CONTENT_CLASS =
-  "z-[220] min-w-36 rounded-2xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
-const ACTION_MENU_ITEM_CLASS =
-  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
-const ACTION_MENU_DANGER_ITEM_CLASS =
-  "flex w-full cursor-default select-none items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium text-rose-600 outline-none transition-colors focus:bg-rose-50 data-[highlighted]:bg-rose-50 dark:text-rose-300 dark:focus:bg-rose-500/10 dark:data-[highlighted]:bg-rose-500/10";
 
 export interface ProviderCardProps {
   /** Card title (provider name) */
@@ -124,14 +117,10 @@ export function ProviderCard({
               </button>
             </DropdownMenu.Trigger>
             <DropdownMenu.Portal>
-              <DropdownMenu.Content
-                align="end"
-                sideOffset={8}
-                className={ACTION_MENU_CONTENT_CLASS}
-              >
+              <DropdownMenu.Content align="end" sideOffset={8}>
                 {onToggleEnabled ? (
                   <DropdownMenu.Item
-                    className={ACTION_MENU_ITEM_CLASS}
+
                     onSelect={() => onToggleEnabled(!enabled)}
                   >
                     <Power size={15} />
@@ -139,14 +128,14 @@ export function ProviderCard({
                   </DropdownMenu.Item>
                 ) : null}
                 {onEdit ? (
-                  <DropdownMenu.Item className={ACTION_MENU_ITEM_CLASS} onSelect={() => onEdit()}>
+                  <DropdownMenu.Item onSelect={() => onEdit()}>
                     <Settings2 size={15} />
                     <span>{t("providers.edit")}</span>
                   </DropdownMenu.Item>
                 ) : null}
                 {onDelete ? (
                   <DropdownMenu.Item
-                    className={ACTION_MENU_DANGER_ITEM_CLASS}
+                    className="text-rose-600 focus:text-rose-700 dark:text-rose-300"
                     onSelect={() => onDelete()}
                   >
                     <Trash2 size={15} />

--- a/pages/providers/components/ProvidersToolbar.tsx
+++ b/pages/providers/components/ProvidersToolbar.tsx
@@ -1,8 +1,7 @@
 import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { CheckSquare, Download, Plus, RefreshCw, Upload } from "lucide-react";
-import { Button } from "@code-proxy/ui";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Button, DropdownMenu } from "@code-proxy/ui";
 
 export type ProvidersToolbarProps = {
   currentImportKind: string | null;
@@ -19,11 +18,6 @@ export type ProvidersToolbarProps = {
   addLabel?: string;
   children?: ReactNode;
 };
-
-const DROPDOWN_CONTENT =
-  "z-[220] min-w-36 rounded-xl border border-slate-200 bg-white p-1.5 shadow-xl shadow-slate-900/10 dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-black/35";
-const DROPDOWN_ITEM =
-  "flex w-full cursor-default select-none items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-slate-700 outline-none transition-colors focus:bg-slate-100 data-[highlighted]:bg-slate-100 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10";
 
 export function ProvidersToolbar({
   currentImportKind,
@@ -74,12 +68,12 @@ export function ProvidersToolbar({
                 </Button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
-                <DropdownMenu.Content align="start" sideOffset={6} className={DROPDOWN_CONTENT}>
-                  <DropdownMenu.Item className={DROPDOWN_ITEM} onSelect={() => onExport()}>
+                <DropdownMenu.Content align="start" sideOffset={6}>
+                  <DropdownMenu.Item onSelect={() => onExport()}>
                     {t("providers.export_json")}
                   </DropdownMenu.Item>
                   <DropdownMenu.Item
-                    className={DROPDOWN_ITEM}
+
                     onSelect={() => onExportSelected()}
                     disabled={selectedExportCount === 0}
                   >


### PR DESCRIPTION
## 修改内容

- 重构管理端侧边栏分组交互，稳定展开/收起期间的图标与文字位置
- 将收起态二级菜单改为受控浮层，完善 hover、focus、Escape、点击关闭及防止立即重开逻辑
- 优化侧边栏文字、内联子菜单、Logo/展开按钮和账户区域动效
- 重做账户入口及向上弹出的账户菜单，移除三点图标
- 增加仅限本地开发 `preview=1` 的任意非空管理密钥登录能力，不影响生产鉴权
- 抽取全局 `code-proxy-floating-surface`，统一 DropdownMenu、Select、多选筛选、语言/主题菜单等浮层的边框、12px 圆角、阴影与方向动效
- 将 Providers、Auth Files 等直接使用 Radix 的菜单迁移到 `@code-proxy/ui` 全局组件

## 根因

此前侧边栏浮层依赖纯 CSS `group-hover`，点击菜单项后 hover 状态仍成立，导致菜单无法可靠关闭；同时语言菜单、筛选器、账户菜单等各自维护浮层样式，产生边框、圆角和阴影不一致。

## 验证

- `rtk bun run build`
- `rtk bun run lint`（0 errors，2 个既有 warning）
- AppShell 与 Providers 单元测试：24 passed
- 侧边栏 Chromium E2E：passed
- 请求日志共享浮层 Chromium E2E：passed
- 真实 Chromium 检查账户菜单、语言菜单、请求日志筛选菜单的 border、12px radius 和 shadow 一致
