### PR TITLE
feat(apikey-lookup): sticky tabs with animated header collapse

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -276,6 +276,33 @@ export function ApiKeyLookupPage() {
     return () => mq.removeEventListener("change", handler);
   }, []);
 
+  // 向上滚动内容时顶栏自然收起，给 sticky tabs 让出视口；回到顶部附近再展开。
+  const [headerCollapsed, setHeaderCollapsed] = useState(false);
+  useEffect(() => {
+    const HIDE_AFTER = 28;
+    const SHOW_BELOW = 12;
+    let frame = 0;
+    const syncHeader = () => {
+      frame = 0;
+      const y = window.scrollY || document.documentElement.scrollTop || 0;
+      setHeaderCollapsed((prev) => {
+        if (y > HIDE_AFTER) return true;
+        if (y < SHOW_BELOW) return false;
+        return prev;
+      });
+    };
+    const onScroll = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(syncHeader);
+    };
+    syncHeader();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, []);
+
   const initialLookupKey = useMemo(
     () => readLegacyLookupKeyFromUrl() || readStoredLookupKey(),
     [],
@@ -902,8 +929,19 @@ export function ApiKeyLookupPage() {
 
   return (
     <div className="relative min-h-dvh bg-gradient-to-br from-slate-50 via-white to-slate-100 pt-14 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
-      {/* Header */}
-      <header className="fixed inset-x-0 top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70">
+      {/* Header：滚动后上滑淡出，给 sticky tabs 让位 */}
+      <header
+        data-testid="apikey-lookup-header"
+        data-collapsed={headerCollapsed ? "true" : "false"}
+        aria-hidden={headerCollapsed || undefined}
+        className={[
+          "fixed inset-x-0 top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70",
+          "motion-safe:transition-[transform,opacity,border-color] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+          headerCollapsed
+            ? "pointer-events-none -translate-y-full border-transparent opacity-0"
+            : "translate-y-0 opacity-100",
+        ].join(" ")}
+      >
         <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-4 sm:px-6">
           <div className="flex items-center gap-2.5">
             <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-slate-900 shadow-sm dark:bg-white">

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -525,4 +525,48 @@ describe("ApiKeyLookupPage", () => {
       pending.some((request) => request.days === 30 && request.signal?.aborted),
     ).toBe(true);
   });
+
+  test("pins results toolbar with sticky top offset and collapses header on scroll", async () => {
+    window.sessionStorage.setItem(
+      "apiKeyLookup.lastApiKey.v1",
+      "sk-restored-key",
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const toolbar = await screen.findByTestId("apikey-lookup-toolbar-sticky");
+    expect(toolbar.className).toMatch(/(?:^|\s)sticky(?:\s|$)/);
+    expect(toolbar.className).toMatch(/(?:^|\s)top-3(?:\s|$)/);
+
+    const header = screen.getByTestId("apikey-lookup-header");
+    expect(header).toHaveAttribute("data-collapsed", "false");
+
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 80,
+    });
+    window.dispatchEvent(new Event("scroll"));
+
+    await waitFor(() => {
+      expect(header).toHaveAttribute("data-collapsed", "true");
+    });
+    expect(header.className).toMatch(/-translate-y-full/);
+    expect(header.className).toMatch(/opacity-0/);
+
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 0,
+    });
+    window.dispatchEvent(new Event("scroll"));
+
+    await waitFor(() => {
+      expect(header).toHaveAttribute("data-collapsed", "false");
+    });
+  });
 });

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -27,35 +27,45 @@ export function LookupResultsToolbar({
   modelsLoading: boolean;
 }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3">
-      <div className="flex flex-wrap items-center gap-3">
-        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
-          <TabsList>
-            <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
-            <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
-            <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
-            <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
-          </TabsList>
-        </Tabs>
-        {activeTab === "usage" || activeTab === "logs" ? (
-          <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-        ) : null}
-      </div>
-      <div className="flex items-center gap-2">
-        <HoverTooltip content={t("common.refresh")}>
-          <button
-            type="button"
-            onClick={handleRefresh}
-            disabled={loading || chartLoading || modelsLoading}
-            aria-label={t("common.refresh")}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
+    // sticky 与窗口顶留 12px 间距；与 header 消失联动，避免叠在固定顶栏上。
+    // 不要在祖先加 overflow-x-hidden，否则会切断 sticky。
+    <div
+      data-testid="apikey-lookup-toolbar-sticky"
+      className="sticky top-3 z-20 -mx-1 rounded-2xl bg-white/80 px-1 py-1.5 backdrop-blur-md dark:bg-neutral-950/70"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => setActiveTab(value as typeof activeTab)}
           >
-            <RefreshCw
-              size={16}
-              className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
-            />
-          </button>
-        </HoverTooltip>
+            <TabsList>
+              <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
+              <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
+              <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
+              <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {activeTab === "usage" || activeTab === "logs" ? (
+            <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <HoverTooltip content={t("common.refresh")}>
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={loading || chartLoading || modelsLoading}
+              aria-label={t("common.refresh")}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
+            >
+              <RefreshCw
+                size={16}
+                className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
+              />
+            </button>
+          </HoverTooltip>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Scroll collapses the fixed API key lookup header with transform/opacity motion so it leaves the viewport naturally.
- Pins the results toolbar (tabs, time range, refresh) with `sticky top-3` so controls stay reachable with a gap from the window top.
- Adds unit coverage for sticky classes and header collapse/expand on scroll.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, full test:ci, build, bundle:diff, critical e2e)
- [x] `ApiKeyLookupPage` unit tests including sticky/header collapse case
- [ ] Manual: open `/manage/apikey-lookup`, scroll down and confirm header fades out and toolbar sticks with top gap; scroll back to top and header returns