### PR TITLE
fix(model-plaza): use app background for sticky tabs

### DIFF
--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -426,7 +426,7 @@ export function ModelPlazaPage() {
       {vendorStats.length > 0 && !loading ? (
         <div
           data-testid="model-plaza-tabs-sticky"
-          className="sticky top-0 z-20 -mx-4 border-b border-slate-200/70 bg-white/95 px-4 py-2.5 backdrop-blur-md sm:-mx-6 sm:px-6 dark:border-neutral-800/80 dark:bg-neutral-950/95"
+          className="sticky top-0 z-20 -mx-4 bg-[var(--pl-bg)] px-4 py-2.5 sm:-mx-6 sm:px-6"
         >
           <Tabs
             value={tabValue}

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -262,6 +262,9 @@ describe("ModelPlazaPage", () => {
     const sticky = screen.getByTestId("model-plaza-tabs-sticky");
     expect(sticky.className).toMatch(/(?:^|\s)sticky(?:\s|$)/);
     expect(sticky.className).toMatch(/(?:^|\s)top-0(?:\s|$)/);
+    expect(sticky.className).toMatch(/bg-\[var\(--pl-bg\)\]/);
+    expect(sticky.className).not.toMatch(/border-b/);
+    expect(sticky.className).not.toMatch(/backdrop-blur/);
     // overflow-x-hidden on an ancestor computes overflow-y as auto and breaks sticky
     expect(container.firstElementChild?.className ?? "").not.toMatch(/overflow-x-hidden/);
   });


### PR DESCRIPTION
## Summary
- Remove border, white/dark chrome, and backdrop blur from the Model Plaza sticky vendor tabs bar
- Use `bg-[var(--pl-bg)]` so the sticky strip matches the app page background while still covering scrolling cards

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, full test:ci, build, bundle:diff)
- [x] ModelPlazaPage unit tests (5/5)
- [ ] Manual: open Model Plaza, scroll — tabs stay pinned with no extra bar border/background