### PR TITLE
fix(apikey-lookup): show toolbar border when sticky is stuck

### DIFF
--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -92,6 +92,22 @@ describe("ApiKeyLookupPage", () => {
     window.sessionStorage.clear();
     window.history.replaceState({}, "", "/manage/apikey-lookup");
     vi.clearAllMocks();
+    // jsdom 无 IntersectionObserver；默认 stub，避免 toolbar sticky 监听挂载崩溃。
+    if (typeof window.IntersectionObserver === "undefined") {
+      window.IntersectionObserver = class MockIntersectionObserver
+        implements IntersectionObserver
+      {
+        readonly root: Element | Document | null = null;
+        readonly rootMargin = "";
+        readonly thresholds: ReadonlyArray<number> = [];
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+        takeRecords(): IntersectionObserverEntry[] {
+          return [];
+        }
+      };
+    }
   });
 
   test("opens the API key login modal when no key is stored", async () => {
@@ -527,46 +543,101 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("pins results toolbar with sticky top offset and collapses header on scroll", async () => {
+    const io = {
+      callback: null as IntersectionObserverCallback | null,
+    };
+    const OriginalIO = window.IntersectionObserver;
+    window.IntersectionObserver = class MockIntersectionObserver
+      implements IntersectionObserver
+    {
+      readonly root: Element | Document | null = null;
+      readonly rootMargin = "";
+      readonly thresholds: ReadonlyArray<number> = [];
+      constructor(callback: IntersectionObserverCallback) {
+        io.callback = callback;
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    };
+
+    const emitIo = (isIntersecting: boolean) => {
+      const callback = io.callback;
+      if (!callback) {
+        throw new Error("IntersectionObserver callback was not registered");
+      }
+      callback(
+        [
+          {
+            isIntersecting,
+            intersectionRatio: isIntersecting ? 1 : 0,
+          } as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    };
+
     window.sessionStorage.setItem(
       "apiKeyLookup.lastApiKey.v1",
       "sk-restored-key",
     );
 
-    render(
-      <ThemeProvider>
-        <ToastProvider>
-          <ApiKeyLookupPage />
-        </ToastProvider>
-      </ThemeProvider>,
-    );
+    try {
+      render(
+        <ThemeProvider>
+          <ToastProvider>
+            <ApiKeyLookupPage />
+          </ToastProvider>
+        </ThemeProvider>,
+      );
 
-    const toolbar = await screen.findByTestId("apikey-lookup-toolbar-sticky");
-    expect(toolbar.className).toMatch(/(?:^|\s)sticky(?:\s|$)/);
-    expect(toolbar.className).toMatch(/(?:^|\s)top-3(?:\s|$)/);
+      const toolbar = await screen.findByTestId("apikey-lookup-toolbar-sticky");
+      expect(toolbar.className).toMatch(/(?:^|\s)sticky(?:\s|$)/);
+      expect(toolbar.className).toMatch(/(?:^|\s)top-3(?:\s|$)/);
+      expect(toolbar).toHaveAttribute("data-stuck", "false");
+      expect(toolbar.className).toMatch(/border-transparent/);
 
-    const header = screen.getByTestId("apikey-lookup-header");
-    expect(header).toHaveAttribute("data-collapsed", "false");
-
-    Object.defineProperty(window, "scrollY", {
-      configurable: true,
-      value: 80,
-    });
-    window.dispatchEvent(new Event("scroll"));
-
-    await waitFor(() => {
-      expect(header).toHaveAttribute("data-collapsed", "true");
-    });
-    expect(header.className).toMatch(/-translate-y-full/);
-    expect(header.className).toMatch(/opacity-0/);
-
-    Object.defineProperty(window, "scrollY", {
-      configurable: true,
-      value: 0,
-    });
-    window.dispatchEvent(new Event("scroll"));
-
-    await waitFor(() => {
+      const header = screen.getByTestId("apikey-lookup-header");
       expect(header).toHaveAttribute("data-collapsed", "false");
-    });
+
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 80,
+      });
+      window.dispatchEvent(new Event("scroll"));
+
+      await waitFor(() => {
+        expect(header).toHaveAttribute("data-collapsed", "true");
+      });
+      expect(header.className).toMatch(/-translate-y-full/);
+      expect(header.className).toMatch(/opacity-0/);
+
+      // sentinel 离开视口 = 吸顶，toolbar 应出现 border 描边
+      emitIo(false);
+
+      await waitFor(() => {
+        expect(toolbar).toHaveAttribute("data-stuck", "true");
+      });
+      expect(toolbar.className).toMatch(/border-slate-200/);
+      expect(toolbar.className).not.toMatch(/border-transparent/);
+
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 0,
+      });
+      window.dispatchEvent(new Event("scroll"));
+      emitIo(true);
+
+      await waitFor(() => {
+        expect(header).toHaveAttribute("data-collapsed", "false");
+        expect(toolbar).toHaveAttribute("data-stuck", "false");
+      });
+      expect(toolbar.className).toMatch(/border-transparent/);
+    } finally {
+      window.IntersectionObserver = OriginalIO;
+    }
   });
 });

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -1,9 +1,13 @@
+import { useEffect, useRef, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { HoverTooltip, Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { TimeRangeSelector } from "@features/monitor-widgets";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 
 export type ApiKeyLookupTab = "usage" | "logs" | "models" | "quickImport";
+
+/** sticky top-3 = 0.75rem，与 IntersectionObserver rootMargin 对齐 */
+const STICKY_TOP_OFFSET_PX = 12;
 
 export function LookupResultsToolbar({
   t,
@@ -26,45 +30,83 @@ export function LookupResultsToolbar({
   chartLoading: boolean;
   modelsLoading: boolean;
 }) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [stuck, setStuck] = useState(false);
+
+  // sentinel 滚过 sticky 偏移后 toolbar 真正吸顶，再淡入 border / 阴影，避免未吸顶时多一层框。
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry) return;
+        setStuck(!entry.isIntersecting);
+      },
+      {
+        root: null,
+        rootMargin: `-${STICKY_TOP_OFFSET_PX}px 0px 0px 0px`,
+        threshold: 0,
+      },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    // sticky 与窗口顶留 12px 间距；与 header 消失联动，避免叠在固定顶栏上。
-    // 不要在祖先加 overflow-x-hidden，否则会切断 sticky。
-    <div
-      data-testid="apikey-lookup-toolbar-sticky"
-      className="sticky top-3 z-20 -mx-1 rounded-2xl bg-white/80 px-1 py-1.5 backdrop-blur-md dark:bg-neutral-950/70"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <Tabs
-            value={activeTab}
-            onValueChange={(value) => setActiveTab(value as typeof activeTab)}
-          >
-            <TabsList>
-              <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
-              <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
-              <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
-              <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          {activeTab === "usage" || activeTab === "logs" ? (
-            <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-          ) : null}
-        </div>
-        <div className="flex items-center gap-2">
-          <HoverTooltip content={t("common.refresh")}>
-            <button
-              type="button"
-              onClick={handleRefresh}
-              disabled={loading || chartLoading || modelsLoading}
-              aria-label={t("common.refresh")}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
+    // 单层包裹，避免 main 的 space-y 把 sentinel 与 sticky 拆开。
+    <div className="relative">
+      <div
+        ref={sentinelRef}
+        className="pointer-events-none absolute inset-x-0 -top-px h-px"
+        aria-hidden="true"
+        data-testid="apikey-lookup-toolbar-sentinel"
+      />
+      {/* sticky 与窗口顶留 12px；吸顶后出现边框。不要在祖先加 overflow-x-hidden。 */}
+      <div
+        data-testid="apikey-lookup-toolbar-sticky"
+        data-stuck={stuck ? "true" : "false"}
+        className={[
+          "sticky top-3 z-20 -mx-1 rounded-2xl px-1.5 py-1.5 backdrop-blur-md",
+          "motion-safe:transition-[border-color,box-shadow,background-color] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+          stuck
+            ? "border border-slate-200/80 bg-white/90 shadow-sm shadow-slate-900/5 dark:border-white/10 dark:bg-neutral-950/85 dark:shadow-black/25"
+            : "border border-transparent bg-white/80 dark:bg-neutral-950/70",
+        ].join(" ")}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) => setActiveTab(value as typeof activeTab)}
             >
-              <RefreshCw
-                size={16}
-                className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
-              />
-            </button>
-          </HoverTooltip>
+              <TabsList>
+                <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
+                <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
+                <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
+                <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {activeTab === "usage" || activeTab === "logs" ? (
+              <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            <HoverTooltip content={t("common.refresh")}>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                disabled={loading || chartLoading || modelsLoading}
+                aria-label={t("common.refresh")}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
+              >
+                <RefreshCw
+                  size={16}
+                  className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
+                />
+              </button>
+            </HoverTooltip>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Detect when the results toolbar is actually stuck via a sentinel + IntersectionObserver.
- Animate in border, soft shadow, and a slightly stronger surface only while pinned; transparent border when free-scrolling.
- Cover stuck/unstuck border classes in unit tests (jsdom IntersectionObserver stub).

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] ApiKeyLookupPage unit tests including `data-stuck` border toggle
- [ ] Manual: scroll `/manage/apikey-lookup` until tabs pin; confirm a light border appears around the toolbar bar and fades out near the top