### PR TITLE
fix: gate CC Switch import settings on routing.read

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.test.ts
+++ b/apps/admin-panel/src/app/AppRouter.test.ts
@@ -40,6 +40,8 @@ describe("AppRouter", () => {
     expect(ccSwitchRoute).toContain(
       '{ from: "/manage/ccswitch-import-settings", to: "/access/ccswitch-import-settings" }',
     );
+    // Tenant-scoped: ordinary tenants have routing.read, not platform system.config.read.
+    expect(ccSwitchRoute).toContain('requiredPermission: "routing.read"');
 
     expect(apiKeyPermissionsRoute).toContain("ApiKeyPermissionsPage");
     expect(apiKeyPermissionsRoute).toMatch(/path:\s*"\/access\/api-key-permissions"/);

--- a/pages/ccswitch-import-settings/route.tsx
+++ b/pages/ccswitch-import-settings/route.tsx
@@ -18,6 +18,7 @@ export const ccswitchImportSettingsRoute = {
     { from: "/ccswitch-import-settings", to: "/access/ccswitch-import-settings" },
     { from: "/manage/ccswitch-import-settings", to: "/access/ccswitch-import-settings" },
   ],
-  requiredPermission: "system.config.read",
+  // Tenant-scoped: aligns with management API auth for /ccswitch-import-configs (routing.read).
+  requiredPermission: "routing.read",
   preload: preloadCcSwitchImportSettingsPage,
 };


### PR DESCRIPTION
## Summary
- Frontend route for CC Switch import settings required platform `system.config.read`.
- Change `requiredPermission` to tenant-scoped `routing.read`, matching backend management API auth.
- Add regression assertion in AppRouter path/permission test.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, full vitest, build, bundle:diff)
- [x] `bun test apps/admin-panel/src/app/AppRouter.test.ts`

## Pairing
Works with CliRelay PR that updates menu seed `access.ccswitch` to `routing.read`.