### PR TITLE
fix: align sidebar icon label spacing

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -239,7 +239,7 @@ function SidebarChildLink({
       onMouseEnter={() => onWarm(item.to)}
       onFocus={() => onWarm(item.to)}
       className={
-        "flex h-9 min-w-0 items-center gap-2.5 rounded-xl px-3 text-sm whitespace-nowrap transition-colors duration-150 " +
+        "flex h-9 min-w-0 items-center gap-3 rounded-xl px-3 text-sm whitespace-nowrap transition-colors duration-150 " +
         (active
           ? "bg-slate-100 font-semibold text-slate-950 dark:bg-white/10 dark:text-white"
           : "font-medium text-slate-600 hover:bg-slate-100/80 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/[0.06] dark:hover:text-white")
@@ -287,12 +287,12 @@ function SidebarPrimaryLink({
           : "font-medium text-slate-600 hover:bg-slate-100/80 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-white/[0.06] dark:hover:text-white")
       }
     >
-      <span className="grid h-10 w-12 shrink-0 place-items-center">
+      <span className="ml-1 grid h-10 w-10 shrink-0 place-items-center">
         <Icon size={16} className="opacity-80" />
       </span>
       <span
         className={
-          "min-w-0 truncate pl-2 pr-3 text-sm transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+          "min-w-0 truncate pr-3 text-sm transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
           (labelVisible
             ? "translate-x-0 opacity-100 delay-100"
             : "-translate-x-1 opacity-0 delay-0")
@@ -505,12 +505,12 @@ function SidebarMenuGroup({
             : "text-slate-500 hover:bg-slate-100/80 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/[0.06] dark:hover:text-slate-200")
         }
       >
-        <span className="grid h-10 w-12 shrink-0 place-items-center">
+        <span className="ml-1 grid h-10 w-10 shrink-0 place-items-center">
           <GroupIcon size={16} className="opacity-80" />
         </span>
         <span
           className={
-            "min-w-0 flex-1 truncate pl-2 text-sm font-semibold transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
+            "min-w-0 flex-1 truncate text-sm font-semibold transition-[opacity,transform] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] " +
             (labelsVisible
               ? "translate-x-0 opacity-100 delay-100"
               : "-translate-x-1 opacity-0 delay-0")

--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -118,6 +118,24 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
   await expect(requestLogsLink).toBeVisible();
   await expect(requestLogsLink).toHaveCSS("font-size", "14px");
 
+  const runtimeGroup = page.getByRole("button", { name: /Operations|运行监控/i });
+  const iconLabelGaps = await Promise.all(
+    [dashboardLink, runtimeGroup, requestLogsLink].map((row) =>
+      row.evaluate((element) => {
+        const icon = element.querySelector("svg");
+        const label = element.children.item(1);
+        if (!icon || !(label instanceof HTMLElement)) {
+          throw new Error("Missing sidebar icon or label");
+        }
+        return label.getBoundingClientRect().left - icon.getBoundingClientRect().right;
+      }),
+    ),
+  );
+  for (const gap of iconLabelGaps) {
+    expect(gap).toBeGreaterThanOrEqual(11);
+    expect(gap).toBeLessThanOrEqual(13);
+  }
+
   const configLink = page.getByRole("link", { name: /^Config|配置面板$/i });
   await expect(configLink).toHaveAttribute("aria-current", "page");
   await expect(configLink).toHaveClass(/bg-slate-100/);


### PR DESCRIPTION
## 修改内容

- 将 Dashboard、一级分组菜单的图标列从 `48px + 8px` 文字内边距调整为保持图标中心不变的 `40px + 4px` 图标列
- 将二级菜单 `gap` 从 `10px` 调整为 `12px`
- 统一一级菜单、父级分组、二级菜单的“图标右边缘到文字左边缘”为 `12px`
- 保持收起状态的图标中心位置不变，避免影响此前稳定的侧边栏展开/收起动效
- 增加 E2E 几何回归断言，防止父子菜单间距再次不一致

## 验证

- `rtk bun run build`
- `rtk bun run --filter @code-proxy/admin-panel test -- src/app/layout/AppShell.test.tsx`（6 passed）
- Chromium 侧边栏 E2E（passed）
- `rtk bun run lint`（0 errors，2 个既有 warning）
- 真实 Chromium 测量：Dashboard、父级分组、二级菜单间距均为 `12px`
