### PR TITLE
fix(ui): keep TabsList content-width in flex layouts

### DIFF
--- a/packages/ui/src/primitives/Tabs.tsx
+++ b/packages/ui/src/primitives/Tabs.tsx
@@ -111,7 +111,9 @@ export function TabsList({
       {...divProps}
       role="tablist"
       className={[
-        "scrollbar-hidden relative inline-flex max-w-full gap-0.5 overflow-x-auto whitespace-nowrap rounded-full bg-[#EBEBEC] p-0.5 dark:bg-[#27272A]",
+        // w-fit + self-start: stay content-sized even when parent is flex-col
+        // (default align-items:stretch would stretch the pill bar full width)
+        "scrollbar-hidden relative inline-flex w-fit max-w-full shrink-0 self-start gap-0.5 overflow-x-auto whitespace-nowrap rounded-full bg-[#EBEBEC] p-0.5 dark:bg-[#27272A]",
         tabsListHeightBySize[size],
         className,
       ].join(" ")}

--- a/pages/logs/LogsPage.tsx
+++ b/pages/logs/LogsPage.tsx
@@ -295,7 +295,7 @@ export function LogsPage() {
   return (
     <div className="space-y-6 md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:space-y-0 md:gap-4 md:overflow-hidden">
       <Tabs value={tab} onValueChange={(next) => setTab(next as typeof tab)}>
-        <TabsList className="md:shrink-0">
+        <TabsList>
           <TabsTrigger value="content">{t("logs_page.log_content")}</TabsTrigger>
           <TabsTrigger value="errors">{t("logs_page.error_logs")}</TabsTrigger>
         </TabsList>


### PR DESCRIPTION
## Summary
- Fix shared `TabsList` so it stays content-sized (`w-fit self-start shrink-0`) instead of stretching full-width in flex column parents.
- Drop redundant `md:shrink-0` on the logs page tab list.

## Why
On the runtime logs page, the pill tabs bar was stretched to the same width as the content panel because flex children default to `align-items: stretch`. That made the gray track look like a full-width toolbar instead of a compact segmented control.

## Test plan
- [x] `./scripts/ci-pr.sh` in isolated worktree
- [ ] Refresh 运行日志 page: tabs should only wrap「日志内容 / 错误日志」