### PR TITLE
feat: use governance trees and icon actions

### DIFF
--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -162,6 +162,37 @@ const menuItems = [
   },
 ];
 
+const roleMenuItems = [
+  {
+    code: "group.governance",
+    parent_code: "",
+    type: "directory",
+    path: "",
+    label_key: "shell.nav_group_governance",
+    icon: "users-round",
+    permission_code: "",
+    sort_order: 50,
+    visible: true,
+    enabled: true,
+    system_protected: true,
+    version: 1,
+  },
+  {
+    code: "governance.users",
+    parent_code: "group.governance",
+    type: "menu",
+    path: "/users",
+    label_key: "shell.nav_users",
+    icon: "user-round",
+    permission_code: "tenant.users.read",
+    sort_order: 20,
+    visible: true,
+    enabled: true,
+    system_protected: true,
+    version: 1,
+  },
+];
+
 const standardTenant = {
   ...principal.home_tenant,
   id: "t-acme",
@@ -176,12 +207,15 @@ async function mockIdentity(
   roles = [administratorRole],
   users = [principal.user],
   menus = menuItems,
+  principalMenus?: typeof roleMenuItems,
 ) {
   await page.route("**/v0/auth/me", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ principal }),
+      body: JSON.stringify({
+        principal: principalMenus ? { ...principal, menus: principalMenus } : principal,
+      }),
     }),
   );
   await page.route("**/v0/management/**", (route) => {
@@ -196,8 +230,15 @@ async function mockIdentity(
           code,
           name: code,
           scope: code.startsWith("platform.") ? "platform" : "tenant",
-          resource: code.split(".").slice(0, -1).join("."),
+          resource:
+            code.startsWith("tenant.") || code.startsWith("platform.")
+              ? (code.split(".")[1] ?? "")
+              : code.split(".").slice(0, -1).join("_"),
           action: code.split(".").at(-1),
+          menu_code:
+            code.startsWith("tenant.users.") || code.startsWith("platform.users.")
+              ? "governance.users"
+              : "",
           sensitive: false,
         })),
       },
@@ -382,6 +423,9 @@ test("uses a switch for the two user availability states", async ({ page }) => {
   const memberRow = page.locator('[data-vt-row-key="u-member"]');
   await expect(memberRow.getByRole("switch")).toHaveAttribute("aria-checked", "true");
   await expect(memberRow.getByRole("combobox")).toHaveCount(0);
+  await expect(memberRow.getByRole("button", { name: "Reset password" })).toHaveText("");
+  await expect(memberRow.getByRole("button", { name: "Delete" })).toHaveText("");
+  await expect(memberRow.getByRole("button", { name: "More actions" })).toHaveCount(0);
   await memberRow.getByRole("switch").click();
   await expect(page.getByRole("dialog", { name: "Disable user" })).toBeVisible();
 });
@@ -403,13 +447,28 @@ test("edits role permissions and assigns users from action modals", async ({ pag
     [principal.home_tenant],
     [administratorRole, operatorRole],
     [principal.user, memberUser],
+    menuItems,
+    roleMenuItems,
   );
   await page.goto("/#/roles");
 
+  await page.getByRole("button", { name: "New role" }).click();
+  await expect(page.getByRole("dialog", { name: "New role" }).getByLabel("Role code")).toHaveCount(
+    0,
+  );
+  await page.keyboard.press("Escape");
+
   const roleRow = page.locator('[data-vt-row-key="r-operator"]');
-  await roleRow.getByRole("button", { name: "Edit permissions" }).click();
+  const permissionButton = roleRow.getByRole("button", { name: "Edit permissions" });
+  const assignButton = roleRow.getByRole("button", { name: "Assign users" });
+  await expect(permissionButton).toHaveText("");
+  await expect(assignButton).toHaveText("");
+  await permissionButton.click();
   await expect(page.getByRole("dialog", { name: "Permissions for Operator" })).toBeVisible();
-  await expect(page.getByRole("dialog").getByRole("checkbox").first()).toBeVisible();
+  const permissionDialog = page.getByRole("dialog");
+  await expect(permissionDialog.getByRole("tree")).toBeVisible();
+  await expect(permissionDialog.getByRole("treeitem", { name: /Users/ })).toBeVisible();
+  await expect(permissionDialog.getByRole("checkbox", { name: "Update Users" })).toBeVisible();
   await page.keyboard.press("Escape");
 
   await roleRow.getByRole("button", { name: "Assign users" }).click();
@@ -434,6 +493,10 @@ test("manages dynamic menu visibility and ordering", async ({ page }) => {
   await page.goto("/#/menu-management");
 
   await expect(page.getByRole("heading", { name: "Menu Management", level: 2 })).toBeVisible();
+  const systemGroupRow = page.locator('[data-vt-row-key="group.system"]');
+  await systemGroupRow.getByRole("button", { name: "Collapse" }).click();
+  await expect(page.locator('[data-vt-row-key="system.config"]')).toHaveCount(0);
+  await systemGroupRow.getByRole("button", { name: "Expand", exact: true }).click();
   const menuRow = page.locator('[data-vt-row-key="system.config"]');
   await expect(menuRow.getByRole("switch")).toHaveCount(2);
   await menuRow.getByRole("button", { name: "Adjust order" }).click();
@@ -543,7 +606,7 @@ test("creates a tenant without selecting it on the login page", async ({ page })
   });
   await page.goto("/#/tenants");
   await page.getByRole("button", { name: "New tenant" }).click();
-  await page.getByLabel("Slug", { exact: true }).fill("tenant-a");
+  await expect(page.getByLabel("Slug", { exact: true })).toHaveCount(0);
   await page.getByLabel("Name", { exact: true }).fill("Tenant A");
   await page.getByLabel("Expires at", { exact: true }).fill("2030-01-01T00:00");
   await page.getByLabel("Admin username", { exact: true }).fill("tenant-admin");
@@ -552,8 +615,8 @@ test("creates a tenant without selecting it on the login page", async ({ page })
   await page.getByLabel("Description", { exact: true }).fill("Primary tenant");
   await page.getByRole("button", { name: "Create tenant" }).click();
   await expect.poll(() => createBody).not.toBeNull();
+  expect(createBody).not.toHaveProperty("slug");
   expect(createBody).toMatchObject({
-    slug: "tenant-a",
     name: "Tenant A",
     admin_username: "tenant-admin",
     admin_display_name: "Tenant Admin",

--- a/packages/api-client/src/endpoints/__tests__/identity.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/identity.test.ts
@@ -47,6 +47,45 @@ describe("identityApi", () => {
     expect(headers.get("Authorization")).toBe("Bearer cps_test");
   });
 
+  test("creates tenants without a caller-provided identifier", async () => {
+    apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ tenant: {}, admin: {} }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await identityApi.createTenant({
+      name: "Tenant A",
+      description: "Primary tenant",
+      expires_at: "2030-01-01T00:00:00Z",
+      admin_username: "tenant-admin",
+      admin_display_name: "Tenant Admin",
+      admin_password: "tenant-password-123",
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).not.toHaveProperty("slug");
+  });
+
+  test("creates roles without a caller-provided code", async () => {
+    apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "role-a" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await identityApi.createRole({
+      name: "Operator",
+      description: "Operates users",
+      permissions: [],
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      name: "Operator",
+      description: "Operates users",
+      permissions: [],
+    });
+  });
+
   test("updates tenant details with optimistic versioning", async () => {
     apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/packages/api-client/src/endpoints/identity.ts
+++ b/packages/api-client/src/endpoints/identity.ts
@@ -84,6 +84,7 @@ export interface PermissionIdentity {
   scope: "platform" | "tenant";
   resource: string;
   action: string;
+  menu_code: string;
   sensitive: boolean;
 }
 
@@ -109,7 +110,6 @@ export const identityApi = {
     apiClient.put<void>("/../auth/password", body),
   tenants: () => apiClient.get<{ items: TenantIdentity[] }>("/tenants"),
   createTenant: (body: {
-    slug: string;
     name: string;
     description: string;
     expires_at: string;
@@ -159,7 +159,7 @@ export const identityApi = {
     return menu;
   },
   permissions: () => apiClient.get<{ items: PermissionIdentity[] }>("/permissions"),
-  createRole: (body: { code: string; name: string; description: string; permissions: string[] }) =>
+  createRole: (body: { name: string; description: string; permissions: string[] }) =>
     apiClient.post<RoleIdentity>("/roles", body),
   auditLogs: () => apiClient.get<{ items: AuditLogIdentity[] }>("/audit-logs"),
   deleteRole: (id: string) => apiClient.delete<void>(`/roles/${encodeURIComponent(id)}`),

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4326,6 +4326,8 @@
     "menu_enabled": "Enabled",
     "sort_order": "Order",
     "adjust_order": "Adjust order",
+    "tree_expand": "Expand",
+    "tree_collapse": "Collapse",
     "change_menu_visible": "Change visibility for menu {{name}}",
     "change_menu_enabled": "Change enabled state for menu {{name}}",
     "menu_management_title": "Menu Management",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2500,6 +2500,8 @@
     "menu_enabled": "Включено",
     "sort_order": "Порядок",
     "adjust_order": "Изменить порядок",
+    "tree_expand": "Развернуть",
+    "tree_collapse": "Свернуть",
     "change_menu_visible": "Изменить видимость меню {{name}}",
     "change_menu_enabled": "Изменить состояние меню {{name}}",
     "menu_management_title": "Управление меню",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4340,6 +4340,8 @@
     "menu_enabled": "启用",
     "sort_order": "排序",
     "adjust_order": "调整排序",
+    "tree_expand": "展开",
+    "tree_collapse": "收起",
     "change_menu_visible": "切换菜单 {{name}} 的显示状态",
     "change_menu_enabled": "切换菜单 {{name}} 的启用状态",
     "menu_management_title": "菜单管理",

--- a/pages/menu-management/MenuManagementPage.tsx
+++ b/pages/menu-management/MenuManagementPage.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { Menu as MenuIcon, Settings2 } from "lucide-react";
+import { ChevronRight, FileText, FolderTree, Settings2 } from "lucide-react";
 import { identityApi, type MenuIdentity } from "@code-proxy/api-client";
 import {
   Button,
@@ -20,6 +20,8 @@ export function MenuManagementPage() {
   const [editing, setEditing] = useState<MenuIdentity | null>(null);
   const [sortOrder, setSortOrder] = useState("0");
   const [busy, setBusy] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const expansionInitialized = useRef(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -32,24 +34,41 @@ export function MenuManagementPage() {
 
   useEffect(() => void load(), [load]);
 
-  const rows = useMemo(() => {
-    const byParent = new Map<string, MenuIdentity[]>();
+  const childrenByParent = useMemo(() => {
+    const children = new Map<string, MenuIdentity[]>();
     for (const menu of menus) {
-      byParent.set(menu.parent_code, [...(byParent.get(menu.parent_code) ?? []), menu]);
+      children.set(menu.parent_code, [...(children.get(menu.parent_code) ?? []), menu]);
     }
-    for (const children of byParent.values()) {
-      children.sort((a, b) => a.sort_order - b.sort_order || a.code.localeCompare(b.code));
+    for (const siblings of children.values()) {
+      siblings.sort((a, b) => a.sort_order - b.sort_order || a.code.localeCompare(b.code));
     }
-    const result: Array<MenuIdentity & { depth: number }> = [];
+    return children;
+  }, [menus]);
+
+  useEffect(() => {
+    if (expansionInitialized.current || menus.length === 0) return;
+    expansionInitialized.current = true;
+    setExpanded(
+      new Set(
+        menus
+          .filter((menu) => (childrenByParent.get(menu.code)?.length ?? 0) > 0)
+          .map((menu) => menu.code),
+      ),
+    );
+  }, [childrenByParent, menus]);
+
+  const rows = useMemo(() => {
+    const result: Array<MenuIdentity & { depth: number; hasChildren: boolean }> = [];
     const append = (parentCode: string, depth: number) => {
-      for (const menu of byParent.get(parentCode) ?? []) {
-        result.push({ ...menu, depth });
-        append(menu.code, depth + 1);
+      for (const menu of childrenByParent.get(parentCode) ?? []) {
+        const hasChildren = (childrenByParent.get(menu.code)?.length ?? 0) > 0;
+        result.push({ ...menu, depth, hasChildren });
+        if (hasChildren && expanded.has(menu.code)) append(menu.code, depth + 1);
       }
     };
     append("", 0);
     return result;
-  }, [menus]);
+  }, [childrenByParent, expanded]);
 
   const updateMenu = useCallback(
     async (
@@ -86,19 +105,52 @@ export function MenuManagementPage() {
         key: "menu",
         label: t("identity_admin.menu"),
         width: "w-56",
-        render: (menu) => (
-          <div className="flex min-w-0 items-center gap-2" style={{ paddingLeft: menu.depth * 20 }}>
-            <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-slate-100 text-slate-500 dark:bg-white/8 dark:text-slate-300">
-              <MenuIcon size={15} />
-            </span>
-            <span className="min-w-0">
-              <span className="block truncate font-medium text-slate-900 dark:text-white">
-                {t(menu.label_key, { defaultValue: menu.code })}
+        render: (menu) => {
+          const isExpanded = expanded.has(menu.code);
+          const label = t(menu.label_key, { defaultValue: menu.code });
+          const Icon = menu.type === "directory" ? FolderTree : FileText;
+          return (
+            <div
+              className="flex min-w-0 items-center gap-2"
+              style={{ paddingLeft: menu.depth * 22 }}
+            >
+              {menu.hasChildren ? (
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  tooltip={
+                    isExpanded ? t("identity_admin.tree_collapse") : t("identity_admin.tree_expand")
+                  }
+                  aria-expanded={isExpanded}
+                  onClick={() => {
+                    setExpanded((current) => {
+                      const next = new Set(current);
+                      if (isExpanded) next.delete(menu.code);
+                      else next.add(menu.code);
+                      return next;
+                    });
+                  }}
+                >
+                  <ChevronRight
+                    size={15}
+                    className={
+                      isExpanded ? "rotate-90 transition-transform" : "transition-transform"
+                    }
+                  />
+                </Button>
+              ) : (
+                <span className="h-7 w-7" aria-hidden="true" />
+              )}
+              <Icon size={16} className="shrink-0 text-slate-400" aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="block truncate font-medium text-slate-900 dark:text-white">
+                  {label}
+                </span>
+                <span className="block truncate text-xs text-slate-400">{menu.code}</span>
               </span>
-              <span className="block truncate text-xs text-slate-400">{menu.code}</span>
-            </span>
-          </div>
-        ),
+            </div>
+          );
+        },
       },
       {
         key: "type",
@@ -155,23 +207,26 @@ export function MenuManagementPage() {
         label: t("identity_admin.sort_order"),
         minWidthPx: 96,
         render: (menu) => (
-          <Button
-            size="xs"
-            variant="ghost"
-            onClick={() => {
-              setEditing(menu);
-              setSortOrder(String(menu.sort_order));
-            }}
-            aria-label={t("identity_admin.adjust_order")}
-            tooltip={t("identity_admin.adjust_order")}
-          >
-            <Settings2 size={14} />
-            {menu.sort_order}
-          </Button>
+          <div className="flex items-center gap-2">
+            <span className="min-w-5 text-sm tabular-nums text-slate-600 dark:text-slate-300">
+              {menu.sort_order}
+            </span>
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={() => {
+                setEditing(menu);
+                setSortOrder(String(menu.sort_order));
+              }}
+              tooltip={t("identity_admin.adjust_order")}
+            >
+              <Settings2 size={14} />
+            </Button>
+          </div>
         ),
       },
     ],
-    [busy, t, updateMenu],
+    [busy, expanded, t, updateMenu],
   );
 
   const saveOrder = async (event: FormEvent) => {

--- a/pages/roles/PermissionTree.tsx
+++ b/pages/roles/PermissionTree.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from "react";
+import { ChevronRight, FileKey2, Folder, PanelTop } from "lucide-react";
+import { Button, Checkbox } from "@code-proxy/ui";
+import type { MenuIdentity, PermissionIdentity } from "@code-proxy/api-client";
+
+export interface PermissionTreeNode {
+  id: string;
+  kind: "directory" | "menu" | "permission";
+  label: string;
+  description: string;
+  permissionCodes: string[];
+  children: PermissionTreeNode[];
+}
+
+interface BuildPermissionTreeOptions {
+  menus: MenuIdentity[];
+  permissions: PermissionIdentity[];
+  menuLabel: (menu: MenuIdentity) => string;
+  permissionLabel: (permission: PermissionIdentity) => string;
+  resourceLabel: (resource: string) => string;
+}
+
+export function buildPermissionTree({
+  menus,
+  permissions,
+  menuLabel,
+  permissionLabel,
+  resourceLabel,
+}: BuildPermissionTreeOptions): PermissionTreeNode[] {
+  const menuByCode = new Map(menus.map((menu) => [menu.code, menu]));
+  const childMenus = new Map<string, MenuIdentity[]>();
+  for (const menu of menus) {
+    childMenus.set(menu.parent_code, [...(childMenus.get(menu.parent_code) ?? []), menu]);
+  }
+  for (const children of childMenus.values()) {
+    children.sort((a, b) => a.sort_order - b.sort_order || a.code.localeCompare(b.code));
+  }
+
+  const permissionsByMenu = new Map<string, PermissionIdentity[]>();
+  const unmatched: PermissionIdentity[] = [];
+  for (const permission of permissions) {
+    if (permission.menu_code && menuByCode.has(permission.menu_code)) {
+      permissionsByMenu.set(permission.menu_code, [
+        ...(permissionsByMenu.get(permission.menu_code) ?? []),
+        permission,
+      ]);
+    } else {
+      unmatched.push(permission);
+    }
+  }
+
+  const buildMenuNode = (menu: MenuIdentity): PermissionTreeNode | null => {
+    const mapped = permissionsByMenu.get(menu.code) ?? [];
+    const direct = mapped.filter((permission) => permission.code === menu.permission_code);
+    const actions = mapped
+      .filter((permission) => permission.code !== menu.permission_code)
+      .map((permission) => ({
+        id: `permission:${permission.code}`,
+        kind: "permission" as const,
+        label: permissionLabel(permission),
+        description: permission.code,
+        permissionCodes: [permission.code],
+        children: [],
+      }));
+    const children = (childMenus.get(menu.code) ?? [])
+      .map(buildMenuNode)
+      .filter((node): node is PermissionTreeNode => node !== null);
+    if (direct.length === 0 && actions.length === 0 && children.length === 0) return null;
+    return {
+      id: `menu:${menu.code}`,
+      kind: menu.type,
+      label: menuLabel(menu),
+      description: menu.path || menu.code,
+      permissionCodes: direct.map((permission) => permission.code),
+      children: [...children, ...actions],
+    };
+  };
+
+  const roots = (childMenus.get("") ?? [])
+    .map(buildMenuNode)
+    .filter((node): node is PermissionTreeNode => node !== null);
+
+  const unmatchedByResource = new Map<string, PermissionIdentity[]>();
+  for (const permission of unmatched) {
+    unmatchedByResource.set(permission.resource, [
+      ...(unmatchedByResource.get(permission.resource) ?? []),
+      permission,
+    ]);
+  }
+  for (const [resource, resourcePermissions] of unmatchedByResource) {
+    roots.push({
+      id: `resource:${resource}`,
+      kind: "directory",
+      label: resourceLabel(resource),
+      description: resource,
+      permissionCodes: [],
+      children: resourcePermissions.map((permission) => ({
+        id: `permission:${permission.code}`,
+        kind: "permission",
+        label: permissionLabel(permission),
+        description: permission.code,
+        permissionCodes: [permission.code],
+        children: [],
+      })),
+    });
+  }
+  return roots;
+}
+
+function collectPermissionCodes(node: PermissionTreeNode): string[] {
+  return [node.permissionCodes, ...node.children.map(collectPermissionCodes)].flat();
+}
+
+function collectExpandableIds(nodes: PermissionTreeNode[]): string[] {
+  return nodes.flatMap((node) => [
+    ...(node.children.length > 0 ? [node.id] : []),
+    ...collectExpandableIds(node.children),
+  ]);
+}
+
+interface PermissionTreeProps {
+  nodes: PermissionTreeNode[];
+  selected: Set<string>;
+  disabled?: boolean;
+  onChange: (selected: Set<string>) => void;
+  expandLabel: string;
+  collapseLabel: string;
+}
+
+export function PermissionTree({
+  nodes,
+  selected,
+  disabled = false,
+  onChange,
+  expandLabel,
+  collapseLabel,
+}: PermissionTreeProps) {
+  const expandableIds = useMemo(() => collectExpandableIds(nodes), [nodes]);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(expandableIds));
+
+  useEffect(() => {
+    setExpanded((current) => new Set([...current, ...expandableIds]));
+  }, [expandableIds]);
+
+  const renderNode = (node: PermissionTreeNode, depth: number) => {
+    const codes = collectPermissionCodes(node);
+    const selectedCount = codes.filter((code) => selected.has(code)).length;
+    const checked = codes.length > 0 && selectedCount === codes.length;
+    const indeterminate = selectedCount > 0 && !checked;
+    const hasChildren = node.children.length > 0;
+    const isExpanded = expanded.has(node.id);
+    const Icon = node.kind === "directory" ? Folder : node.kind === "menu" ? PanelTop : FileKey2;
+
+    return (
+      <li
+        key={node.id}
+        role="treeitem"
+        aria-level={depth + 1}
+        aria-expanded={hasChildren ? isExpanded : undefined}
+      >
+        <div
+          className="flex min-h-11 items-center gap-2 border-b border-black/[0.045] px-3 py-2 last:border-b-0 hover:bg-slate-50/80 dark:border-white/[0.055] dark:hover:bg-white/[0.035]"
+          style={{ paddingLeft: 12 + depth * 24 }}
+        >
+          {hasChildren ? (
+            <Button
+              size="xs"
+              variant="ghost"
+              tooltip={isExpanded ? collapseLabel : expandLabel}
+              onClick={() => {
+                setExpanded((current) => {
+                  const next = new Set(current);
+                  if (isExpanded) next.delete(node.id);
+                  else next.add(node.id);
+                  return next;
+                });
+              }}
+            >
+              <ChevronRight
+                size={15}
+                className={isExpanded ? "rotate-90 transition-transform" : "transition-transform"}
+              />
+            </Button>
+          ) : (
+            <span className="h-7 w-7" aria-hidden="true" />
+          )}
+          <Checkbox
+            checked={checked}
+            indeterminate={indeterminate}
+            disabled={disabled || codes.length === 0}
+            aria-label={node.label}
+            onCheckedChange={(nextChecked) => {
+              const next = new Set(selected);
+              for (const code of codes) {
+                if (nextChecked) next.add(code);
+                else next.delete(code);
+              }
+              onChange(next);
+            }}
+          />
+          <Icon size={15} className="shrink-0 text-slate-400" aria-hidden="true" />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+              {node.label}
+            </span>
+            <span className="block truncate text-xs text-slate-400">{node.description}</span>
+          </span>
+        </div>
+        {hasChildren && isExpanded ? (
+          <ul role="group">{node.children.map((child) => renderNode(child, depth + 1))}</ul>
+        ) : null}
+      </li>
+    );
+  };
+
+  return (
+    <ul
+      role="tree"
+      className="overflow-hidden rounded-2xl bg-slate-50/70 ring-1 ring-black/[0.045] dark:bg-white/[0.025] dark:ring-white/[0.055]"
+    >
+      {nodes.map((node) => renderNode(node, 0))}
+    </ul>
+  );
+}

--- a/pages/roles/RolesPage.tsx
+++ b/pages/roles/RolesPage.tsx
@@ -19,13 +19,17 @@ import {
 } from "@code-proxy/ui";
 import { PermissionGate } from "@app/guards/PermissionGate";
 import { useAuth } from "@app/providers/AuthProvider";
+import { buildPermissionTree, PermissionTree } from "./PermissionTree";
 
-const emptyForm = { code: "", name: "", description: "" };
+const emptyForm = { name: "", description: "" };
 
 export function RolesPage() {
   const { notify } = useToast();
   const { t } = useTranslation();
-  const { can } = useAuth();
+  const {
+    can,
+    state: { principal },
+  } = useAuth();
   const [roles, setRoles] = useState<RoleIdentity[]>([]);
   const [permissions, setPermissions] = useState<PermissionIdentity[]>([]);
   const [users, setUsers] = useState<UserIdentity[]>([]);
@@ -121,13 +125,28 @@ export function RolesPage() {
     );
   }, [can, permissionRole, permissions]);
 
-  const permissionGroups = useMemo(() => {
-    const groups = new Map<string, PermissionIdentity[]>();
-    for (const permission of availablePermissions) {
-      groups.set(permission.resource, [...(groups.get(permission.resource) ?? []), permission]);
-    }
-    return groups;
-  }, [availablePermissions]);
+  const menuLabel = useCallback(
+    (menu: { label_key: string; code: string }) => t(menu.label_key, { defaultValue: menu.code }),
+    [t],
+  );
+
+  const resourceLabel = useCallback(
+    (resource: string) =>
+      t(`identity_admin.permission_resources.${resource}`, { defaultValue: resource }),
+    [t],
+  );
+
+  const permissionTreeNodes = useMemo(
+    () =>
+      buildPermissionTree({
+        menus: principal?.menus ?? [],
+        permissions: availablePermissions,
+        menuLabel,
+        permissionLabel,
+        resourceLabel,
+      }),
+    [availablePermissions, menuLabel, permissionLabel, principal?.menus, resourceLabel],
+  );
 
   const assignedUserCount = useMemo(() => {
     const counts = new Map<string, number>();
@@ -186,26 +205,31 @@ export function RolesPage() {
       {
         key: "actions",
         label: t("identity_admin.actions"),
-        minWidthPx: 300,
-        width: "w-64",
+        minWidthPx: 132,
+        width: "w-36",
         lockOrder: "end",
         render: (role) => (
           <div className="flex items-center gap-2">
             <Button
               size="xs"
+              variant="ghost"
+              tooltip={
+                role.system_protected || !canUpdateRoles
+                  ? t("identity_admin.view_permissions")
+                  : t("identity_admin.edit_permissions")
+              }
               onClick={() => {
                 setPermissionRole(role);
                 setSelectedPermissions(new Set(role.permissions));
               }}
             >
-              <ShieldCheck size={14} />
-              {role.system_protected || !canUpdateRoles
-                ? t("identity_admin.view_permissions")
-                : t("identity_admin.edit_permissions")}
+              <ShieldCheck size={15} />
             </Button>
             {role.scope === "tenant" && canAssignUsers ? (
               <Button
                 size="xs"
+                variant="ghost"
+                tooltip={t("identity_admin.assign_users")}
                 onClick={() => {
                   setUserRole(role);
                   setSelectedUsers(
@@ -217,19 +241,19 @@ export function RolesPage() {
                   );
                 }}
               >
-                <UserRoundCog size={14} />
-                {t("identity_admin.assign_users")}
+                <UserRoundCog size={15} />
               </Button>
             ) : null}
             {!role.system_protected ? (
               <PermissionGate permission="tenant.roles.delete">
                 <Button
                   size="xs"
-                  variant="error"
+                  variant="ghost"
+                  className="text-rose-600 hover:text-rose-700 dark:text-rose-300 dark:hover:text-rose-200"
                   onClick={() => setDeleteRole(role)}
                   tooltip={t("identity_admin.delete")}
                 >
-                  <Trash2 size={14} />
+                  <Trash2 size={15} />
                 </Button>
               </PermissionGate>
             ) : null}
@@ -328,16 +352,6 @@ export function RolesPage() {
         <form id="create-role-form" onSubmit={createRole} className="space-y-4">
           <label className="block space-y-1.5">
             <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
-              {t("identity_admin.role_code")}
-            </span>
-            <TextInput
-              value={form.code}
-              onChange={(event) => setForm({ ...form, code: event.target.value })}
-              required
-            />
-          </label>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
               {t("identity_admin.role_name")}
             </span>
             <TextInput
@@ -383,45 +397,14 @@ export function RolesPage() {
           )
         }
       >
-        <div className="space-y-6">
-          {[...permissionGroups].map(([resource, resourcePermissions]) => (
-            <fieldset
-              key={resource}
-              disabled={Boolean(permissionRole?.system_protected) || !canUpdateRoles}
-            >
-              <legend className="mb-2 text-sm font-semibold text-slate-900 dark:text-white">
-                {t(`identity_admin.permission_resources.${resource}`, { defaultValue: resource })}
-              </legend>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {resourcePermissions.map((permission) => (
-                  <label
-                    key={permission.code}
-                    className="flex cursor-pointer items-start gap-3 rounded-xl bg-slate-50 px-3.5 py-3 transition-colors hover:bg-slate-100 dark:bg-white/5 dark:hover:bg-white/8"
-                  >
-                    <Checkbox
-                      checked={selectedPermissions.has(permission.code)}
-                      disabled={Boolean(permissionRole?.system_protected) || !canUpdateRoles}
-                      onCheckedChange={(checked) => {
-                        const next = new Set(selectedPermissions);
-                        if (checked) next.add(permission.code);
-                        else next.delete(permission.code);
-                        setSelectedPermissions(next);
-                      }}
-                    />
-                    <span className="min-w-0">
-                      <span className="block text-sm font-medium text-slate-800 dark:text-slate-200">
-                        {permissionLabel(permission)}
-                      </span>
-                      <span className="mt-0.5 block truncate text-xs text-slate-400">
-                        {permission.code}
-                      </span>
-                    </span>
-                  </label>
-                ))}
-              </div>
-            </fieldset>
-          ))}
-        </div>
+        <PermissionTree
+          nodes={permissionTreeNodes}
+          selected={selectedPermissions}
+          disabled={Boolean(permissionRole?.system_protected) || !canUpdateRoles}
+          onChange={setSelectedPermissions}
+          expandLabel={t("identity_admin.tree_expand")}
+          collapseLabel={t("identity_admin.tree_collapse")}
+        />
       </Modal>
 
       <Modal

--- a/pages/tenants/TenantsPage.tsx
+++ b/pages/tenants/TenantsPage.tsx
@@ -14,7 +14,6 @@ import {
 import { PermissionGate } from "@app/guards/PermissionGate";
 
 const emptyCreateForm = {
-  slug: "",
   name: "",
   expires_at: "",
   admin_username: "",
@@ -290,7 +289,6 @@ export function TenantsPage() {
         <form id="create-tenant-form" onSubmit={createTenant} className="grid gap-4 md:grid-cols-2">
           {(
             [
-              ["slug", t("identity_admin.slug")],
               ["name", t("identity_admin.name")],
               ["expires_at", t("identity_admin.expires_at")],
               ["admin_username", t("identity_admin.admin_username")],

--- a/pages/users/UsersPage.tsx
+++ b/pages/users/UsersPage.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { KeyRound, MoreHorizontal, Trash2 } from "lucide-react";
+import { KeyRound, Trash2 } from "lucide-react";
 import { identityApi, type RoleIdentity, type UserIdentity } from "@code-proxy/api-client";
 import {
   Button,
   ConfirmModal,
   DataTable,
-  DropdownMenu,
   Modal,
   MultiSelect,
   TextInput,
@@ -215,45 +214,40 @@ export function UsersPage() {
       {
         key: "actions",
         label: t("identity_admin.actions"),
-        minWidthPx: 80,
-        width: "w-20",
+        minWidthPx: 104,
+        width: "w-28",
         lockOrder: "end",
         render: (user) => {
           const protectedUser = isProtected(user);
           return (
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <Button size="xs" aria-label={t("identity_admin.more_actions")}>
-                  <MoreHorizontal size={15} />
+            <div className="flex items-center gap-1.5">
+              <PermissionGate permission="tenant.users.reset_password">
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  disabled={protectedUser || busy}
+                  tooltip={t("identity_admin.reset_password")}
+                  onClick={() => {
+                    setResetUser(user);
+                    setResetPassword("");
+                  }}
+                >
+                  <KeyRound size={15} />
                 </Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content align="end">
-                  <PermissionGate permission="tenant.users.reset_password">
-                    <DropdownMenu.Item
-                      disabled={protectedUser}
-                      onSelect={() => {
-                        setResetUser(user);
-                        setResetPassword("");
-                      }}
-                    >
-                      <KeyRound size={15} />
-                      {t("identity_admin.reset_password")}
-                    </DropdownMenu.Item>
-                  </PermissionGate>
-                  <PermissionGate permission="tenant.users.delete">
-                    <DropdownMenu.Item
-                      disabled={protectedUser}
-                      onSelect={() => setDeleteUser(user)}
-                      className="text-rose-600 focus:text-rose-700 dark:text-rose-300"
-                    >
-                      <Trash2 size={15} />
-                      {t("identity_admin.delete")}
-                    </DropdownMenu.Item>
-                  </PermissionGate>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
+              </PermissionGate>
+              <PermissionGate permission="tenant.users.delete">
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  className="text-rose-600 hover:text-rose-700 dark:text-rose-300 dark:hover:text-rose-200"
+                  disabled={protectedUser || busy}
+                  tooltip={t("identity_admin.delete")}
+                  onClick={() => setDeleteUser(user)}
+                >
+                  <Trash2 size={15} />
+                </Button>
+              </PermissionGate>
+            </div>
           );
         },
       },


### PR DESCRIPTION
## 修改内容

- 菜单管理改为可展开、折叠的多级树形表格
- 角色权限改为目录、页面和按钮三级权限树，支持级联选择与半选状态
- 角色及用户操作列统一为纯 Icon 按钮和 Tooltip
- 创建租户与角色表单移除手工编码字段
- 补充 API、权限树、菜单展开和 Icon 操作 E2E 覆盖

## 交互与视觉

- 继续复用 DataTable、Modal、Checkbox、ToggleSwitch 和 Button
- 桌面 1440px 与移动端 390px 真实应用页面均完成视觉检查，无横向溢出

## 验证

- `bun run ci:pr`，79 files / 620 tests passed，生产构建通过
- `bun run e2e`，60 passed
- Lint 0 errors，仅保留 2 个既有 warnings
