### PR TITLE
fix: gate dashboard system monitor by permission

### DIFF
--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -32,6 +32,7 @@ import {
   getCompactNumberParts,
   type CompactNumberOptions,
 } from "@code-proxy/domain";
+import { useAuth } from "@app/providers/AuthProvider";
 import { SystemMonitorSection } from "./SystemMonitorSection";
 import { useSystemStats } from "./useSystemStats";
 import { AnimatedNumber } from "@code-proxy/ui";
@@ -437,7 +438,11 @@ function ThroughputTrendChart({
 export function DashboardPage() {
   const { t } = useTranslation();
   const { notify } = useToast();
-  const { stats, connected } = useSystemStats(5);
+  const { can } = useAuth();
+  // Host-level system monitor is gated by platform permission (and thus menus/roles).
+  // Throughput trends stay on dashboard.read and are always tenant-scoped via dashboard-summary.
+  const canViewSystemMonitor = can("system.status.read");
+  const { stats, connected } = useSystemStats(5, canViewSystemMonitor);
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
   const summaryRef = useRef<DashboardSummary | null>(null);
   const [range, setRange] = useState<DashboardRange>(7);
@@ -492,6 +497,10 @@ export function DashboardPage() {
     () => trends?.throughput_series ?? [],
     [trends?.throughput_series],
   );
+  // Latest minute from tenant-scoped series (not host-wide system-stats RPM/TPM).
+  const latestThroughput = throughputSeries[throughputSeries.length - 1];
+  const tenantRpm = latestThroughput?.rpm ?? 0;
+  const tenantTpm = latestThroughput?.tpm ?? 0;
 
   const totalRequestOption = useMemo(
     () => createSparklineOption(trends?.request_volume ?? [], "#2563eb"),
@@ -653,18 +662,21 @@ export function DashboardPage() {
         />
       </div>
 
-      <SystemMonitorSection
-        stats={stats}
-        connected={connected}
-        apiKeyCount={summary?.counts.api_keys ?? 0}
-      />
+      {canViewSystemMonitor ? (
+        <SystemMonitorSection
+          stats={stats}
+          connected={connected}
+          apiKeyCount={summary?.counts.api_keys ?? 0}
+        />
+      ) : null}
 
       <ThroughputTrendChart
         title={t("dashboard.throughput_title")}
         points={throughputSeries}
-        rpm={stats?.total_rpm ?? 0}
-        tpm={stats?.total_tpm ?? 0}
-        connected={connected}
+        rpm={tenantRpm}
+        tpm={tenantTpm}
+        // Series comes from dashboard-summary polling, not the system-stats websocket.
+        connected={false}
         showRPM={throughputLegend.rpm}
         showTPM={throughputLegend.tpm}
         onToggle={(key) =>

--- a/pages/dashboard/__tests__/DashboardCards.test.ts
+++ b/pages/dashboard/__tests__/DashboardCards.test.ts
@@ -18,9 +18,11 @@ describe("dashboard card composition", () => {
     expect(source).toContain("ChartLegend");
     expect(source).toContain("useInterval");
     expect(source).toContain("summary?.trends");
-    expect(source).toContain("const { stats, connected } = useSystemStats(5)");
-    expect(source).toContain("rpm={stats?.total_rpm ?? 0}");
-    expect(source).toContain("tpm={stats?.total_tpm ?? 0}");
+    expect(source).toContain('can("system.status.read")');
+    expect(source).toContain("useSystemStats(5, canViewSystemMonitor)");
+    expect(source).toContain("rpm={tenantRpm}");
+    expect(source).toContain("tpm={tenantTpm}");
+    expect(source).toContain("canViewSystemMonitor");
     expect(source).toContain("meta.generated_at");
     expect(source).toContain('<EChart option={option} className="h-10" overflowVisible />');
     expect(source).toContain("}, 5000);");

--- a/pages/dashboard/__tests__/DashboardPage.test.tsx
+++ b/pages/dashboard/__tests__/DashboardPage.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getDashboardSummary: vi.fn(),
   notify: vi.fn(),
   useSystemStats: vi.fn(),
+  can: vi.fn((permission: string) => permission === "system.status.read" || permission === "dashboard.read"),
   intervalCallback: null as null | (() => void),
 }));
 
@@ -14,6 +15,14 @@ vi.mock("@code-proxy/api-client/endpoints/usage", () => ({
   usageApi: {
     getDashboardSummary: mocks.getDashboardSummary,
   },
+}));
+
+vi.mock("@app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    can: mocks.can,
+    state: { principal: null },
+    actions: {},
+  }),
 }));
 
 vi.mock("../useSystemStats", () => ({
@@ -113,11 +122,15 @@ describe("DashboardPage", () => {
     await i18n.changeLanguage("en");
     mocks.notify.mockReset();
     mocks.getDashboardSummary.mockReset();
+    mocks.can.mockReset();
+    mocks.can.mockImplementation(
+      (permission: string) => permission === "system.status.read" || permission === "dashboard.read",
+    );
     mocks.intervalCallback = null;
     mocks.useSystemStats.mockReturnValue({
       stats: {
-        total_rpm: 12,
-        total_tpm: 345,
+        total_rpm: 99,
+        total_tpm: 999,
       },
       connected: true,
       error: null,
@@ -191,5 +204,33 @@ describe("DashboardPage", () => {
     expect(tooltipValues).toContain("2,819,900,000.00");
     expect(tooltipValues).toContain("13,100,000.00");
     expect(tooltipValues).toContain("$12,345.6789");
+  });
+
+  test("hides system monitor without system.status.read but still shows tenant throughput", async () => {
+    mocks.can.mockImplementation((permission: string) => permission === "dashboard.read");
+    mocks.getDashboardSummary.mockResolvedValueOnce(summary);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Throughput Trend")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("system-monitor-section")).toBeNull();
+    // RPM/TPM cards use the latest tenant-scoped series point, not host system-stats.
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("345")).toBeInTheDocument();
+    expect(mocks.useSystemStats).toHaveBeenCalledWith(5, false);
+  });
+
+  test("shows system monitor when system.status.read is granted", async () => {
+    mocks.getDashboardSummary.mockResolvedValueOnce(summary);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("system-monitor-section")).toBeInTheDocument();
+    });
+    expect(mocks.useSystemStats).toHaveBeenCalledWith(5, true);
   });
 });

--- a/pages/dashboard/useSystemStats.ts
+++ b/pages/dashboard/useSystemStats.ts
@@ -66,7 +66,11 @@ function buildWsUrl(apiBase: string, managementKey: string): string | null {
   }
 }
 
-export function useSystemStats(interval = 3): {
+export function useSystemStats(
+  interval = 3,
+  /** When false, skip WebSocket/HTTP and expose an empty idle state. */
+  enabled = true,
+): {
   stats: SystemStats | null;
   connected: boolean;
   error: string | null;
@@ -164,6 +168,14 @@ export function useSystemStats(interval = 3): {
 
   useEffect(() => {
     mountedRef.current = true;
+    if (!enabled) {
+      setStats(null);
+      setConnected(false);
+      setError(null);
+      return () => {
+        mountedRef.current = false;
+      };
+    }
     connect();
     return () => {
       mountedRef.current = false;
@@ -174,7 +186,11 @@ export function useSystemStats(interval = 3): {
         wsRef.current = null;
       }
     };
-  }, [connect, stopHttpFallback]);
+  }, [connect, enabled, stopHttpFallback]);
+
+  if (!enabled) {
+    return { stats: null, connected: false, error: null };
+  }
 
   return { stats, connected, error };
 }


### PR DESCRIPTION
## Summary
- Gate the host-level **System Monitor** section on `system.status.read`, so tenants without that platform permission no longer see or poll `/system-stats`.
- Keep **Throughput Trend** on `dashboard.read`, always visible, and drive RPM/TPM cards from the latest tenant-scoped `throughput_series` point instead of global concurrency counters.
- Add unit coverage for hide/show system monitor and tenant throughput values.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, test:ci, build, bundle:diff)
- [x] Dashboard unit tests covering:
  - no `system.status.read` → system monitor hidden, throughput still shown with tenant series values
  - with `system.status.read` → system monitor shown and `useSystemStats(..., true)`