### PR TITLE
fix(i18n): formal Chinese label for audit action column

### DIFF
--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4322,7 +4322,7 @@
     "time": "时间",
     "actor": "操作人",
     "action": "动作",
-    "what_happened": "干了啥",
+    "what_happened": "操作内容",
     "result_success": "成功",
     "result_failed": "失败",
     "request_id": "请求 ID",


### PR DESCRIPTION
## Summary
- Replace colloquial audit column label 干了啥 with 操作内容 in zh-CN.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e critical)
- [ ] After deploy: open `/manage/governance/audit-logs` in zh-CN and confirm column/detail label is 操作内容