### PR TITLE
fix(auth-files): SWR paint from tenant-scoped cache on remount

### DIFF
--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -15,6 +15,10 @@ import {
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
   AUTH_FILES_UI_STATE_KEY,
+  DEFAULT_CACHE_TENANT_ID,
+  setActiveCacheTenantId,
+  setCacheTenantResolver,
+  writeAuthFilesDataCache,
 } from "@code-proxy/domain";
 import i18n from "@code-proxy/i18n";
 
@@ -193,6 +197,8 @@ describe("AuthFilesPage files table", () => {
     await i18n.changeLanguage("en");
     window.localStorage.clear();
     window.sessionStorage.clear();
+    setCacheTenantResolver(null);
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
     mocks.list.mockReset();
     mocks.list.mockImplementation(async () => ({
       files: [
@@ -1397,6 +1403,143 @@ describe("AuthFilesPage files table", () => {
     );
 
     expect(await screen.findByTestId("auth-files-table-skeleton")).toBeInTheDocument();
+  });
+
+  test("paints tenant-cached auth files immediately without skeleton (warm remount SWR)", async () => {
+    const now = Date.now();
+    setActiveCacheTenantId("tenant-warm");
+    writeAuthFilesDataCache({
+      tenantId: "tenant-warm",
+      savedAtMs: now,
+      files: [
+        {
+          name: "cached-codex.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        } as AuthFileItem,
+      ],
+    });
+
+    let resolveList: (value: { files: AuthFileItem[] }) => void = () => {};
+    mocks.list.mockImplementationOnce(
+      () =>
+        new Promise<{ files: AuthFileItem[] }>((resolve) => {
+          resolveList = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("cached-codex.json")).toBeInTheDocument();
+    expect(screen.queryByTestId("auth-files-table-skeleton")).not.toBeInTheDocument();
+
+    resolveList({
+      files: [
+        {
+          name: "fresh-codex.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        } as AuthFileItem,
+      ],
+    });
+    expect(await screen.findByText("fresh-codex.json")).toBeInTheDocument();
+    expect(screen.queryByText("cached-codex.json")).not.toBeInTheDocument();
+  });
+
+  test("keeps empty-list warm remount free of skeleton", async () => {
+    setActiveCacheTenantId("tenant-empty");
+    writeAuthFilesDataCache({
+      tenantId: "tenant-empty",
+      savedAtMs: Date.now(),
+      files: [],
+    });
+
+    mocks.list.mockImplementationOnce(() => new Promise(() => {}));
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("auth-files-table-skeleton")).not.toBeInTheDocument();
+    expect(await screen.findByText(/No auth files|No files/i)).toBeInTheDocument();
+  });
+
+  test("does not paint another tenant's cached auth files on remount", async () => {
+    const now = Date.now();
+    setActiveCacheTenantId("tenant-a");
+    writeAuthFilesDataCache({
+      tenantId: "tenant-a",
+      savedAtMs: now,
+      files: [
+        {
+          name: "tenant-a.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        } as AuthFileItem,
+      ],
+    });
+    setActiveCacheTenantId("tenant-b");
+
+    let resolveList: (value: { files: AuthFileItem[] }) => void = () => {};
+    mocks.list.mockImplementationOnce(
+      () =>
+        new Promise<{ files: AuthFileItem[] }>((resolve) => {
+          resolveList = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("tenant-a.json")).not.toBeInTheDocument();
+    expect(await screen.findByTestId("auth-files-table-skeleton")).toBeInTheDocument();
+
+    resolveList({
+      files: [
+        {
+          name: "tenant-b.json",
+          type: "codex",
+          size: 1024,
+          modified: now,
+          disabled: false,
+        } as AuthFileItem,
+      ],
+    });
+    expect(await screen.findByText("tenant-b.json")).toBeInTheDocument();
+    expect(screen.queryByText("tenant-a.json")).not.toBeInTheDocument();
   });
 
   test("restores last data on route switch and refreshes quietly", async () => {

--- a/pages/auth-files/hooks/useAuthFilesDataState.ts
+++ b/pages/auth-files/hooks/useAuthFilesDataState.ts
@@ -69,6 +69,13 @@ const buildEntityStatsScopeForFiles = (targetFiles: AuthFileItem[]): EntityStats
 const isRequestCancelled = (err: unknown, signal?: AbortSignal) =>
   signal?.aborted || (err instanceof Error && err.message === "Request was cancelled");
 
+/**
+ * Warm paint = this effective-tenant bucket already has a list snapshot
+ * (including empty lists). Empty must not force skeleton on remount.
+ */
+const hasWarmAuthFilesCache = (tenantId: string): boolean =>
+  readAuthFilesDataCache(tenantId) != null;
+
 export function useAuthFilesDataState() {
   const { t } = useTranslation();
   const { notify } = useToast();
@@ -80,9 +87,11 @@ export function useAuthFilesDataState() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-seed only
     [],
   );
+  // Bucket presence (not files.length) decides cold skeleton vs SWR refresh.
+  const initialWarm = initialDataCache != null;
 
   const [files, setFiles] = useState<AuthFileItem[]>(() => initialDataCache?.files ?? []);
-  const [loading, setLoading] = useState(() => !((initialDataCache?.files?.length ?? 0) > 0));
+  const [loading, setLoading] = useState(() => !initialWarm);
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [usageLoading, setUsageLoading] = useState(false);
   const [usageData, setUsageData] = useState<EntityStatsResponse | null>(
@@ -92,6 +101,8 @@ export function useAuthFilesDataState() {
   const filesRef = useRef<AuthFileItem[]>(files);
   const usageDataRef = useRef<EntityStatsResponse | null>(usageData);
   const cacheTenantIdRef = useRef(cacheTenantId);
+  // After a successful load (or warm seed), keep subsequent refreshes non-blocking.
+  const warmPaintRef = useRef(initialWarm);
   const mountedRef = useRef(true);
   const loadSeqRef = useRef(0);
 
@@ -106,7 +117,12 @@ export function useAuthFilesDataState() {
       const signal = options?.signal;
       const isActive = () =>
         mountedRef.current && loadSeqRef.current === seq && signal?.aborted !== true;
-      const hasExisting = filesRef.current.length > 0;
+      // SWR: keep cards/table when we already painted from cache or in-memory list.
+      // Re-read the tenant bucket so empty-list warm remounts still skip skeleton.
+      const hasExisting =
+        filesRef.current.length > 0 ||
+        warmPaintRef.current ||
+        hasWarmAuthFilesCache(cacheTenantIdRef.current);
       if (hasExisting) setRefreshingAll(true);
       else setLoading(true);
       if (!hasExisting) setUsageLoading(true);
@@ -116,6 +132,7 @@ export function useAuthFilesDataState() {
         const list = Array.isArray(filesRes?.files) ? filesRes.files : [];
         filesRef.current = list;
         setFiles(list);
+        warmPaintRef.current = true;
 
         const scope = buildEntityStatsScopeForFiles(list);
         const hasUsageScope =

--- a/pages/auth-files/hooks/useAuthFilesQuotaState.ts
+++ b/pages/auth-files/hooks/useAuthFilesQuotaState.ts
@@ -143,7 +143,9 @@ export function useAuthFilesQuotaState({
     const timer = window.setTimeout(() => {
       const tenantId = getActiveCacheTenantId();
       const current = readAuthFilesDataCache(tenantId);
-      if (!current?.files?.length) return;
+      // Persist quota for this tenant even when the list is empty (warm empty remount).
+      // Still require a list bucket so we never invent a cross-tenant files snapshot.
+      if (!current || !Array.isArray(current.files)) return;
       writeAuthFilesDataCache({
         ...current,
         tenantId,


### PR DESCRIPTION
## Summary
- AI Accounts (`/access/ai-accounts`) already stores list/quota in `authFilesPage.dataCache.v3` tenant buckets, but warm paint only counted `files.length > 0`. Empty lists and some remounts still forced a full skeleton.
- Treat bucket presence as warm: seed files/usage/quota, use `refreshingAll` for revalidate, skeleton only on true cold tenants.
- Persist quota updates even for empty list buckets; add warm/empty/cross-tenant remount regression tests.

## Test plan
- [x] `bun run test -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/__tests__/auth-files-helpers.test.tsx` (109 passed)
- [x] `./scripts/ci-pr.sh`
- [ ] Manually switch tenants on `/manage/access/ai-accounts`: warm tenant should show cached cards/empty state immediately