### PR TITLE
fix(providers): SWR paint from tenant-scoped cache on remount

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -71,6 +71,7 @@ describe("ProvidersPage import/export", () => {
   const clickSpy = vi.fn();
 
   beforeEach(() => {
+    localStorage.clear();
     Object.values(mocks).forEach((mock) => mock.mockReset());
     mocks.getGeminiKeys.mockImplementation(async () => []);
     mocks.getClaudeConfigs.mockImplementation(async () => []);
@@ -181,9 +182,14 @@ describe("ProvidersPage import/export", () => {
 
   test("shows skeleton cards when switching to an unloaded provider tab", async () => {
     const user = userEvent.setup();
-    let resolveSwitch: ((configs: any[]) => void) | undefined;
-    mocks.getCodexConfigs.mockImplementationOnce(
-      () => new Promise<any[]>((resolve) => (resolveSwitch = resolve)),
+    // Keep Codex cold (no tenant cache, empty in-memory list) until the tab is opened.
+    // Mount refreshAll and the tab-click refresh may both call getCodexConfigs; release all.
+    const pendingResolvers: Array<(configs: any[]) => void> = [];
+    mocks.getCodexConfigs.mockImplementation(
+      () =>
+        new Promise<any[]>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
     );
 
     render(
@@ -203,15 +209,17 @@ describe("ProvidersPage import/export", () => {
 
     await waitFor(() => expect(refreshButton).toBeDisabled());
     expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
-    expect(screen.getByTestId("providers-list-skeleton")).toBeInTheDocument();
+    // Cold tab (no tenant-scoped cache) still uses list skeleton, not a full-page overlay.
+    expect(await screen.findByTestId("providers-list-skeleton")).toBeInTheDocument();
     expect(screen.queryByText(/Loading/i)).not.toBeInTheDocument();
 
-    resolveSwitch?.([
+    const codexConfigs = [
       {
         name: "Codex Main",
         apiKey: "sk-old",
       },
-    ]);
+    ];
+    pendingResolvers.splice(0).forEach((resolve) => resolve(codexConfigs));
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument(),
@@ -233,13 +241,20 @@ describe("ProvidersPage import/export", () => {
       </MemoryRouter>,
     );
 
+    // Mount refreshAll already loads every provider tab once.
+    await waitFor(() => expect(mocks.getCodexConfigs).toHaveBeenCalled());
+    const afterMount = mocks.getCodexConfigs.mock.calls.length;
+
     const codexTab = await screen.findByRole("tab", { name: /Codex/ });
     await user.click(codexTab);
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(afterMount + 1),
+    );
 
+    // Re-clicking the active tab must not re-fetch.
     await user.click(codexTab);
-    expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(1);
+    expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(afterMount + 1);
   });
 
   test("keeps provider import, refresh, and export actions together in the batch toolbar", async () => {

--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -3,9 +3,15 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ProviderSimpleConfig } from "@code-proxy/api-client";
+import {
+  DEFAULT_CACHE_TENANT_ID,
+  setActiveCacheTenantId,
+  setCacheTenantResolver,
+} from "@code-proxy/domain";
 import { ProvidersPage } from "@pages/providers/ProvidersPage";
 import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
+import { setCachedData } from "../provider-cache";
 
 const mocks = vi.hoisted(() => ({
   getGeminiKeys: vi.fn(async (): Promise<unknown[]> => []),
@@ -76,6 +82,10 @@ describe("ProvidersPage openai tab", () => {
   });
 
   beforeEach(() => {
+    localStorage.clear();
+    setCacheTenantResolver(null);
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
+
     mocks.getGeminiKeys.mockReset();
     mocks.getClaudeConfigs.mockReset();
     mocks.getCodexConfigs.mockReset();
@@ -207,6 +217,78 @@ describe("ProvidersPage openai tab", () => {
 
     resolveGemini([]);
     expect(await screen.findByText("No configuration")).toBeInTheDocument();
+  });
+
+  test("paints tenant-cached gemini cards immediately without skeleton (warm remount SWR)", async () => {
+    localStorage.setItem("providers-page:tab", "gemini");
+    setActiveCacheTenantId("tenant-warm");
+    setCachedData<ProviderSimpleConfig[]>("gemini", [
+      { name: "Cached Gemini", apiKey: "sk-cached-gemini" },
+    ]);
+
+    let resolveGemini: (value: ProviderSimpleConfig[]) => void = () => {};
+    mocks.getGeminiKeys.mockImplementationOnce(
+      () =>
+        new Promise<ProviderSimpleConfig[]>((resolve) => {
+          resolveGemini = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Cached Gemini")).toBeInTheDocument();
+    expect(screen.queryByTestId("providers-list-skeleton")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+
+    resolveGemini([{ name: "Fresh Gemini", apiKey: "sk-fresh-gemini" }]);
+    expect(await screen.findByText("Fresh Gemini")).toBeInTheDocument();
+    expect(screen.queryByText("Cached Gemini")).not.toBeInTheDocument();
+  });
+
+  test("does not paint another tenant's cached gemini list on remount", async () => {
+    localStorage.setItem("providers-page:tab", "gemini");
+    setActiveCacheTenantId("tenant-a");
+    setCachedData<ProviderSimpleConfig[]>("gemini", [
+      { name: "Tenant A Gemini", apiKey: "sk-a" },
+    ]);
+    setActiveCacheTenantId("tenant-b");
+
+    let resolveGemini: (value: ProviderSimpleConfig[]) => void = () => {};
+    mocks.getGeminiKeys.mockImplementationOnce(
+      () =>
+        new Promise<ProviderSimpleConfig[]>((resolve) => {
+          resolveGemini = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/access/ai-providers"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("Tenant A Gemini")).not.toBeInTheDocument();
+    expect(await screen.findByTestId("providers-list-skeleton")).toBeInTheDocument();
+
+    resolveGemini([{ name: "Tenant B Gemini", apiKey: "sk-b" }]);
+    expect(await screen.findByText("Tenant B Gemini")).toBeInTheDocument();
+    expect(screen.queryByText("Tenant A Gemini")).not.toBeInTheDocument();
   });
 
   test("keeps existing provider cards visible during toolbar refresh", async () => {

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -150,6 +150,8 @@ vi.mock("@code-proxy/api-client/endpoints/proxies", () => ({
 
 describe("ProvidersPage OpenCode Go tab", () => {
   beforeEach(() => {
+    // Tenant-scoped provider cache is read at mount; clear so cases cannot seed each other.
+    localStorage.clear();
     Object.values(mocks).forEach((mock) => mock.mockReset());
     mocks.getGeminiKeys.mockImplementation(async () => []);
     mocks.getClaudeConfigs.mockImplementation(async () => []);

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -194,6 +194,35 @@ const isModelAccessProvider = (
 ): tabId is ModelAccessProvider =>
   tabId === "opencode-go" || tabId === "cline" || tabId === "ollama-cloud";
 
+/** Provider list slots that seed from tenant-scoped localStorage. */
+const PROVIDER_LIST_CACHE_SLOTS: Record<
+  Exclude<ProviderTab, "ampcode">,
+  string
+> = {
+  gemini: "gemini",
+  claude: "claude",
+  codex: "codex",
+  "opencode-go": "opencode-go",
+  cline: "cline",
+  "ollama-cloud": "ollama-cloud",
+  vertex: "vertex",
+  bedrock: "bedrock",
+  openai: "openai",
+};
+
+/**
+ * Seed list state from the active tenant bucket only.
+ * DashboardLayout remounts on tenant switch; a one-shot mount read keeps
+ * paint tenant-isolated and avoids full-page skeleton when the bucket is warm.
+ */
+const readCachedProviderList = <T,>(slot: string): T[] =>
+  getCachedData<T[]>(slot) ?? [];
+
+const activeTabHasCachedList = (tabId: ProviderTab): boolean => {
+  if (tabId === "ampcode") return false;
+  return getCachedData(PROVIDER_LIST_CACHE_SLOTS[tabId]) != null;
+};
+
 export function ProvidersPage() {
   const { t } = useTranslation();
   const { notify } = useToast();
@@ -222,7 +251,10 @@ export function ProvidersPage() {
   useEffect(() => {
     if (!isSystemTenant && tab === "ampcode") setTab("gemini");
   }, [isSystemTenant, setTab, tab]);
-  const [loading, setLoading] = useState(true);
+  // `loading` = cold paint (no tenant cache for active tab) → list skeleton.
+  // `refreshing` = background / toolbar revalidate → spin button, keep cards.
+  const [loading, setLoading] = useState(() => !activeTabHasCachedList(tab));
+  const [refreshing, setRefreshing] = useState(false);
 
   const openCodeGoUsageStoreRef = useRef<OpenCodeGoUsageStore | null>(null);
   if (!openCodeGoUsageStoreRef.current) {
@@ -324,21 +356,33 @@ export function ProvidersPage() {
     [refreshProviderUsage],
   );
 
-  const [geminiKeys, setGeminiKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [claudeKeys, setClaudeKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [codexKeys, setCodexKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>(
-    () => getCachedData<ProviderSimpleConfig[]>("opencode-go") ?? [],
+  const [geminiKeys, setGeminiKeys] = useState<ProviderSimpleConfig[]>(() =>
+    readCachedProviderList<ProviderSimpleConfig>("gemini"),
   );
-  const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>(
-    () => getCachedData<ProviderSimpleConfig[]>("cline") ?? [],
+  const [claudeKeys, setClaudeKeys] = useState<ProviderSimpleConfig[]>(() =>
+    readCachedProviderList<ProviderSimpleConfig>("claude"),
+  );
+  const [codexKeys, setCodexKeys] = useState<ProviderSimpleConfig[]>(() =>
+    readCachedProviderList<ProviderSimpleConfig>("codex"),
+  );
+  const [openCodeGoKeys, setOpenCodeGoKeys] = useState<ProviderSimpleConfig[]>(
+    () => readCachedProviderList<ProviderSimpleConfig>("opencode-go"),
+  );
+  const [clineKeys, setClineKeys] = useState<ProviderSimpleConfig[]>(() =>
+    readCachedProviderList<ProviderSimpleConfig>("cline"),
   );
   const [ollamaCloudKeys, setOllamaCloudKeys] = useState<
     ProviderSimpleConfig[]
-  >(() => getCachedData<ProviderSimpleConfig[]>("ollama-cloud") ?? []);
-  const [vertexKeys, setVertexKeys] = useState<ProviderSimpleConfig[]>([]);
-  const [bedrockKeys, setBedrockKeys] = useState<BedrockProviderConfig[]>([]);
-  const [openaiProviders, setOpenaiProviders] = useState<OpenAIProvider[]>([]);
+  >(() => readCachedProviderList<ProviderSimpleConfig>("ollama-cloud"));
+  const [vertexKeys, setVertexKeys] = useState<ProviderSimpleConfig[]>(() =>
+    readCachedProviderList<ProviderSimpleConfig>("vertex"),
+  );
+  const [bedrockKeys, setBedrockKeys] = useState<BedrockProviderConfig[]>(() =>
+    readCachedProviderList<BedrockProviderConfig>("bedrock"),
+  );
+  const [openaiProviders, setOpenaiProviders] = useState<OpenAIProvider[]>(() =>
+    readCachedProviderList<OpenAIProvider>("openai"),
+  );
 
   // Auto-refresh dashboard usage when switching to providers with saved dashboard cookies.
   const PROVIDER_USAGE_STALE_MS = 5 * 60 * 1000;
@@ -580,7 +624,11 @@ export function ProvidersPage() {
 
   const refreshTab = useCallback(
     async (tabId: typeof tab) => {
-      setLoading(true);
+      // Skeleton only when this tenant has no list for the tab yet (cold paint).
+      // Cached remounts / tab revisits keep existing cards and toolbar-refresh only.
+      const shouldBlock = !activeTabHasCachedList(tabId);
+      if (shouldBlock) setLoading(true);
+      else setRefreshing(true);
       try {
         await loadProviderTab(tabId);
       } catch (err: unknown) {
@@ -590,7 +638,8 @@ export function ProvidersPage() {
             err instanceof Error ? err.message : t("providers.load_failed"),
         });
       } finally {
-        setLoading(false);
+        if (shouldBlock) setLoading(false);
+        else setRefreshing(false);
       }
     },
     [loadProviderTab, notify, t],
@@ -639,7 +688,11 @@ export function ProvidersPage() {
   });
 
   const refreshAll = useCallback(async () => {
-    setLoading(true);
+    // SWR: block with skeleton only when the active tab has no tenant cache.
+    // Toolbar refresh and warm tenant remounts keep cards visible.
+    const shouldBlock = !activeTabHasCachedList(tab);
+    if (shouldBlock) setLoading(true);
+    else setRefreshing(true);
     const tabsToRefresh: ProviderTab[] =
       isSystemTenant && tab === "ampcode"
         ? [...PROVIDER_LIST_TAB_VALUES, "ampcode"]
@@ -660,7 +713,8 @@ export function ProvidersPage() {
             : t("providers.load_failed"),
       });
     }
-    setLoading(false);
+    if (shouldBlock) setLoading(false);
+    else setRefreshing(false);
   }, [
     canReadProxies,
     canReadUsage,
@@ -1188,7 +1242,7 @@ export function ProvidersPage() {
         currentTabItemsCount={currentTabItems.length}
         selectedExportCount={selectedExportCount}
         allCurrentSelected={allCurrentSelected}
-        loading={loading}
+        loading={loading || refreshing}
         onImportClick={() => importInputRef.current?.click()}
         onExport={handleExport}
         onExportSelected={handleExportSelected}
@@ -1585,7 +1639,7 @@ export function ProvidersPage() {
               className="min-h-0 flex flex-1 flex-col"
             >
               <AmpcodePanel
-                loading={loading}
+                loading={loading || refreshing}
                 isPending={isPending}
                 saveAmpcode={saveAmpcode}
                 ampcode={ampcode}


### PR DESCRIPTION
## Summary
- AI Providers page already stores lists in `providers-page:cache.v2` tenant buckets, but remount on tenant switch always started with `loading=true` and empty lists for most tabs, so the UI showed a full list skeleton.
- Seed every provider list from the active tenant cache on mount; only cold tabs (no cache) use skeleton; warm remounts keep cards and spin the toolbar refresh instead.
- Add regression tests for warm-cache paint and cross-tenant isolation; clear localStorage between provider tests so cache seeding cannot leak.

## Test plan
- [x] `bun run test -- pages/providers/__tests__/ProvidersPage.openai.test.tsx pages/providers/__tests__/ProvidersPage.import-export.test.tsx pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx pages/providers/__tests__/ProvidersPage.bedrock.test.tsx`
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, critical e2e)
- [ ] Manually switch tenants on `/manage/access/ai-providers`: warm tenant should show cached cards immediately; first visit to a cold tenant may still skeleton