### PR TITLE
feat(auth-files): pack multi-select download into one zip

### DIFF
--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -23,6 +23,8 @@ export const authFilesApi = {
   deleteAll: () => apiClient.delete("/auth-files", undefined, { params: { all: true } }),
   downloadText: (name: string) =>
     apiClient.getText("/auth-files/download", { params: { name }, timeoutMs: 60000 }),
+  downloadBlob: (name: string) =>
+    apiClient.getBlob("/auth-files/download", { params: { name }, timeoutMs: 60000 }),
   downloadFile: (name: string) =>
     apiClient.downloadToFile("/auth-files/download", name, { params: { name }, timeoutMs: 60000 }),
   patchFields: (payload: {

--- a/packages/domain/src/auth-files/__tests__/zip.test.ts
+++ b/packages/domain/src/auth-files/__tests__/zip.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAuthFilesBatchZipName,
+  crc32,
+  createStoreZipBlob,
+  createStoreZipBytes,
+} from "../zip";
+
+const readUint32LE = (bytes: Uint8Array, offset: number) =>
+  bytes[offset]! |
+  (bytes[offset + 1]! << 8) |
+  (bytes[offset + 2]! << 16) |
+  (bytes[offset + 3]! << 24);
+
+const readUint16LE = (bytes: Uint8Array, offset: number) =>
+  bytes[offset]! | (bytes[offset + 1]! << 8);
+
+describe("createStoreZipBytes", () => {
+  it("builds a valid store zip with multiple entries", () => {
+    const a = new TextEncoder().encode('{"type":"a"}');
+    const b = new TextEncoder().encode('{"type":"b"}');
+    const zip = createStoreZipBytes([
+      { name: "alpha.json", data: a },
+      { name: "beta.json", data: b },
+    ]);
+
+    // Local file headers
+    expect(readUint32LE(zip, 0)).toBe(0x04034b50);
+    const nameLenA = readUint16LE(zip, 26);
+    expect(nameLenA).toBe("alpha.json".length);
+    const dataStartA = 30 + nameLenA;
+    // Compare via Array.from: vitest can fail Uint8Array views with "no visual difference".
+    expect(Array.from(zip.slice(dataStartA, dataStartA + a.length))).toEqual(Array.from(a));
+
+    const localB = dataStartA + a.length;
+    expect(readUint32LE(zip, localB)).toBe(0x04034b50);
+    const nameLenB = readUint16LE(zip, localB + 26);
+    const dataStartB = localB + 30 + nameLenB;
+    expect(Array.from(zip.slice(dataStartB, dataStartB + b.length))).toEqual(Array.from(b));
+
+    // End of central directory
+    const eocd = zip.length - 22;
+    expect(readUint32LE(zip, eocd)).toBe(0x06054b50);
+    expect(readUint16LE(zip, eocd + 8)).toBe(2);
+    expect(readUint16LE(zip, eocd + 10)).toBe(2);
+
+    // CRC of first entry matches
+    expect(readUint32LE(zip, 14) >>> 0).toBe(crc32(a));
+  });
+
+  it("rejects empty entry lists", () => {
+    expect(() => createStoreZipBytes([])).toThrow(/at least one entry/);
+  });
+
+  it("creates a zip blob", async () => {
+    const blob = createStoreZipBlob([{ name: "x.json", data: new Uint8Array([1, 2, 3]) }]);
+    expect(blob.type).toBe("application/zip");
+    expect(blob.size).toBeGreaterThan(22);
+  });
+});
+
+describe("buildAuthFilesBatchZipName", () => {
+  it("includes count and timestamp", () => {
+    const name = buildAuthFilesBatchZipName(3, new Date("2026-07-12T08:09:10"));
+    expect(name).toMatch(/^auth-files-3-\d{8}-\d{6}\.zip$/);
+  });
+});

--- a/packages/domain/src/auth-files/zip.ts
+++ b/packages/domain/src/auth-files/zip.ts
@@ -147,8 +147,9 @@ export const createStoreZipBlob = (
   options?: { modifiedAt?: Date },
 ): Blob => {
   const bytes = createStoreZipBytes(entries, options);
-  // Copy into a fresh ArrayBuffer so BlobPart typing stays compatible across DOM libs.
-  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  // Copy into a plain ArrayBuffer (not SharedArrayBuffer) for BlobPart compatibility.
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
   return new Blob([buffer], { type: "application/zip" });
 };
 

--- a/packages/domain/src/auth-files/zip.ts
+++ b/packages/domain/src/auth-files/zip.ts
@@ -1,0 +1,167 @@
+/** Minimal ZIP (STORE) builder for browser batch downloads. No external deps. */
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+export const crc32 = (data: Uint8Array): number => {
+  let c = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    c = CRC_TABLE[(c ^ data[i]!) & 0xff]! ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+};
+
+export type ZipStoreEntry = {
+  name: string;
+  data: Uint8Array;
+};
+
+const textEncoder = new TextEncoder();
+
+const writeUint16LE = (view: DataView, offset: number, value: number) => {
+  view.setUint16(offset, value & 0xffff, true);
+};
+
+const writeUint32LE = (view: DataView, offset: number, value: number) => {
+  view.setUint32(offset, value >>> 0, true);
+};
+
+const concatBytes = (chunks: Uint8Array[]): Uint8Array => {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+};
+
+const dosDateTime = (date = new Date()): { time: number; date: number } => {
+  const year = Math.max(1980, date.getFullYear());
+  const time =
+    ((date.getHours() & 0x1f) << 11) |
+    ((date.getMinutes() & 0x3f) << 5) |
+    (Math.floor(date.getSeconds() / 2) & 0x1f);
+  const dosDate =
+    (((year - 1980) & 0x7f) << 9) | (((date.getMonth() + 1) & 0xf) << 5) | (date.getDate() & 0x1f);
+  return { time, date: dosDate };
+};
+
+/**
+ * Build an uncompressed (STORE) ZIP archive.
+ * Filenames are encoded as UTF-8 with the language-encoding flag set.
+ */
+export const createStoreZipBytes = (
+  entries: ZipStoreEntry[],
+  options?: { modifiedAt?: Date },
+): Uint8Array => {
+  if (entries.length === 0) {
+    throw new Error("createStoreZipBytes requires at least one entry");
+  }
+
+  const { time, date } = dosDateTime(options?.modifiedAt);
+  // Bit 11: UTF-8 filename
+  const generalPurposeFlag = 0x0800;
+  const localChunks: Uint8Array[] = [];
+  const centralChunks: Uint8Array[] = [];
+  let localOffset = 0;
+
+  for (const entry of entries) {
+    const name = String(entry.name ?? "").trim() || "file";
+    // ZIP paths use forward slashes; strip leading slashes / drive tricks.
+    const safeName = name.replace(/\\/g, "/").replace(/^\/+/, "");
+    const nameBytes = textEncoder.encode(safeName);
+    const data = entry.data;
+    const checksum = crc32(data);
+    const size = data.length;
+
+    const localHeader = new Uint8Array(30 + nameBytes.length);
+    const localView = new DataView(localHeader.buffer);
+    writeUint32LE(localView, 0, 0x04034b50);
+    writeUint16LE(localView, 4, 20); // version needed
+    writeUint16LE(localView, 6, generalPurposeFlag);
+    writeUint16LE(localView, 8, 0); // store
+    writeUint16LE(localView, 10, time);
+    writeUint16LE(localView, 12, date);
+    writeUint32LE(localView, 14, checksum);
+    writeUint32LE(localView, 18, size);
+    writeUint32LE(localView, 22, size);
+    writeUint16LE(localView, 26, nameBytes.length);
+    writeUint16LE(localView, 28, 0); // extra length
+    localHeader.set(nameBytes, 30);
+
+    localChunks.push(localHeader, data);
+
+    const centralHeader = new Uint8Array(46 + nameBytes.length);
+    const centralView = new DataView(centralHeader.buffer);
+    writeUint32LE(centralView, 0, 0x02014b50);
+    writeUint16LE(centralView, 4, 20); // version made by
+    writeUint16LE(centralView, 6, 20); // version needed
+    writeUint16LE(centralView, 8, generalPurposeFlag);
+    writeUint16LE(centralView, 10, 0);
+    writeUint16LE(centralView, 12, time);
+    writeUint16LE(centralView, 14, date);
+    writeUint32LE(centralView, 16, checksum);
+    writeUint32LE(centralView, 20, size);
+    writeUint32LE(centralView, 24, size);
+    writeUint16LE(centralView, 28, nameBytes.length);
+    writeUint16LE(centralView, 30, 0); // extra
+    writeUint16LE(centralView, 32, 0); // comment
+    writeUint16LE(centralView, 34, 0); // disk start
+    writeUint16LE(centralView, 36, 0); // internal attrs
+    writeUint32LE(centralView, 38, 0); // external attrs
+    writeUint32LE(centralView, 42, localOffset);
+    centralHeader.set(nameBytes, 46);
+    centralChunks.push(centralHeader);
+
+    localOffset += localHeader.length + data.length;
+  }
+
+  const centralDirectory = concatBytes(centralChunks);
+  const endRecord = new Uint8Array(22);
+  const endView = new DataView(endRecord.buffer);
+  writeUint32LE(endView, 0, 0x06054b50);
+  writeUint16LE(endView, 4, 0);
+  writeUint16LE(endView, 6, 0);
+  writeUint16LE(endView, 8, entries.length);
+  writeUint16LE(endView, 10, entries.length);
+  writeUint32LE(endView, 12, centralDirectory.length);
+  writeUint32LE(endView, 16, localOffset);
+  writeUint16LE(endView, 20, 0);
+
+  return concatBytes([...localChunks, centralDirectory, endRecord]);
+};
+
+export const createStoreZipBlob = (
+  entries: ZipStoreEntry[],
+  options?: { modifiedAt?: Date },
+): Blob => {
+  const bytes = createStoreZipBytes(entries, options);
+  // Copy into a fresh ArrayBuffer so BlobPart typing stays compatible across DOM libs.
+  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  return new Blob([buffer], { type: "application/zip" });
+};
+
+export const buildAuthFilesBatchZipName = (count: number, now = new Date()): string => {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const stamp = [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    "-",
+    pad(now.getHours()),
+    pad(now.getMinutes()),
+    pad(now.getSeconds()),
+  ].join("");
+  return `auth-files-${count}-${stamp}.zip`;
+};

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,6 +5,7 @@ export * from "./ccswitch/ccswitchImportLinks";
 export * from "./ccswitch/ccswitchImportSettings";
 export * from "./auth-files/authFiles";
 export * from "./auth-files/types";
+export * from "./auth-files/zip";
 export * from "./quota";
 export * from "./usage";
 export { isRuntimeOnlyAuthFile, normalizeAuthIndexValue } from "./auth-files/authFiles";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -565,6 +565,8 @@
     "batch_download_sensitive_confirm": "This downloads {{count}} full auth file(s) and may include sensitive credentials. Continue?",
     "batch_download_success": "Downloaded {{count}} auth file(s)",
     "batch_download_partial": "Batch download finished: {{success}} succeeded, {{failed}} failed",
+    "batch_download_zip_success": "Downloaded {{count}} auth file(s) as a zip archive",
+    "batch_download_zip_partial": "Zip download finished: {{success}} packed, {{failed}} failed",
     "selection_actions": "Selection actions",
     "more_actions": "More actions",
     "status_filter": "Status",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -661,6 +661,8 @@
     "batch_download_sensitive_confirm": "Будет скачано {{count}} полных auth-файлов, которые могут содержать чувствительные учётные данные. Продолжить?",
     "batch_download_success": "Скачано {{count}} auth-файл(ов)",
     "batch_download_partial": "Пакетное скачивание завершено: успешно {{success}}, ошибок {{failed}}",
+    "batch_download_zip_success": "Скачано {{count}} auth-файл(ов) в zip-архиве",
+    "batch_download_zip_partial": "Zip-скачивание завершено: упаковано {{success}}, ошибок {{failed}}",
     "selection_actions": "Действия выбора",
     "more_actions": "Ещё действия",
     "status_filter": "Статус",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -573,6 +573,8 @@
     "batch_download_sensitive_confirm": "将下载 {{count}} 个完整认证文件，可能包含敏感凭据。确认继续？",
     "batch_download_success": "已下载 {{count}} 个认证文件",
     "batch_download_partial": "批量下载完成，成功 {{success}} 个，失败 {{failed}} 个",
+    "batch_download_zip_success": "已打包下载 {{count}} 个认证文件（zip）",
+    "batch_download_zip_partial": "zip 打包完成，成功 {{success}} 个，失败 {{failed}} 个",
     "selection_actions": "选择批量操作",
     "more_actions": "更多操作",
     "status_filter": "状态",

--- a/pages/auth-files/hooks/__tests__/useAuthFilesFileActions.download.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesFileActions.download.test.tsx
@@ -66,9 +66,10 @@ describe("useAuthFilesFileActions handleDownloadSelection", () => {
     mocks.downloadBlobAsFile.mockReset();
     mocks.buildAuthFilesBatchZipName.mockReset();
     mocks.downloadFile.mockResolvedValue(undefined);
-    mocks.downloadBlob.mockImplementation(
-      async (name: string) => new Blob([`content:${name}`], { type: "application/json" }),
-    );
+    mocks.downloadBlob.mockImplementation(async (...args: unknown[]) => {
+      const name = String(args[0] ?? "");
+      return new Blob([`content:${name}`], { type: "application/json" });
+    });
     mocks.createStoreZipBlob.mockReturnValue(new Blob(["zip"], { type: "application/zip" }));
     mocks.buildAuthFilesBatchZipName.mockReturnValue("auth-files-2-test.zip");
     vi.spyOn(window, "confirm").mockReturnValue(true);
@@ -108,7 +109,10 @@ describe("useAuthFilesFileActions handleDownloadSelection", () => {
     expect(mocks.downloadBlob).toHaveBeenCalledWith("a.json");
     expect(mocks.downloadBlob).toHaveBeenCalledWith("b.json");
     expect(mocks.createStoreZipBlob).toHaveBeenCalledTimes(1);
-    const entries = mocks.createStoreZipBlob.mock.calls[0]?.[0] as { name: string; data: Uint8Array }[];
+    const zipCall = mocks.createStoreZipBlob.mock.calls[0] as unknown as [
+      { name: string; data: Uint8Array }[],
+    ];
+    const entries = zipCall[0];
     expect(entries.map((e) => e.name)).toEqual(["a.json", "b.json"]);
     expect(mocks.downloadBlobAsFile).toHaveBeenCalledWith(
       expect.any(Blob),

--- a/pages/auth-files/hooks/__tests__/useAuthFilesFileActions.download.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesFileActions.download.test.tsx
@@ -1,0 +1,131 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createRef } from "react";
+
+const mocks = vi.hoisted(() => ({
+  downloadFile: vi.fn(async () => undefined),
+  downloadBlob: vi.fn(async () => new Blob(["{}"], { type: "application/json" })),
+  notify: vi.fn(),
+  createStoreZipBlob: vi.fn(() => new Blob(["zip"], { type: "application/zip" })),
+  downloadBlobAsFile: vi.fn(),
+  buildAuthFilesBatchZipName: vi.fn(() => "auth-files-2-test.zip"),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number; defaultValue?: string; success?: number; failed?: number }) => {
+      if (opts?.defaultValue) {
+        return String(opts.defaultValue)
+          .replace("{{count}}", String(opts.count ?? ""))
+          .replace("{{success}}", String(opts.success ?? ""))
+          .replace("{{failed}}", String(opts.failed ?? ""));
+      }
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@code-proxy/ui", () => ({
+  useToast: () => ({ notify: mocks.notify }),
+}));
+
+vi.mock("@code-proxy/api-client", () => ({
+  authFilesApi: {
+    downloadFile: mocks.downloadFile,
+    downloadBlob: mocks.downloadBlob,
+    upload: vi.fn(),
+    deleteFile: vi.fn(),
+    setStatus: vi.fn(),
+    patchFields: vi.fn(),
+  },
+}));
+
+vi.mock("@features/model-availability", () => ({
+  invalidateConfiguredModelAvailability: vi.fn(),
+}));
+
+vi.mock("@code-proxy/domain", async () => {
+  const actual = await vi.importActual<typeof import("@code-proxy/domain")>("@code-proxy/domain");
+  return {
+    ...actual,
+    createStoreZipBlob: mocks.createStoreZipBlob,
+    downloadBlobAsFile: mocks.downloadBlobAsFile,
+    buildAuthFilesBatchZipName: mocks.buildAuthFilesBatchZipName,
+  };
+});
+
+import { useAuthFilesFileActions } from "../useAuthFilesFileActions";
+
+describe("useAuthFilesFileActions handleDownloadSelection", () => {
+  beforeEach(() => {
+    mocks.downloadFile.mockReset();
+    mocks.downloadBlob.mockReset();
+    mocks.notify.mockReset();
+    mocks.createStoreZipBlob.mockReset();
+    mocks.downloadBlobAsFile.mockReset();
+    mocks.buildAuthFilesBatchZipName.mockReset();
+    mocks.downloadFile.mockResolvedValue(undefined);
+    mocks.downloadBlob.mockImplementation(
+      async (name: string) => new Blob([`content:${name}`], { type: "application/json" }),
+    );
+    mocks.createStoreZipBlob.mockReturnValue(new Blob(["zip"], { type: "application/zip" }));
+    mocks.buildAuthFilesBatchZipName.mockReturnValue("auth-files-2-test.zip");
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  const setup = () =>
+    renderHook(() =>
+      useAuthFilesFileActions({
+        loadAll: vi.fn(async () => []),
+        fileInputRef: createRef<HTMLInputElement>(),
+        detailFile: null,
+        setDetailFile: vi.fn(),
+        setDetailOpen: vi.fn(),
+        setFiles: vi.fn(),
+        setSelectedFileNames: vi.fn(),
+      }),
+    );
+
+  it("downloads a single selected file without zipping", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.handleDownloadSelection(["one.json"]);
+    });
+    expect(mocks.downloadFile).toHaveBeenCalledWith("one.json");
+    expect(mocks.downloadBlob).not.toHaveBeenCalled();
+    expect(mocks.createStoreZipBlob).not.toHaveBeenCalled();
+    expect(mocks.downloadBlobAsFile).not.toHaveBeenCalled();
+  });
+
+  it("packs multiple selected files into one zip", async () => {
+    const { result } = setup();
+    await act(async () => {
+      await result.current.handleDownloadSelection(["a.json", "b.json"]);
+    });
+    expect(mocks.downloadFile).not.toHaveBeenCalled();
+    expect(mocks.downloadBlob).toHaveBeenCalledTimes(2);
+    expect(mocks.downloadBlob).toHaveBeenCalledWith("a.json");
+    expect(mocks.downloadBlob).toHaveBeenCalledWith("b.json");
+    expect(mocks.createStoreZipBlob).toHaveBeenCalledTimes(1);
+    const entries = mocks.createStoreZipBlob.mock.calls[0]?.[0] as { name: string; data: Uint8Array }[];
+    expect(entries.map((e) => e.name)).toEqual(["a.json", "b.json"]);
+    expect(mocks.downloadBlobAsFile).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "auth-files-2-test.zip",
+    );
+    expect(mocks.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "success" }),
+    );
+  });
+
+  it("does nothing when user cancels confirm", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    const { result } = setup();
+    await act(async () => {
+      await result.current.handleDownloadSelection(["a.json", "b.json"]);
+    });
+    expect(mocks.downloadFile).not.toHaveBeenCalled();
+    expect(mocks.downloadBlob).not.toHaveBeenCalled();
+  });
+});

--- a/pages/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/pages/auth-files/hooks/useAuthFilesFileActions.ts
@@ -4,7 +4,14 @@ import { authFilesApi } from "@code-proxy/api-client";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 import { useToast } from "@code-proxy/ui";
-import { formatFileSize, MAX_AUTH_FILE_SIZE, readAuthFileDefaultTags } from "@code-proxy/domain";
+import {
+  buildAuthFilesBatchZipName,
+  createStoreZipBlob,
+  downloadBlobAsFile,
+  formatFileSize,
+  MAX_AUTH_FILE_SIZE,
+  readAuthFileDefaultTags,
+} from "@code-proxy/domain";
 
 const AUTH_FILES_UPLOAD_CONCURRENCY = 4;
 
@@ -97,26 +104,83 @@ export function useAuthFilesFileActions({
       );
       if (!confirmed) return;
 
-      let success = 0;
+      // Single selection: keep one-file download UX.
+      if (targets.length === 1) {
+        try {
+          await authFilesApi.downloadFile(targets[0]!);
+          notify({
+            type: "success",
+            message: t("auth_files.batch_download_success", { count: 1 }),
+          });
+        } catch (err: unknown) {
+          notify({
+            type: "error",
+            message: err instanceof Error ? err.message : t("auth_files.download_failed"),
+          });
+        }
+        return;
+      }
+
+      // Multiple selection: pack into one zip so the browser gets a single artifact.
+      const zipEntries: { name: string; data: Uint8Array }[] = [];
       let failed = 0;
+      const usedNames = new Set<string>();
+
       for (const name of targets) {
         try {
-          await authFilesApi.downloadFile(name);
-          success += 1;
+          const blob = await authFilesApi.downloadBlob(name);
+          const buffer = new Uint8Array(await blob.arrayBuffer());
+          let entryName = name;
+          if (usedNames.has(entryName)) {
+            const extIndex = entryName.lastIndexOf(".");
+            const base = extIndex > 0 ? entryName.slice(0, extIndex) : entryName;
+            const ext = extIndex > 0 ? entryName.slice(extIndex) : "";
+            let i = 2;
+            while (usedNames.has(`${base} (${i})${ext}`)) i += 1;
+            entryName = `${base} (${i})${ext}`;
+          }
+          usedNames.add(entryName);
+          zipEntries.push({ name: entryName, data: buffer });
         } catch {
           failed += 1;
         }
       }
 
-      if (failed === 0) {
-        notify({
-          type: "success",
-          message: t("auth_files.batch_download_success", { count: success }),
-        });
-      } else {
+      const success = zipEntries.length;
+      if (success === 0) {
         notify({
           type: "error",
-          message: t("auth_files.batch_download_partial", { success, failed }),
+          message: t("auth_files.batch_download_partial", { success: 0, failed }),
+        });
+        return;
+      }
+
+      try {
+        const zipBlob = createStoreZipBlob(zipEntries);
+        downloadBlobAsFile(zipBlob, buildAuthFilesBatchZipName(success));
+        if (failed === 0) {
+          notify({
+            type: "success",
+            message: t("auth_files.batch_download_zip_success", {
+              count: success,
+              defaultValue: "Downloaded {{count}} auth file(s) as a zip archive",
+            }),
+          });
+        } else {
+          notify({
+            type: "error",
+            message: t("auth_files.batch_download_zip_partial", {
+              success,
+              failed,
+              defaultValue:
+                "Zip download finished: {{success}} packed, {{failed}} failed",
+            }),
+          });
+        }
+      } catch (err: unknown) {
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("auth_files.download_failed"),
         });
       }
     },


### PR DESCRIPTION
## Summary
- When batch-downloading **more than one** auth file, fetch blobs client-side and emit a single STORE zip instead of sequential single-file downloads.
- Single selection still uses the existing one-file download path.
- Adds `downloadBlob` on `authFilesApi`, a dependency-free ZIP builder in domain, and zh/en/ru copy for zip success/partial results.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, test:ci 647, build, bundle:diff)
- [x] Unit: zip STORE archive structure + `handleDownloadSelection` single vs multi vs cancel