### PR TITLE
fix(ui): contain TabsList horizontal overscroll

### DIFF
--- a/packages/ui/src/primitives/Tabs.tsx
+++ b/packages/ui/src/primitives/Tabs.tsx
@@ -113,7 +113,9 @@ export function TabsList({
       className={[
         // w-fit + self-start: stay content-sized even when parent is flex-col
         // (default align-items:stretch would stretch the pill bar full width)
-        "scrollbar-hidden relative inline-flex w-fit max-w-full shrink-0 self-start gap-0.5 overflow-x-auto whitespace-nowrap rounded-full bg-[#EBEBEC] p-0.5 dark:bg-[#27272A]",
+        // overscroll-x-contain: keep edge bounce on the tab strip only; without it,
+        // horizontal overscroll chains to the viewport and rubber-bands PageBackground.
+        "scrollbar-hidden relative inline-flex w-fit max-w-full shrink-0 self-start gap-0.5 overflow-x-auto overscroll-x-contain whitespace-nowrap rounded-full bg-[#EBEBEC] p-0.5 dark:bg-[#27272A]",
         tabsListHeightBySize[size],
         className,
       ].join(" ")}

--- a/packages/ui/src/primitives/__tests__/Tabs.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Tabs.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Tabs, TabsList, TabsTrigger } from "../Tabs";
+
+describe("TabsList", () => {
+  test("contains horizontal overscroll so parent/viewport does not rubber-band", () => {
+    render(
+      <Tabs value="a" onValueChange={() => {}}>
+        <TabsList>
+          <TabsTrigger value="a">Alpha</TabsTrigger>
+          <TabsTrigger value="b">Beta</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveClass("overflow-x-auto");
+    expect(tablist).toHaveClass("overscroll-x-contain");
+  });
+});


### PR DESCRIPTION
## Summary
- `TabsList` 增加 `overscroll-x-contain`，避免横向滚到边界时 overscroll 链到视口，带动 `PageBackground` 整页 rubber-band。
- 回归测试锁住该 class，防止再漏。
- 影响面：所有使用共享 `TabsList` 的页面（含 `/access/ai-providers` 顶部 provider Tab 条）。

## Root cause
`TabsList` 仅有 `overflow-x-auto`，无 overscroll 约束；边界回弹向上传递到视口，背景光晕随页面一起动。

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / e2e critical）
- [x] `bun run test:ci -- packages/ui/src/primitives/__tests__/Tabs.test.tsx`
- [ ] 浏览器：`/manage/access/ai-providers` 左右拖 Tab 到尽头，仅 Tab 条回弹，背景不动