### PR TITLE
feat(providers): Claude/Codex /models discovery and auth-file refresh

### DIFF
--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -85,9 +85,16 @@ export const authFilesApi = {
 
   getModelsForAuthFile: async (
     name: string,
+    options?: { force?: boolean },
   ): Promise<{ id: string; display_name?: string; type?: string; owned_by?: string }[]> => {
+    const params: Record<string, string> = { name };
+    // refresh=1 asks the backend to re-fetch live upstream /models for
+    // claude/codex (and other live-capable providers) and update the registry.
+    if (options?.force) {
+      params.refresh = "1";
+    }
     const data = await apiClient.get<Record<string, unknown>>("/auth-files/models", {
-      params: { name },
+      params,
     });
     const models = data.models ?? data["models"];
     return Array.isArray(models)

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3591,6 +3591,8 @@
     "fetch_models_failed": "Failed to fetch models",
     "no_models_selected": "No models selected",
     "models_merged": "Model list merged",
+    "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
+    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead.",
     "ampcode_saved": "Ampcode configuration saved",
     "current_status": "Current: {{status}} · {{count}} mappings",
     "status_loaded": "Loaded",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2851,6 +2851,8 @@
     "fetch_models_failed": "获取模型失败",
     "no_models_selected": "未选择任何模型",
     "models_merged": "模型列表已合并",
+    "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
+    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。",
     "ampcode_saved": "Ampcode 配置已保存",
     "current_status": "当前：{{status}} · 映射 {{count}} 条",
     "status_loaded": "已加载",

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -263,7 +263,9 @@ export function useAuthFilesDetailEditors(
       }
 
       try {
-        const list = await authFilesApi.getModelsForAuthFile(file.name);
+        const list = await authFilesApi.getModelsForAuthFile(file.name, {
+          force,
+        });
         modelsCacheRef.current.set(file.name, list);
         setModelsList(list);
       } catch (err: unknown) {

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   buildOpenAIDraft,
   buildProviderKeyDraft,
+  buildProviderModelsEndpoint,
   maskApiKey,
   normalizeDiscoveredModels,
 } from "@pages/providers/providers-helpers";
@@ -110,6 +111,34 @@ describe("providers helpers", () => {
         ],
       }),
     ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
+  });
+
+  test("normalizes Claude/Codex payloads via models, items, and slug fields", () => {
+    expect(
+      normalizeDiscoveredModels({
+        models: [{ id: "claude-sonnet-4-5", display_name: "Sonnet" }],
+      }),
+    ).toEqual([{ id: "claude-sonnet-4-5" }]);
+    expect(
+      normalizeDiscoveredModels({
+        items: [{ slug: "gpt-5.1-codex", title: "Codex" }],
+      }),
+    ).toEqual([{ id: "gpt-5.1-codex" }]);
+  });
+
+  test("builds Claude and Codex /models endpoints with defaults", () => {
+    expect(buildProviderModelsEndpoint("claude", "")).toBe(
+      "https://api.anthropic.com/v1/models",
+    );
+    expect(buildProviderModelsEndpoint("claude", "https://gw.example/v1")).toBe(
+      "https://gw.example/v1/models",
+    );
+    expect(buildProviderModelsEndpoint("codex", "")).toBe(
+      "https://api.openai.com/v1/models",
+    );
+    expect(
+      buildProviderModelsEndpoint("codex", "https://api.openai.com/v1"),
+    ).toBe("https://api.openai.com/v1/models");
   });
 
   test("normalizes discovered models from a JSON string payload", () => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -8,16 +8,24 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
-import { modelsApi } from "@code-proxy/api-client";
+import {
+  apiCallApi,
+  getApiCallErrorMessage,
+  modelsApi,
+} from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
+import { useToast } from "@code-proxy/ui";
 import type { ProviderKeyDraft } from "../providers-helpers";
 import {
+  buildProviderModelsEndpoint,
   excludedModelsFromText,
   hasDisableAllModelsRule,
+  normalizeDiscoveredModels,
 } from "../providers-helpers";
+import { keyValueEntriesToRecord } from "../KeyValueInputList";
 import { createEmptyModelEntry, type ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
@@ -112,6 +120,7 @@ export function ProviderKeyModal({
   maskApiKey,
 }: ProviderKeyModalProps) {
   const { t } = useTranslation();
+  const { notify } = useToast();
   const [modalTab, setModalTab] = useState<ProviderKeyModalTab>("basic");
   const [openCodeModels, setOpenCodeModels] = useState<
     { id: string; owned_by?: string }[]
@@ -121,12 +130,22 @@ export function ProviderKeyModal({
     null,
   );
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
+  // Live /models discovery for Claude & Codex provider keys (issue #492).
+  const [discoveredModels, setDiscoveredModels] = useState<
+    { id: string; owned_by?: string }[]
+  >([]);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverSelected, setDiscoverSelected] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const isBedrock = editKeyType === "bedrock";
   const isOpenCodeGo = editKeyType === "opencode-go";
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
+  const supportsLiveDiscovery =
+    editKeyType === "claude" || editKeyType === "codex";
   const modelAccessProvider: ModelAccessProvider | null = isCline
     ? "cline"
     : isOllamaCloud
@@ -191,7 +210,137 @@ export function ProviderKeyModal({
     setModalTab("basic");
     setOpenCodeModelQuery("");
     setSelectedModelGroup("");
+    setDiscoveredModels([]);
+    setDiscoverSelected(new Set());
+    setDiscovering(false);
   }, [editKeyIndex, editKeyType, open]);
+
+  const discoverModels = useCallback(async () => {
+    if (!supportsLiveDiscovery) return;
+    const providerType = editKeyType === "claude" ? "claude" : "codex";
+    const endpoint = buildProviderModelsEndpoint(
+      providerType,
+      keyDraft.baseUrl,
+    );
+    if (!endpoint) {
+      notify({ type: "info", message: t("providers.fill_base_url_first") });
+      return;
+    }
+
+    setDiscovering(true);
+    setDiscoveredModels([]);
+    setDiscoverSelected(new Set());
+    try {
+      const customHeaders =
+        keyValueEntriesToRecord(keyDraft.headersEntries) ?? {};
+      const headers: Record<string, string> = { ...customHeaders };
+      const apiKey = keyDraft.apiKey.trim();
+
+      if (providerType === "claude") {
+        // Anthropic official + most compatible gateways accept x-api-key.
+        // Also send Authorization for gateways that only accept Bearer.
+        if (apiKey) {
+          if (
+            !Object.keys(headers).some(
+              (key) => key.toLowerCase() === "x-api-key",
+            )
+          ) {
+            headers["x-api-key"] = apiKey;
+          }
+          if (
+            !Object.keys(headers).some(
+              (key) => key.toLowerCase() === "authorization",
+            )
+          ) {
+            headers.Authorization = `Bearer ${apiKey}`;
+          }
+        }
+        if (
+          !Object.keys(headers).some(
+            (key) => key.toLowerCase() === "anthropic-version",
+          )
+        ) {
+          headers["anthropic-version"] = "2023-06-01";
+        }
+        if (
+          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
+        ) {
+          headers.Accept = "application/json";
+        }
+      } else {
+        // Codex / OpenAI-compatible: Bearer API key.
+        if (
+          apiKey &&
+          !Object.keys(headers).some(
+            (key) => key.toLowerCase() === "authorization",
+          )
+        ) {
+          headers.Authorization = `Bearer ${apiKey}`;
+        }
+        if (
+          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
+        ) {
+          headers.Accept = "application/json";
+        }
+      }
+
+      const result = await apiCallApi.request({
+        method: "GET",
+        url: endpoint,
+        header: Object.keys(headers).length ? headers : undefined,
+      });
+      if (result.statusCode < 200 || result.statusCode >= 300) {
+        throw new Error(getApiCallErrorMessage(result));
+      }
+      const list = normalizeDiscoveredModels(result.body ?? result.bodyText);
+      setDiscoveredModels(list);
+      setDiscoverSelected(new Set(list.map((model) => model.id)));
+      if (list.length === 0) {
+        notify({ type: "info", message: t("providers.no_discovered_models") });
+      }
+    } catch (err: unknown) {
+      notify({
+        type: "error",
+        message:
+          err instanceof Error ? err.message : t("providers.fetch_models_failed"),
+      });
+    } finally {
+      setDiscovering(false);
+    }
+  }, [
+    editKeyType,
+    keyDraft.apiKey,
+    keyDraft.baseUrl,
+    keyDraft.headersEntries,
+    notify,
+    supportsLiveDiscovery,
+    t,
+  ]);
+
+  const applyDiscoveredModels = useCallback(() => {
+    const selected = new Set(discoverSelected);
+    const picked = discoveredModels.filter((model) => selected.has(model.id));
+    if (picked.length === 0) {
+      notify({ type: "info", message: t("providers.no_models_selected") });
+      return;
+    }
+    setKeyDraft((prev) => {
+      const seen = new Set(
+        prev.modelEntries
+          .map((model) => model.name.trim().toLowerCase())
+          .filter(Boolean),
+      );
+      const merged = [...prev.modelEntries];
+      for (const model of picked) {
+        const key = model.id.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        merged.push({ ...createEmptyModelEntry(), name: model.id });
+      }
+      return { ...prev, modelEntries: merged };
+    });
+    notify({ type: "success", message: t("providers.models_merged") });
+  }, [discoverSelected, discoveredModels, notify, setKeyDraft, t]);
 
   useEffect(() => {
     if (!open || !showModelsTab) return;
@@ -607,6 +756,18 @@ export function ProviderKeyModal({
                 setKeyDraft={setKeyDraft}
                 editKeyExcludedCount={editKeyExcludedCount}
                 editKeyEnabledToggle={editKeyEnabledToggle}
+                discovering={discovering}
+                discoverModels={
+                  supportsLiveDiscovery ? discoverModels : undefined
+                }
+                applyDiscoveredModels={
+                  supportsLiveDiscovery ? applyDiscoveredModels : undefined
+                }
+                discoveredModels={discoveredModels}
+                discoverSelected={discoverSelected}
+                setDiscoverSelected={
+                  supportsLiveDiscovery ? setDiscoverSelected : undefined
+                }
               />
             </TabsContent>
           ) : null}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -13,6 +13,7 @@ import {
   type ModelEntryDraft,
 } from "../ModelInputList";
 import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
+import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 
 type ModelAccessRow = { id: string; owned_by?: string };
 
@@ -50,6 +51,13 @@ interface ProviderKeyModelsTabProps {
   setKeyDraft: React.Dispatch<React.SetStateAction<ProviderKeyDraft>>;
   editKeyExcludedCount: number;
   editKeyEnabledToggle: (checked: boolean) => void;
+  /** Live /models discovery for Claude & Codex provider keys (aligned with OpenAI). */
+  discovering?: boolean;
+  discoverModels?: () => Promise<void>;
+  applyDiscoveredModels?: () => void;
+  discoveredModels?: { id: string; owned_by?: string }[];
+  discoverSelected?: Set<string>;
+  setDiscoverSelected?: (value: React.SetStateAction<Set<string>>) => void;
 }
 
 export function ProviderKeyModelsTab({
@@ -80,10 +88,21 @@ export function ProviderKeyModelsTab({
   setKeyDraft,
   editKeyExcludedCount,
   editKeyEnabledToggle,
+  discovering = false,
+  discoverModels,
+  applyDiscoveredModels,
+  discoveredModels = [],
+  discoverSelected = new Set(),
+  setDiscoverSelected,
 }: ProviderKeyModelsTabProps) {
   const { t } = useTranslation();
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
+  const supportsLiveDiscovery =
+    (editKeyType === "claude" || editKeyType === "codex") &&
+    typeof discoverModels === "function" &&
+    typeof applyDiscoveredModels === "function" &&
+    typeof setDiscoverSelected === "function";
   const modelAccessTitle = isCline
     ? t("providers.cline_models_title")
     : isOllamaCloud
@@ -353,6 +372,24 @@ export function ProviderKeyModelsTab({
           </p>
         )}
       </SectionCard>
+
+      {supportsLiveDiscovery ? (
+        <SectionCard>
+          <OpenAIModelDiscoveryPanel
+            discovering={discovering}
+            discoverModels={discoverModels!}
+            applyDiscoveredModels={applyDiscoveredModels!}
+            discoveredModels={discoveredModels}
+            discoverSelected={discoverSelected}
+            setDiscoverSelected={setDiscoverSelected!}
+          />
+          <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
+            {editKeyType === "claude"
+              ? t("providers.claude_models_discovery_hint")
+              : t("providers.codex_models_discovery_hint")}
+          </p>
+        </SectionCard>
+      ) : null}
 
       <ExcludedModelsEditor
         count={editKeyExcludedCount}

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -74,6 +74,47 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
   return `${normalized}/models`;
 };
 
+/** Default bases when the provider key leaves base URL empty (official endpoints). */
+export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
+export const DEFAULT_CODEX_MODELS_BASE = "https://api.openai.com";
+export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
+
+/**
+ * Build the upstream /models URL for a provider key type.
+ * Claude uses Anthropic-style `/v1/models`; Codex/OpenAI-compatible use `/models`
+ * (or `/v1/models` when the base already ends with `/v1`).
+ */
+export const buildProviderModelsEndpoint = (
+  providerType: "claude" | "codex" | "openai",
+  baseUrl: string,
+): string => {
+  const fallback =
+    providerType === "claude"
+      ? DEFAULT_CLAUDE_MODELS_BASE
+      : providerType === "codex"
+        ? DEFAULT_CODEX_MODELS_BASE
+        : "";
+  const normalized = normalizeOpenAIBaseUrl(baseUrl || fallback);
+  if (!normalized) return "";
+  const lower = normalized.toLowerCase();
+  if (lower.endsWith("/models") || lower.includes("/models?")) {
+    return normalized;
+  }
+  if (providerType === "claude") {
+    if (lower.endsWith("/v1")) return `${normalized}/models`;
+    return `${normalized}/v1/models`;
+  }
+  // Codex / OpenAI-compatible: prefer /v1/models when base has no path tail.
+  if (lower.endsWith("/v1")) return `${normalized}/models`;
+  if (lower.includes("api.openai.com") || providerType === "codex") {
+    // Official OpenAI and typical Codex API-key bases expect /v1/models.
+    if (!/\/v\d+(\/|$)/i.test(lower)) {
+      return `${normalized}/v1/models`;
+    }
+  }
+  return `${normalized}/models`;
+};
+
 export const normalizeDiscoveredModels = (
   payload: unknown,
 ): { id: string; owned_by?: string }[] => {
@@ -90,14 +131,18 @@ export const normalizeDiscoveredModels = (
     }
   }
   const root = isRecord(payload) ? payload : null;
-  const data = root ? (root.data ?? root.models ?? payload) : payload;
+  // Codex manifests may nest under data / models / items.
+  const data = root
+    ? (root.data ?? root.models ?? root.items ?? payload)
+    : payload;
   if (!Array.isArray(data)) return [];
 
   const seen = new Set<string>();
   const result: { id: string; owned_by?: string }[] = [];
   for (const item of data) {
     if (!isRecord(item)) continue;
-    const id = String(item.id ?? item.name ?? "").trim();
+    // Claude: id; Codex: id | slug | name
+    const id = String(item.id ?? item.slug ?? item.name ?? "").trim();
     if (!id) continue;
     const key = id.toLowerCase();
     if (seen.has(key)) continue;


### PR DESCRIPTION
## Summary

- **Providers → Claude / Codex key editor → Models tab**: live **Fetch /models** discovery (same UX as OpenAI-compatible), via management `api-call` to Anthropic-compatible `/v1/models` or OpenAI-compatible `/v1/models`
- **Auth files detail → Models → Refresh** now passes `refresh=1` so the backend re-fetches live upstream models (Claude/Codex OAuth + other live-capable providers) instead of only returning the registry cache
- Endpoint helpers + normalize support for Claude/Codex payload shapes (`models` / `items` / `slug`)

Closes the panel half of CliRelay #492. Requires CliRelay backend PR for live refresh to work.

## Test plan

- [x] `bun run lint` / `design:check` / `build` / `bundle:diff`
- [x] `bun test pages/providers/__tests__/providers-helpers.test.ts` (new Claude/Codex endpoint + normalize cases)
- [x] Full `bun run test:ci`: 722 passed; 3 `CcSwitchImportSettingsPage` timeouts under full parallel load (re-ran file alone: 21/21 pass — pre-existing flaky, unrelated to this change)
- [ ] Manual: open Claude/Codex provider key → Models → Fetch /models with valid key
- [ ] Manual: Auth file (Claude/Codex OAuth) → Models → Refresh after CliRelay backend is deployed

## Related

- Issue: https://github.com/kittors/CliRelay/issues/492
- Backend: CliRelay `feat/live-upstream-models-claude-codex`