### PR TITLE
fix(ui): polish EmptyState with default icon well

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2670,7 +2670,8 @@
     "clear_status_filter": "Clear status filter",
     "cache_rate": "Cache Token Ratio",
     "auth_type_api": "API",
-    "auth_type_oauth": "OAuth"
+    "auth_type_oauth": "OAuth",
+    "no_data_desc": "No request logs match the current filters. Try another range or clear filters."
   },
   "ccswitch": {
     "import_to_ccswitch": "Import to CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2965,7 +2965,8 @@
     "clear_channel_filter": "清空渠道筛选",
     "clear_status_filter": "清空状态筛选",
     "auth_type_api": "API",
-    "auth_type_oauth": "OAuth"
+    "auth_type_oauth": "OAuth",
+    "no_data_desc": "当前筛选条件下没有请求记录，可调整时间范围或筛选条件后重试。"
   },
   "ccswitch": {
     "import_to_ccswitch": "导入到 CC Switch",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -3513,7 +3513,8 @@ export function DataTable<T>({
                       middle of the blank body, not stuck under the header.
                     */}
                     <div className="flex min-h-[min(22rem,calc(100dvh-26rem))] w-full items-center justify-center">
-                      <div className="mx-auto w-full max-w-2xl">
+                      {/* Keep empty card compact so it reads as a centerpiece, not a stretched dashed bar. */}
+                      <div className="mx-auto w-full max-w-sm sm:max-w-md">
                         <EmptyState
                           title={emptyText || t("common.no_data")}
                           description={emptyDescription}

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -260,6 +260,8 @@ describe("DataTable empty state", () => {
     expect(emptyRow).not.toBeNull();
     expect(screen.getByText("No request logs")).toBeInTheDocument();
     expect(screen.getByText("Try a different filter range")).toBeInTheDocument();
+    // Default EmptyState icon well (Inbox) when emptyIcon is omitted.
+    expect(document.querySelector("[data-empty-icon]")).not.toBeNull();
 
     const firstHeader = document.querySelector<HTMLElement>(
       'th[data-vt-column-key="id"]',

--- a/packages/ui/src/feedback/EmptyState.tsx
+++ b/packages/ui/src/feedback/EmptyState.tsx
@@ -1,5 +1,13 @@
 import type { ReactNode } from "react";
+import { Inbox } from "lucide-react";
 
+/**
+ * Shared empty / no-data surface used by DataTable and page-level cards.
+ *
+ * - `icon` omitted → soft Inbox glyph in a rounded well (default empty look)
+ * - `icon={null}` → no icon (rare; prefer the default)
+ * - `icon={<MyIcon />}` → custom glyph, still framed by the same well
+ */
 export function EmptyState({
   title = "",
   description,
@@ -8,23 +16,44 @@ export function EmptyState({
 }: {
   title?: string;
   description?: string;
-  icon?: ReactNode;
+  /** Custom icon node. Omit for the default Inbox; pass `null` to hide. */
+  icon?: ReactNode | null;
   action?: ReactNode;
 }) {
+  const showIcon = icon !== null;
+  const resolvedIcon =
+    icon === undefined ? (
+      <Inbox
+        size={28}
+        strokeWidth={1.6}
+        className="text-slate-500 dark:text-white/70"
+        aria-hidden
+      />
+    ) : (
+      icon
+    );
+
   return (
-    <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 px-6 py-10 text-center shadow-sm dark:border-neutral-800 dark:bg-neutral-950/40">
-      {icon ? (
-        <div className="mx-auto mb-3 flex justify-center text-slate-500 dark:text-white/55">
-          {icon}
+    <div className="rounded-2xl border border-dashed border-slate-200/90 bg-gradient-to-b from-slate-50/90 to-white/80 px-6 py-12 text-center shadow-sm dark:border-neutral-800 dark:from-neutral-950/50 dark:to-neutral-950/30">
+      {showIcon && resolvedIcon ? (
+        <div
+          className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-white shadow-sm ring-1 ring-inset ring-slate-200/90 dark:bg-white/[0.06] dark:ring-white/10"
+          data-empty-icon
+        >
+          <div className="flex items-center justify-center text-slate-500 dark:text-white/70 [&>svg]:h-7 [&>svg]:w-7">
+            {resolvedIcon}
+          </div>
         </div>
       ) : null}
-      <p className="text-sm font-semibold text-slate-900 dark:text-white">{title}</p>
+      <p className="text-sm font-semibold tracking-tight text-slate-900 dark:text-white">
+        {title}
+      </p>
       {description ? (
-        <p className="mx-auto mt-2 max-w-[42rem] text-sm text-slate-600 dark:text-white/65">
+        <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-slate-500 dark:text-white/60">
           {description}
         </p>
       ) : null}
-      {action ? <div className="mt-4 flex justify-center">{action}</div> : null}
+      {action ? <div className="mt-5 flex justify-center">{action}</div> : null}
     </div>
   );
 }

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -659,6 +659,8 @@ export function RequestLogsPage() {
             minHeight="min-h-full"
             caption={t("request_logs.table_caption")}
             emptyText={t("request_logs.no_data")}
+            emptyDescription={t("request_logs.no_data_desc")}
+            emptyIcon={<ScrollText size={28} strokeWidth={1.6} aria-hidden />}
             showAllLoadedMessage={false}
           />
 


### PR DESCRIPTION
## Summary
- EmptyState now defaults to an Inbox glyph inside a soft icon well instead of a bare dashed box with title-only text.
- DataTable empty cards use a tighter max-width so the empty surface reads as a centerpiece.
- Request logs pass ScrollText + a short empty description (zh-CN / en).

## Test plan
- [x] `./scripts/ci-pr.sh` (install, lint, design:check, test:ci, build, bundle:diff, critical e2e)
- [ ] Visually confirm request-logs empty: icon well + title + description, compact card