### PR TITLE
fix: request logs channel identity and tenant spacing

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -1179,7 +1179,7 @@ function ShellHeader({
               aria-label={t("shell.switch_tenant")}
               searchPlaceholder={t("shell.search_tenant")}
               placeholder={t("shell.switch_tenant")}
-              className="hidden max-w-64 min-w-36 border-0 bg-transparent text-slate-600 shadow-none hover:border-0 hover:bg-slate-100 hover:text-slate-950 focus-visible:border-0 focus-visible:ring-2 focus-visible:ring-blue-500/25 sm:inline-flex dark:bg-transparent dark:text-slate-300 dark:hover:border-0 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:border-0"
+              className="hidden w-auto max-w-48 min-w-0 gap-1 border-0 bg-transparent px-2 text-slate-600 shadow-none hover:border-0 hover:bg-slate-100 hover:text-slate-950 focus-visible:border-0 focus-visible:ring-2 focus-visible:ring-blue-500/25 sm:inline-flex dark:bg-transparent dark:text-slate-300 dark:hover:border-0 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:border-0 [&>span:first-child]:flex-none [&>span:first-child]:max-w-36 [&>svg]:ml-0"
             />
           ) : null}
           <LanguageSelector className="inline-flex h-9 items-center justify-center gap-0.5 rounded-xl px-1.5 text-slate-500 transition-colors duration-200 ease-out hover:text-slate-900 dark:text-slate-400 dark:hover:text-white" />

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { UsageLogItem } from "@code-proxy/api-client/endpoints/usage";
+import { VendorIcon } from "@code-proxy/assets";
 import {
   formatFixedNumber,
   formatUsageMetricCost,
@@ -42,6 +43,8 @@ export type RequestLogsRow = {
   apiKeyName: string;
   isSystemCall: boolean;
   channelName: string;
+  channelProvider?: string;
+  channelAuthType?: string;
   maskedApiKey: string;
   model: string;
   upstreamModel: string;
@@ -57,6 +60,103 @@ export type RequestLogsRow = {
   cost: number;
   hasContent: boolean;
 };
+
+export function normalizeChannelAuthType(
+  authType?: string | null,
+): "oauth" | "api" | "" {
+  const raw = String(authType ?? "")
+    .trim()
+    .toLowerCase();
+  if (raw === "oauth") return "oauth";
+  if (raw === "api" || raw === "api_key" || raw === "apikey") return "api";
+  return "";
+}
+
+function channelAuthTypeBadgeClass(authType: "oauth" | "api" | ""): string {
+  if (authType === "api") {
+    return "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-200";
+  }
+  if (authType === "oauth") {
+    return "bg-violet-50 text-violet-700 dark:bg-violet-500/15 dark:text-violet-200";
+  }
+  return "bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/65";
+}
+
+/**
+ * Shared channel identity chip: vendor icon + truncated name + auth-type badge.
+ * Used by request-log filter options and the table channel column so both stay
+ * visually aligned across narrow/wide column widths.
+ */
+export function ChannelIdentityLabel({
+  name,
+  provider,
+  authType,
+  apiLabel,
+  oauthLabel,
+  iconSize = 14,
+  className,
+  nameClassName,
+}: {
+  name: string;
+  provider?: string | null;
+  authType?: string | null;
+  apiLabel: string;
+  oauthLabel: string;
+  iconSize?: number;
+  className?: string;
+  nameClassName?: string;
+}) {
+  const trimmedName = String(name || "").trim();
+  const displayName = trimmedName || "--";
+  const vendor = String(provider ?? "").trim();
+  const normalizedAuth = normalizeChannelAuthType(authType);
+  const badgeLabel =
+    normalizedAuth === "api"
+      ? apiLabel
+      : normalizedAuth === "oauth"
+        ? oauthLabel
+        : "";
+  // Callers can fully override name typography via nameClassName; do not stack
+  // conflicting text-* utilities (plain class join is not Tailwind-merge).
+  const resolvedNameClassName =
+    nameClassName ??
+    [
+      "text-xs font-medium",
+      trimmedName
+        ? "text-slate-700 dark:text-slate-200"
+        : "text-slate-400 dark:text-white/30",
+    ].join(" ");
+
+  return (
+    <span
+      className={[
+        "inline-flex min-w-0 max-w-full items-center gap-1.5",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {vendor ? (
+        <span className="inline-flex shrink-0 items-center" aria-hidden="true">
+          <VendorIcon modelId={vendor} size={iconSize} />
+        </span>
+      ) : null}
+      <span className={["min-w-0 truncate", resolvedNameClassName].join(" ")}>
+        {displayName}
+      </span>
+      {badgeLabel ? (
+        <span
+          className={[
+            "inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-2xs font-semibold leading-none",
+            channelAuthTypeBadgeClass(normalizedAuth),
+          ].join(" ")}
+        >
+          {badgeLabel}
+        </span>
+      ) : null}
+    </span>
+  );
+}
 
 const parseLatencyTextToSeconds = (text: string): number | null => {
   const trimmed = String(text || "").trim();
@@ -419,6 +519,7 @@ export const formatOptionalRequestLogLatencyMs = (value: number): string => {
 
 export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
   const isSystemCall = isSystemRequestLogKey(item.api_key, item.api_key_name);
+  const channelAuthType = normalizeChannelAuthType(item.auth_type);
   return {
     id: String(item.id),
     timestamp: item.timestamp,
@@ -427,6 +528,8 @@ export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
     apiKeyName: item.api_key_name || "",
     isSystemCall,
     channelName: item.channel_name || "",
+    channelProvider: String(item.provider ?? "").trim() || undefined,
+    channelAuthType: channelAuthType || undefined,
     maskedApiKey: maskRequestLogApiKey(item.api_key),
     model: item.model,
     upstreamModel: item.upstream_model || "",
@@ -528,6 +631,8 @@ export function buildRequestLogsColumns(
   onContentClick?: (logId: number, tab: "input" | "output") => void,
   onErrorClick?: (logId: number, model: string) => void,
 ): RequestLogsTableColumn<RequestLogsRow>[] {
+  const apiLabel = t("request_logs.auth_type_api");
+  const oauthLabel = t("request_logs.auth_type_oauth");
   return [
     {
       key: "id",
@@ -563,21 +668,40 @@ export function buildRequestLogsColumns(
     {
       key: "channelName",
       label: t("request_logs.col_channel"),
-      width: "w-32",
+      // Wider default so icon + name + auth badge can share the cell; DataTable
+      // still lets users resize. Name truncates first; icon/badge stay visible.
+      width: "w-44",
       headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
-      render: (row) => (
-        <OverflowTooltip
-          content={row.channelName || "--"}
-          className="block min-w-0"
-        >
-          <span
-            className={`block min-w-0 truncate text-xs font-medium ${row.channelName ? "text-violet-600 dark:text-violet-400" : "text-slate-400 dark:text-white/30"}`}
+      render: (row) => {
+        const authLabel =
+          row.channelAuthType === "api"
+            ? apiLabel
+            : row.channelAuthType === "oauth"
+              ? oauthLabel
+              : "";
+        const tooltipParts = [
+          row.channelName || "--",
+          authLabel,
+          row.channelProvider,
+        ].filter(Boolean);
+        return (
+          <OverflowTooltip
+            content={tooltipParts.join(" · ")}
+            className="mx-auto block min-w-0 max-w-full"
           >
-            {row.channelName || "--"}
-          </span>
-        </OverflowTooltip>
-      ),
+            <ChannelIdentityLabel
+              name={row.channelName}
+              provider={row.channelProvider}
+              authType={row.channelAuthType}
+              apiLabel={apiLabel}
+              oauthLabel={oauthLabel}
+              iconSize={14}
+              className="justify-center"
+            />
+          </OverflowTooltip>
+        );
+      },
     },
     {
       key: "status",

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -253,6 +253,9 @@ function toLogRow(item: PublicLogItem): RequestLogsRow {
     apiKeyName: item.api_key_name || "",
     isSystemCall: false,
     channelName: item.channel_name || "",
+    // Public lookup logs do not currently expose provider/auth metadata.
+    channelProvider: undefined,
+    channelAuthType: undefined,
     maskedApiKey: maskRequestLogApiKey(item.api_key || ""),
     model: item.model,
     upstreamModel: item.upstream_model || "",

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -24,6 +24,8 @@ describe("requestLogsShared", () => {
       model: "gpt-image-2",
       source: "codex",
       channel_name: "GptPlus1",
+      provider: "codex",
+      auth_type: "oauth",
       auth_index: "auth-1",
       failed: false,
       streaming: true,
@@ -41,6 +43,35 @@ describe("requestLogsShared", () => {
     expect(row.isSystemCall).toBe(true);
     expect(row.apiKeyName).toBe("");
     expect(row.streaming).toBe(true);
+    expect(row.channelProvider).toBe("codex");
+    expect(row.channelAuthType).toBe("oauth");
+  });
+
+  test("normalizes channel auth_type aliases for table badges", () => {
+    expect(
+      toRequestLogsRow({
+        id: 2,
+        timestamp: "2026-04-23T10:00:00Z",
+        api_key: "sk-live",
+        api_key_name: "Live",
+        model: "gpt-5.4",
+        source: "openai",
+        channel_name: "Relay",
+        provider: "openai",
+        auth_type: "api_key",
+        auth_index: "auth-2",
+        failed: false,
+        latency_ms: 100,
+        first_token_ms: 0,
+        input_tokens: 1,
+        output_tokens: 1,
+        reasoning_tokens: 0,
+        cached_tokens: 0,
+        total_tokens: 2,
+        cost: 0,
+        has_content: false,
+      }).channelAuthType,
+    ).toBe("api");
   });
 
   test("deduplicates system call filter options", () => {

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -8,7 +8,6 @@ import type {
   UsageLogItem,
   UsageLogsResponse,
 } from "@code-proxy/api-client/endpoints/usage";
-import { VendorIcon } from "@code-proxy/assets";
 import {
   formatUsageMetricNumber,
   formatUsageMetricRate,
@@ -31,6 +30,7 @@ import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import {
   buildRequestLogKeyOptions,
   buildRequestLogsColumns,
+  ChannelIdentityLabel,
   DEFAULT_REQUEST_LOG_PAGE_SIZE,
   hasActiveFilterSelection,
   normalizeFilterSelection,
@@ -62,52 +62,6 @@ const DEFAULT_CLEAR_OPTIONS: ClearUsageLogsPayload = {
 const isRequestCancelled = (err: unknown, signal?: AbortSignal) =>
   signal?.aborted ||
   (err instanceof Error && err.message === "Request was cancelled");
-
-function authTypeBadgeClass(authType?: string): string {
-  if (authType === "api") {
-    return "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-200";
-  }
-  if (authType === "oauth") {
-    return "bg-violet-50 text-violet-700 dark:bg-violet-500/15 dark:text-violet-200";
-  }
-  return "bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/65";
-}
-
-function ChannelFilterOptionLabel({
-  option,
-  apiLabel,
-  oauthLabel,
-}: {
-  option: UsageChannelFilterOption;
-  apiLabel: string;
-  oauthLabel: string;
-}) {
-  const authType = String(option.auth_type ?? "").toLowerCase();
-  const badgeLabel =
-    authType === "api" ? apiLabel : authType === "oauth" ? oauthLabel : "";
-  const provider = String(option.provider ?? "").trim();
-
-  return (
-    <span className="flex min-w-0 items-center gap-2">
-      {provider ? (
-        <span className="inline-flex shrink-0 items-center" aria-hidden="true">
-          <VendorIcon modelId={provider} size={14} />
-        </span>
-      ) : null}
-      <span className="min-w-0 truncate">{option.label}</span>
-      {badgeLabel ? (
-        <span
-          className={[
-            "inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-2xs font-semibold leading-none",
-            authTypeBadgeClass(authType),
-          ].join(" ")}
-        >
-          {badgeLabel}
-        </span>
-      ) : null}
-    </span>
-  );
-}
 
 function RequestLogsRecordsCount({ count }: { count: number }) {
   const { t } = useTranslation();
@@ -281,10 +235,14 @@ export function RequestLogsPage() {
       return {
         value: option.value,
         label: (
-          <ChannelFilterOptionLabel
-            option={option}
+          <ChannelIdentityLabel
+            name={option.label}
+            provider={option.provider}
+            authType={option.auth_type}
             apiLabel={apiLabel}
             oauthLabel={oauthLabel}
+            className="w-full"
+            nameClassName="text-sm font-normal text-inherit"
           />
         ),
         searchText: [option.label, provider, authType, option.value]

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -85,6 +85,8 @@ const buildUsageLogItem = (overrides: Partial<UsageLogItem> = {}): UsageLogItem 
   model: "gpt-5.4",
   source: "codex",
   channel_name: "Codex",
+  provider: "codex",
+  auth_type: "oauth",
   auth_index: "auth-1",
   failed: false,
   latency_ms: 1200,
@@ -199,6 +201,8 @@ describe("RequestLogsPage", () => {
           model: "gpt-5.4",
           source: "codex",
           channel_name: "Codex",
+          provider: "codex",
+          auth_type: "oauth",
           auth_index: "auth-1",
           failed: false,
           streaming: true,
@@ -248,6 +252,40 @@ describe("RequestLogsPage", () => {
 
     await user.hover(within(table).getByLabelText("Duration: 1.20s"));
     expect(await screen.findByRole("tooltip")).toHaveTextContent("First Token Latency: 183ms");
+  });
+
+  test("renders channel column with vendor identity and auth-type badge", async () => {
+    await i18n.changeLanguage("en");
+
+    mocks.getUsageLogs.mockResolvedValue(
+      responseWithRows([
+        buildUsageLogItem({
+          channel_name: "asherandersenloqv@outlook.com",
+          provider: "xai",
+          auth_type: "oauth",
+        }),
+        buildUsageLogItem({
+          id: 2,
+          channel_name: "Relay",
+          provider: "openai",
+          auth_type: "api",
+        }),
+      ]),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const table = await screen.findByRole("table", { name: "Request Logs Table" });
+    expect(within(table).getByText("asherandersenloqv@outlook.com")).toBeInTheDocument();
+    expect(within(table).getByText("Relay")).toBeInTheDocument();
+    expect(within(table).getAllByText("OAuth").length).toBeGreaterThanOrEqual(1);
+    expect(within(table).getByText("API")).toBeInTheDocument();
   });
 
   test("labels non-streaming logs without rendering a first token placeholder", async () => {


### PR DESCRIPTION
## Summary
- Request logs channel column now shows vendor icon + channel name + OAuth/API badge, aligned with the channel filter dropdown.
- Extracted shared `ChannelIdentityLabel` so filter options and table cells stay consistent across column widths.
- Tightened header tenant switcher spacing so label and chevron sit closer without looking cramped.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, full test:ci, build, bundle:diff)
- [x] Unit: request logs page + requestLogsShared mapping/auth-type normalization
- [ ] Manual: open `/manage/runtime/request-logs`, confirm channel column icon/badge and header tenant control spacing