### PR TITLE
fix(model-plaza): restore TabsList track, drop outer sticky bar

### DIFF
--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -426,17 +426,14 @@ export function ModelPlazaPage() {
       {vendorStats.length > 0 && !loading ? (
         <div
           data-testid="model-plaza-tabs-sticky"
-          className="sticky top-0 z-20 -mx-4 bg-[var(--pl-bg)] px-4 py-2.5 sm:-mx-6 sm:px-6"
+          className="sticky top-0 z-20 py-2.5"
         >
           <Tabs
             value={tabValue}
             onValueChange={(next) => setSelectedVendor(next as VendorFilter)}
             size="sm"
           >
-            <TabsList
-              aria-label={t("model_plaza.vendor_tabs")}
-              className="max-w-full !bg-transparent dark:!bg-transparent"
-            >
+            <TabsList aria-label={t("model_plaza.vendor_tabs")} className="max-w-full">
               <TabsTrigger value="all">
                 <Layers size={12} aria-hidden="true" />
                 {t("common.all", { defaultValue: "All" })}

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -262,11 +262,15 @@ describe("ModelPlazaPage", () => {
     const sticky = screen.getByTestId("model-plaza-tabs-sticky");
     expect(sticky.className).toMatch(/(?:^|\s)sticky(?:\s|$)/);
     expect(sticky.className).toMatch(/(?:^|\s)top-0(?:\s|$)/);
-    expect(sticky.className).toMatch(/bg-\[var\(--pl-bg\)\]/);
+    // no full-width outer chrome bar (border / solid page paint / blur)
     expect(sticky.className).not.toMatch(/border-b/);
     expect(sticky.className).not.toMatch(/backdrop-blur/);
+    expect(sticky.className).not.toMatch(/bg-\[var\(--pl-bg\)\]/);
+    expect(sticky.className).not.toMatch(/bg-white/);
+    // TabsList keeps its default gray pill track
     const tabList = screen.getByRole("tablist", { name: /filter by vendor/i });
-    expect(tabList.className).toMatch(/!bg-transparent/);
+    expect(tabList.className).not.toMatch(/!bg-transparent/);
+    expect(tabList.className).toMatch(/bg-\[#EBEBEC\]/);
     // overflow-x-hidden on an ancestor computes overflow-y as auto and breaks sticky
     expect(container.firstElementChild?.className ?? "").not.toMatch(/overflow-x-hidden/);
   });


### PR DESCRIPTION
## Summary
- **Restore** the default gray `TabsList` pill track (reverts mistaken transparent override)
- **Remove** the full-width sticky outer strip background that looked like an extra gray bar across the content area

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] ModelPlazaPage unit tests
- [ ] Manual: vendor tabs show gray capsule track only; no full-width gray bar behind them