### PR TITLE
fix: show auth-files quota errors as badge with tooltip

### DIFF
--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -786,12 +786,12 @@ export function AuthFilesPage() {
       ) ?? null)
     : null;
   const {
-    translateQuotaText,
     formatPlanTypeLabel,
     renderRestrictionBadges,
     renderClaudeOAuthHealthBadges,
     renderSubscriptionBadge,
     renderQuotaBar,
+    renderQuotaErrorBadge,
     renderFilesViewModeTabs,
     fileColumns,
   } = useAuthFilesFilesPresentation({
@@ -893,11 +893,11 @@ export function AuthFilesPage() {
         resolveAuthFileStats={resolveAuthFileStats}
         toggleFileSelection={toggleFileSelection}
         formatPlanTypeLabel={formatPlanTypeLabel}
-        translateQuotaText={translateQuotaText}
         renderRestrictionBadges={renderRestrictionBadges}
         renderClaudeOAuthHealthBadges={renderClaudeOAuthHealthBadges}
         renderSubscriptionBadge={renderSubscriptionBadge}
         renderQuotaBar={renderQuotaBar}
+        renderQuotaErrorBadge={renderQuotaErrorBadge}
         openTagsEditor={(file) => setTagsEditorFileName(file.name)}
         openDetail={openDetailWithQuotaRefresh}
         downloadAuthFile={downloadAuthFile}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -4983,7 +4983,10 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(
       within(screen.getByTestId("auth-files-cards")).getByRole("button", { name: "Refresh" }),
     );
-    expect(await screen.findByText("Request failed")).toBeInTheDocument();
+    const errorBadge = await screen.findByTestId("auth-file-quota-error-badge");
+    expect(errorBadge).toHaveTextContent("Error");
+    fireEvent.mouseEnter(errorBadge);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Request failed");
   });
 
   test("group overview summarizes current filtered results from shared quota state", async () => {

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -654,11 +654,11 @@ interface AuthFilesFilesTabProps {
   ) => { success: number; failure: number };
   toggleFileSelection: (name: string, checked: boolean) => void;
   formatPlanTypeLabel: (planType: string) => string;
-  translateQuotaText: (text: string) => string;
   renderRestrictionBadges: (file: AuthFileItem) => ReactNode | null;
   renderClaudeOAuthHealthBadges: (file: AuthFileItem) => ReactNode | null;
   renderSubscriptionBadge: (file: AuthFileItem) => ReactNode | null;
   renderQuotaBar: (label: string, item: QuotaItem | null) => ReactNode;
+  renderQuotaErrorBadge: (errorText: string) => ReactNode;
   openTagsEditor: (file: AuthFileItem) => void;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
@@ -735,11 +735,11 @@ export function AuthFilesFilesTab({
   resolveAuthFileStats,
   toggleFileSelection,
   formatPlanTypeLabel,
-  translateQuotaText,
   renderRestrictionBadges,
   renderClaudeOAuthHealthBadges,
   renderSubscriptionBadge,
   renderQuotaBar,
+  renderQuotaErrorBadge,
   openTagsEditor,
   openDetail,
   downloadAuthFile,
@@ -1744,11 +1744,11 @@ export function AuthFilesFilesTab({
                       >
                         {provider &&
                         (state.status === "error" || state.error) ? (
-                          <p className="truncate text-xs font-semibold text-rose-700 dark:text-rose-200">
-                            {translateQuotaText(
+                          <div className="mb-2 min-w-0">
+                            {renderQuotaErrorBadge(
                               state.error ?? t("common.error"),
                             )}
-                          </p>
+                          </div>
                         ) : null}
 
                         {!provider && slots.length === 0 ? (

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -508,6 +508,40 @@ export function useAuthFilesFilesPresentation({
     [formatQuotaResetTextCompact, t, translateQuotaText],
   );
 
+  const resolveQuotaErrorBadgeLabel = useCallback(
+    (errorText: string) => {
+      const translated = translateQuotaText(errorText);
+      const statusMatch = translated.match(/^(\d{3})\b/);
+      if (statusMatch) {
+        return t("auth_files.restriction_http_label", { status: statusMatch[1] });
+      }
+      return t("common.error");
+    },
+    [t, translateQuotaText],
+  );
+
+  const renderQuotaErrorBadge = useCallback(
+    (errorText: string): ReactNode => {
+      const detail = translateQuotaText(errorText || t("common.error"));
+      const label = resolveQuotaErrorBadgeLabel(detail);
+      return (
+        <HoverTooltip content={detail} placement="top" className="max-w-full">
+          <span
+            data-testid="auth-file-quota-error-badge"
+            className={[
+              "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums",
+              RESTRICTION_TONE_CLASSES.danger,
+            ].join(" ")}
+          >
+            <AlertTriangle size={11} className="shrink-0" />
+            <span className="min-w-0 truncate">{label}</span>
+          </span>
+        </HoverTooltip>
+      );
+    },
+    [resolveQuotaErrorBadgeLabel, t, translateQuotaText],
+  );
+
   const renderQuotaHoverContent = useCallback(
     (state: QuotaState, options?: { suppressItemMeta?: boolean }) => {
       const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
@@ -516,7 +550,7 @@ export function useAuthFilesFilesPresentation({
       return (
         <div className="space-y-1">
           {hasError ? (
-            <p className="max-w-80 truncate text-xs font-semibold text-rose-700 dark:text-rose-200">
+            <p className="max-w-80 whitespace-pre-wrap break-words text-xs font-semibold text-rose-700 dark:text-rose-200">
               {translateQuotaText(state.error ?? t("common.error"))}
             </p>
           ) : null}
@@ -886,20 +920,20 @@ export function useAuthFilesFilesPresentation({
             );
           };
 
+          if (hasError && items.length === 0) {
+            return renderQuotaErrorBadge(state.error ?? t("common.error"));
+          }
+
           return (
             <HoverTooltip
-              disabled={!hasError && items.length === 0}
+              disabled={items.length === 0}
               className="w-full min-w-0"
               content={renderQuotaHoverContent(displayState, {
                 suppressItemMeta: provider === "antigravity",
               })}
             >
               <div className="w-full min-w-0">
-                {hasError && items.length === 0 ? (
-                  <p className="truncate text-xs font-semibold text-rose-700 dark:text-rose-200">
-                    {translateQuotaText(state.error ?? t("common.error"))}
-                  </p>
-                ) : items.length === 0 ? (
+                {items.length === 0 ? (
                   <span className="text-xs text-slate-400 dark:text-white/40">--</span>
                 ) : (
                   renderQuotaLinePreview(pickQuotaPreviewItem(items, quotaPreviewMode) ?? items[0])
@@ -1053,6 +1087,7 @@ export function useAuthFilesFilesPresentation({
     quotaProgressCircle,
     refreshQuota,
     requestResetCredit,
+    renderQuotaErrorBadge,
     renderRestrictionBadges,
     renderClaudeOAuthHealthBadges,
     renderSubscriptionBadge,
@@ -1077,6 +1112,7 @@ export function useAuthFilesFilesPresentation({
     renderClaudeOAuthHealthBadges,
     renderSubscriptionBadge,
     renderQuotaBar,
+    renderQuotaErrorBadge,
     renderFilesViewModeTabs,
     fileColumns,
   };


### PR DESCRIPTION
## Summary
- Replace long red quota error text on auth-files cards/table with a compact danger badge.
- Show the full error message in HoverTooltip on hover.
- Keep HTTP status-prefixed labels like `401 Error` / `401 错误`, and fall back to the generic Error label otherwise.

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx`
- [x] Typecheck admin panel
- [ ] Manually verify auth-files cards view: quota 401 shows badge, hover shows full message