### PR TITLE
fix: invalidate model availability cache on tenant switch

### DIFF
--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -22,6 +22,7 @@ import {
   writePersistedAuthSnapshot,
   type ManagementPrincipal,
 } from "@code-proxy/api-client";
+import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 
 interface AuthContextState {
   state: {
@@ -290,12 +291,16 @@ export function AuthProvider({ children }: PropsWithChildren) {
           : principal.effective_tenant.id;
       setEffectiveTenant(tenantId);
       configureClient(apiBase, accessToken, tenantId);
+      // Drop process-global availability cache so the next models page load
+      // cannot reuse the previous tenant's configured-availability response.
+      invalidateConfiguredModelAvailability();
       try {
         const response = await identityApi.me();
         setPrincipal(response.principal);
       } catch {
         setEffectiveTenant(previousTenant);
         configureClient(apiBase, accessToken, previousTenant);
+        invalidateConfiguredModelAvailability();
       }
     },
     [accessToken, apiBase, configureClient, principal?.platform_admin],


### PR DESCRIPTION
## Summary
- Defense-in-depth for multi-tenant models page: when a platform admin switches effective tenant, invalidate the process-global configured-availability cache.
- Prevents remounted `/models` from briefly or incorrectly reusing the previous tenant’s availability response (15s TTL cache).

## Test plan
- [x] `bunx tsc -p apps/admin-panel/tsconfig.json --noEmit`
- [ ] Switch tenant in the shell and open Models; network should re-fetch configured-availability for the new tenant