### PR TITLE
fix(ui): quiet EmptyState to match admin shell density

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2671,7 +2671,7 @@
     "cache_rate": "Cache Token Ratio",
     "auth_type_api": "API",
     "auth_type_oauth": "OAuth",
-    "no_data_desc": "No request logs match the current filters. Try another range or clear filters."
+    "no_data_desc": "Try another range or clear filters."
   },
   "ccswitch": {
     "import_to_ccswitch": "Import to CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2966,7 +2966,7 @@
     "clear_status_filter": "清空状态筛选",
     "auth_type_api": "API",
     "auth_type_oauth": "OAuth",
-    "no_data_desc": "当前筛选条件下没有请求记录，可调整时间范围或筛选条件后重试。"
+    "no_data_desc": "调整时间范围或筛选条件后再试"
   },
   "ccswitch": {
     "import_to_ccswitch": "导入到 CC Switch",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -3512,16 +3512,13 @@ export function DataTable<T>({
                       Fill the remaining table viewport so EmptyState sits in the
                       middle of the blank body, not stuck under the header.
                     */}
-                    <div className="flex min-h-[min(22rem,calc(100dvh-26rem))] w-full items-center justify-center">
-                      {/* Keep empty card compact so it reads as a centerpiece, not a stretched dashed bar. */}
-                      <div className="mx-auto w-full max-w-sm sm:max-w-md">
-                        <EmptyState
-                          title={emptyText || t("common.no_data")}
-                          description={emptyDescription}
-                          icon={emptyIcon}
-                          action={emptyAction}
-                        />
-                      </div>
+                    <div className="flex min-h-[min(18rem,calc(100dvh-28rem))] w-full items-center justify-center">
+                      <EmptyState
+                        title={emptyText || t("common.no_data")}
+                        description={emptyDescription}
+                        icon={emptyIcon}
+                        action={emptyAction}
+                      />
                     </div>
                   </td>
                 </tr>

--- a/packages/ui/src/feedback/EmptyState.tsx
+++ b/packages/ui/src/feedback/EmptyState.tsx
@@ -2,11 +2,14 @@ import type { ReactNode } from "react";
 import { Inbox } from "lucide-react";
 
 /**
- * Shared empty / no-data surface used by DataTable and page-level cards.
+ * Quiet empty / no-data surface used by DataTable and page-level cards.
  *
- * - `icon` omitted → soft Inbox glyph in a rounded well (default empty look)
- * - `icon={null}` → no icon (rare; prefer the default)
- * - `icon={<MyIcon />}` → custom glyph, still framed by the same well
+ * Matches the admin shell: soft slate hierarchy, no dashed card chrome,
+ * no floating icon tile. Reads as inline feedback inside an existing panel.
+ *
+ * - `icon` omitted → default Inbox glyph
+ * - `icon={null}` → no icon
+ * - `icon={<MyIcon />}` → custom glyph at the same muted weight
  */
 export function EmptyState({
   title = "",
@@ -23,37 +26,31 @@ export function EmptyState({
   const showIcon = icon !== null;
   const resolvedIcon =
     icon === undefined ? (
-      <Inbox
-        size={28}
-        strokeWidth={1.6}
-        className="text-slate-500 dark:text-white/70"
-        aria-hidden
-      />
+      <Inbox size={22} strokeWidth={1.5} aria-hidden />
     ) : (
       icon
     );
 
   return (
-    <div className="rounded-2xl border border-dashed border-slate-200/90 bg-gradient-to-b from-slate-50/90 to-white/80 px-6 py-12 text-center shadow-sm dark:border-neutral-800 dark:from-neutral-950/50 dark:to-neutral-950/30">
+    <div
+      className="flex flex-col items-center justify-center px-4 py-8 text-center sm:px-6 sm:py-10"
+      data-empty-state
+    >
       {showIcon && resolvedIcon ? (
         <div
-          className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-white shadow-sm ring-1 ring-inset ring-slate-200/90 dark:bg-white/[0.06] dark:ring-white/10"
+          className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-slate-100/90 text-slate-400 dark:bg-white/[0.06] dark:text-white/40 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:stroke-[1.5]"
           data-empty-icon
         >
-          <div className="flex items-center justify-center text-slate-500 dark:text-white/70 [&>svg]:h-7 [&>svg]:w-7">
-            {resolvedIcon}
-          </div>
+          {resolvedIcon}
         </div>
       ) : null}
-      <p className="text-sm font-semibold tracking-tight text-slate-900 dark:text-white">
-        {title}
-      </p>
+      <p className="text-sm font-medium text-slate-600 dark:text-white/70">{title}</p>
       {description ? (
-        <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-slate-500 dark:text-white/60">
+        <p className="mx-auto mt-1.5 max-w-[18rem] text-xs leading-relaxed text-slate-400 dark:text-white/40">
           {description}
         </p>
       ) : null}
-      {action ? <div className="mt-5 flex justify-center">{action}</div> : null}
+      {action ? <div className="mt-4 flex justify-center">{action}</div> : null}
     </div>
   );
 }

--- a/pages/api-key-lookup/components/LookupEmptyState.tsx
+++ b/pages/api-key-lookup/components/LookupEmptyState.tsx
@@ -1,4 +1,5 @@
 import { Search } from "lucide-react";
+import { EmptyState } from "@code-proxy/ui";
 
 export function LookupEmptyState({
   t,
@@ -6,16 +7,12 @@ export function LookupEmptyState({
   t: (key: string, options?: Record<string, unknown>) => string;
 }) {
   return (
-    <section className="rounded-2xl border border-dashed border-slate-200 bg-white px-6 py-10 text-center shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60 sm:p-16">
-      <div className="mx-auto flex max-w-sm flex-col items-center gap-4">
-        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 dark:bg-white/10">
-          <Search size={28} className="text-slate-600 dark:text-white/70" />
-        </div>
-        <h3 className="text-base font-semibold text-slate-900 dark:text-white">
-          {t("apikey_lookup.empty_title")}
-        </h3>
-        <p className="text-sm text-slate-600 dark:text-white/65">{t("apikey_lookup.empty_desc")}</p>
-      </div>
+    <section className="rounded-2xl border border-slate-200/80 bg-white/70 px-4 py-6 dark:border-neutral-800 dark:bg-neutral-950/40 sm:px-6 sm:py-10">
+      <EmptyState
+        title={t("apikey_lookup.empty_title")}
+        description={t("apikey_lookup.empty_desc")}
+        icon={<Search size={20} strokeWidth={1.5} aria-hidden />}
+      />
     </section>
   );
 }

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -660,7 +660,7 @@ export function RequestLogsPage() {
             caption={t("request_logs.table_caption")}
             emptyText={t("request_logs.no_data")}
             emptyDescription={t("request_logs.no_data_desc")}
-            emptyIcon={<ScrollText size={28} strokeWidth={1.6} aria-hidden />}
+            emptyIcon={<ScrollText size={20} strokeWidth={1.5} aria-hidden />}
             showAllLoadedMessage={false}
           />
 


### PR DESCRIPTION
## Summary
- Strip EmptyState of dashed borders, gradient fill, shadow, and the large floating icon tile that read as a second card inside tables.
- Quiet inline empty: soft circular glyph, medium title, compact caption in the existing slate hierarchy.
- Request-logs empty copy shortened; LookupEmptyState reuses the shared EmptyState.

## Test plan
- [x] `./scripts/ci-pr.sh`
- [ ] Visually confirm request-logs empty sits quietly in the table body (no dashed box)