### PR TITLE
fix: make forced password change standalone

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -48,6 +48,7 @@ export function AppRouter() {
   const publicRoutes = routes.filter((r) => !r.auth);
   const loginRoute = publicRoutes.find((r) => r.path === "/login");
   const standalonePublicRoutes = publicRoutes.filter((r) => r.path !== "/login");
+  const authStandaloneRoutes = routes.filter((r) => r.auth && r.layout === "standalone");
   const authDashboardRoutes = routes.filter((r) => r.auth && r.layout === "dashboard");
 
   return (
@@ -90,6 +91,13 @@ export function AppRouter() {
                         )}
                         <Route path="/login" element={<Navigate to="/dashboard" replace />} />
                         <Route element={<ProtectedRoute />}>
+                          {authStandaloneRoutes.map((route) => (
+                            <Route
+                              key={route.path}
+                              path={route.path}
+                              element={<AuthorizedPage route={route} />}
+                            />
+                          ))}
                           <Route element={<DashboardLayout />}>
                             {authDashboardRoutes.map((route) => (
                               <Route

--- a/apps/admin-panel/src/app/guards/ProtectedRoute.tsx
+++ b/apps/admin-panel/src/app/guards/ProtectedRoute.tsx
@@ -6,7 +6,7 @@ import { PageLoader } from "@code-proxy/ui";
 export function ProtectedRoute() {
   const location = useLocation();
   const {
-    state: { isAuthenticated, isRestoring },
+    state: { isAuthenticated, isRestoring, principal },
   } = useAuth();
 
   if (isRestoring) {
@@ -16,6 +16,10 @@ export function ProtectedRoute() {
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (principal?.user.must_change_password && location.pathname !== "/change-password") {
+    return <Navigate to="/change-password" replace />;
   }
 
   return <Outlet />;

--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -165,6 +165,24 @@ test("logs in with username and password without selecting a tenant", async ({ p
   await page.getByLabel(/^password$/i).fill("correct-password");
   await page.getByRole("button", { name: /^login$/i }).click();
   await expect(page.getByRole("heading", { name: /change password/i })).toBeVisible();
+  await expect(page.locator("aside")).toHaveCount(0);
+  await expect(page.locator("header")).toHaveCount(0);
+  const passwordCard = await page.locator("main section").boundingBox();
+  const viewport = page.viewportSize();
+  expect(passwordCard).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(
+    Math.abs((passwordCard?.x ?? 0) + (passwordCard?.width ?? 0) / 2 - (viewport?.width ?? 0) / 2),
+  ).toBeLessThan(12);
+  expect(
+    Math.abs(
+      (passwordCard?.y ?? 0) + (passwordCard?.height ?? 0) / 2 - (viewport?.height ?? 0) / 2,
+    ),
+  ).toBeLessThan(12);
+  await page.evaluate(() => {
+    window.location.hash = "/dashboard";
+  });
+  await expect(page).toHaveURL(/#\/change-password$/);
 });
 
 test("shows tenant governance routes from server permissions", async ({ page }) => {
@@ -364,6 +382,8 @@ test("renders role, audit, and password governance pages from server permissions
   await expect(page.getByRole("heading", { name: "Audit logs" })).toBeVisible();
   await page.goto("/#/change-password");
   await expect(page.getByRole("heading", { name: "Change password" })).toBeVisible();
+  await expect(page.locator("aside")).toHaveCount(0);
+  await expect(page.locator("header")).toHaveCount(0);
 });
 
 test("shows an expired tenant message when restoring a rejected session", async ({ page }) => {

--- a/pages/change-password/ChangePasswordPage.tsx
+++ b/pages/change-password/ChangePasswordPage.tsx
@@ -1,8 +1,16 @@
 import { useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { Eye, EyeOff, KeyRound, ShieldCheck } from "lucide-react";
 import { identityApi } from "@code-proxy/api-client";
-import { TextInput, useToast } from "@code-proxy/ui";
+import {
+  Button,
+  PageBackground,
+  Reveal,
+  TextInput,
+  ThemeToggleButton,
+  useToast,
+} from "@code-proxy/ui";
 import { useAuth } from "@app/providers/AuthProvider";
 
 export function ChangePasswordPage() {
@@ -15,7 +23,11 @@ export function ChangePasswordPage() {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirm, setConfirm] = useState("");
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
   const [loading, setLoading] = useState(false);
+
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     if (newPassword !== confirm) {
@@ -41,46 +53,112 @@ export function ChangePasswordPage() {
       setLoading(false);
     }
   };
+
   return (
-    <div className="mx-auto max-w-lg">
-      <h2 className="text-2xl font-semibold text-slate-950 dark:text-white">
-        {t("identity_admin.change_password")}
-      </h2>
-      <p className="mt-2 text-sm text-slate-500">{t("identity_admin.password_requirement")}</p>
-      <form
-        onSubmit={submit}
-        className="mt-6 space-y-4 rounded-2xl border border-slate-200 bg-white p-6 dark:border-neutral-800 dark:bg-neutral-950"
-      >
-        <TextInput
-          type="password"
-          value={currentPassword}
-          onChange={(e) => setCurrentPassword(e.target.value)}
-          placeholder={t("identity_admin.current_password")}
-          required
-        />
-        <TextInput
-          type="password"
-          value={newPassword}
-          onChange={(e) => setNewPassword(e.target.value)}
-          placeholder={t("identity_admin.new_password")}
-          required
-          minLength={12}
-        />
-        <TextInput
-          type="password"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          placeholder={t("identity_admin.confirm_new_password")}
-          required
-          minLength={12}
-        />
-        <button
-          disabled={loading}
-          className="w-full rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-60 dark:bg-white/10"
-        >
-          {loading ? t("identity_admin.saving") : t("identity_admin.save_password")}
-        </button>
-      </form>
-    </div>
+    <PageBackground variant="login">
+      <div className="absolute right-6 top-6 z-20">
+        <ThemeToggleButton className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white/70 text-slate-700 shadow-sm backdrop-blur transition hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-slate-200" />
+      </div>
+      <main className="relative flex min-h-[100dvh] items-center justify-center px-6 py-12">
+        <Reveal className="w-full max-w-md">
+          <section className="rounded-3xl border border-white/70 bg-white/90 p-7 shadow-xl shadow-slate-300/25 backdrop-blur-xl sm:p-9 dark:border-white/10 dark:bg-neutral-950/85 dark:shadow-black/25">
+            <div className="mb-8 text-center">
+              <div className="mx-auto mb-4 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-sm dark:bg-white dark:text-neutral-950">
+                <ShieldCheck size={22} aria-hidden="true" />
+              </div>
+              <h1 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
+                {t("identity_admin.change_password")}
+              </h1>
+              <p className="mt-2 text-sm text-slate-500 dark:text-white/55">
+                {t("identity_admin.password_requirement")}
+              </p>
+            </div>
+
+            <form className="space-y-5" onSubmit={submit}>
+              <label className="block space-y-2">
+                <span className="text-xs font-medium text-slate-600 dark:text-white/60">
+                  {t("identity_admin.current_password")}
+                </span>
+                <TextInput
+                  type={showCurrent ? "text" : "password"}
+                  value={currentPassword}
+                  onChange={(event) => setCurrentPassword(event.target.value)}
+                  autoComplete="current-password"
+                  required
+                  className="rounded-full px-5"
+                  startAdornment={<KeyRound size={17} />}
+                  endAdornment={
+                    <button
+                      type="button"
+                      onClick={() => setShowCurrent((value) => !value)}
+                      className="rounded-full p-2 text-slate-500 hover:bg-slate-100 dark:hover:bg-white/10"
+                      aria-label={showCurrent ? t("login.hide_key") : t("login.show_key")}
+                    >
+                      {showCurrent ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
+                  }
+                />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-xs font-medium text-slate-600 dark:text-white/60">
+                  {t("identity_admin.new_password")}
+                </span>
+                <TextInput
+                  type={showNew ? "text" : "password"}
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                  autoComplete="new-password"
+                  required
+                  minLength={12}
+                  className="rounded-full px-5"
+                  startAdornment={<KeyRound size={17} />}
+                  endAdornment={
+                    <button
+                      type="button"
+                      onClick={() => setShowNew((value) => !value)}
+                      className="rounded-full p-2 text-slate-500 hover:bg-slate-100 dark:hover:bg-white/10"
+                      aria-label={showNew ? t("login.hide_key") : t("login.show_key")}
+                    >
+                      {showNew ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
+                  }
+                />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-xs font-medium text-slate-600 dark:text-white/60">
+                  {t("identity_admin.confirm_new_password")}
+                </span>
+                <TextInput
+                  type={showConfirm ? "text" : "password"}
+                  value={confirm}
+                  onChange={(event) => setConfirm(event.target.value)}
+                  autoComplete="new-password"
+                  required
+                  minLength={12}
+                  className="rounded-full px-5"
+                  startAdornment={<KeyRound size={17} />}
+                  endAdornment={
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirm((value) => !value)}
+                      className="rounded-full p-2 text-slate-500 hover:bg-slate-100 dark:hover:bg-white/10"
+                      aria-label={showConfirm ? t("login.hide_key") : t("login.show_key")}
+                    >
+                      {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
+                  }
+                />
+              </label>
+
+              <Button type="submit" variant="primary" disabled={loading} className="h-11 w-full">
+                {loading ? t("identity_admin.saving") : t("identity_admin.save_password")}
+              </Button>
+            </form>
+          </section>
+        </Reveal>
+      </main>
+    </PageBackground>
   );
 }

--- a/pages/change-password/route.tsx
+++ b/pages/change-password/route.tsx
@@ -6,7 +6,7 @@ export const changePasswordRoute = {
   path: "/change-password",
   element: <Page />,
   auth: true,
-  layout: "dashboard",
+  layout: "standalone",
   nav: null,
   preload,
 };


### PR DESCRIPTION
## 变更说明

- 将强制修改密码页面从 `DashboardLayout` 中移出，改为独立认证页面，不再显示侧边栏和顶部 Header。
- 页面复用登录页背景、主题切换和单层表单卡片，内容在视口内水平、垂直居中。
- 当前密码、新密码、确认密码均增加密码图标和独立显隐按钮。
- 使用项目默认输入框尺寸和现有 Button、TextInput、PageBackground、Reveal 组件。
- 当用户仍处于 `must_change_password` 状态时，访问其他受保护页面会自动返回修改密码页。
- 保留后端现有的强制改密 API 访问限制，不用前端显示逻辑替代安全边界。

## 验证

- `bun run ci:pr`：通过
- `bun run test:ci`：79 files / 616 tests passed
- `bun run e2e`：54 passed
- `bun run build`：通过，仅既有 large chunk warning
- `bun run lint`：0 errors / 2 existing warnings
- `bun run design:check`：通过
- E2E 验证无 sidebar/header、表单水平垂直居中，以及改密前无法进入 dashboard
- 真实应用代码路径配合 mock 认证接口完成视觉检查
