### PR TITLE
fix(apikey-lookup): restore sticky by removing short relative wrapper

### DIFF
--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -92,22 +92,6 @@ describe("ApiKeyLookupPage", () => {
     window.sessionStorage.clear();
     window.history.replaceState({}, "", "/manage/apikey-lookup");
     vi.clearAllMocks();
-    // jsdom 无 IntersectionObserver；默认 stub，避免 toolbar sticky 监听挂载崩溃。
-    if (typeof window.IntersectionObserver === "undefined") {
-      window.IntersectionObserver = class MockIntersectionObserver
-        implements IntersectionObserver
-      {
-        readonly root: Element | Document | null = null;
-        readonly rootMargin = "";
-        readonly thresholds: ReadonlyArray<number> = [];
-        observe(): void {}
-        unobserve(): void {}
-        disconnect(): void {}
-        takeRecords(): IntersectionObserverEntry[] {
-          return [];
-        }
-      };
-    }
   });
 
   test("opens the API key login modal when no key is stored", async () => {
@@ -543,41 +527,25 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("pins results toolbar with sticky top offset and collapses header on scroll", async () => {
-    const io = {
-      callback: null as IntersectionObserverCallback | null,
-    };
-    const OriginalIO = window.IntersectionObserver;
-    window.IntersectionObserver = class MockIntersectionObserver
-      implements IntersectionObserver
-    {
-      readonly root: Element | Document | null = null;
-      readonly rootMargin = "";
-      readonly thresholds: ReadonlyArray<number> = [];
-      constructor(callback: IntersectionObserverCallback) {
-        io.callback = callback;
+    let toolbarTop = 120;
+    const originalGetBoundingClientRect =
+      Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      const el = this as HTMLElement;
+      if (el.dataset?.testid === "apikey-lookup-toolbar-sticky") {
+        return {
+          x: 0,
+          y: toolbarTop,
+          top: toolbarTop,
+          left: 0,
+          right: 800,
+          bottom: toolbarTop + 48,
+          width: 800,
+          height: 48,
+          toJSON: () => ({}),
+        } as DOMRect;
       }
-      observe(): void {}
-      unobserve(): void {}
-      disconnect(): void {}
-      takeRecords(): IntersectionObserverEntry[] {
-        return [];
-      }
-    };
-
-    const emitIo = (isIntersecting: boolean) => {
-      const callback = io.callback;
-      if (!callback) {
-        throw new Error("IntersectionObserver callback was not registered");
-      }
-      callback(
-        [
-          {
-            isIntersecting,
-            intersectionRatio: isIntersecting ? 1 : 0,
-          } as IntersectionObserverEntry,
-        ],
-        {} as IntersectionObserver,
-      );
+      return originalGetBoundingClientRect.call(this);
     };
 
     window.sessionStorage.setItem(
@@ -597,6 +565,8 @@ describe("ApiKeyLookupPage", () => {
       const toolbar = await screen.findByTestId("apikey-lookup-toolbar-sticky");
       expect(toolbar.className).toMatch(/(?:^|\s)sticky(?:\s|$)/);
       expect(toolbar.className).toMatch(/(?:^|\s)top-3(?:\s|$)/);
+      // sticky 必须是自身节点，不能再包一层短 relative 切断包含块。
+      expect(toolbar.parentElement?.tagName.toLowerCase()).toBe("main");
       expect(toolbar).toHaveAttribute("data-stuck", "false");
       expect(toolbar.className).toMatch(/border-transparent/);
 
@@ -607,20 +577,15 @@ describe("ApiKeyLookupPage", () => {
         configurable: true,
         value: 80,
       });
+      toolbarTop = 12;
       window.dispatchEvent(new Event("scroll"));
 
       await waitFor(() => {
         expect(header).toHaveAttribute("data-collapsed", "true");
+        expect(toolbar).toHaveAttribute("data-stuck", "true");
       });
       expect(header.className).toMatch(/-translate-y-full/);
       expect(header.className).toMatch(/opacity-0/);
-
-      // sentinel 离开视口 = 吸顶，toolbar 应出现 border 描边
-      emitIo(false);
-
-      await waitFor(() => {
-        expect(toolbar).toHaveAttribute("data-stuck", "true");
-      });
       expect(toolbar.className).toMatch(/border-slate-200/);
       expect(toolbar.className).not.toMatch(/border-transparent/);
 
@@ -628,8 +593,8 @@ describe("ApiKeyLookupPage", () => {
         configurable: true,
         value: 0,
       });
+      toolbarTop = 120;
       window.dispatchEvent(new Event("scroll"));
-      emitIo(true);
 
       await waitFor(() => {
         expect(header).toHaveAttribute("data-collapsed", "false");
@@ -637,7 +602,7 @@ describe("ApiKeyLookupPage", () => {
       });
       expect(toolbar.className).toMatch(/border-transparent/);
     } finally {
-      window.IntersectionObserver = OriginalIO;
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
     }
   });
 });

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -6,8 +6,10 @@ import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 
 export type ApiKeyLookupTab = "usage" | "logs" | "models" | "quickImport";
 
-/** sticky top-3 = 0.75rem，与 IntersectionObserver rootMargin 对齐 */
+/** sticky top-3 = 0.75rem */
 const STICKY_TOP_OFFSET_PX = 12;
+/** 亚像素容差，避免临界抖动 */
+const STUCK_EPSILON_PX = 1;
 
 export function LookupResultsToolbar({
   t,
@@ -30,83 +32,84 @@ export function LookupResultsToolbar({
   chartLoading: boolean;
   modelsLoading: boolean;
 }) {
-  const sentinelRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
   const [stuck, setStuck] = useState(false);
 
-  // sentinel 滚过 sticky 偏移后 toolbar 真正吸顶，再淡入 border / 阴影，避免未吸顶时多一层框。
+  // 不要再用短 relative 包裹 sticky：sticky 只能在「包含块」高度内钉住，
+  // 外层高度≈自身时，一滚就会整段被带走，表现为「没吸顶、飘走」。
+  // stuck 用元素自身 getBoundingClientRect 判断，避免 sentinel 再引入包裹层。
   useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || typeof IntersectionObserver === "undefined") return;
+    const el = toolbarRef.current;
+    if (!el) return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry) return;
-        setStuck(!entry.isIntersecting);
-      },
-      {
-        root: null,
-        rootMargin: `-${STICKY_TOP_OFFSET_PX}px 0px 0px 0px`,
-        threshold: 0,
-      },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
+    let frame = 0;
+    const syncStuck = () => {
+      frame = 0;
+      const top = el.getBoundingClientRect().top;
+      const next = top <= STICKY_TOP_OFFSET_PX + STUCK_EPSILON_PX;
+      setStuck((prev) => (prev === next ? prev : next));
+    };
+    const onScrollOrResize = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(syncStuck);
+    };
+
+    syncStuck();
+    window.addEventListener("scroll", onScrollOrResize, { passive: true });
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize);
+      window.removeEventListener("resize", onScrollOrResize);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
   }, []);
 
   return (
-    // 单层包裹，避免 main 的 space-y 把 sentinel 与 sticky 拆开。
-    <div className="relative">
-      <div
-        ref={sentinelRef}
-        className="pointer-events-none absolute inset-x-0 -top-px h-px"
-        aria-hidden="true"
-        data-testid="apikey-lookup-toolbar-sentinel"
-      />
-      {/* sticky 与窗口顶留 12px；吸顶后出现边框。不要在祖先加 overflow-x-hidden。 */}
-      <div
-        data-testid="apikey-lookup-toolbar-sticky"
-        data-stuck={stuck ? "true" : "false"}
-        className={[
-          "sticky top-3 z-20 -mx-1 rounded-2xl px-1.5 py-1.5 backdrop-blur-md",
-          "motion-safe:transition-[border-color,box-shadow,background-color] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
-          stuck
-            ? "border border-slate-200/80 bg-white/90 shadow-sm shadow-slate-900/5 dark:border-white/10 dark:bg-neutral-950/85 dark:shadow-black/25"
-            : "border border-transparent bg-white/80 dark:bg-neutral-950/70",
-        ].join(" ")}
-      >
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap items-center gap-3">
-            <Tabs
-              value={activeTab}
-              onValueChange={(value) => setActiveTab(value as typeof activeTab)}
+    // sticky 直接作为 main 子节点；不要在祖先加 overflow-x-hidden。
+    <div
+      ref={toolbarRef}
+      data-testid="apikey-lookup-toolbar-sticky"
+      data-stuck={stuck ? "true" : "false"}
+      className={[
+        "sticky top-3 z-20 -mx-1 rounded-2xl px-1.5 py-1.5 backdrop-blur-md",
+        "motion-safe:transition-[border-color,box-shadow,background-color] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+        stuck
+          ? "border border-slate-200/80 bg-white/90 shadow-sm shadow-slate-900/5 dark:border-white/10 dark:bg-neutral-950/85 dark:shadow-black/25"
+          : "border border-transparent bg-white/80 dark:bg-neutral-950/70",
+      ].join(" ")}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Tabs
+            value={activeTab}
+            onValueChange={(value) => setActiveTab(value as typeof activeTab)}
+          >
+            <TabsList>
+              <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
+              <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
+              <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
+              <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {activeTab === "usage" || activeTab === "logs" ? (
+            <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <HoverTooltip content={t("common.refresh")}>
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={loading || chartLoading || modelsLoading}
+              aria-label={t("common.refresh")}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
             >
-              <TabsList>
-                <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
-                <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
-                <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
-                <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
-              </TabsList>
-            </Tabs>
-            {activeTab === "usage" || activeTab === "logs" ? (
-              <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
-            ) : null}
-          </div>
-          <div className="flex items-center gap-2">
-            <HoverTooltip content={t("common.refresh")}>
-              <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={loading || chartLoading || modelsLoading}
-                aria-label={t("common.refresh")}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
-              >
-                <RefreshCw
-                  size={16}
-                  className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
-                />
-              </button>
-            </HoverTooltip>
-          </div>
+              <RefreshCw
+                size={16}
+                className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
+              />
+            </button>
+          </HoverTooltip>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Root cause: sticky lived inside a short `relative` wrapper (height ≈ toolbar), so sticky only pinned within that box and scrolled away with the page.
- Make the sticky element itself a direct `main` child; detect stuck state with `getBoundingClientRect` for the border/shadow transition.
- Unit test asserts sticky is a `main` child and border appears when top reaches the sticky offset.

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] ApiKeyLookupPage sticky/header collapse unit test
- [ ] Manual: hard-refresh `/manage/apikey-lookup`, scroll down; tabs should stay under the top with a small gap and border, not float away with content