### PR TITLE
fix: hide single-tenant switcher and refresh on tenant changes

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -1,14 +1,37 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ThemeProvider } from "@code-proxy/ui";
-import type { MenuIdentity } from "@code-proxy/api-client";
+import { IDENTITY_TENANTS_UPDATED_EVENT, type MenuIdentity, type TenantIdentity } from "@code-proxy/api-client";
 import { preloadPageRoute } from "@pages/registry";
 import { AppShell } from "./AppShell";
 
 vi.mock("@pages/registry", () => ({
   preloadPageRoute: vi.fn(() => Promise.resolve()),
 }));
+
+const tenantsMock = vi.fn<() => Promise<{ items: TenantIdentity[] }>>();
+
+vi.mock("@code-proxy/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@code-proxy/api-client")>();
+  return {
+    ...actual,
+    identityApi: {
+      ...actual.identityApi,
+      tenants: (...args: unknown[]) => tenantsMock(...(args as [])),
+    },
+  };
+});
+
+type AuthPrincipal = {
+  kind?: string;
+  platform_admin?: boolean;
+  menus: MenuIdentity[];
+  user: { display_name: string; username: string; role_codes: string[] };
+  effective_tenant: TenantIdentity;
+};
+
+let authPrincipal: AuthPrincipal;
 
 const menu = (partial: Partial<MenuIdentity> & Pick<MenuIdentity, "code" | "type">): MenuIdentity => ({
   parent_code: "",
@@ -145,15 +168,27 @@ const testMenus: MenuIdentity[] = [
   }),
 ];
 
+const systemTenant: TenantIdentity = {
+  id: "t-system",
+  type: "system",
+  name: "System Administration",
+  slug: "system",
+  effective_status: "active",
+} as TenantIdentity;
+
+const acmeTenant: TenantIdentity = {
+  id: "t-acme",
+  type: "standard",
+  name: "Acme Team",
+  slug: "acme",
+  effective_status: "active",
+} as TenantIdentity;
+
 vi.mock("@app/providers/AuthProvider", () => ({
   useOptionalAuth: () => ({
     can: () => true,
     state: {
-      principal: {
-        menus: testMenus,
-        user: { display_name: "Admin", username: "admin", role_codes: [] },
-        effective_tenant: { type: "system", name: "System" },
-      },
+      principal: authPrincipal,
     },
     actions: {
       switchTenant: vi.fn(),
@@ -179,7 +214,22 @@ function renderShell(initialPath = "/dashboard") {
   );
 }
 
+function defaultPrincipal(overrides: Partial<AuthPrincipal> = {}): AuthPrincipal {
+  return {
+    menus: testMenus,
+    user: { display_name: "Admin", username: "admin", role_codes: [] },
+    effective_tenant: systemTenant,
+    ...overrides,
+  };
+}
+
 describe("AppShell route progress", () => {
+  beforeEach(() => {
+    authPrincipal = defaultPrincipal();
+    tenantsMock.mockReset();
+    tenantsMock.mockResolvedValue({ items: [] });
+  });
+
   afterEach(() => {
     vi.useRealTimers();
     vi.mocked(preloadPageRoute).mockClear();
@@ -383,5 +433,68 @@ describe("AppShell route progress", () => {
       screen.getByRole("button", { name: /Models & Routing|模型与(?:路由|调度)/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Admin" })).toBeInTheDocument();
+  });
+});
+
+describe("AppShell tenant switcher", () => {
+  beforeEach(() => {
+    authPrincipal = defaultPrincipal({ platform_admin: true });
+    tenantsMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("hides the tenant switcher when only one tenant is available", async () => {
+    tenantsMock.mockResolvedValue({ items: [systemTenant] });
+    renderShell();
+
+    await waitFor(() => {
+      expect(tenantsMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("combobox", { name: /Switch Tenant|切换租户/i })).not.toBeInTheDocument();
+  });
+
+  test("shows the tenant switcher when multiple tenants are available", async () => {
+    tenantsMock.mockResolvedValue({ items: [systemTenant, acmeTenant] });
+    renderShell();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /Switch Tenant|切换租户/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("refreshes the tenant switcher after tenants are created", async () => {
+    tenantsMock.mockResolvedValueOnce({ items: [systemTenant] });
+    renderShell();
+
+    await waitFor(() => {
+      expect(tenantsMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByRole("combobox", { name: /Switch Tenant|切换租户/i })).not.toBeInTheDocument();
+
+    tenantsMock.mockResolvedValueOnce({ items: [systemTenant, acmeTenant] });
+    act(() => {
+      window.dispatchEvent(new Event(IDENTITY_TENANTS_UPDATED_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(tenantsMock).toHaveBeenCalledTimes(2);
+      expect(
+        screen.getByRole("combobox", { name: /Switch Tenant|切换租户/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("hides the tenant switcher for non platform admins", async () => {
+    authPrincipal = defaultPrincipal({ platform_admin: false });
+    tenantsMock.mockResolvedValue({ items: [systemTenant, acmeTenant] });
+    renderShell();
+
+    expect(tenantsMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("combobox", { name: /Switch Tenant|切换租户/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -34,7 +34,12 @@ import {
   ThemeToggleButton,
 } from "@code-proxy/ui";
 import { preloadPageRoute } from "@pages/registry";
-import { identityApi, type MenuIdentity, type TenantIdentity } from "@code-proxy/api-client";
+import {
+  identityApi,
+  IDENTITY_TENANTS_UPDATED_EVENT,
+  type MenuIdentity,
+  type TenantIdentity,
+} from "@code-proxy/api-client";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 import { resolveMenuIcon } from "@app/navigation/menuIconMap";
 
@@ -1075,21 +1080,38 @@ function ShellHeader({
     auth?.state.principal?.platform_admin && auth.state.principal.kind !== "service_credential";
   const [tenants, setTenants] = useState<TenantIdentity[]>([]);
   const [tenantSwitching, setTenantSwitching] = useState(false);
+  // Bumped on IDENTITY_TENANTS_UPDATED_EVENT so create/update/delete refresh the switcher
+  // without remounting the shell.
+  const [tenantsEpoch, setTenantsEpoch] = useState(0);
   useEffect(() => {
     if (!canSwitchTenants) {
       setTenants([]);
       return;
     }
+    let cancelled = false;
     void identityApi
       .tenants()
-      .then((response) =>
+      .then((response) => {
+        if (cancelled) return;
         setTenants(
           (response.items ?? []).filter(
             (tenant) => tenant.type === "system" || tenant.effective_status === "active",
           ),
-        ),
-      )
-      .catch(() => setTenants([]));
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setTenants([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canSwitchTenants, tenantsEpoch]);
+
+  useEffect(() => {
+    if (!canSwitchTenants) return;
+    const onTenantsUpdated = () => setTenantsEpoch((epoch) => epoch + 1);
+    window.addEventListener(IDENTITY_TENANTS_UPDATED_EVENT, onTenantsUpdated);
+    return () => window.removeEventListener(IDENTITY_TENANTS_UPDATED_EVENT, onTenantsUpdated);
   }, [canSwitchTenants]);
 
   const systemTenantLabel = t("shell.system_tenant");
@@ -1124,6 +1146,11 @@ function ShellHeader({
     [auth, effectiveTenantId, tenantSwitching],
   );
 
+  // Single-tenant installs have nothing to switch to — hide the control entirely
+  // (including the system-admin-only bootstrap case).
+  const showTenantSwitcher =
+    Boolean(canSwitchTenants && auth?.state.principal) && tenantOptions.length > 1;
+
   const sidebarLabel = sidebarCollapsed ? t("shell.expand_sidebar") : t("shell.collapse_sidebar");
 
   return (
@@ -1143,7 +1170,7 @@ function ShellHeader({
           ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-1 sm:gap-2">
-          {canSwitchTenants && auth?.state.principal ? (
+          {showTenantSwitcher ? (
             <SearchableSelect
               value={effectiveTenantId}
               onChange={handleTenantChange}

--- a/packages/api-client/src/endpoints/__tests__/identity.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/identity.test.ts
@@ -1,12 +1,22 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { apiClient } from "../../client/client";
-import { identityApi } from "../identity";
+import { IDENTITY_TENANTS_UPDATED_EVENT, identityApi } from "../identity";
+
+function stubWindowEvents() {
+  const target = new EventTarget();
+  vi.stubGlobal("window", target);
+  return target;
+}
 
 describe("identityApi", () => {
   beforeEach(() => {
     apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "" });
     apiClient.setDefaultHeaders({});
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   test("logs in through the public auth endpoint", async () => {
@@ -49,12 +59,15 @@ describe("identityApi", () => {
 
   test("creates tenants without a caller-provided identifier", async () => {
     apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
+    const win = stubWindowEvents();
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ tenant: {}, admin: {} }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
       }),
     );
+    const eventSpy = vi.fn();
+    win.addEventListener(IDENTITY_TENANTS_UPDATED_EVENT, eventSpy);
     await identityApi.createTenant({
       name: "Tenant A",
       description: "Primary tenant",
@@ -64,6 +77,7 @@ describe("identityApi", () => {
       admin_password: "tenant-password-123",
     });
     expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).not.toHaveProperty("slug");
+    expect(eventSpy).toHaveBeenCalledOnce();
   });
 
   test("creates roles without a caller-provided code", async () => {
@@ -88,12 +102,15 @@ describe("identityApi", () => {
 
   test("updates tenant details with optimistic versioning", async () => {
     apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
+    const win = stubWindowEvents();
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ id: "tenant-a" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
     );
+    const eventSpy = vi.fn();
+    win.addEventListener(IDENTITY_TENANTS_UPDATED_EVENT, eventSpy);
     await identityApi.updateTenant("tenant-a", {
       name: "Tenant A",
       description: "Updated",
@@ -107,6 +124,25 @@ describe("identityApi", () => {
       description: "Updated",
       version: 3,
     });
+    expect(eventSpy).toHaveBeenCalledOnce();
+  });
+
+  test("deletes tenants and notifies shell listeners", async () => {
+    apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
+    const win = stubWindowEvents();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "tenant-a" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const eventSpy = vi.fn();
+    win.addEventListener(IDENTITY_TENANTS_UPDATED_EVENT, eventSpy);
+    await identityApi.deleteTenant("tenant-a", 2);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(new URL(String(url)).pathname).toBe("/v0/management/tenants/tenant-a");
+    expect(init?.method).toBe("DELETE");
+    expect(eventSpy).toHaveBeenCalledOnce();
   });
   test("updates menu configuration with optimistic versioning", async () => {
     apiClient.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });

--- a/packages/api-client/src/endpoints/identity.ts
+++ b/packages/api-client/src/endpoints/identity.ts
@@ -1,6 +1,14 @@
 import { apiClient } from "../client/client";
 
 export const IDENTITY_MENUS_UPDATED_EVENT = "identity-menus-updated";
+/** Fired after tenant create / update / delete so shell switchers can refresh. */
+export const IDENTITY_TENANTS_UPDATED_EVENT = "identity-tenants-updated";
+
+function notifyTenantsUpdated() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(IDENTITY_TENANTS_UPDATED_EVENT));
+  }
+}
 
 export interface TenantIdentity {
   id: string;
@@ -137,15 +145,22 @@ export const identityApi = {
   changePassword: (body: { current_password: string; new_password: string }) =>
     apiClient.put<void>("/../auth/password", body),
   tenants: () => apiClient.get<{ items: TenantIdentity[] }>("/tenants"),
-  createTenant: (body: {
+  createTenant: async (body: {
     name: string;
     description: string;
     expires_at: string;
     admin_username: string;
     admin_display_name: string;
     admin_password: string;
-  }) => apiClient.post<{ tenant: TenantIdentity; admin: UserIdentity }>("/tenants", body),
-  updateTenant: (
+  }) => {
+    const result = await apiClient.post<{ tenant: TenantIdentity; admin: UserIdentity }>(
+      "/tenants",
+      body,
+    );
+    notifyTenantsUpdated();
+    return result;
+  },
+  updateTenant: async (
     id: string,
     body: {
       name?: string;
@@ -154,11 +169,21 @@ export const identityApi = {
       expires_at?: string;
       version: number;
     },
-  ) => apiClient.patch<TenantIdentity>(`/tenants/${encodeURIComponent(id)}`, body),
-  deleteTenant: (id: string, version: number) =>
-    apiClient.delete<TenantIdentity>(`/tenants/${encodeURIComponent(id)}`, {
+  ) => {
+    const tenant = await apiClient.patch<TenantIdentity>(
+      `/tenants/${encodeURIComponent(id)}`,
+      body,
+    );
+    notifyTenantsUpdated();
+    return tenant;
+  },
+  deleteTenant: async (id: string, version: number) => {
+    const tenant = await apiClient.delete<TenantIdentity>(`/tenants/${encodeURIComponent(id)}`, {
       version,
-    }),
+    });
+    notifyTenantsUpdated();
+    return tenant;
+  },
   users: () => apiClient.get<{ items: UserIdentity[] }>("/users"),
   createUser: (body: {
     username: string;

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -90,5 +90,9 @@ export {
   normalizeApiKeyEntries,
 } from "./endpoints/helpers";
 
-export { identityApi, IDENTITY_MENUS_UPDATED_EVENT } from "./endpoints/identity";
+export {
+  identityApi,
+  IDENTITY_MENUS_UPDATED_EVENT,
+  IDENTITY_TENANTS_UPDATED_EVENT,
+} from "./endpoints/identity";
 export type * from "./endpoints/identity";


### PR DESCRIPTION
## Summary
- Hide the header tenant dropdown when only one active tenant is available (e.g. bootstrap with only System Administration).
- Emit `IDENTITY_TENANTS_UPDATED_EVENT` after tenant create/update/delete so the shell switcher reloads immediately.
- Cover single/multi-tenant visibility, event-driven refresh, and API event dispatch with unit tests.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, full test:ci, build, bundle:diff)
- [x] AppShell tenant switcher unit tests (hide at 1 tenant, show at 2+, refresh after event)
- [x] identityApi create/update/delete event dispatch tests
- [ ] Manual: with only system tenant, header has no tenant combobox
- [ ] Manual: create a second tenant, switcher appears and lists the new tenant without reload
- [ ] Manual: delete back to one tenant, switcher disappears