### PR TITLE
feat(auth-files): show predicted weekly quota for xAI usage modal

### DIFF
--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -425,6 +425,47 @@ describe("AuthFileDetailModal", () => {
     expectSummaryCard("Current weekly cycle", "116");
     // Remaining snapshot percent 75% => used 25%.
     expectSummaryCard("Weekly quota used", "25%");
+    // xAI shows weekly prediction (zero when cycle cost is missing), never the Codex 5h card.
+    expectSummaryCard("Predicted weekly window quota", "$0.0000");
+    expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
+  });
+
+  test("predicts xAI weekly window quota from cycle cost and used percent", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "xai-user.json",
+        label: "xAI Grok",
+        type: "xai",
+        provider: "xai",
+        size: 256,
+      },
+      modelsFileType: "xai",
+      quotaState: {
+        status: "success",
+        planType: "supergrok-heavy",
+        items: [],
+        updatedAt: Date.now(),
+      },
+      detailTrend: {
+        auth_index: "xai-auth",
+        days: 7,
+        hours: 5,
+        request_total: 180,
+        cycle_request_total: 180,
+        cycle_cost_total: 7.352,
+        weekly_quota_used_percent: 6,
+        cycle_known: true,
+        cycle_start: "2026-07-12T05:05:02Z",
+        daily_usage: [],
+        hourly_usage: [],
+        quota_series: [],
+      },
+    });
+
+    expectSummaryCard("Current cycle cost", "$7.3520");
+    expectSummaryCard("Weekly quota used", "6%");
+    // $7.352 / 6% ≈ $122.5333 full weekly window budget.
+    expectSummaryCard("Predicted weekly window quota", "$122.5333");
     expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
   });
 

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -1102,10 +1102,12 @@ export function AuthFileDetailModal({
 
   const renderUsageTrend = () => {
     const isCodexDetail = detailProviderKey === "codex";
-    const summaryGridClassName = isCodexDetail
+    // xAI only has a weekly window (no Codex 5h slot); still show predicted weekly quota like Codex.
+    const showPredictedWeeklyQuota = isCodexDetail || detailProviderKey === "xai";
+    const summaryGridClassName = showPredictedWeeklyQuota
       ? "grid gap-3 sm:grid-cols-2 xl:grid-cols-6"
       : "grid gap-3 sm:grid-cols-2 xl:grid-cols-5";
-    const summarySkeletonCount = isCodexDetail ? 6 : 5;
+    const summarySkeletonCount = showPredictedWeeklyQuota ? 6 : 5;
 
     if (detailTrendLoading && !detailTrend) {
       const skeletonClass = "animate-pulse rounded-lg bg-slate-100/80 dark:bg-white/[0.06]";
@@ -1208,20 +1210,20 @@ export function AuthFileDetailModal({
             <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(displayCycleCostTotal)}</p>
           </div>
           {isCodexDetail ? (
-            <>
-              <div className={SUMMARY_CARD_CLASS_NAME}>
-                <p className={SUMMARY_LABEL_CLASS_NAME}>
-                  {t("auth_files.trend_predicted_5h_window_quota")}
-                </p>
-                <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedFiveHourQuota)}</p>
-              </div>
-              <div className={SUMMARY_CARD_CLASS_NAME}>
-                <p className={SUMMARY_LABEL_CLASS_NAME}>
-                  {t("auth_files.trend_predicted_week_window_quota")}
-                </p>
-                <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
-              </div>
-            </>
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>
+                {t("auth_files.trend_predicted_5h_window_quota")}
+              </p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedFiveHourQuota)}</p>
+            </div>
+          ) : null}
+          {showPredictedWeeklyQuota ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>
+                {t("auth_files.trend_predicted_week_window_quota")}
+              </p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
+            </div>
           ) : null}
           <div className={SUMMARY_CARD_CLASS_NAME}>
             <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_weekly_quota_used")}</p>


### PR DESCRIPTION
## Summary
- Show **Predicted weekly window quota** on the xAI / SuperGrok auth-file usage modal, matching Codex.
- Formula reuses `estimateQuotaBudget(cycle_cost, weekly_quota_used_percent)` (e.g. `$7.3520 / 6% → $122.5333`).
- Does **not** show the Codex-only 5-hour prediction card for xAI.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e critical)
- [x] Unit: `AuthFileDetailModal.test.tsx` — incomplete data → `$0.0000`; known cycle → predicted amount
- [ ] Manual: open SuperGrok auth detail → Usage tab shows 预测周窗口额度 between cycle cost and weekly used %