### PR TITLE
fix: resolve Routes child crash blocking /dashboard

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.test.tsx
+++ b/apps/admin-panel/src/app/AppRouter.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Outlet } from "react-router-dom";
+import { describe, expect, test, vi } from "vitest";
+import type { ReactNode } from "react";
+
+const principal = {
+  menus: [
+    {
+      code: "dashboard",
+      parent_code: "",
+      type: "menu" as const,
+      path: "/dashboard",
+      component: "dashboard",
+      link_url: "",
+      label_key: "shell.nav_dashboard",
+      title: "",
+      icon: "layout-dashboard",
+      permission_code: "dashboard.read",
+      sort_order: 10,
+      visible: true,
+      enabled: true,
+      badge_type: "",
+      badge_content: "",
+      hide_menu: false,
+      system_protected: true,
+      version: 1,
+    },
+    {
+      code: "docs.embed",
+      parent_code: "",
+      type: "embed" as const,
+      path: "/docs-embed",
+      component: "",
+      link_url: "https://example.com",
+      label_key: "shell.nav_docs",
+      title: "Docs",
+      icon: "link",
+      permission_code: "",
+      sort_order: 20,
+      visible: true,
+      enabled: true,
+      badge_type: "",
+      badge_content: "",
+      hide_menu: false,
+      system_protected: false,
+      version: 1,
+    },
+  ],
+  permissions: ["dashboard.read"],
+  user: {
+    display_name: "Admin",
+    username: "admin",
+    role_codes: [],
+    must_change_password: false,
+  },
+  effective_tenant: { type: "system", name: "System" },
+  home_tenant: { type: "system", name: "System" },
+  roles: [],
+  platform_admin: true,
+  kind: "user_session" as const,
+};
+
+vi.mock("@app/providers/AuthProvider", () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: () => ({
+    can: () => true,
+    state: {
+      isAuthenticated: true,
+      isRestoring: false,
+      principal,
+    },
+    actions: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchTenant: vi.fn(),
+      refresh: vi.fn(),
+    },
+  }),
+  useOptionalAuth: () => ({
+    can: () => true,
+    state: {
+      isAuthenticated: true,
+      isRestoring: false,
+      principal,
+    },
+    actions: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      switchTenant: vi.fn(),
+      refresh: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@app/guards/ProtectedRoute", () => ({
+  ProtectedRoute: () => <Outlet />,
+}));
+
+vi.mock("@app/layout/DashboardLayout", () => ({
+  DashboardLayout: () => (
+    <div data-testid="dashboard-layout">
+      <Outlet />
+    </div>
+  ),
+}));
+
+vi.mock("@app/update/AutoUpdatePrompt", () => ({
+  AutoUpdatePrompt: () => null,
+}));
+
+vi.mock("@/app/bootstrap/dismissAppLoader", () => ({
+  dismissAppLoader: vi.fn(),
+}));
+
+vi.mock("@pages/registry", async () => {
+  const React = await import("react");
+  return {
+    pageRoutes: [
+      {
+        path: "/login",
+        element: React.createElement("div", null, "login"),
+        auth: false,
+        layout: "standalone",
+        nav: null,
+      },
+      {
+        path: "/dashboard",
+        component: "dashboard",
+        element: React.createElement("div", { "data-testid": "dashboard-page" }, "dashboard"),
+        auth: true,
+        layout: "dashboard",
+        nav: { labelKey: "nav.dashboard" },
+        requiredPermission: "dashboard.read",
+      },
+    ],
+  };
+});
+
+vi.mock("@pages/embed/EmbedPage", () => ({
+  EmbedPage: () => <div data-testid="embed-page">embed</div>,
+}));
+
+import { AppRouter } from "./AppRouter";
+
+describe("AppRouter", () => {
+  test("renders dashboard without invalid Route children error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <AppRouter />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByTestId("dashboard-page")).toBeInTheDocument();
+    const routeChildErrors = errorSpy.mock.calls
+      .flat()
+      .map((arg) => String(arg ?? ""))
+      .filter((msg) => msg.includes("is not a <Route> component"));
+    expect(routeChildErrors).toEqual([]);
+    errorSpy.mockRestore();
+  });
+
+  test("registers embed menu paths as real routes", async () => {
+    render(
+      <MemoryRouter initialEntries={["/docs-embed"]}>
+        <AppRouter />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByTestId("embed-page")).toBeInTheDocument();
+  });
+});

--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useMemo } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { AuthProvider, useAuth } from "@app/providers/AuthProvider";
 import { ProtectedRoute } from "@/app/guards/ProtectedRoute";
@@ -39,9 +39,7 @@ const readyRoute = (element: React.ReactElement) => (
 );
 
 function menuChainEnabled(
-  menus:
-    | Array<{ code: string; parent_code: string; path: string; enabled: boolean }>
-    | undefined,
+  menus: Array<{ code: string; parent_code: string; path: string; enabled: boolean }> | undefined,
   path: string,
 ) {
   if (!menus?.length) return true;
@@ -63,27 +61,81 @@ function AuthorizedPage({ route }: { route: PageRoute }) {
   return readyRoute(route.element);
 }
 
-function DynamicEmbedRoutes() {
+function AuthorizedEmbedPage({ path }: { path: string }) {
   const { state } = useAuth();
-  const embeds =
-    state.principal?.menus?.filter(
-      (menu) => menu.type === "embed" && menu.path && menu.enabled && menu.visible,
-    ) ?? [];
+  if (!menuChainEnabled(state.principal?.menus, path)) return <ForbiddenPage />;
+  return readyRoute(<EmbedPage />);
+}
+
+/** Must render Routes itself so embed <Route>s are direct children of <Routes>. */
+function AuthenticatedRoutes() {
+  const { state } = useAuth();
+  const routes = pageRoutes;
+  const publicRoutes = routes.filter((r) => !r.auth);
+  const authStandaloneRoutes = routes.filter((r) => r.auth && r.layout === "standalone");
+  const authDashboardRoutes = routes.filter((r) => r.auth && r.layout === "dashboard");
+  const embedMenus = useMemo(
+    () =>
+      state.principal?.menus?.filter(
+        (menu) => menu.type === "embed" && menu.path && menu.enabled && menu.visible,
+      ) ?? [],
+    [state.principal?.menus],
+  );
+
   return (
     <>
-      {embeds.map((menu) => (
-        <Route
-          key={`embed:${menu.code}`}
-          path={menu.path}
-          element={
-            menuChainEnabled(state.principal?.menus, menu.path) ? (
-              readyRoute(<EmbedPage />)
-            ) : (
-              <ForbiddenPage />
-            )
-          }
-        />
-      ))}
+      <AutoUpdatePrompt />
+      <Suspense fallback={<RouteFallback />}>
+        <Routes>
+          {publicRoutes.flatMap((route) =>
+            (route.redirects ?? []).map((rd) => (
+              <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
+            )),
+          )}
+          <Route path="/login" element={<Navigate to="/dashboard" replace />} />
+          <Route element={<ProtectedRoute />}>
+            {authStandaloneRoutes.map((route) => (
+              <Route
+                key={route.path}
+                path={route.path}
+                element={<AuthorizedPage route={route} />}
+              />
+            ))}
+            <Route element={<DashboardLayout />}>
+              {authDashboardRoutes.map((route) => (
+                <Route
+                  key={route.path}
+                  path={route.path}
+                  element={<AuthorizedPage route={route} />}
+                />
+              ))}
+              {authDashboardRoutes.flatMap((route) =>
+                (route.redirects ?? []).map((rd) => (
+                  <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
+                )),
+              )}
+              {embedMenus.map((menu) => (
+                <Route
+                  key={`embed:${menu.code}`}
+                  path={menu.path}
+                  element={<AuthorizedEmbedPage path={menu.path} />}
+                />
+              ))}
+              {authDashboardRoutes
+                .filter((r) => r.hasWildcard)
+                .map((route) => (
+                  <Route
+                    key={`${route.path}-wildcard`}
+                    path={`${route.path}/*`}
+                    element={<AuthorizedPage route={route} />}
+                  />
+                ))}
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            </Route>
+          </Route>
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        </Routes>
+      </Suspense>
     </>
   );
 }
@@ -93,8 +145,6 @@ export function AppRouter() {
   const publicRoutes = routes.filter((r) => !r.auth);
   const loginRoute = publicRoutes.find((r) => r.path === "/login");
   const standalonePublicRoutes = publicRoutes.filter((r) => r.path !== "/login");
-  const authStandaloneRoutes = routes.filter((r) => r.auth && r.layout === "standalone");
-  const authDashboardRoutes = routes.filter((r) => r.auth && r.layout === "dashboard");
 
   return (
     <ThemeProvider>
@@ -102,7 +152,6 @@ export function AppRouter() {
         <div className="font-sans antialiased">
           <Suspense fallback={<RouteFallback />}>
             <Routes>
-              {/* Public routes */}
               {standalonePublicRoutes.map((route) => (
                 <Route key={route.path} path={route.path} element={readyRoute(route.element)} />
               ))}
@@ -117,66 +166,11 @@ export function AppRouter() {
                 />
               ) : null}
 
-              {/* Auth-protected routes */}
               <Route
                 path="*"
                 element={
                   <AuthProvider>
-                    <AutoUpdatePrompt />
-                    <Suspense fallback={<RouteFallback />}>
-                      <Routes>
-                        {publicRoutes.map((route) =>
-                          route.redirects?.map((rd) => (
-                            <Route
-                              key={rd.from}
-                              path={rd.from}
-                              element={<Navigate to={rd.to} replace />}
-                            />
-                          )),
-                        )}
-                        <Route path="/login" element={<Navigate to="/dashboard" replace />} />
-                        <Route element={<ProtectedRoute />}>
-                          {authStandaloneRoutes.map((route) => (
-                            <Route
-                              key={route.path}
-                              path={route.path}
-                              element={<AuthorizedPage route={route} />}
-                            />
-                          ))}
-                          <Route element={<DashboardLayout />}>
-                            {authDashboardRoutes.map((route) => (
-                              <Route
-                                key={route.path}
-                                path={route.path}
-                                element={<AuthorizedPage route={route} />}
-                              />
-                            ))}
-                            {authDashboardRoutes.flatMap((route) =>
-                              (route.redirects ?? []).map((rd) => (
-                                <Route
-                                  key={rd.from}
-                                  path={rd.from}
-                                  element={<Navigate to={rd.to} replace />}
-                                />
-                              )),
-                            )}
-                            {/* Wildcard for /ai-providers/* */}
-                            <DynamicEmbedRoutes />
-                            {authDashboardRoutes
-                              .filter((r) => r.hasWildcard)
-                              .map((route) => (
-                                <Route
-                                  key={`${route.path}-wildcard`}
-                                  path={`${route.path}/*`}
-                                  element={<AuthorizedPage route={route} />}
-                                />
-                              ))}
-                            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-                          </Route>
-                        </Route>
-                        <Route path="*" element={<Navigate to="/dashboard" replace />} />
-                      </Routes>
-                    </Suspense>
+                    <AuthenticatedRoutes />
                   </AuthProvider>
                 }
               />


### PR DESCRIPTION
## Summary
- Fix production crash: `is not a <Route> component` when opening `/manage/dashboard`
- Root cause: `<DynamicEmbedRoutes />` custom component nested under `<Routes>`
- Render embed `<Route>`s as direct children inside `AuthenticatedRoutes`
- Add AppRouter regression tests for dashboard + embed paths

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test:ci -- src/app/AppRouter.test.tsx src/app/layout/AppShell.test.tsx`
- [x] `bun run build`