### PR TITLE
fix(model-plaza): remove TabsList gray track background

### DIFF
--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -433,7 +433,10 @@ export function ModelPlazaPage() {
             onValueChange={(next) => setSelectedVendor(next as VendorFilter)}
             size="sm"
           >
-            <TabsList aria-label={t("model_plaza.vendor_tabs")} className="max-w-full">
+            <TabsList
+              aria-label={t("model_plaza.vendor_tabs")}
+              className="max-w-full !bg-transparent dark:!bg-transparent"
+            >
               <TabsTrigger value="all">
                 <Layers size={12} aria-hidden="true" />
                 {t("common.all", { defaultValue: "All" })}

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -265,6 +265,8 @@ describe("ModelPlazaPage", () => {
     expect(sticky.className).toMatch(/bg-\[var\(--pl-bg\)\]/);
     expect(sticky.className).not.toMatch(/border-b/);
     expect(sticky.className).not.toMatch(/backdrop-blur/);
+    const tabList = screen.getByRole("tablist", { name: /filter by vendor/i });
+    expect(tabList.className).toMatch(/!bg-transparent/);
     // overflow-x-hidden on an ancestor computes overflow-y as auto and breaks sticky
     expect(container.firstElementChild?.className ?? "").not.toMatch(/overflow-x-hidden/);
   });


### PR DESCRIPTION
## Summary
- Override Model Plaza `TabsList` with transparent background so vendor tabs no longer show the default gray pill track
- Keep sticky pin behavior; only remove list chrome

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] ModelPlazaPage unit tests
- [ ] Manual: open Model Plaza — vendor tabs sit on app background without gray bar