### PR TITLE
fix: harden tenant override restore and add critical auth e2e smoke

### DIFF
--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -399,6 +399,34 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
   }),
 ];
 
+/** Override is only dropped when the server explicitly rejects the tenant scope. */
+const RECOVERABLE_TENANT_OVERRIDE_CODES = new Set([
+  "tenant_scope_forbidden",
+  "tenant_suspended",
+  "tenant_expired",
+  "not_found",
+]);
+
+export function isRecoverableTenantOverrideError(error: unknown): boolean {
+  if (!isApiClientError(error)) return false;
+  // Network/timeout leave status 0; 5xx is transient server failure.
+  if (isTransientRestoreError(error)) return false;
+  const code = extractApiErrorCode(error.payload);
+  if (code && RECOVERABLE_TENANT_OVERRIDE_CODES.has(code)) return true;
+  // 404 without a known code still means the override target is gone.
+  return error.status === 404;
+}
+
+/** Transient failures must keep the persisted override for the next retry/refresh. */
+export function isTransientRestoreError(error: unknown): boolean {
+  if (!isApiClientError(error)) {
+    // Non-API errors (TypeError from fetch, etc.) are treated as transient.
+    return error instanceof Error;
+  }
+  if (error.isTimeout || error.status === 0 || error.status >= 500) return true;
+  return false;
+}
+
 const legacyServicePrincipal = (): ManagementPrincipal => ({
   kind: "service_credential",
   user: {
@@ -522,9 +550,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
       try {
         restoredPrincipal = (await identityApi.me()).principal;
       } catch (overrideError) {
-        // Stale/invalid override can fail Authenticate entirely — retry home tenant
-        // before treating the session as dead (matches previous two-step restore).
-        if (!requestedTenant) throw overrideError;
+        // Only drop a persisted override when the server says it is invalid.
+        // Transient network/timeout/5xx must keep the override and surface as
+        // restore failure instead of silently switching the user home.
+        if (!requestedTenant || !isRecoverableTenantOverrideError(overrideError)) {
+          throw overrideError;
+        }
         configureClient(resolvedBase, resolvedToken, "");
         syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
         restoredPrincipal = (await identityApi.me()).principal;
@@ -553,7 +584,11 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setPrincipal(null);
       syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
       setAuthFailureCode(isApiClientError(error) ? extractApiErrorCode(error.payload) : "");
-      clearPersistedAuthSnapshot();
+      // Transient restore failures keep the snapshot (including tenant override)
+      // so a refresh can retry the same context instead of wiping it.
+      if (!isTransientRestoreError(error)) {
+        clearPersistedAuthSnapshot();
+      }
     } finally {
       setIsRestoring(false);
     }

--- a/apps/admin-panel/src/app/providers/__tests__/tenantOverrideRestore.test.ts
+++ b/apps/admin-panel/src/app/providers/__tests__/tenantOverrideRestore.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { ApiError } from "@code-proxy/api-client";
+import {
+  isRecoverableTenantOverrideError,
+  isTransientRestoreError,
+} from "../AuthProvider";
+
+const apiError = (opts: {
+  status?: number;
+  code?: string;
+  isTimeout?: boolean;
+}): ApiError =>
+  new ApiError({
+    message: "test",
+    status: opts.status ?? 0,
+    isTimeout: opts.isTimeout,
+    payload: opts.code ? { error: { code: opts.code, message: opts.code } } : null,
+  });
+
+describe("isRecoverableTenantOverrideError", () => {
+  test("returns true for explicit override-invalid codes", () => {
+    expect(
+      isRecoverableTenantOverrideError(apiError({ status: 403, code: "tenant_scope_forbidden" })),
+    ).toBe(true);
+    expect(
+      isRecoverableTenantOverrideError(apiError({ status: 403, code: "tenant_suspended" })),
+    ).toBe(true);
+    expect(
+      isRecoverableTenantOverrideError(apiError({ status: 403, code: "tenant_expired" })),
+    ).toBe(true);
+    expect(isRecoverableTenantOverrideError(apiError({ status: 404, code: "not_found" }))).toBe(
+      true,
+    );
+    expect(isRecoverableTenantOverrideError(apiError({ status: 404 }))).toBe(true);
+  });
+
+  test("returns false for transient network/timeout/5xx", () => {
+    expect(isRecoverableTenantOverrideError(apiError({ status: 0 }))).toBe(false);
+    expect(isRecoverableTenantOverrideError(apiError({ status: 0, isTimeout: true }))).toBe(false);
+    expect(isRecoverableTenantOverrideError(apiError({ status: 500 }))).toBe(false);
+    expect(isRecoverableTenantOverrideError(apiError({ status: 503, code: "unavailable" }))).toBe(
+      false,
+    );
+  });
+
+  test("returns false for non-API errors and unrelated 4xx", () => {
+    expect(isRecoverableTenantOverrideError(new Error("boom"))).toBe(false);
+    expect(isRecoverableTenantOverrideError(apiError({ status: 401, code: "unauthorized" }))).toBe(
+      false,
+    );
+    expect(
+      isRecoverableTenantOverrideError(apiError({ status: 403, code: "permission_denied" })),
+    ).toBe(false);
+  });
+});
+
+describe("isTransientRestoreError", () => {
+  test("detects network, timeout, and 5xx", () => {
+    expect(isTransientRestoreError(apiError({ status: 0 }))).toBe(true);
+    expect(isTransientRestoreError(apiError({ status: 0, isTimeout: true }))).toBe(true);
+    expect(isTransientRestoreError(apiError({ status: 500 }))).toBe(true);
+    expect(isTransientRestoreError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  test("does not treat auth or scope rejection as transient", () => {
+    expect(isTransientRestoreError(apiError({ status: 401, code: "unauthorized" }))).toBe(false);
+    expect(
+      isTransientRestoreError(apiError({ status: 403, code: "tenant_scope_forbidden" })),
+    ).toBe(false);
+  });
+});

--- a/e2e/login-lifecycle.spec.ts
+++ b/e2e/login-lifecycle.spec.ts
@@ -45,7 +45,7 @@ const principal = {
   platform_admin: true,
 };
 
-test("Login: successful sign in persists auth snapshot and restores dashboard after reload", async ({
+test("Login: successful sign in persists auth snapshot and restores dashboard after reload @critical", async ({
   page,
 }) => {
   await page.route("**/v0/auth/login", async (route) => {

--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -282,6 +282,8 @@ async function mockIdentity(
   });
 }
 
+// Layout assertions (touch targets, centering) stay untagged; critical set
+// only needs force-change-password redirect after login.
 test("logs in with username and password without selecting a tenant", async ({ page }) => {
   await page.route("**/v0/auth/login", async (route) => {
     const body = route.request().postDataJSON();
@@ -343,6 +345,34 @@ test("logs in with username and password without selecting a tenant", async ({ p
       return Math.abs(passwordCard.y + passwordCard.height / 2 - viewport.height / 2);
     })
     .toBeLessThan(12);
+  await page.evaluate(() => {
+    window.location.hash = "/dashboard";
+  });
+  await expect(page).toHaveURL(/#\/change-password$/);
+});
+
+test("forces password change after login and blocks dashboard @critical", async ({ page }) => {
+  await page.route("**/v0/auth/login", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        access_token: "cps_test",
+        token_type: "Bearer",
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        principal: {
+          ...principal,
+          user: { ...principal.user, must_change_password: true },
+        },
+      }),
+    });
+  });
+  await mockIdentity(page);
+  await page.goto("/#/login");
+  await page.getByLabel(/username/i).fill("admin");
+  await page.getByLabel(/^password$/i).fill("correct-password");
+  await page.getByRole("button", { name: /^login$/i }).click();
+  await expect(page.getByRole("heading", { name: /change password/i })).toBeVisible();
   await page.evaluate(() => {
     window.location.hash = "/dashboard";
   });
@@ -411,7 +441,7 @@ test("uses the localized searchable tenant select with checkmark selection", asy
   await expect(listbox.getByRole("option", { name: "Acme Team" })).toBeVisible();
 });
 
-test("switching tenant remounts the current page and reloads tenant-scoped data", async ({
+test("switching tenant remounts the current page and reloads tenant-scoped data @critical", async ({
   page,
 }) => {
   await page.addInitScript(() =>
@@ -525,7 +555,7 @@ test("switching tenant remounts the current page and reloads tenant-scoped data"
   expect(authSnapshot).toContain(standardTenant.id);
 });
 
-test("restores the selected tenant after full page reload", async ({ page }) => {
+test("restores the selected tenant after full page reload @critical", async ({ page }) => {
   await page.addInitScript(() =>
     sessionStorage.setItem(
       "code-proxy-admin-auth",
@@ -724,7 +754,7 @@ test("manages dynamic menu visibility and ordering", async ({ page }) => {
   await expect(page.getByRole("dialog", { name: "Adjust order" })).toBeVisible();
 });
 
-test("applies server menu visibility and enabled state to navigation and routes", async ({
+test("applies server menu visibility and enabled state to navigation and routes @critical", async ({
   page,
 }) => {
   const dynamicPrincipal = {
@@ -949,7 +979,9 @@ test("renders role, audit, and password governance pages from server permissions
   await expect(page.locator("header")).toHaveCount(0);
 });
 
-test("shows an expired tenant message when restoring a rejected session", async ({ page }) => {
+test("shows an expired tenant message when restoring a rejected session @critical", async ({
+  page,
+}) => {
   await page.addInitScript(() =>
     sessionStorage.setItem(
       "code-proxy-admin-auth",
@@ -1134,4 +1166,133 @@ test("standard tenant redirects the unavailable OAuth excluded tab to tenant-saf
   await expect(page.getByRole("tab", { name: /model aliases/i })).toBeVisible();
   await expect(page.getByRole("tab", { name: /excluded models/i })).toHaveCount(0);
   expect(excludedRequests).toBe(0);
+});
+
+test("keeps tenant override when first /me returns 500 @critical", async ({ page }) => {
+  await page.addInitScript(() =>
+    sessionStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: false,
+        expiresAt: Date.now() + 60_000,
+        effectiveTenantId: "t-acme",
+      }),
+    ),
+  );
+
+  const meTenantHeaders: string[] = [];
+  let meCalls = 0;
+  await page.route("**/v0/auth/me", (route) => {
+    meCalls += 1;
+    const tenantHeader = route.request().headers()["x-effective-tenant-id"] ?? "";
+    meTenantHeaders.push(tenantHeader);
+    // First restore fails with a transient 500; must not fall back to home.
+    return route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ error: { code: "internal", message: "temporary" } }),
+    });
+  });
+  await page.route("**/v0/management/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "{}" }),
+  );
+
+  await page.goto("/#/roles");
+  // Auth restore fails → login; override must still be in the snapshot.
+  await expect(page).toHaveURL(/#\/login$/);
+  expect(meCalls).toBeGreaterThan(0);
+  expect(meTenantHeaders[0]).toBe(standardTenant.id);
+  // Must not have retried without the override (that would clear context).
+  expect(meTenantHeaders.every((h) => h === standardTenant.id)).toBe(true);
+
+  const snapshot = await page.evaluate(() => sessionStorage.getItem("code-proxy-admin-auth"));
+  expect(snapshot).toBeTruthy();
+  expect(snapshot).toContain("t-acme");
+  expect(snapshot).toContain("cps_test");
+});
+
+test("falls back to home tenant on tenant_scope_forbidden override @critical", async ({
+  page,
+}) => {
+  await page.addInitScript(() =>
+    sessionStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: false,
+        expiresAt: Date.now() + 60_000,
+        effectiveTenantId: "t-stale",
+      }),
+    ),
+  );
+
+  const meTenantHeaders: string[] = [];
+  await page.route("**/v0/auth/me", (route) => {
+    const tenantHeader = route.request().headers()["x-effective-tenant-id"] ?? "";
+    meTenantHeaders.push(tenantHeader);
+    if (tenantHeader === "t-stale") {
+      return route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { code: "tenant_scope_forbidden", message: "tenant scope forbidden" },
+        }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ principal }),
+    });
+  });
+  await page.route("**/v0/management/**", (route) => {
+    const path = new URL(route.request().url()).pathname.replace("/v0/management", "");
+    const bodies: Record<string, unknown> = {
+      "/tenants": { items: [principal.home_tenant, standardTenant] },
+      "/users": { items: [principal.user] },
+      "/roles": { items: [administratorRole] },
+      "/menus": { items: menuItems },
+      "/permissions": { items: [] },
+      "/audit-logs": { items: [] },
+    };
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(bodies[path] ?? {}),
+    });
+  });
+
+  await page.goto("/#/roles");
+  await expect(page.getByRole("heading", { name: /Roles/i })).toBeVisible();
+  expect(meTenantHeaders[0]).toBe("t-stale");
+  expect(meTenantHeaders.some((h) => h === "")).toBe(true);
+
+  const snapshot = await page.evaluate(() => sessionStorage.getItem("code-proxy-admin-auth"));
+  expect(snapshot).toBeTruthy();
+  expect(snapshot).not.toContain("t-stale");
+});
+
+// Dashboard mount under dynamic menus is covered by login-lifecycle @critical.
+// Keep a roles-page shell smoke here so multi-tenant-auth still asserts layout chrome.
+test("renders governance shell from dynamic menus @critical", async ({ page }) => {
+  await page.addInitScript(() =>
+    sessionStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: false,
+        expiresAt: Date.now() + 60_000,
+      }),
+    ),
+  );
+  await mockIdentity(page);
+  await page.goto("/#/roles");
+  await expect(page.getByText(/Something went wrong/i)).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: /Roles/i })).toBeVisible();
+  await expect(page.locator("aside")).toBeVisible();
+  await expect(page.locator("header")).toBeVisible();
 });

--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -691,7 +691,7 @@ export function DashboardPage() {
         <SystemMonitorSection
           stats={stats}
           connected={connected}
-          apiKeyCount={summary?.counts.api_keys ?? 0}
+          apiKeyCount={summary?.counts?.api_keys ?? 0}
         />
       ) : null}
 

--- a/scripts/ci-pr.sh
+++ b/scripts/ci-pr.sh
@@ -9,3 +9,19 @@ bun run design:check
 bun run test:ci
 bun run build
 bun run bundle:diff
+
+# Critical multi-tenant / auth browser smoke (mock APIs; no real backend).
+# Full E2E stays optional — only @critical tags run on every PR.
+if [[ "${SKIP_E2E_CRITICAL:-}" == "1" ]]; then
+  echo "SKIP_E2E_CRITICAL=1 — skipping Playwright critical smoke"
+  exit 0
+fi
+
+if ! command -v bunx >/dev/null 2>&1; then
+  echo "bunx is required for Playwright critical smoke" >&2
+  exit 1
+fi
+
+# Install browser only when missing; CI runners are clean so this is needed once.
+bunx playwright install chromium
+bunx playwright test e2e/multi-tenant-auth.spec.ts e2e/login-lifecycle.spec.ts --grep '@critical'


### PR DESCRIPTION
## Summary
- Tenant override restore only falls back on explicit invalid-scope codes (`tenant_scope_forbidden`, suspended, expired, not_found).
- Transient network / timeout / 5xx keep the persisted override and auth snapshot.
- Tag multi-tenant auth critical Playwright cases and run them in `./scripts/ci-pr.sh`.
- Guard `summary?.counts?.api_keys` optional chaining on dashboard.

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test:ci -- src/app/providers/__tests__/tenantOverrideRestore.test.ts`
- [x] `bunx playwright test e2e/multi-tenant-auth.spec.ts e2e/login-lifecycle.spec.ts --grep '@critical'` (9 passed)
- [x] `bun run lint` (0 errors)
- [ ] Full `./scripts/ci-pr.sh` on PR CI

Addresses review findings in CliProxy `docs/issue/001-grok-45-review-findings-20260713.md` (P2 #3, #4).