### PR TITLE
fix: add batch download to auth-files multi-select toolbar

### DIFF
--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -311,6 +311,7 @@ export function AuthFilesPage() {
     statusUpdating,
     tagSavingByName,
     downloadAuthFile,
+    handleDownloadSelection,
     handleUpload,
     handleDeleteSelection,
     setFileEnabled,
@@ -901,6 +902,7 @@ export function AuthFilesPage() {
         openTagsEditor={(file) => setTagsEditorFileName(file.name)}
         openDetail={openDetailWithQuotaRefresh}
         downloadAuthFile={downloadAuthFile}
+        handleDownloadSelection={handleDownloadSelection}
         safePage={safePage}
         totalPages={totalPages}
         setPage={setPage}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -662,6 +662,7 @@ interface AuthFilesFilesTabProps {
   openTagsEditor: (file: AuthFileItem) => void;
   openDetail: (file: AuthFileItem) => Promise<void>;
   downloadAuthFile: (file: AuthFileItem) => Promise<void>;
+  handleDownloadSelection: (names: string[]) => Promise<void>;
   safePage: number;
   totalPages: number;
   setPage: (value: number | ((prev: number) => number)) => void;
@@ -743,6 +744,7 @@ export function AuthFilesFilesTab({
   openTagsEditor,
   openDetail,
   downloadAuthFile,
+  handleDownloadSelection,
   safePage,
   totalPages,
   setPage,
@@ -1053,6 +1055,16 @@ export function AuthFilesFilesTab({
           disabled={deletingAll}
         >
           {t("auth_files.batch_delete_action", { count: selectedCount })}
+        </Button>
+        <Button
+          variant="secondary"
+          size="xs"
+          className="px-2"
+          onClick={() => void handleDownloadSelection([...selectedFileNames])}
+          disabled={deletingAll || selectedCount === 0}
+        >
+          <Download size={13} className="shrink-0" />
+          <span>{t("auth_files.batch_download_action", { count: selectedCount })}</span>
         </Button>
       </div>
     ) : (

--- a/pages/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/pages/auth-files/hooks/useAuthFilesFileActions.ts
@@ -83,6 +83,46 @@ export function useAuthFilesFileActions({
     [notify, t],
   );
 
+  const handleDownloadSelection = useCallback(
+    async (names: string[]) => {
+      const targets = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
+      if (targets.length === 0) return;
+
+      const confirmed = window.confirm(
+        t("auth_files.batch_download_sensitive_confirm", {
+          count: targets.length,
+          defaultValue:
+            "This downloads {{count}} full auth file(s) and may include sensitive credentials. Continue?",
+        }),
+      );
+      if (!confirmed) return;
+
+      let success = 0;
+      let failed = 0;
+      for (const name of targets) {
+        try {
+          await authFilesApi.downloadFile(name);
+          success += 1;
+        } catch {
+          failed += 1;
+        }
+      }
+
+      if (failed === 0) {
+        notify({
+          type: "success",
+          message: t("auth_files.batch_download_success", { count: success }),
+        });
+      } else {
+        notify({
+          type: "error",
+          message: t("auth_files.batch_download_partial", { success, failed }),
+        });
+      }
+    },
+    [notify, t],
+  );
+
   const handleUpload = useCallback(
     async (input: FileList | File[] | null): Promise<AuthFilesUploadResult | null> => {
       const list = Array.isArray(input) ? input : input ? Array.from(input) : [];
@@ -349,6 +389,7 @@ export function useAuthFilesFileActions({
     statusUpdating,
     tagSavingByName,
     downloadAuthFile,
+    handleDownloadSelection,
     handleUpload,
     handleDeleteSelection,
     setFileEnabled,


### PR DESCRIPTION
## Summary
- Add bulk download next to “delete selected” in the auth-files card multi-select toolbar.
- Confirm before downloading sensitive credential files and report success/partial results.

## Test plan
- [x] `./scripts/ci-pr.sh`
- [ ] Multi-select auth cards → “批量下载” appears to the right of delete
- [ ] Confirm dialog and sequential downloads for selected files