### PR TITLE
fix: searchable tenant switch with page refresh

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -15,7 +15,6 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
   Building2,
-  Check,
   ChevronDown,
   LayoutDashboard,
   LogOut,
@@ -30,6 +29,8 @@ import {
   floatingPanelSurface,
   PageBackground,
   ScrollArea,
+  SearchableSelect,
+  type SearchableSelectOption,
   ThemeToggleButton,
 } from "@code-proxy/ui";
 import { preloadPageRoute } from "@pages/registry";
@@ -1028,6 +1029,7 @@ function ShellHeader({
   const canSwitchTenants =
     auth?.state.principal?.platform_admin && auth.state.principal.kind !== "service_credential";
   const [tenants, setTenants] = useState<TenantIdentity[]>([]);
+  const [tenantSwitching, setTenantSwitching] = useState(false);
   useEffect(() => {
     if (!canSwitchTenants) {
       setTenants([]);
@@ -1044,6 +1046,39 @@ function ShellHeader({
       )
       .catch(() => setTenants([]));
   }, [canSwitchTenants]);
+
+  const systemTenantLabel = t("shell.system_tenant");
+  const effectiveTenant = auth?.state.principal?.effective_tenant;
+  const effectiveTenantId = effectiveTenant?.id ?? "";
+  const tenantOptions = useMemo<SearchableSelectOption[]>(() => {
+    const byId = new Map<string, TenantIdentity>();
+    for (const tenant of tenants) byId.set(tenant.id, tenant);
+    if (effectiveTenant && !byId.has(effectiveTenant.id)) {
+      byId.set(effectiveTenant.id, effectiveTenant);
+    }
+    return Array.from(byId.values()).map((tenant) => {
+      const label = tenantDisplayName(tenant, systemTenantLabel);
+      return {
+        value: tenant.id,
+        label,
+        searchText: `${label} ${tenant.slug ?? ""} ${tenant.name}`,
+        icon: <Building2 size={16} className="shrink-0 opacity-65" />,
+      };
+    });
+  }, [effectiveTenant, systemTenantLabel, tenants]);
+
+  const handleTenantChange = useCallback(
+    (tenantId: string) => {
+      if (!auth || tenantId === effectiveTenantId || tenantSwitching) return;
+      setTenantSwitching(true);
+      void auth.actions
+        .switchTenant(tenantId)
+        .catch(() => undefined)
+        .finally(() => setTenantSwitching(false));
+    },
+    [auth, effectiveTenantId, tenantSwitching],
+  );
+
   const sidebarLabel = sidebarCollapsed ? t("shell.expand_sidebar") : t("shell.collapse_sidebar");
 
   return (
@@ -1064,65 +1099,16 @@ function ShellHeader({
         </div>
         <div className="flex shrink-0 items-center gap-1 sm:gap-2">
           {canSwitchTenants && auth?.state.principal ? (
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button
-                  type="button"
-                  aria-label={t("shell.switch_tenant")}
-                  className="group/tenant hidden h-9 max-w-64 items-center gap-2 rounded-xl px-2.5 text-sm font-medium text-slate-600 outline-none transition-colors duration-150 hover:bg-slate-100 hover:text-slate-950 focus-visible:ring-2 focus-visible:ring-blue-500/25 data-[state=open]:bg-slate-100 data-[state=open]:text-slate-950 sm:inline-flex dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white dark:data-[state=open]:bg-white/10 dark:data-[state=open]:text-white"
-                >
-                  <Building2 size={16} className="shrink-0 text-slate-400 dark:text-slate-500" />
-                  <span className="truncate">
-                    {tenantDisplayName(
-                      auth.state.principal.effective_tenant,
-                      t("shell.system_tenant"),
-                    )}
-                  </span>
-                  <ChevronDown
-                    size={14}
-                    className="shrink-0 text-slate-400 transition-transform duration-150 group-data-[state=open]/tenant:rotate-180 dark:text-slate-500"
-                    aria-hidden="true"
-                  />
-                </button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  align="end"
-                  sideOffset={8}
-                  collisionPadding={8}
-                  className="w-64"
-                >
-                  <div className="px-3 pb-1.5 pt-1 text-2xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-                    {t("shell.switch_tenant")}
-                  </div>
-                  {tenants.map((tenant) => {
-                    const selected = tenant.id === auth.state.principal?.effective_tenant.id;
-                    return (
-                      <DropdownMenu.Item
-                        key={tenant.id}
-                        aria-current={selected ? "true" : undefined}
-                        onSelect={() => {
-                          if (!selected) void auth.actions.switchTenant(tenant.id);
-                        }}
-                        className={
-                          selected
-                            ? "bg-blue-50 text-blue-700 focus:bg-blue-50 data-[highlighted]:bg-blue-50 dark:bg-blue-500/10 dark:text-blue-300 dark:focus:bg-blue-500/10 dark:data-[highlighted]:bg-blue-500/10"
-                            : undefined
-                        }
-                      >
-                        <Building2 size={16} className="shrink-0 opacity-65" />
-                        <span className="min-w-0 flex-1 truncate">
-                          {tenantDisplayName(tenant, t("shell.system_tenant"))}
-                        </span>
-                        {selected ? (
-                          <Check size={15} className="shrink-0" aria-hidden="true" />
-                        ) : null}
-                      </DropdownMenu.Item>
-                    );
-                  })}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
+            <SearchableSelect
+              value={effectiveTenantId}
+              onChange={handleTenantChange}
+              options={tenantOptions}
+              disabled={tenantSwitching}
+              aria-label={t("shell.switch_tenant")}
+              searchPlaceholder={t("shell.search_tenant")}
+              placeholder={t("shell.switch_tenant")}
+              className="hidden max-w-64 min-w-36 border-0 bg-transparent text-slate-600 shadow-none hover:border-0 hover:bg-slate-100 hover:text-slate-950 focus-visible:border-0 focus-visible:ring-2 focus-visible:ring-blue-500/25 sm:inline-flex dark:bg-transparent dark:text-slate-300 dark:hover:border-0 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:border-0"
+            />
           ) : null}
           <LanguageSelector className="inline-flex h-9 items-center justify-center gap-0.5 rounded-xl px-1.5 text-slate-500 transition-colors duration-200 ease-out hover:text-slate-900 dark:text-slate-400 dark:hover:text-white" />
           <ThemeToggleButton className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition-colors duration-200 ease-out hover:text-slate-900 dark:text-slate-400 dark:hover:text-white" />

--- a/apps/admin-panel/src/app/layout/DashboardLayout.tsx
+++ b/apps/admin-panel/src/app/layout/DashboardLayout.tsx
@@ -8,11 +8,14 @@ export function DashboardLayout() {
   const location = useLocation();
   const outlet = useOutlet();
   const auth = useOptionalAuth();
+  // Remount page content when the effective tenant changes so list/detail
+  // data reloads under the new tenant header instead of keeping stale state.
+  const tenantKey = auth?.state.principal?.effective_tenant?.id ?? "default";
 
   return (
     <AppShell onLogout={() => auth?.actions?.logout?.()}>
       <AnimatePresence mode="wait">
-        <Reveal key={location.pathname} className="min-h-full">
+        <Reveal key={`${location.pathname}:${tenantKey}`} className="min-h-full">
           {outlet}
         </Reveal>
       </AnimatePresence>

--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -368,7 +368,7 @@ test("shows tenant governance routes from server permissions", async ({ page }) 
   await expect(page.getByText("System Administration").first()).toBeVisible();
 });
 
-test("uses the localized borderless tenant dropdown menu", async ({ page }) => {
+test("uses the localized searchable tenant select with checkmark selection", async ({ page }) => {
   await page.addInitScript(() => {
     sessionStorage.setItem(
       "code-proxy-admin-auth",
@@ -387,7 +387,7 @@ test("uses the localized borderless tenant dropdown menu", async ({ page }) => {
   await mockIdentity(page, [principal.home_tenant, standardTenant]);
   await page.goto("/#/tenants");
 
-  const trigger = page.getByRole("button", { name: "切换租户" });
+  const trigger = page.getByRole("combobox", { name: "切换租户" });
   await expect(trigger).toContainText("系统管理");
   await expect(trigger).not.toContainText("System Administration");
   await expect
@@ -395,12 +395,128 @@ test("uses the localized borderless tenant dropdown menu", async ({ page }) => {
     .toBe("0px");
 
   await trigger.click();
-  const menu = page.getByRole("menu");
-  await expect(menu.getByRole("menuitem", { name: "系统管理" })).toHaveAttribute(
-    "aria-current",
-    "true",
+  const listbox = page.getByRole("listbox", { name: "切换租户" });
+  await expect(listbox.getByPlaceholder("搜索租户")).toBeVisible();
+  const selected = listbox.getByRole("option", { name: "系统管理" });
+  await expect(selected).toHaveAttribute("aria-selected", "true");
+  // Selected option uses a checkmark only — no solid selected background fill.
+  await expect
+    .poll(() =>
+      selected.evaluate((element) => {
+        const bg = getComputedStyle(element).backgroundColor;
+        return bg === "rgba(0, 0, 0, 0)" || bg === "transparent";
+      }),
+    )
+    .toBe(true);
+  await expect(listbox.getByRole("option", { name: "Acme Team" })).toBeVisible();
+});
+
+test("switching tenant remounts the current page and reloads tenant-scoped data", async ({
+  page,
+}) => {
+  await page.addInitScript(() =>
+    sessionStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: false,
+        expiresAt: Date.now() + 60_000,
+      }),
+    ),
   );
-  await expect(menu.getByRole("menuitem", { name: "Acme Team" })).toBeVisible();
+
+  let currentTenantId = principal.effective_tenant.id;
+  const acmeRoles = [
+    {
+      ...administratorRole,
+      id: "r-acme-admin",
+      tenant_id: standardTenant.id,
+      code: "tenant_admin",
+      name: "Acme Admin Role",
+      scope: "tenant",
+      system_protected: false,
+    },
+  ];
+
+  await page.route("**/v0/auth/me", (route) => {
+    const tenantHeader = route.request().headers()["x-effective-tenant-id"] ?? "";
+    const effective =
+      tenantHeader === standardTenant.id
+        ? standardTenant
+        : tenantHeader
+          ? { ...principal.effective_tenant, id: tenantHeader }
+          : principal.effective_tenant;
+    currentTenantId = effective.id;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        principal: {
+          ...principal,
+          effective_tenant: effective,
+        },
+      }),
+    });
+  });
+
+  let rolesFetchCount = 0;
+  await page.route("**/v0/management/**", (route) => {
+    const path = new URL(route.request().url()).pathname.replace("/v0/management", "");
+    const tenantHeader = route.request().headers()["x-effective-tenant-id"] ?? "";
+    if (path === "/roles") {
+      rolesFetchCount += 1;
+      const items =
+        tenantHeader === standardTenant.id || currentTenantId === standardTenant.id
+          ? acmeRoles
+          : [administratorRole];
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items }),
+      });
+    }
+    const bodies: Record<string, unknown> = {
+      "/tenants": { items: [principal.home_tenant, standardTenant] },
+      "/users": { items: [principal.user] },
+      "/menus": { items: menuItems },
+      "/permissions": {
+        items: administratorRole.permissions.map((code) => ({
+          code,
+          name: code,
+          scope: code.startsWith("platform.") ? "platform" : "tenant",
+          resource:
+            code.startsWith("tenant.") || code.startsWith("platform.")
+              ? (code.split(".")[1] ?? "")
+              : code.split(".").slice(0, -1).join("_"),
+          action: code.split(".").at(-1),
+          menu_code: "",
+          sensitive: false,
+        })),
+      },
+      "/audit-logs": { items: [] },
+    };
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(bodies[path] ?? {}),
+    });
+  });
+
+  await page.goto("/#/roles");
+  await expect(page.getByRole("heading", { name: /Roles/i })).toBeVisible();
+  await expect(page.getByText("Administrator")).toBeVisible();
+  const initialRolesFetches = rolesFetchCount;
+  expect(initialRolesFetches).toBeGreaterThan(0);
+
+  const trigger = page.getByRole("combobox", { name: /switch tenant/i });
+  await trigger.click();
+  await page.getByRole("option", { name: "Acme Team" }).click();
+
+  await expect(trigger).toContainText("Acme Team");
+  await expect(page.getByText("Acme Admin Role")).toBeVisible();
+  await expect(page.getByText("Administrator")).toHaveCount(0);
+  expect(rolesFetchCount).toBeGreaterThan(initialRolesFetches);
 });
 
 test("shows tenant row actions including protected system tenant details", async ({ page }) => {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -1980,6 +1980,7 @@
     "nav_group_governance": "Governance",
     "nav_tenants": "Tenants",
     "switch_tenant": "Switch tenant",
+    "search_tenant": "Search tenants",
     "system_tenant": "System Administration",
     "nav_users": "Users",
     "nav_roles": "Roles & Permissions",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -1625,6 +1625,7 @@
     "nav_group_governance": "Governance",
     "nav_tenants": "Tenants",
     "switch_tenant": "Сменить арендатора",
+    "search_tenant": "Поиск арендаторов",
     "system_tenant": "Системное администрирование",
     "nav_users": "Users",
     "nav_roles": "Roles & Permissions",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -1997,6 +1997,7 @@
     "nav_group_governance": "租户与权限",
     "nav_tenants": "租户管理",
     "switch_tenant": "切换租户",
+    "search_tenant": "搜索租户",
     "system_tenant": "系统管理",
     "nav_users": "用户管理",
     "nav_roles": "角色权限",


### PR DESCRIPTION
## Summary
- 顶栏租户切换改为封装好的 `SearchableSelect`（带搜索），选中态仅右侧勾号，无蓝色背景填充。
- 切换租户后根据 `effective_tenant.id` remount 当前 dashboard 页面内容，使角色/用户等租户数据重新加载。
- 补充中/英/俄文案 `shell.search_tenant`，并更新 multi-tenant e2e（UI 断言 + 切换后刷新断言）。

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- src/app/layout/AppShell.test.tsx src/app/AppRouter.test.tsx`
- [x] `bun run build`
- [ ] 手动：平台管理员在角色页切换租户，列表数据应立即变为目标租户数据