### PR TITLE
fix: nest admin routes under menu group prefixes

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.test.ts
+++ b/apps/admin-panel/src/app/AppRouter.test.ts
@@ -18,30 +18,30 @@ describe("AppRouter", () => {
     const apiKeyPermissionsRoute = readRepoModule("pages/api-key-permissions/route.tsx");
 
     expect(source).toContain("pageRoutes");
-    expect(modelsRoute).toMatch(/path:\s*"\/models"/);
-    expect(modelsRoute).toContain('redirects: [{ from: "/manage/models", to: "/models" }]');
+    expect(modelsRoute).toMatch(/path:\s*"\/models\/catalog"/);
+    expect(modelsRoute).toContain('{ from: "/manage/models", to: "/models/catalog" }');
     expect(source).not.toContain('to="/manage/models" replace');
 
-    expect(accountSecurityRoute).toMatch(/path:\s*"\/account-security"/);
+    expect(accountSecurityRoute).toMatch(/path:\s*"\/system\/account-security"/);
     expect(accountSecurityRoute).toContain(
-      '{ from: "/manage/identity-fingerprint", to: "/account-security" }',
+      '{ from: "/manage/identity-fingerprint", to: "/system/account-security" }',
     );
 
     expect(identityRoute).toMatch(/path:\s*"\/identity-fingerprint"/);
     expect(identityRoute).toContain(
-      'redirects: [{ from: "/manage/identity-fingerprint", to: "/account-security" }]',
+      'redirects: [{ from: "/manage/identity-fingerprint", to: "/system/account-security" }]',
     );
 
     expect(ccSwitchRoute).toContain("CcSwitchImportSettingsPage");
-    expect(ccSwitchRoute).toMatch(/path:\s*"\/ccswitch-import-settings"/);
+    expect(ccSwitchRoute).toMatch(/path:\s*"\/access\/ccswitch-import-settings"/);
     expect(ccSwitchRoute).toContain(
-      'redirects: [{ from: "/manage/ccswitch-import-settings", to: "/ccswitch-import-settings" }]',
+      '{ from: "/manage/ccswitch-import-settings", to: "/access/ccswitch-import-settings" }',
     );
 
     expect(apiKeyPermissionsRoute).toContain("ApiKeyPermissionsPage");
-    expect(apiKeyPermissionsRoute).toMatch(/path:\s*"\/api-key-permissions"/);
+    expect(apiKeyPermissionsRoute).toMatch(/path:\s*"\/system\/api-key-permissions"/);
     expect(apiKeyPermissionsRoute).toContain(
-      'redirects: [{ from: "/manage/api-key-permissions", to: "/api-key-permissions" }]',
+      '{ from: "/manage/api-key-permissions", to: "/system/api-key-permissions" }',
     );
   });
 

--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useMemo } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider, useAuth } from "@app/providers/AuthProvider";
 import { ProtectedRoute } from "@/app/guards/ProtectedRoute";
 import { DashboardLayout } from "@app/layout/DashboardLayout";
@@ -11,6 +11,38 @@ import { ForbiddenPage } from "@pages/forbidden/ForbiddenPage";
 import { EmbedPage } from "@pages/embed/EmbedPage";
 
 const RouteFallback = () => null;
+
+/** Preserve deep-link suffixes when remapping legacy flat routes to nested secondary routes. */
+function PrefixRedirect({ fromPrefix, toPrefix }: { fromPrefix: string; toPrefix: string }) {
+  const location = useLocation();
+  const rest = location.pathname.startsWith(fromPrefix)
+    ? location.pathname.slice(fromPrefix.length)
+    : "";
+  return <Navigate to={`${toPrefix}${rest}${location.search}${location.hash}`} replace />;
+}
+
+/** Legacy first-level page paths remapped under group prefixes. */
+const LEGACY_PREFIX_REDIRECTS: ReadonlyArray<{ fromPrefix: string; toPrefix: string }> = [
+  { fromPrefix: "/ai-providers", toPrefix: "/access/ai-providers" },
+  { fromPrefix: "/monitor/request-logs", toPrefix: "/runtime/request-logs" },
+  { fromPrefix: "/monitor", toPrefix: "/runtime/monitor" },
+  { fromPrefix: "/logs", toPrefix: "/runtime/logs" },
+  { fromPrefix: "/api-keys", toPrefix: "/access/api-keys" },
+  { fromPrefix: "/ccswitch-import-settings", toPrefix: "/access/ccswitch-import-settings" },
+  { fromPrefix: "/image-generation", toPrefix: "/models/image-generation" },
+  { fromPrefix: "/channel-groups", toPrefix: "/models/channel-groups" },
+  { fromPrefix: "/proxies", toPrefix: "/models/proxies" },
+  { fromPrefix: "/tenants", toPrefix: "/governance/tenants" },
+  { fromPrefix: "/users", toPrefix: "/governance/users" },
+  { fromPrefix: "/roles", toPrefix: "/governance/roles" },
+  { fromPrefix: "/audit-logs", toPrefix: "/governance/audit-logs" },
+  { fromPrefix: "/account-security", toPrefix: "/system/account-security" },
+  { fromPrefix: "/api-key-permissions", toPrefix: "/system/api-key-permissions" },
+  { fromPrefix: "/menu-management", toPrefix: "/system/menu-management" },
+  { fromPrefix: "/config", toPrefix: "/system/config" },
+  // Do not prefix-redirect "/system" or "/models": new secondary routes already live under those bases
+  // (/system/config, /models/catalog). Exact legacy remaps stay on each page route's redirects.
+];
 
 function InitialRouteReady({ children }: { children: React.ReactElement }) {
   useEffect(() => {
@@ -114,6 +146,14 @@ function AuthenticatedRoutes() {
                   <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
                 )),
               )}
+              {/* Prefix redirects cover deep links under legacy flat paths (e.g. /ai-providers/openai). */}
+              {LEGACY_PREFIX_REDIRECTS.map((rd) => (
+                <Route
+                  key={`legacy:${rd.fromPrefix}`}
+                  path={`${rd.fromPrefix}/*`}
+                  element={<PrefixRedirect fromPrefix={rd.fromPrefix} toPrefix={rd.toPrefix} />}
+                />
+              ))}
               {embedMenus.map((menu) => (
                 <Route
                   key={`embed:${menu.code}`}

--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -44,6 +44,8 @@ const testMenus: MenuIdentity[] = [
   menu({
     code: "group.runtime",
     type: "directory",
+    path: "/runtime",
+    component: "Layout",
     label_key: "shell.nav_group_runtime",
     icon: "activity",
     sort_order: 20,
@@ -52,7 +54,7 @@ const testMenus: MenuIdentity[] = [
     code: "runtime.monitor",
     parent_code: "group.runtime",
     type: "menu",
-    path: "/monitor",
+    path: "/runtime/monitor",
     component: "monitor",
     label_key: "shell.nav_monitor",
     icon: "activity",
@@ -63,7 +65,7 @@ const testMenus: MenuIdentity[] = [
     code: "runtime.request-logs",
     parent_code: "group.runtime",
     type: "menu",
-    path: "/monitor/request-logs",
+    path: "/runtime/request-logs",
     component: "request-logs",
     label_key: "shell.nav_request_logs",
     icon: "scroll-text",
@@ -73,6 +75,8 @@ const testMenus: MenuIdentity[] = [
   menu({
     code: "group.access",
     type: "directory",
+    path: "/access",
+    component: "Layout",
     label_key: "shell.nav_group_access",
     icon: "bot",
     sort_order: 30,
@@ -81,7 +85,7 @@ const testMenus: MenuIdentity[] = [
     code: "access.providers",
     parent_code: "group.access",
     type: "menu",
-    path: "/ai-providers",
+    path: "/access/ai-providers",
     component: "providers",
     label_key: "shell.nav_ai_providers",
     icon: "bot",
@@ -91,6 +95,8 @@ const testMenus: MenuIdentity[] = [
   menu({
     code: "group.models",
     type: "directory",
+    path: "/models",
+    component: "Layout",
     label_key: "shell.nav_group_models",
     icon: "layers",
     sort_order: 40,
@@ -99,7 +105,7 @@ const testMenus: MenuIdentity[] = [
     code: "models.catalog",
     parent_code: "group.models",
     type: "menu",
-    path: "/models",
+    path: "/models/catalog",
     component: "models",
     label_key: "shell.nav_models",
     icon: "cpu",
@@ -109,6 +115,8 @@ const testMenus: MenuIdentity[] = [
   menu({
     code: "group.system",
     type: "directory",
+    path: "/system",
+    component: "Layout",
     label_key: "shell.nav_group_system",
     icon: "settings",
     sort_order: 60,
@@ -117,7 +125,7 @@ const testMenus: MenuIdentity[] = [
     code: "system.config",
     parent_code: "group.system",
     type: "menu",
-    path: "/config",
+    path: "/system/config",
     component: "config",
     label_key: "shell.nav_config",
     icon: "settings",
@@ -177,12 +185,12 @@ describe("AppShell route progress", () => {
     renderShell();
     fireEvent.click(screen.getByRole("button", { name: /Access|接入管理/i }));
 
-    const link = document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]');
+    const link = document.querySelector<HTMLAnchorElement>('a[href="/access/ai-providers"]');
     expect(link).toBeInstanceOf(HTMLAnchorElement);
 
     fireEvent.click(link as HTMLAnchorElement);
 
-    expect(preloadPageRoute).toHaveBeenCalledWith("/ai-providers");
+    expect(preloadPageRoute).toHaveBeenCalledWith("/access/ai-providers");
     expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
 
     const progress = document.querySelector(".rp");
@@ -208,7 +216,7 @@ describe("AppShell route progress", () => {
       vi.advanceTimersByTime(360);
     });
 
-    expect(screen.getByTestId("location")).toHaveTextContent("/ai-providers");
+    expect(screen.getByTestId("location")).toHaveTextContent("/access/ai-providers");
     expect(document.querySelector(".rp")).not.toBeInTheDocument();
   });
 
@@ -217,7 +225,7 @@ describe("AppShell route progress", () => {
     renderShell();
     fireEvent.click(screen.getByRole("button", { name: /Access|接入管理/i }));
 
-    const link = document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]');
+    const link = document.querySelector<HTMLAnchorElement>('a[href="/access/ai-providers"]');
     expect(link).toBeInstanceOf(HTMLAnchorElement);
 
     fireEvent.click(link as HTMLAnchorElement);
@@ -238,7 +246,7 @@ describe("AppShell route progress", () => {
       vi.advanceTimersByTime(360);
     });
 
-    expect(screen.getByTestId("location")).toHaveTextContent("/ai-providers");
+    expect(screen.getByTestId("location")).toHaveTextContent("/access/ai-providers");
     expect(document.querySelector(".rp")).not.toBeInTheDocument();
   });
 
@@ -247,14 +255,14 @@ describe("AppShell route progress", () => {
     renderShell();
     fireEvent.click(screen.getByRole("button", { name: /Access|接入管理/i }));
 
-    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]')!);
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/access/ai-providers"]')!);
 
     act(() => {
       vi.advanceTimersByTime(300);
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Models & Routing|模型与路由/i }));
-    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/models"]')!);
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/models/catalog"]')!);
 
     await act(async () => {
       vi.advanceTimersByTime(679);
@@ -274,7 +282,7 @@ describe("AppShell route progress", () => {
       vi.advanceTimersByTime(360);
     });
 
-    expect(screen.getByTestId("location")).toHaveTextContent("/models");
+    expect(screen.getByTestId("location")).toHaveTextContent("/models/catalog");
   });
 
   test("lets modified clicks keep the browser's native link behavior", () => {
@@ -282,7 +290,7 @@ describe("AppShell route progress", () => {
     renderShell();
     fireEvent.click(screen.getByRole("button", { name: /Access|接入管理/i }));
 
-    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/ai-providers"]')!, {
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/access/ai-providers"]')!, {
       ctrlKey: true,
     });
 
@@ -291,7 +299,7 @@ describe("AppShell route progress", () => {
     expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
   });
   test("groups sidebar routes and uses a compact neutral active state", () => {
-    renderShell("/monitor/request-logs");
+    renderShell("/runtime/request-logs");
 
     const runtimeGroup = screen.getByRole("button", { name: /Operations|运行监控/i });
     expect(runtimeGroup).toHaveAttribute("aria-expanded", "true");
@@ -308,7 +316,7 @@ describe("AppShell route progress", () => {
 
   test("keeps a stable icon rail and the same sidebar toggle icon when collapsed", () => {
     vi.useFakeTimers();
-    renderShell("/config");
+    renderShell("/system/config");
 
     const collapseButton = screen.getByRole("button", {
       name: /Collapse Sidebar|收起侧边栏/i,

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -98,7 +98,7 @@ const FALLBACK_NAV_GROUPS: readonly SidebarNavGroup[] = [
     items: [
       {
         menuCode: "system.menus",
-        to: "/menu-management",
+        to: "/system/menu-management",
         i18nKey: "shell.nav_menu_management",
         icon: resolveMenuIcon("menu"),
         permission: "platform.menus.read",
@@ -161,7 +161,12 @@ const getPageTitleKey = (pathname: string, menus?: MenuIdentity[] | null): strin
     if (hit) return menuLabelKey(hit);
   }
   if (pathname.startsWith("/dashboard")) return "shell.nav_dashboard";
-  if (pathname.startsWith("/menu-management")) return "shell.nav_menu_management";
+  if (
+    pathname.startsWith("/system/menu-management") ||
+    pathname.startsWith("/menu-management")
+  ) {
+    return "shell.nav_menu_management";
+  }
   return "shell.page_home";
 };
 
@@ -946,7 +951,7 @@ function ShellSidebar({
                     {can("auth_files.read") ? (
                       <DropdownMenu.Item
                         onSelect={() =>
-                          navigate("/account-security", {
+                          navigate("/system/account-security", {
                             viewTransition: true,
                           })
                         }
@@ -958,7 +963,7 @@ function ShellSidebar({
                     ) : null}
                     {can("system.config.read") ? (
                       <DropdownMenu.Item
-                        onSelect={() => navigate("/config", { viewTransition: true })}
+                        onSelect={() => navigate("/system/config", { viewTransition: true })}
                         className="py-2.5"
                       >
                         <Settings size={16} />

--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -57,7 +57,7 @@ test("Config: page should not horizontally scroll; editor should allow horizonta
     });
   });
 
-  await page.goto("/#/config");
+  await page.goto("/#/system/config");
   await page.getByRole("tab", { name: /Source Editor|源码编辑/i }).click();
 
   const editor = page.getByLabel(/config\.yaml (editor|编辑器)/i);
@@ -104,7 +104,7 @@ test("Sidebar: collapse/expand should keep nav items nowrap and slide out of vie
     });
   });
 
-  await page.goto("/#/config");
+  await page.goto("/#/system/config");
 
   const dashboardLink = page.getByRole("link", { name: /Dashboard|仪表盘/i });
   await expect(dashboardLink).toBeVisible();
@@ -582,7 +582,7 @@ test("Config: source editor save should persist edited yaml through save path", 
     });
   });
 
-  await page.goto("/#/config");
+  await page.goto("/#/system/config");
   await page.getByRole("tab", { name: /源代码编辑|Source Editor/i }).click();
 
   const editor = page.getByLabel(/config\.yaml (editor|编辑器)/i);
@@ -719,7 +719,7 @@ test("Config: global Codex OAuth allowed-client preset should persist through ru
     });
   });
 
-  await page.goto("/#/config");
+  await page.goto("/#/system/config");
 
   const panel = page.getByTestId("codex-oauth-global-admission-panel");
   await expect(panel).toBeVisible();

--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -122,8 +122,8 @@ const menuItems = [
     code: "group.system",
     parent_code: "",
     type: "directory",
-    path: "",
-    component: "",
+    path: "/system",
+    component: "Layout",
     link_url: "",
     title: "",
     badge_type: "",
@@ -142,7 +142,7 @@ const menuItems = [
     code: "system.menus",
     parent_code: "group.system",
     type: "menu",
-    path: "/menu-management",
+    path: "/system/menu-management",
     component: "menu-management",
     link_url: "",
     title: "",
@@ -162,7 +162,7 @@ const menuItems = [
     code: "system.config",
     parent_code: "group.system",
     type: "menu",
-    path: "/config",
+    path: "/system/config",
     component: "config",
     link_url: "",
     title: "",
@@ -185,8 +185,8 @@ const roleMenuItems = [
     code: "group.governance",
     parent_code: "",
     type: "directory",
-    path: "",
-    component: "",
+    path: "/governance",
+    component: "Layout",
     link_url: "",
     title: "",
     badge_type: "",
@@ -205,7 +205,7 @@ const roleMenuItems = [
     code: "governance.users",
     parent_code: "group.governance",
     type: "menu",
-    path: "/users",
+    path: "/governance/users",
     component: "users",
     link_url: "",
     title: "",
@@ -564,7 +564,7 @@ test("uses a switch for the two user availability states", async ({ page }) => {
     [administratorRole, operatorRole],
     [principal.user, memberUser],
   );
-  await page.goto("/#/users");
+  await page.goto("/#/governance/users");
 
   const memberRow = page.locator('[data-vt-row-key="u-member"]');
   await expect(memberRow.getByRole("switch")).toHaveAttribute("aria-checked", "true");
@@ -636,7 +636,7 @@ test("manages dynamic menu visibility and ordering", async ({ page }) => {
     ),
   );
   await mockIdentity(page);
-  await page.goto("/#/menu-management");
+  await page.goto("/#/system/menu-management");
 
   await expect(page.getByRole("heading", { name: "Menu Management", level: 2 })).toBeVisible();
   const systemGroupRow = page.locator('[data-vt-row-key="group.system"]');
@@ -684,11 +684,11 @@ test("applies server menu visibility and enabled state to navigation and routes"
     }),
   );
 
-  await page.goto("/#/menu-management");
+  await page.goto("/#/system/menu-management");
   await expect(page.getByText("Menu Management", { exact: true }).last()).toBeVisible();
   await expect(page.getByText("Tenants", { exact: true })).toHaveCount(0);
   await expect(page.getByText("Dashboard", { exact: true })).toHaveCount(0);
-  await page.goto("/#/config");
+  await page.goto("/#/system/config");
   await expect(page.getByRole("heading", { name: "Access denied" })).toBeVisible();
 });
 
@@ -706,7 +706,7 @@ test("shows the built-in administrator role and super administrator account", as
   );
   await mockIdentity(page);
 
-  await page.goto("/#/users");
+  await page.goto("/#/governance/users");
   const adminRow = page.locator('[data-vt-row-key="u-admin"]');
   await expect(adminRow).toBeVisible();
   await expect(adminRow.getByText("Super Administrator", { exact: true })).toBeVisible();
@@ -839,7 +839,7 @@ test("users page does not fetch or expose role assignment without role read perm
     }),
   );
 
-  await page.goto("/#/users");
+  await page.goto("/#/governance/users");
   await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
   await expect(page.getByText("Limited Manager")).toBeVisible();
   await expect(page.getByText("reader")).toBeVisible();
@@ -984,7 +984,7 @@ test("provider read permission hides tenant write/test controls and system-only 
     });
   });
 
-  await page.goto("/#/ai-providers/opencode-go/new");
+  await page.goto("/#/access/ai-providers/opencode-go/new");
   await expect(page.getByText("Read only provider", { exact: true })).toBeVisible();
   await expect(page.getByRole("tab", { name: "Ampcode" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: /add new/i })).toHaveCount(0);

--- a/e2e/openai-providers.spec.ts
+++ b/e2e/openai-providers.spec.ts
@@ -62,7 +62,7 @@ test("AI Providers (OpenAI): typing provider name should not crash page", async 
     });
   });
 
-  await page.goto("/#/ai-providers");
+  await page.goto("/#/access/ai-providers");
 
   await page.getByRole("tab", { name: /openai compatible|openai 兼容/i }).click();
 

--- a/e2e/opencode-go-layout.spec.ts
+++ b/e2e/opencode-go-layout.spec.ts
@@ -205,7 +205,7 @@ test("AI Providers: OpenCode Go cards should not overlap on responsive layouts",
       width: viewport.width,
       height: viewport.height,
     });
-    await page.goto("/#/ai-providers");
+    await page.goto("/#/access/ai-providers");
 
     const list = page.getByTestId("providers-tab-scroll");
     await expect(list).toBeVisible();
@@ -275,7 +275,7 @@ test("AI Providers: dashboard provider cards stay compact and left aligned", asy
   await setAuthed(page);
   await mockManagementApi(page);
   await page.setViewportSize({ width: 1280, height: 720 });
-  await page.goto("/#/ai-providers");
+  await page.goto("/#/access/ai-providers");
 
   for (const provider of [
     {

--- a/packages/api-client/src/endpoints/__tests__/identity.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/identity.test.ts
@@ -119,7 +119,7 @@ describe("identityApi", () => {
     await identityApi.updateMenu("system.menus", {
       parent_code: "group.system",
       type: "menu",
-      path: "/menu-management",
+      path: "/system/menu-management",
       component: "menu-management",
       link_url: "",
       label_key: "shell.nav_menu_management",

--- a/pages/account-security/route.tsx
+++ b/pages/account-security/route.tsx
@@ -5,16 +5,17 @@ const { Page: AuthFilesPage, preload: preloadAuthFilesPage } = preloadablePage((
 );
 
 export const accountSecurityRoute = {
-  path: "/account-security",
+  path: "/system/account-security",
   component: "account-security",
   element: <AuthFilesPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.accountSecurity" },
   redirects: [
-    { from: "/auth-files/oauth-excluded", to: "/account-security?tab=excluded" },
-    { from: "/auth-files/oauth-model-alias", to: "/account-security?tab=alias" },
-    { from: "/manage/identity-fingerprint", to: "/account-security" },
+    { from: "/account-security", to: "/system/account-security" },
+    { from: "/auth-files/oauth-excluded", to: "/system/account-security?tab=excluded" },
+    { from: "/auth-files/oauth-model-alias", to: "/system/account-security?tab=alias" },
+    { from: "/manage/identity-fingerprint", to: "/system/account-security" },
   ],
   requiredPermission: "auth_files.read",
   preload: preloadAuthFilesPage,

--- a/pages/api-key-permissions/route.tsx
+++ b/pages/api-key-permissions/route.tsx
@@ -7,13 +7,16 @@ const { Page: ApiKeyPermissionsPage, preload: preloadApiKeyPermissionsPage } = p
 );
 
 export const apiKeyPermissionsRoute = {
-  path: "/api-key-permissions",
+  path: "/system/api-key-permissions",
   component: "api-key-permissions",
   element: <ApiKeyPermissionsPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.apiKeyPermissions" },
-  redirects: [{ from: "/manage/api-key-permissions", to: "/api-key-permissions" }],
+  redirects: [
+    { from: "/api-key-permissions", to: "/system/api-key-permissions" },
+    { from: "/manage/api-key-permissions", to: "/system/api-key-permissions" },
+  ],
   requiredPermission: "api_key_profiles.read",
   preload: preloadApiKeyPermissionsPage,
 };

--- a/pages/api-keys/route.tsx
+++ b/pages/api-keys/route.tsx
@@ -5,12 +5,13 @@ const { Page: ApiKeysPage, preload: preloadApiKeysPage } = preloadablePage(() =>
 );
 
 export const apiKeysRoute = {
-  path: "/api-keys",
+  path: "/access/api-keys",
   component: "api-keys",
   element: <ApiKeysPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.apiKeys" },
+  redirects: [{ from: "/api-keys", to: "/access/api-keys" }],
   requiredPermission: "api_keys.read",
   preload: preloadApiKeysPage,
 };

--- a/pages/audit-logs/route.tsx
+++ b/pages/audit-logs/route.tsx
@@ -3,12 +3,13 @@ const { Page, preload } = preloadablePage(() =>
   import("./AuditLogsPage").then((m) => ({ default: m.AuditLogsPage })),
 );
 export const auditLogsRoute = {
-  path: "/audit-logs",
+  path: "/governance/audit-logs",
   component: "audit-logs",
   element: <Page />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.auditLogs" },
+  redirects: [{ from: "/audit-logs", to: "/governance/audit-logs" }],
   requiredPermission: "tenant.audit.read",
   preload,
 };

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1409,7 +1409,7 @@ describe("AuthFilesPage files table", () => {
     const router = createMemoryRouter(
       [
         { path: "/auth-files", element: wrap(<AuthFilesPage />) },
-        { path: "/api-keys", element: wrap(<div>api keys</div>) },
+        { path: "/access/api-keys", element: wrap(<div>api keys</div>) },
       ],
       { initialEntries: ["/auth-files"] },
     );
@@ -1419,7 +1419,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("qwen.json")).toBeInTheDocument();
 
     await act(async () => {
-      await router.navigate("/api-keys");
+      await router.navigate("/access/api-keys");
     });
     expect(screen.getByText("api keys")).toBeInTheDocument();
 
@@ -1493,9 +1493,9 @@ describe("AuthFilesPage files table", () => {
     const router = createMemoryRouter(
       [
         { path: "/auth-files", element: wrap(<AuthFilesPage />) },
-        { path: "/api-keys", element: wrap(<div>api keys</div>) },
+        { path: "/access/api-keys", element: wrap(<div>api keys</div>) },
       ],
-      { initialEntries: ["/api-keys"] },
+      { initialEntries: ["/access/api-keys"] },
     );
 
     render(<RouterProvider router={router} />);
@@ -2396,7 +2396,7 @@ describe("AuthFilesPage files table", () => {
 
     const router = createMemoryRouter(
       [
-        { path: "/monitor/request-logs", element: <div>request logs</div> },
+        { path: "/runtime/request-logs", element: <div>request logs</div> },
         {
           path: "/auth-files",
           element: (
@@ -2408,7 +2408,7 @@ describe("AuthFilesPage files table", () => {
           ),
         },
       ],
-      { initialEntries: ["/monitor/request-logs"] },
+      { initialEntries: ["/runtime/request-logs"] },
     );
 
     render(<RouterProvider router={router} />);

--- a/pages/auth-files/route.tsx
+++ b/pages/auth-files/route.tsx
@@ -2,7 +2,7 @@ import { Navigate, useLocation } from "react-router-dom";
 
 function AuthFilesRedirect() {
   const location = useLocation();
-  return <Navigate to={{ pathname: "/account-security", search: location.search }} replace />;
+  return <Navigate to={{ pathname: "/system/account-security", search: location.search }} replace />;
 }
 
 export const authFilesRoute = {
@@ -13,7 +13,7 @@ export const authFilesRoute = {
   requiredPermission: "auth_files.read",
   nav: { labelKey: "nav.authFiles" },
   redirects: [
-    { from: "/auth-files/oauth-excluded", to: "/account-security?tab=excluded" },
-    { from: "/auth-files/oauth-model-alias", to: "/account-security?tab=alias" },
+    { from: "/auth-files/oauth-excluded", to: "/system/account-security?tab=excluded" },
+    { from: "/auth-files/oauth-model-alias", to: "/system/account-security?tab=alias" },
   ],
 };

--- a/pages/ccswitch-import-settings/route.tsx
+++ b/pages/ccswitch-import-settings/route.tsx
@@ -8,13 +8,16 @@ const { Page: CcSwitchImportSettingsPage, preload: preloadCcSwitchImportSettings
   );
 
 export const ccswitchImportSettingsRoute = {
-  path: "/ccswitch-import-settings",
+  path: "/access/ccswitch-import-settings",
   component: "ccswitch-import-settings",
   element: <CcSwitchImportSettingsPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.ccswitchImportSettings" },
-  redirects: [{ from: "/manage/ccswitch-import-settings", to: "/ccswitch-import-settings" }],
+  redirects: [
+    { from: "/ccswitch-import-settings", to: "/access/ccswitch-import-settings" },
+    { from: "/manage/ccswitch-import-settings", to: "/access/ccswitch-import-settings" },
+  ],
   requiredPermission: "system.config.read",
   preload: preloadCcSwitchImportSettingsPage,
 };

--- a/pages/channel-groups/route.tsx
+++ b/pages/channel-groups/route.tsx
@@ -7,12 +7,13 @@ const { Page: ChannelGroupsPage, preload: preloadChannelGroupsPage } = preloadab
 );
 
 export const channelGroupsRoute = {
-  path: "/channel-groups",
+  path: "/models/channel-groups",
   component: "channel-groups",
   element: <ChannelGroupsPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.channelGroups" },
+  redirects: [{ from: "/channel-groups", to: "/models/channel-groups" }],
   requiredPermission: "routing.read",
   preload: preloadChannelGroupsPage,
 };

--- a/pages/config/route.tsx
+++ b/pages/config/route.tsx
@@ -5,13 +5,16 @@ const { Page: ConfigPage, preload: preloadConfigPage } = preloadablePage(() =>
 );
 
 export const configRoute = {
-  path: "/config",
+  path: "/system/config",
   component: "config",
   element: <ConfigPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.config" },
-  redirects: [{ from: "/settings", to: "/config" }],
+  redirects: [
+    { from: "/config", to: "/system/config" },
+    { from: "/settings", to: "/system/config" },
+  ],
   requiredPermission: "system.config.read",
   preload: preloadConfigPage,
 };

--- a/pages/config/visual/VisualConfigEditor.tsx
+++ b/pages/config/visual/VisualConfigEditor.tsx
@@ -114,7 +114,7 @@ export function VisualConfigEditor({
               <p className="text-sm text-indigo-800 dark:text-indigo-300">
                 {t("visual_config.api_migrated")}
                 <a
-                  href="/manage/api-keys"
+                  href="/access/api-keys"
                   className="ml-1 font-semibold underline underline-offset-2 hover:text-indigo-600 dark:hover:text-indigo-200"
                 >
                   {t("visual_config.go_to_api_keys")}

--- a/pages/identity-fingerprint/route.tsx
+++ b/pages/identity-fingerprint/route.tsx
@@ -2,10 +2,10 @@ import { Navigate } from "react-router-dom";
 
 export const identityFingerprintRoute = {
   path: "/identity-fingerprint",
-  element: <Navigate to="/account-security" replace />,
+  element: <Navigate to="/system/account-security" replace />,
   auth: true,
   layout: "dashboard",
   requiredPermission: "auth_files.read",
   nav: { labelKey: "nav.identityFingerprint" },
-  redirects: [{ from: "/manage/identity-fingerprint", to: "/account-security" }],
+  redirects: [{ from: "/manage/identity-fingerprint", to: "/system/account-security" }],
 };

--- a/pages/image-generation/route.tsx
+++ b/pages/image-generation/route.tsx
@@ -7,12 +7,13 @@ const { Page: ImageGenerationPage, preload: preloadImageGenerationPage } = prelo
 );
 
 export const imageGenerationRoute = {
-  path: "/image-generation",
+  path: "/models/image-generation",
   component: "image-generation",
   element: <ImageGenerationPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.imageGeneration" },
+  redirects: [{ from: "/image-generation", to: "/models/image-generation" }],
   requiredPermission: "system.config.read",
   preload: preloadImageGenerationPage,
 };

--- a/pages/logs/route.tsx
+++ b/pages/logs/route.tsx
@@ -5,12 +5,13 @@ const { Page: LogsPage, preload: preloadLogsPage } = preloadablePage(() =>
 );
 
 export const logsRoute = {
-  path: "/logs",
+  path: "/runtime/logs",
   component: "logs",
   element: <LogsPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.logs" },
+  redirects: [{ from: "/logs", to: "/runtime/logs" }],
   requiredPermission: "system.logs.read",
   preload: preloadLogsPage,
 };

--- a/pages/menu-management/MenuManagementPage.tsx
+++ b/pages/menu-management/MenuManagementPage.tsx
@@ -57,6 +57,18 @@ const emptyForm = (): MenuWriteBody => ({
   hide_menu: false,
 });
 
+/** Display helper: never collapse real empty metadata to a blank cell without meaning. */
+const displayCell = (value: string | null | undefined, fallback = "—") => {
+  const text = (value ?? "").trim();
+  return text || fallback;
+};
+
+const parentPathPrefix = (menus: MenuIdentity[], parentCode: string) => {
+  if (!parentCode) return "";
+  const parent = menus.find((item) => item.code === parentCode);
+  return (parent?.path ?? "").replace(/\/$/, "");
+};
+
 const toWriteBody = (menu: MenuIdentity): MenuWriteBody => ({
   parent_code: menu.parent_code ?? "",
   type: menu.type,
@@ -182,7 +194,15 @@ export function MenuManagementPage() {
   const openCreate = (parentCode = "") => {
     setDrawerMode("create");
     setEditing(null);
-    setForm({ ...emptyForm(), parent_code: parentCode });
+    const prefix = parentPathPrefix(menus, parentCode);
+    setForm({
+      ...emptyForm(),
+      parent_code: parentCode,
+      // Nested create under a directory defaults to secondary route under parent path.
+      path: prefix ? `${prefix}/` : "",
+      type: "menu",
+      component: "",
+    });
     setDrawerOpen(true);
   };
 
@@ -326,7 +346,7 @@ export function MenuManagementPage() {
         width: "w-40",
         render: (menu) => (
           <span className="truncate text-xs text-slate-600 dark:text-slate-300">
-            {menu.permission_code || "—"}
+            {displayCell(menu.permission_code)}
           </span>
         ),
       },
@@ -336,7 +356,9 @@ export function MenuManagementPage() {
         width: "w-40",
         render: (menu) => (
           <div className="min-w-0 text-xs">
-            <div className="truncate text-slate-700 dark:text-slate-200">{menu.path || "—"}</div>
+            <div className="truncate text-slate-700 dark:text-slate-200">
+              {displayCell(menu.path)}
+            </div>
             {menu.link_url ? (
               <div className="truncate text-slate-400">{menu.link_url}</div>
             ) : null}
@@ -349,7 +371,9 @@ export function MenuManagementPage() {
         width: "w-36",
         render: (menu) => (
           <span className="truncate text-xs text-slate-600 dark:text-slate-300">
-            {menu.component || "—"}
+            {menu.type === "directory"
+              ? displayCell(menu.component, "Layout")
+              : displayCell(menu.component)}
           </span>
         ),
       },
@@ -411,8 +435,9 @@ export function MenuManagementPage() {
     [canUpdate, expanded, t],
   );
 
-  const showPath = form.type === "menu" || form.type === "embed" || form.type === "link";
-  const showComponent = form.type === "menu";
+  const showPath =
+    form.type === "directory" || form.type === "menu" || form.type === "embed" || form.type === "link";
+  const showComponent = form.type === "directory" || form.type === "menu";
   const showLink = form.type === "embed" || form.type === "link";
   const showPermission = form.type !== "directory";
 
@@ -478,7 +503,16 @@ export function MenuManagementPage() {
               value={form.type}
               onValueChange={(next) => {
                 if (drawerMode === "edit" && editing?.system_protected) return;
-                setForm((current) => ({ ...current, type: next as MenuType }));
+                const type = next as MenuType;
+                setForm((current) => {
+                  const nextForm = { ...current, type };
+                  if (type === "directory") {
+                    nextForm.component = current.component || "Layout";
+                    nextForm.link_url = "";
+                    nextForm.permission_code = "";
+                  }
+                  return nextForm;
+                });
               }}
               size="sm"
             >
@@ -583,7 +617,13 @@ export function MenuManagementPage() {
                     setForm((current) => ({ ...current, path: event.target.value }))
                   }
                   required
-                  placeholder="/feature"
+                  placeholder={
+                    form.type === "directory"
+                      ? "/runtime"
+                      : parentPathPrefix(menus, form.parent_code || "")
+                        ? `${parentPathPrefix(menus, form.parent_code || "")}/feature`
+                        : "/group/feature"
+                  }
                 />
               </label>
             ) : null}
@@ -597,7 +637,7 @@ export function MenuManagementPage() {
                   onChange={(event) =>
                     setForm((current) => ({ ...current, component: event.target.value }))
                   }
-                  placeholder="/dashboard/workspace/index"
+                  placeholder={form.type === "directory" ? "Layout" : "feature-page"}
                 />
               </label>
             ) : null}

--- a/pages/menu-management/route.tsx
+++ b/pages/menu-management/route.tsx
@@ -5,12 +5,13 @@ const { Page, preload } = preloadablePage(() =>
 );
 
 export const menuManagementRoute = {
-  path: "/menu-management",
+  path: "/system/menu-management",
   component: "menu-management",
   element: <Page />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.menuManagement" },
+  redirects: [{ from: "/menu-management", to: "/system/menu-management" }],
   requiredPermission: "platform.menus.read",
   preload,
 };

--- a/pages/models/route.tsx
+++ b/pages/models/route.tsx
@@ -5,13 +5,16 @@ const { Page: ModelsPage, preload: preloadModelsPage } = preloadablePage(() =>
 );
 
 export const modelsRoute = {
-  path: "/models",
+  path: "/models/catalog",
   component: "models",
   element: <ModelsPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.models" },
-  redirects: [{ from: "/manage/models", to: "/models" }],
+  redirects: [
+    { from: "/models", to: "/models/catalog" },
+    { from: "/manage/models", to: "/models/catalog" },
+  ],
   requiredPermission: "models.read",
   preload: preloadModelsPage,
 };

--- a/pages/monitor/route.tsx
+++ b/pages/monitor/route.tsx
@@ -5,13 +5,16 @@ const { Page: MonitorPage, preload: preloadMonitorPage } = preloadablePage(() =>
 );
 
 export const monitorRoute = {
-  path: "/monitor",
+  path: "/runtime/monitor",
   component: "monitor",
   element: <MonitorPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.monitor" },
-  redirects: [{ from: "/usage", to: "/monitor" }],
+  redirects: [
+    { from: "/monitor", to: "/runtime/monitor" },
+    { from: "/usage", to: "/runtime/monitor" },
+  ],
   requiredPermission: "monitor.read",
   preload: preloadMonitorPage,
 };

--- a/pages/providers/__tests__/ProvidersPage.bedrock.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.bedrock.test.tsx
@@ -88,11 +88,11 @@ describe("ProvidersPage Bedrock tab", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/bedrock/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/bedrock/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>

--- a/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -110,11 +110,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -147,11 +147,11 @@ describe("ProvidersPage import/export", () => {
       .mockImplementationOnce(() => new Promise<any[]>((resolve) => (resolveRefresh = resolve)));
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -187,11 +187,11 @@ describe("ProvidersPage import/export", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -222,11 +222,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -246,11 +246,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -272,11 +272,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -298,11 +298,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -326,11 +326,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -353,11 +353,11 @@ describe("ProvidersPage import/export", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -438,11 +438,11 @@ describe("ProvidersPage import/export", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>

--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -157,11 +157,11 @@ describe("ProvidersPage openai tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -191,11 +191,11 @@ describe("ProvidersPage openai tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -219,11 +219,11 @@ describe("ProvidersPage openai tab", () => {
     mocks.getGeminiKeys.mockImplementationOnce(async () => [geminiProvider]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -254,11 +254,11 @@ describe("ProvidersPage openai tab", () => {
 
   test("renders openai provider card with masked key and aggregated status", async () => {
     render(
-      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/openai"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -287,11 +287,11 @@ describe("ProvidersPage openai tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -335,11 +335,11 @@ describe("ProvidersPage openai tab", () => {
     mocks.getOpenAIProviders.mockImplementation(async () => [provider] as any);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/openai"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -387,11 +387,11 @@ describe("ProvidersPage openai tab", () => {
     mocks.getOpenAIProviders.mockImplementation(async () => [provider] as any);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/openai"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -431,11 +431,11 @@ describe("ProvidersPage openai tab", () => {
     mocks.getOpenAIProviders.mockImplementation(async () => [provider] as any);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/openai"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/openai"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -248,11 +248,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -292,11 +292,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -363,11 +363,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -405,11 +405,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -429,11 +429,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -474,11 +474,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     mocks.saveOpenCodeGoConfigs.mockRejectedValue(new Error("channel name already used"));
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -519,11 +519,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -568,11 +568,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -605,11 +605,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -645,11 +645,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -675,11 +675,11 @@ describe("ProvidersPage OpenCode Go tab", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/opencode-go/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/opencode-go/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -815,11 +815,11 @@ describe("ProvidersPage Cline tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -848,11 +848,11 @@ describe("ProvidersPage Cline tab", () => {
     const user = userEvent.setup();
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/cline/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/cline/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -929,11 +929,11 @@ describe("ProvidersPage Cline tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/cline/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/cline/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -990,11 +990,11 @@ describe("ProvidersPage Cline tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1024,11 +1024,11 @@ describe("ProvidersPage Cline tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1058,11 +1058,11 @@ describe("ProvidersPage Cline tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/cline/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/cline/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1154,11 +1154,11 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     );
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1187,11 +1187,11 @@ describe("ProvidersPage Ollama Cloud tab", () => {
 
   test("shows Ollama Cloud dynamic model list without manual model inputs", async () => {
     render(
-      <MemoryRouter initialEntries={["/ai-providers/ollama-cloud/new"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/ollama-cloud/new"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1226,11 +1226,11 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/ollama-cloud/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/ollama-cloud/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1277,11 +1277,11 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers/ollama-cloud/0"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers/ollama-cloud/0"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>
@@ -1315,11 +1315,11 @@ describe("ProvidersPage Ollama Cloud tab", () => {
     ]);
 
     render(
-      <MemoryRouter initialEntries={["/ai-providers"]}>
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
         <ThemeProvider>
           <ToastProvider>
             <Routes>
-              <Route path="/ai-providers/*" element={<ProvidersPage />} />
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
             </Routes>
           </ToastProvider>
         </ThemeProvider>

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -678,17 +678,19 @@ export function ProvidersPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const providersBasePath = "/access/ai-providers";
+
   const handleKeyEditorRouteClose = useCallback(() => {
-    if (location.pathname !== "/ai-providers") {
-      navigate("/ai-providers", { replace: true, viewTransition: true });
+    if (location.pathname !== providersBasePath) {
+      navigate(providersBasePath, { replace: true, viewTransition: true });
     }
-  }, [location.pathname, navigate]);
+  }, [location.pathname, navigate, providersBasePath]);
 
   const handleOpenAIEditorRouteClose = useCallback(() => {
-    if (location.pathname !== "/ai-providers") {
-      navigate("/ai-providers", { replace: true, viewTransition: true });
+    if (location.pathname !== providersBasePath) {
+      navigate(providersBasePath, { replace: true, viewTransition: true });
     }
-  }, [location.pathname, navigate]);
+  }, [location.pathname, navigate, providersBasePath]);
 
   const {
     editKeyOpen,
@@ -759,16 +761,18 @@ export function ProvidersPage() {
   useEffect(() => {
     if (loading) return;
     const pathname = location.pathname;
-    if (!pathname.startsWith("/ai-providers/")) {
+    const providersPrefix = `${providersBasePath}/`;
+    if (!pathname.startsWith(providersPrefix)) {
       handledRouteRef.current = "";
       return;
     }
     if (handledRouteRef.current === pathname) return;
     handledRouteRef.current = pathname;
 
-    const parts = pathname.split("/").filter(Boolean);
-    const provider = parts[1] ?? "";
-    const action = parts[2] ?? "";
+    // /access/ai-providers/:provider/:action
+    const rest = pathname.slice(providersBasePath.length).split("/").filter(Boolean);
+    const provider = rest[0] ?? "";
+    const action = rest[1] ?? "";
 
     void (async () => {
       if (
@@ -825,6 +829,7 @@ export function ProvidersPage() {
     location.pathname,
     openKeyEditor,
     openOpenAIEditor,
+    providersBasePath,
     refreshTab,
   ]);
 

--- a/pages/providers/route.tsx
+++ b/pages/providers/route.tsx
@@ -5,13 +5,14 @@ const { Page: ProvidersPage, preload: preloadProvidersPage } = preloadablePage(
 );
 
 export const providersRoute = {
-  path: "/ai-providers",
+  path: "/access/ai-providers",
   component: "providers",
   element: <ProvidersPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.providers" },
   hasWildcard: true,
+  redirects: [{ from: "/ai-providers", to: "/access/ai-providers" }],
   requiredPermission: "providers.read",
   preload: preloadProvidersPage,
 };

--- a/pages/proxies/route.tsx
+++ b/pages/proxies/route.tsx
@@ -5,13 +5,16 @@ const { Page: ProxiesPage, preload: preloadProxiesPage } = preloadablePage(() =>
 );
 
 export const proxiesRoute = {
-  path: "/proxies",
+  path: "/models/proxies",
   component: "proxies",
   element: <ProxiesPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.proxies" },
-  redirects: [{ from: "/manage/proxies", to: "/proxies" }],
+  redirects: [
+    { from: "/proxies", to: "/models/proxies" },
+    { from: "/manage/proxies", to: "/models/proxies" },
+  ],
   requiredPermission: "proxies.read",
   preload: preloadProxiesPage,
 };

--- a/pages/request-logs/route.tsx
+++ b/pages/request-logs/route.tsx
@@ -5,12 +5,13 @@ const { Page: RequestLogsPage, preload: preloadRequestLogsPage } = preloadablePa
 );
 
 export const requestLogsRoute = {
-  path: "/monitor/request-logs",
+  path: "/runtime/request-logs",
   component: "request-logs",
   element: <RequestLogsPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.requestLogs" },
+  redirects: [{ from: "/monitor/request-logs", to: "/runtime/request-logs" }],
   requiredPermission: "request_logs.read",
   preload: preloadRequestLogsPage,
 };

--- a/pages/roles/route.tsx
+++ b/pages/roles/route.tsx
@@ -3,12 +3,13 @@ const { Page, preload } = preloadablePage(() =>
   import("./RolesPage").then((m) => ({ default: m.RolesPage })),
 );
 export const rolesRoute = {
-  path: "/roles",
+  path: "/governance/roles",
   component: "roles",
   element: <Page />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.roles" },
+  redirects: [{ from: "/roles", to: "/governance/roles" }],
   requiredPermission: "tenant.roles.read",
   preload,
 };

--- a/pages/system/route.tsx
+++ b/pages/system/route.tsx
@@ -5,12 +5,13 @@ const { Page: SystemPage, preload: preloadSystemPage } = preloadablePage(() =>
 );
 
 export const systemRoute = {
-  path: "/system",
+  path: "/runtime/system",
   component: "system",
   element: <SystemPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.system" },
+  redirects: [{ from: "/system", to: "/runtime/system" }],
   requiredPermission: "system.status.read",
   preload: preloadSystemPage,
 };

--- a/pages/tenants/route.tsx
+++ b/pages/tenants/route.tsx
@@ -3,12 +3,13 @@ const { Page, preload } = preloadablePage(() =>
   import("./TenantsPage").then((m) => ({ default: m.TenantsPage })),
 );
 export const tenantsRoute = {
-  path: "/tenants",
+  path: "/governance/tenants",
   component: "tenants",
   element: <Page />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.tenants" },
+  redirects: [{ from: "/tenants", to: "/governance/tenants" }],
   requiredPermission: "platform.tenants.read",
   preload,
 };

--- a/pages/users/route.tsx
+++ b/pages/users/route.tsx
@@ -3,12 +3,13 @@ const { Page, preload } = preloadablePage(() =>
   import("./UsersPage").then((m) => ({ default: m.UsersPage })),
 );
 export const usersRoute = {
-  path: "/users",
+  path: "/governance/users",
   component: "users",
   element: <Page />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.users" },
+  redirects: [{ from: "/users", to: "/governance/users" }],
   requiredPermission: "tenant.users.read",
   preload,
 };


### PR DESCRIPTION
## Summary
- Move admin page routes under menu group prefixes (`/runtime/*`, `/access/*`, `/models/*`, `/governance/*`, `/system/*`) so submenu paths match the secondary route structure.
- Keep legacy first-level path redirects (including deep links like `/ai-providers/...`).
- Menu management shows directory path/component instead of blank dashes, and directory create/edit can set route prefix + Layout component.
- Providers deep-link parsing updated for `/access/ai-providers/...`.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full test:ci, build, bundle:diff)
- [x] AppRouter / AppShell / Providers / identity unit tests
- [ ] Restart backend with CliRelay menu seed update
- [ ] Open menu management: directory rows show path/component
- [ ] Navigate nested routes and legacy redirects

Depends on: https://github.com/kittors/CliRelay/pull/637