### PR TITLE
fix(data-table): keep column reorder grip off header labels

### DIFF
--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -342,17 +342,10 @@ test("Request Logs: centers every header except ID over its column content", asy
   const channelLabel = channelHeader.locator(
     "[data-vt-column-header-content] > span > span",
   );
-  const centerBeforeHover = await channelLabel.evaluate((element) => {
-    const rect = element.getBoundingClientRect();
-    return rect.left + rect.width / 2;
-  });
-
-  await channelHeader.hover();
-  await expect(
-    channelHeader.locator("[data-vt-column-reorder-handle]"),
-  ).toHaveCSS("opacity", "1");
-
-  const hoverState = await channelLabel.evaluate((element) => {
+  const channelHandle = channelHeader.locator(
+    "[data-vt-column-reorder-handle]",
+  );
+  const beforeHover = await channelLabel.evaluate((element) => {
     const rect = element.getBoundingClientRect();
     const content = element.closest<HTMLElement>(
       "[data-vt-column-header-content]",
@@ -360,10 +353,46 @@ test("Request Logs: centers every header except ID over its column content", asy
     return {
       center: rect.left + rect.width / 2,
       paddingLeft: content ? getComputedStyle(content).paddingLeft : null,
+      paddingRight: content ? getComputedStyle(content).paddingRight : null,
     };
   });
-  expect(hoverState.paddingLeft).toBe("0px");
-  expect(Math.abs(hoverState.center - centerBeforeHover)).toBeLessThanOrEqual(
+  // Reorderable headers always reserve grip gutters (no hover-only padding shift).
+  expect(beforeHover.paddingLeft).toBe("20px");
+  expect(beforeHover.paddingRight).toBe("20px");
+
+  await channelHeader.hover();
+  await expect(channelHandle).toHaveCSS("opacity", "1");
+
+  const hoverState = await page.evaluate(() => {
+    const header = document.querySelector<HTMLElement>(
+      'th[data-vt-column-key="channelName"]',
+    );
+    const label = header?.querySelector<HTMLElement>(
+      "[data-vt-column-header-content] > span > span",
+    );
+    const handle = header?.querySelector<HTMLElement>(
+      "[data-vt-column-reorder-handle]",
+    );
+    const content = header?.querySelector<HTMLElement>(
+      "[data-vt-column-header-content]",
+    );
+    if (!label || !handle || !content) {
+      throw new Error("Missing channel header label/handle for overlap check");
+    }
+    const labelRect = label.getBoundingClientRect();
+    const handleRect = handle.getBoundingClientRect();
+    return {
+      center: labelRect.left + labelRect.width / 2,
+      paddingLeft: getComputedStyle(content).paddingLeft,
+      paddingRight: getComputedStyle(content).paddingRight,
+      // Positive means handle ends left of label start (no horizontal overlap).
+      gap: labelRect.left - handleRect.right,
+    };
+  });
+  expect(hoverState.paddingLeft).toBe("20px");
+  expect(hoverState.paddingRight).toBe("20px");
+  expect(hoverState.gap).toBeGreaterThanOrEqual(0);
+  expect(Math.abs(hoverState.center - beforeHover.center)).toBeLessThanOrEqual(
     1,
   );
 });

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -3299,7 +3299,7 @@ export function DataTable<T>({
                             activeResizeColumnKey !== null
                               ? "pointer-events-none"
                               : activeReorderColumnKey === col.key
-                                ? "pointer-events-none"
+                                ? "pointer-events-none opacity-100"
                                 : "group-hover/column:opacity-100"
                           }`}
                           onPointerDown={(event) =>
@@ -3312,9 +3312,12 @@ export function DataTable<T>({
                           </span>
                         </button>
                       ) : null}
+                      {/* Always reserve handle-width gutters when reorderable so the absolute grip never covers the label; keep L/R symmetric so centered headers do not shift on hover. */}
                       <div
                         data-vt-column-header-content
-                        className="min-w-0 max-w-full overflow-hidden"
+                        className={`min-w-0 max-w-full overflow-hidden ${
+                          canReorder ? "px-5" : ""
+                        }`}
                       >
                         {isRowReorderColumn ? (
                           <span className="flex items-center justify-center text-slate-400/70 dark:text-white/35">

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -170,6 +170,43 @@ describe("DataTable sorting and row reordering", () => {
   });
 });
 
+describe("DataTable column reorder handle layout", () => {
+  test("reserves symmetric gutters so the grip never covers the header label", () => {
+    render(
+      <DataTable
+        tableId="column-reorder-overlap"
+        rows={initialRows}
+        columns={plainColumns}
+        rowKey={(row) => row.id}
+        naturalFlow
+        height="h-auto"
+        minHeight="min-h-0"
+        minWidth="min-w-[320px]"
+        showAllLoadedMessage={false}
+      />,
+    );
+
+    const header = document.querySelector<HTMLElement>(
+      'th[data-vt-column-key="name"]',
+    );
+    const content = header?.querySelector<HTMLElement>(
+      "[data-vt-column-header-content]",
+    );
+    const handle = header?.querySelector<HTMLElement>(
+      "[data-vt-column-reorder-handle]",
+    );
+    expect(header).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(handle).not.toBeNull();
+    expect(content).toHaveClass("px-5");
+    expect(content).not.toHaveClass(
+      "group-hover/column:pl-5",
+      "group-focus-within/column:pl-5",
+    );
+    expect(handle).toHaveClass("absolute", "left-1");
+  });
+});
+
 describe("DataTable scroll chrome and row dividers", () => {
   test("keeps header cells attached and forwards boundary wheel scrolling to the parent", () => {
     render(


### PR DESCRIPTION
## Summary
- 可拖拽列表头始终预留对称 `px-5` gutter，避免绝对定位的拖拽手柄盖住列名（如审计日志「干了啥」）。
- 不再使用 hover-only padding，hover 时列名位置保持稳定；居中列表头中心线不偏移。
- 补充 unit / e2e 回归：固定 gutter + 手柄与文字无重叠。

## Test plan
- [x] `./scripts/ci-pr.sh`（含 lint、design:check、test:ci、build、bundle:diff、critical e2e）
- [x] `bun run --filter @code-proxy/admin-panel test packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx`
- [ ] 管理端审计日志表 hover「干了啥」列，确认手柄与列名不重叠