### PR TITLE
fix: keep sidebar collapse control visible

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -768,7 +768,7 @@ function ShellSidebar({
         <SidebarToggle
           label={sidebarLabel}
           onToggle={onToggleSidebar}
-          alwaysVisible={isMobile}
+          alwaysVisible={isMobile || !visualRailCollapsed}
         />
         <div className="flex h-full w-full flex-col">
           <div className="flex h-14 shrink-0 items-center overflow-hidden text-slate-900 whitespace-nowrap dark:text-white">

--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -189,10 +189,15 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
     )
     .toBeLessThan(0.05);
 
-  await aside.hover();
   const collapseButton = page.getByRole("button", {
     name: /Collapse Sidebar|收起侧边栏/i,
   });
+  await expect
+    .poll(async () =>
+      Number(await collapseButton.evaluate((el) => getComputedStyle(el).opacity)),
+    )
+    .toBeGreaterThan(0.95);
+  await aside.hover();
   const toggleIconClass = await collapseButton
     .locator("svg")
     .getAttribute("class");


### PR DESCRIPTION
## 修改内容

- 展开桌面侧边栏时，收起按钮始终保持可见，不再依赖侧边栏 hover
- 收起侧边栏后仍保持原交互：默认显示 Logo，hover Logo 区域切换为展开按钮
- 移动端按钮继续常显
- 保留展开/收起过渡期间的稳定切换逻辑
- 增加 E2E 回归断言，验证鼠标位于内容区时展开态收起按钮仍为完全可见

## 验证

- `rtk bun run build`
- AppShell 单元测试：6 passed
- Chromium 侧边栏 E2E：passed
