### PR TITLE
feat(ui): Form/FormField/Textarea + edit tenant modal

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -55,6 +55,16 @@ export { DateTimePicker } from "./primitives/DateTimePicker";
 export { DropdownMenu } from "./primitives/DropdownMenu";
 export type { DropdownMenuRootProps } from "./primitives/DropdownMenu";
 export { Fieldset } from "./primitives/Fieldset";
+export { Form, FormField, FormLabel, FormControl, FormDescription, FormError } from "./primitives/Form";
+export type {
+  FormProps,
+  FormFieldProps,
+  FormFieldOrientation,
+  FormLabelProps,
+  FormControlProps,
+  FormDescriptionProps,
+  FormErrorProps,
+} from "./primitives/Form";
 export { TextInput } from "./primitives/Input";
 export { MultiSelect } from "./primitives/MultiSelect";
 export type { MultiSelectOption } from "./primitives/MultiSelect";
@@ -69,6 +79,8 @@ export type { SearchableSelectOption, SearchableSelectProps } from "./primitives
 export { Select } from "./primitives/Select";
 export type { SelectOption, SelectProps } from "./primitives/Select";
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "./primitives/Tabs";
+export { Textarea } from "./primitives/Textarea";
+export type { TextareaProps } from "./primitives/Textarea";
 export { ToggleSwitch } from "./primitives/ToggleSwitch";
 
 export { ThemeProvider, useTheme, ThemeToggleButton } from "./theme/ThemeProvider";

--- a/packages/ui/src/primitives/Form.tsx
+++ b/packages/ui/src/primitives/Form.tsx
@@ -1,0 +1,238 @@
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useId,
+  useMemo,
+  type FormHTMLAttributes,
+  type HTMLAttributes,
+  type LabelHTMLAttributes,
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { cn } from "../utils/selectStyles";
+
+/* ------------------------------------------------------------------ */
+/*  Context                                                            */
+/* ------------------------------------------------------------------ */
+
+type FormFieldContextValue = {
+  id: string;
+  descriptionId?: string;
+  errorId?: string;
+  invalid: boolean;
+};
+
+const FormFieldContext = createContext<FormFieldContextValue | null>(null);
+
+function useFormFieldContext(component: string): FormFieldContextValue {
+  const ctx = useContext(FormFieldContext);
+  if (!ctx) {
+    throw new Error(`${component} must be used within FormField`);
+  }
+  return ctx;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Form                                                               */
+/* ------------------------------------------------------------------ */
+
+export type FormProps = FormHTMLAttributes<HTMLFormElement>;
+
+function FormRoot({ className, ...props }: FormProps) {
+  return <form data-slot="form" className={cn("space-y-4", className)} {...props} />;
+}
+
+/* ------------------------------------------------------------------ */
+/*  FormField                                                          */
+/* ------------------------------------------------------------------ */
+
+export type FormFieldOrientation = "vertical" | "horizontal";
+
+export type FormFieldProps = PropsWithChildren<
+  HTMLAttributes<HTMLDivElement> & {
+    /** Field label. Prefer this for the common label-above-control layout. */
+    label?: ReactNode;
+    /** Optional helper text under the control. */
+    description?: ReactNode;
+    /** Optional error message; also marks the field invalid for a11y. */
+    error?: ReactNode;
+    /** Show a required marker next to the label. */
+    required?: boolean;
+    /** Layout: vertical stacks label above control; horizontal puts label beside control. */
+    orientation?: FormFieldOrientation;
+    /** Optional explicit control id; defaults to a generated id. */
+    htmlFor?: string;
+  }
+>;
+
+function FormField({
+  children,
+  className,
+  label,
+  description,
+  error,
+  required = false,
+  orientation = "vertical",
+  htmlFor,
+  ...props
+}: FormFieldProps) {
+  const generatedId = useId();
+  const id = htmlFor ?? generatedId;
+  const descriptionId = description ? `${id}-description` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const invalid = Boolean(error);
+
+  const contextValue = useMemo<FormFieldContextValue>(
+    () => ({ id, descriptionId, errorId, invalid }),
+    [descriptionId, errorId, id, invalid],
+  );
+
+  const control = (
+    <FormControl className={orientation === "horizontal" ? "min-w-0 flex-1" : undefined}>
+      {children}
+    </FormControl>
+  );
+
+  return (
+    <FormFieldContext.Provider value={contextValue}>
+      <div
+        data-slot="form-field"
+        data-orientation={orientation}
+        data-invalid={invalid || undefined}
+        className={cn(
+          orientation === "horizontal"
+            ? "flex flex-wrap items-center gap-x-3 gap-y-1.5"
+            : "flex flex-col gap-1.5",
+          className,
+        )}
+        {...props}
+      >
+        {label != null && label !== false ? (
+          <FormLabel required={required} className={orientation === "horizontal" ? "shrink-0" : undefined}>
+            {label}
+          </FormLabel>
+        ) : null}
+        {control}
+        {description ? <FormDescription id={descriptionId}>{description}</FormDescription> : null}
+        {error ? <FormError id={errorId}>{error}</FormError> : null}
+      </div>
+    </FormFieldContext.Provider>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  FormLabel                                                          */
+/* ------------------------------------------------------------------ */
+
+export type FormLabelProps = LabelHTMLAttributes<HTMLLabelElement> & {
+  required?: boolean;
+};
+
+function FormLabel({ children, className, required = false, ...props }: FormLabelProps) {
+  const { id } = useFormFieldContext("FormLabel");
+  return (
+    <label
+      data-slot="form-label"
+      htmlFor={id}
+      className={cn("text-sm font-medium text-slate-700 dark:text-slate-200", className)}
+      {...props}
+    >
+      {children}
+      {required ? (
+        <span className="ml-0.5 text-rose-500" aria-hidden="true">
+          *
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  FormControl                                                        */
+/* ------------------------------------------------------------------ */
+
+export type FormControlProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
+
+function FormControl({ children, className, ...props }: FormControlProps) {
+  const { id, descriptionId, errorId, invalid } = useFormFieldContext("FormControl");
+  const describedBy = [descriptionId, errorId].filter(Boolean).join(" ") || undefined;
+
+  const child = Children.only(children);
+  if (!isValidElement(child)) {
+    return (
+      <div data-slot="form-control" className={className} {...props}>
+        {children}
+      </div>
+    );
+  }
+
+  const element = child as ReactElement<Record<string, unknown>>;
+  const existingDescribedBy =
+    typeof element.props["aria-describedby"] === "string"
+      ? element.props["aria-describedby"]
+      : undefined;
+  const mergedDescribedBy = [existingDescribedBy, describedBy].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div data-slot="form-control" className={className} {...props}>
+      {cloneElement(element, {
+        id: (element.props.id as string | undefined) ?? id,
+        "aria-invalid": element.props["aria-invalid"] ?? (invalid || undefined),
+        "aria-describedby": mergedDescribedBy,
+      })}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  FormDescription / FormError                                        */
+/* ------------------------------------------------------------------ */
+
+export type FormDescriptionProps = PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>;
+
+function FormDescription({ children, className, id, ...props }: FormDescriptionProps) {
+  return (
+    <p
+      data-slot="form-description"
+      id={id}
+      className={cn("text-xs leading-5 text-slate-500 dark:text-white/45", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+export type FormErrorProps = PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>;
+
+function FormError({ children, className, id, ...props }: FormErrorProps) {
+  return (
+    <p
+      data-slot="form-error"
+      id={id}
+      role="alert"
+      className={cn("text-xs leading-5 text-rose-600 dark:text-rose-400", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Export compound                                                    */
+/* ------------------------------------------------------------------ */
+
+export const Form = Object.assign(FormRoot, {
+  Field: FormField,
+  Label: FormLabel,
+  Control: FormControl,
+  Description: FormDescription,
+  Error: FormError,
+});
+
+export { FormField, FormLabel, FormControl, FormDescription, FormError };

--- a/packages/ui/src/primitives/Select.tsx
+++ b/packages/ui/src/primitives/Select.tsx
@@ -45,8 +45,14 @@ export interface SelectProps {
   options: SelectOption[];
   /** Optional placeholder shown when value is empty */
   placeholder?: ReactNode;
+  /** Optional control id (used by FormField label association) */
+  id?: string;
   /** Optional aria-label */
   "aria-label"?: string;
+  /** Optional invalid state for form fields */
+  "aria-invalid"?: boolean | "true" | "false";
+  /** Optional describedby ids for form description/error */
+  "aria-describedby"?: string;
   /** Optional HTML name attribute */
   name?: string;
   /** Extra className on the trigger button */
@@ -68,7 +74,10 @@ export function Select({
   onChange,
   options,
   placeholder = "",
+  id,
   "aria-label": ariaLabel,
+  "aria-invalid": ariaInvalid,
+  "aria-describedby": ariaDescribedBy,
   name,
   className,
   disabled = false,
@@ -159,11 +168,14 @@ export function Select({
       {/* Trigger */}
       <button
         ref={triggerRef}
+        id={id}
         type="button"
         role="combobox"
         aria-expanded={open}
         aria-haspopup="listbox"
         aria-label={ariaLabel}
+        aria-invalid={ariaInvalid}
+        aria-describedby={ariaDescribedBy}
         disabled={disabled}
         onClick={() => setOpen((prev) => !prev)}
         className={cn(

--- a/packages/ui/src/primitives/Textarea.tsx
+++ b/packages/ui/src/primitives/Textarea.tsx
@@ -1,0 +1,23 @@
+import { forwardRef, type TextareaHTMLAttributes } from "react";
+import { controlSurface } from "../utils/controlStyles";
+import { cn } from "../utils/selectStyles";
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "min-h-28 w-full resize-y px-3.5 py-3 text-sm outline-none transition",
+        "focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0",
+        controlSurface,
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/packages/ui/src/primitives/__tests__/Form.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Form.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Form, FormField } from "../Form";
+import { TextInput } from "../Input";
+import { Textarea } from "../Textarea";
+
+describe("FormField", () => {
+  test("wires label, description, and control id for accessibility", () => {
+    render(
+      <FormField label="名称" description="租户显示名称" htmlFor="tenant-name">
+        <TextInput />
+      </FormField>,
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("id", "tenant-name");
+    expect(screen.getByText("名称")).toHaveAttribute("for", "tenant-name");
+    expect(input).toHaveAttribute("aria-describedby", "tenant-name-description");
+    expect(screen.getByText("租户显示名称")).toHaveAttribute("id", "tenant-name-description");
+  });
+
+  test("marks the control invalid and exposes the error message", () => {
+    render(
+      <FormField label="名称" error="名称不能为空" htmlFor="tenant-name-error">
+        <TextInput />
+      </FormField>,
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", "tenant-name-error-error");
+    expect(screen.getByRole("alert")).toHaveTextContent("名称不能为空");
+  });
+
+  test("supports horizontal orientation for compact fields", () => {
+    const { container } = render(
+      <FormField label="状态" orientation="horizontal" htmlFor="tenant-status">
+        <TextInput />
+      </FormField>,
+    );
+
+    const field = container.querySelector("[data-slot='form-field']");
+    expect(field).toHaveAttribute("data-orientation", "horizontal");
+    expect(field).toHaveClass("items-center");
+  });
+});
+
+describe("Form", () => {
+  test("renders a form shell with default field spacing", () => {
+    const { container } = render(
+      <Form id="edit-tenant-form" aria-label="edit-tenant">
+        <FormField label="描述">
+          <Textarea defaultValue="demo" />
+        </FormField>
+      </Form>,
+    );
+
+    const form = container.querySelector("form");
+    expect(form).toHaveAttribute("id", "edit-tenant-form");
+    expect(form).toHaveClass("space-y-4");
+    expect(screen.getByRole("textbox")).toHaveValue("demo");
+  });
+});

--- a/pages/tenants/TenantsPage.tsx
+++ b/pages/tenants/TenantsPage.tsx
@@ -7,8 +7,11 @@ import {
   ConfirmModal,
   DataTable,
   DateTimePicker,
+  Form,
+  FormField,
   Modal,
   Select,
+  Textarea,
   TextInput,
   type DataTableColumn,
   useToast,
@@ -407,21 +410,15 @@ export function TenantsPage() {
           </>
         }
       >
-        <form id="edit-tenant-form" onSubmit={saveTenant} className="space-y-4">
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
-              {t("identity_admin.name")}
-            </span>
+        <Form id="edit-tenant-form" onSubmit={saveTenant}>
+          <FormField label={t("identity_admin.name")} required>
             <TextInput
               value={editForm.name}
               onChange={(event) => setEditForm({ ...editForm, name: event.target.value })}
               required
             />
-          </label>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
-              {t("identity_admin.status")}
-            </span>
+          </FormField>
+          <FormField label={t("identity_admin.status")} orientation="horizontal">
             <Select
               value={editForm.status}
               onChange={(status) => setEditForm({ ...editForm, status })}
@@ -431,18 +428,14 @@ export function TenantsPage() {
                 { value: "disabled", label: t("identity_admin.status_disabled") },
               ]}
             />
-          </label>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
-              {t("identity_admin.description")}
-            </span>
-            <textarea
+          </FormField>
+          <FormField label={t("identity_admin.description")}>
+            <Textarea
               value={editForm.description}
               onChange={(event) => setEditForm({ ...editForm, description: event.target.value })}
-              className="min-h-28 w-full rounded-2xl border border-black/[0.04] bg-white px-3.5 py-3 text-sm text-slate-700 outline-none shadow-[2px_2px_6px_rgb(0_0_0_/_0.055)] focus:ring-2 focus:ring-slate-300/50 dark:border-transparent dark:bg-[#27272A] dark:text-slate-200"
             />
-          </label>
-        </form>
+          </FormField>
+        </Form>
       </Modal>
 
       <Modal


### PR DESCRIPTION
## Summary
- 在 `@code-proxy/ui` 新增统一表单原语：`Form`、`FormField`、`FormLabel`、`FormControl`、`FormDescription`、`FormError`、`Textarea`
- `FormField` 统一 label / description / error 布局，并自动关联 `id` / `aria-describedby` / `aria-invalid`
- 支持 `orientation="horizontal"`（状态等紧凑字段）与 `required` 标记
- `Select` 补齐 `id` / `aria-invalid` / `aria-describedby`，可被 FormField 正确关联
- 编辑租户弹窗改用新组件，去掉手写 label 与裸 `textarea` 样式

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- packages/ui/src/primitives/__tests__/Form.test.tsx`
- [x] `bun run build`
- [ ] 管理端打开租户页 → 编辑租户：名称/状态/描述布局与保存行为正常
- [ ] 状态字段为横向布局，名称与描述为纵向布局