### PR TITLE
fix(ui): honor text-center/right on DataTable header flex labels

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -623,8 +623,8 @@ export function RequestLogsTimeRangeSelector({
   );
 }
 
-const CENTERED_REQUEST_LOG_HEADER_CLASS =
-  "text-center [&_[data-vt-column-header-content]>span]:justify-center";
+// DataTable maps header text-center to flex justify-center on the label row.
+const CENTERED_REQUEST_LOG_HEADER_CLASS = "text-center";
 
 export function buildRequestLogsColumns(
   t: (key: string) => string,

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -317,6 +317,29 @@ function hasStickyColumnClass<T>(column: DataTableColumn<T>) {
     );
 }
 
+/**
+ * Map Tailwind text-align utilities on the header cell to flex justify on the
+ * header content row. `th` may carry `text-center` / `text-right`, but the label
+ * wrapper is `display: flex`, so text-align alone never centers/right-aligns it.
+ */
+function resolveHeaderContentJustifyClass(headerClassName?: string) {
+  let justifyClass = "";
+  for (const className of (headerClassName ?? "").split(/\s+/).filter(Boolean)) {
+    if (/(?:^|:)text-center$/.test(className)) {
+      justifyClass = "justify-center";
+      continue;
+    }
+    if (/(?:^|:)text-right$/.test(className)) {
+      justifyClass = "justify-end";
+      continue;
+    }
+    if (/(?:^|:)text-left$/.test(className)) {
+      justifyClass = "justify-start";
+    }
+  }
+  return justifyClass;
+}
+
 function resolveColumnLayoutWidth<T>(
   column: DataTableColumn<T>,
   widths: ColumnWidthMap,
@@ -3359,7 +3382,9 @@ export function DataTable<T>({
                             <span className="sr-only">{col.label}</span>
                           </span>
                         ) : (
-                          <span className="flex min-w-0 items-center gap-1.5">
+                          <span
+                            className={`flex min-w-0 items-center gap-1.5 ${resolveHeaderContentJustifyClass(col.headerClassName)}`}
+                          >
                             <span className="min-w-0 truncate">
                               {col.headerRender
                                 ? col.headerRender()

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -207,6 +207,55 @@ describe("DataTable column reorder handle layout", () => {
   });
 });
 
+describe("DataTable header text alignment", () => {
+  test("maps headerClassName text-align utilities onto the flex label row", () => {
+    const alignedColumns: DataTableColumn<TestRow>[] = [
+      {
+        key: "left",
+        label: "Left",
+        headerClassName: "text-left",
+        render: (row) => row.name,
+      },
+      {
+        key: "center",
+        label: "Center",
+        headerClassName: "text-center md:sticky",
+        render: (row) => row.name,
+      },
+      {
+        key: "right",
+        label: "Right",
+        headerClassName: "text-right",
+        render: (row) => row.name,
+      },
+    ];
+
+    render(
+      <DataTable
+        tableId="header-align-table"
+        rows={initialRows}
+        columns={alignedColumns}
+        rowKey={(row) => row.id}
+        naturalFlow
+        height="h-auto"
+        minHeight="min-h-0"
+        minWidth="min-w-[320px]"
+        showAllLoadedMessage={false}
+      />,
+    );
+
+    const labelRow = (key: string) =>
+      document
+        .querySelector<HTMLElement>(`th[data-vt-column-key="${key}"]`)
+        ?.querySelector<HTMLElement>("[data-vt-column-header-content] > span");
+
+    expect(labelRow("left")).toHaveClass("justify-start");
+    expect(labelRow("center")).toHaveClass("justify-center");
+    expect(labelRow("center")).not.toHaveClass("justify-start");
+    expect(labelRow("right")).toHaveClass("justify-end");
+  });
+});
+
 describe("DataTable empty state", () => {
   test("renders EmptyState and collapses min-width so empty tables do not scroll sideways", () => {
     const wideColumns: DataTableColumn<TestRow>[] = [


### PR DESCRIPTION
## Summary
- DataTable header labels use `display: flex`, so `text-center` / `text-right` on `th` never affected layout; sticky action columns looked left-biased.
- Map those text-align utilities onto the header flex row (`justify-center` / `justify-end` / `justify-start`).
- Drop the request-logs descendant-selector workaround now that DataTable handles this centrally.
- Add a unit test for the three alignment mappings.

## Test plan
- [x] `./scripts/ci-pr.sh` in worktree (lint, design:check, full test:ci, build, bundle:diff, critical e2e)
- [x] DataTable interactions test including new header alignment case
- [ ] Visual check: Models / API Keys sticky「操作」column — divider→label vs content→right edge spacing should match