### PR TITLE
fix: halt management poll storms on 401/403

### DIFF
--- a/pages/auth-files/__tests__/isFatalQuotaRefreshError.test.ts
+++ b/pages/auth-files/__tests__/isFatalQuotaRefreshError.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { ApiError } from "@code-proxy/api-client";
+import { isFatalQuotaRefreshError } from "../hooks/useAuthFilesQuotaState";
+
+describe("isFatalQuotaRefreshError", () => {
+  test("halts on 401/403 ApiError", () => {
+    expect(
+      isFatalQuotaRefreshError(new ApiError({ message: "denied", status: 403 })),
+    ).toBe(true);
+    expect(
+      isFatalQuotaRefreshError(new ApiError({ message: "unauth", status: 401 })),
+    ).toBe(true);
+  });
+
+  test("halts on tenant scope code", () => {
+    expect(
+      isFatalQuotaRefreshError(
+        new ApiError({
+          message: "scope",
+          status: 403,
+          payload: { error: { code: "tenant_resource_scope_unavailable" } },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not halt on generic or network errors", () => {
+    expect(isFatalQuotaRefreshError(new Error("network"))).toBe(false);
+    expect(
+      isFatalQuotaRefreshError(new ApiError({ message: "server", status: 500 })),
+    ).toBe(false);
+  });
+});

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -8,7 +8,13 @@ import {
   type SetStateAction,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { authFilesApi, quotaApi, usageApi } from "@code-proxy/api-client";
+import {
+  authFilesApi,
+  extractApiErrorCode,
+  isApiClientError,
+  quotaApi,
+  usageApi,
+} from "@code-proxy/api-client";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { useInterval, useLocalStorage } from "@code-proxy/ui";
 import {
@@ -44,6 +50,21 @@ interface UseAuthFilesQuotaStateOptions {
   refreshUsageDataForFiles?: (files: AuthFileItem[]) => Promise<unknown>;
 }
 
+/** Auth / tenant-scope failures that must stop quota auto-refresh storms. */
+export function isFatalQuotaRefreshError(error: unknown): boolean {
+  if (!isApiClientError(error)) return false;
+  if (error.status === 401 || error.status === 403) return true;
+  if (error.isAuthError) return true;
+  const code = extractApiErrorCode(error.payload);
+  return (
+    code === "permission_denied" ||
+    code === "tenant_resource_scope_unavailable" ||
+    code === "session_expired" ||
+    code === "session_revoked" ||
+    code === "invalid_credentials"
+  );
+}
+
 export function useAuthFilesQuotaState({
   tab,
   pageItems,
@@ -67,6 +88,9 @@ export function useAuthFilesQuotaState({
   const quotaByFileNameRef = useRef<Record<string, QuotaState>>(quotaByFileName);
   const quotaWarmupAttemptRef = useRef<Map<string, number>>(new Map());
   const visibleScopeKeyRef = useRef<string | null>(null);
+  // After 401/403 (missing providers.test or tenant scope), stop auto-refresh to avoid storms.
+  const [quotaRefreshHalted, setQuotaRefreshHalted] = useState(false);
+  const quotaRefreshHaltedRef = useRef(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   const [quotaPreviewMode, setQuotaPreviewMode] = useLocalStorage<QuotaPreviewMode>(
@@ -85,12 +109,23 @@ export function useAuthFilesQuotaState({
     () => normalizeQuotaAutoRefreshMs(quotaAutoRefreshMsRaw),
     [quotaAutoRefreshMsRaw],
   );
+  const effectiveQuotaAutoRefreshMs = quotaRefreshHalted ? 0 : quotaAutoRefreshMs;
+
+  const haltQuotaAutoRefresh = useCallback(() => {
+    if (quotaRefreshHaltedRef.current) return;
+    quotaRefreshHaltedRef.current = true;
+    setQuotaRefreshHalted(true);
+    // Persist off so a reload does not immediately resume the 403 storm.
+    setQuotaAutoRefreshMsRaw(0);
+  }, [setQuotaAutoRefreshMsRaw]);
 
   useInterval(
     () => {
       setNowMs(Date.now());
     },
-    tab === "files" && quotaAutoRefreshMs > 0 ? Math.min(10_000, quotaAutoRefreshMs) : null,
+    tab === "files" && effectiveQuotaAutoRefreshMs > 0
+      ? Math.min(10_000, effectiveQuotaAutoRefreshMs)
+      : null,
   );
 
   useEffect(() => {
@@ -387,6 +422,9 @@ export function useAuthFilesQuotaState({
           await refreshUsageDataAfterQuota([file]);
         }
       } catch (err: unknown) {
+        if (isFatalQuotaRefreshError(err)) {
+          haltQuotaAutoRefresh();
+        }
         const message = err instanceof Error ? err.message : t("auth_files.unknown_error");
         setQuotaByFileName((prev) => ({
           ...prev,
@@ -404,7 +442,7 @@ export function useAuthFilesQuotaState({
         quotaInFlightRef.current.delete(name);
       }
     },
-    [patchAuthFileByName, refreshUsageDataAfterQuota, resolveQuotaCardSlots, t],
+    [haltQuotaAutoRefresh, patchAuthFileByName, refreshUsageDataAfterQuota, resolveQuotaCardSlots, t],
   );
 
   const checkAuthFileConnectivity = useCallback(
@@ -538,6 +576,7 @@ export function useAuthFilesQuotaState({
   useEffect(() => {
     if (tab !== "files") return;
     if (loading) return;
+    if (quotaRefreshHalted) return;
 
     const previousVisibleScopeKey = visibleScopeKeyRef.current;
     visibleScopeKeyRef.current = visibleScopeKey;
@@ -545,7 +584,7 @@ export function useAuthFilesQuotaState({
     const firstVisibleScope = previousVisibleScopeKey === null;
     const initialVisibleScope = firstVisibleScope;
     const switchedVisibleScope = !firstVisibleScope && previousVisibleScopeKey !== visibleScopeKey;
-    if (!initialVisibleScope && !switchedVisibleScope && quotaAutoRefreshMs <= 0) return;
+    if (!initialVisibleScope && !switchedVisibleScope && effectiveQuotaAutoRefreshMs <= 0) return;
 
     const toFetch =
       initialVisibleScope || switchedVisibleScope
@@ -573,10 +612,11 @@ export function useAuthFilesQuotaState({
     };
   }, [
     collectQuotaFetchTargets,
+    effectiveQuotaAutoRefreshMs,
     loading,
     markQuotaTargetsLoading,
     pageItems,
-    quotaAutoRefreshMs,
+    quotaRefreshHalted,
     resolveQuotaTargets,
     runQuotaRefreshBatch,
     tab,
@@ -630,7 +670,7 @@ export function useAuthFilesQuotaState({
     () => {
       void refreshCurrentPageQuota();
     },
-    tab === "files" && quotaAutoRefreshMs > 0 ? quotaAutoRefreshMs : null,
+    tab === "files" && effectiveQuotaAutoRefreshMs > 0 ? effectiveQuotaAutoRefreshMs : null,
   );
 
   return {
@@ -640,8 +680,15 @@ export function useAuthFilesQuotaState({
     nowMs,
     quotaPreviewMode,
     setQuotaPreviewMode,
-    quotaAutoRefreshMs,
-    setQuotaAutoRefreshMsRaw,
+    quotaAutoRefreshMs: effectiveQuotaAutoRefreshMs,
+    setQuotaAutoRefreshMsRaw: (value: number) => {
+      // Manual re-enable clears the halt latch.
+      if (value > 0) {
+        quotaRefreshHaltedRef.current = false;
+        setQuotaRefreshHalted(false);
+      }
+      setQuotaAutoRefreshMsRaw(value);
+    },
     filesViewMode,
     setFilesViewMode,
     resolveQuotaCardSlots,

--- a/pages/dashboard/__tests__/useSystemStats.helpers.test.ts
+++ b/pages/dashboard/__tests__/useSystemStats.helpers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+import { isFatalSystemStatsStatus } from "../useSystemStats";
+
+describe("isFatalSystemStatsStatus", () => {
+  test("treats 401/403 as fatal", () => {
+    expect(isFatalSystemStatsStatus(401)).toBe(true);
+    expect(isFatalSystemStatsStatus(403)).toBe(true);
+  });
+
+  test("treats other statuses as non-fatal", () => {
+    expect(isFatalSystemStatsStatus(200)).toBe(false);
+    expect(isFatalSystemStatsStatus(500)).toBe(false);
+    expect(isFatalSystemStatsStatus(0)).toBe(false);
+  });
+});

--- a/pages/dashboard/useSystemStats.ts
+++ b/pages/dashboard/useSystemStats.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { computeManagementApiBase } from "@code-proxy/api-client";
 import { useAuth } from "@app/providers/AuthProvider";
-import { apiClient } from "@code-proxy/api-client";
+import { apiClient, extractApiErrorCode, isApiClientError } from "@code-proxy/api-client";
 
 export interface SystemStats {
   db_size_bytes: number;
@@ -49,6 +49,25 @@ export interface ConcurrencySnapshot {
   tpm_limit: number;
 }
 
+/** Auth/permission failures that should stop reconnect storms. */
+export function isFatalSystemStatsStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+function isFatalSystemStatsError(error: unknown): boolean {
+  if (!isApiClientError(error)) return false;
+  if (isFatalSystemStatsStatus(error.status)) return true;
+  if (error.isAuthError) return true;
+  const code = extractApiErrorCode(error.payload);
+  return (
+    code === "permission_denied" ||
+    code === "tenant_resource_scope_unavailable" ||
+    code === "session_expired" ||
+    code === "session_revoked" ||
+    code === "invalid_credentials"
+  );
+}
+
 /** Build WebSocket URL from auth context */
 function buildWsUrl(apiBase: string, managementKey: string): string | null {
   const httpBase = computeManagementApiBase(apiBase);
@@ -85,20 +104,53 @@ export function useSystemStats(
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const httpFallbackTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const mountedRef = useRef(true);
+  // Stop WS reconnect + HTTP polling after auth/permission failures.
+  const haltedRef = useRef(false);
 
-  // --- HTTP fallback: poll if WebSocket fails ---
-  const fetchHttp = useCallback(async () => {
-    try {
-      const data = await apiClient.get<SystemStats>("/system-stats");
-      if (mountedRef.current) setStats(data);
-    } catch {
-      // silently ignore
+  const haltPolling = useCallback((message: string) => {
+    haltedRef.current = true;
+    if (reconnectTimer.current) {
+      clearTimeout(reconnectTimer.current);
+      reconnectTimer.current = undefined;
+    }
+    if (httpFallbackTimer.current) {
+      clearInterval(httpFallbackTimer.current as unknown as number);
+      httpFallbackTimer.current = undefined;
+    }
+    if (wsRef.current) {
+      const ws = wsRef.current;
+      wsRef.current = null;
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+    }
+    if (mountedRef.current) {
+      setConnected(false);
+      setError(message);
     }
   }, []);
 
+  // --- HTTP fallback: poll if WebSocket fails ---
+  const fetchHttp = useCallback(async () => {
+    if (haltedRef.current) return;
+    try {
+      const data = await apiClient.get<SystemStats>("/system-stats");
+      if (mountedRef.current && !haltedRef.current) setStats(data);
+    } catch (err) {
+      if (isFatalSystemStatsError(err)) {
+        haltPolling("System monitor unauthorized or forbidden");
+      }
+      // transient errors: silently ignore
+    }
+  }, [haltPolling]);
+
   const startHttpFallback = useCallback(() => {
+    if (haltedRef.current) return;
     // Only start if WebSocket is not connected
     if (wsRef.current?.readyState === WebSocket.OPEN) return;
+    if (httpFallbackTimer.current) return;
     void fetchHttp();
     httpFallbackTimer.current = setInterval(
       () => void fetchHttp(),
@@ -115,6 +167,8 @@ export function useSystemStats(
 
   // --- WebSocket connection ---
   const connect = useCallback(() => {
+    if (haltedRef.current) return;
+
     const url = buildWsUrl(apiBase, managementKey);
     if (!url) {
       // No WebSocket URL — use HTTP polling instead
@@ -125,9 +179,11 @@ export function useSystemStats(
     try {
       const ws = new WebSocket(url);
       wsRef.current = ws;
+      let sawOpen = false;
 
       ws.onopen = () => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || haltedRef.current) return;
+        sawOpen = true;
         setConnected(true);
         setError(null);
         stopHttpFallback();
@@ -135,7 +191,7 @@ export function useSystemStats(
       };
 
       ws.onmessage = (ev) => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || haltedRef.current) return;
         try {
           const data = JSON.parse(ev.data as string) as SystemStats;
           setStats(data);
@@ -145,17 +201,47 @@ export function useSystemStats(
       };
 
       ws.onerror = () => {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current || haltedRef.current) return;
         setError("WebSocket connection error");
       };
 
-      ws.onclose = () => {
+      ws.onclose = (ev) => {
         if (!mountedRef.current) return;
         setConnected(false);
-        wsRef.current = null;
+        if (wsRef.current === ws) {
+          wsRef.current = null;
+        }
+
+        // Auth handshake failures close before open with 4xx-class codes.
+        // Also stop if the socket never opened (common for rejected Upgrade).
+        if (isFatalSystemStatsStatus(ev.code) || (!sawOpen && (ev.code === 1006 || ev.code === 1002))) {
+          // Confirm with one HTTP probe so we only halt on real 401/403, not network blips.
+          void (async () => {
+            try {
+              await apiClient.get<SystemStats>("/system-stats");
+              // HTTP works — keep HTTP fallback, do not reconnect WS forever on transient WS issues.
+              if (!haltedRef.current) {
+                startHttpFallback();
+              }
+            } catch (err) {
+              if (isFatalSystemStatsError(err)) {
+                haltPolling("System monitor unauthorized or forbidden");
+                return;
+              }
+              if (!haltedRef.current) {
+                startHttpFallback();
+              }
+            }
+          })();
+          return;
+        }
+
+        if (haltedRef.current) return;
+
         // Fall back to HTTP, then retry WebSocket in 5s
         startHttpFallback();
         reconnectTimer.current = setTimeout(() => {
+          if (haltedRef.current) return;
           stopHttpFallback();
           connect();
         }, 5000);
@@ -164,10 +250,11 @@ export function useSystemStats(
       // WebSocket creation failed, use HTTP polling
       startHttpFallback();
     }
-  }, [apiBase, managementKey, interval, startHttpFallback, stopHttpFallback]);
+  }, [apiBase, managementKey, interval, startHttpFallback, stopHttpFallback, haltPolling]);
 
   useEffect(() => {
     mountedRef.current = true;
+    haltedRef.current = false;
     if (!enabled) {
       setStats(null);
       setConnected(false);


### PR DESCRIPTION
## Summary
- `useSystemStats`: stop WebSocket reconnect + HTTP fallback after 401/403 / session-permission failures (was 5s reconnect storm on dashboard).
- `useAuthFilesQuotaState`: on fatal quota `api-call` errors (401/403, `tenant_resource_scope_unavailable`, session revoked/expired), halt auto-refresh and persist interval to `0` so reloads do not resume the storm.
- Manual re-enable of auto-refresh clears the halt latch.
- Adds unit coverage for fatal-status helpers.

Pairs with CliRelay #641 (accept `cps_` query tokens on system-stats WS).

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff)
- [x] Focused unit tests for fatal helpers + dashboard tests
- [ ] Open dashboard as admin: no 401 WS loop after backend deploy
- [ ] As tenant admin on AI accounts with auto-refresh: first 403 stops further 10s storms

## Commands run
```bash
./scripts/ci-pr.sh
```