### PR TITLE
fix(providers): disable Codex live /models discovery

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3592,7 +3592,6 @@
     "no_models_selected": "No models selected",
     "models_merged": "Model list merged",
     "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
-    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead.",
     "ampcode_saved": "Ampcode configuration saved",
     "current_status": "Current: {{status}} · {{count}} mappings",
     "status_loaded": "Loaded",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2852,7 +2852,6 @@
     "no_models_selected": "未选择任何模型",
     "models_merged": "模型列表已合并",
     "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
-    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。",
     "ampcode_saved": "Ampcode 配置已保存",
     "current_status": "当前：{{status}} · 映射 {{count}} 条",
     "status_loaded": "已加载",

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -113,32 +113,21 @@ describe("providers helpers", () => {
     ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
   });
 
-  test("normalizes Claude/Codex payloads via models, items, and slug fields", () => {
+  test("normalizes Claude payloads via models field", () => {
     expect(
       normalizeDiscoveredModels({
         models: [{ id: "claude-sonnet-4-5", display_name: "Sonnet" }],
       }),
     ).toEqual([{ id: "claude-sonnet-4-5" }]);
-    expect(
-      normalizeDiscoveredModels({
-        items: [{ slug: "gpt-5.1-codex", title: "Codex" }],
-      }),
-    ).toEqual([{ id: "gpt-5.1-codex" }]);
   });
 
-  test("builds Claude and Codex /models endpoints with defaults", () => {
+  test("builds Claude /models endpoints with defaults", () => {
     expect(buildProviderModelsEndpoint("claude", "")).toBe(
       "https://api.anthropic.com/v1/models",
     );
     expect(buildProviderModelsEndpoint("claude", "https://gw.example/v1")).toBe(
       "https://gw.example/v1/models",
     );
-    expect(buildProviderModelsEndpoint("codex", "")).toBe(
-      "https://api.openai.com/v1/models",
-    );
-    expect(
-      buildProviderModelsEndpoint("codex", "https://api.openai.com/v1"),
-    ).toBe("https://api.openai.com/v1/models");
   });
 
   test("normalizes discovered models from a JSON string payload", () => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -144,8 +144,9 @@ export function ProviderKeyModal({
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
-  const supportsLiveDiscovery =
-    editKeyType === "claude" || editKeyType === "codex";
+  // Codex must NOT use live /models discovery: ChatGPT/OpenAI catalogs are
+  // incomplete vs our static registry and previously wiped gpt-5.x routing.
+  const supportsLiveDiscovery = editKeyType === "claude";
   const modelAccessProvider: ModelAccessProvider | null = isCline
     ? "cline"
     : isOllamaCloud
@@ -217,11 +218,8 @@ export function ProviderKeyModal({
 
   const discoverModels = useCallback(async () => {
     if (!supportsLiveDiscovery) return;
-    const providerType = editKeyType === "claude" ? "claude" : "codex";
-    const endpoint = buildProviderModelsEndpoint(
-      providerType,
-      keyDraft.baseUrl,
-    );
+    // Claude only — Codex live discovery is intentionally disabled.
+    const endpoint = buildProviderModelsEndpoint("claude", keyDraft.baseUrl);
     if (!endpoint) {
       notify({ type: "info", message: t("providers.fill_base_url_first") });
       return;
@@ -236,52 +234,35 @@ export function ProviderKeyModal({
       const headers: Record<string, string> = { ...customHeaders };
       const apiKey = keyDraft.apiKey.trim();
 
-      if (providerType === "claude") {
-        // Anthropic official + most compatible gateways accept x-api-key.
-        // Also send Authorization for gateways that only accept Bearer.
-        if (apiKey) {
-          if (
-            !Object.keys(headers).some(
-              (key) => key.toLowerCase() === "x-api-key",
-            )
-          ) {
-            headers["x-api-key"] = apiKey;
-          }
-          if (
-            !Object.keys(headers).some(
-              (key) => key.toLowerCase() === "authorization",
-            )
-          ) {
-            headers.Authorization = `Bearer ${apiKey}`;
-          }
-        }
+      // Anthropic official + most compatible gateways accept x-api-key.
+      // Also send Authorization for gateways that only accept Bearer.
+      if (apiKey) {
         if (
           !Object.keys(headers).some(
-            (key) => key.toLowerCase() === "anthropic-version",
+            (key) => key.toLowerCase() === "x-api-key",
           )
         ) {
-          headers["anthropic-version"] = "2023-06-01";
+          headers["x-api-key"] = apiKey;
         }
         if (
-          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
-        ) {
-          headers.Accept = "application/json";
-        }
-      } else {
-        // Codex / OpenAI-compatible: Bearer API key.
-        if (
-          apiKey &&
           !Object.keys(headers).some(
             (key) => key.toLowerCase() === "authorization",
           )
         ) {
           headers.Authorization = `Bearer ${apiKey}`;
         }
-        if (
-          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
-        ) {
-          headers.Accept = "application/json";
-        }
+      }
+      if (
+        !Object.keys(headers).some(
+          (key) => key.toLowerCase() === "anthropic-version",
+        )
+      ) {
+        headers["anthropic-version"] = "2023-06-01";
+      }
+      if (
+        !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
+      ) {
+        headers.Accept = "application/json";
       }
 
       const result = await apiCallApi.request({
@@ -308,7 +289,6 @@ export function ProviderKeyModal({
       setDiscovering(false);
     }
   }, [
-    editKeyType,
     keyDraft.apiKey,
     keyDraft.baseUrl,
     keyDraft.headersEntries,

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -99,7 +99,7 @@ export function ProviderKeyModelsTab({
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
   const supportsLiveDiscovery =
-    (editKeyType === "claude" || editKeyType === "codex") &&
+    editKeyType === "claude" &&
     typeof discoverModels === "function" &&
     typeof applyDiscoveredModels === "function" &&
     typeof setDiscoverSelected === "function";
@@ -384,9 +384,7 @@ export function ProviderKeyModelsTab({
             setDiscoverSelected={setDiscoverSelected!}
           />
           <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-            {editKeyType === "claude"
-              ? t("providers.claude_models_discovery_hint")
-              : t("providers.codex_models_discovery_hint")}
+            {t("providers.claude_models_discovery_hint")}
           </p>
         </SectionCard>
       ) : null}

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -76,41 +76,37 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
 
 /** Default bases when the provider key leaves base URL empty (official endpoints). */
 export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
-export const DEFAULT_CODEX_MODELS_BASE = "https://api.openai.com";
 export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
 
 /**
- * Build the upstream /models URL for a provider key type.
- * Claude uses Anthropic-style `/v1/models`; Codex/OpenAI-compatible use `/models`
- * (or `/v1/models` when the base already ends with `/v1`).
+ * Build the upstream /models URL for Claude provider keys.
+ * Claude uses Anthropic-style `/v1/models`. Codex intentionally has no live
+ * discovery path — incomplete upstream catalogs must not replace the static list.
  */
 export const buildProviderModelsEndpoint = (
-  providerType: "claude" | "codex" | "openai",
+  providerType: "claude" | "openai",
   baseUrl: string,
 ): string => {
-  const fallback =
-    providerType === "claude"
-      ? DEFAULT_CLAUDE_MODELS_BASE
-      : providerType === "codex"
-        ? DEFAULT_CODEX_MODELS_BASE
-        : "";
-  const normalized = normalizeOpenAIBaseUrl(baseUrl || fallback);
+  if (providerType === "claude") {
+    const normalized = normalizeOpenAIBaseUrl(baseUrl || DEFAULT_CLAUDE_MODELS_BASE);
+    if (!normalized) return "";
+    const lower = normalized.toLowerCase();
+    if (lower.endsWith("/models") || lower.includes("/models?")) {
+      return normalized;
+    }
+    if (lower.endsWith("/v1")) return `${normalized}/models`;
+    return `${normalized}/v1/models`;
+  }
+  // OpenAI-compatible: prefer /v1/models when base has no path tail.
+  const normalized = normalizeOpenAIBaseUrl(baseUrl);
   if (!normalized) return "";
   const lower = normalized.toLowerCase();
   if (lower.endsWith("/models") || lower.includes("/models?")) {
     return normalized;
   }
-  if (providerType === "claude") {
-    if (lower.endsWith("/v1")) return `${normalized}/models`;
-    return `${normalized}/v1/models`;
-  }
-  // Codex / OpenAI-compatible: prefer /v1/models when base has no path tail.
   if (lower.endsWith("/v1")) return `${normalized}/models`;
-  if (lower.includes("api.openai.com") || providerType === "codex") {
-    // Official OpenAI and typical Codex API-key bases expect /v1/models.
-    if (!/\/v\d+(\/|$)/i.test(lower)) {
-      return `${normalized}/v1/models`;
-    }
+  if (lower.includes("api.openai.com") && !/\/v\d+(\/|$)/i.test(lower)) {
+    return `${normalized}/v1/models`;
   }
   return `${normalized}/models`;
 };


### PR DESCRIPTION
## Summary

Disable Codex from the provider-key **Fetch /models** discovery UI and helpers. Incomplete upstream catalogs must not be used for Codex; keep Claude discovery only.

Pairs with CliRelay `fix/revert-codex-live-models` (restore static codex registry).

## Test plan
- [x] `bun run lint` / `design:check` / `build` / `bundle:diff`
- [x] `bun test pages/providers/__tests__/providers-helpers.test.ts`