### PR TITLE
feat: unify frontend typography and radii

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -165,7 +165,7 @@ describe("AppShell route progress", () => {
 
     const requestLogs = screen.getByRole("link", { name: /Request Logs|请求日志/i });
     expect(requestLogs).toHaveAttribute("aria-current", "page");
-    expect(requestLogs).toHaveClass("bg-slate-100", "text-[13px]", "h-9");
+    expect(requestLogs).toHaveClass("bg-slate-100", "text-sm", "h-9");
     expect(requestLogs.className).not.toContain("from-blue-600");
 
     fireEvent.click(runtimeGroup);

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -239,7 +239,7 @@ function SidebarChildLink({
       onMouseEnter={() => onWarm(item.to)}
       onFocus={() => onWarm(item.to)}
       className={
-        "flex h-9 min-w-0 items-center gap-2.5 rounded-xl px-3 text-[13px] whitespace-nowrap transition-colors duration-150 " +
+        "flex h-9 min-w-0 items-center gap-2.5 rounded-xl px-3 text-sm whitespace-nowrap transition-colors duration-150 " +
         (active
           ? "bg-slate-100 font-semibold text-slate-950 dark:bg-white/10 dark:text-white"
           : "font-medium text-slate-600 hover:bg-slate-100/80 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/[0.06] dark:hover:text-white")
@@ -292,7 +292,7 @@ function SidebarPrimaryLink({
       </span>
       <span
         className={
-          "min-w-0 truncate pl-2 pr-3 text-[13px] transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+          "min-w-0 truncate pl-2 pr-3 text-sm transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
           (labelVisible
             ? "translate-x-0 opacity-100 delay-100"
             : "-translate-x-1 opacity-0 delay-0")
@@ -364,7 +364,7 @@ function SidebarGroupFlyout({
           : "invisible pointer-events-none -translate-x-1 scale-[0.98] opacity-0")
       }
     >
-      <div className="px-3 pb-1.5 pt-1 text-[11px] font-semibold tracking-wide text-slate-400">
+      <div className="px-3 pb-1.5 pt-1 text-xs font-semibold tracking-wide text-slate-400">
         {label}
       </div>
       <div className="space-y-0.5">
@@ -510,7 +510,7 @@ function SidebarMenuGroup({
         </span>
         <span
           className={
-            "min-w-0 flex-1 truncate pl-2 text-[13px] font-semibold transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+            "min-w-0 flex-1 truncate pl-2 text-sm font-semibold transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
             (labelsVisible
               ? "translate-x-0 opacity-100 delay-100"
               : "-translate-x-1 opacity-0 delay-0")
@@ -795,10 +795,10 @@ function ShellSidebar({
                   : "-translate-x-1 opacity-0 delay-0")
               }
             >
-              <span className="block truncate text-[15px] font-semibold tracking-tight">
+              <span className="block truncate text-base font-semibold tracking-tight">
                 {t("shell.console")}
               </span>
-              <span className="block text-[10px] font-medium text-slate-400">
+              <span className="block text-2xs font-medium text-slate-400">
                 CLI Proxy
               </span>
             </span>
@@ -866,7 +866,7 @@ function ShellSidebar({
                     <span className="grid h-14 w-12 shrink-0 place-items-center">
                       <span
                         data-sidebar-account-avatar="true"
-                        className="relative grid h-9 w-9 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white"
+                        className="relative grid h-9 w-9 place-items-center rounded-full bg-blue-600 text-xs font-semibold text-white"
                       >
                         AD
                         <span className="absolute bottom-0 right-0 h-2.5 w-2.5 rounded-full border-2 border-white bg-emerald-500 dark:border-neutral-950" />
@@ -880,10 +880,10 @@ function ShellSidebar({
                           : "-translate-x-1 opacity-0 delay-0")
                       }
                     >
-                      <span className="block truncate text-[13px] font-semibold text-slate-950 dark:text-white">
+                      <span className="block truncate text-sm font-semibold text-slate-950 dark:text-white">
                         Admin
                       </span>
-                      <span className="mt-0.5 block truncate text-[10px] text-slate-400">
+                      <span className="mt-0.5 block truncate text-2xs text-slate-400">
                         {t("shell.sidebar_account_role")}
                       </span>
                     </span>
@@ -899,14 +899,14 @@ function ShellSidebar({
                     className="w-[var(--radix-dropdown-menu-trigger-width)] p-2"
                   >
                     <div className="flex items-center gap-3 px-2 py-2">
-                      <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white">
+                      <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-blue-600 text-xs font-semibold text-white">
                         AD
                       </div>
                       <div className="min-w-0 flex-1 leading-tight">
-                        <div className="truncate text-[13px] font-semibold text-slate-950 dark:text-white">
+                        <div className="truncate text-sm font-semibold text-slate-950 dark:text-white">
                           Admin
                         </div>
-                        <div className="mt-0.5 truncate text-[10px] text-slate-400">
+                        <div className="mt-0.5 truncate text-2xs text-slate-400">
                           {t("shell.sidebar_account_role")}
                         </div>
                       </div>
@@ -947,14 +947,14 @@ function ShellSidebar({
                   }
                 >
                   <div className="flex items-center gap-3 px-2 py-2">
-                    <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-blue-600 text-[11px] font-semibold text-white">
+                    <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-blue-600 text-xs font-semibold text-white">
                       AD
                     </div>
                     <div className="min-w-0 flex-1 leading-tight">
-                      <div className="truncate text-[13px] font-semibold text-slate-950 dark:text-white">
+                      <div className="truncate text-sm font-semibold text-slate-950 dark:text-white">
                         Admin
                       </div>
-                      <div className="mt-0.5 truncate text-[10px] text-slate-400">
+                      <div className="mt-0.5 truncate text-2xs text-slate-400">
                         {t("shell.sidebar_account_role")}
                       </div>
                     </div>

--- a/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
+++ b/apps/admin-panel/src/app/update/UpdateDetailsModal.tsx
@@ -28,7 +28,7 @@ const RELEASE_NOTES_PROSE_CLASSES = `prose prose-sm dark:prose-invert max-w-none
   prose-headings:mt-3 prose-headings:mb-2 prose-headings:font-semibold
   prose-h1:text-base prose-h2:text-sm prose-h3:text-sm
   prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5
-  prose-code:rounded-md prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[13px] prose-code:font-mono prose-code:text-slate-700 prose-code:before:content-none prose-code:after:content-none
+  prose-code:rounded-md prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-slate-700 prose-code:before:content-none prose-code:after:content-none
   dark:prose-code:bg-neutral-800 dark:prose-code:text-slate-300
   prose-pre:rounded-lg prose-pre:bg-slate-900 prose-pre:text-xs dark:prose-pre:bg-neutral-900
   prose-a:break-all prose-a:text-indigo-600 dark:prose-a:text-indigo-300

--- a/apps/admin-panel/src/styles/index.css
+++ b/apps/admin-panel/src/styles/index.css
@@ -8,7 +8,61 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --font-sans: "Inter", "SF Pro Text", "PingFang SC", "Microsoft YaHei", sans-serif;
+  /*
+   * 全局排版与圆角规范。页面只使用这些 Tailwind token，图表等非 DOM 渲染同样遵循对应像素值。
+   * 字号：10 / 12 / 14 / 16 / 18 / 20 / 24 / 30 / 36 / 48 / 60 px
+   * 圆角：2 / 4 / 6 / 8 / 12 / 16 / 24 / 32 px，以及 full
+   */
+  --font-sans: "SF Pro Text", "Segoe UI", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+
+  --text-2xs: 0.625rem;
+  --text-2xs--line-height: 0.875rem;
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1rem;
+  --text-sm: 0.875rem;
+  --text-sm--line-height: 1.25rem;
+  --text-base: 1rem;
+  --text-base--line-height: 1.5rem;
+  --text-lg: 1.125rem;
+  --text-lg--line-height: 1.75rem;
+  --text-xl: 1.25rem;
+  --text-xl--line-height: 1.75rem;
+  --text-2xl: 1.5rem;
+  --text-2xl--line-height: 2rem;
+  --text-3xl: 1.875rem;
+  --text-3xl--line-height: 2.25rem;
+  --text-4xl: 2.25rem;
+  --text-4xl--line-height: 2.5rem;
+  --text-5xl: 3rem;
+  --text-5xl--line-height: 1;
+  --text-6xl: 3.75rem;
+  --text-6xl--line-height: 1;
+
+  --radius-xs: 0.125rem;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-2xl: 1rem;
+  --radius-3xl: 1.5rem;
+  --radius-4xl: 2rem;
+  --radius-full: 9999px;
+}
+
+@layer base {
+  body {
+    font-family: var(--font-sans);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+  }
+
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(--font-mono);
+  }
 }
 
 html.theme-transition-lock,
@@ -247,7 +301,7 @@ html.theme-transition-lock *::after {
 
 .dark ::-webkit-scrollbar-thumb {
   background-color: rgba(255 255 255 / 0.2);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   border: 2px solid transparent;
   background-clip: content-box;
 }
@@ -362,7 +416,7 @@ html.theme-transition-lock *::after {
 
 .pl-glow {
   position: absolute;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   filter: blur(80px);
   pointer-events: none;
   animation: pl-glow-pulse 4s ease-in-out infinite alternate;

--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -116,7 +116,7 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
     name: /Request Logs|请求日志/i,
   });
   await expect(requestLogsLink).toBeVisible();
-  await expect(requestLogsLink).toHaveCSS("font-size", "13px");
+  await expect(requestLogsLink).toHaveCSS("font-size", "14px");
 
   const configLink = page.getByRole("link", { name: /^Config|配置面板$/i });
   await expect(configLink).toHaveAttribute("aria-current", "page");

--- a/features/api-key-restrictions/useApiKeyPermissionOptions.tsx
+++ b/features/api-key-restrictions/useApiKeyPermissionOptions.tsx
@@ -160,7 +160,7 @@ export function useApiKeyPermissionOptions() {
           value: name,
           label: name,
           icon: (
-            <span className="inline-flex rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-600 dark:bg-neutral-800 dark:text-white/60">
+            <span className="inline-flex rounded-md bg-slate-100 px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wide text-slate-600 dark:bg-neutral-800 dark:text-white/60">
               {source}
             </span>
           ),

--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -55,7 +55,7 @@ const iconByType: Record<CcSwitchClientType, string> = {
 };
 
 const labelClassName =
-  "text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
+  "text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
 const controlClassName =
   "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
 const fieldClassName = "flex flex-col gap-1.5";
@@ -621,7 +621,7 @@ export function CcSwitchImportConfigModal({
         triggerLabel: (
           <span className="flex min-w-0 items-center gap-2">
             <span className="truncate font-semibold">{option.label}</span>
-            <span className="shrink-0 font-mono text-[11px] text-slate-500 dark:text-white/50">
+            <span className="shrink-0 font-mono text-xs text-slate-500 dark:text-white/50">
               {path}
             </span>
           </span>
@@ -632,7 +632,7 @@ export function CcSwitchImportConfigModal({
             <span className="truncate text-sm font-semibold text-slate-900 dark:text-white">
               {option.label}
             </span>
-            <span className="truncate font-mono text-[11px] text-slate-500 dark:text-white/50">
+            <span className="truncate font-mono text-xs text-slate-500 dark:text-white/50">
               {path}
               {option.description ? ` · ${option.description}` : ""}
             </span>
@@ -1016,7 +1016,7 @@ export function CcSwitchImportConfigModal({
           <div className="space-y-2">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <span className={labelClassName}>{t("ccswitch.config_full_base_url")}</span>
-              <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-300">
+              <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-300">
                 {t("ccswitch.config_live_preview")}
               </span>
             </div>
@@ -1131,7 +1131,7 @@ export function CcSwitchImportConfigModal({
               </p>
             </div>
             {modelMappingsLoading ? (
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55">
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55">
                 <LoaderCircle size={12} className="animate-spin" />
                 {t("ccswitch.import_model_loading")}
               </span>

--- a/features/log-content-viewer/components/ErrorDetailModal.tsx
+++ b/features/log-content-viewer/components/ErrorDetailModal.tsx
@@ -167,13 +167,13 @@ export function ErrorDetailModal({ open, logId, model, onClose }: ErrorDetailMod
               {/* Full response */}
               <div className="relative">
                 <div className="flex items-center justify-between mb-1.5">
-                  <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-white/35">
+                  <span className="text-2xs font-semibold uppercase tracking-widest text-slate-400 dark:text-white/35">
                     {t("error_detail.full_response")}
                   </span>
                   <button
                     type="button"
                     onClick={handleCopy}
-                    className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-100 dark:text-white/40 dark:hover:bg-neutral-800"
+                    className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-slate-500 transition hover:bg-slate-100 dark:text-white/40 dark:hover:bg-neutral-800"
                   >
                     {copied ? <Check size={12} className="text-emerald-500" /> : <Copy size={12} />}
                     {copied ? t("common.copied") : t("log_content.copy")}

--- a/features/log-content-viewer/components/LogContentModal.tsx
+++ b/features/log-content-viewer/components/LogContentModal.tsx
@@ -365,10 +365,10 @@ function RequestDetailRows({ rows }: { rows: RequestDetailRow[] }) {
           key={`${row.label}:${row.value}`}
           className="grid min-w-0 gap-1.5 px-3 py-2.5 sm:grid-cols-[minmax(8rem,13rem)_minmax(0,1fr)] sm:gap-3"
         >
-          <span className="min-w-0 font-mono text-[12px] leading-5 break-all text-slate-500 dark:text-white/40">
+          <span className="min-w-0 font-mono text-xs leading-5 break-all text-slate-500 dark:text-white/40">
             {row.label}
           </span>
-          <span className="min-w-0 font-mono text-[12px] leading-5 break-words whitespace-pre-wrap text-slate-900 dark:text-slate-100">
+          <span className="min-w-0 font-mono text-xs leading-5 break-words whitespace-pre-wrap text-slate-900 dark:text-slate-100">
             {row.value}
           </span>
         </div>
@@ -381,7 +381,7 @@ function RequestDetailGroupView({ group }: { group: RequestDetailGroup }) {
   if (group.rows.length === 0) return null;
   return (
     <div className="border-t border-slate-100 dark:border-neutral-800/80">
-      <div className="px-3 pt-3 pb-1.5 text-[11px] font-medium text-slate-400 dark:text-white/35">
+      <div className="px-3 pt-3 pb-1.5 text-xs font-medium text-slate-400 dark:text-white/35">
         {group.title}
       </div>
       <RequestDetailRows rows={group.rows} />
@@ -399,7 +399,7 @@ function RequestDetailAttemptView({
   return (
     <div className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950/60">
       {showTitle && attempt.title ? (
-        <div className="border-b border-slate-100 px-3 py-2 font-mono text-[11px] text-slate-400 dark:border-neutral-800/80 dark:text-white/35">
+        <div className="border-b border-slate-100 px-3 py-2 font-mono text-xs text-slate-400 dark:border-neutral-800/80 dark:text-white/35">
           {attempt.title}
         </div>
       ) : null}
@@ -613,7 +613,7 @@ function StructuredRequestCard({
   return (
     <div
       data-testid={testId}
-      className="overflow-hidden rounded-[28px] border border-slate-200 bg-slate-50/90 dark:border-neutral-800 dark:bg-neutral-900/75"
+      className="overflow-hidden rounded-3xl border border-slate-200 bg-slate-50/90 dark:border-neutral-800 dark:bg-neutral-900/75"
     >
       <div className="grid gap-0 divide-y divide-slate-200/90 dark:divide-neutral-800">
         {model ? (
@@ -647,7 +647,7 @@ function StructuredRequestCard({
                   key={item.key}
                   className="rounded-2xl border border-slate-200 bg-white px-3 py-3 dark:border-neutral-800 dark:bg-neutral-950"
                 >
-                  <p className="font-mono text-[11px] text-slate-500 dark:text-white/40">
+                  <p className="font-mono text-xs text-slate-500 dark:text-white/40">
                     {item.key}
                   </p>
                   <pre className="mt-1 whitespace-pre-wrap break-words font-sans text-sm leading-6 text-slate-900 dark:text-white">
@@ -1366,7 +1366,7 @@ export function LogContentModal({
       egressBadges.push(
         <span
           key="loading"
-          className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600 dark:bg-white/10 dark:text-white/60"
+          className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-white/10 dark:text-white/60"
         >
           {t("log_content.egress_badge_verifying")}
         </span>,
@@ -1375,7 +1375,7 @@ export function LogContentModal({
       egressBadges.push(
         <span
           key="proxy"
-          className="rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-medium text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+          className="rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
         >
           {t("log_content.egress_badge_proxy")}
         </span>,
@@ -1384,7 +1384,7 @@ export function LogContentModal({
       egressBadges.push(
         <span
           key="direct"
-          className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-700 dark:bg-white/10 dark:text-white/70"
+          className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-white/10 dark:text-white/70"
         >
           {t("log_content.egress_badge_server")}
         </span>,
@@ -1395,7 +1395,7 @@ export function LogContentModal({
         <span
           key="compare"
           className={[
-            "rounded-full px-2 py-0.5 text-[11px] font-medium",
+            "rounded-full px-2 py-0.5 text-xs font-medium",
             egressInfo.matches_server_ip
               ? "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-200"
               : "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200",
@@ -1411,7 +1411,7 @@ export function LogContentModal({
       egressBadges.push(
         <span
           key="error"
-          className="rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-medium text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+          className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
         >
           {t("log_content.egress_badge_failed")}
         </span>,

--- a/features/log-content-viewer/log-content/rendering-markdown.tsx
+++ b/features/log-content-viewer/log-content/rendering-markdown.tsx
@@ -69,7 +69,7 @@ function CodeBlock({ language, children }: { language: string; children: string 
         customStyle={{
           margin: 0,
           borderRadius: 0,
-          fontSize: "13px",
+          fontSize: "14px",
           lineHeight: "1.6",
           padding: "10px 16px 16px 16px",
         }}

--- a/features/log-content-viewer/log-content/rendering.tsx
+++ b/features/log-content-viewer/log-content/rendering.tsx
@@ -124,7 +124,7 @@ const PROSE_CLASSES = `prose prose-sm dark:prose-invert max-w-none break-words l
   prose-h1:text-lg prose-h2:text-base prose-h3:text-sm
   prose-p:my-2 prose-p:leading-relaxed
   prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5
-  prose-code:rounded-md prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[13px] prose-code:font-mono prose-code:text-slate-700 prose-code:before:content-none prose-code:after:content-none
+  prose-code:rounded-md prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-slate-700 prose-code:before:content-none prose-code:after:content-none
   dark:prose-code:bg-neutral-800 dark:prose-code:text-slate-300
   prose-pre:rounded-lg prose-pre:bg-slate-900 prose-pre:text-xs dark:prose-pre:bg-neutral-900
   prose-strong:font-semibold
@@ -146,7 +146,7 @@ function MarkdownBlock({ text }: { text: string }) {
 function TagBadge({ name, content }: { name: string; content: string }) {
   return (
     <div className="flex items-baseline gap-2 rounded-lg bg-slate-50 px-3 py-2 dark:bg-neutral-800/50">
-      <code className="shrink-0 rounded bg-slate-200/70 px-1.5 py-0.5 font-mono text-[11px] text-slate-500 dark:bg-neutral-700 dark:text-slate-400">
+      <code className="shrink-0 rounded bg-slate-200/70 px-1.5 py-0.5 font-mono text-xs text-slate-500 dark:bg-neutral-700 dark:text-slate-400">
         {name}
       </code>
       <span className="text-sm text-slate-700 dark:text-slate-200">{content}</span>
@@ -171,7 +171,7 @@ function TagSection({
         onClick={() => setExpanded((prev) => !prev)}
         className="flex w-full items-center gap-2 bg-slate-50 px-3.5 py-2 text-left text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 dark:bg-neutral-800/50 dark:text-slate-400 dark:hover:bg-neutral-800/80"
       >
-        <code className="shrink-0 rounded bg-slate-200/70 px-1.5 py-0.5 font-mono text-[11px] text-slate-600 dark:bg-neutral-700 dark:text-slate-300">
+        <code className="shrink-0 rounded bg-slate-200/70 px-1.5 py-0.5 font-mono text-xs text-slate-600 dark:bg-neutral-700 dark:text-slate-300">
           {name}
         </code>
         <span className="flex-1" />

--- a/features/model-tags/index.tsx
+++ b/features/model-tags/index.tsx
@@ -265,11 +265,11 @@ const MODEL_VENDOR_DEFINITIONS: ModelVendorDefinition[] = [
 
 const MODEL_TAG_SIZE_CLASSES = {
   xs: {
-    wrapper: "gap-1 rounded-md px-1.5 py-0.5 text-[10px]",
+    wrapper: "gap-1 rounded-md px-1.5 py-0.5 text-2xs",
     icon: 11,
   },
   sm: {
-    wrapper: "gap-1.5 rounded-md px-2 py-0.5 text-[11px]",
+    wrapper: "gap-1.5 rounded-md px-2 py-0.5 text-xs",
     icon: 12,
   },
   md: {
@@ -427,7 +427,7 @@ export function ModelVendorStatBadge({
 }) {
   const tone = getModelVendorColor(vendorKey);
   const className = cn(
-    "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-semibold",
+    "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-2xs font-semibold",
     tone.bg,
     active ? "ring-2 ring-indigo-500/35 ring-offset-1 ring-offset-white dark:ring-indigo-300/40 dark:ring-offset-neutral-950" : "",
     onClick ? "cursor-pointer transition hover:shadow-sm" : "",

--- a/features/monitor-widgets/chart-options/model-distribution.ts
+++ b/features/monitor-widgets/chart-options/model-distribution.ts
@@ -62,7 +62,7 @@ export const createModelDistributionOption = (input: {
         label: { show: false },
         labelLine: { show: false },
         itemStyle: {
-          borderRadius: 3,
+          borderRadius: 4,
           borderWidth: 2,
           borderColor: input.isDark ? "rgba(10,10,10,0.75)" : "rgba(255,255,255,0.92)",
         },

--- a/features/provider-latency/components/ProviderStatusBar.tsx
+++ b/features/provider-latency/components/ProviderStatusBar.tsx
@@ -50,7 +50,7 @@ export function ProviderStatusBar({
         {data.blocks.map((state, idx) => (
           <div
             key={idx}
-            className={barHeight + " w-full rounded-[1px] " + blockClass(state)}
+            className={barHeight + " w-full rounded-xs " + blockClass(state)}
             aria-hidden="true"
           />
         ))}

--- a/features/proxy-pool/ProxyPoolSelect.tsx
+++ b/features/proxy-pool/ProxyPoolSelect.tsx
@@ -91,7 +91,7 @@ export function ProxyPoolSelect({
                 <span className="ml-1 text-xs text-slate-500 dark:text-white/50">({id})</span>
               </span>
               {showDetails ? (
-                <span className="mt-0.5 flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] text-slate-500 dark:text-white/50">
+                <span className="mt-0.5 flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-slate-500 dark:text-white/50">
                   <span className="font-semibold">{protocol}</span>
                   <span className="font-mono">{endpoint}</span>
                   {entry.description ? <span className="truncate">{entry.description}</span> : null}
@@ -107,7 +107,7 @@ export function ProxyPoolSelect({
               <span
                 data-latency-tone={tone}
                 className={[
-                  "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold",
+                  "shrink-0 rounded-full px-2 py-0.5 text-2xs font-semibold",
                   latencyToneClasses[tone],
                 ].join(" ")}
                 title={result?.message}
@@ -116,7 +116,7 @@ export function ProxyPoolSelect({
               </span>
             ) : null}
             {!entry.enabled ? (
-              <span className="shrink-0 rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-200">
+              <span className="shrink-0 rounded-md bg-amber-500/10 px-1.5 py-0.5 text-2xs font-semibold text-amber-700 dark:text-amber-200">
                 {t("proxies.disabled")}
               </span>
             ) : null}

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -126,7 +126,7 @@ function RequestLogMetricChip({
   return (
     <span
       className={[
-        "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] whitespace-nowrap",
+        "inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-xs whitespace-nowrap",
         className,
       ].join(" ")}
       aria-label={ariaLabel}

--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -335,7 +335,7 @@ function renderChannelTags(tags: string[]) {
       {tags.map((tag) => (
         <span
           key={tag}
-          className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+          className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-2xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
         >
           {tag}
         </span>
@@ -1111,7 +1111,7 @@ export function RoutingConfigEditor({
                   {channels.map((channel) => (
                     <span
                       key={channel.id}
-                      className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                      className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                     >
                       {channel.name}
                       {channel.priority.trim()
@@ -1178,7 +1178,7 @@ export function RoutingConfigEditor({
                   {routePaths.map((path) => (
                     <span
                       key={path}
-                      className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-[11px] text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                      className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                     >
                       {path}
                     </span>
@@ -1254,12 +1254,12 @@ export function RoutingConfigEditor({
                 >
                   <span className="truncate">{channel.name}</span>
                   {isStale ? (
-                    <span className="inline-flex shrink-0 items-center rounded-full bg-rose-50 px-2 py-0.5 text-[10px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                    <span className="inline-flex shrink-0 items-center rounded-full bg-rose-50 px-2 py-0.5 text-2xs font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
                       {t("channel_groups_page.deleted_badge")}
                     </span>
                   ) : null}
                   {!isStale && isDisabled ? (
-                    <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/55">
+                    <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/55">
                       {t("channel_groups_page.disabled_badge")}
                     </span>
                   ) : null}
@@ -1269,7 +1269,7 @@ export function RoutingConfigEditor({
                     {displayTags.map((tag) => (
                       <span
                         key={tag}
-                        className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                        className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-2xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
                       >
                         {tag}
                       </span>
@@ -1383,7 +1383,7 @@ export function RoutingConfigEditor({
               </OverflowTooltip>
               {model.description ? (
                 <OverflowTooltip content={model.description} className="block min-w-0">
-                  <span className="block min-w-0 truncate text-[11px] text-slate-500 dark:text-white/45">
+                  <span className="block min-w-0 truncate text-xs text-slate-500 dark:text-white/45">
                     {model.description}
                   </span>
                 </OverflowTooltip>
@@ -1609,7 +1609,7 @@ export function RoutingConfigEditor({
                         {channel.name}
                       </span>
                     </OverflowTooltip>
-                    <span className="inline-flex justify-center rounded-full bg-rose-50 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-100">
+                    <span className="inline-flex justify-center rounded-full bg-rose-50 px-2 py-0.5 text-xs font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-100">
                       {t("channel_groups_page.deleted_badge")}
                     </span>
                   </div>
@@ -1682,7 +1682,7 @@ export function RoutingConfigEditor({
                         className="inline-flex items-center gap-1.5 rounded-full border border-rose-200 bg-white/80 px-2.5 py-1 text-xs font-medium text-rose-700 dark:border-rose-400/30 dark:bg-neutral-950/50 dark:text-rose-100"
                       >
                         <span>{channel.name}</span>
-                        <span className="rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                        <span className="rounded-full bg-rose-100 px-1.5 py-0.5 text-2xs font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
                           {t("channel_groups_page.deleted_badge")}
                         </span>
                       </span>

--- a/package.json
+++ b/package.json
@@ -15,13 +15,14 @@
     "lint": "oxlint .",
     "format": "oxfmt .",
     "ci:pr": "./scripts/ci-pr.sh",
-    "check": "bun run lint && bun run boundary:imports && bun run build && bun run bundle:diff",
+    "check": "bun run lint && bun run design:check && bun run boundary:imports && bun run build && bun run bundle:diff",
     "boundary:imports": "node scripts/check-import-boundaries.mjs",
     "bundle:diff": "node scripts/bundle-diff.mjs",
     "test": "bun run --filter @code-proxy/admin-panel test",
     "test:ci": "bun run --filter @code-proxy/admin-panel test:ci",
     "test:watch": "bun run --filter @code-proxy/admin-panel test:watch",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "design:check": "node scripts/check-design-tokens.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/packages/ui/src/primitives/DateTimePicker.tsx
+++ b/packages/ui/src/primitives/DateTimePicker.tsx
@@ -345,7 +345,7 @@ export function DateTimePicker({
                 </button>
               </div>
 
-              <div className="mt-3 grid grid-cols-7 gap-1 text-center text-[10px] font-semibold uppercase text-[#96969B] dark:text-[#9F9FA8]">
+              <div className="mt-3 grid grid-cols-7 gap-1 text-center text-2xs font-semibold uppercase text-[#96969B] dark:text-[#9F9FA8]">
                 {weekdayLabels.map((day) => (
                   <span key={day}>{day}</span>
                 ))}
@@ -384,7 +384,7 @@ export function DateTimePicker({
 
               <div className="mt-3 grid grid-cols-2 gap-2 border-t border-black/[0.06] pt-3 dark:border-white/10">
                 <label className="space-y-1">
-                  <span className="text-[10px] font-semibold uppercase text-[#96969B] dark:text-[#9F9FA8]">
+                  <span className="text-2xs font-semibold uppercase text-[#96969B] dark:text-[#9F9FA8]">
                     {labels.hour}
                   </span>
                   <input
@@ -398,7 +398,7 @@ export function DateTimePicker({
                   />
                 </label>
                 <label className="space-y-1">
-                  <span className="text-[10px] font-semibold uppercase text-[#96969B] dark:text-[#9F9FA8]">
+                  <span className="text-2xs font-semibold uppercase text-[#96969B] dark:text-[#9F9FA8]">
                     {labels.minute}
                   </span>
                   <input

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -452,7 +452,7 @@ export function SearchableCheckboxMultiSelect({
           </span>
           <span className="flex shrink-0 items-center gap-2">
             {showSelectionBadge ? (
-              <span className="rounded-md bg-sky-50 px-1.5 py-0.5 text-[11px] font-semibold text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">
+              <span className="rounded-md bg-sky-50 px-1.5 py-0.5 text-xs font-semibold text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">
                 {selectedCountLabel(activeExplicitValue.length)}
               </span>
             ) : null}

--- a/packages/ui/src/primitives/Tabs.tsx
+++ b/packages/ui/src/primitives/Tabs.tsx
@@ -41,7 +41,7 @@ const tabsTriggerPaddingBySize: Record<ControlSize, string> = {
 };
 
 const tabsTriggerTextBySize: Record<ControlSize, string> = {
-  sm: "text-[11px]",
+  sm: "text-xs",
   default: "text-xs",
   lg: "text-sm",
 };

--- a/packages/ui/src/theme/LanguageSelector.tsx
+++ b/packages/ui/src/theme/LanguageSelector.tsx
@@ -129,7 +129,7 @@ export function LanguageSelector({ className }: { className?: string }) {
           aria-haspopup="listbox"
         >
           <Languages size={16} />
-          <span className="ml-1 text-[11px] font-bold leading-none">{shortLabel}</span>
+          <span className="ml-1 text-xs font-bold leading-none">{shortLabel}</span>
         </button>
       </HoverTooltip>
 

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -51,11 +51,11 @@ export function ModelsTabContent({
           <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
             {t("apikey_lookup.available_models")}
           </h3>
-          <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-bold tabular-nums text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300">
+          <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-bold tabular-nums text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300">
             {filteredModels.length}
           </span>
           {isModelFilterActive && filteredModels.length !== models.length ? (
-            <span className="text-[10px] text-slate-400 dark:text-white/30">/ {models.length}</span>
+            <span className="text-2xs text-slate-400 dark:text-white/30">/ {models.length}</span>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -80,7 +80,7 @@ export function ModelsTabContent({
             aria-pressed={selectedModelVendor === "all"}
             onClick={() => setSelectedModelVendor("all")}
             className={[
-              "inline-flex items-center gap-1.5 rounded-md border border-slate-200/70 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-600 transition hover:shadow-sm dark:border-neutral-700/60 dark:bg-neutral-900 dark:text-white/70",
+              "inline-flex items-center gap-1.5 rounded-md border border-slate-200/70 bg-white px-2 py-0.5 text-2xs font-semibold text-slate-600 transition hover:shadow-sm dark:border-neutral-700/60 dark:bg-neutral-900 dark:text-white/70",
               selectedModelVendor === "all"
                 ? "ring-2 ring-indigo-500/35 ring-offset-1 ring-offset-white dark:ring-indigo-300/40 dark:ring-offset-neutral-950"
                 : "",

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -232,7 +232,7 @@ function QuickImportCard({
             <span className="truncate text-sm font-semibold text-slate-900 dark:text-white">
               {config.providerName}
             </span>
-            <span className="rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 text-[10px] font-semibold text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+            <span className="rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 text-2xs font-semibold text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
               {t(clientLabelKey[clientType])}
             </span>
           </span>
@@ -242,11 +242,11 @@ function QuickImportCard({
             </span>
           ) : null}
           <span className="mt-3 flex flex-wrap items-center gap-2">
-            <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+            <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
               {config.defaultModel || t("common.no_model_data")}
             </span>
             {config.allowedChannelGroups.length > 0 ? (
-              <span className="truncate text-[10px] text-slate-400 dark:text-white/35">
+              <span className="truncate text-2xs text-slate-400 dark:text-white/35">
                 {config.allowedChannelGroups.join(", ")}
               </span>
             ) : null}
@@ -535,7 +535,7 @@ export function QuickImportTabContent({
                           initial={reduceMotion ? false : { opacity: 0, y: 4 }}
                           animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                           exit={reduceMotion ? undefined : { opacity: 0, y: -4 }}
-                          className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-bold tabular-nums text-slate-500 dark:bg-neutral-900 dark:text-white/45"
+                          className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-bold tabular-nums text-slate-500 dark:bg-neutral-900 dark:text-white/45"
                         >
                           {items.length}
                         </motion.span>

--- a/pages/api-key-lookup/components/UsageTabSection.tsx
+++ b/pages/api-key-lookup/components/UsageTabSection.tsx
@@ -154,7 +154,7 @@ function CalendarHeatmap({
               >
                 <span
                   tabIndex={0}
-                  className={`block h-3 w-3 cursor-pointer rounded-[3px] ring-1 ring-black/[0.03] transition duration-150 hover:scale-110 hover:ring-blue-400/70 focus:outline-none focus:ring-2 focus:ring-blue-400/70 dark:ring-white/[0.04] ${HEATMAP_LEVEL_CLASSES[level]}`}
+                  className={`block h-3 w-3 cursor-pointer rounded-sm ring-1 ring-black/[0.03] transition duration-150 hover:scale-110 hover:ring-blue-400/70 focus:outline-none focus:ring-2 focus:ring-blue-400/70 dark:ring-white/[0.04] ${HEATMAP_LEVEL_CLASSES[level]}`}
                   aria-label={`${date}: ${point?.requests ?? 0} ${t("apikey_lookup.requests")}`}
                 />
               </HoverTooltip>
@@ -167,7 +167,7 @@ function CalendarHeatmap({
         {HEATMAP_LEVEL_CLASSES.map((className) => (
           <span
             key={className}
-            className={`h-3 w-3 rounded-[3px] ring-1 ring-black/[0.03] dark:ring-white/[0.04] ${className}`}
+            className={`h-3 w-3 rounded-sm ring-1 ring-black/[0.03] dark:ring-white/[0.04] ${className}`}
             aria-hidden="true"
           />
         ))}
@@ -188,7 +188,7 @@ function HeatmapSkeleton() {
           {Array.from({ length: 371 }, (_, index) => (
             <span
               key={index}
-              className="h-3 w-3 rounded-[3px] bg-slate-100 motion-safe:animate-pulse dark:bg-white/10"
+              className="h-3 w-3 rounded-sm bg-slate-100 motion-safe:animate-pulse dark:bg-white/10"
             />
           ))}
         </div>

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -95,7 +95,7 @@ function ApiKeyPermissionSummary({
         >
           {count}
         </span>
-        <span className="block min-w-0 flex-1 truncate font-mono text-[11px] leading-5">
+        <span className="block min-w-0 flex-1 truncate font-mono text-xs leading-5">
           {firstValue}
         </span>
       </span>
@@ -288,7 +288,7 @@ export const createApiKeyColumns = ({
               {row["allowed-models"].map((model) => (
                 <span
                   key={model}
-                  className="inline-flex items-center gap-1 rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-[11px] text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                  className="inline-flex items-center gap-1 rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                 >
                   <VendorIcon modelId={model} size={12} />
                   {model}
@@ -319,7 +319,7 @@ export const createApiKeyColumns = ({
               {row["allowed-channel-groups"].map((group) => (
                 <span
                   key={group}
-                  className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-[11px] text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                  className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                 >
                   {group}
                 </span>
@@ -349,7 +349,7 @@ export const createApiKeyColumns = ({
               {row["allowed-channels"].map((channel) => (
                 <span
                   key={channel}
-                  className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-[11px] text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                  className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                 >
                   {channel}
                 </span>

--- a/pages/api-keys/components/CcSwitchImportCardList.tsx
+++ b/pages/api-keys/components/CcSwitchImportCardList.tsx
@@ -70,7 +70,7 @@ export function CcSwitchImportCardList({
                         {config.providerName}
                       </span>
                       {config.clientType === "claude" && config.apiKeyField ? (
-                        <span className="shrink-0 rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+                        <span className="shrink-0 rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
                           {config.apiKeyField}
                         </span>
                       ) : null}
@@ -81,11 +81,11 @@ export function CcSwitchImportCardList({
                       </p>
                     ) : null}
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+                      <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
                         {config.defaultModel}
                       </span>
                       {config.allowedChannelGroups.length > 0 ? (
-                        <span className="truncate text-[10px] text-slate-400 dark:text-white/35">
+                        <span className="truncate text-2xs text-slate-400 dark:text-white/35">
                           {config.allowedChannelGroups.join(", ")}
                         </span>
                       ) : null}

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -608,7 +608,7 @@ export function AuthFileDetailModal({
 
   const renderHealthValue = (label: string, value: string) => (
     <div className="min-w-0">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.02em] text-slate-500 dark:text-white/45">
+      <p className="text-xs font-semibold uppercase tracking-[0.02em] text-slate-500 dark:text-white/45">
         {label}
       </p>
       <p className="mt-1 min-w-0 break-words font-mono text-xs text-slate-900 dark:text-white/85">
@@ -654,7 +654,7 @@ export function AuthFileDetailModal({
 
     return (
       <span
-        className={`inline-flex max-w-full items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${className}`}
+        className={`inline-flex max-w-full items-center rounded-full px-2 py-0.5 text-xs font-semibold ${className}`}
       >
         {formatIdentitySource(source)}
       </span>
@@ -669,7 +669,7 @@ export function AuthFileDetailModal({
 
   const renderIdentitySummaryItem = (label: string, value: string) => (
     <div className="min-w-0">
-      <dt className="text-[11px] font-semibold uppercase tracking-[0.02em] text-slate-500 dark:text-white/45">
+      <dt className="text-xs font-semibold uppercase tracking-[0.02em] text-slate-500 dark:text-white/45">
         {label}
       </dt>
       <dd className="mt-1 min-w-0 break-words text-sm font-semibold text-slate-950 dark:text-white">
@@ -904,21 +904,21 @@ export function AuthFileDetailModal({
                               <p className="break-words text-sm font-semibold text-slate-950 dark:text-white">
                                 {label}
                               </p>
-                              <p className="mt-1 break-all font-mono text-[11px] text-slate-500 dark:text-white/45">
+                              <p className="mt-1 break-all font-mono text-xs text-slate-500 dark:text-white/45">
                                 {profileKey}
                               </p>
                             </div>
                             {outbound ? (
-                              <span className="shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
+                              <span className="shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
                                 {t("auth_files.identity_outbound_active")}
                               </span>
                             ) : profile.selectable === false ? (
-                              <span className="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-200">
+                              <span className="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-200">
                                 {t("auth_files.identity_profile_observe_only")}
                               </span>
                             ) : null}
                           </div>
-                          <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-slate-500 dark:text-white/50">
+                          <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-white/50">
                             <span>{formatOptionalText(profile.summary.version)}</span>
                             <span>{formatOptionalDate(profile.summary.last_seen_at)}</span>
                           </div>
@@ -1277,7 +1277,7 @@ export function AuthFileDetailModal({
       title={detailTitle}
       titleAccessory={
         detailPlanLabel ? (
-          <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+          <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-2xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
             {detailPlanLabel}
           </span>
         ) : undefined
@@ -1826,14 +1826,14 @@ export function AuthFileDetailModal({
                         </div>
                         <div className="flex flex-wrap items-center gap-1.5 sm:justify-end">
                           {model.owned_by ? (
-                            <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                            <span className="rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
                               {model.owned_by}
                             </span>
                           ) : null}
                           {excludedModels.some((pattern) =>
                             matchesModelPattern(model.id, pattern),
                           ) ? (
-                            <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
+                            <span className="rounded-full bg-rose-600/10 px-2 py-0.5 text-xs font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-200">
                               {t("auth_files.oauth_excluded")}
                             </span>
                           ) : null}

--- a/pages/auth-files/components/AuthFileTagsModal.tsx
+++ b/pages/auth-files/components/AuthFileTagsModal.tsx
@@ -181,11 +181,11 @@ export function AuthFileTagsModal({
                       <span className="min-w-0 truncate font-medium">{tag}</span>
                       <span className="flex shrink-0 items-center gap-2">
                         {custom ? (
-                          <span className="rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200">
+                          <span className="rounded-full bg-sky-50 px-2 py-0.5 text-2xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200">
                             {t("auth_files.custom_tag_label")}
                           </span>
                         ) : inherited ? (
-                          <span className="rounded-full bg-[#EBEBEC] px-2 py-0.5 text-[10px] font-semibold text-[#71717A] dark:bg-white/10 dark:text-white/60">
+                          <span className="rounded-full bg-[#EBEBEC] px-2 py-0.5 text-2xs font-semibold text-[#71717A] dark:bg-white/10 dark:text-white/60">
                             {t("auth_files.default_tags_label")}
                           </span>
                         ) : null}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -65,7 +65,7 @@ import type { QuotaProvider } from "@features/quota-preview/quota-fetch";
 
 const MAX_FILENAME_PART_LENGTH = 72;
 const FILTER_LABEL_CLASS =
-  "truncate text-[11px] font-semibold uppercase tracking-[0.02em] text-slate-600 dark:text-white/65";
+  "truncate text-xs font-semibold uppercase tracking-[0.02em] text-slate-600 dark:text-white/65";
 const FILTER_FIELD_CLASS = "min-w-0 space-y-2";
 const FILTER_GRID_CLASS =
   "grid min-w-0 grid-cols-1 items-end gap-x-5 gap-y-3 sm:grid-cols-2 xl:grid-cols-[repeat(4,minmax(0,1fr))_minmax(320px,1.8fr)]";
@@ -725,7 +725,7 @@ export function AuthFilesFilesTab({
           key === "all" ? filterCounts.total : (filterCounts.counts[normalizedKey] ?? 0);
         const label = key === "all" ? t("auth_files.all") : key;
         const countPill = (
-          <span className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-[10px] font-semibold tabular-nums text-slate-700 dark:bg-white/10 dark:text-white/70">
+          <span className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-2xs font-semibold tabular-nums text-slate-700 dark:bg-white/10 dark:text-white/70">
             {count}
           </span>
         );
@@ -759,7 +759,7 @@ export function AuthFilesFilesTab({
           label: (
             <span className="flex min-w-0 items-center gap-2">
               <span className="min-w-0 truncate">{label}</span>
-              <span className="ml-auto inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-[10px] font-semibold tabular-nums text-slate-700 dark:bg-white/10 dark:text-white/70">
+              <span className="ml-auto inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full bg-slate-100 px-1 text-2xs font-semibold tabular-nums text-slate-700 dark:bg-white/10 dark:text-white/70">
                 {count}
               </span>
             </span>
@@ -1026,7 +1026,7 @@ export function AuthFilesFilesTab({
                 <span className="truncate">{t("auth_files.filters")}</span>
               </span>
               {activeFilterCount > 0 ? (
-                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-slate-900 px-1.5 text-[10px] font-semibold tabular-nums text-white dark:bg-white dark:text-neutral-950">
+                <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-slate-900 px-1.5 text-2xs font-semibold tabular-nums text-white dark:bg-white dark:text-neutral-950">
                   {activeFilterCount}
                 </span>
               ) : null}
@@ -1461,7 +1461,7 @@ export function AuthFilesFilesTab({
                           {showTypeBadge ? (
                             <span
                               className={[
-                                "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold",
+                                "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-2xs font-semibold",
                                 badgeClass,
                               ].join(" ")}
                             >
@@ -1469,7 +1469,7 @@ export function AuthFilesFilesTab({
                             </span>
                           ) : null}
                           {showPlanBadge && planType ? (
-                            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+                            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-2xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
                               {t("codex_quota.plan_label")} {formatPlanTypeLabel(planType)}
                             </span>
                           ) : null}
@@ -1477,7 +1477,7 @@ export function AuthFilesFilesTab({
                             <HoverTooltip content={resetCreditBadgeTitle} className="shrink-0">
                               <button
                                 type="button"
-                                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-blue-50 hover:text-blue-700 disabled:cursor-wait disabled:opacity-70 dark:bg-white/10 dark:text-white/70 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
+                                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-700 transition-colors hover:bg-blue-50 hover:text-blue-700 disabled:cursor-wait disabled:opacity-70 dark:bg-white/10 dark:text-white/70 dark:hover:bg-blue-500/15 dark:hover:text-blue-200"
                                 disabled={quotaRefreshing}
                                 onClick={() => void refreshQuota(file, provider)}
                                 aria-label={t("auth_files.reset_credits_query")}
@@ -1494,10 +1494,10 @@ export function AuthFilesFilesTab({
                               </button>
                             </HoverTooltip>
                           ) : null}
-                          <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
+                          <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
                             {t("auth_files.calls_count", { count: displayCalls })}
                           </span>
-                          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
+                          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
                             <span>{t("common.success_rate")}</span>
                             <span className={`tabular-nums ${successRateClass}`}>
                               {successRate === null ? "--" : `${successRate.toFixed(1)}%`}
@@ -1507,7 +1507,7 @@ export function AuthFilesFilesTab({
                           {renderClaudeOAuthHealthBadges(file)}
                           {subscriptionBadge}
                           {runtimeOnly ? (
-                            <span className="inline-flex shrink-0 items-center rounded-full bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-neutral-950">
+                            <span className="inline-flex shrink-0 items-center rounded-full bg-slate-900 px-2 py-0.5 text-2xs font-semibold text-white dark:bg-white dark:text-neutral-950">
                               {t("auth_files.virtual_auth_file")}
                             </span>
                           ) : null}
@@ -1517,7 +1517,7 @@ export function AuthFilesFilesTab({
                             {displayTags.map((tag) => (
                               <span
                                 key={tag}
-                                className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                                className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-2xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
                               >
                                 {tag}
                               </span>
@@ -1531,7 +1531,7 @@ export function AuthFilesFilesTab({
                         data-testid="auth-file-card-quota"
                       >
                         {provider && (state.status === "error" || state.error) ? (
-                          <p className="truncate text-[11px] font-semibold text-rose-700 dark:text-rose-200">
+                          <p className="truncate text-xs font-semibold text-rose-700 dark:text-rose-200">
                             {translateQuotaText(state.error ?? t("common.error"))}
                           </p>
                         ) : null}
@@ -1677,13 +1677,13 @@ export function AuthFilesFilesTab({
         onClose={() => setUploadProgressDismissed(true)}
       >
         <div className="space-y-4" data-testid="auth-files-upload-progress" aria-live="polite">
-          <div className="overflow-hidden rounded-[28px] border border-slate-200/80 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.95),_rgba(241,245,249,0.95))] p-4 shadow-[0_20px_50px_rgb(15_23_42_/_0.08)] dark:border-white/10 dark:bg-[radial-gradient(circle_at_top_left,_rgba(39,39,42,0.98),_rgba(9,9,11,0.98))] dark:shadow-[0_24px_60px_rgb(0_0_0_/_0.28)]">
+          <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.95),_rgba(241,245,249,0.95))] p-4 shadow-[0_20px_50px_rgb(15_23_42_/_0.08)] dark:border-white/10 dark:bg-[radial-gradient(circle_at_top_left,_rgba(39,39,42,0.98),_rgba(9,9,11,0.98))] dark:shadow-[0_24px_60px_rgb(0_0_0_/_0.28)]">
             <div className="flex items-start gap-3">
               <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-lg shadow-slate-900/15 dark:bg-white dark:text-neutral-950 dark:shadow-black/25">
                 <Loader2 size={18} className="animate-spin" />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400 dark:text-white/35">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400 dark:text-white/35">
                   {uploadProgress.phase === "refreshing"
                     ? t("auth_files.upload_progress_refreshing_short")
                     : t("auth_files.upload")}
@@ -1732,14 +1732,14 @@ export function AuthFilesFilesTab({
 
           {uploadProgress.activeFileNames.length > 0 ? (
             <div className="rounded-2xl border border-dashed border-slate-200 bg-white/80 px-3 py-3 dark:border-white/10 dark:bg-white/[0.02]">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400 dark:text-white/35">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400 dark:text-white/35">
                 {t("auth_files.upload")}
               </p>
               <div className="mt-2 flex flex-wrap gap-2">
                 {uploadProgress.activeFileNames.map((name) => (
                   <span
                     key={name}
-                    className="inline-flex max-w-full items-center rounded-full bg-slate-900 px-2.5 py-1 text-[11px] font-medium text-white dark:bg-white dark:text-neutral-950"
+                    className="inline-flex max-w-full items-center rounded-full bg-slate-900 px-2.5 py-1 text-xs font-medium text-white dark:bg-white dark:text-neutral-950"
                   >
                     <span className="truncate">{name}</span>
                   </span>
@@ -1810,7 +1810,7 @@ export function AuthFilesFilesTab({
                     <Loader2 size={13} className="animate-spin" />
                     <span>{uploadStatusTitle}</span>
                   </div>
-                  <p className="mt-1 text-[11px] text-slate-500 dark:text-white/50">
+                  <p className="mt-1 text-xs text-slate-500 dark:text-white/50">
                     {uploadStatusDescription}
                   </p>
                 </div>
@@ -1881,7 +1881,7 @@ export function AuthFilesFilesTab({
 
             <div className="flex min-w-0 items-center rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3 dark:border-neutral-800 dark:bg-white/[0.04]">
               <div className="min-w-0">
-                <p className="text-[11px] font-semibold uppercase text-slate-400 dark:text-white/35">
+                <p className="text-xs font-semibold uppercase text-slate-400 dark:text-white/35">
                   {t("auth_files.type_filter")}
                 </p>
                 <p className="mt-1 truncate font-mono text-sm font-semibold text-slate-900 dark:text-white">
@@ -1897,7 +1897,7 @@ export function AuthFilesFilesTab({
                 {t("auth_files.detail_tab_models")}
               </p>
               {draftModelOwnerGroup ? (
-                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-white/10 dark:text-white/65">
                   {t("auth_files.count_items", { count: draftModelOwnerGroup.models.length })}
                 </span>
               ) : null}

--- a/pages/auth-files/components/GroupOverviewModal.tsx
+++ b/pages/auth-files/components/GroupOverviewModal.tsx
@@ -94,7 +94,7 @@ export function GroupOverviewModal({
 
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {activeGroupTitle}
             </p>
             <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
@@ -105,7 +105,7 @@ export function GroupOverviewModal({
             </p>
           </div>
           <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {t("auth_files.group_overview_total_calls_label")}
             </p>
             <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
@@ -116,7 +116,7 @@ export function GroupOverviewModal({
             </p>
           </div>
           <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {t("auth_files.group_overview_avg_week_label")}
             </p>
             <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
@@ -127,7 +127,7 @@ export function GroupOverviewModal({
             </p>
           </div>
           <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {t("auth_files.group_overview_sample_count", {
                 count: activeGroupOverview.quotaSampleCount,
               })}

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -313,7 +313,7 @@ export function useAuthFilesFilesPresentation({
             <HoverTooltip key={badge.key} content={formatRestrictionTooltip(badge)} placement="top">
               <span
                 className={[
-                  "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tabular-nums",
+                  "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums",
                   RESTRICTION_TONE_CLASSES[badge.tone],
                 ].join(" ")}
               >
@@ -369,7 +369,7 @@ export function useAuthFilesFilesPresentation({
             <HoverTooltip key={badge.key} content={formatBadgeTooltip(badge)} placement="top">
               <span
                 className={[
-                  "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tabular-nums",
+                  "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums",
                   CLAUDE_OAUTH_HEALTH_TONE_CLASSES[badge.tone],
                 ].join(" ")}
               >
@@ -405,7 +405,7 @@ export function useAuthFilesFilesPresentation({
         <HoverTooltip content={title}>
           <span
             className={[
-              "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold tabular-nums",
+              "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums",
               SUBSCRIPTION_TONE_CLASSES[status.tone],
             ].join(" ")}
           >
@@ -516,7 +516,7 @@ export function useAuthFilesFilesPresentation({
       return (
         <div className="space-y-1">
           {hasError ? (
-            <p className="max-w-80 truncate text-[11px] font-semibold text-rose-700 dark:text-rose-200">
+            <p className="max-w-80 truncate text-xs font-semibold text-rose-700 dark:text-rose-200">
               {translateQuotaText(state.error ?? t("common.error"))}
             </p>
           ) : null}
@@ -533,7 +533,7 @@ export function useAuthFilesFilesPresentation({
                   options?.suppressItemMeta || resetText ? undefined : item.meta;
                 return (
                   <div key={item.label} className="contents">
-                    <span className="min-w-0 truncate text-[10px] font-semibold text-slate-600 dark:text-white/70">
+                    <span className="min-w-0 truncate text-2xs font-semibold text-slate-600 dark:text-white/70">
                       {translateQuotaText(item.label)}
                     </span>
                     <span className="flex items-center justify-center">
@@ -541,17 +541,17 @@ export function useAuthFilesFilesPresentation({
                     </span>
                     <span
                       className={[
-                        "justify-self-end whitespace-nowrap text-[10px] font-semibold tabular-nums",
+                        "justify-self-end whitespace-nowrap text-2xs font-semibold tabular-nums",
                         tone.percentClass,
                       ].join(" ")}
                     >
                       {percentText}
                     </span>
-                    <span className="whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
+                    <span className="whitespace-nowrap text-right text-2xs tabular-nums text-slate-500 dark:text-white/40">
                       {resetText ?? "--"}
                     </span>
                     {itemMeta ? (
-                      <span className="col-span-4 truncate text-[10px] text-slate-500 dark:text-white/55">
+                      <span className="col-span-4 truncate text-2xs text-slate-500 dark:text-white/55">
                         {itemMeta}
                       </span>
                     ) : null}
@@ -579,12 +579,12 @@ export function useAuthFilesFilesPresentation({
       return (
         <div key={label} className="space-y-1">
           <div className="flex items-center justify-between gap-2">
-            <span className="min-w-0 truncate text-[11px] font-semibold text-slate-700 dark:text-white/80">
+            <span className="min-w-0 truncate text-xs font-semibold text-slate-700 dark:text-white/80">
               {translateQuotaText(label)}
             </span>
             <span
               className={[
-                "shrink-0 text-[11px] font-semibold tabular-nums",
+                "shrink-0 text-xs font-semibold tabular-nums",
                 tone.percentClass,
               ].join(" ")}
             >
@@ -598,7 +598,7 @@ export function useAuthFilesFilesPresentation({
               aria-hidden="true"
             />
           </div>
-          <div className="min-h-[14px] truncate text-[10px] tabular-nums text-slate-500 dark:text-white/45">
+          <div className="min-h-[14px] truncate text-2xs tabular-nums text-slate-500 dark:text-white/45">
             {detailText ?? "\u00A0"}
           </div>
         </div>
@@ -671,7 +671,7 @@ export function useAuthFilesFilesPresentation({
                   {supplementalTags.map((tag) => (
                     <span
                       key={tag}
-                      className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+                      className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-2xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
                     >
                       {tag}
                     </span>
@@ -762,7 +762,7 @@ export function useAuthFilesFilesPresentation({
             <button
               type="button"
               disabled={state?.loading}
-              className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-[11px] tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 disabled:cursor-default disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
+              className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-xs tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 disabled:cursor-default disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
               onClick={() => void checkAuthFileConnectivity(file.name)}
               title={t("auth_files.check_connectivity")}
               aria-label={t("auth_files.check_connectivity")}
@@ -827,7 +827,7 @@ export function useAuthFilesFilesPresentation({
         headerClassName: "text-center",
         headerRender: () => (
           <div className="flex items-center justify-center gap-2 normal-case">
-            <span className="text-[11px] font-semibold text-slate-500 dark:text-white/60">
+            <span className="text-xs font-semibold text-slate-500 dark:text-white/60">
               {t("auth_files.col_quota")}
             </span>
             <Select
@@ -867,19 +867,19 @@ export function useAuthFilesFilesPresentation({
                 key={item.label}
                 className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_0.875rem_auto_3.25rem] items-center gap-1"
               >
-                <span className="min-w-0 truncate text-[10px] font-semibold text-slate-600 dark:text-white/70">
+                <span className="min-w-0 truncate text-2xs font-semibold text-slate-600 dark:text-white/70">
                   {translateQuotaText(item.label)}
                 </span>
                 {quotaProgressCircle(item.percent)}
                 <span
                   className={[
-                    "justify-self-end text-[10px] font-semibold tabular-nums",
+                    "justify-self-end text-2xs font-semibold tabular-nums",
                     tone.percentClass,
                   ].join(" ")}
                 >
                   {percentText}
                 </span>
-                <span className="min-w-0 truncate whitespace-nowrap text-right text-[10px] tabular-nums text-slate-500 dark:text-white/40">
+                <span className="min-w-0 truncate whitespace-nowrap text-right text-2xs tabular-nums text-slate-500 dark:text-white/40">
                   {detailText}
                 </span>
               </div>

--- a/pages/auth-files/hooks/useAuthFilesGroupOverview.ts
+++ b/pages/auth-files/hooks/useAuthFilesGroupOverview.ts
@@ -209,7 +209,7 @@ export function useAuthFilesGroupOverview({
       legend: {
         top: 0,
         left: 0,
-        textStyle: { color: "#64748b", fontSize: 11 },
+        textStyle: { color: "#64748b", fontSize: 12 },
       },
       xAxis: {
         type: "category",
@@ -218,14 +218,14 @@ export function useAuthFilesGroupOverview({
         axisLabel: {
           interval: 0,
           color: "#64748b",
-          fontSize: 11,
+          fontSize: 12,
         },
         axisLine: { lineStyle: { color: "rgba(148,163,184,0.45)" } },
       },
       yAxis: [
         {
           type: "value",
-          axisLabel: { color: "#64748b", fontSize: 11, margin: 10 },
+          axisLabel: { color: "#64748b", fontSize: 12, margin: 10 },
           splitLine: { lineStyle: { color: "rgba(148,163,184,0.18)" } },
         },
         {
@@ -234,7 +234,7 @@ export function useAuthFilesGroupOverview({
           max: 100,
           axisLabel: {
             color: "#64748b",
-            fontSize: 11,
+            fontSize: 12,
             margin: 10,
             formatter: (value: number) => `${Math.round(value)}%`,
           },

--- a/pages/ccswitch-import-settings/CcSwitchImportModal.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportModal.tsx
@@ -42,7 +42,7 @@ export interface CcSwitchImportConfigOption {
 }
 
 const labelClassName =
-  "text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
+  "text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
 const controlClassName =
   "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
 const fieldClassName = "flex flex-col gap-1.5";
@@ -236,7 +236,7 @@ export function CcSwitchImportModal({
                 <div className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-white/55">
                   {t(client.descriptionKey)}
                 </div>
-                <div className="mt-1 font-mono text-[11px] text-slate-500 dark:text-white/45">
+                <div className="mt-1 font-mono text-xs text-slate-500 dark:text-white/45">
                   {t("ccswitch.import_endpoint_path_hint", { path: endpointHint })}
                 </div>
               </div>

--- a/pages/ccswitch-import-settings/CcSwitchImportOptions.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportOptions.tsx
@@ -87,7 +87,7 @@ function ImportOptionButton({
           </span>
         )}
         {model && !compact ? (
-          <span className="mt-2 inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-[10px] text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+          <span className="mt-2 inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
             {t("ccswitch.model_hint", { model })}
           </span>
         ) : null}
@@ -196,7 +196,7 @@ export function CcSwitchImportOptions({
       aria-label={t("ccswitch.import_to_ccswitch")}
       className="inline-flex min-w-0 flex-wrap items-center gap-1 rounded-xl border border-slate-200/70 bg-slate-50/75 p-1 dark:border-neutral-800 dark:bg-neutral-900/45"
     >
-      <span className="px-1.5 text-[11px] font-semibold text-slate-500 dark:text-white/45">
+      <span className="px-1.5 text-xs font-semibold text-slate-500 dark:text-white/45">
         {t("ccswitch.import_to_ccswitch")}
       </span>
       <ClaudeAuthFieldSelect

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -202,7 +202,7 @@ export function CcSwitchImportSettingsPage() {
                 <div className="truncate font-medium text-slate-900 dark:text-white">
                   {t(client.labelKey)}
                 </div>
-                <div className="font-mono text-[11px] text-slate-500 dark:text-white/45">
+                <div className="font-mono text-xs text-slate-500 dark:text-white/45">
                   {row.routePath || row.endpointPath || t("ccswitch.import_endpoint_root")}
                 </div>
               </div>
@@ -250,7 +250,7 @@ export function CcSwitchImportSettingsPage() {
               {row.allowedChannelGroups.map((group) => (
                 <span
                   key={group}
-                  className="rounded-full border border-slate-200/75 bg-slate-50 px-2 py-1 text-[11px] font-medium text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/60"
+                  className="rounded-full border border-slate-200/75 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/60"
                 >
                   {group}
                 </span>

--- a/pages/channel-groups/routingConfigUtils.tsx
+++ b/pages/channel-groups/routingConfigUtils.tsx
@@ -287,7 +287,7 @@ export function renderChannelTags(tags: string[]) {
       {tags.map((tag) => (
         <span
           key={tag}
-          className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-[10px] font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
+          className="inline-flex items-center rounded-full bg-sky-50 px-2 py-0.5 text-2xs font-semibold text-sky-700 dark:bg-sky-500/15 dark:text-sky-200"
         >
           {tag}
         </span>

--- a/pages/config/ConfigPage.tsx
+++ b/pages/config/ConfigPage.tsx
@@ -398,7 +398,7 @@ export function ConfigPage() {
                               </HoverTooltip>
                             }
                           />
-                          <p className="text-[11px] text-slate-500 dark:text-white/55">
+                          <p className="text-xs text-slate-500 dark:text-white/55">
                             Enter: next · Shift+Enter: prev · Results:
                             <span className="ml-1 font-mono tabular-nums">
                               {!lastSearchedQuery.trim()

--- a/pages/config/YamlCodeEditor.tsx
+++ b/pages/config/YamlCodeEditor.tsx
@@ -476,7 +476,7 @@ export const YamlCodeEditor = forwardRef<
           ref={gutterRef}
           aria-hidden="true"
           className={[
-            "scrollbar-hidden w-14 shrink-0 overflow-y-scroll overflow-x-hidden border-r border-slate-200 bg-slate-50/70 px-3 py-3 text-right font-mono text-[11px] leading-6 text-slate-400 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/35",
+            "scrollbar-hidden w-14 shrink-0 overflow-y-scroll overflow-x-hidden border-r border-slate-200 bg-slate-50/70 px-3 py-3 text-right font-mono text-xs leading-6 text-slate-400 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/35",
             "pointer-events-none",
           ].join(" ")}
         >

--- a/pages/config/visual/VisualConfigEditor.tsx
+++ b/pages/config/visual/VisualConfigEditor.tsx
@@ -215,7 +215,7 @@ export function VisualConfigEditor({
           <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-xs leading-5 text-emerald-900 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-100">
             <div className="font-semibold">{t("visual_config.cors_default_title")}</div>
             <p className="mt-1">{t("visual_config.cors_default_desc")}</p>
-            <p className="mt-3 rounded-xl bg-white/65 px-3 py-2 font-mono text-[11px] text-emerald-950 dark:bg-black/20 dark:text-emerald-100">
+            <p className="mt-3 rounded-xl bg-white/65 px-3 py-2 font-mono text-xs text-emerald-950 dark:bg-black/20 dark:text-emerald-100">
               chrome-extension://&lt;extension-id&gt;
             </p>
           </div>

--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -128,7 +128,7 @@ const formatThroughputValue = (value: number) =>
   throughputNumberFormatter.format(Number.isFinite(value) ? value : 0);
 const formatRate = (rate: number) => `${rate.toFixed(2)}%`;
 const PANEL_SURFACE =
-  "rounded-[18px] border border-slate-200/85 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
+  "rounded-2xl border border-slate-200/85 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
 
 const formatThroughputTooltip = (params: any) => {
   const items = Array.isArray(params) ? params : [params];
@@ -152,7 +152,7 @@ function createSparklineOption(points: DashboardTrendPoint[], color: string): EC
       trigger: "axis",
       borderWidth: 0,
       backgroundColor: "rgba(15, 23, 42, 0.9)",
-      textStyle: { color: "#fff", fontSize: 11 },
+      textStyle: { color: "#fff", fontSize: 12 },
       formatter: (params: any) => {
         const first = Array.isArray(params) ? params[0] : params;
         return `${first?.axisValueLabel ?? ""}<br/>${formatDashboardTooltipNumber(Number(first?.data ?? 0))}`;
@@ -325,17 +325,17 @@ function DashboardKpiCard({
     >
       <div className="flex items-start justify-between gap-2">
         <div
-          className={`inline-flex h-9 w-9 items-center justify-center rounded-[14px] ${accent.iconWrap}`}
+          className={`inline-flex h-9 w-9 items-center justify-center rounded-2xl ${accent.iconWrap}`}
         >
           <Icon size={16} className={accent.iconColor} />
         </div>
       </div>
       <div className="mt-3">
         <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</p>
-        <div className="mt-2 text-[2rem] font-semibold leading-none tracking-tight text-slate-950 dark:text-white">
+        <div className="mt-2 text-3xl font-semibold leading-none tracking-tight text-slate-950 dark:text-white">
           {value}
         </div>
-        <p className="mt-2 text-[11px] text-slate-500 dark:text-white/45">{hint}</p>
+        <p className="mt-2 text-xs text-slate-500 dark:text-white/45">{hint}</p>
       </div>
       <div className="mt-auto pt-3">
         <EChart option={option} className="h-10" overflowVisible />
@@ -376,7 +376,7 @@ function ThroughputTrendChart({
       title={title}
       actions={
         <div
-          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold ${
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
             connected
               ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
               : "bg-slate-100 text-slate-400 dark:bg-neutral-800 dark:text-white/45"
@@ -393,16 +393,16 @@ function ThroughputTrendChart({
       padding="compact"
     >
       <div className="mb-3 grid gap-3 sm:grid-cols-2">
-        <div className="rounded-[14px] bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+        <div className="rounded-2xl bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
+          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
             RPM
           </div>
           <div className="mt-1 text-xl font-semibold tabular-nums text-blue-600 dark:text-blue-400">
             <DashboardMetricValue value={rpm} />
           </div>
         </div>
-        <div className="rounded-[14px] bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+        <div className="rounded-2xl bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
+          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
             TPM
           </div>
           <div className="mt-1 text-xl font-semibold tabular-nums text-violet-600 dark:text-violet-400">
@@ -519,13 +519,13 @@ export function DashboardPage() {
     <div className="space-y-4">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h2 className="text-[2rem] font-semibold tracking-tight text-slate-950 text-balance dark:text-white">
+          <h2 className="text-3xl font-semibold tracking-tight text-slate-950 text-balance dark:text-white">
             {t("dashboard.heading")}
           </h2>
           <p className="mt-1 text-sm text-slate-500 dark:text-white/55">
             {t("dashboard.hero_subtitle")}
           </p>
-          <p className="mt-2 text-[11px] text-slate-400 dark:text-white/40">
+          <p className="mt-2 text-xs text-slate-400 dark:text-white/40">
             {t("dashboard.overview_hint", { time: generatedAt })}
           </p>
         </div>

--- a/pages/dashboard/SystemMonitorSection.tsx
+++ b/pages/dashboard/SystemMonitorSection.tsx
@@ -18,7 +18,7 @@ import { Card } from "@code-proxy/ui";
 import type { SystemStats } from "./useSystemStats";
 
 const PANEL_SURFACE =
-  "rounded-[18px] border border-slate-200/85 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
+  "rounded-2xl border border-slate-200/85 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
 
 /* ═══════════════════════════════════════════════════════════
    Helpers
@@ -144,7 +144,7 @@ function HealthGauge({ score }: { score: number }) {
           <span className={`mt-0.5 text-xs font-semibold ${hl.color}`}>{t(hl.key)}</span>
         </div>
       </div>
-      <p className="mt-2 text-[11px] text-slate-400 dark:text-white/40">
+      <p className="mt-2 text-xs text-slate-400 dark:text-white/40">
         {t("system_monitor.health_score")}
       </p>
     </div>
@@ -182,7 +182,7 @@ function DiskUsageRingCard({ stats }: { stats: SystemStats }) {
           <HardDrive size={15} className="text-slate-400" />
           {t("system_monitor.disk")}
         </div>
-        <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${sc.labelBg}`}>
+        <span className={`rounded-full px-2 py-0.5 text-2xs font-semibold ${sc.labelBg}`}>
           {t(sc.labelKey)}
         </span>
       </div>
@@ -214,7 +214,7 @@ function DiskUsageRingCard({ stats }: { stats: SystemStats }) {
             <span className={`text-2xl font-bold tabular-nums ${sc.text}`}>
               {stats.disk_pct.toFixed(1)}%
             </span>
-            <span className="mt-0.5 text-[10px] font-semibold text-slate-400 dark:text-white/45">
+            <span className="mt-0.5 text-2xs font-semibold text-slate-400 dark:text-white/45">
               {t("system_monitor.disk")}
             </span>
           </div>
@@ -222,16 +222,16 @@ function DiskUsageRingCard({ stats }: { stats: SystemStats }) {
       </div>
 
       <div className="grid grid-cols-2 gap-2">
-        <div className="rounded-[14px] bg-white/70 px-3 py-2 shadow-sm ring-1 ring-slate-200/70 dark:bg-neutral-900/70 dark:ring-white/10">
-          <p className="text-[10px] text-slate-400 dark:text-white/45">
+        <div className="rounded-2xl bg-white/70 px-3 py-2 shadow-sm ring-1 ring-slate-200/70 dark:bg-neutral-900/70 dark:ring-white/10">
+          <p className="text-2xs text-slate-400 dark:text-white/45">
             {t("system_monitor.disk_free")}
           </p>
           <p className="mt-1 text-sm font-bold tabular-nums text-emerald-500">
             {formatBytes(stats.disk_free)}
           </p>
         </div>
-        <div className="rounded-[14px] bg-white/70 px-3 py-2 shadow-sm ring-1 ring-slate-200/70 dark:bg-neutral-900/70 dark:ring-white/10">
-          <p className="text-[10px] text-slate-400 dark:text-white/45">
+        <div className="rounded-2xl bg-white/70 px-3 py-2 shadow-sm ring-1 ring-slate-200/70 dark:bg-neutral-900/70 dark:ring-white/10">
+          <p className="text-2xs text-slate-400 dark:text-white/45">
             {t("system_monitor.total_size", { size: formatBytes(stats.disk_total) })}
           </p>
           <p className="mt-1 text-sm font-bold tabular-nums text-slate-700 dark:text-white">
@@ -285,7 +285,7 @@ function ResourceBar({
           style={{ width: `${Math.min(pct, 100)}%` }}
         />
       </div>
-      {detail && <p className="mt-1 text-[10px] text-slate-400 dark:text-white/35">{detail}</p>}
+      {detail && <p className="mt-1 text-2xs text-slate-400 dark:text-white/35">{detail}</p>}
     </Card>
   );
 }
@@ -309,13 +309,13 @@ function MiniKpi({
 }) {
   return (
     <Card padding="compact" bodyClassName="mt-0" className={`${PANEL_SURFACE} h-full`}>
-      <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-white/40">
+      <div className="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-widest text-slate-400 dark:text-white/40">
         <Icon size={12} />
         {label}
       </div>
       <p className={`mt-1.5 text-lg font-bold tabular-nums ${color}`}>{value}</p>
       {sublabel && (
-        <p className="mt-0.5 text-[10px] text-slate-400 dark:text-white/35">{sublabel}</p>
+        <p className="mt-0.5 text-2xs text-slate-400 dark:text-white/35">{sublabel}</p>
       )}
     </Card>
   );
@@ -329,7 +329,7 @@ function NetworkCard({ stats }: { stats: SystemStats }) {
   const { t } = useTranslation();
   return (
     <Card padding="compact" bodyClassName="mt-0" className={`${PANEL_SURFACE} h-full`}>
-      <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-white/40 mb-2.5">
+      <div className="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-widest text-slate-400 dark:text-white/40 mb-2.5">
         <Wifi size={12} />
         {t("system_monitor.network_traffic")}
       </div>
@@ -341,7 +341,7 @@ function NetworkCard({ stats }: { stats: SystemStats }) {
               {formatRate(stats.net_send_rate)}
             </span>
           </div>
-          <p className="mt-0.5 text-[10px] text-slate-400 dark:text-white/35">
+          <p className="mt-0.5 text-2xs text-slate-400 dark:text-white/35">
             {t("system_monitor.up_total", { size: formatBytes(stats.net_bytes_sent) })}
           </p>
         </div>
@@ -352,13 +352,13 @@ function NetworkCard({ stats }: { stats: SystemStats }) {
               {formatRate(stats.net_recv_rate)}
             </span>
           </div>
-          <p className="mt-0.5 text-[10px] text-slate-400 dark:text-white/35">
+          <p className="mt-0.5 text-2xs text-slate-400 dark:text-white/35">
             {t("system_monitor.down_total", { size: formatBytes(stats.net_bytes_recv) })}
           </p>
         </div>
       </div>
-      <div className="mt-2 flex items-center justify-between rounded-[12px] bg-slate-50 px-2.5 py-1.5 dark:bg-neutral-800/50">
-        <span className="text-[10px] text-slate-500 dark:text-white/45">
+      <div className="mt-2 flex items-center justify-between rounded-xl bg-slate-50 px-2.5 py-1.5 dark:bg-neutral-800/50">
+        <span className="text-2xs text-slate-500 dark:text-white/45">
           {t("system_monitor.total_traffic")}
         </span>
         <span className="text-xs font-bold tabular-nums text-slate-700 dark:text-white">
@@ -388,21 +388,21 @@ function AverageLatencyCard({
       bodyClassName="mt-0"
       className={`${PANEL_SURFACE} h-full overflow-hidden`}
     >
-      <div className="mb-2.5 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-white/40">
+      <div className="mb-2.5 flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-widest text-slate-400 dark:text-white/40">
         <Network size={12} />
         {t("system_monitor.channel_avg_latency")}
       </div>
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-[12px] bg-slate-50 px-3 py-2.5 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
-          <div className="text-[9px] font-semibold uppercase tracking-wider text-slate-400 dark:text-white/45">
+        <div className="rounded-xl bg-slate-50 px-3 py-2.5 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
+          <div className="text-2xs font-semibold uppercase tracking-wider text-slate-400 dark:text-white/45">
             {t("system_monitor.latency")}
           </div>
           <div className="mt-1 text-xl font-bold tabular-nums text-slate-900 dark:text-white">
             {formatMs(avgLatency)}
           </div>
         </div>
-        <div className="rounded-[12px] bg-slate-50 px-3 py-2.5 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
-          <div className="text-[9px] font-semibold uppercase tracking-wider text-slate-400 dark:text-white/45">
+        <div className="rounded-xl bg-slate-50 px-3 py-2.5 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
+          <div className="text-2xs font-semibold uppercase tracking-wider text-slate-400 dark:text-white/45">
             {t("system_monitor.key_count")}
           </div>
           <div className="mt-1 text-xl font-bold tabular-nums text-slate-900 dark:text-white">

--- a/pages/identity-fingerprint/CodexRecommendationsModal.tsx
+++ b/pages/identity-fingerprint/CodexRecommendationsModal.tsx
@@ -290,7 +290,7 @@ function RecommendationDetail({
             })}
           </p>
         </div>
-        <span className="shrink-0 rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950 dark:text-white/65 dark:ring-neutral-800">
+        <span className="shrink-0 rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 dark:bg-neutral-950 dark:text-white/65 dark:ring-neutral-800">
           {t("identity_fingerprint.recommend_count", { count: item.count })}
         </span>
       </div>
@@ -304,7 +304,7 @@ function RecommendationDetail({
           <div className="space-y-2">
             {diffs.map((diff) => (
               <div key={diff.key} className="rounded-lg bg-white px-3 py-2 dark:bg-neutral-950/70">
-                <div className="text-[11px] font-semibold text-slate-500 dark:text-white/45">
+                <div className="text-xs font-semibold text-slate-500 dark:text-white/45">
                   {diff.label}
                 </div>
                 <div className="mt-1 grid gap-1 text-xs">
@@ -341,7 +341,7 @@ function RecommendationDetail({
                 <span className="font-mono">#{sample.log_id}</span>
                 <span>{formatDateTime(sample.timestamp)}</span>
               </div>
-              <div className="mt-1 truncate font-mono text-[11px] text-slate-500 dark:text-white/45">
+              <div className="mt-1 truncate font-mono text-xs text-slate-500 dark:text-white/45">
                 {sample.method || "POST"} {sample.path || "-"}
               </div>
             </div>
@@ -355,7 +355,7 @@ function RecommendationDetail({
 function DetailSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="mt-4">
-      <h4 className="mb-2 text-[11px] font-semibold uppercase text-slate-500 dark:text-white/45">
+      <h4 className="mb-2 text-xs font-semibold uppercase text-slate-500 dark:text-white/45">
         {title}
       </h4>
       {children}
@@ -377,7 +377,7 @@ function HeaderValueList({
     <div className="space-y-2">
       {entries.map(([key, value]) => (
         <div key={key} className="min-w-0 rounded-lg bg-white px-3 py-2 dark:bg-neutral-950/70">
-          <div className="text-[11px] font-semibold text-slate-500 dark:text-white/45">{key}</div>
+          <div className="text-xs font-semibold text-slate-500 dark:text-white/45">{key}</div>
           <div
             className={[
               "mt-1 whitespace-pre-wrap break-words [overflow-wrap:anywhere] font-mono text-xs leading-relaxed",

--- a/pages/identity-fingerprint/IdentityFingerprintPage.tsx
+++ b/pages/identity-fingerprint/IdentityFingerprintPage.tsx
@@ -1794,7 +1794,7 @@ function SourcePill({
         ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-200"
         : "bg-slate-100 text-slate-600 dark:bg-neutral-800 dark:text-white/60";
   return (
-    <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${className}`}>
+    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${className}`}>
       {children}
     </span>
   );

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -408,7 +408,7 @@ function EndpointCallDoc({ doc }: { doc: EndpointDoc }) {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-[22px] border border-slate-200 bg-slate-50 p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="rounded-3xl border border-slate-200 bg-slate-50 p-4 dark:border-neutral-800 dark:bg-neutral-900">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -439,7 +439,7 @@ function EndpointCallDoc({ doc }: { doc: EndpointDoc }) {
         <div className="border-b border-white/10 px-4 py-2 text-xs font-medium text-slate-300">
           curl
         </div>
-        <pre className="overflow-x-auto px-4 py-3 text-[13px] leading-6 text-slate-100">
+        <pre className="overflow-x-auto px-4 py-3 text-sm leading-6 text-slate-100">
           <code>{doc.curl}</code>
         </pre>
       </div>
@@ -1149,7 +1149,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                 <div className="relative z-10 flex h-full w-full items-start">
                   {showGeneratingState ? (
                     <div className="max-w-md">
-                      <p className="text-3xl font-semibold tracking-tight text-slate-700 dark:text-white/92 sm:text-[38px]">
+                      <p className="text-3xl font-semibold tracking-tight text-slate-700 dark:text-white/92 sm:text-4xl">
                         {statusText}
                       </p>
                       <p className="mt-2 text-sm text-slate-500 dark:text-white/45">
@@ -1193,7 +1193,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
 
           <div
             data-testid="image-generation-composer"
-            className="relative shrink-0 overflow-hidden rounded-[20px] border border-slate-200 bg-white px-2.5 pt-2.5 pb-11 shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
+            className="relative shrink-0 overflow-hidden rounded-2xl border border-slate-200 bg-white px-2.5 pt-2.5 pb-11 shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
           >
             {IMAGE_EDITS_ENABLED && uploadedImages.length > 0 ? (
               <div

--- a/pages/login/LoginPage.tsx
+++ b/pages/login/LoginPage.tsx
@@ -141,7 +141,7 @@ export function LoginPage() {
             </aside>
 
             <section className="relative">
-              <div className="rounded-[34px] border border-slate-200 bg-white/90 p-8 text-slate-900 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.6)] backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-slate-50 dark:shadow-[0_30px_80px_-60px_rgba(0,0,0,0.8)]">
+              <div className="rounded-4xl border border-slate-200 bg-white/90 p-8 text-slate-900 shadow-[0_30px_80px_-60px_rgba(15,23,42,0.6)] backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-slate-50 dark:shadow-[0_30px_80px_-60px_rgba(0,0,0,0.8)]">
                 <div className="space-y-6">
                   <h2 className="text-center text-3xl font-semibold tracking-tight">
                     {t("login.sign_in")}
@@ -167,7 +167,7 @@ export function LoginPage() {
                         autoComplete="url"
                         className="rounded-full px-5 py-3"
                       />
-                      <p className="text-[11px] leading-5 text-slate-500 dark:text-white/50">
+                      <p className="text-xs leading-5 text-slate-500 dark:text-white/50">
                         {t("login.endpoint_label")}: {managementEndpoint}
                       </p>
                     </label>

--- a/pages/logs/components/ErrorLogsTab.tsx
+++ b/pages/logs/components/ErrorLogsTab.tsx
@@ -127,7 +127,7 @@ function DiagnosticLine({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid gap-1 text-xs sm:grid-cols-[7rem_minmax(0,1fr)]">
       <span className="text-slate-500 dark:text-white/45">{label}</span>
-      <code className="min-w-0 break-all rounded-md bg-slate-100 px-2 py-1 text-[11px] text-slate-800 dark:bg-white/5 dark:text-white/75">
+      <code className="min-w-0 break-all rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-800 dark:bg-white/5 dark:text-white/75">
         {value}
       </code>
     </div>
@@ -255,7 +255,7 @@ export function ErrorLogsTab({
                             {badges.map((badge) => (
                               <span
                                 key={badge.key}
-                                className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-[11px] ${badge.className}`}
+                                className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-xs ${badge.className}`}
                               >
                                 <span className="shrink-0 text-current opacity-65">
                                   {badge.label}

--- a/pages/logs/components/LiveLogsTab.tsx
+++ b/pages/logs/components/LiveLogsTab.tsx
@@ -11,7 +11,7 @@ function Badge({ children, className }: { children: React.ReactNode; className: 
   return (
     <span
       className={[
-        "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold",
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold",
         className,
       ].join(" ")}
     >
@@ -22,7 +22,7 @@ function Badge({ children, className }: { children: React.ReactNode; className: 
 
 function RequestPath({ children }: { children: string }) {
   return (
-    <code className="inline-block max-w-full rounded-md border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-[11px] font-medium leading-relaxed text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70">
+    <code className="inline-block max-w-full rounded-md border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-xs font-medium leading-relaxed text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70">
       <span className="break-all">{children}</span>
     </code>
   );
@@ -237,7 +237,7 @@ export function LiveLogsTab({
                       className={rowClassName}
                     >
                       <div className="flex items-start gap-3">
-                        <div className="w-36 shrink-0 tabular-nums text-[11px] text-slate-500 dark:text-white/55">
+                        <div className="w-36 shrink-0 tabular-nums text-xs text-slate-500 dark:text-white/55">
                           {line.timestamp ?? ""}
                         </div>
                         <div className="min-w-0 flex-1">

--- a/pages/models/ModelsPage.tsx
+++ b/pages/models/ModelsPage.tsx
@@ -629,7 +629,7 @@ export function ModelsPage() {
                 <span className="min-w-0 truncate font-medium">{t("models_page.all_owners")}</span>
                 <span
                   className={[
-                    "shrink-0 rounded-full px-2 py-0.5 text-[11px]",
+                    "shrink-0 rounded-full px-2 py-0.5 text-xs",
                     ownerFilter === ""
                       ? "bg-white/15 text-white/80 dark:bg-slate-950/10 dark:text-slate-700"
                       : "bg-white text-slate-500 dark:bg-neutral-950 dark:text-white/45",
@@ -674,11 +674,11 @@ export function ModelsPage() {
                           <span className="block truncate text-sm font-medium text-slate-900 dark:text-white">
                             {owner.label || owner.value}
                           </span>
-                          <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
+                          <span className="block truncate text-xs text-slate-500 dark:text-white/45">
                             {owner.value}
                           </span>
                         </button>
-                        <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-500 transition-transform duration-200 ease-out group-focus-within/owner:-translate-x-16 group-hover/owner:-translate-x-16 motion-reduce:transition-none dark:bg-white/[0.08] dark:text-white/45">
+                        <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 transition-transform duration-200 ease-out group-focus-within/owner:-translate-x-16 group-hover/owner:-translate-x-16 motion-reduce:transition-none dark:bg-white/[0.08] dark:text-white/45">
                           {t("models_page.owner_model_count", { count })}
                         </span>
                         <div className="pointer-events-none absolute right-2 top-1/2 flex -translate-y-1/2 translate-x-3 items-center gap-1 opacity-0 transition-all duration-200 ease-out group-focus-within/owner:pointer-events-auto group-focus-within/owner:translate-x-0 group-focus-within/owner:opacity-100 group-hover/owner:pointer-events-auto group-hover/owner:translate-x-0 group-hover/owner:opacity-100 motion-reduce:transition-none">
@@ -760,7 +760,7 @@ export function ModelsPage() {
                       <span>{t("models_page.openrouter_sync_title")}</span>
                       <span
                         className={[
-                          "rounded-full px-2 py-0.5 text-[10px] font-semibold",
+                          "rounded-full px-2 py-0.5 text-2xs font-semibold",
                           openRouterSyncState.enabled
                             ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-300"
                             : "bg-slate-100 text-slate-500 dark:bg-white/[0.08] dark:text-white/45",

--- a/pages/models/components/ModelCapabilityBadges.tsx
+++ b/pages/models/components/ModelCapabilityBadges.tsx
@@ -42,7 +42,7 @@ export function ModelCapabilityBadges({ model }: { model: ModelItem }) {
       {badges.map((badge) => (
         <span
           key={badge.key}
-          className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${badge.className}`}
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-2xs font-semibold ${badge.className}`}
         >
           {badge.label}
         </span>

--- a/pages/models/hooks/useModelColumns.tsx
+++ b/pages/models/hooks/useModelColumns.tsx
@@ -74,7 +74,7 @@ export function useModelColumns({
               </OverflowTooltip>
               {row.description ? (
                 <OverflowTooltip content={row.description} className="block min-w-0">
-                  <span className="block min-w-0 truncate text-[11px] text-slate-500 dark:text-white/45">
+                  <span className="block min-w-0 truncate text-xs text-slate-500 dark:text-white/45">
                     {row.description}
                   </span>
                 </OverflowTooltip>
@@ -120,7 +120,7 @@ export function useModelColumns({
           return (
             <span
               className={[
-                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-semibold",
+                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-2xs font-semibold",
                 row.enabled && priced
                   ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/15 dark:text-emerald-300"
                   : "bg-slate-100 text-slate-500 dark:bg-neutral-800 dark:text-white/40",

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -200,7 +200,7 @@ export function ProviderKeyListCard({
                         return (
                           <button
                             type="button"
-                            className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] tabular-nums font-medium transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 dark:hover:bg-white/10 dark:focus-visible:ring-white/20 ${entry.loading ? "text-slate-500" : entry.error ? "text-rose-500" : latencyColor}`}
+                            className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs tabular-nums font-medium transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 dark:hover:bg-white/10 dark:focus-visible:ring-white/20 ${entry.loading ? "text-slate-500" : entry.error ? "text-rose-500" : latencyColor}`}
                             onClick={(e) => {
                               e.stopPropagation();
                               if (providerBaseUrl)
@@ -290,7 +290,7 @@ export function ProviderKeyListCard({
                     {headerEntries.map(([k, v]) => (
                       <span
                         key={k}
-                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
                         title={`${k}: ${String(v)}`}
                       >
                         <span className="shrink-0 font-semibold">{k}:</span>
@@ -309,7 +309,7 @@ export function ProviderKeyListCard({
                     {excludedModels.map((model) => (
                       <span
                         key={model}
-                        className="inline-flex max-w-full min-w-0 rounded-full bg-rose-600/10 px-2 py-0.5 text-[11px] text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+                        className="inline-flex max-w-full min-w-0 rounded-full bg-rose-600/10 px-2 py-0.5 text-xs text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
                         title={model}
                       >
                         <span className="min-w-0 truncate">{model}</span>

--- a/pages/providers/components/OpenAIProvidersTab.tsx
+++ b/pages/providers/components/OpenAIProvidersTab.tsx
@@ -123,7 +123,7 @@ export function OpenAIProvidersTab({
                     {headerEntries.map(([key, value]) => (
                       <span
                         key={key}
-                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px] text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
                         title={`${key}: ${String(value)}`}
                       >
                         <span className="shrink-0 font-semibold">{key}:</span>
@@ -161,7 +161,7 @@ export function OpenAIProvidersTab({
                     label={t("providers.failed_stats", { count: stats.failure })}
                   />
                   {provider.testModel ? (
-                    <span className="inline-flex items-center rounded-full bg-slate-600/10 px-2 py-0.5 text-[11px] font-medium text-slate-700 dark:bg-white/10 dark:text-white/65">
+                    <span className="inline-flex items-center rounded-full bg-slate-600/10 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-white/10 dark:text-white/65">
                       testModel: {provider.testModel}
                     </span>
                   ) : null}

--- a/pages/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/pages/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -259,11 +259,11 @@ export function OpenCodeGoUsageCardSection({
               key={type}
               className="grid grid-cols-[2.5rem_minmax(0,1fr)_5.25rem] items-center gap-2"
             >
-              <span className="truncate text-[11px] font-semibold">
+              <span className="truncate text-xs font-semibold">
                 {getCompactUsageLabel(type, usageByType, t)}
               </span>
               <div className="h-1.5 rounded-full bg-slate-200/70 dark:bg-white/8" />
-              <span className="text-right text-[11px] tabular-nums">{remainingUnknownText}</span>
+              <span className="text-right text-xs tabular-nums">{remainingUnknownText}</span>
             </div>
           ))}
         </div>
@@ -280,13 +280,13 @@ export function OpenCodeGoUsageCardSection({
               key={type}
               className="grid grid-cols-[2.5rem_minmax(0,1fr)_5.25rem] items-center gap-2"
             >
-              <span className="truncate text-[11px] font-semibold text-slate-400 dark:text-white/45">
+              <span className="truncate text-xs font-semibold text-slate-400 dark:text-white/45">
                 {getCompactUsageLabel(type, usageByType, t)}
               </span>
               <div className="relative h-1.5 overflow-hidden rounded-full bg-slate-200/70 dark:bg-white/8">
                 <div className="absolute inset-y-0 -left-full w-1/2 animate-pulse rounded-full bg-slate-300/50 dark:bg-white/20" />
               </div>
-              <span className="text-right text-[11px] tabular-nums text-slate-400 dark:text-white/45">
+              <span className="text-right text-xs tabular-nums text-slate-400 dark:text-white/45">
                 {remainingUnknownText}
               </span>
             </div>
@@ -310,7 +310,7 @@ export function OpenCodeGoUsageCardSection({
                 key={type}
                 className="grid grid-cols-[2.5rem_minmax(0,1fr)_5.25rem] items-center gap-2"
               >
-                <span className="truncate text-[11px] font-semibold text-slate-600 dark:text-white/65">
+                <span className="truncate text-xs font-semibold text-slate-600 dark:text-white/65">
                   {getCompactUsageLabel(type, usageByType, t)}
                 </span>
                 <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
@@ -322,7 +322,7 @@ export function OpenCodeGoUsageCardSection({
                 </div>
                 <span
                   className={[
-                    "truncate text-right text-[11px] font-semibold tabular-nums",
+                    "truncate text-right text-xs font-semibold tabular-nums",
                     tone.percentClass,
                   ].join(" ")}
                 >
@@ -339,7 +339,7 @@ export function OpenCodeGoUsageCardSection({
       ) : null}
 
       {usageEntry?.error ? (
-        <p className="mt-1 text-[11px] font-semibold text-rose-700 dark:text-rose-200">
+        <p className="mt-1 text-xs font-semibold text-rose-700 dark:text-rose-200">
           {usageEntry.error?.length > 60
             ? t("providers.opencode_go_usage_query_failed")
             : usageEntry.error}

--- a/pages/providers/components/ProviderAccessChips.tsx
+++ b/pages/providers/components/ProviderAccessChips.tsx
@@ -32,7 +32,7 @@ export function ProviderAccessChips({ accessSummary }: ProviderAccessChipsProps)
           : t("providers.access_all", { total: accessSummary.totalKeys });
 
   return (
-    <div className="flex flex-wrap gap-1.5 text-[11px]">
+    <div className="flex flex-wrap gap-1.5 text-xs">
       <span className={`rounded-full border px-2 py-0.5 font-medium ${accessTone}`}>{label}</span>
       {accessSummary.exactOverrideKeys > 0 ? (
         <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -145,7 +145,7 @@ export function ProviderKeyModelsTab({
               {model.id}
             </span>
             {model.owned_by ? (
-              <span className="block truncate text-[11px] text-slate-500 dark:text-white/45">
+              <span className="block truncate text-xs text-slate-500 dark:text-white/45">
                 {model.owned_by}
               </span>
             ) : null}

--- a/pages/providers/components/ProviderMetricChip.tsx
+++ b/pages/providers/components/ProviderMetricChip.tsx
@@ -21,7 +21,7 @@ const toneClass: Record<MetricTone, string> = {
 export function ProviderMetricChip({ tone, icon, label, value, title }: ProviderMetricChipProps) {
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${toneClass[tone]}`}
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${toneClass[tone]}`}
       title={title}
     >
       {icon ? <span className="shrink-0">{icon}</span> : null}

--- a/pages/providers/components/ProviderModelChips.tsx
+++ b/pages/providers/components/ProviderModelChips.tsx
@@ -37,7 +37,7 @@ export function ProviderModelChips({
             placement="top"
             className="min-w-0"
           >
-            <span className="inline-flex w-full min-w-0 cursor-default rounded-full bg-slate-900 px-2 py-0.5 text-[11px] text-white dark:bg-white dark:text-neutral-950">
+            <span className="inline-flex w-full min-w-0 cursor-default rounded-full bg-slate-900 px-2 py-0.5 text-xs text-white dark:bg-white dark:text-neutral-950">
               <span className="min-w-0 truncate">{modelLabel}</span>
             </span>
           </HoverTooltip>
@@ -52,7 +52,7 @@ export function ProviderModelChips({
           placement="top"
           className="min-w-0"
         >
-          <span className="inline-flex min-w-0 cursor-default justify-center rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold tabular-nums text-slate-500 dark:bg-neutral-800 dark:text-white/55">
+          <span className="inline-flex min-w-0 cursor-default justify-center rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold tabular-nums text-slate-500 dark:bg-neutral-800 dark:text-white/55">
             +{remaining}
           </span>
         </HoverTooltip>

--- a/pages/providers/components/ProviderTabsWithCounts.tsx
+++ b/pages/providers/components/ProviderTabsWithCounts.tsx
@@ -85,8 +85,8 @@ export function ProviderTabsWithCounts({ tabs, value }: ProviderTabsWithCountsPr
                   <span
                     className={
                       value === tab.id
-                        ? "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[#18181B] px-1 text-[10px] font-semibold leading-none tabular-nums text-white shadow-sm ring-1 ring-black/10 dark:bg-white dark:text-[#18181B] dark:ring-white/15"
-                        : "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-100 px-1 text-[10px] font-semibold leading-none tabular-nums text-blue-700 shadow-sm ring-1 ring-blue-200/80 dark:bg-blue-500/25 dark:text-blue-100 dark:ring-blue-300/25"
+                        ? "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[#18181B] px-1 text-2xs font-semibold leading-none tabular-nums text-white shadow-sm ring-1 ring-black/10 dark:bg-white dark:text-[#18181B] dark:ring-white/15"
+                        : "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-100 px-1 text-2xs font-semibold leading-none tabular-nums text-blue-700 shadow-sm ring-1 ring-blue-200/80 dark:bg-blue-500/25 dark:text-blue-100 dark:ring-blue-300/25"
                     }
                   >
                     {tab.count}

--- a/pages/providers/components/ProvidersToolbar.tsx
+++ b/pages/providers/components/ProvidersToolbar.tsx
@@ -95,7 +95,7 @@ export function ProvidersToolbar({
                 ? t("providers.batch_deselect_all")
                 : t("providers.batch_select_all")}
               {hasSelection ? (
-                <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[10px] font-semibold leading-none text-white">
+                <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-2xs font-semibold leading-none text-white">
                   {selectedExportCount}
                 </span>
               ) : null}

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -261,7 +261,7 @@ export function ProxiesPage() {
         render: (entry) => (
           <div className="min-w-0">
             <p className="truncate font-semibold text-slate-950 dark:text-white">{entry.name}</p>
-            <p className="mt-1 truncate font-mono text-[11px] text-slate-500 dark:text-white/50">
+            <p className="mt-1 truncate font-mono text-xs text-slate-500 dark:text-white/50">
               {entry.id}
             </p>
           </div>
@@ -273,7 +273,7 @@ export function ProxiesPage() {
         width: "w-[180px]",
         render: (entry) => (
           <div className="flex min-w-0 items-center gap-2">
-            <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-300">
+            <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-300">
               {proxyProtocol(entry.url)}
             </span>
             <span className="truncate font-mono text-xs text-slate-700 dark:text-white/70">
@@ -308,7 +308,7 @@ export function ProxiesPage() {
               <span
                 data-latency-tone={tone}
                 className={[
-                  "inline-flex max-w-full rounded-full px-2 py-0.5 text-[11px] font-semibold",
+                  "inline-flex max-w-full rounded-full px-2 py-0.5 text-xs font-semibold",
                   latencyToneClasses[tone],
                 ].join(" ")}
               >

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -98,7 +98,7 @@ function ChannelFilterOptionLabel({
       {badgeLabel ? (
         <span
           className={[
-            "inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none",
+            "inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-2xs font-semibold leading-none",
             authTypeBadgeClass(authType),
           ].join(" ")}
         >

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -93,7 +93,7 @@ function InfoCard({
 
       <div className="flex items-center gap-2 mb-1.5">
         <Icon size={13} className="hidden text-slate-400 dark:text-white/35 sm:block" />
-        <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-white/35">
+        <span className="text-2xs font-semibold uppercase tracking-widest text-slate-400 dark:text-white/35">
           {label}
         </span>
       </div>
@@ -173,11 +173,11 @@ const renderModelSourcesTooltip = (
     <span className="block min-w-44 max-w-[18rem] space-y-1 text-left">
       {entries.map((entry) => (
         <span key={`${entry.label}\x00${entry.actualModelId}`} className="block">
-          <span className="block text-[12px] font-medium text-slate-900 dark:text-white">
+          <span className="block text-xs font-medium text-slate-900 dark:text-white">
             {entry.label}
           </span>
           {entry.mapped ? (
-            <span className="mt-0.5 flex min-w-0 items-start gap-1.5 text-[11px] text-slate-500 dark:text-white/55">
+            <span className="mt-0.5 flex min-w-0 items-start gap-1.5 text-xs text-slate-500 dark:text-white/55">
               <span className="shrink-0">{actualCallLabel}</span>
               <span className="min-w-0 break-all font-mono text-slate-700 dark:text-white/75">
                 {entry.actualModelId}
@@ -360,11 +360,11 @@ export function SystemPage({
                 <CircleAlert size={14} aria-hidden="true" />
               </span>
             </HoverTooltip>
-            <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-bold tabular-nums text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300">
+            <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-bold tabular-nums text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300">
               {filteredModels.length}
             </span>
             {modelFilter && filteredModels.length !== models.length && (
-              <span className="text-[10px] text-slate-400 dark:text-white/30">
+              <span className="text-2xs text-slate-400 dark:text-white/30">
                 / {models.length}
               </span>
             )}
@@ -401,7 +401,7 @@ export function SystemPage({
               aria-pressed={selectedModelVendor === "all"}
               onClick={() => setSelectedModelVendor("all")}
               className={[
-                "inline-flex items-center gap-1.5 rounded-md border border-slate-200/70 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-600 transition hover:shadow-sm dark:border-neutral-700/60 dark:bg-neutral-900 dark:text-white/70",
+                "inline-flex items-center gap-1.5 rounded-md border border-slate-200/70 bg-white px-2 py-0.5 text-2xs font-semibold text-slate-600 transition hover:shadow-sm dark:border-neutral-700/60 dark:bg-neutral-900 dark:text-white/70",
                 selectedModelVendor === "all"
                   ? "ring-2 ring-indigo-500/35 ring-offset-1 ring-offset-white dark:ring-indigo-300/40 dark:ring-offset-neutral-950"
                   : "",

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { exit } from "node:process";
+
+const root = resolve(import.meta.dirname, "..");
+const SCANNED_DIRS = ["apps", "pages", "features", "packages"];
+const ALLOWED_FONT_SIZES = new Set([10, 12, 14, 16, 18, 20, 24, 30, 36, 48, 60]);
+const ALLOWED_RADII = new Set([0, 2, 4, 6, 8, 12, 16, 24, 32, 9999]);
+
+const violations = [];
+
+function report(filePath, content, index, message) {
+  const line = content.slice(0, index).split("\n").length;
+  violations.push(`${relative(root, filePath)}:${line} ${message}`);
+}
+
+function checkFile(filePath) {
+  const content = readFileSync(filePath, "utf8");
+
+  for (const match of content.matchAll(/text-\[(\d*\.?\d+)(px|rem)\]/g)) {
+    report(
+      filePath,
+      content,
+      match.index,
+      `使用了任意字号 ${match[0]}，请改用 text-2xs 至 text-6xl`,
+    );
+  }
+
+  for (const match of content.matchAll(/rounded(?:-[trblxy]{1,2})?-\[(\d*\.?\d+)(px|rem)\]/g)) {
+    report(
+      filePath,
+      content,
+      match.index,
+      `使用了任意圆角 ${match[0]}，请改用 rounded-xs 至 rounded-4xl/full`,
+    );
+  }
+
+  for (const match of content.matchAll(/fontSize\s*:\s*["']?(\d*\.?\d+)(?:px)?["']?/g)) {
+    const value = Number(match[1]);
+    if (!ALLOWED_FONT_SIZES.has(value)) {
+      report(filePath, content, match.index, `fontSize ${value}px 不在全局字号规范内`);
+    }
+  }
+
+  for (const match of content.matchAll(/borderRadius\s*:\s*(\d*\.?\d+)/g)) {
+    const value = Number(match[1]);
+    if (!ALLOWED_RADII.has(value)) {
+      report(filePath, content, match.index, `borderRadius ${value}px 不在全局圆角规范内`);
+    }
+  }
+}
+
+function walk(dirPath) {
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name.startsWith(".")) {
+      continue;
+    }
+    const fullPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath);
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      checkFile(fullPath);
+    }
+  }
+}
+
+for (const dir of SCANNED_DIRS) {
+  const path = join(root, dir);
+  if (existsSync(path)) walk(path);
+}
+
+if (violations.length > 0) {
+  console.error(`\n❌ Found ${violations.length} design token violation(s):\n`);
+  for (const violation of violations) console.error(`  ${violation}`);
+  console.error();
+  exit(1);
+}
+
+console.log("\n✅ Typography and radius tokens are consistent.\n");

--- a/scripts/ci-pr.sh
+++ b/scripts/ci-pr.sh
@@ -5,6 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 bun install --frozen-lockfile
 bun run lint
+bun run design:check
 bun run test:ci
 bun run build
 bun run bundle:diff


### PR DESCRIPTION
## 修改内容

- 在 Tailwind 主题中集中定义前端字体栈、字号阶梯和圆角阶梯
- 将全项目任意像素字号、圆角替换为统一设计 Token
- 同步规范 ECharts、Markdown 等非 Tailwind 渲染场景
- 新增 `design:check`，阻止后续引入非规范字号和圆角，并接入 PR CI

## 影响

管理端所有页面共享同一套字体、字号与圆角规范，减少组件之间的视觉偏差。默认正文统一为 14px，保留语义化字号层级和胶囊圆角。

## 验证

- `bun run check`
- `bun run test:ci`, 78 个测试文件、610 个测试通过
- `bunx playwright test e2e/config-editor-and-sidebar.spec.ts --project=chromium`, 6 个测试通过
- 桌面端与 375px 登录页真实渲染检查
