### PR TITLE
fix(ui): left-aligned horizontal form labels for edit tenant

### DIFF
--- a/packages/ui/src/primitives/Form.tsx
+++ b/packages/ui/src/primitives/Form.tsx
@@ -69,6 +69,9 @@ export type FormFieldProps = PropsWithChildren<
   }
 >;
 
+/** Fixed label column width so multi-field horizontal forms share one left edge. */
+const HORIZONTAL_LABEL_CLASS = "w-16 shrink-0 text-left leading-9";
+
 function FormField({
   children,
   className,
@@ -85,16 +88,19 @@ function FormField({
   const descriptionId = description ? `${id}-description` : undefined;
   const errorId = error ? `${id}-error` : undefined;
   const invalid = Boolean(error);
+  const isHorizontal = orientation === "horizontal";
 
   const contextValue = useMemo<FormFieldContextValue>(
     () => ({ id, descriptionId, errorId, invalid }),
     [descriptionId, errorId, id, invalid],
   );
 
-  const control = (
-    <FormControl className={orientation === "horizontal" ? "min-w-0 flex-1" : undefined}>
-      {children}
-    </FormControl>
+  const control = <FormControl className={isHorizontal ? "min-w-0 w-full" : undefined}>{children}</FormControl>;
+  const meta = (
+    <>
+      {description ? <FormDescription id={descriptionId}>{description}</FormDescription> : null}
+      {error ? <FormError id={errorId}>{error}</FormError> : null}
+    </>
   );
 
   return (
@@ -104,21 +110,27 @@ function FormField({
         data-orientation={orientation}
         data-invalid={invalid || undefined}
         className={cn(
-          orientation === "horizontal"
-            ? "flex flex-wrap items-center gap-x-3 gap-y-1.5"
-            : "flex flex-col gap-1.5",
+          isHorizontal ? "flex items-start gap-x-3" : "flex flex-col gap-1.5",
           className,
         )}
         {...props}
       >
         {label != null && label !== false ? (
-          <FormLabel required={required} className={orientation === "horizontal" ? "shrink-0" : undefined}>
+          <FormLabel required={required} className={isHorizontal ? HORIZONTAL_LABEL_CLASS : undefined}>
             {label}
           </FormLabel>
         ) : null}
-        {control}
-        {description ? <FormDescription id={descriptionId}>{description}</FormDescription> : null}
-        {error ? <FormError id={errorId}>{error}</FormError> : null}
+        {isHorizontal ? (
+          <div data-slot="form-field-content" className="min-w-0 flex-1 space-y-1.5">
+            {control}
+            {meta}
+          </div>
+        ) : (
+          <>
+            {control}
+            {meta}
+          </>
+        )}
       </div>
     </FormFieldContext.Provider>
   );

--- a/packages/ui/src/primitives/__tests__/Form.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Form.test.tsx
@@ -32,16 +32,27 @@ describe("FormField", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("名称不能为空");
   });
 
-  test("supports horizontal orientation for compact fields", () => {
+  test("supports horizontal orientation with label left and control right", () => {
     const { container } = render(
-      <FormField label="状态" orientation="horizontal" htmlFor="tenant-status">
+      <FormField
+        label="状态"
+        description="租户状态"
+        orientation="horizontal"
+        htmlFor="tenant-status"
+      >
         <TextInput />
       </FormField>,
     );
 
     const field = container.querySelector("[data-slot='form-field']");
+    const label = screen.getByText("状态");
+    const content = container.querySelector("[data-slot='form-field-content']");
     expect(field).toHaveAttribute("data-orientation", "horizontal");
-    expect(field).toHaveClass("items-center");
+    expect(field).toHaveClass("items-start");
+    expect(label).toHaveClass("w-16", "text-left");
+    expect(content).not.toBeNull();
+    expect(content).toContainElement(screen.getByRole("textbox"));
+    expect(content).toContainElement(screen.getByText("租户状态"));
   });
 });
 

--- a/pages/tenants/TenantsPage.tsx
+++ b/pages/tenants/TenantsPage.tsx
@@ -411,7 +411,7 @@ export function TenantsPage() {
         }
       >
         <Form id="edit-tenant-form" onSubmit={saveTenant}>
-          <FormField label={t("identity_admin.name")} required>
+          <FormField label={t("identity_admin.name")} required orientation="horizontal">
             <TextInput
               value={editForm.name}
               onChange={(event) => setEditForm({ ...editForm, name: event.target.value })}
@@ -429,7 +429,7 @@ export function TenantsPage() {
               ]}
             />
           </FormField>
-          <FormField label={t("identity_admin.description")}>
+          <FormField label={t("identity_admin.description")} orientation="horizontal">
             <Textarea
               value={editForm.description}
               onChange={(event) => setEditForm({ ...editForm, description: event.target.value })}


### PR DESCRIPTION
## Summary
- 强化 `FormField` 的 `orientation="horizontal"`：左侧固定 label 列（左对齐），右侧控件占满剩余宽度
- description / error 归入右侧内容列，避免破坏左右对齐
- 编辑租户弹窗的名称 / 状态 / 描述全部改为横向布局

## Test plan
- [x] Form 单测
- [x] `bun run build`
- [ ] 打开编辑租户：label 左对齐、输入控件在右侧同一列