### PR TITLE
fix: surface request-log and 429 error details in admin UI

### DIFF
--- a/features/log-content-viewer/components/ErrorDetailModal.tsx
+++ b/features/log-content-viewer/components/ErrorDetailModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { createPortal } from "react-dom";
 import { AlertTriangle, X, Loader2, Copy, Check } from "lucide-react";
 import { usageApi } from "@code-proxy/api-client";
+import { extractErrorFromLogContent } from "../error-detail/extractErrorFromLogContent";
 
 interface ErrorDetailModalProps {
   open: boolean;
@@ -17,6 +18,8 @@ export function ErrorDetailModal({ open, logId, model, onClose }: ErrorDetailMod
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorContent, setErrorContent] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [reconstructed, setReconstructed] = useState(false);
   const [copied, setCopied] = useState(false);
 
   // Animation
@@ -28,21 +31,54 @@ export function ErrorDetailModal({ open, logId, model, onClose }: ErrorDetailMod
     }
   }, [open]);
 
-  // Fetch
+  // Fetch output first; when empty, fall back to request details so historical
+  // failed logs (store-content off) can still surface status / diagnostic info.
   useEffect(() => {
     if (!open || !logId) return;
+    let cancelled = false;
     setLoading(true);
     setError(null);
     setErrorContent("");
-    usageApi
-      .getLogContent(logId)
-      .then((res) => {
-        setErrorContent(res.output_content || "");
-      })
-      .catch((err) => {
-        setError(err instanceof Error ? err.message : t("error_detail.load_failed"));
-      })
-      .finally(() => setLoading(false));
+    setErrorMessage("");
+    setReconstructed(false);
+
+    void (async () => {
+      try {
+        const outputRes = await usageApi.getLogContent(logId);
+        if (cancelled) return;
+        const extracted = extractErrorFromLogContent(outputRes.output_content || "");
+        if (extracted) {
+          setErrorContent(extracted.content);
+          setErrorMessage(extracted.message);
+          setReconstructed(extracted.reconstructed);
+          return;
+        }
+
+        try {
+          const detailsRes = await usageApi.getLogContentPart(logId, "details");
+          if (cancelled) return;
+          const fromDetails = extractErrorFromLogContent("", detailsRes.content || "");
+          if (fromDetails) {
+            setErrorContent(fromDetails.content);
+            setErrorMessage(fromDetails.message);
+            setReconstructed(fromDetails.reconstructed);
+            return;
+          }
+        } catch {
+          // Details may be unauthorized or missing; keep empty-state UX.
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : t("error_detail.load_failed"));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [logId, open, t]);
 
   // Escape key
@@ -65,20 +101,14 @@ export function ErrorDetailModal({ open, logId, model, onClose }: ErrorDetailMod
 
   const hasErrorContent = errorContent.trim().length > 0;
 
-  /** Try to format JSON nicely, extract error message */
+  /** Try to format JSON nicely */
   let formattedContent = errorContent;
-  let errorMessage = "";
   if (hasErrorContent) {
     try {
       const parsed = JSON.parse(errorContent);
       formattedContent = JSON.stringify(parsed, null, 2);
-      // Extract common error message patterns
-      if (parsed?.error?.message) errorMessage = parsed.error.message;
-      else if (parsed?.error && typeof parsed.error === "string") errorMessage = parsed.error;
-      else if (parsed?.message) errorMessage = parsed.message;
     } catch {
-      // Not JSON, use raw text
-      errorMessage = errorContent.slice(0, 200);
+      // keep raw text
     }
   }
 
@@ -119,7 +149,9 @@ export function ErrorDetailModal({ open, logId, model, onClose }: ErrorDetailMod
               </h2>
               <p className="mt-0.5 text-xs text-red-600/70 dark:text-red-400/60">
                 {hasErrorContent
-                  ? t("error_detail.upstream_error")
+                  ? reconstructed
+                    ? t("error_detail.reconstructed_from_details")
+                    : t("error_detail.upstream_error")
                   : t("error_detail.historical_missing")}
               </p>
             </div>

--- a/features/log-content-viewer/error-detail/__tests__/extractErrorFromLogContent.test.ts
+++ b/features/log-content-viewer/error-detail/__tests__/extractErrorFromLogContent.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { extractErrorFromLogContent } from "../extractErrorFromLogContent";
+
+describe("extractErrorFromLogContent", () => {
+  test("prefers stored output content", () => {
+    const result = extractErrorFromLogContent(
+      `{"error":{"message":"boom","type":"upstream_error"}}`,
+      `{"diagnostic":{"upstream":{"status":500}}}`,
+    );
+    expect(result).toEqual({
+      content: `{"error":{"message":"boom","type":"upstream_error"}}`,
+      message: "boom",
+      reconstructed: false,
+    });
+  });
+
+  test("reconstructs from diagnostic status when output and body are missing", () => {
+    const details = JSON.stringify({
+      diagnostic: {
+        upstream: {
+          status: 429,
+          provider: "xai",
+          auth_label: "user@example.com",
+          url: "https://example.com/v1/responses",
+          attempt: 3,
+        },
+      },
+      response: {
+        upstream_log: "=== API RESPONSE 1 ===\nStatus: 429\nHeaders:\nX-Request-Id: abc\n\n",
+      },
+    });
+    const result = extractErrorFromLogContent("", details);
+    expect(result?.reconstructed).toBe(true);
+    expect(result?.message).toContain("HTTP 429");
+    expect(result?.message).toContain("xai");
+    expect(result?.content).toContain('"http_status": 429');
+  });
+
+  test("prefers body from upstream_log when present", () => {
+    const details = JSON.stringify({
+      response: {
+        upstream_log:
+          "=== API RESPONSE 1 ===\nStatus: 429\nHeaders:\nX-Test: 1\nBody:\n{\"error\":{\"message\":\"too many requests\"}}\n",
+      },
+    });
+    const result = extractErrorFromLogContent("", details);
+    expect(result?.reconstructed).toBe(true);
+    expect(result?.message).toBe("too many requests");
+    expect(result?.content).toContain("too many requests");
+  });
+
+  test("returns null when nothing reconstructable exists", () => {
+    expect(extractErrorFromLogContent("", "")).toBeNull();
+    expect(extractErrorFromLogContent("", `{"client":{"ip":"1.2.3.4"}}`)).toBeNull();
+  });
+});

--- a/features/log-content-viewer/error-detail/extractErrorFromLogContent.ts
+++ b/features/log-content-viewer/error-detail/extractErrorFromLogContent.ts
@@ -1,0 +1,150 @@
+/**
+ * Builds a displayable upstream error payload for the error-detail modal.
+ * Prefers stored output_content; when body storage was off (or older failed
+ * logs never wrote output), reconstructs a compact summary from request details.
+ */
+
+export type ExtractedErrorPayload = {
+  /** Raw text shown in the "full response" block. */
+  content: string;
+  /** Short human-readable summary. */
+  message: string;
+  /** True when content was reconstructed from details, not a stored error body. */
+  reconstructed: boolean;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function pickString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function extractMessageFromJsonText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const record = asRecord(parsed);
+    if (!record) return trimmed.slice(0, 200);
+    const error = asRecord(record.error);
+    if (error) {
+      const message = pickString(error.message, error.type, error.code);
+      if (message) return message;
+    }
+    const message = pickString(record.message, record.error);
+    if (message) return message;
+  } catch {
+    return trimmed.slice(0, 200);
+  }
+  return trimmed.slice(0, 200);
+}
+
+function extractLastApiResponseStatus(upstreamLog: string): number | null {
+  if (!upstreamLog) return null;
+  const matches = [...upstreamLog.matchAll(/Status:\s*(\d{3})\b/g)];
+  if (matches.length === 0) return null;
+  const last = matches[matches.length - 1]?.[1];
+  const status = Number(last);
+  return Number.isFinite(status) && status > 0 ? status : null;
+}
+
+function extractLastApiResponseBody(upstreamLog: string): string {
+  if (!upstreamLog) return "";
+  const parts = upstreamLog.split(/===\s*API RESPONSE\b/i);
+  for (let i = parts.length - 1; i >= 1; i -= 1) {
+    const block = parts[i] ?? "";
+    const bodyIdx = block.search(/\nBody:\n/i);
+    if (bodyIdx < 0) continue;
+    const body = block.slice(bodyIdx + "\nBody:\n".length).trim();
+    if (!body || body === "<not stored>") continue;
+    return body;
+  }
+  return "";
+}
+
+function buildReconstructedError(detailsRaw: string): ExtractedErrorPayload | null {
+  const trimmed = detailsRaw.trim();
+  if (!trimmed) return null;
+
+  let details: Record<string, unknown> | null = null;
+  try {
+    details = asRecord(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+  if (!details) return null;
+
+  const diagnostic = asRecord(details.diagnostic);
+  const diagnosticUpstream = asRecord(diagnostic?.upstream);
+  const response = asRecord(details.response);
+  const upstreamLog =
+    typeof response?.upstream_log === "string" ? response.upstream_log : "";
+
+  const bodyFromLog = extractLastApiResponseBody(upstreamLog);
+  if (bodyFromLog) {
+    const message = extractMessageFromJsonText(bodyFromLog) || bodyFromLog.slice(0, 200);
+    return { content: bodyFromLog, message, reconstructed: true };
+  }
+
+  const statusFromDiagnostic = Number(diagnosticUpstream?.status);
+  const statusFromLog = extractLastApiResponseStatus(upstreamLog);
+  const status =
+    Number.isFinite(statusFromDiagnostic) && statusFromDiagnostic > 0
+      ? Math.round(statusFromDiagnostic)
+      : statusFromLog;
+
+  if (!status || status < 400) return null;
+
+  const provider = pickString(diagnosticUpstream?.provider);
+  const authLabel = pickString(diagnosticUpstream?.auth_label);
+  const url = pickString(diagnosticUpstream?.url);
+  const attempt = Number(diagnosticUpstream?.attempt);
+
+  const messageParts = [`Upstream returned HTTP ${status}`];
+  if (provider) messageParts.push(`via ${provider}`);
+  if (authLabel) messageParts.push(`(${authLabel})`);
+
+  const payload: Record<string, unknown> = {
+    error: {
+      message: messageParts.join(" "),
+      type: "upstream_error",
+      http_status: status,
+      ...(provider ? { provider } : {}),
+      ...(authLabel ? { auth_label: authLabel } : {}),
+      ...(url ? { url } : {}),
+      ...(Number.isFinite(attempt) && attempt > 0 ? { attempt: Math.round(attempt) } : {}),
+      source: "reconstructed_from_request_details",
+    },
+  };
+
+  const content = JSON.stringify(payload, null, 2);
+  return {
+    content,
+    message: String((payload.error as Record<string, unknown>).message),
+    reconstructed: true,
+  };
+}
+
+/**
+ * Resolve error modal content from stored output and optional request details.
+ */
+export function extractErrorFromLogContent(
+  outputContent: string,
+  detailsContent = "",
+): ExtractedErrorPayload | null {
+  const output = (outputContent || "").trim();
+  if (output) {
+    return {
+      content: output,
+      message: extractMessageFromJsonText(output),
+      reconstructed: false,
+    };
+  }
+  return buildReconstructedError(detailsContent);
+}

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -899,12 +899,24 @@ const resolveRestrictionReason = (restriction: AuthFileRestriction): string => {
           const type = String(errorRecord.type ?? "").trim();
           if (type && type !== "usage_limit_reached") return type;
         }
+        const topMessage = String(record.message ?? "").trim();
+        if (topMessage) return topMessage;
       }
     } catch {
+      // Keep raw non-JSON upstream bodies (often the full 429 text).
       return rawMessage;
     }
   }
-  return String(restriction.reason || restriction.code || "").trim();
+  const reason = String(restriction.reason || restriction.code || "").trim();
+  if (reason && reason !== "quota") return reason;
+  const status = Number(restriction.http_status);
+  if (status === 429) {
+    // quota reason alone is not user-facing; surface a clear rate-limit label.
+    return "rate limited (HTTP 429)";
+  }
+  if (reason) return reason;
+  if (Number.isFinite(status) && status > 0) return `HTTP ${Math.round(status)}`;
+  return "";
 };
 
 export const resolveAuthFileRestrictionBadges = (

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3860,9 +3860,10 @@
   },
   "error_detail": {
     "upstream_error": "Error response from upstream API",
+    "reconstructed_from_details": "Reconstructed upstream error summary from request details",
     "historical_missing": "This historical request did not record any upstream error response",
     "full_response": "Full Response",
-    "no_content": "This historical log did not record any upstream error response, so the original upstream failure cannot be reconstructed. New failed logs will store the actual error details.",
+    "no_content": "This historical log did not record any upstream error response, and the failure could not be reconstructed from request details. New failed logs will store the actual error details.",
     "load_failed": "Load failed",
     "request_failed": "Request failed"
   },

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4042,9 +4042,10 @@
   },
   "error_detail": {
     "upstream_error": "上游 API 错误响应",
-    "historical_missing": "No upstream error response was recorded for this historical request",
+    "reconstructed_from_details": "已从请求详情还原上游错误摘要",
+    "historical_missing": "该历史请求未记录上游错误响应",
     "full_response": "完整响应",
-    "no_content": "No upstream error response was recorded for this historical log, so the original upstream failure cannot be reconstructed. New failed logs will store the actual error details.",
+    "no_content": "该历史日志未记录上游错误响应，也无法从请求详情还原失败原因。新的失败日志会保存错误详情。",
     "load_failed": "加载失败",
     "request_failed": "请求失败"
   },

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -551,7 +551,32 @@ describe("Auth Files helper coverage", () => {
     );
   });
 
-  test("shows auth-level quota recovery records as 429 restriction badges", () => {
+  
+  test("shows a clear reason for 429 badges without status_message", () => {
+    const file = {
+      name: "xai.json",
+      restrictions: [
+        {
+          scope: "auth",
+          http_status: 429,
+          quota_exceeded: true,
+          reason: "quota",
+          status: "error",
+          unavailable: true,
+        },
+      ],
+    } as AuthFileItem;
+
+    expect(resolveAuthFileRestrictionBadges(file, Date.now())).toEqual([
+      expect.objectContaining({
+        label: "429 Error",
+        reason: "rate limited (HTTP 429)",
+        quotaLimited: true,
+      }),
+    ]);
+  });
+
+test("shows auth-level quota recovery records as 429 restriction badges", () => {
     const file = {
       name: "codex.json",
       restrictions: [
@@ -576,6 +601,7 @@ describe("Auth Files helper coverage", () => {
         quotaWindow: "5h",
         quotaWindowMinutes: 300,
         reason: "usage limit",
+        quotaLimited: true,
         recoverAtMs: Date.parse("2026-05-06T13:00:00.000Z"),
       }),
     ]);

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -275,13 +275,13 @@ export function useAuthFilesFilesPresentation({
   const formatRestrictionTooltip = useCallback(
     (badge: ReturnType<typeof resolveAuthFileRestrictionBadges>[number]) => {
       const quotaWindow = formatRestrictionQuotaWindowLabel(badge);
+      // Always surface the upstream reason (parsed status_message / quota reason).
+      // Hiding it for quota-limited badges left 429 chips without any error detail.
       const parts = [
         badge.quotaLimited ? t("auth_files.restriction_limited") : "",
         quotaWindow ? t("auth_files.restriction_window", { window: quotaWindow }) : "",
         badge.model ? t("auth_files.restriction_model", { model: badge.model }) : "",
-        badge.reason && !badge.quotaLimited
-          ? t("auth_files.restriction_reason", { reason: badge.reason })
-          : "",
+        badge.reason ? t("auth_files.restriction_reason", { reason: badge.reason }) : "",
       ].filter(Boolean);
       if (badge.recoverAtMs) {
         const remaining = formatAuthFileRestrictionRemaining(

--- a/pages/monitor/__tests__/ErrorDetailModal.test.tsx
+++ b/pages/monitor/__tests__/ErrorDetailModal.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getLogContent: vi.fn(),
+  getLogContentPart: vi.fn(),
 }));
 
 vi.mock("@code-proxy/api-client", async (importOriginal) => {
@@ -12,6 +13,7 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
     usageApi: {
       ...mod.usageApi,
       getLogContent: mocks.getLogContent,
+      getLogContentPart: mocks.getLogContentPart,
     },
   };
 });
@@ -24,16 +26,68 @@ describe("ErrorDetailModal", () => {
   afterEach(async () => {
     cleanup();
     mocks.getLogContent.mockReset();
+    mocks.getLogContentPart.mockReset();
     await i18n.changeLanguage("zh-CN");
   });
 
-  test("shows a historical-missing hint when an old failed log has no upstream error body", async () => {
+  test("reconstructs a compact error summary from request details when output is empty", async () => {
+    await i18n.changeLanguage("zh-CN");
+    mocks.getLogContent.mockResolvedValue({
+      id: 486781,
+      model: "grok-4.5",
+      input_content: "",
+      output_content: "",
+    });
+    mocks.getLogContentPart.mockResolvedValue({
+      id: 486781,
+      model: "grok-4.5",
+      part: "details",
+      content: JSON.stringify({
+        diagnostic: {
+          upstream: {
+            provider: "xai",
+            status: 429,
+            auth_label: "p8i7bwc5wt@aokkas.com",
+            url: "https://cli-chat-proxy.grok.com/v1/responses",
+            attempt: 109,
+          },
+        },
+        response: {
+          upstream_log:
+            "=== API RESPONSE 1 ===\nStatus: 429\nHeaders:\nX-Request-Id: abc\n\n",
+        },
+      }),
+    });
+
+    render(
+      <ThemeProvider>
+        <ErrorDetailModal open logId={486781} model="grok-4.5" onClose={() => {}} />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.getLogContent).toHaveBeenCalledWith(486781);
+      expect(mocks.getLogContentPart).toHaveBeenCalledWith(486781, "details");
+    });
+
+    expect(await screen.findByText("已从请求详情还原上游错误摘要")).toBeInTheDocument();
+    expect(screen.getAllByText(/Upstream returned HTTP 429/).length).toBeGreaterThan(0);
+    expect(screen.getByText("完整响应")).toBeInTheDocument();
+  });
+
+  test("shows historical-missing when neither output nor reconstructable details exist", async () => {
     await i18n.changeLanguage("zh-CN");
     mocks.getLogContent.mockResolvedValue({
       id: 53912,
       model: "gpt-image-2",
       input_content: '{"model":"gpt-image-2"}',
       output_content: "",
+    });
+    mocks.getLogContentPart.mockResolvedValue({
+      id: 53912,
+      model: "gpt-image-2",
+      part: "details",
+      content: "",
     });
 
     render(
@@ -46,12 +100,10 @@ describe("ErrorDetailModal", () => {
       expect(mocks.getLogContent).toHaveBeenCalledWith(53912);
     });
 
-    expect(
-      screen.getByText("No upstream error response was recorded for this historical request"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("该历史请求未记录上游错误响应")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "No upstream error response was recorded for this historical log, so the original upstream failure cannot be reconstructed. New failed logs will store the actual error details.",
+        "该历史日志未记录上游错误响应，也无法从请求详情还原失败原因。新的失败日志会保存错误详情。",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("完整响应")).not.toBeInTheDocument();
@@ -78,5 +130,6 @@ describe("ErrorDetailModal", () => {
 
     expect(screen.getByText("context canceled")).toBeInTheDocument();
     expect(screen.getByText("完整响应")).toBeInTheDocument();
+    expect(mocks.getLogContentPart).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ErrorDetailModal falls back to log `details` when `output` is empty (common with store-content off).
- Extract shared error parsing helper with unit tests.
- Auth-files 429 badges always show rate-limit reason, with a generic fallback when the API omits a message.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff)
- [ ] Open a failed request log with empty output and confirm error modal shows details
- [ ] Hover 429 badge on auth-files and confirm reason/tooltip text