### PR TITLE
fix(ui): tighter form gap + tenant action icons

### DIFF
--- a/packages/ui/src/primitives/Form.tsx
+++ b/packages/ui/src/primitives/Form.tsx
@@ -70,7 +70,7 @@ export type FormFieldProps = PropsWithChildren<
 >;
 
 /** Fixed label column width so multi-field horizontal forms share one left edge. */
-const HORIZONTAL_LABEL_CLASS = "w-16 shrink-0 text-left leading-9";
+const HORIZONTAL_LABEL_CLASS = "w-12 shrink-0 text-left leading-9";
 
 function FormField({
   children,
@@ -110,7 +110,7 @@ function FormField({
         data-orientation={orientation}
         data-invalid={invalid || undefined}
         className={cn(
-          isHorizontal ? "flex items-start gap-x-3" : "flex flex-col gap-1.5",
+          isHorizontal ? "flex items-start gap-x-2" : "flex flex-col gap-1.5",
           className,
         )}
         {...props}

--- a/packages/ui/src/primitives/__tests__/Form.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Form.test.tsx
@@ -49,7 +49,7 @@ describe("FormField", () => {
     const content = container.querySelector("[data-slot='form-field-content']");
     expect(field).toHaveAttribute("data-orientation", "horizontal");
     expect(field).toHaveClass("items-start");
-    expect(label).toHaveClass("w-16", "text-left");
+    expect(label).toHaveClass("w-12", "text-left");
     expect(content).not.toBeNull();
     expect(content).toContainElement(screen.getByRole("textbox"));
     expect(content).toContainElement(screen.getByText("租户状态"));

--- a/pages/tenants/TenantsPage.tsx
+++ b/pages/tenants/TenantsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { Eye } from "lucide-react";
+import { Ban, CalendarClock, Eye, Pencil } from "lucide-react";
 import { identityApi, type TenantIdentity } from "@code-proxy/api-client";
 import {
   Button,
@@ -167,11 +167,11 @@ export function TenantsPage() {
       {
         key: "actions",
         label: t("identity_admin.actions"),
-        minWidthPx: 280,
-        width: "w-64",
+        minWidthPx: 148,
+        width: "w-36",
         lockOrder: "end",
         render: (item) => (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             <Button
               size="xs"
               variant="ghost"
@@ -185,6 +185,7 @@ export function TenantsPage() {
               <PermissionGate permission="platform.tenants.update">
                 <Button
                   size="xs"
+                  variant="ghost"
                   onClick={() => {
                     setEditTenant(item);
                     setEditForm({
@@ -193,20 +194,32 @@ export function TenantsPage() {
                       status: item.status,
                     });
                   }}
+                  title={t("identity_admin.edit")}
+                  aria-label={t("identity_admin.edit")}
                 >
-                  {t("identity_admin.edit")}
+                  <Pencil size={14} />
                 </Button>
                 <Button
                   size="xs"
+                  variant="ghost"
                   onClick={() => {
                     setRenewTenant(item);
                     setRenewAt(toLocalDateTimeInput(item.expires_at));
                   }}
+                  title={t("identity_admin.renew")}
+                  aria-label={t("identity_admin.renew")}
                 >
-                  {t("identity_admin.renew")}
+                  <CalendarClock size={14} />
                 </Button>
-                <Button size="xs" variant="error" onClick={() => setDisableTenant(item)}>
-                  {t("identity_admin.disable")}
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  className="text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:text-rose-400 dark:hover:bg-rose-500/10 dark:hover:text-rose-300"
+                  onClick={() => setDisableTenant(item)}
+                  title={t("identity_admin.disable")}
+                  aria-label={t("identity_admin.disable")}
+                >
+                  <Ban size={14} />
                 </Button>
               </PermissionGate>
             ) : null}


### PR DESCRIPTION
## Summary
- 收紧 `FormField` 横向布局：label 列 `w-12`，与控件间距 `gap-x-2`
- 租户列表操作列：编辑 / 续期 / 禁用改为图标按钮（Pencil / CalendarClock / Ban），与查看一致，保留 title/aria-label tooltip
- 禁用保持危险色提示；操作列宽度收窄

## Test plan
- [x] Form 单测
- [x] `bun run build`
- [ ] 编辑租户：label 与输入间距更紧
- [ ] 租户列表：操作列为图标按钮，hover 有中文 tooltip