### PR TITLE
fix(models): color model-test results and drop bare channel rows

### DIFF
--- a/packages/ui/src/overlays/Modal.tsx
+++ b/packages/ui/src/overlays/Modal.tsx
@@ -1,8 +1,17 @@
 import { createPortal } from "react-dom";
-import { useEffect, useId, useRef, useState, type PropsWithChildren, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
 import { X } from "lucide-react";
 
-const ANIMATION_MS = 180;
+/** Exit animation duration — keep content mounted until this finishes. */
+const ANIMATION_MS = 220;
+const EASE = "cubic-bezier(0.16, 1, 0.3, 1)";
 
 export function Modal({
   open,
@@ -38,6 +47,25 @@ export function Modal({
   const [visible, setVisible] = useState(open);
   const timeoutRef = useRef<number | null>(null);
   const titleId = useId();
+  // Snapshot title/description/footer/children while open so parents can clear
+  // props immediately without collapsing the panel mid-exit animation.
+  const contentRef = useRef({
+    title,
+    titleAccessory,
+    description,
+    footer,
+    children,
+  });
+  if (open) {
+    contentRef.current = {
+      title,
+      titleAccessory,
+      description,
+      footer,
+      children,
+    };
+  }
+  const snapshot = contentRef.current;
 
   useEffect(() => {
     if (open) {
@@ -46,8 +74,15 @@ export function Modal({
         timeoutRef.current = null;
       }
       setMounted(true);
-      const raf = window.requestAnimationFrame(() => setVisible(true));
-      return () => window.cancelAnimationFrame(raf);
+      // Double rAF ensures the browser paints the "hidden" frame before animating in.
+      let raf2 = 0;
+      const raf1 = window.requestAnimationFrame(() => {
+        raf2 = window.requestAnimationFrame(() => setVisible(true));
+      });
+      return () => {
+        window.cancelAnimationFrame(raf1);
+        if (raf2) window.cancelAnimationFrame(raf2);
+      };
     }
 
     setVisible(false);
@@ -82,6 +117,10 @@ export function Modal({
 
   const bodyHeightCls = bodyHeightClassName ?? "max-h-[70vh]";
   const bodyOverflowCls = bodyOverflowClassName ?? "overflow-y-auto";
+  const transitionStyle = {
+    transitionDuration: `${ANIMATION_MS}ms`,
+    transitionTimingFunction: EASE,
+  } as const;
 
   return createPortal(
     <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
@@ -92,9 +131,10 @@ export function Modal({
           onClose();
         }}
         aria-label="close"
+        style={transitionStyle}
         className={[
           "absolute inset-0 cursor-default bg-slate-900/40 backdrop-blur-sm dark:bg-black/50",
-          "transition-opacity duration-200 ease-out motion-reduce:transition-none",
+          "transition-opacity motion-reduce:transition-none",
           visible ? "opacity-100" : "opacity-0",
         ].join(" ")}
       />
@@ -102,12 +142,16 @@ export function Modal({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label={hideHeader ? title : undefined}
+        aria-label={hideHeader ? snapshot.title : undefined}
         aria-labelledby={hideHeader ? undefined : titleId}
+        style={transitionStyle}
         className={[
           `relative z-10 w-full ${maxWidth} overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-950`,
-          "transition-all duration-200 ease-out motion-reduce:transition-none",
-          visible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-95",
+          // Animate opacity + subtle rise only — avoid scale that makes height feel like it collapses.
+          "transition-[opacity,transform] will-change-transform motion-reduce:transition-none motion-reduce:transform-none",
+          visible
+            ? "opacity-100 translate-y-0"
+            : "opacity-0 translate-y-3",
           panelClassName,
         ].join(" ")}
       >
@@ -126,16 +170,18 @@ export function Modal({
             <div className="min-w-0">
               <h2 className="flex min-w-0 items-center gap-2 text-base font-semibold tracking-tight text-slate-900 dark:text-white">
                 <span id={titleId} className="min-w-0 truncate">
-                  {title}
+                  {snapshot.title}
                 </span>
-                {titleAccessory ? (
+                {snapshot.titleAccessory ? (
                   <span className="shrink-0" aria-hidden="true">
-                    {titleAccessory}
+                    {snapshot.titleAccessory}
                   </span>
                 ) : null}
               </h2>
-              {description ? (
-                <p className="mt-1 text-sm text-slate-600 dark:text-white/65">{description}</p>
+              {snapshot.description ? (
+                <p className="mt-1 text-sm text-slate-600 dark:text-white/65">
+                  {snapshot.description}
+                </p>
               ) : null}
             </div>
             <button
@@ -154,12 +200,12 @@ export function Modal({
           data-testid={bodyTestId}
           className={`${bodyHeightCls} ${bodyOverflowCls} overscroll-contain px-5 py-4 ${bodyClassName ?? ""}`}
         >
-          {children}
+          {snapshot.children}
         </div>
 
-        {footer ? (
+        {snapshot.footer ? (
           <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 px-5 py-4 dark:border-neutral-800">
-            {footer}
+            {snapshot.footer}
           </div>
         ) : null}
       </div>

--- a/pages/models/__tests__/ModelTestModal.test.tsx
+++ b/pages/models/__tests__/ModelTestModal.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { ThemeProvider } from "@code-proxy/ui";
+import {
+  buildChannelOptions,
+  isBareProviderOnlySource,
+  ModelTestModal,
+} from "../components/ModelTestModal";
+import type { ModelItem } from "../types";
+
+const baseModel: ModelItem = {
+  id: "grok-4.5",
+  owned_by: "xai",
+  description: "test",
+  enabled: true,
+  source: "oauth",
+  pricing: {
+    mode: "token",
+    inputPricePerMillion: 0,
+    outputPricePerMillion: 0,
+    cachedPricePerMillion: 0,
+    cacheReadPricePerMillion: 0,
+    cacheWritePricePerMillion: 0,
+    pricePerCall: 0,
+  },
+  inputModalities: ["text"],
+  outputModalities: ["text"],
+  supportsVision: false,
+  sources: [
+    {
+      label: "xai · GinofkFerraiuolo@hotmail.com",
+      provider: "xai",
+      channel: "GinofkFerraiuolo@hotmail.com",
+      clientId: "xai-1",
+    },
+    {
+      label: "xai · LatoriaqcDarr@hotmail.com",
+      provider: "xai",
+      channel: "LatoriaqcDarr@hotmail.com",
+      clientId: "xai-2",
+    },
+    {
+      // Incomplete auth: no email/label beyond provider name (the blank "xai" row).
+      label: "xai",
+      provider: "xai",
+      clientId: "xai-orphan",
+    },
+    {
+      label: "xai",
+      provider: "xai",
+      channel: "xai",
+      clientId: "xai-orphan-2",
+    },
+  ],
+};
+
+describe("buildChannelOptions / isBareProviderOnlySource", () => {
+  test("filters bare provider-only sources like orphan xai rows", () => {
+    expect(
+      isBareProviderOnlySource({ label: "xai", provider: "xai", clientId: "x" }),
+    ).toBe(true);
+    expect(
+      isBareProviderOnlySource({
+        label: "xai",
+        provider: "xai",
+        channel: "xai",
+      }),
+    ).toBe(true);
+    expect(
+      isBareProviderOnlySource({
+        label: "xai · user@example.com",
+        provider: "xai",
+        channel: "user@example.com",
+      }),
+    ).toBe(false);
+    expect(
+      isBareProviderOnlySource({
+        label: "openai · Primary OpenAI",
+        provider: "openai",
+        channel: "Primary OpenAI",
+      }),
+    ).toBe(false);
+
+    const options = buildChannelOptions(baseModel);
+    expect(options.map((o) => o.channel)).toEqual([
+      "GinofkFerraiuolo@hotmail.com",
+      "LatoriaqcDarr@hotmail.com",
+    ]);
+    expect(options.some((o) => o.label === "xai" || o.channel === "xai")).toBe(
+      false,
+    );
+  });
+
+  test("keeps bare provider source only when it is the sole option", () => {
+    const options = buildChannelOptions({
+      ...baseModel,
+      sources: [
+        { label: "xai", provider: "xai", channel: "xai", clientId: "orphan" },
+      ],
+    });
+    expect(options).toEqual([
+      { value: "xai", label: "xai", channel: "xai" },
+    ]);
+  });
+});
+
+describe("ModelTestModal", () => {
+  test("renders success response in green and hides bare channels", async () => {
+    await i18n.changeLanguage("en");
+    const onRun = vi.fn();
+    render(
+      <ThemeProvider>
+        <ModelTestModal
+          model={baseModel}
+          running={false}
+          resultText="I'll check the weather."
+          errorText={null}
+          onClose={() => undefined}
+          onRun={onRun}
+        />
+      </ThemeProvider>,
+    );
+
+    const success = screen.getByTestId("model-test-success");
+    expect(success).toHaveTextContent("I'll check the weather.");
+    expect(success.querySelector("pre")?.className).toMatch(/emerald/);
+
+    // Open channel select and ensure bare "xai" is not listed.
+    const channelTrigger = screen.getByLabelText(/channel/i);
+    await userEvent.click(channelTrigger);
+    await waitFor(() => {
+      expect(screen.queryByRole("option", { name: /^xai$/i })).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("option", { name: /GinofkFerraiuolo@hotmail.com/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders error response in red", async () => {
+    await i18n.changeLanguage("en");
+    render(
+      <ThemeProvider>
+        <ModelTestModal
+          model={baseModel}
+          running={false}
+          resultText={null}
+          errorText="upstream timeout"
+          onClose={() => undefined}
+          onRun={() => undefined}
+        />
+      </ThemeProvider>,
+    );
+
+    const error = screen.getByTestId("model-test-error");
+    expect(error).toHaveTextContent("upstream timeout");
+    expect(error.querySelector("[role='alert']")?.className).toMatch(/rose/);
+  });
+});

--- a/pages/models/components/ModelTestModal.tsx
+++ b/pages/models/components/ModelTestModal.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_MODEL_TEST_PROMPT,
   formatModelSourceLabel,
 } from "../modelsUtils";
-import type { ModelItem } from "../types";
+import type { ModelAvailabilitySource, ModelItem } from "../types";
 
 export type ModelTestChannelOption = {
   value: string;
@@ -14,26 +14,83 @@ export type ModelTestChannelOption = {
   channel: string;
 };
 
-function buildChannelOptions(model: ModelItem | null): ModelTestChannelOption[] {
+function equalsIgnoreCase(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/**
+ * Incomplete auth sources often surface as bare provider names (e.g. "xai")
+ * when Label/email metadata is missing. Those are not usable test channels.
+ *
+ * Real channels look like:
+ * - "user@example.com"
+ * - "xai · user@example.com"
+ * - "Primary OpenAI" (distinct from provider "openai")
+ */
+export function isBareProviderOnlySource(source: ModelAvailabilitySource): boolean {
+  const provider = String(source.provider ?? "").trim();
+  const channel = String(source.channel ?? "").trim();
+  const label = String(source.label ?? "").trim();
+
+  // Email identity is always a real account channel.
+  if (channel.includes("@") || label.includes("@")) return false;
+
+  const channelIsBare =
+    !channel || (Boolean(provider) && equalsIgnoreCase(channel, provider));
+
+  const normalizedLabel = label.replace(/\s*·\s*/g, " · ");
+  const labelIsBare =
+    !label ||
+    (Boolean(provider) &&
+      (equalsIgnoreCase(label, provider) ||
+        equalsIgnoreCase(normalizedLabel, `${provider} · ${provider}`)));
+
+  // Both channel and label collapse to the provider (or are empty) → incomplete source.
+  return channelIsBare && labelIsBare;
+}
+
+function sourceToOption(source: ModelAvailabilitySource): ModelTestChannelOption | null {
+  const channel =
+    String(source.channel ?? "").trim() ||
+    String(source.label ?? "").trim() ||
+    String(source.clientId ?? "").trim();
+  if (!channel) return null;
+  return {
+    value: channel,
+    label: formatModelSourceLabel(source),
+    channel,
+  };
+}
+
+export function buildChannelOptions(model: ModelItem | null): ModelTestChannelOption[] {
   if (!model?.sources?.length) return [];
+
+  const rich: ModelTestChannelOption[] = [];
+  const bare: ModelTestChannelOption[] = [];
   const seen = new Set<string>();
-  const options: ModelTestChannelOption[] = [];
-  for (const source of model.sources) {
-    const channel =
-      String(source.channel ?? "").trim() ||
-      String(source.label ?? "").trim() ||
-      String(source.clientId ?? "").trim();
-    if (!channel) continue;
-    const key = channel.toLowerCase();
-    if (seen.has(key)) continue;
+
+  const pushUnique = (
+    list: ModelTestChannelOption[],
+    option: ModelTestChannelOption,
+  ) => {
+    const key = option.channel.toLowerCase();
+    if (seen.has(key)) return;
     seen.add(key);
-    options.push({
-      value: channel,
-      label: formatModelSourceLabel(source),
-      channel,
-    });
+    list.push(option);
+  };
+
+  for (const source of model.sources) {
+    const option = sourceToOption(source);
+    if (!option) continue;
+    if (isBareProviderOnlySource(source)) {
+      pushUnique(bare, option);
+    } else {
+      pushUnique(rich, option);
+    }
   }
-  return options;
+
+  // Prefer account-level sources; only fall back to bare provider rows when nothing else exists.
+  return rich.length > 0 ? rich : bare;
 }
 
 export interface ModelTestModalProps {
@@ -54,7 +111,22 @@ export function ModelTestModal({
   onRun,
 }: ModelTestModalProps) {
   const { t } = useTranslation();
-  const channelOptions = useMemo(() => buildChannelOptions(model), [model]);
+  // Keep last model/result during Modal exit animation so the panel does not collapse.
+  const [displayModel, setDisplayModel] = useState<ModelItem | null>(model);
+  const [displayResult, setDisplayResult] = useState<string | null>(resultText);
+  const [displayError, setDisplayError] = useState<string | null>(errorText);
+
+  useEffect(() => {
+    if (!model) return;
+    setDisplayModel(model);
+    setDisplayResult(resultText);
+    setDisplayError(errorText);
+  }, [model, resultText, errorText]);
+
+  const channelOptions = useMemo(
+    () => buildChannelOptions(displayModel),
+    [displayModel],
+  );
   const [channel, setChannel] = useState("");
   const [prompt, setPrompt] = useState(DEFAULT_MODEL_TEST_PROMPT);
 
@@ -65,17 +137,20 @@ export function ModelTestModal({
     setPrompt(DEFAULT_MODEL_TEST_PROMPT);
   }, [model]);
 
+  const open = model !== null;
   const canRun = Boolean(model && channel && prompt.trim() && !running);
-  const noChannels = Boolean(model) && channelOptions.length === 0;
+  const noChannels = Boolean(displayModel) && channelOptions.length === 0;
+  const showSuccess = Boolean(displayResult) && !displayError;
+  const showError = Boolean(displayError);
 
   return (
     <Modal
-      open={model !== null}
+      open={open}
       onClose={onClose}
       title={t("models_page.test_model_title")}
       description={
-        model
-          ? t("models_page.test_model_desc", { model: model.id })
+        displayModel
+          ? t("models_page.test_model_desc", { model: displayModel.id })
           : undefined
       }
       maxWidth="max-w-xl"
@@ -97,7 +172,7 @@ export function ModelTestModal({
         </>
       }
     >
-      {model ? (
+      {displayModel ? (
         <div className="space-y-4">
           <div>
             <label
@@ -142,25 +217,43 @@ export function ModelTestModal({
             />
           </div>
 
-          {errorText ? (
-            <div
-              role="alert"
-              className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200"
-            >
-              {errorText}
-            </div>
-          ) : null}
+          {/* Always reserve the response slot while open so success/error swaps don't collapse height. */}
+          <div
+            className={[
+              "grid transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+              showError || showSuccess
+                ? "grid-rows-[1fr] opacity-100"
+                : "grid-rows-[0fr] opacity-0",
+            ].join(" ")}
+            aria-live="polite"
+          >
+            <div className="min-h-0 overflow-hidden">
+              {showError ? (
+                <div data-testid="model-test-error">
+                  <div className="mb-1 text-sm font-medium text-rose-700 dark:text-rose-300">
+                    {t("models_page.test_response")}
+                  </div>
+                  <div
+                    role="alert"
+                    className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200"
+                  >
+                    {displayError}
+                  </div>
+                </div>
+              ) : null}
 
-          {resultText ? (
-            <div>
-              <div className="mb-1 text-sm font-medium text-slate-700 dark:text-white/80">
-                {t("models_page.test_response")}
-              </div>
-              <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-800 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/80">
-                {resultText}
-              </pre>
+              {showSuccess ? (
+                <div data-testid="model-test-success">
+                  <div className="mb-1 text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                    {t("models_page.test_response")}
+                  </div>
+                  <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+                    {displayResult}
+                  </pre>
+                </div>
+              ) : null}
             </div>
-          ) : null}
+          </div>
         </div>
       ) : null}
     </Modal>


### PR DESCRIPTION
## Summary
- Model test dialog success/error responses use green/red semantic styling.
- Incomplete bare-provider sources (e.g. orphan `xai` without email/label) are hidden when richer account channels exist.
- Shared `Modal` keeps content stable during exit animation and uses smoother opacity/translate transitions so height no longer collapses on close.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full test:ci, build, bundle:diff, critical e2e)
- [x] `bun run test -- pages/models/__tests__/ModelTestModal.test.tsx pages/models/__tests__/ModelsPage.test.tsx`
- [ ] Open `/manage/models/catalog` → Test a model → confirm success response is green and failure is red
- [ ] Confirm channel dropdown no longer shows bare provider-only rows when email channels exist
- [ ] Open/close the test modal and confirm no height collapse mid-animation