### PR TITLE
fix: persist effective tenant across refresh and keep-alive

### DIFF
--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -19,6 +19,7 @@ import {
   configApi,
   normalizeApiBase,
   readPersistedAuthSnapshot,
+  updatePersistedEffectiveTenantId,
   writePersistedAuthSnapshot,
   type ManagementPrincipal,
   type MenuIdentity,
@@ -54,28 +55,23 @@ interface AuthContextState {
 }
 
 const AuthContext = createContext<AuthContextState | null>(null);
-const EFFECTIVE_TENANT_KEY = "code-proxy-effective-tenant";
 
 const isLocalPreviewMode = () =>
   import.meta.env.DEV &&
   ["127.0.0.1", "localhost", "::1"].includes(window.location.hostname) &&
   new URLSearchParams(window.location.search).get("preview") === "1";
 
-const readEffectiveTenant = () => {
-  try {
-    return localStorage.getItem(EFFECTIVE_TENANT_KEY) ?? "";
-  } catch {
-    return "";
-  }
-};
+/** Empty string means home tenant (no X-Effective-Tenant-ID header). */
+const normalizeTenantOverride = (tenantId: string | undefined | null): string =>
+  typeof tenantId === "string" ? tenantId.trim() : "";
 
-const setEffectiveTenant = (tenantId: string) => {
-  try {
-    if (tenantId) localStorage.setItem(EFFECTIVE_TENANT_KEY, tenantId);
-    else localStorage.removeItem(EFFECTIVE_TENANT_KEY);
-  } catch {
-    // Storage is optional; server authorization remains authoritative.
-  }
+/**
+ * Persist the platform-admin tenant override alongside the auth snapshot so
+ * refresh / keep-alive restore reuses the same X-Effective-Tenant-ID without a
+ * home-tenant flash. Home tenant is stored as an empty override.
+ */
+const persistEffectiveTenantOverride = (tenantId: string): void => {
+  updatePersistedEffectiveTenantId(normalizeTenantOverride(tenantId));
 };
 
 /** Mirrors CliRelay MenuCatalog so management-key / preview mode has a usable sidebar. */
@@ -434,9 +430,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const [principal, setPrincipal] = useState<ManagementPrincipal | null>(null);
   const [authFailureCode, setAuthFailureCode] = useState("");
 
-  const configureClient = useCallback((base: string, token: string, effectiveTenant?: string) => {
+  const configureClient = useCallback((base: string, token: string, effectiveTenant = "") => {
     apiClient.setConfig({ apiBase: base, managementKey: token });
-    const tenantId = effectiveTenant ?? readEffectiveTenant();
+    const tenantId = normalizeTenantOverride(effectiveTenant);
+    // Always replace headers so a previous tenant override cannot leak into home-tenant mode.
     apiClient.setDefaultHeaders(tenantId ? { "X-Effective-Tenant-ID": tenantId } : {});
   }, []);
 
@@ -446,12 +443,14 @@ export function AuthProvider({ children }: PropsWithChildren) {
     const resolvedBase = snapshot?.apiBase ?? fallbackBase;
     const resolvedToken = snapshot?.managementKey ?? "";
     const resolvedRemember = snapshot?.rememberPassword ?? false;
+    // Restore the last platform-admin tenant override on the first /me call so
+    // refresh does not briefly render home tenant then jump to the override.
+    const requestedTenant = normalizeTenantOverride(snapshot?.effectiveTenantId);
 
     setApiBase(resolvedBase);
     setAccessToken(resolvedToken);
     setRememberPassword(resolvedRemember);
-    const requestedTenant = readEffectiveTenant();
-    configureClient(resolvedBase, resolvedToken, "");
+    configureClient(resolvedBase, resolvedToken, requestedTenant);
 
     if (!resolvedToken) {
       setIsAuthenticated(false);
@@ -473,31 +472,38 @@ export function AuthProvider({ children }: PropsWithChildren) {
         setIsAuthenticated(true);
         return;
       }
-      const response = await identityApi.me();
-      let restoredPrincipal = response.principal;
-      if (
-        restoredPrincipal.platform_admin &&
-        requestedTenant &&
-        requestedTenant !== restoredPrincipal.home_tenant.id
-      ) {
-        setEffectiveTenant(requestedTenant);
-        configureClient(resolvedBase, resolvedToken, requestedTenant);
-        try {
-          restoredPrincipal = (await identityApi.me()).principal;
-        } catch {
-          setEffectiveTenant("");
-          configureClient(resolvedBase, resolvedToken, "");
-        }
-      } else {
-        setEffectiveTenant("");
+      let restoredPrincipal: ManagementPrincipal;
+      try {
+        restoredPrincipal = (await identityApi.me()).principal;
+      } catch (overrideError) {
+        // Stale/invalid override can fail Authenticate entirely — retry home tenant
+        // before treating the session as dead (matches previous two-step restore).
+        if (!requestedTenant) throw overrideError;
+        configureClient(resolvedBase, resolvedToken, "");
+        restoredPrincipal = (await identityApi.me()).principal;
       }
+      // If the server ignored or could not apply the override, drop the stale value.
+      if (requestedTenant && restoredPrincipal.effective_tenant.id !== requestedTenant) {
+        configureClient(resolvedBase, resolvedToken, "");
+        if (restoredPrincipal.effective_tenant.id !== restoredPrincipal.home_tenant.id) {
+          restoredPrincipal = (await identityApi.me()).principal;
+        }
+      }
+      // Sync storage to what the server accepted so refresh keeps the same tenant.
+      const confirmedOverride =
+        restoredPrincipal.effective_tenant.id === restoredPrincipal.home_tenant.id
+          ? ""
+          : restoredPrincipal.effective_tenant.id;
+      if (confirmedOverride !== requestedTenant) {
+        configureClient(resolvedBase, resolvedToken, confirmedOverride);
+      }
+      persistEffectiveTenantOverride(confirmedOverride);
       setPrincipal(restoredPrincipal);
       setIsAuthenticated(true);
     } catch (error) {
       setIsAuthenticated(false);
       setPrincipal(null);
       setAuthFailureCode(isApiClientError(error) ? extractApiErrorCode(error.payload) : "");
-      setEffectiveTenant("");
       clearPersistedAuthSnapshot();
     } finally {
       setIsRestoring(false);
@@ -518,7 +524,6 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setAuthFailureCode((event as CustomEvent<{ code?: string }>).detail?.code?.trim() ?? "");
       setIsAuthenticated(false);
       setPrincipal(null);
-      setEffectiveTenant("");
       clearPersistedAuthSnapshot();
     };
     const handleVersion = (event: Event) => {
@@ -542,14 +547,14 @@ export function AuthProvider({ children }: PropsWithChildren) {
       rememberPassword: boolean;
     }) => {
       const normalizedBase = normalizeApiBase(input.apiBase);
-      setEffectiveTenant("");
+      // Login always starts on the home tenant; do not carry a previous override.
       configureClient(normalizedBase, "", "");
       const response = await identityApi.login({
         username: input.username.trim(),
         password: input.password,
         remember_me: input.rememberPassword,
       });
-      configureClient(normalizedBase, response.access_token);
+      configureClient(normalizedBase, response.access_token, "");
       setApiBase(normalizedBase);
       setAccessToken(response.access_token);
       setRememberPassword(input.rememberPassword);
@@ -560,6 +565,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
         apiBase: normalizedBase,
         managementKey: response.access_token,
         rememberPassword: input.rememberPassword,
+        // Explicit empty override so a leftover legacy key cannot re-apply.
+        effectiveTenantId: undefined,
       });
       return response.principal;
     },
@@ -572,9 +579,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setAccessToken("");
     setPrincipal(null);
     setAuthFailureCode("");
-    setEffectiveTenant("");
+    configureClient(apiBase, "", "");
     clearPersistedAuthSnapshot();
-  }, []);
+  }, [apiBase, configureClient]);
 
   const restore = useCallback(async () => {
     setIsRestoring(true);
@@ -584,25 +591,37 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const switchTenant = useCallback(
     async (tenantId: string) => {
       if (!principal?.platform_admin) return;
+      const nextTenant = normalizeTenantOverride(tenantId);
       const previousTenant =
         principal.effective_tenant.id === principal.home_tenant.id
           ? ""
           : principal.effective_tenant.id;
-      setEffectiveTenant(tenantId);
-      configureClient(apiBase, accessToken, tenantId);
+      // Home tenant is represented as no override header.
+      const nextOverride =
+        nextTenant && nextTenant !== principal.home_tenant.id ? nextTenant : "";
+      configureClient(apiBase, accessToken, nextOverride);
+      persistEffectiveTenantOverride(nextOverride);
       // Drop process-global availability cache so the next models page load
       // cannot reuse the previous tenant's configured-availability response.
       invalidateConfiguredModelAvailability();
       try {
         const response = await identityApi.me();
+        const effective = response.principal.effective_tenant;
+        const confirmedOverride =
+          effective.id === response.principal.home_tenant.id ? "" : effective.id;
+        // Align storage with what the server actually accepted.
+        if (confirmedOverride !== nextOverride) {
+          configureClient(apiBase, accessToken, confirmedOverride);
+          persistEffectiveTenantOverride(confirmedOverride);
+        }
         setPrincipal(response.principal);
       } catch {
-        setEffectiveTenant(previousTenant);
         configureClient(apiBase, accessToken, previousTenant);
+        persistEffectiveTenantOverride(previousTenant);
         invalidateConfiguredModelAvailability();
       }
     },
-    [accessToken, apiBase, configureClient, principal?.platform_admin],
+    [accessToken, apiBase, configureClient, principal],
   );
 
   const permissions = useMemo(

--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -505,7 +505,8 @@ test("switching tenant remounts the current page and reloads tenant-scoped data"
 
   await page.goto("/#/roles");
   await expect(page.getByRole("heading", { name: /Roles/i })).toBeVisible();
-  await expect(page.getByText("Administrator")).toBeVisible();
+  // exact: true — sidebar shows "Super Administrator" which would also match /Administrator/.
+  await expect(page.getByText("Administrator", { exact: true })).toBeVisible();
   const initialRolesFetches = rolesFetchCount;
   expect(initialRolesFetches).toBeGreaterThan(0);
 
@@ -514,9 +515,83 @@ test("switching tenant remounts the current page and reloads tenant-scoped data"
   await page.getByRole("option", { name: "Acme Team" }).click();
 
   await expect(trigger).toContainText("Acme Team");
-  await expect(page.getByText("Acme Admin Role")).toBeVisible();
-  await expect(page.getByText("Administrator")).toHaveCount(0);
+  // tenant_admin is localized via i18n; role.name is only shown for custom codes.
+  await expect(page.getByText("Tenant Administrator")).toBeVisible();
+  await expect(page.getByText("Administrator", { exact: true })).toHaveCount(0);
   expect(rolesFetchCount).toBeGreaterThan(initialRolesFetches);
+
+  const authSnapshot = await page.evaluate(() => sessionStorage.getItem("code-proxy-admin-auth"));
+  expect(authSnapshot).toBeTruthy();
+  expect(authSnapshot).toContain(standardTenant.id);
+});
+
+test("restores the selected tenant after full page reload", async ({ page }) => {
+  await page.addInitScript(() =>
+    sessionStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: false,
+        expiresAt: Date.now() + 60_000,
+        effectiveTenantId: "t-acme",
+      }),
+    ),
+  );
+
+  const meTenantHeaders: string[] = [];
+  await page.route("**/v0/auth/me", (route) => {
+    const tenantHeader = route.request().headers()["x-effective-tenant-id"] ?? "";
+    meTenantHeaders.push(tenantHeader);
+    const effective = tenantHeader === standardTenant.id ? standardTenant : principal.home_tenant;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        principal: {
+          ...principal,
+          effective_tenant: effective,
+        },
+      }),
+    });
+  });
+
+  // Same management mock shape as the switch-tenant test (path → body map).
+  await page.route("**/v0/management/**", (route) => {
+    const path = new URL(route.request().url()).pathname.replace("/v0/management", "");
+    if (path === "/roles") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [administratorRole] }),
+      });
+    }
+    const bodies: Record<string, unknown> = {
+      "/tenants": { items: [principal.home_tenant, standardTenant] },
+      "/users": { items: [principal.user] },
+      "/menus": { items: menuItems },
+      "/permissions": { items: [] },
+      "/audit-logs": { items: [] },
+    };
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(bodies[path] ?? {}),
+    });
+  });
+
+  await page.goto("/#/roles");
+  const trigger = page.getByRole("combobox", { name: /switch tenant/i });
+  // Header must restore the persisted tenant without a home-tenant flash.
+  await expect(trigger).toContainText("Acme Team");
+  // First restore /me must already carry the persisted override.
+  expect(meTenantHeaders.length).toBeGreaterThan(0);
+  expect(meTenantHeaders[0]).toBe(standardTenant.id);
+
+  const snapshotAfterRestore = await page.evaluate(() =>
+    sessionStorage.getItem("code-proxy-admin-auth"),
+  );
+  expect(snapshotAfterRestore).toContain(standardTenant.id);
 });
 
 test("shows tenant row actions including protected system tenant details", async ({ page }) => {

--- a/packages/api-client/src/client/__tests__/auth-storage.test.ts
+++ b/packages/api-client/src/client/__tests__/auth-storage.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  clearPersistedAuthSnapshot,
+  LEGACY_EFFECTIVE_TENANT_KEY,
+  readPersistedAuthSnapshot,
+  updatePersistedEffectiveTenantId,
+  writePersistedAuthSnapshot,
+} from "../auth-storage";
+import { AUTH_STORAGE_KEY } from "../constants";
+
+describe("auth-storage effective tenant persistence", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  test("writes and reads effectiveTenantId with the auth snapshot", () => {
+    writePersistedAuthSnapshot({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_test",
+      rememberPassword: true,
+      effectiveTenantId: "tenant-acme",
+    });
+
+    expect(readPersistedAuthSnapshot()).toEqual({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_test",
+      rememberPassword: true,
+      effectiveTenantId: "tenant-acme",
+    });
+
+    const raw = localStorage.getItem(AUTH_STORAGE_KEY);
+    expect(raw).toContain("tenant-acme");
+    expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
+  });
+
+  test("falls back to the legacy effective-tenant key once", () => {
+    localStorage.setItem(
+      AUTH_STORAGE_KEY,
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: true,
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    localStorage.setItem(LEGACY_EFFECTIVE_TENANT_KEY, "tenant-legacy");
+
+    expect(readPersistedAuthSnapshot()?.effectiveTenantId).toBe("tenant-legacy");
+
+    updatePersistedEffectiveTenantId("tenant-migrated");
+    expect(readPersistedAuthSnapshot()?.effectiveTenantId).toBe("tenant-migrated");
+    expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
+  });
+
+  test("updatePersistedEffectiveTenantId patches only the tenant override", () => {
+    writePersistedAuthSnapshot({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_test",
+      rememberPassword: false,
+    });
+    expect(sessionStorage.getItem(AUTH_STORAGE_KEY)).toBeTruthy();
+
+    updatePersistedEffectiveTenantId("tenant-b");
+    expect(readPersistedAuthSnapshot()).toMatchObject({
+      managementKey: "cps_test",
+      rememberPassword: false,
+      effectiveTenantId: "tenant-b",
+    });
+
+    updatePersistedEffectiveTenantId("");
+    expect(readPersistedAuthSnapshot()).toEqual({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_test",
+      rememberPassword: false,
+    });
+  });
+
+  test("clearPersistedAuthSnapshot removes auth and legacy tenant keys", () => {
+    writePersistedAuthSnapshot({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_test",
+      rememberPassword: true,
+      effectiveTenantId: "tenant-acme",
+    });
+    localStorage.setItem(LEGACY_EFFECTIVE_TENANT_KEY, "stale");
+
+    clearPersistedAuthSnapshot();
+    expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
+  });
+});

--- a/packages/api-client/src/client/auth-storage.ts
+++ b/packages/api-client/src/client/auth-storage.ts
@@ -1,6 +1,9 @@
 import type { AuthSnapshot } from "../dto/types";
 import { AUTH_PERSIST_TTL_MS, AUTH_STORAGE_KEY, normalizeApiBase } from "./constants";
 
+/** Legacy key used before effective tenant was stored inside the auth snapshot. */
+export const LEGACY_EFFECTIVE_TENANT_KEY = "code-proxy-effective-tenant";
+
 interface PersistedAuthSnapshot extends AuthSnapshot {
   expiresAt: number;
 }
@@ -13,6 +16,28 @@ const storages = (): Storage[] => {
     /* unavailable */
   }
   return items;
+};
+
+const normalizeEffectiveTenantId = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const readLegacyEffectiveTenantId = (): string | undefined => {
+  try {
+    return normalizeEffectiveTenantId(window.localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY));
+  } catch {
+    return undefined;
+  }
+};
+
+const clearLegacyEffectiveTenantId = (): void => {
+  try {
+    window.localStorage.removeItem(LEGACY_EFFECTIVE_TENANT_KEY);
+  } catch {
+    /* Storage is optional. */
+  }
 };
 
 export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
@@ -30,10 +55,14 @@ export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
         storage.removeItem(AUTH_STORAGE_KEY);
         continue;
       }
+      // Prefer the value stored with the session; fall back to the pre-migration key once.
+      const effectiveTenantId =
+        normalizeEffectiveTenantId(parsed.effectiveTenantId) ?? readLegacyEffectiveTenantId();
       return {
         apiBase: normalizeApiBase(parsed.apiBase),
         managementKey: parsed.managementKey,
         rememberPassword: Boolean(parsed.rememberPassword),
+        ...(effectiveTenantId ? { effectiveTenantId } : {}),
       };
     } catch {
       storage.removeItem(AUTH_STORAGE_KEY);
@@ -47,12 +76,37 @@ export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
   const target = snapshot.rememberPassword ? local : session;
   if (!target) return;
   clearPersistedAuthSnapshot();
-  target.setItem(
-    AUTH_STORAGE_KEY,
-    JSON.stringify({ ...snapshot, expiresAt: Date.now() + AUTH_PERSIST_TTL_MS }),
-  );
+  const effectiveTenantId = normalizeEffectiveTenantId(snapshot.effectiveTenantId);
+  const payload: PersistedAuthSnapshot = {
+    apiBase: snapshot.apiBase,
+    managementKey: snapshot.managementKey,
+    rememberPassword: snapshot.rememberPassword,
+    expiresAt: Date.now() + AUTH_PERSIST_TTL_MS,
+    ...(effectiveTenantId ? { effectiveTenantId } : {}),
+  };
+  target.setItem(AUTH_STORAGE_KEY, JSON.stringify(payload));
+  // Drop the legacy key after a successful write so we do not keep two sources of truth.
+  clearLegacyEffectiveTenantId();
 };
 
 export const clearPersistedAuthSnapshot = (): void => {
   for (const storage of storages()) storage.removeItem(AUTH_STORAGE_KEY);
+  clearLegacyEffectiveTenantId();
+};
+
+/**
+ * Patch only the effective-tenant field of the current auth snapshot.
+ * No-op when there is no active snapshot (logged out).
+ */
+export const updatePersistedEffectiveTenantId = (tenantId: string): void => {
+  const current = readPersistedAuthSnapshot();
+  if (!current) {
+    // Still clear any leftover override when the session is gone.
+    if (!normalizeEffectiveTenantId(tenantId)) clearLegacyEffectiveTenantId();
+    return;
+  }
+  writePersistedAuthSnapshot({
+    ...current,
+    effectiveTenantId: normalizeEffectiveTenantId(tenantId),
+  });
 };

--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -2,6 +2,8 @@ export interface AuthSnapshot {
   apiBase: string;
   managementKey: string;
   rememberPassword: boolean;
+  /** Platform-admin override; empty/omitted means home tenant (no X-Effective-Tenant-ID). */
+  effectiveTenantId?: string;
 }
 
 export type AuthFileType =

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -25,7 +25,9 @@ export type { ApiEnvelope, ApiListPayload, ApiSuccessEnvelope } from "./client/r
 export { publicApiClient, PublicApiClient } from "./client/public-client";
 export {
   clearPersistedAuthSnapshot,
+  LEGACY_EFFECTIVE_TENANT_KEY,
   readPersistedAuthSnapshot,
+  updatePersistedEffectiveTenantId,
   writePersistedAuthSnapshot,
 } from "./client/auth-storage";
 export type * from "./dto/types";


### PR DESCRIPTION
## Summary
- Store the platform-admin tenant override (`effectiveTenantId`) inside the auth snapshot so it shares the same keep-alive lifecycle as login state.
- Restore with `X-Effective-Tenant-ID` on the first `/me` call to avoid flashing the home tenant on refresh.
- Fall back to home tenant when a stale override fails auth, and keep switch/login/logout storage in sync.
- Cover persistence with unit tests and an e2e reload scenario.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, test:ci, build, bundle:diff)
- [x] `bun run test -- packages/api-client/src/client/__tests__/auth-storage.test.ts`
- [x] Playwright: `e2e/multi-tenant-auth.spec.ts` (`switching tenant remounts…`, `restores the selected tenant…`)