### PR TITLE
fix: scope browser data caches by effective tenant

### DIFF
--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -24,6 +24,11 @@ import {
   type ManagementPrincipal,
   type MenuIdentity,
 } from "@code-proxy/api-client";
+import {
+  DEFAULT_CACHE_TENANT_ID,
+  setActiveCacheTenantId,
+  setCacheTenantResolver,
+} from "@code-proxy/domain";
 import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 
 interface AuthContextState {
@@ -72,6 +77,17 @@ const normalizeTenantOverride = (tenantId: string | undefined | null): string =>
  */
 const persistEffectiveTenantOverride = (tenantId: string): void => {
   updatePersistedEffectiveTenantId(normalizeTenantOverride(tenantId));
+};
+
+/**
+ * Pin the browser data-cache tenant to the effective management tenant.
+ * Data caches (providers, auth-files, pricing, proxy checks, lookup charts)
+ * all read getActiveCacheTenantId() so they never reuse another tenant's payload.
+ */
+const syncActiveDataCacheTenant = (tenantId?: string | null): void => {
+  setActiveCacheTenantId(tenantId ?? DEFAULT_CACHE_TENANT_ID);
+  // Hard-invalidate process-global availability so in-flight promises cannot leak.
+  invalidateConfiguredModelAvailability();
 };
 
 /** Mirrors CliRelay MenuCatalog so management-key / preview mode has a usable sidebar. */
@@ -437,6 +453,17 @@ export function AuthProvider({ children }: PropsWithChildren) {
     apiClient.setDefaultHeaders(tenantId ? { "X-Effective-Tenant-ID": tenantId } : {});
   }, []);
 
+  // Prefer live principal.effective_tenant for cache keys; fall back to last explicit pin.
+  useEffect(() => {
+    setCacheTenantResolver(() => principal?.effective_tenant?.id ?? null);
+    if (principal?.effective_tenant?.id) {
+      setActiveCacheTenantId(principal.effective_tenant.id);
+    }
+    return () => {
+      setCacheTenantResolver(null);
+    };
+  }, [principal?.effective_tenant?.id]);
+
   const bootstrap = useCallback(async () => {
     const fallbackBase = detectApiBaseFromLocation();
     const snapshot = readPersistedAuthSnapshot();
@@ -451,15 +478,20 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setAccessToken(resolvedToken);
     setRememberPassword(resolvedRemember);
     configureClient(resolvedBase, resolvedToken, requestedTenant);
+    // Pin cache tenant before any page paints from localStorage/sessionStorage.
+    syncActiveDataCacheTenant(requestedTenant || DEFAULT_CACHE_TENANT_ID);
 
     if (!resolvedToken) {
       setIsAuthenticated(false);
       setPrincipal(null);
+      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
       setIsRestoring(false);
       return;
     }
     if (isLocalPreviewMode()) {
-      setPrincipal(legacyServicePrincipal());
+      const preview = legacyServicePrincipal();
+      setPrincipal(preview);
+      syncActiveDataCacheTenant(preview.effective_tenant.id);
       setIsAuthenticated(true);
       setIsRestoring(false);
       return;
@@ -468,7 +500,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
     try {
       if (!resolvedToken.startsWith("cps_")) {
         await configApi.getConfig();
-        setPrincipal(legacyServicePrincipal());
+        const legacy = legacyServicePrincipal();
+        setPrincipal(legacy);
+        syncActiveDataCacheTenant(legacy.effective_tenant.id);
         setIsAuthenticated(true);
         return;
       }
@@ -480,6 +514,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
         // before treating the session as dead (matches previous two-step restore).
         if (!requestedTenant) throw overrideError;
         configureClient(resolvedBase, resolvedToken, "");
+        syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
         restoredPrincipal = (await identityApi.me()).principal;
       }
       // If the server ignored or could not apply the override, drop the stale value.
@@ -499,10 +534,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
       }
       persistEffectiveTenantOverride(confirmedOverride);
       setPrincipal(restoredPrincipal);
+      syncActiveDataCacheTenant(restoredPrincipal.effective_tenant.id);
       setIsAuthenticated(true);
     } catch (error) {
       setIsAuthenticated(false);
       setPrincipal(null);
+      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
       setAuthFailureCode(isApiClientError(error) ? extractApiErrorCode(error.payload) : "");
       clearPersistedAuthSnapshot();
     } finally {
@@ -524,6 +561,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setAuthFailureCode((event as CustomEvent<{ code?: string }>).detail?.code?.trim() ?? "");
       setIsAuthenticated(false);
       setPrincipal(null);
+      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
       clearPersistedAuthSnapshot();
     };
     const handleVersion = (event: Event) => {
@@ -559,6 +597,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setAccessToken(response.access_token);
       setRememberPassword(input.rememberPassword);
       setPrincipal(response.principal);
+      syncActiveDataCacheTenant(response.principal.effective_tenant.id);
       setAuthFailureCode("");
       setIsAuthenticated(true);
       writePersistedAuthSnapshot({
@@ -580,6 +619,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setPrincipal(null);
     setAuthFailureCode("");
     configureClient(apiBase, "", "");
+    syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
     clearPersistedAuthSnapshot();
   }, [apiBase, configureClient]);
 
@@ -601,9 +641,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
         nextTenant && nextTenant !== principal.home_tenant.id ? nextTenant : "";
       configureClient(apiBase, accessToken, nextOverride);
       persistEffectiveTenantOverride(nextOverride);
-      // Drop process-global availability cache so the next models page load
-      // cannot reuse the previous tenant's configured-availability response.
-      invalidateConfiguredModelAvailability();
+      // Switch cache bucket immediately so remounted pages never paint prior tenant data.
+      syncActiveDataCacheTenant(nextTenant || principal.home_tenant.id);
       try {
         const response = await identityApi.me();
         const effective = response.principal.effective_tenant;
@@ -615,10 +654,11 @@ export function AuthProvider({ children }: PropsWithChildren) {
           persistEffectiveTenantOverride(confirmedOverride);
         }
         setPrincipal(response.principal);
+        syncActiveDataCacheTenant(effective.id);
       } catch {
         configureClient(apiBase, accessToken, previousTenant);
         persistEffectiveTenantOverride(previousTenant);
-        invalidateConfiguredModelAvailability();
+        syncActiveDataCacheTenant(previousTenant || principal.home_tenant.id);
       }
     },
     [accessToken, apiBase, configureClient, principal],

--- a/features/model-availability/configuredAvailabilityCache.ts
+++ b/features/model-availability/configuredAvailabilityCache.ts
@@ -2,6 +2,11 @@ let configuredAvailabilityCacheVersion = 0;
 
 export const getConfiguredAvailabilityCacheVersion = () => configuredAvailabilityCacheVersion;
 
+/**
+ * Bump the process-global availability cache version.
+ * Used as a hard invalidation on tenant switch / logout so in-flight promises
+ * from a previous tenant cannot be reused even if a tenant map entry lingers.
+ */
 export const invalidateConfiguredModelAvailability = () => {
   configuredAvailabilityCacheVersion += 1;
 };

--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -7,6 +7,7 @@ import type {
   ProviderSimpleConfig,
 } from "@code-proxy/api-client";
 import {
+  getActiveCacheTenantId,
   matchesModelPattern,
   normalizeProviderKey,
   resolveFileType,
@@ -938,18 +939,20 @@ const loadConfiguredAvailabilityEndpoint = async (
   return normalizeConfiguredModelAvailability(payload);
 };
 
-/* ── In-flight/TTL cache ── */
+/* ── In-flight/TTL cache (tenant-scoped) ── */
 
 const CONFIGURED_AVAILABILITY_TTL_MS = 15_000;
-let configuredAvailabilityCache: {
+
+type TenantConfiguredAvailabilityCache = {
   expiresAt: number;
   version: number;
   value: ConfiguredModelAvailability;
-} | null = null;
-let configuredAvailabilityInFlight: {
+};
+
+type TenantConfiguredAvailabilityInFlight = {
   version: number;
   promise: Promise<ConfiguredModelAvailability>;
-} | null = null;
+};
 
 interface GroupAvailabilityCacheEntry {
   expiresAt: number;
@@ -958,7 +961,21 @@ interface GroupAvailabilityCacheEntry {
 }
 
 const GROUP_AVAILABILITY_TTL_MS = 15_000;
-const groupAvailabilityCache = new Map<string, GroupAvailabilityCacheEntry>();
+
+/** Per-tenant full-catalog cache (no channel-group filter). */
+const configuredAvailabilityByTenant = new Map<string, TenantConfiguredAvailabilityCache>();
+/** Per-tenant in-flight full-catalog request. */
+const configuredAvailabilityInFlightByTenant = new Map<
+  string,
+  TenantConfiguredAvailabilityInFlight
+>();
+/**
+ * Per-tenant channel-group availability cache.
+ * Outer key = tenant id; inner key = sorted allowed groups.
+ */
+const groupAvailabilityByTenant = new Map<string, Map<string, GroupAvailabilityCacheEntry>>();
+
+const tenantCacheKey = () => getActiveCacheTenantId();
 
 export { invalidateConfiguredModelAvailability };
 
@@ -972,12 +989,18 @@ export const loadConfiguredModelAvailability = async (options?: {
     loadConfiguredModelAvailabilityFallback(
       await loadAuthGroupOwnerMappingMap(),
     );
+  const tenantId = tenantCacheKey();
 
   if (validGroups.length > 0) {
     const cacheKey = validGroups.join(",");
     const now = Date.now();
     const cacheVersion = getConfiguredAvailabilityCacheVersion();
-    const cached = groupAvailabilityCache.get(cacheKey);
+    let tenantGroupCache = groupAvailabilityByTenant.get(tenantId);
+    if (!tenantGroupCache) {
+      tenantGroupCache = new Map();
+      groupAvailabilityByTenant.set(tenantId, tenantGroupCache);
+    }
+    const cached = tenantGroupCache.get(cacheKey);
     if (
       cached &&
       cached.cacheVersion === cacheVersion &&
@@ -991,17 +1014,19 @@ export const loadConfiguredModelAvailability = async (options?: {
           `/models/configured-availability?allowed_channel_groups=${encodeURIComponent(cacheKey)}`,
         );
         if (!result) return loadFallback();
-        groupAvailabilityCache.set(cacheKey, {
-          expiresAt: now + GROUP_AVAILABILITY_TTL_MS,
+        const current = groupAvailabilityByTenant.get(tenantId) ?? new Map();
+        current.set(cacheKey, {
+          expiresAt: Date.now() + GROUP_AVAILABILITY_TTL_MS,
           cacheVersion,
           promise: Promise.resolve(result),
         });
+        groupAvailabilityByTenant.set(tenantId, current);
         return result;
       } catch {
         return loadFallback();
       }
     })();
-    groupAvailabilityCache.set(cacheKey, {
+    tenantGroupCache.set(cacheKey, {
       expiresAt: now + GROUP_AVAILABILITY_TTL_MS,
       cacheVersion,
       promise,
@@ -1011,6 +1036,7 @@ export const loadConfiguredModelAvailability = async (options?: {
 
   const now = Date.now();
   const cacheVersion = getConfiguredAvailabilityCacheVersion();
+  const configuredAvailabilityCache = configuredAvailabilityByTenant.get(tenantId);
   if (
     configuredAvailabilityCache &&
     configuredAvailabilityCache.version === cacheVersion &&
@@ -1018,6 +1044,8 @@ export const loadConfiguredModelAvailability = async (options?: {
   ) {
     return configuredAvailabilityCache.value;
   }
+  const configuredAvailabilityInFlight =
+    configuredAvailabilityInFlightByTenant.get(tenantId);
   if (
     configuredAvailabilityInFlight &&
     configuredAvailabilityInFlight.version === cacheVersion
@@ -1031,24 +1059,28 @@ export const loadConfiguredModelAvailability = async (options?: {
         "/models/configured-availability",
       );
       if (!result) return loadFallback();
-      configuredAvailabilityCache = {
-        expiresAt: now + CONFIGURED_AVAILABILITY_TTL_MS,
+      configuredAvailabilityByTenant.set(tenantId, {
+        expiresAt: Date.now() + CONFIGURED_AVAILABILITY_TTL_MS,
         version: cacheVersion,
         value: result,
-      };
+      });
       return result;
     } catch {
       // Fallback to old multi-API aggregation for backward compatibility.
       return loadFallback();
     }
   })();
-  configuredAvailabilityInFlight = { version: cacheVersion, promise };
+  configuredAvailabilityInFlightByTenant.set(tenantId, {
+    version: cacheVersion,
+    promise,
+  });
 
   try {
     return await promise;
   } finally {
-    if (configuredAvailabilityInFlight?.promise === promise) {
-      configuredAvailabilityInFlight = null;
+    const current = configuredAvailabilityInFlightByTenant.get(tenantId);
+    if (current?.promise === promise) {
+      configuredAvailabilityInFlightByTenant.delete(tenantId);
     }
   }
 };

--- a/features/proxy-pool/proxy-utils.ts
+++ b/features/proxy-pool/proxy-utils.ts
@@ -1,11 +1,18 @@
 import type { ProxyCheckResult, ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
+import {
+  getActiveCacheTenantId,
+  readTenantBucket,
+  writeTenantBucket,
+} from "@code-proxy/domain";
 
 export type ProxyCheckStateEntry = Partial<ProxyCheckResult> & { checking?: boolean };
 export type ProxyCheckState = Record<string, ProxyCheckStateEntry>;
 
 export type ProxyLatencyTone = "none" | "fast" | "medium" | "slow" | "failed";
 
-export const PROXIES_CHECK_STATE_CACHE_KEY = "proxiesPage.checkState.v1";
+/** Tenant-scoped proxy check results (v2). Legacy v1 migrates into the default tenant only. */
+export const PROXIES_CHECK_STATE_CACHE_KEY = "proxiesPage.checkState.v2";
+export const PROXIES_CHECK_STATE_CACHE_KEY_V1 = "proxiesPage.checkState.v1";
 
 const readCachedNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.round(value) : undefined;
@@ -51,52 +58,64 @@ export const proxyLatencyTone = (result?: ProxyCheckStateEntry): ProxyLatencyTon
   return "slow";
 };
 
-export const readCachedProxyCheckState = (): ProxyCheckState => {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = window.sessionStorage.getItem(PROXIES_CHECK_STATE_CACHE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-
-    const next: ProxyCheckState = {};
-    for (const [id, value] of Object.entries(parsed)) {
-      if (!id || !value || typeof value !== "object" || Array.isArray(value)) continue;
-      const item = value as Record<string, unknown>;
-      if (typeof item.ok !== "boolean") continue;
-      const statusCode = readCachedNumber(item.statusCode);
-      const latencyMs = readCachedNumber(item.latencyMs);
-      const message = typeof item.message === "string" ? item.message : "";
-      next[id] = {
-        ok: item.ok,
-        ...(typeof statusCode === "number" ? { statusCode } : {}),
-        ...(typeof latencyMs === "number" ? { latencyMs } : {}),
-        ...(message ? { message } : {}),
-      };
-    }
-    return next;
-  } catch {
-    return {};
+const parseProxyCheckState = (value: unknown): ProxyCheckState | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const next: ProxyCheckState = {};
+  for (const [id, itemValue] of Object.entries(value as Record<string, unknown>)) {
+    if (!id || !itemValue || typeof itemValue !== "object" || Array.isArray(itemValue)) continue;
+    const item = itemValue as Record<string, unknown>;
+    if (typeof item.ok !== "boolean") continue;
+    const statusCode = readCachedNumber(item.statusCode);
+    const latencyMs = readCachedNumber(item.latencyMs);
+    const message = typeof item.message === "string" ? item.message : "";
+    next[id] = {
+      ok: item.ok,
+      ...(typeof statusCode === "number" ? { statusCode } : {}),
+      ...(typeof latencyMs === "number" ? { latencyMs } : {}),
+      ...(message ? { message } : {}),
+    };
   }
+  return next;
 };
 
-export const writeCachedProxyCheckState = (state: ProxyCheckState) => {
-  if (typeof window === "undefined") return;
-  try {
-    const cache: Record<string, ProxyCheckResult> = {};
-    for (const [id, result] of Object.entries(state)) {
-      if (typeof result.ok !== "boolean") continue;
-      cache[id] = {
-        ok: result.ok,
-        ...(typeof result.statusCode === "number" ? { statusCode: result.statusCode } : {}),
-        ...(typeof result.latencyMs === "number" ? { latencyMs: result.latencyMs } : {}),
-        ...(result.message ? { message: result.message } : {}),
-      };
-    }
-    window.sessionStorage.setItem(PROXIES_CHECK_STATE_CACHE_KEY, JSON.stringify(cache));
-  } catch {
-    // 忽略缓存写入失败。
+export const readCachedProxyCheckState = (tenantId?: string | null): ProxyCheckState => {
+  return (
+    readTenantBucket({
+      key: PROXIES_CHECK_STATE_CACHE_KEY,
+      kind: "session",
+      tenantId: tenantId ?? getActiveCacheTenantId(),
+      legacyKey: PROXIES_CHECK_STATE_CACHE_KEY_V1,
+      parseBucket: parseProxyCheckState,
+      acceptUnscopedCurrent: true,
+    }) ?? {}
+  );
+};
+
+export const writeCachedProxyCheckState = (
+  state: ProxyCheckState,
+  tenantId?: string | null,
+): void => {
+  // Persist only completed checks (ok is required); drop in-flight "checking" rows.
+  const cache: ProxyCheckState = {};
+  for (const [id, result] of Object.entries(state)) {
+    if (typeof result.ok !== "boolean") continue;
+    cache[id] = {
+      ok: result.ok,
+      ...(typeof result.statusCode === "number" ? { statusCode: result.statusCode } : {}),
+      ...(typeof result.latencyMs === "number" ? { latencyMs: result.latencyMs } : {}),
+      ...(result.message ? { message: result.message } : {}),
+    };
   }
+  writeTenantBucket({
+    key: PROXIES_CHECK_STATE_CACHE_KEY,
+    kind: "session",
+    tenantId: tenantId ?? getActiveCacheTenantId(),
+    legacyKey: PROXIES_CHECK_STATE_CACHE_KEY_V1,
+    parseBucket: parseProxyCheckState,
+    acceptUnscopedCurrent: true,
+    legacyKeysToRemove: [PROXIES_CHECK_STATE_CACHE_KEY_V1],
+    bucket: cache,
+  });
 };
 
 export const slugifyProxyID = (name: string, fallback: string): string => {

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -15,6 +15,12 @@ import { resolveCodexPlanType } from "../quota/resolvers";
 import { normalizePlanType } from "../quota/parsers";
 import type { QuotaItem, QuotaState, QuotaStatus } from "../quota/types";
 import type { StatusBarData, StatusBlockDetail, StatusBlockState } from "../usage";
+import {
+  getActiveCacheTenantId,
+  normalizeCacheTenantId,
+  readTenantBucket,
+  writeTenantBucket,
+} from "../tenant-cache";
 
 export type AuthFileModelItem = {
   id: string;
@@ -44,7 +50,9 @@ export const AUTH_FILES_PAGE_SIZE = 9;
 export const MAX_AUTH_FILE_SIZE = 50 * 1024;
 
 export const AUTH_FILES_UI_STATE_KEY = "authFilesPage.uiState.v3";
-export const AUTH_FILES_DATA_CACHE_KEY = "authFilesPage.dataCache.v2";
+/** Tenant-scoped auth-files list/quota cache (v3). Legacy v2 is read only for migration. */
+export const AUTH_FILES_DATA_CACHE_KEY = "authFilesPage.dataCache.v3";
+export const AUTH_FILES_DATA_CACHE_KEY_V2 = "authFilesPage.dataCache.v2";
 export const AUTH_FILES_QUOTA_PREVIEW_KEY = "authFilesPage.quotaPreview.v1";
 export const AUTH_FILES_QUOTA_AUTO_REFRESH_KEY = "authFilesPage.quotaAutoRefreshMs.v1";
 export const AUTH_FILES_FILES_VIEW_MODE_KEY = "authFilesPage.filesViewMode.v1";
@@ -81,11 +89,15 @@ export type AuthFilesUiState = {
 };
 
 export type AuthFilesDataCache = {
+  /** Effective tenant id that owns this cache bucket. Required to prevent cross-tenant reuse. */
+  tenantId: string;
   savedAtMs: number;
   files: AuthFileItem[];
   usageData?: EntityStatsResponse | null;
   quotaByFileName?: Record<string, QuotaState>;
 };
+
+type AuthFilesDataCacheBucket = Omit<AuthFilesDataCache, "tenantId">;
 
 const sanitizeDecodedIdToken = (value: unknown): unknown => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
@@ -518,55 +530,76 @@ const sanitizeQuotaByFileNameForCache = (
   return Object.keys(output).length > 0 ? output : undefined;
 };
 
-export const readAuthFilesDataCache = (): AuthFilesDataCache | null => {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<AuthFilesDataCache>;
-    const files = Array.isArray(parsed?.files) ? (parsed.files as AuthFileItem[]) : null;
-    if (!files) return null;
-    const savedAtMs =
-      typeof parsed?.savedAtMs === "number" && Number.isFinite(parsed.savedAtMs)
-        ? parsed.savedAtMs
-        : Date.now();
+const parseAuthFilesDataCacheBucket = (
+  value: unknown,
+): AuthFilesDataCacheBucket | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const parsed = value as Partial<AuthFilesDataCacheBucket> & { tenantId?: string };
+  const files = Array.isArray(parsed.files) ? (parsed.files as AuthFileItem[]) : null;
+  if (!files) return null;
+  const savedAtMs =
+    typeof parsed.savedAtMs === "number" && Number.isFinite(parsed.savedAtMs)
+      ? parsed.savedAtMs
+      : Date.now();
+  return {
+    savedAtMs,
+    files,
+    usageData:
+      parsed.usageData && typeof parsed.usageData === "object"
+        ? (parsed.usageData as EntityStatsResponse)
+        : undefined,
+    quotaByFileName: sanitizeQuotaByFileNameForCache(parsed.quotaByFileName),
+  };
+};
 
-    return {
-      savedAtMs,
-      files,
-      usageData:
-        parsed?.usageData && typeof parsed.usageData === "object"
-          ? (parsed.usageData as EntityStatsResponse)
-          : undefined,
-      quotaByFileName: sanitizeQuotaByFileNameForCache(parsed?.quotaByFileName),
-    };
-  } catch {
-    return null;
-  }
+/**
+ * Read auth-files list/quota cache for a tenant.
+ * Prefer explicit tenantId; fall back to the active cache tenant from AuthProvider.
+ */
+export const readAuthFilesDataCache = (
+  tenantId?: string | null,
+): AuthFilesDataCache | null => {
+  const tenantKey = normalizeCacheTenantId(tenantId ?? getActiveCacheTenantId());
+  const bucket = readTenantBucket({
+    key: AUTH_FILES_DATA_CACHE_KEY,
+    tenantId: tenantKey,
+    legacyKey: AUTH_FILES_DATA_CACHE_KEY_V2,
+    parseBucket: parseAuthFilesDataCacheBucket,
+    // v3 may still hold a single unscoped bucket mid-migration.
+    acceptUnscopedCurrent: true,
+  });
+  if (!bucket) return null;
+  return { tenantId: tenantKey, ...bucket };
 };
 
 export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
-  if (typeof window === "undefined") return;
-  try {
-    const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
-    const previous = raw ? (JSON.parse(raw) as Partial<AuthFilesDataCache>) : null;
-    const fileNames = new Set(cache.files.map((file) => file.name).filter(Boolean));
-    const quotaByFileName = sanitizeQuotaByFileNameForCache(
-      cache.quotaByFileName ?? previous?.quotaByFileName,
-      fileNames,
-    );
-    window.localStorage.setItem(
-      AUTH_FILES_DATA_CACHE_KEY,
-      JSON.stringify({
-        savedAtMs: cache.savedAtMs,
-        files: cache.files,
-        usageData: cache.usageData ?? previous?.usageData,
-        quotaByFileName,
-      }),
-    );
-  } catch {
-    // ignore
-  }
+  const tenantKey = normalizeCacheTenantId(cache.tenantId || getActiveCacheTenantId());
+  writeTenantBucket({
+    key: AUTH_FILES_DATA_CACHE_KEY,
+    tenantId: tenantKey,
+    legacyKey: AUTH_FILES_DATA_CACHE_KEY_V2,
+    parseBucket: parseAuthFilesDataCacheBucket,
+    acceptUnscopedCurrent: true,
+    legacyKeysToRemove: [AUTH_FILES_DATA_CACHE_KEY_V2],
+    bucket: {
+      savedAtMs: cache.savedAtMs,
+      files: cache.files,
+      usageData: cache.usageData,
+      quotaByFileName: cache.quotaByFileName,
+    },
+    merge: (previous, next) => {
+      const fileNames = new Set(next.files.map((file) => file.name).filter(Boolean));
+      return {
+        savedAtMs: next.savedAtMs,
+        files: next.files,
+        usageData: next.usageData ?? previous?.usageData,
+        quotaByFileName: sanitizeQuotaByFileNameForCache(
+          next.quotaByFileName ?? previous?.quotaByFileName,
+          fileNames,
+        ),
+      };
+    },
+  });
 };
 
 export const formatFileSize = (bytes?: number): string => {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -8,4 +8,5 @@ export * from "./auth-files/types";
 export * from "./auth-files/zip";
 export * from "./quota";
 export * from "./usage";
+export * from "./tenant-cache";
 export { isRuntimeOnlyAuthFile, normalizeAuthIndexValue } from "./auth-files/authFiles";

--- a/packages/domain/src/tenant-cache/__tests__/tenantScopedStorage.test.ts
+++ b/packages/domain/src/tenant-cache/__tests__/tenantScopedStorage.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  DEFAULT_CACHE_TENANT_ID,
+  getActiveCacheTenantId,
+  normalizeCacheTenantId,
+  readTenantBucket,
+  readTenantBucketMapEntry,
+  readTenantTtlSlot,
+  setActiveCacheTenantId,
+  setCacheTenantResolver,
+  updateTenantBucketMapEntry,
+  writeTenantBucket,
+  writeTenantTtlSlot,
+} from "../index";
+
+describe("tenant-scoped storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    setCacheTenantResolver(null);
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
+  });
+
+  test("normalizeCacheTenantId collapses empty values", () => {
+    expect(normalizeCacheTenantId(null)).toBe(DEFAULT_CACHE_TENANT_ID);
+    expect(normalizeCacheTenantId("")).toBe(DEFAULT_CACHE_TENANT_ID);
+    expect(normalizeCacheTenantId("  ")).toBe(DEFAULT_CACHE_TENANT_ID);
+    expect(normalizeCacheTenantId(" tenant-a ")).toBe("tenant-a");
+  });
+
+  test("active tenant follows setActiveCacheTenantId and resolver", () => {
+    setActiveCacheTenantId("tenant-a");
+    expect(getActiveCacheTenantId()).toBe("tenant-a");
+
+    setCacheTenantResolver(() => "tenant-b");
+    expect(getActiveCacheTenantId()).toBe("tenant-b");
+
+    setCacheTenantResolver(() => "  ");
+    expect(getActiveCacheTenantId()).toBe("tenant-a");
+  });
+
+  test("write/read buckets are isolated per tenant", () => {
+    const key = "test.cache.v1";
+    const parseBucket = (value: unknown) =>
+      value && typeof value === "object" && !Array.isArray(value)
+        ? (value as { items: string[] })
+        : null;
+
+    writeTenantBucket({
+      key,
+      tenantId: "tenant-a",
+      bucket: { items: ["a"] },
+      parseBucket,
+    });
+    writeTenantBucket({
+      key,
+      tenantId: "tenant-b",
+      bucket: { items: ["b"] },
+      parseBucket,
+    });
+
+    expect(readTenantBucket({ key, tenantId: "tenant-a", parseBucket })?.items).toEqual([
+      "a",
+    ]);
+    expect(readTenantBucket({ key, tenantId: "tenant-b", parseBucket })?.items).toEqual([
+      "b",
+    ]);
+    expect(readTenantBucket({ key, tenantId: "tenant-c", parseBucket })).toBeNull();
+  });
+
+  test("uses active tenant when tenantId is omitted", () => {
+    const key = "test.active.v1";
+    const parseBucket = (value: unknown) =>
+      typeof value === "object" && value !== null ? (value as { n: number }) : null;
+
+    setActiveCacheTenantId("tenant-x");
+    writeTenantBucket({ key, bucket: { n: 1 }, parseBucket });
+    setActiveCacheTenantId("tenant-y");
+    writeTenantBucket({ key, bucket: { n: 2 }, parseBucket });
+
+    expect(readTenantBucket({ key, tenantId: "tenant-x", parseBucket })).toEqual({ n: 1 });
+    expect(readTenantBucket({ key, tenantId: "tenant-y", parseBucket })).toEqual({ n: 2 });
+  });
+
+  test("migrates legacy unscoped payload into default tenant only", () => {
+    const key = "test.migrated.v2";
+    const legacyKey = "test.migrated.v1";
+    const parseBucket = (value: unknown) =>
+      typeof value === "object" && value !== null ? (value as { v: string }) : null;
+
+    window.localStorage.setItem(legacyKey, JSON.stringify({ v: "legacy" }));
+
+    expect(
+      readTenantBucket({
+        key,
+        tenantId: DEFAULT_CACHE_TENANT_ID,
+        legacyKey,
+        parseBucket,
+      }),
+    ).toEqual({ v: "legacy" });
+
+    expect(
+      readTenantBucket({
+        key,
+        tenantId: "other-tenant",
+        legacyKey,
+        parseBucket,
+      }),
+    ).toBeNull();
+
+    writeTenantBucket({
+      key,
+      tenantId: DEFAULT_CACHE_TENANT_ID,
+      bucket: { v: "promoted" },
+      legacyKey,
+      parseBucket,
+    });
+    expect(window.localStorage.getItem(legacyKey)).toBeNull();
+  });
+
+  test("map entries stay inside the active tenant bucket", () => {
+    const key = "test.map.v1";
+    updateTenantBucketMapEntry({
+      key,
+      kind: "session",
+      tenantId: "tenant-a",
+      entryKey: "k1",
+      entryValue: { ok: true },
+      maxEntries: 8,
+    });
+    updateTenantBucketMapEntry({
+      key,
+      kind: "session",
+      tenantId: "tenant-b",
+      entryKey: "k1",
+      entryValue: { ok: false },
+      maxEntries: 8,
+    });
+
+    expect(
+      readTenantBucketMapEntry({
+        key,
+        kind: "session",
+        tenantId: "tenant-a",
+        entryKey: "k1",
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      readTenantBucketMapEntry({
+        key,
+        kind: "session",
+        tenantId: "tenant-b",
+        entryKey: "k1",
+      }),
+    ).toEqual({ ok: false });
+  });
+
+  test("ttl slots isolate tenants and expire", () => {
+    const key = "test.ttl.v2";
+    writeTenantTtlSlot({
+      key,
+      tenantId: "tenant-a",
+      slot: "gemini",
+      data: ["a"],
+      ttlMs: 60_000,
+    });
+    writeTenantTtlSlot({
+      key,
+      tenantId: "tenant-b",
+      slot: "gemini",
+      data: ["b"],
+      ttlMs: 60_000,
+    });
+
+    expect(
+      readTenantTtlSlot<string[]>({
+        key,
+        tenantId: "tenant-a",
+        slot: "gemini",
+        ttlMs: 60_000,
+      }),
+    ).toEqual(["a"]);
+    expect(
+      readTenantTtlSlot<string[]>({
+        key,
+        tenantId: "tenant-b",
+        slot: "gemini",
+        ttlMs: 60_000,
+      }),
+    ).toEqual(["b"]);
+
+    // Force expiry by rewriting with a past timestamp via storage.
+    const raw = window.localStorage.getItem(key);
+    const parsed = JSON.parse(raw ?? "{}") as {
+      byTenant: Record<string, Record<string, { data: string[]; timestamp: number }>>;
+    };
+    parsed.byTenant["tenant-a"].gemini.timestamp = Date.now() - 120_000;
+    window.localStorage.setItem(key, JSON.stringify(parsed));
+
+    expect(
+      readTenantTtlSlot<string[]>({
+        key,
+        tenantId: "tenant-a",
+        slot: "gemini",
+        ttlMs: 60_000,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/domain/src/tenant-cache/activeTenant.ts
+++ b/packages/domain/src/tenant-cache/activeTenant.ts
@@ -1,0 +1,48 @@
+/** Fallback bucket when no effective tenant is available (logged out / first paint). */
+export const DEFAULT_CACHE_TENANT_ID = "default";
+
+let activeCacheTenantId = DEFAULT_CACHE_TENANT_ID;
+let cacheTenantResolver: (() => string | null | undefined) | null = null;
+
+/**
+ * Normalize a tenant id for cache buckets.
+ * Empty / whitespace collapses to DEFAULT_CACHE_TENANT_ID so reads and writes
+ * always share one stable key instead of inventing empty-string buckets.
+ */
+export const normalizeCacheTenantId = (tenantId?: string | null): string => {
+  const trimmed = typeof tenantId === "string" ? tenantId.trim() : "";
+  return trimmed || DEFAULT_CACHE_TENANT_ID;
+};
+
+/**
+ * Optional live resolver (e.g. AuthProvider principal).
+ * When set, getActiveCacheTenantId prefers the resolver over the last explicit set.
+ */
+export const setCacheTenantResolver = (
+  resolver: (() => string | null | undefined) | null,
+): void => {
+  cacheTenantResolver = resolver;
+};
+
+/** Explicitly pin the active cache tenant (switchTenant / login / logout). */
+export const setActiveCacheTenantId = (tenantId?: string | null): void => {
+  activeCacheTenantId = normalizeCacheTenantId(tenantId);
+};
+
+/**
+ * Current tenant used by tenant-scoped data caches.
+ * Resolution order: resolver() → last setActiveCacheTenantId → default.
+ */
+export const getActiveCacheTenantId = (): string => {
+  if (cacheTenantResolver) {
+    try {
+      const resolved = cacheTenantResolver();
+      if (resolved != null && String(resolved).trim()) {
+        return normalizeCacheTenantId(resolved);
+      }
+    } catch {
+      // Resolver is best-effort; fall through to the pinned value.
+    }
+  }
+  return activeCacheTenantId;
+};

--- a/packages/domain/src/tenant-cache/index.ts
+++ b/packages/domain/src/tenant-cache/index.ts
@@ -1,0 +1,23 @@
+export {
+  DEFAULT_CACHE_TENANT_ID,
+  getActiveCacheTenantId,
+  normalizeCacheTenantId,
+  setActiveCacheTenantId,
+  setCacheTenantResolver,
+} from "./activeTenant";
+
+export {
+  clearTenantBucketMap,
+  readTenantBucket,
+  readTenantBucketMapEntry,
+  readTenantBucketStore,
+  readTenantTtlSlot,
+  removeTenantTtlSlot,
+  updateTenantBucketMapEntry,
+  writeTenantBucket,
+  writeTenantBucketStore,
+  writeTenantTtlSlot,
+  type TenantBucketStore,
+  type TtlSlotEntry,
+  type WebStorageKind,
+} from "./tenantScopedStorage";

--- a/packages/domain/src/tenant-cache/tenantScopedStorage.ts
+++ b/packages/domain/src/tenant-cache/tenantScopedStorage.ts
@@ -1,0 +1,432 @@
+import {
+  DEFAULT_CACHE_TENANT_ID,
+  getActiveCacheTenantId,
+  normalizeCacheTenantId,
+} from "./activeTenant";
+
+export type WebStorageKind = "local" | "session";
+
+export type TenantBucketStore<T> = {
+  byTenant: Record<string, T>;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getStorage = (kind: WebStorageKind): Storage | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return kind === "session" ? window.sessionStorage : window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const parseJson = (raw: string | null): unknown => {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Read a tenant-bucketed store from web storage.
+ * Shape: `{ byTenant: { [tenantId]: T } }`.
+ * Optionally migrates a legacy unscoped payload into the default tenant once.
+ */
+export function readTenantBucketStore<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  /** Legacy storage key without tenant isolation; migrated into default tenant only. */
+  legacyKey?: string;
+  /** Parse + validate one tenant bucket. Return null to drop invalid data. */
+  parseBucket: (value: unknown) => T | null;
+  /** When the current key holds a single unscoped bucket, treat it as default-tenant data. */
+  acceptUnscopedCurrent?: boolean;
+}): TenantBucketStore<T> {
+  const kind = options.kind ?? "local";
+  const storage = getStorage(kind);
+  if (!storage) return { byTenant: {} };
+
+  try {
+    const raw = storage.getItem(options.key);
+    const parsed = parseJson(raw);
+    if (isRecord(parsed) && isRecord(parsed.byTenant)) {
+      const byTenant: Record<string, T> = {};
+      for (const [tenantKey, bucket] of Object.entries(parsed.byTenant)) {
+        const normalizedKey = normalizeCacheTenantId(tenantKey);
+        const parsedBucket = options.parseBucket(bucket);
+        if (parsedBucket != null) byTenant[normalizedKey] = parsedBucket;
+      }
+      return { byTenant };
+    }
+
+    if (options.acceptUnscopedCurrent && parsed != null) {
+      const single = options.parseBucket(parsed);
+      if (single != null) {
+        return { byTenant: { [DEFAULT_CACHE_TENANT_ID]: single } };
+      }
+    }
+
+    if (options.legacyKey) {
+      const legacyRaw = storage.getItem(options.legacyKey);
+      const legacyParsed = parseJson(legacyRaw);
+      if (legacyParsed != null) {
+        const legacyBucket = options.parseBucket(legacyParsed);
+        if (legacyBucket != null) {
+          return { byTenant: { [DEFAULT_CACHE_TENANT_ID]: legacyBucket } };
+        }
+      }
+    }
+
+    return { byTenant: {} };
+  } catch {
+    return { byTenant: {} };
+  }
+}
+
+export function writeTenantBucketStore<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  store: TenantBucketStore<T>;
+  /** Drop these legacy keys after a successful write. */
+  legacyKeysToRemove?: string[];
+}): void {
+  const kind = options.kind ?? "local";
+  const storage = getStorage(kind);
+  if (!storage) return;
+  try {
+    storage.setItem(options.key, JSON.stringify(options.store));
+    for (const legacy of options.legacyKeysToRemove ?? []) {
+      try {
+        storage.removeItem(legacy);
+      } catch {
+        // ignore
+      }
+    }
+  } catch {
+    // Quota / private mode: keep in-memory behavior only.
+  }
+}
+
+export function readTenantBucket<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  legacyKey?: string;
+  parseBucket: (value: unknown) => T | null;
+  acceptUnscopedCurrent?: boolean;
+}): T | null {
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore(options);
+  return store.byTenant[tenantKey] ?? null;
+}
+
+export function writeTenantBucket<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  bucket: T;
+  legacyKey?: string;
+  parseBucket: (value: unknown) => T | null;
+  acceptUnscopedCurrent?: boolean;
+  legacyKeysToRemove?: string[];
+  /** Merge with previous bucket for the same tenant before write. */
+  merge?: (previous: T | null, next: T) => T;
+}): void {
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    legacyKey: options.legacyKey,
+    parseBucket: options.parseBucket,
+    acceptUnscopedCurrent: options.acceptUnscopedCurrent,
+  });
+  const previous = store.byTenant[tenantKey] ?? null;
+  store.byTenant[tenantKey] = options.merge
+    ? options.merge(previous, options.bucket)
+    : options.bucket;
+  writeTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    store,
+    legacyKeysToRemove: [
+      ...(options.legacyKeysToRemove ?? []),
+      ...(options.legacyKey ? [options.legacyKey] : []),
+    ],
+  });
+}
+
+export function updateTenantBucketMapEntry<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  entryKey: string;
+  entryValue: T;
+  /** Max entries kept per tenant map (LRU-ish: drop oldest insertion order). */
+  maxEntries?: number;
+  legacyKey?: string;
+  legacyKeysToRemove?: string[];
+}): void {
+  const parseBucket = (value: unknown): Record<string, T> | null => {
+    if (!isRecord(value)) return null;
+    return value as Record<string, T>;
+  };
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    legacyKey: options.legacyKey,
+    parseBucket,
+    acceptUnscopedCurrent: true,
+  });
+  const previous = store.byTenant[tenantKey] ?? {};
+  const next: Record<string, T> = { ...previous, [options.entryKey]: options.entryValue };
+  if (options.maxEntries && options.maxEntries > 0) {
+    const keys = Object.keys(next);
+    if (keys.length > options.maxEntries) {
+      const drop = keys.slice(0, keys.length - options.maxEntries);
+      for (const k of drop) delete next[k];
+    }
+  }
+  store.byTenant[tenantKey] = next;
+  writeTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    store,
+    legacyKeysToRemove: [
+      ...(options.legacyKeysToRemove ?? []),
+      ...(options.legacyKey ? [options.legacyKey] : []),
+    ],
+  });
+}
+
+export function readTenantBucketMapEntry<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  entryKey: string;
+  legacyKey?: string;
+  isEntry?: (value: unknown) => value is T;
+}): T | null {
+  const parseBucket = (value: unknown): Record<string, T> | null => {
+    if (!isRecord(value)) return null;
+    return value as Record<string, T>;
+  };
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    legacyKey: options.legacyKey,
+    parseBucket,
+    acceptUnscopedCurrent: true,
+  });
+  const bucket = store.byTenant[tenantKey];
+  if (!bucket) return null;
+  const entry = bucket[options.entryKey];
+  if (entry === undefined) return null;
+  if (options.isEntry && !options.isEntry(entry)) return null;
+  return entry;
+}
+
+export function clearTenantBucketMap(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+}): void {
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    parseBucket: (value) => (isRecord(value) ? (value as Record<string, unknown>) : null),
+  });
+  delete store.byTenant[tenantKey];
+  writeTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    store,
+  });
+}
+
+/**
+ * TTL-aware per-slot cache under a tenant bucket.
+ * Used by providers page: each provider tab is a slot with its own timestamp.
+ */
+export type TtlSlotEntry<T> = {
+  data: T;
+  timestamp: number;
+};
+
+export function readTenantTtlSlot<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  slot: string;
+  ttlMs: number;
+  /** Prefix used by legacy unscoped keys: `${legacyPrefix}${slot}`. */
+  legacyPrefix?: string;
+}): T | null {
+  const now = Date.now();
+  const parseSlot = (value: unknown): TtlSlotEntry<T> | null => {
+    if (!isRecord(value)) return null;
+    const timestamp = Number(value.timestamp);
+    if (!Number.isFinite(timestamp)) return null;
+    if (now - timestamp > options.ttlMs) return null;
+    if (!("data" in value)) return null;
+    return { data: value.data as T, timestamp };
+  };
+
+  const parseBucket = (value: unknown): Record<string, TtlSlotEntry<T>> | null => {
+    if (!isRecord(value)) return null;
+    // Single-slot legacy shape stored under providers-page:cache:${slot}
+    if ("data" in value && "timestamp" in value) {
+      const slotEntry = parseSlot(value);
+      return slotEntry ? { [options.slot]: slotEntry } : {};
+    }
+    const out: Record<string, TtlSlotEntry<T>> = {};
+    for (const [slot, raw] of Object.entries(value)) {
+      const entry = parseSlot(raw);
+      if (entry) out[slot] = entry;
+    }
+    return out;
+  };
+
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    parseBucket,
+  });
+
+  const fromStore = store.byTenant[tenantKey]?.[options.slot];
+  if (fromStore) return fromStore.data;
+
+  // One-shot migration from unscoped per-slot keys into default tenant only.
+  if (options.legacyPrefix && tenantKey === DEFAULT_CACHE_TENANT_ID) {
+    const storage = getStorage(options.kind ?? "local");
+    if (!storage) return null;
+    try {
+      const legacyRaw = storage.getItem(`${options.legacyPrefix}${options.slot}`);
+      const legacyEntry = parseSlot(parseJson(legacyRaw));
+      if (!legacyEntry) return null;
+      // Promote into the new store so subsequent reads stay tenant-scoped.
+      writeTenantTtlSlot({
+        key: options.key,
+        kind: options.kind,
+        tenantId: tenantKey,
+        slot: options.slot,
+        data: legacyEntry.data,
+        ttlMs: options.ttlMs,
+        legacyPrefix: options.legacyPrefix,
+      });
+      return legacyEntry.data;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function writeTenantTtlSlot<T>(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  slot: string;
+  data: T;
+  ttlMs: number;
+  legacyPrefix?: string;
+}): void {
+  const parseBucket = (value: unknown): Record<string, TtlSlotEntry<T>> | null => {
+    if (!isRecord(value)) return null;
+    if ("data" in value && "timestamp" in value) {
+      return { [options.slot]: value as TtlSlotEntry<T> };
+    }
+    return value as Record<string, TtlSlotEntry<T>>;
+  };
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    parseBucket,
+  });
+  const previous = store.byTenant[tenantKey] ?? {};
+  // Drop expired slots while writing.
+  const now = Date.now();
+  const next: Record<string, TtlSlotEntry<T>> = {};
+  for (const [slot, entry] of Object.entries(previous)) {
+    if (
+      entry &&
+      typeof entry === "object" &&
+      Number.isFinite(entry.timestamp) &&
+      now - entry.timestamp <= options.ttlMs
+    ) {
+      next[slot] = entry;
+    }
+  }
+  next[options.slot] = { data: options.data, timestamp: now };
+  store.byTenant[tenantKey] = next;
+
+  const legacyKeysToRemove: string[] = [];
+  if (options.legacyPrefix) {
+    legacyKeysToRemove.push(`${options.legacyPrefix}${options.slot}`);
+  }
+
+  writeTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    store,
+    legacyKeysToRemove,
+  });
+}
+
+export function removeTenantTtlSlot(options: {
+  key: string;
+  kind?: WebStorageKind;
+  tenantId?: string | null;
+  slot: string;
+  legacyPrefix?: string;
+}): void {
+  const parseBucket = (value: unknown): Record<string, TtlSlotEntry<unknown>> | null => {
+    if (!isRecord(value)) return null;
+    return value as Record<string, TtlSlotEntry<unknown>>;
+  };
+  const tenantKey = normalizeCacheTenantId(
+    options.tenantId ?? getActiveCacheTenantId(),
+  );
+  const store = readTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    parseBucket,
+  });
+  const previous = store.byTenant[tenantKey];
+  if (previous) {
+    delete previous[options.slot];
+    if (Object.keys(previous).length === 0) delete store.byTenant[tenantKey];
+    else store.byTenant[tenantKey] = previous;
+  }
+  writeTenantBucketStore({
+    key: options.key,
+    kind: options.kind,
+    store,
+    legacyKeysToRemove: options.legacyPrefix
+      ? [`${options.legacyPrefix}${options.slot}`]
+      : undefined,
+  });
+}

--- a/packages/domain/src/usage/pricing.ts
+++ b/packages/domain/src/usage/pricing.ts
@@ -2,6 +2,7 @@ import {
   getApisRecord,
   isRecord,
   MODEL_PRICE_STORAGE_KEY,
+  MODEL_PRICE_STORAGE_KEY_V2,
   TOKENS_PER_PRICE_UNIT,
   type ApiStats,
   type ModelPrice,
@@ -9,6 +10,11 @@ import {
 } from "./shared";
 import { collectUsageDetails } from "./details";
 import { maskUsageSensitiveValue } from "./sanitize";
+import {
+  getActiveCacheTenantId,
+  readTenantBucket,
+  writeTenantBucket,
+} from "../tenant-cache";
 
 export function calculateCost(
   detail: UsageDetail,
@@ -56,55 +62,71 @@ export function calculateTotalCost(
   return details.reduce((sum, detail) => sum + calculateCost(detail, modelPrices), 0);
 }
 
-export function loadModelPrices(): Record<string, ModelPrice> {
-  try {
-    if (typeof localStorage === "undefined") return {};
-    const raw = localStorage.getItem(MODEL_PRICE_STORAGE_KEY);
-    if (!raw) return {};
-    const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) return {};
+const parseModelPricesBucket = (value: unknown): Record<string, ModelPrice> | null => {
+  if (!isRecord(value)) return null;
+  // Tenant store may wrap as { prices: ... } or be the prices map itself.
+  const source = isRecord(value.prices) ? value.prices : value;
+  if (!isRecord(source)) return null;
 
-    const normalized: Record<string, ModelPrice> = {};
-    Object.entries(parsed).forEach(([model, price]: [string, unknown]) => {
-      if (!model) return;
-      const priceRecord = isRecord(price) ? price : null;
-      const promptRaw = Number(priceRecord?.prompt);
-      const completionRaw = Number(priceRecord?.completion);
-      const cacheRaw = Number(priceRecord?.cache);
-      const perCallRaw = Number(priceRecord?.perCall);
-      const mode = priceRecord?.mode === "call" ? "call" : "token";
+  const normalized: Record<string, ModelPrice> = {};
+  Object.entries(source).forEach(([model, price]: [string, unknown]) => {
+    if (!model) return;
+    const priceRecord = isRecord(price) ? price : null;
+    const promptRaw = Number(priceRecord?.prompt);
+    const completionRaw = Number(priceRecord?.completion);
+    const cacheRaw = Number(priceRecord?.cache);
+    const perCallRaw = Number(priceRecord?.perCall);
+    const mode = priceRecord?.mode === "call" ? "call" : "token";
 
-      if (
-        !Number.isFinite(promptRaw) &&
-        !Number.isFinite(completionRaw) &&
-        !Number.isFinite(cacheRaw) &&
-        !Number.isFinite(perCallRaw)
-      ) {
-        return;
-      }
+    if (
+      !Number.isFinite(promptRaw) &&
+      !Number.isFinite(completionRaw) &&
+      !Number.isFinite(cacheRaw) &&
+      !Number.isFinite(perCallRaw)
+    ) {
+      return;
+    }
 
-      const prompt = Number.isFinite(promptRaw) && promptRaw >= 0 ? promptRaw : 0;
-      const completion = Number.isFinite(completionRaw) && completionRaw >= 0 ? completionRaw : 0;
-      const cache =
-        Number.isFinite(cacheRaw) && cacheRaw >= 0
-          ? cacheRaw
-          : Number.isFinite(promptRaw) && promptRaw >= 0
-            ? promptRaw
-            : prompt;
-      const perCall = Number.isFinite(perCallRaw) && perCallRaw >= 0 ? perCallRaw : 0;
+    const prompt = Number.isFinite(promptRaw) && promptRaw >= 0 ? promptRaw : 0;
+    const completion = Number.isFinite(completionRaw) && completionRaw >= 0 ? completionRaw : 0;
+    const cache =
+      Number.isFinite(cacheRaw) && cacheRaw >= 0
+        ? cacheRaw
+        : Number.isFinite(promptRaw) && promptRaw >= 0
+          ? promptRaw
+          : prompt;
+    const perCall = Number.isFinite(perCallRaw) && perCallRaw >= 0 ? perCallRaw : 0;
 
-      normalized[model] = { mode, prompt, completion, cache, perCall };
-    });
-    return normalized;
-  } catch {
-    return {};
-  }
+    normalized[model] = { mode, prompt, completion, cache, perCall };
+  });
+  return normalized;
+};
+
+export function loadModelPrices(tenantId?: string | null): Record<string, ModelPrice> {
+  const bucket = readTenantBucket({
+    key: MODEL_PRICE_STORAGE_KEY,
+    tenantId: tenantId ?? getActiveCacheTenantId(),
+    legacyKey: MODEL_PRICE_STORAGE_KEY_V2,
+    parseBucket: parseModelPricesBucket,
+    acceptUnscopedCurrent: true,
+  });
+  return bucket ?? {};
 }
 
-export function saveModelPrices(prices: Record<string, ModelPrice>): void {
+export function saveModelPrices(
+  prices: Record<string, ModelPrice>,
+  tenantId?: string | null,
+): void {
   try {
-    if (typeof localStorage === "undefined") return;
-    localStorage.setItem(MODEL_PRICE_STORAGE_KEY, JSON.stringify(prices));
+    writeTenantBucket({
+      key: MODEL_PRICE_STORAGE_KEY,
+      tenantId: tenantId ?? getActiveCacheTenantId(),
+      legacyKey: MODEL_PRICE_STORAGE_KEY_V2,
+      parseBucket: parseModelPricesBucket,
+      acceptUnscopedCurrent: true,
+      legacyKeysToRemove: [MODEL_PRICE_STORAGE_KEY_V2],
+      bucket: prices,
+    });
   } catch {
     console.warn("Failed to save model pricing");
   }

--- a/packages/domain/src/usage/shared.ts
+++ b/packages/domain/src/usage/shared.ts
@@ -63,7 +63,9 @@ export interface ApiStats {
 export type UsageTimeRange = "7h" | "24h" | "7d" | "all";
 
 export const TOKENS_PER_PRICE_UNIT = 1_000_000;
-export const MODEL_PRICE_STORAGE_KEY = "cli-proxy-model-prices-v2";
+/** Tenant-scoped model price cache (v3). Legacy v2 is migrated into the default tenant only. */
+export const MODEL_PRICE_STORAGE_KEY = "cli-proxy-model-prices-v3";
+export const MODEL_PRICE_STORAGE_KEY_V2 = "cli-proxy-model-prices-v2";
 export const USAGE_TIME_RANGE_MS: Record<Exclude<UsageTimeRange, "all">, number> = {
   "7h": 7 * 60 * 60 * 1000,
   "24h": 24 * 60 * 60 * 1000,

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -42,11 +42,20 @@ import {
   type RequestLogsRow,
   type StatusFilterValue,
 } from "@features/request-log-viewer";
+import {
+  clearTenantBucketMap,
+  getActiveCacheTenantId,
+  readTenantBucketMapEntry,
+  updateTenantBucketMapEntry,
+} from "@code-proxy/domain";
 
 const DEFAULT_PAGE_SIZE = 50;
 const LOOKUP_LAST_API_KEY_STORAGE_KEY = "apiKeyLookup.lastApiKey.v1";
-const LOOKUP_CHART_CACHE_STORAGE_KEY = "apiKeyLookup.chartCache.v1";
-const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v1";
+/** Tenant-scoped chart cache (v2). Legacy v1 migrates into the default tenant only. */
+const LOOKUP_CHART_CACHE_STORAGE_KEY = "apiKeyLookup.chartCache.v2";
+const LOOKUP_CHART_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.chartCache.v1";
+const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v2";
+const LOOKUP_MODELS_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.modelsCache.v1";
 const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -88,49 +97,40 @@ function isChartDataResponse(value: unknown): value is ChartDataResponse {
 }
 
 const readStoredChartCache = (cacheKey: string): ChartDataResponse | null => {
-  try {
-    const raw = window.sessionStorage.getItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) return null;
-    const cached = parsed[cacheKey];
-    return isChartDataResponse(cached) ? cached : null;
-  } catch {
-    return null;
-  }
+  return readTenantBucketMapEntry({
+    key: LOOKUP_CHART_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+    entryKey: cacheKey,
+    legacyKey: LOOKUP_CHART_CACHE_STORAGE_KEY_V1,
+    isEntry: isChartDataResponse,
+  });
 };
 
 const writeStoredChartCache = (
   cacheKey: string,
   data: ChartDataResponse,
 ): void => {
-  try {
-    const raw = window.sessionStorage.getItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
-    const parsed: unknown = raw ? JSON.parse(raw) : {};
-    const entries = isRecord(parsed)
-      ? Object.entries(parsed).filter(
-          (entry): entry is [string, ChartDataResponse] =>
-            isChartDataResponse(entry[1]),
-        )
-      : [];
-    const next: Record<string, ChartDataResponse> = {};
-    const keptEntries = entries.filter(([key]) => key !== cacheKey);
-    const cacheEntry: [string, ChartDataResponse] = [cacheKey, data];
-    for (const [key, value] of [...keptEntries, cacheEntry].slice(-8)) {
-      next[key] = value;
-    }
-    window.sessionStorage.setItem(
-      LOOKUP_CHART_CACHE_STORAGE_KEY,
-      JSON.stringify(next),
-    );
-  } catch {
-    // ignore storage failures
-  }
+  updateTenantBucketMapEntry({
+    key: LOOKUP_CHART_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+    entryKey: cacheKey,
+    entryValue: data,
+    maxEntries: 8,
+    legacyKey: LOOKUP_CHART_CACHE_STORAGE_KEY_V1,
+    legacyKeysToRemove: [LOOKUP_CHART_CACHE_STORAGE_KEY_V1],
+  });
 };
 
 const clearStoredChartCache = (): void => {
+  clearTenantBucketMap({
+    key: LOOKUP_CHART_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+  });
   try {
-    window.sessionStorage.removeItem(LOOKUP_CHART_CACHE_STORAGE_KEY);
+    window.sessionStorage.removeItem(LOOKUP_CHART_CACHE_STORAGE_KEY_V1);
   } catch {
     // ignore storage failures
   }
@@ -144,42 +144,27 @@ const sameStringArray = (left: string[], right: string[]): boolean =>
   left.every((value, index) => value === right[index]);
 
 const readStoredModelsCache = (cacheKey: string): string[] | null => {
-  try {
-    const raw = window.sessionStorage.getItem(LOOKUP_MODELS_CACHE_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) return null;
-    const cached = parsed[cacheKey];
-    return isStringArray(cached) ? cached : null;
-  } catch {
-    return null;
-  }
+  return readTenantBucketMapEntry({
+    key: LOOKUP_MODELS_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+    entryKey: cacheKey,
+    legacyKey: LOOKUP_MODELS_CACHE_STORAGE_KEY_V1,
+    isEntry: isStringArray,
+  });
 };
 
 const writeStoredModelsCache = (cacheKey: string, models: string[]): void => {
-  try {
-    const raw = window.sessionStorage.getItem(LOOKUP_MODELS_CACHE_STORAGE_KEY);
-    const parsed: unknown = raw ? JSON.parse(raw) : {};
-    const entries = isRecord(parsed)
-      ? Object.entries(parsed).filter((entry): entry is [string, string[]] =>
-          isStringArray(entry[1]),
-        )
-      : [];
-    const next: Record<string, string[]> = {};
-    const keptEntries = entries.filter(([key]) => key !== cacheKey);
-    for (const [key, value] of [
-      ...keptEntries,
-      [cacheKey, models] as const,
-    ].slice(-8)) {
-      next[key] = value;
-    }
-    window.sessionStorage.setItem(
-      LOOKUP_MODELS_CACHE_STORAGE_KEY,
-      JSON.stringify(next),
-    );
-  } catch {
-    // ignore storage failures
-  }
+  updateTenantBucketMapEntry({
+    key: LOOKUP_MODELS_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+    entryKey: cacheKey,
+    entryValue: models,
+    maxEntries: 8,
+    legacyKey: LOOKUP_MODELS_CACHE_STORAGE_KEY_V1,
+    legacyKeysToRemove: [LOOKUP_MODELS_CACHE_STORAGE_KEY_V1],
+  });
 };
 
 const extractServerErrorMessage = (raw: unknown): string => {

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -403,6 +403,7 @@ describe("ApiKeyLookupPage", () => {
       "apiKeyLookup.lastApiKey.v1",
       "sk-restored-key",
     );
+    // Legacy v1 unscoped chart cache migrates into the default tenant bucket.
     window.sessionStorage.setItem(
       "apiKeyLookup.chartCache.v1",
       JSON.stringify({
@@ -460,9 +461,11 @@ describe("ApiKeyLookupPage", () => {
     await waitFor(() =>
       expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"),
     );
+    // After refresh, data is written under the tenant-scoped v2 key.
     expect(
-      window.sessionStorage.getItem("apiKeyLookup.chartCache.v1"),
+      window.sessionStorage.getItem("apiKeyLookup.chartCache.v2"),
     ).toContain('"total":24');
+    expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v1")).toBeNull();
   });
 
   test("ignores stale chart responses after rapid time range changes", async () => {

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -25,6 +25,11 @@ import {
 } from "@code-proxy/domain/ccswitch/ccswitchImportLinks";
 import type { CcSwitchImportConfigListItem } from "@code-proxy/domain/ccswitch/ccswitchImportConfigList";
 import { ccSwitchConfigMatchesApiKeyPermissions } from "@code-proxy/domain/ccswitch/ccswitchImportCompatibility";
+import {
+  getActiveCacheTenantId,
+  readTenantBucketMapEntry,
+  updateTenantBucketMapEntry,
+} from "@code-proxy/domain";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { copyTextToClipboard } from "@code-proxy/ui";
@@ -32,7 +37,9 @@ import { useToast } from "@code-proxy/ui";
 
 const CC_SWITCH_RELEASES_URL = "https://github.com/farion1231/cc-switch/releases";
 const QUICK_IMPORT_CLIENTS: CcSwitchClientType[] = ["codex", "claude"];
-const QUICK_IMPORT_CACHE_STORAGE_KEY = "apiKeyLookup.quickImportCache.v1";
+/** Tenant-scoped quick-import cache (v2). Legacy v1 migrates into the default tenant only. */
+const QUICK_IMPORT_CACHE_STORAGE_KEY = "apiKeyLookup.quickImportCache.v2";
+const QUICK_IMPORT_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.quickImportCache.v1";
 
 const iconByType: Record<"codex" | "claude", string> = {
   codex: iconCodex,
@@ -86,52 +93,46 @@ function getQuickImportCacheKey(apiKey: string): string {
   return [apiKey.trim(), auth?.apiBase ?? "public", auth?.managementKey ?? ""].join("|");
 }
 
-function readStoredQuickImportCache(
-  cacheKey: string,
-): { configs: CcSwitchImportConfigListItem[]; apiKeyEntry: ApiKeyEntry | null } | null {
-  try {
-    const raw = window.sessionStorage.getItem(QUICK_IMPORT_CACHE_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed: unknown = JSON.parse(raw);
-    if (!isRecord(parsed)) return null;
-    const cached = parsed[cacheKey];
-    if (!isRecord(cached)) return null;
-    const configs = normalizeCcSwitchImportConfigs(cached.configs);
-    const entries = normalizeApiKeyEntries([cached.apiKeyEntry]);
-    return { configs, apiKeyEntry: entries[0] ?? null };
-  } catch {
-    return null;
-  }
+type QuickImportCacheEntry = {
+  configs: CcSwitchImportConfigListItem[];
+  apiKeyEntry: ApiKeyEntry | null;
+};
+
+function parseQuickImportCacheEntry(value: unknown): QuickImportCacheEntry | null {
+  if (!isRecord(value)) return null;
+  const configs = normalizeCcSwitchImportConfigs(value.configs);
+  const entries = normalizeApiKeyEntries([value.apiKeyEntry]);
+  return { configs, apiKeyEntry: entries[0] ?? null };
+}
+
+function readStoredQuickImportCache(cacheKey: string): QuickImportCacheEntry | null {
+  const raw = readTenantBucketMapEntry({
+    key: QUICK_IMPORT_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+    entryKey: cacheKey,
+    legacyKey: QUICK_IMPORT_CACHE_STORAGE_KEY_V1,
+  });
+  return parseQuickImportCacheEntry(raw);
 }
 
 function writeStoredQuickImportCache(
   cacheKey: string,
-  value: { configs: CcSwitchImportConfigListItem[]; apiKeyEntry: ApiKeyEntry | null },
+  value: QuickImportCacheEntry,
 ): void {
-  try {
-    const raw = window.sessionStorage.getItem(QUICK_IMPORT_CACHE_STORAGE_KEY);
-    const parsed: unknown = raw ? JSON.parse(raw) : {};
-    const entries = isRecord(parsed)
-      ? Object.entries(parsed).filter((entry): entry is [string, Record<string, unknown>] =>
-          isRecord(entry[1]),
-        )
-      : [];
-    const next: Record<string, Record<string, unknown>> = {};
-    const keptEntries = entries.filter(([key]) => key !== cacheKey);
-    const cacheEntry: [string, Record<string, unknown>] = [
-      cacheKey,
-      {
-        configs: value.configs.map(serializeQuickImportConfig),
-        apiKeyEntry: value.apiKeyEntry,
-      },
-    ];
-    for (const [key, entry] of [...keptEntries, cacheEntry].slice(-8)) {
-      next[key] = entry;
-    }
-    window.sessionStorage.setItem(QUICK_IMPORT_CACHE_STORAGE_KEY, JSON.stringify(next));
-  } catch {
-    // ignore storage failures
-  }
+  updateTenantBucketMapEntry({
+    key: QUICK_IMPORT_CACHE_STORAGE_KEY,
+    kind: "session",
+    tenantId: getActiveCacheTenantId(),
+    entryKey: cacheKey,
+    entryValue: {
+      configs: value.configs.map(serializeQuickImportConfig),
+      apiKeyEntry: value.apiKeyEntry,
+    },
+    maxEntries: 8,
+    legacyKey: QUICK_IMPORT_CACHE_STORAGE_KEY_V1,
+    legacyKeysToRemove: [QUICK_IMPORT_CACHE_STORAGE_KEY_V1],
+  });
 }
 
 const sameJsonValue = (left: unknown, right: unknown): boolean =>

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -295,6 +295,7 @@ describe("Auth Files helper coverage", () => {
     expect(JSON.stringify(sanitized)).not.toContain("should-not-persist");
 
     writeAuthFilesDataCache({
+      tenantId: "tenant-a",
       savedAtMs: 123,
       files: sanitized,
       quotaByFileName: {
@@ -307,7 +308,9 @@ describe("Auth Files helper coverage", () => {
       },
     });
     expect(window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain('"savedAtMs":123');
-    expect(readAuthFilesDataCache()).toEqual({
+    expect(window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain("byTenant");
+    expect(readAuthFilesDataCache("tenant-a")).toEqual({
+      tenantId: "tenant-a",
       savedAtMs: 123,
       files: sanitized,
       quotaByFileName: {
@@ -319,6 +322,8 @@ describe("Auth Files helper coverage", () => {
         },
       },
     });
+    // Different tenant must not see tenant-a's list/quota payload.
+    expect(readAuthFilesDataCache("tenant-b")).toBeNull();
   });
 
   test("keeps xAI identity fingerprint summary in sanitized cache", () => {

--- a/pages/auth-files/hooks/useAuthFilesDataState.ts
+++ b/pages/auth-files/hooks/useAuthFilesDataState.ts
@@ -7,6 +7,7 @@ import { useToast } from "@code-proxy/ui";
 import {
   buildAuthFileSourceCandidates,
   buildUsageIndex,
+  getActiveCacheTenantId,
   normalizeAuthIndexValue,
   readAuthFilesDataCache,
   sanitizeAuthFilesForCache,
@@ -71,7 +72,14 @@ const isRequestCancelled = (err: unknown, signal?: AbortSignal) =>
 export function useAuthFilesDataState() {
   const { t } = useTranslation();
   const { notify } = useToast();
-  const initialDataCache = useMemo(() => readAuthFilesDataCache(), []);
+  // Seed from the active effective-tenant bucket only. DashboardLayout remounts on
+  // tenant switch, so a one-shot read at mount is enough to avoid cross-tenant paint.
+  const cacheTenantId = getActiveCacheTenantId();
+  const initialDataCache = useMemo(
+    () => readAuthFilesDataCache(cacheTenantId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-seed only
+    [],
+  );
 
   const [files, setFiles] = useState<AuthFileItem[]>(() => initialDataCache?.files ?? []);
   const [loading, setLoading] = useState(() => !((initialDataCache?.files?.length ?? 0) > 0));
@@ -83,8 +91,13 @@ export function useAuthFilesDataState() {
 
   const filesRef = useRef<AuthFileItem[]>(files);
   const usageDataRef = useRef<EntityStatsResponse | null>(usageData);
+  const cacheTenantIdRef = useRef(cacheTenantId);
   const mountedRef = useRef(true);
   const loadSeqRef = useRef(0);
+
+  useEffect(() => {
+    cacheTenantIdRef.current = cacheTenantId;
+  }, [cacheTenantId]);
   const { index: usageIndex } = useMemo(() => buildUsageIndex(usageData), [usageData]);
 
   const loadAll = useCallback(
@@ -220,6 +233,7 @@ export function useAuthFilesDataState() {
     if (typeof window === "undefined") return undefined;
     const timer = window.setTimeout(() => {
       writeAuthFilesDataCache({
+        tenantId: cacheTenantIdRef.current,
         savedAtMs: Date.now(),
         files: sanitizeAuthFilesForCache(files),
         usageData,
@@ -231,6 +245,7 @@ export function useAuthFilesDataState() {
   useEffect(() => {
     return () => {
       writeAuthFilesDataCache({
+        tenantId: cacheTenantIdRef.current,
         savedAtMs: Date.now(),
         files: sanitizeAuthFilesForCache(filesRef.current),
         usageData: usageDataRef.current,

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -31,6 +31,7 @@ import {
   AUTH_FILES_FILES_VIEW_MODE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
   AUTH_FILES_QUOTA_PREVIEW_KEY,
+  getActiveCacheTenantId,
   normalizeAuthIndexValue,
   normalizeQuotaAutoRefreshMs,
   parseAdditionalQuotaWindowLabel,
@@ -75,7 +76,12 @@ export function useAuthFilesQuotaState({
   refreshUsageDataForFiles,
 }: UseAuthFilesQuotaStateOptions) {
   const { t } = useTranslation();
-  const initialDataCache = useMemo(() => readAuthFilesDataCache(), []);
+  const cacheTenantId = getActiveCacheTenantId();
+  const initialDataCache = useMemo(
+    () => readAuthFilesDataCache(cacheTenantId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-seed only
+    [],
+  );
 
   const [connectivityState, setConnectivityState] = useState<
     Map<string, { loading: boolean; latencyMs: number | null; error: boolean }>
@@ -135,10 +141,12 @@ export function useAuthFilesQuotaState({
   useEffect(() => {
     if (typeof window === "undefined") return undefined;
     const timer = window.setTimeout(() => {
-      const current = readAuthFilesDataCache();
+      const tenantId = getActiveCacheTenantId();
+      const current = readAuthFilesDataCache(tenantId);
       if (!current?.files?.length) return;
       writeAuthFilesDataCache({
         ...current,
+        tenantId,
         savedAtMs: Date.now(),
         quotaByFileName,
       });

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -840,7 +840,7 @@ describe("ProvidersPage Cline tab", () => {
 
     expect(await screen.findByText("Cline Fresh")).toBeInTheDocument();
     await waitFor(() =>
-      expect(localStorage.getItem("providers-page:cache:cline")).toContain("Cline Fresh"),
+      expect(localStorage.getItem("providers-page:cache.v2")).toContain("Cline Fresh"),
     );
   });
 
@@ -1179,9 +1179,7 @@ describe("ProvidersPage Ollama Cloud tab", () => {
 
     expect(await screen.findByText("Ollama Fresh")).toBeInTheDocument();
     await waitFor(() =>
-      expect(localStorage.getItem("providers-page:cache:ollama-cloud")).toContain(
-        "Ollama Fresh",
-      ),
+      expect(localStorage.getItem("providers-page:cache.v2")).toContain("Ollama Fresh"),
     );
   });
 

--- a/pages/providers/provider-cache.ts
+++ b/pages/providers/provider-cache.ts
@@ -1,38 +1,41 @@
-const CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
+import {
+  getActiveCacheTenantId,
+  readTenantTtlSlot,
+  removeTenantTtlSlot,
+  writeTenantTtlSlot,
+} from "@code-proxy/domain";
 
-interface CacheEntry<T> {
-  data: T;
-  timestamp: number;
-}
+const CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
+/** Tenant-bucketed store. Legacy unscoped keys used `providers-page:cache:${slot}`. */
+export const PROVIDERS_PAGE_CACHE_KEY = "providers-page:cache.v2";
+const LEGACY_PREFIX = "providers-page:cache:";
 
 export function getCachedData<T>(key: string): T | null {
-  try {
-    const raw = localStorage.getItem(`providers-page:cache:${key}`);
-    if (!raw) return null;
-    const entry: CacheEntry<T> = JSON.parse(raw);
-    if (Date.now() - entry.timestamp > CACHE_TTL) {
-      localStorage.removeItem(`providers-page:cache:${key}`);
-      return null;
-    }
-    return entry.data;
-  } catch {
-    return null;
-  }
+  return readTenantTtlSlot<T>({
+    key: PROVIDERS_PAGE_CACHE_KEY,
+    tenantId: getActiveCacheTenantId(),
+    slot: key,
+    ttlMs: CACHE_TTL,
+    legacyPrefix: LEGACY_PREFIX,
+  });
 }
 
 export function setCachedData<T>(key: string, data: T): void {
-  try {
-    const entry: CacheEntry<T> = { data, timestamp: Date.now() };
-    localStorage.setItem(`providers-page:cache:${key}`, JSON.stringify(entry));
-  } catch {
-    // localStorage full or unavailable
-  }
+  writeTenantTtlSlot({
+    key: PROVIDERS_PAGE_CACHE_KEY,
+    tenantId: getActiveCacheTenantId(),
+    slot: key,
+    data,
+    ttlMs: CACHE_TTL,
+    legacyPrefix: LEGACY_PREFIX,
+  });
 }
 
 export function removeCachedData(key: string): void {
-  try {
-    localStorage.removeItem(`providers-page:cache:${key}`);
-  } catch {
-    // ignore
-  }
+  removeTenantTtlSlot({
+    key: PROVIDERS_PAGE_CACHE_KEY,
+    tenantId: getActiveCacheTenantId(),
+    slot: key,
+    legacyPrefix: LEGACY_PREFIX,
+  });
 }

--- a/pages/proxies/__tests__/ProxiesPage.test.tsx
+++ b/pages/proxies/__tests__/ProxiesPage.test.tsx
@@ -13,7 +13,8 @@ const mocks = vi.hoisted(() => ({
   apiPost: vi.fn(),
 }));
 
-const proxyCheckCacheKey = "proxiesPage.checkState.v1";
+const proxyCheckCacheKey = "proxiesPage.checkState.v2";
+const proxyCheckCacheKeyV1 = "proxiesPage.checkState.v1";
 
 vi.mock("@code-proxy/api-client", () => ({
   apiClient: {
@@ -199,8 +200,9 @@ describe("ProxiesPage", () => {
 
   test("renders cached check results on page entry while refreshing them in the background", async () => {
     let resolveNextCheck: ((value: unknown) => void) | undefined;
+    // Legacy v1 unscoped shape migrates into the default tenant bucket only.
     window.sessionStorage.setItem(
-      proxyCheckCacheKey,
+      proxyCheckCacheKeyV1,
       JSON.stringify({
         hk: { ok: true, statusCode: 204, latencyMs: 31 },
       }),


### PR DESCRIPTION
## Summary
- Add shared `tenant-cache` helpers (`byTenant` storage, active tenant pin/resolver, legacy migration into `default` only).
- Bucket auth-files, providers, pricing, proxy checks, API key lookup, and model availability data caches by effective tenant.
- Pin/invalidate cache tenant from AuthProvider on login, restore, switch, logout, and 401; keep UI prefs unscoped.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full vitest, build, bundle:diff)
- [x] Targeted suites: tenant-cache, auth-files-helpers, AuthFilesPage.files-table, ProxiesPage, ApiKeyLookupPage, ProvidersPage.opencode-go
- [ ] Manually switch tenants and confirm auth-files / providers / pricing do not paint the previous tenant's data