### PR TITLE
fix(auth-files): scope UI filter cache by tenant

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -49,6 +49,7 @@ export type OAuthDialogTab =
 export const AUTH_FILES_PAGE_SIZE = 9;
 export const MAX_AUTH_FILE_SIZE = 50 * 1024;
 
+/** Tenant-scoped auth-files UI filters (file group / status / search / page). */
 export const AUTH_FILES_UI_STATE_KEY = "authFilesPage.uiState.v3";
 /** Tenant-scoped auth-files list/quota cache (v3). Legacy v2 is read only for migration. */
 export const AUTH_FILES_DATA_CACHE_KEY = "authFilesPage.dataCache.v3";
@@ -336,25 +337,65 @@ const sanitizeAuthFileRestrictionsForCache = (
   return restrictions.length > 0 ? restrictions : undefined;
 };
 
-export const readAuthFilesUiState = (): AuthFilesUiState | null => {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.localStorage.getItem(AUTH_FILES_UI_STATE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as AuthFilesUiState;
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
+const parseAuthFilesUiStateBucket = (value: unknown): AuthFilesUiState | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  // Reject tenant-store wrappers so only real UI-state objects are accepted.
+  if ("byTenant" in record && !("filter" in record) && !("tab" in record) && !("page" in record)) {
     return null;
   }
+  const output: AuthFilesUiState = {};
+  if (record.tab === "files" || record.tab === "excluded" || record.tab === "alias") {
+    output.tab = record.tab;
+  }
+  if (typeof record.filter === "string") output.filter = record.filter;
+  if (typeof record.tagFilter === "string") output.tagFilter = record.tagFilter;
+  if (
+    typeof record.statusFilter === "string" &&
+    AUTH_FILE_STATUS_FILTERS.includes(record.statusFilter as AuthFileStatusFilter)
+  ) {
+    output.statusFilter = record.statusFilter as AuthFileStatusFilter;
+  }
+  if (typeof record.search === "string") output.search = record.search;
+  if (typeof record.page === "number" && Number.isFinite(record.page)) {
+    output.page = Math.max(1, Math.round(record.page));
+  }
+  return output;
 };
 
-export const writeAuthFilesUiState = (state: AuthFilesUiState) => {
+/**
+ * Read auth-files UI filters for a tenant (file group, status, search, page).
+ * Prefer explicit tenantId; fall back to the active cache tenant from AuthProvider.
+ * Legacy unscoped v3 payloads migrate into the default tenant bucket on first write.
+ */
+export const readAuthFilesUiState = (
+  tenantId?: string | null,
+): AuthFilesUiState | null => {
+  if (typeof window === "undefined") return null;
+  const tenantKey = normalizeCacheTenantId(tenantId ?? getActiveCacheTenantId());
+  return readTenantBucket({
+    key: AUTH_FILES_UI_STATE_KEY,
+    tenantId: tenantKey,
+    parseBucket: parseAuthFilesUiStateBucket,
+    // v3 may still hold a single unscoped UI-state object mid-migration.
+    acceptUnscopedCurrent: true,
+  });
+};
+
+export const writeAuthFilesUiState = (
+  state: AuthFilesUiState,
+  tenantId?: string | null,
+) => {
   if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(AUTH_FILES_UI_STATE_KEY, JSON.stringify(state));
-  } catch {
-    // ignore
-  }
+  const tenantKey = normalizeCacheTenantId(tenantId ?? getActiveCacheTenantId());
+  const bucket = parseAuthFilesUiStateBucket(state) ?? {};
+  writeTenantBucket({
+    key: AUTH_FILES_UI_STATE_KEY,
+    tenantId: tenantKey,
+    parseBucket: parseAuthFilesUiStateBucket,
+    acceptUnscopedCurrent: true,
+    bucket,
+  });
 };
 
 const sanitizeModelOwnerGroupMap = (value: unknown): AuthFilesModelOwnerGroupMap => {

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -44,6 +44,7 @@ import {
 } from "@features/quota-preview/quota-fetch";
 import {
   AUTH_FILE_STATUS_FILTERS,
+  getActiveCacheTenantId,
   normalizeAuthIndexValue,
   normalizeProviderKey,
   normalizeQuotaAutoRefreshMs,
@@ -330,7 +331,9 @@ export function AuthFilesPage() {
   });
 
   useEffect(() => {
-    const state = readAuthFilesUiState();
+    // DashboardLayout remounts on tenant switch; pin to the active cache tenant
+    // so file-group / status / search / page never leak across tenants.
+    const state = readAuthFilesUiState(getActiveCacheTenantId());
     if (!state) return;
     if (typeof state.filter === "string") setFilter(state.filter);
     if (typeof state.tagFilter === "string") setTagFilter(state.tagFilter);
@@ -372,14 +375,17 @@ export function AuthFilesPage() {
   }, [canReadProxies]);
 
   useEffect(() => {
-    writeAuthFilesUiState({
-      tab: "files",
-      filter,
-      tagFilter,
-      statusFilter,
-      search,
-      page,
-    });
+    writeAuthFilesUiState(
+      {
+        tab: "files",
+        filter,
+        tagFilter,
+        statusFilter,
+        search,
+        page,
+      },
+      getActiveCacheTenantId(),
+    );
   }, [filter, page, search, statusFilter, tagFilter]);
 
   useEffect(() => {

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -14,11 +14,11 @@ import type {
 import {
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
-  AUTH_FILES_UI_STATE_KEY,
   DEFAULT_CACHE_TENANT_ID,
   setActiveCacheTenantId,
   setCacheTenantResolver,
   writeAuthFilesDataCache,
+  writeAuthFilesUiState,
 } from "@code-proxy/domain";
 import i18n from "@code-proxy/i18n";
 
@@ -1254,10 +1254,7 @@ describe("AuthFilesPage files table", () => {
       disabled: false,
     };
 
-    window.localStorage.setItem(
-      AUTH_FILES_UI_STATE_KEY,
-      JSON.stringify({ tab: "files", filter: "xai", search: "", page: 1 }),
-    );
+    writeAuthFilesUiState({ tab: "files", filter: "xai", search: "", page: 1 });
     mocks.list.mockImplementation(async () => ({ files: [xaiFile] }));
 
     render(
@@ -2440,10 +2437,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(10000));
-    window.localStorage.setItem(
-      AUTH_FILES_UI_STATE_KEY,
-      JSON.stringify({ tab: "files", filter: "codex", search: "", page: 1 }),
-    );
+    writeAuthFilesUiState({ tab: "files", filter: "codex", search: "", page: 1 });
     window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
@@ -2514,10 +2508,7 @@ describe("AuthFilesPage files table", () => {
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
-    window.localStorage.setItem(
-      AUTH_FILES_UI_STATE_KEY,
-      JSON.stringify({ tab: "files", filter: "qwen", search: "", page: 1 }),
-    );
+    writeAuthFilesUiState({ tab: "files", filter: "qwen", search: "", page: 1 });
     window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
@@ -3923,10 +3914,7 @@ describe("AuthFilesPage files table", () => {
     });
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.localStorage.setItem(
-      AUTH_FILES_UI_STATE_KEY,
-      JSON.stringify({ tab: "files", filter: "qwen", search: "", page: 1 }),
-    );
+    writeAuthFilesUiState({ tab: "files", filter: "qwen", search: "", page: 1 });
     window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({

--- a/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.oauth-dialog.test.tsx
@@ -6,7 +6,7 @@ import { ToastProvider } from "@code-proxy/ui";
 import { ThemeProvider } from "@code-proxy/ui";
 import { AuthFilesPage } from "@pages/auth-files/AuthFilesPage";
 import type { AuthFileItem } from "@code-proxy/api-client";
-import { AUTH_FILES_UI_STATE_KEY } from "@code-proxy/domain";
+import { writeAuthFilesUiState } from "@code-proxy/domain";
 import type {
   ProxyCheckResult,
   ProxyPoolEntry,
@@ -542,10 +542,7 @@ describe("AuthFilesPage OAuth login dialog", () => {
     const secondPoll = deferred<{ status: "ok" }>();
 
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
-    window.localStorage.setItem(
-      AUTH_FILES_UI_STATE_KEY,
-      JSON.stringify({ tab: "files", filter: "qwen", search: "qwen", page: 1 }),
-    );
+    writeAuthFilesUiState({ tab: "files", filter: "qwen", search: "qwen", page: 1 });
     mocks.list
       .mockResolvedValueOnce({ files: [initialFile] })
       .mockResolvedValue({ files: [initialFile, xaiFile] });

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -6,6 +6,7 @@ import {
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_UI_STATE_KEY,
   buildUsageIndex,
+  DEFAULT_CACHE_TENANT_ID,
   pickQuotaPreviewItem,
   readAuthFilesDataCache,
   readAuthFilesUiState,
@@ -21,6 +22,8 @@ import {
   resolveFileType,
   resolveAuthFileStats,
   sanitizeAuthFilesForCache,
+  setActiveCacheTenantId,
+  setCacheTenantResolver,
   shouldShowAuthFileDisplayTag,
   shouldShowAuthFilePlanBadge,
   writeAuthFilesDataCache,
@@ -68,6 +71,8 @@ describe("Auth Files helper coverage", () => {
   beforeEach(() => {
     window.localStorage.clear();
     window.sessionStorage.clear();
+    setCacheTenantResolver(null);
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
     mocks.getOauthExcludedModels.mockReset();
     mocks.getOauthModelAlias.mockReset();
     mocks.downloadText.mockReset();
@@ -88,6 +93,50 @@ describe("Auth Files helper coverage", () => {
   afterEach(() => {
     window.localStorage.clear();
     window.sessionStorage.clear();
+    setCacheTenantResolver(null);
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
+  });
+
+  test("keeps auth-files UI state isolated per tenant and migrates legacy unscoped payload", () => {
+    // Legacy unscoped v3 shape migrates into the default tenant only.
+    window.localStorage.setItem(
+      AUTH_FILES_UI_STATE_KEY,
+      JSON.stringify({ tab: "files", filter: "xai", search: "old", page: 2 }),
+    );
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
+    expect(readAuthFilesUiState()).toEqual({
+      tab: "files",
+      filter: "xai",
+      search: "old",
+      page: 2,
+    });
+    setActiveCacheTenantId("tenant-b");
+    expect(readAuthFilesUiState()).toBeNull();
+
+    writeAuthFilesUiState(
+      { tab: "files", filter: "codex", search: "tenant-a", page: 1 },
+      "tenant-a",
+    );
+    writeAuthFilesUiState(
+      { tab: "files", filter: "qwen", search: "tenant-b", page: 4 },
+      "tenant-b",
+    );
+    expect(readAuthFilesUiState("tenant-a")).toEqual({
+      tab: "files",
+      filter: "codex",
+      search: "tenant-a",
+      page: 1,
+    });
+    expect(readAuthFilesUiState("tenant-b")).toEqual({
+      tab: "files",
+      filter: "qwen",
+      search: "tenant-b",
+      page: 4,
+    });
+    // Writing for one tenant must not clobber the other bucket.
+    writeAuthFilesUiState({ filter: "gemini", page: 1 }, "tenant-a");
+    expect(readAuthFilesUiState("tenant-b")?.filter).toBe("qwen");
+    expect(readAuthFilesUiState("tenant-a")?.filter).toBe("gemini");
   });
 
   test("round-trips ui state and sanitized session cache", () => {
@@ -97,6 +146,7 @@ describe("Auth Files helper coverage", () => {
       search: "oauth",
       page: 3,
     });
+    expect(window.localStorage.getItem(AUTH_FILES_UI_STATE_KEY)).toContain('"byTenant"');
     expect(window.localStorage.getItem(AUTH_FILES_UI_STATE_KEY)).toContain('"filter":"codex"');
     expect(readAuthFilesUiState()).toEqual({
       tab: "files",


### PR DESCRIPTION
## Summary
- Persist auth-files UI filters (file group / status / tag / search / page) under tenant-scoped `byTenant` buckets, matching dataCache isolation.
- Legacy unscoped `authFilesPage.uiState.v3` migrates into the default tenant bucket only.
- Switching tenants no longer reuses another tenant's file-group selection.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e critical)
- [x] Unit: tenant isolation + legacy unscoped migration for `read/writeAuthFilesUiState`
- [x] Auth-files page tests (files-table / oauth-dialog / helpers)

## Local verification
```bash
./scripts/ci-pr.sh
```