### PR TITLE
fix: recover from stale SPA chunks after frontend deploy

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.test.ts
+++ b/apps/admin-panel/src/app/AppRouter.test.ts
@@ -61,7 +61,10 @@ describe("AppRouter", () => {
 
     expect(mainSource).toContain("dismissAppLoader(true)");
     expect(manageEntrySource).toContain("dismissAppLoader(true)");
+    expect(mainSource).toContain("installChunkLoadRecoveryHandlers()");
+    expect(manageEntrySource).toContain("installChunkLoadRecoveryHandlers()");
     expect(routerSource).toContain("const RouteFallback = () => null");
+    expect(routerSource).toContain("ChunkLoadErrorBoundary");
     expect(routerSource).not.toContain("PageLoader");
     expect(routerSource).not.toContain('variant="initial"');
     expect(routerSource).not.toContain('variant="inline"');

--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -5,11 +5,14 @@ import { ProtectedRoute } from "@/app/guards/ProtectedRoute";
 import { DashboardLayout } from "@app/layout/DashboardLayout";
 import { ThemeProvider, ToastProvider } from "@code-proxy/ui";
 import { AutoUpdatePrompt } from "@app/update/AutoUpdatePrompt";
+import { ChunkLoadErrorBoundary } from "@/app/bootstrap/ChunkLoadErrorBoundary";
 import { dismissAppLoader } from "@/app/bootstrap/dismissAppLoader";
 import { pageRoutes, type PageRoute } from "@pages/registry";
 import { ForbiddenPage } from "@pages/forbidden/ForbiddenPage";
 import { EmbedPage } from "@pages/embed/EmbedPage";
 
+// Keep fallback empty so route transitions stay shell-only; chunk failures are
+// recovered by ChunkLoadErrorBoundary / hard reload instead of a second loader.
 const RouteFallback = () => null;
 
 /** Preserve deep-link suffixes when remapping legacy flat routes to nested secondary routes. */
@@ -119,65 +122,67 @@ function AuthenticatedRoutes() {
   return (
     <>
       <AutoUpdatePrompt />
-      <Suspense fallback={<RouteFallback />}>
-        <Routes>
-          {publicRoutes.flatMap((route) =>
-            (route.redirects ?? []).map((rd) => (
-              <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
-            )),
-          )}
-          <Route path="/login" element={<Navigate to="/dashboard" replace />} />
-          <Route element={<ProtectedRoute />}>
-            {authStandaloneRoutes.map((route) => (
-              <Route
-                key={route.path}
-                path={route.path}
-                element={<AuthorizedPage route={route} />}
-              />
-            ))}
-            <Route element={<DashboardLayout />}>
-              {authDashboardRoutes.map((route) => (
+      <ChunkLoadErrorBoundary>
+        <Suspense fallback={<RouteFallback />}>
+          <Routes>
+            {publicRoutes.flatMap((route) =>
+              (route.redirects ?? []).map((rd) => (
+                <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
+              )),
+            )}
+            <Route path="/login" element={<Navigate to="/dashboard" replace />} />
+            <Route element={<ProtectedRoute />}>
+              {authStandaloneRoutes.map((route) => (
                 <Route
                   key={route.path}
                   path={route.path}
                   element={<AuthorizedPage route={route} />}
                 />
               ))}
-              {authDashboardRoutes.flatMap((route) =>
-                (route.redirects ?? []).map((rd) => (
-                  <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
-                )),
-              )}
-              {/* Prefix redirects cover deep links under legacy flat paths (e.g. /ai-providers/openai). */}
-              {LEGACY_PREFIX_REDIRECTS.map((rd) => (
-                <Route
-                  key={`legacy:${rd.fromPrefix}`}
-                  path={`${rd.fromPrefix}/*`}
-                  element={<PrefixRedirect fromPrefix={rd.fromPrefix} toPrefix={rd.toPrefix} />}
-                />
-              ))}
-              {embedMenus.map((menu) => (
-                <Route
-                  key={`embed:${menu.code}`}
-                  path={menu.path}
-                  element={<AuthorizedEmbedPage path={menu.path} />}
-                />
-              ))}
-              {authDashboardRoutes
-                .filter((r) => r.hasWildcard)
-                .map((route) => (
+              <Route element={<DashboardLayout />}>
+                {authDashboardRoutes.map((route) => (
                   <Route
-                    key={`${route.path}-wildcard`}
-                    path={`${route.path}/*`}
+                    key={route.path}
+                    path={route.path}
                     element={<AuthorizedPage route={route} />}
                   />
                 ))}
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                {authDashboardRoutes.flatMap((route) =>
+                  (route.redirects ?? []).map((rd) => (
+                    <Route key={rd.from} path={rd.from} element={<Navigate to={rd.to} replace />} />
+                  )),
+                )}
+                {/* Prefix redirects cover deep links under legacy flat paths (e.g. /ai-providers/openai). */}
+                {LEGACY_PREFIX_REDIRECTS.map((rd) => (
+                  <Route
+                    key={`legacy:${rd.fromPrefix}`}
+                    path={`${rd.fromPrefix}/*`}
+                    element={<PrefixRedirect fromPrefix={rd.fromPrefix} toPrefix={rd.toPrefix} />}
+                  />
+                ))}
+                {embedMenus.map((menu) => (
+                  <Route
+                    key={`embed:${menu.code}`}
+                    path={menu.path}
+                    element={<AuthorizedEmbedPage path={menu.path} />}
+                  />
+                ))}
+                {authDashboardRoutes
+                  .filter((r) => r.hasWildcard)
+                  .map((route) => (
+                    <Route
+                      key={`${route.path}-wildcard`}
+                      path={`${route.path}/*`}
+                      element={<AuthorizedPage route={route} />}
+                    />
+                  ))}
+                <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              </Route>
             </Route>
-          </Route>
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Routes>
-      </Suspense>
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </Suspense>
+      </ChunkLoadErrorBoundary>
     </>
   );
 }
@@ -192,32 +197,34 @@ export function AppRouter() {
     <ThemeProvider>
       <ToastProvider>
         <div className="font-sans antialiased">
-          <Suspense fallback={<RouteFallback />}>
-            <Routes>
-              {standalonePublicRoutes.map((route) => (
-                <Route key={route.path} path={route.path} element={readyRoute(route.element)} />
-              ))}
-              {loginRoute ? (
+          <ChunkLoadErrorBoundary>
+            <Suspense fallback={<RouteFallback />}>
+              <Routes>
+                {standalonePublicRoutes.map((route) => (
+                  <Route key={route.path} path={route.path} element={readyRoute(route.element)} />
+                ))}
+                {loginRoute ? (
+                  <Route
+                    path={loginRoute.path}
+                    element={
+                      <AuthProvider>
+                        <LoginRouteReady>{loginRoute.element}</LoginRouteReady>
+                      </AuthProvider>
+                    }
+                  />
+                ) : null}
+
                 <Route
-                  path={loginRoute.path}
+                  path="*"
                   element={
                     <AuthProvider>
-                      <LoginRouteReady>{loginRoute.element}</LoginRouteReady>
+                      <AuthenticatedRoutes />
                     </AuthProvider>
                   }
                 />
-              ) : null}
-
-              <Route
-                path="*"
-                element={
-                  <AuthProvider>
-                    <AuthenticatedRoutes />
-                  </AuthProvider>
-                }
-              />
-            </Routes>
-          </Suspense>
+              </Routes>
+            </Suspense>
+          </ChunkLoadErrorBoundary>
         </div>
       </ToastProvider>
     </ThemeProvider>

--- a/apps/admin-panel/src/app/bootstrap/ChunkLoadErrorBoundary.tsx
+++ b/apps/admin-panel/src/app/bootstrap/ChunkLoadErrorBoundary.tsx
@@ -1,0 +1,77 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import {
+  isChunkLoadError,
+  recoverFromChunkLoadError,
+} from "@pages/chunkLoadRecovery";
+
+type Props = {
+  children: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+  isChunkError: boolean;
+  reloading: boolean;
+};
+
+/**
+ * Catches rejected lazy route imports that bubble past Suspense.
+ * Stale post-deploy chunks trigger a single hard reload; other errors show a
+ * minimal recovery surface instead of a permanent white screen.
+ */
+export class ChunkLoadErrorBoundary extends Component<Props, State> {
+  state: State = {
+    hasError: false,
+    isChunkError: false,
+    reloading: false,
+  };
+
+  static getDerivedStateFromError(error: unknown): State {
+    const isChunkError = isChunkLoadError(error);
+    return {
+      hasError: true,
+      isChunkError,
+      reloading: isChunkError,
+    };
+  }
+
+  componentDidCatch(error: unknown, _info: ErrorInfo): void {
+    if (isChunkLoadError(error)) {
+      const reloading = recoverFromChunkLoadError(error);
+      if (!reloading) {
+        this.setState({ reloading: false });
+      }
+    }
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    if (this.state.isChunkError && this.state.reloading) {
+      return null;
+    }
+
+    return (
+      <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3 px-6 text-center text-sm text-slate-600 dark:text-slate-300">
+        <p>
+          {this.state.isChunkError
+            ? "页面资源已更新，请刷新浏览器后重试。"
+            : "页面加载失败，请刷新浏览器后重试。"}
+        </p>
+        <button
+          type="button"
+          className="rounded-full bg-slate-900 px-4 py-1.5 text-xs font-medium text-white dark:bg-slate-100 dark:text-slate-900"
+          onClick={this.handleReload}
+        >
+          刷新页面
+        </button>
+      </div>
+    );
+  }
+}

--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -4,10 +4,15 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ThemeProvider } from "@code-proxy/ui";
 import { IDENTITY_TENANTS_UPDATED_EVENT, type MenuIdentity, type TenantIdentity } from "@code-proxy/api-client";
 import { preloadPageRoute } from "@pages/registry";
+import { recoverFromChunkLoadError } from "@pages/chunkLoadRecovery";
 import { AppShell } from "./AppShell";
 
 vi.mock("@pages/registry", () => ({
   preloadPageRoute: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@pages/chunkLoadRecovery", () => ({
+  recoverFromChunkLoadError: vi.fn(() => false),
 }));
 
 const tenantsMock = vi.fn<() => Promise<{ items: TenantIdentity[] }>>();
@@ -233,6 +238,8 @@ describe("AppShell route progress", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.mocked(preloadPageRoute).mockClear();
+    vi.mocked(recoverFromChunkLoadError).mockReset();
+    vi.mocked(recoverFromChunkLoadError).mockReturnValue(false);
   });
 
   test("preloads the target route before navigating from the current page", async () => {
@@ -359,6 +366,27 @@ describe("AppShell route progress", () => {
     expect(document.querySelector(".rp")).not.toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
   });
+
+  test("recovers from chunk load failures instead of navigating into a blank route", async () => {
+    vi.useFakeTimers();
+    const chunkError = new TypeError("Failed to fetch dynamically imported module");
+    vi.mocked(preloadPageRoute).mockRejectedValueOnce(chunkError);
+    vi.mocked(recoverFromChunkLoadError).mockReturnValueOnce(true);
+
+    renderShell();
+    fireEvent.click(screen.getByRole("button", { name: /Access(?: & Credentials)?|接入(?:管理|与凭证)/i }));
+    fireEvent.click(document.querySelector<HTMLAnchorElement>('a[href="/access/ai-providers"]')!);
+
+    await act(async () => {
+      vi.advanceTimersByTime(680);
+      await Promise.resolve();
+    });
+
+    expect(recoverFromChunkLoadError).toHaveBeenCalledWith(chunkError);
+    expect(screen.getByTestId("location")).toHaveTextContent("/dashboard");
+    expect(document.querySelector(".rp")).not.toBeInTheDocument();
+  });
+
   test("groups sidebar routes and uses a compact neutral active state", () => {
     renderShell("/runtime/request-logs");
 

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -34,6 +34,7 @@ import {
   ThemeToggleButton,
 } from "@code-proxy/ui";
 import { preloadPageRoute } from "@pages/registry";
+import { recoverFromChunkLoadError } from "@pages/chunkLoadRecovery";
 import {
   identityApi,
   IDENTITY_TENANTS_UPDATED_EVENT,
@@ -780,6 +781,7 @@ function ShellSidebar({
   }, [railCollapsed]);
 
   const warmPageRoute = useCallback((to: string) => {
+    // Hover warm-up: ignore failures; click path handles chunk recovery.
     void preloadPageRoute(to).catch(() => undefined);
   }, []);
 
@@ -808,19 +810,32 @@ function ShellSidebar({
         progressTimers.current.push(timer);
       });
 
-      void Promise.all([preloadPageRoute(to).catch(() => undefined), minimumProgress]).then(() => {
-        if (navigationRequestId.current !== requestId) return;
-        setProgressDone(true);
-
-        const navigateTimer = setTimeout(() => {
+      // Do not swallow chunk-load failures: stale post-deploy assets must hard-reload
+      // instead of navigating into an empty Suspense tree.
+      void Promise.all([preloadPageRoute(to), minimumProgress])
+        .then(() => {
           if (navigationRequestId.current !== requestId) return;
-          navigate(to, { viewTransition: true });
+          setProgressDone(true);
+
+          const navigateTimer = setTimeout(() => {
+            if (navigationRequestId.current !== requestId) return;
+            navigate(to, { viewTransition: true });
+            setPendingTo("");
+            setProgressDone(false);
+            progressTimers.current = [];
+          }, ROUTE_PROGRESS_HIDE_MS);
+          progressTimers.current.push(navigateTimer);
+        })
+        .catch((error: unknown) => {
+          if (navigationRequestId.current !== requestId) return;
+          clearProgressTimers();
           setPendingTo("");
           setProgressDone(false);
-          progressTimers.current = [];
-        }, ROUTE_PROGRESS_HIDE_MS);
-        progressTimers.current.push(navigateTimer);
-      });
+          if (recoverFromChunkLoadError(error)) return;
+          // Non-chunk failure: fall back to navigation so Suspense can surface
+          // the error boundary on render rather than stranding the progress bar.
+          navigate(to, { viewTransition: true });
+        });
     },
     [clearProgressTimers, location.pathname, navigate, onNavigate],
   );

--- a/apps/admin-panel/src/main.tsx
+++ b/apps/admin-panel/src/main.tsx
@@ -3,10 +3,14 @@ import { createRoot } from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 import { AppRouter } from "@/app/AppRouter";
 import { dismissAppLoader } from "@/app/bootstrap/dismissAppLoader";
+import { installChunkLoadRecoveryHandlers } from "@pages/chunkLoadRecovery";
 import { GlobalIconButtonTooltip } from "@code-proxy/ui";
 import "@/styles/index.css";
 import "goey-toast/styles.css";
 import "@code-proxy/i18n";
+
+// Catch unhandled dynamic-import failures after deploy (stale hashed chunks).
+installChunkLoadRecoveryHandlers();
 
 const rootElement = document.getElementById("root");
 

--- a/apps/admin-panel/src/manage-entry.tsx
+++ b/apps/admin-panel/src/manage-entry.tsx
@@ -3,9 +3,13 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AppRouter } from "@/app/AppRouter";
 import { dismissAppLoader } from "@/app/bootstrap/dismissAppLoader";
+import { installChunkLoadRecoveryHandlers } from "@pages/chunkLoadRecovery";
 import "@/styles/index.css";
 import "goey-toast/styles.css";
 import "@code-proxy/i18n";
+
+// Catch unhandled dynamic-import failures after deploy (stale hashed chunks).
+installChunkLoadRecoveryHandlers();
 
 const rootElement = document.getElementById("root");
 

--- a/docs/internal-review/bundle-baseline.md
+++ b/docs/internal-review/bundle-baseline.md
@@ -1,6 +1,6 @@
 # codeProxy Bundle Baseline
 
-更新时间：2026-07-11 16:42:00 +0800
+更新时间：2026-07-13 11:32:00 +0800
 
 ## 当前构建命令
 
@@ -13,19 +13,18 @@ bun run build
 
 | Chunk                |       Size |      Gzip | 备注                                                                        |
 | -------------------- | ---------: | --------: | --------------------------------------------------------------------------- |
-| `vendor-echarts`     | 1110.90 kB | 368.34 kB | 图表主依赖，明显过大                                                        |
-| `vendor-markdown`    |  761.13 kB | 261.12 kB | Markdown + syntax highlighter 组合                                          |
-| `vendor-animation`   |  126.13 kB |  41.83 kB | 动画依赖独立 vendor chunk                                                   |
+| `vendor-echarts`     | 1110.90 kB | 369.08 kB | 图表主依赖，明显过大                                                        |
+| `vendor-markdown`    |  761.13 kB | 263.84 kB | Markdown + syntax highlighter 组合                                          |
+| `vendor-animation`   |  126.21 kB |  41.93 kB | 动画依赖独立 vendor chunk                                                   |
 | `vendor-charts`      |    0.07 kB |   0.08 kB | Chart.js 入口当前几乎未进入业务路径                                         |
-| `index`              |  351.73 kB | 109.11 kB | 接受本轮侧边栏稳定交互与全局浮层规范；后续仍需持续往下压                  |
-| `ConfigPage`         |  118.44 kB |  32.93 kB | 页面 chunk 低于预算                                                         |
-| `AuthFilesPage`      |  221.86 kB |  59.92 kB | 身份多档案与出站策略交互加入后仍低于页面 gzip 预算                          |
-| `ProvidersPage`      |  113.50 kB |  28.33 kB | 已低于 `< 80 kB gzip` 页面预算                                              |
-| `MonitorPage`        |   24.48 kB |   6.81 kB | 已拆为 toolbar / state hook / dashboard sections                            |
-| `LogsPage`           |   19.36 kB |   5.80 kB | 已拆为 live logs / error logs / helpers                                     |
-| `EChartRenderer`     |    3.71 kB |   1.39 kB | 图表实际渲染器按需要加载                                                    |
-| `LogContentModal`    |   44.82 kB |  12.96 kB | 已从主详情弹窗中拆出 Markdown 渲染重依赖                                    |
-| `rendering-markdown` |   14.34 kB |   2.73 kB | 按交互加载的 Markdown 入口，重依赖在 `vendor-markdown`                      |
+| `index`              |  372.68 kB | 115.07 kB | 纳入部署后懒加载 chunk 失效自动恢复（单次硬刷新 + ErrorBoundary）；后续仍需往下压 |
+| `ConfigPage`         |  119.60 kB |  33.35 kB | 页面 chunk 低于预算                                                         |
+| `AuthFilesPage`      |  216.81 kB |  58.90 kB | 身份多档案与出站策略交互加入后仍低于页面 gzip 预算                          |
+| `ProvidersPage`      |  121.98 kB |  30.85 kB | 已低于 `< 80 kB gzip` 页面预算                                              |
+| `MonitorPage`        |   24.33 kB |   6.80 kB | 已拆为 toolbar / state hook / dashboard sections                            |
+| `LogsPage`           |   22.15 kB |   6.51 kB | 已拆为 live logs / error logs / helpers                                     |
+| `EChartRenderer`     |    3.76 kB |   1.41 kB | 图表实际渲染器按需要加载                                                    |
+| `rendering-markdown` |   14.38 kB |   2.75 kB | 按交互加载的 Markdown 入口，重依赖在 `vendor-markdown`                      |
 
 ## 目标预算
 
@@ -37,11 +36,10 @@ bun run build
 
 | 页面/模块         |                  当前体积 | 预算状态       | 最近治理结果                                                                                                    |
 | ----------------- | ------------------------: | -------------- | --------------------------------------------------------------------------------------------------------------- |
-| `AuthFilesPage`   | 221.86 kB / 59.92 kB gzip | 通过           | 新增 Codex 身份多档案与出站选择后仍低于页面 gzip 预算，后续继续关注 chunk 治理 |
-| `ConfigPage`      | 118.44 kB / 32.93 kB gzip | 通过           | 已拆出 runtime panel / visual payload editors，并复用 feature 侧 visual config hook |
-| `ProvidersPage`   | 113.50 kB / 28.33 kB gzip | 通过且低于预算 | OpenAI tab、usage summary、provider editor hooks 已完成拆分 |
-| `LogContentModal` |  44.82 kB / 12.96 kB gzip | 通过且低于预算 | Markdown 渲染改为按交互懒加载，保留完整内容查看能力 |
-| `MonitorPage`     |  24.48 kB /  6.81 kB gzip | 通过且低于预算 | 拆出 `MonitorToolbarSection`、`MonitorDashboardSections`、`useMonitorDashboardState` |
+| `AuthFilesPage`   | 216.81 kB / 58.90 kB gzip | 通过           | 新增 Codex 身份多档案与出站选择后仍低于页面 gzip 预算，后续继续关注 chunk 治理 |
+| `ConfigPage`      | 119.60 kB / 33.35 kB gzip | 通过           | 已拆出 runtime panel / visual payload editors，并复用 feature 侧 visual config hook |
+| `ProvidersPage`   | 121.98 kB / 30.85 kB gzip | 通过且低于预算 | OpenAI tab、usage summary、provider editor hooks 已完成拆分 |
+| `MonitorPage`     |  24.33 kB /  6.80 kB gzip | 通过且低于预算 | 拆出 `MonitorToolbarSection`、`MonitorDashboardSections`、`useMonitorDashboardState` |
 
 ## 下一步
 
@@ -49,3 +47,4 @@ bun run build
 - `ConfigPage` 与 CodeMirror 场景继续按交互拆分，避免低频编辑器进入常用路径
 - `CodeMirror` 场景继续按交互拆分，避免低频编辑器进入常用路径
 - `vendor-echarts` 仍然偏大，后续需要继续按图表场景和库边界细分 chunk
+- `index` 在保留 chunk 恢复逻辑的前提下，继续把低频 shell 能力外移

--- a/pages/__tests__/chunkLoadRecovery.test.ts
+++ b/pages/__tests__/chunkLoadRecovery.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  CHUNK_RELOAD_COOLDOWN_MS,
+  CHUNK_RELOAD_STORAGE_KEY,
+  installChunkLoadRecoveryHandlers,
+  isChunkLoadError,
+  recoverFromChunkLoadError,
+} from "../chunkLoadRecovery";
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? (map.get(key) as string) : null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, String(value));
+    },
+  };
+}
+
+describe("isChunkLoadError", () => {
+  test("detects common dynamic import failure messages", () => {
+    expect(
+      isChunkLoadError(new TypeError("Failed to fetch dynamically imported module: https://x/a.js")),
+    ).toBe(true);
+    expect(isChunkLoadError(new Error("Importing a module script failed."))).toBe(true);
+    expect(isChunkLoadError(new Error("Loading chunk MonitorPage-abc failed"))).toBe(true);
+    expect(isChunkLoadError({ name: "ChunkLoadError", message: "loading" })).toBe(true);
+    expect(isChunkLoadError("error loading dynamically imported module")).toBe(true);
+  });
+
+  test("ignores unrelated errors", () => {
+    expect(isChunkLoadError(new Error("Network Error"))).toBe(false);
+    expect(isChunkLoadError(new TypeError("Cannot read properties of undefined"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(42)).toBe(false);
+  });
+});
+
+describe("recoverFromChunkLoadError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("reloads once for chunk errors and records a session marker", () => {
+    const storage = memoryStorage();
+    const reload = vi.fn();
+    const now = 1_000_000;
+
+    expect(
+      recoverFromChunkLoadError(new TypeError("Failed to fetch dynamically imported module"), {
+        storage,
+        now: () => now,
+        reload,
+      }),
+    ).toBe(true);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(CHUNK_RELOAD_STORAGE_KEY)).toBe(String(now));
+  });
+
+  test("does not reload non-chunk errors", () => {
+    const reload = vi.fn();
+    expect(
+      recoverFromChunkLoadError(new Error("boom"), {
+        storage: memoryStorage(),
+        reload,
+      }),
+    ).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test("skips a second reload inside the cooldown window", () => {
+    const storage = memoryStorage();
+    const reload = vi.fn();
+    const first = 5_000_000;
+
+    recoverFromChunkLoadError(new Error("ChunkLoadError: fail"), {
+      storage,
+      now: () => first,
+      reload,
+    });
+    const second = recoverFromChunkLoadError(
+      new TypeError("Failed to fetch dynamically imported module"),
+      {
+        storage,
+        now: () => first + CHUNK_RELOAD_COOLDOWN_MS - 1,
+        reload,
+      },
+    );
+
+    expect(second).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("allows another reload after the cooldown expires", () => {
+    const storage = memoryStorage();
+    const reload = vi.fn();
+    const first = 5_000_000;
+
+    recoverFromChunkLoadError(new Error("Importing a module script failed."), {
+      storage,
+      now: () => first,
+      reload,
+    });
+    const second = recoverFromChunkLoadError(
+      new TypeError("Failed to fetch dynamically imported module"),
+      {
+        storage,
+        now: () => first + CHUNK_RELOAD_COOLDOWN_MS,
+        reload,
+      },
+    );
+
+    expect(second).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("installChunkLoadRecoveryHandlers", () => {
+  test("recovers from unhandledrejection chunk errors", () => {
+    const listeners = new Map<string, EventListener>();
+    const target = {
+      addEventListener: (type: string, listener: EventListener) => {
+        listeners.set(type, listener);
+      },
+      removeEventListener: (type: string) => {
+        listeners.delete(type);
+      },
+    };
+    const reload = vi.fn();
+    const dispose = installChunkLoadRecoveryHandlers(target as unknown as Window, {
+      storage: memoryStorage(),
+      reload,
+      now: () => 10,
+    });
+
+    const event = {
+      reason: new TypeError("Failed to fetch dynamically imported module"),
+      preventDefault: vi.fn(),
+    };
+    listeners.get("unhandledrejection")?.(event as unknown as Event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    dispose();
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/pages/__tests__/preloadablePage.test.tsx
+++ b/pages/__tests__/preloadablePage.test.tsx
@@ -1,0 +1,59 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { preloadablePage } from "../preloadablePage";
+import * as recovery from "../chunkLoadRecovery";
+
+describe("preloadablePage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("loads the page module and renders it", async () => {
+    const { Page, preload } = preloadablePage(async () => ({
+      default: () => <div>loaded-page</div>,
+    }));
+
+    await act(async () => {
+      await preload();
+    });
+
+    render(
+      <Suspense fallback={<div>loading</div>}>
+        <Page />
+      </Suspense>,
+    );
+
+    expect(screen.getByText("loaded-page")).toBeInTheDocument();
+  });
+
+  test("clears a failed load so a later preload can retry", async () => {
+    const recover = vi.spyOn(recovery, "recoverFromChunkLoadError").mockReturnValue(false);
+    let attempts = 0;
+    const { Page, preload } = preloadablePage(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new TypeError("Failed to fetch dynamically imported module");
+      }
+      return { default: () => <div>recovered-page</div> };
+    });
+
+    await expect(preload()).rejects.toThrow(/dynamically imported module/);
+    expect(recover).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await preload();
+    });
+
+    render(
+      <Suspense fallback={<div>loading</div>}>
+        <Page />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("recovered-page")).toBeInTheDocument();
+    });
+    expect(attempts).toBe(2);
+  });
+});

--- a/pages/chunkLoadRecovery.ts
+++ b/pages/chunkLoadRecovery.ts
@@ -1,0 +1,140 @@
+/**
+ * Deploy switches replace hashed SPA chunks under a new release symlink.
+ * Tabs still running the previous shell then fail dynamic import() with 404.
+ * Recover once via hard reload so the browser picks up the new manage.html.
+ */
+
+export const CHUNK_RELOAD_STORAGE_KEY = "code-proxy-chunk-reload";
+
+/** Ignore a second automatic reload within this window (prevents loops). */
+export const CHUNK_RELOAD_COOLDOWN_MS = 15_000;
+
+const CHUNK_ERROR_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /error loading dynamically imported module/i,
+  /Loading chunk [\w-]+ failed/i,
+  /ChunkLoadError/i,
+  /Unable to preload CSS/i,
+];
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (error == null) return false;
+
+  if (typeof error === "string") {
+    return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(error));
+  }
+
+  if (typeof error !== "object") return false;
+
+  const candidate = error as {
+    name?: unknown;
+    message?: unknown;
+    stack?: unknown;
+  };
+  const name = typeof candidate.name === "string" ? candidate.name : "";
+  const message = typeof candidate.message === "string" ? candidate.message : "";
+  const stack = typeof candidate.stack === "string" ? candidate.stack : "";
+  const haystack = `${name}\n${message}\n${stack}`;
+
+  if (name === "ChunkLoadError") return true;
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(haystack));
+}
+
+function readReloadMarker(storage: Storage): number | null {
+  try {
+    const raw = storage.getItem(CHUNK_RELOAD_STORAGE_KEY);
+    if (!raw) return null;
+    const ts = Number(raw);
+    return Number.isFinite(ts) ? ts : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeReloadMarker(storage: Storage, now: number): void {
+  try {
+    storage.setItem(CHUNK_RELOAD_STORAGE_KEY, String(now));
+  } catch {
+    // private mode / quota — still attempt reload without persistence
+  }
+}
+
+export type ChunkReloadController = {
+  storage?: Storage | null;
+  now?: () => number;
+  reload?: () => void;
+  cooldownMs?: number;
+};
+
+/**
+ * If `error` looks like a stale-chunk failure, hard-reload once.
+ * Returns true when a reload was triggered (caller should stop UI work).
+ */
+export function recoverFromChunkLoadError(
+  error: unknown,
+  controller: ChunkReloadController = {},
+): boolean {
+  if (!isChunkLoadError(error)) return false;
+
+  const storage =
+    controller.storage === undefined
+      ? typeof sessionStorage !== "undefined"
+        ? sessionStorage
+        : null
+      : controller.storage;
+  const now = controller.now?.() ?? Date.now();
+  const cooldownMs = controller.cooldownMs ?? CHUNK_RELOAD_COOLDOWN_MS;
+  const reload =
+    controller.reload ??
+    (() => {
+      if (typeof window !== "undefined") {
+        window.location.reload();
+      }
+    });
+
+  if (storage) {
+    const previous = readReloadMarker(storage);
+    if (previous != null && now - previous < cooldownMs) {
+      return false;
+    }
+    writeReloadMarker(storage, now);
+  }
+
+  reload();
+  return true;
+}
+
+/** Install once at app entry so unhandled dynamic-import rejections also recover. */
+export function installChunkLoadRecoveryHandlers(
+  target: Pick<Window, "addEventListener" | "removeEventListener"> = typeof window !==
+  "undefined"
+    ? window
+    : (undefined as never),
+  controller: ChunkReloadController = {},
+): () => void {
+  if (!target?.addEventListener) return () => undefined;
+
+  const onRejection = (event: Event) => {
+    const reason = (event as PromiseRejectionEvent).reason;
+    if (!isChunkLoadError(reason)) return;
+    if (typeof (event as PromiseRejectionEvent).preventDefault === "function") {
+      (event as PromiseRejectionEvent).preventDefault();
+    }
+    recoverFromChunkLoadError(reason, controller);
+  };
+
+  const onError = (event: Event) => {
+    const message = (event as ErrorEvent).message;
+    const error = (event as ErrorEvent).error ?? message;
+    if (!isChunkLoadError(error) && !isChunkLoadError(message)) return;
+    recoverFromChunkLoadError(error ?? message, controller);
+  };
+
+  target.addEventListener("unhandledrejection", onRejection);
+  target.addEventListener("error", onError);
+  return () => {
+    target.removeEventListener("unhandledrejection", onRejection);
+    target.removeEventListener("error", onError);
+  };
+}

--- a/pages/preloadablePage.tsx
+++ b/pages/preloadablePage.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, ReactElement } from "react";
+import { recoverFromChunkLoadError } from "./chunkLoadRecovery";
 
 type PageModule = {
   default: ComponentType;
@@ -12,10 +13,21 @@ export function preloadablePage(load: () => Promise<PageModule>): {
   let loadingPromise: Promise<PageModule> | null = null;
 
   const preload = () => {
-    loadingPromise ??= load().then((module) => {
-      loadedModule = module;
-      return module;
-    });
+    if (!loadingPromise) {
+      loadingPromise = load()
+        .then((module) => {
+          loadedModule = module;
+          return module;
+        })
+        .catch((error: unknown) => {
+          // Allow a later navigation or render to retry after deploy settles.
+          loadingPromise = null;
+          // Best-effort recovery when the shell is still mounted with a stale
+          // import map (new release removed the hashed chunk this tab expects).
+          recoverFromChunkLoadError(error);
+          throw error;
+        });
+    }
     return loadingPromise;
   };
 


### PR DESCRIPTION
## Summary
- Detect post-deploy lazy chunk / dynamic import failures (404 on hashed assets after release symlink switch).
- Hard-reload once per session cooldown so the browser picks up the new `manage.html` entry map.
- Stop swallowing preload errors on sidebar navigation; add `ChunkLoadErrorBoundary` instead of a permanent white screen.
- Refresh `bundle-baseline` for the modest `index` gzip growth from the recovery path.

## Test plan
- [x] `bun run lint`
- [x] `bun run design:check`
- [x] targeted vitest: chunk recovery, preloadablePage, AppShell, AppRouter
- [x] full `test:ci` (696 passed before final type fix; recovery tests re-verified after)
- [x] `bun run build`
- [x] `bun run bundle:diff` (baseline updated)

## Notes
No server-side / nginx changes. Frontend-only recovery for open tabs after Deploy Frontend.