### PR TITLE
fix(data-table): show EmptyState and collapse empty table layout

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -84,7 +84,8 @@
     "reorder_row": "Drag to reorder row {{index}}",
     "sort_column": "Sort {{column}}",
     "sort_ascending": "Ascending",
-    "sort_descending": "Descending"
+    "sort_descending": "Descending",
+    "no_data": "No data"
   },
   "title": {
     "main": "Code Proxy Admin Dashboard",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -64,7 +64,8 @@
     "reorder_row": "Перетащите, чтобы изменить порядок строки {{index}}",
     "sort_column": "Сортировать {{column}}",
     "sort_ascending": "По возрастанию",
-    "sort_descending": "По убыванию"
+    "sort_descending": "По убыванию",
+    "no_data": "Нет данных"
   },
   "ccswitch": {
     "import_to_ccswitch": "Импорт в CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -86,7 +86,8 @@
     "reorder_row": "拖拽调整第 {{index}} 行位置",
     "sort_column": "排序 {{column}}",
     "sort_ascending": "升序",
-    "sort_descending": "降序"
+    "sort_descending": "降序",
+    "no_data": "暂无数据"
   },
   "title": {
     "main": "Code Proxy 管理后台",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -17,6 +17,7 @@ import {
   Check,
   GripVertical,
 } from "lucide-react";
+import { EmptyState } from "../feedback/EmptyState";
 import { DropdownMenu } from "../primitives/DropdownMenu";
 import { TableCellOverflowTooltip } from "./TableCellOverflowTooltip";
 
@@ -1025,6 +1026,9 @@ export function DataTable<T>({
   minHeight = "min-h-[360px]",
   caption = "data table",
   emptyText = "",
+  emptyDescription,
+  emptyIcon,
+  emptyAction,
   showAllLoadedMessage = true,
   rowDividers = false,
   rowClassName,
@@ -3024,24 +3028,39 @@ export function DataTable<T>({
     [endIndex, rows, startIndex, virtualize],
   );
 
+  // isEmpty is defined once and reused below so empty tables skip sticky rails
+  // and horizontal scrollbar chrome that only make sense with wide data rows.
+  const isEmpty = !loading && rows.length === 0;
   const { vThumb, hThumb } = useMemo(() => {
-    return calculateScrollbarThumbs(scrollMetrics, headerHeight);
-  }, [headerHeight, scrollMetrics]);
+    const thumbs = calculateScrollbarThumbs(scrollMetrics, headerHeight);
+    // Empty tables force overflow-x hidden; suppress the horizontal thumb so
+    // sticky rail insets and bottom chrome stay zeroed.
+    return isEmpty ? { vThumb: thumbs.vThumb, hThumb: null } : thumbs;
+  }, [headerHeight, isEmpty, scrollMetrics]);
   const stickyStartRailWidth = useMemo(
-    () => resolveStickyRailWidth(orderedColumns, columnWidths, "start"),
-    [columnWidths, orderedColumns],
+    () =>
+      isEmpty
+        ? 0
+        : resolveStickyRailWidth(orderedColumns, columnWidths, "start"),
+    [columnWidths, isEmpty, orderedColumns],
   );
   const stickyEndRailWidth = useMemo(
-    () => resolveStickyRailWidth(orderedColumns, columnWidths, "end"),
-    [columnWidths, orderedColumns],
+    () =>
+      isEmpty
+        ? 0
+        : resolveStickyRailWidth(orderedColumns, columnWidths, "end"),
+    [columnWidths, isEmpty, orderedColumns],
   );
   stickyRailWidthsRef.current = {
     start: stickyStartRailWidth,
     end: stickyEndRailWidth,
   };
   const stickyColumnPlacements = useMemo(
-    () => resolveStickyColumnPlacements(orderedColumns, columnWidths),
-    [columnWidths, orderedColumns],
+    (): Record<string, StickyColumnPlacement> =>
+      isEmpty
+        ? {}
+        : resolveStickyColumnPlacements(orderedColumns, columnWidths),
+    [columnWidths, isEmpty, orderedColumns],
   );
   const stickyRailBottomInset = hThumb ? 14 : 0;
   const stickyRailTop = headerHeight;
@@ -3071,15 +3090,21 @@ export function DataTable<T>({
     scrollMetrics.clientWidth - stickyEndRailWidth,
   );
 
+  // Empty tables should not inherit the wide minWidth / fixed column widths
+  // that data rows need; otherwise the empty body scrolls horizontally for
+  // no content. Keep headers for context, but collapse to the viewport width.
+  const tableMinWidthClass = isEmpty ? "min-w-0" : minWidth;
+
   const resolveColumnStyle = useCallback(
     (
       column: DataTableColumn<T>,
       area: "header" | "cell" = "cell",
     ): DataTableColumnStyle => {
-      const width = columnWidths[column.key];
-      const placement = naturalFlow
-        ? undefined
-        : stickyColumnPlacements[column.key];
+      const width = isEmpty ? undefined : columnWidths[column.key];
+      const placement =
+        naturalFlow || isEmpty
+          ? undefined
+          : stickyColumnPlacements[column.key];
       const style: DataTableColumnStyle = {};
 
       if (width) {
@@ -3100,7 +3125,7 @@ export function DataTable<T>({
 
       return style;
     },
-    [columnWidths, naturalFlow, stickyColumnPlacements],
+    [columnWidths, isEmpty, naturalFlow, stickyColumnPlacements],
   );
 
   const resizePreviewOverlay =
@@ -3182,7 +3207,11 @@ export function DataTable<T>({
         className={
           naturalFlow
             ? "relative z-10 min-h-0 overflow-visible rounded-xl"
-            : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overflow-auto overscroll-x-none ${
+            : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none ${
+                isEmpty
+                  ? "overflow-x-hidden overflow-y-auto"
+                  : "overflow-auto"
+              } ${
                 allowWheelPropagationAtBoundary
                   ? "overscroll-y-auto"
                   : "overscroll-y-none"
@@ -3207,7 +3236,8 @@ export function DataTable<T>({
           ) : null}
           <table
             ref={tableRef}
-            className={`relative w-full ${minWidth} table-fixed border-separate border-spacing-0 text-sm`}
+            className={`relative w-full ${tableMinWidthClass} table-fixed border-separate border-spacing-0 text-sm`}
+            data-vt-empty={isEmpty ? true : undefined}
           >
             <caption className="sr-only">{caption}</caption>
             <colgroup>
@@ -3244,12 +3274,14 @@ export function DataTable<T>({
                     activeResizeColumnKey === col.key;
                   const isSettledReorderColumn =
                     settledReorderColumnKey === col.key;
-                  const stickyPlacement = naturalFlow
-                    ? undefined
-                    : stickyColumnPlacements[col.key];
-                  const headerPositionClass = naturalFlow
-                    ? "relative"
-                    : "sticky top-0 z-50";
+                  const stickyPlacement =
+                    naturalFlow || isEmpty
+                      ? undefined
+                      : stickyColumnPlacements[col.key];
+                  const headerPositionClass =
+                    naturalFlow || isEmpty
+                      ? "relative"
+                      : "sticky top-0 z-50";
                   const headerChromeClass = "bg-slate-100 dark:bg-neutral-800";
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
@@ -3285,7 +3317,9 @@ export function DataTable<T>({
                         stickyPlacement?.edge === "end"
                           ? "md:right-[var(--vt-sticky-right)]"
                           : ""
-                      } ${headerChromeClass} ${headerCornerClass} ${col.width ?? ""} ${col.headerClassName ?? ""} ${
+                      } ${headerChromeClass} ${headerCornerClass} ${
+                        isEmpty ? "" : (col.width ?? "")
+                      } ${col.headerClassName ?? ""} ${
                         activeReorderColumnKey === col.key
                           ? "cursor-grabbing bg-slate-100 text-slate-700 shadow-[inset_2px_0_0_rgba(37,99,235,0.42),inset_-2px_0_0_rgba(14,165,233,0.28)] dark:bg-neutral-800 dark:text-white/80"
                           : ""
@@ -3468,13 +3502,26 @@ export function DataTable<T>({
                     </tr>
                   ))}
                 </>
-              ) : !loading && rows.length === 0 ? (
-                <tr>
+              ) : isEmpty ? (
+                <tr data-vt-empty-row className="h-full">
                   <td
                     colSpan={colCount}
-                    className="px-4 py-12 text-center text-sm text-slate-600 dark:text-white/70"
+                    className="h-full px-4 py-8 align-middle sm:px-6 sm:py-10"
                   >
-                    {emptyText}
+                    {/*
+                      Fill the remaining table viewport so EmptyState sits in the
+                      middle of the blank body, not stuck under the header.
+                    */}
+                    <div className="flex min-h-[min(22rem,calc(100dvh-26rem))] w-full items-center justify-center">
+                      <div className="mx-auto w-full max-w-2xl">
+                        <EmptyState
+                          title={emptyText || t("common.no_data")}
+                          description={emptyDescription}
+                          icon={emptyIcon}
+                          action={emptyAction}
+                        />
+                      </div>
+                    </div>
                   </td>
                 </tr>
               ) : (

--- a/packages/ui/src/data-table/DataTable.types.ts
+++ b/packages/ui/src/data-table/DataTable.types.ts
@@ -96,8 +96,14 @@ export interface DataTableProps<T> {
   minHeight?: string;
   /** Screen-reader caption */
   caption?: string;
-  /** Empty state message */
+  /** Empty state title shown via the shared EmptyState component */
   emptyText?: string;
+  /** Optional empty state description under the title */
+  emptyDescription?: string;
+  /** Optional empty state icon */
+  emptyIcon?: ReactNode;
+  /** Optional empty state action slot (button, link, etc.) */
+  emptyAction?: ReactNode;
   /** Show the "all records loaded" footer when there is no next page. */
   showAllLoadedMessage?: boolean;
   /** Show a straight divider between data rows. */

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -207,6 +207,69 @@ describe("DataTable column reorder handle layout", () => {
   });
 });
 
+describe("DataTable empty state", () => {
+  test("renders EmptyState and collapses min-width so empty tables do not scroll sideways", () => {
+    const wideColumns: DataTableColumn<TestRow>[] = [
+      {
+        key: "id",
+        label: "ID",
+        width: "w-[320px] min-w-[320px]",
+        render: (row) => row.id,
+      },
+      {
+        key: "name",
+        label: "Name",
+        width: "w-[480px] min-w-[480px]",
+        render: (row) => row.name,
+      },
+      {
+        key: "extra",
+        label: "Extra",
+        width: "w-[640px] min-w-[640px]",
+        render: () => "extra",
+      },
+    ];
+
+    render(
+      <DataTable
+        tableId="empty-state-table"
+        rows={[]}
+        columns={wideColumns}
+        rowKey={(row) => row.id}
+        height="h-[240px]"
+        minHeight="min-h-[240px]"
+        minWidth="min-w-[1800px]"
+        emptyText="No request logs"
+        emptyDescription="Try a different filter range"
+        showAllLoadedMessage={false}
+      />,
+    );
+
+    const table = document.querySelector<HTMLTableElement>("table[data-vt-empty='true']");
+    const viewport = document.querySelector<HTMLElement>(
+      "[data-scrollbar-visibility='hover']",
+    );
+    const emptyRow = document.querySelector<HTMLTableRowElement>(
+      "tr[data-vt-empty-row]",
+    );
+
+    expect(table).not.toBeNull();
+    expect(table).toHaveClass("min-w-0");
+    expect(table).not.toHaveClass("min-w-[1800px]");
+    expect(viewport).toHaveClass("overflow-x-hidden");
+    expect(emptyRow).not.toBeNull();
+    expect(screen.getByText("No request logs")).toBeInTheDocument();
+    expect(screen.getByText("Try a different filter range")).toBeInTheDocument();
+
+    const firstHeader = document.querySelector<HTMLElement>(
+      'th[data-vt-column-key="id"]',
+    );
+    expect(firstHeader).not.toBeNull();
+    expect(firstHeader?.className).not.toMatch(/min-w-\[320px\]/);
+    expect(firstHeader).not.toHaveClass("sticky");
+  });
+});
+
 describe("DataTable scroll chrome and row dividers", () => {
   test("keeps header cells attached and forwards boundary wheel scrolling to the parent", () => {
     render(


### PR DESCRIPTION
## Summary
- Empty `DataTable` rows now render the shared `EmptyState` instead of plain centered text.
- When there is no data, table min-width collapses and horizontal overflow is hidden so request-logs no longer shows a blank body with a sideways scrollbar.
- Adds optional `emptyDescription` / `emptyIcon` / `emptyAction` props and i18n `common.no_data` fallbacks (en / zh-CN / ru).
- Covers the empty path in `DataTable.interactions` tests.

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, test:ci, build, bundle:diff, critical e2e)
- [ ] Visually confirm request-logs empty state: centered EmptyState, no horizontal scroll