### PR TITLE
fix(providers): disable Claude live /models discovery

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3591,7 +3591,6 @@
     "fetch_models_failed": "Failed to fetch models",
     "no_models_selected": "No models selected",
     "models_merged": "Model list merged",
-    "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
     "ampcode_saved": "Ampcode configuration saved",
     "current_status": "Current: {{status}} · {{count}} mappings",
     "status_loaded": "Loaded",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2851,7 +2851,6 @@
     "fetch_models_failed": "获取模型失败",
     "no_models_selected": "未选择任何模型",
     "models_merged": "模型列表已合并",
-    "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
     "ampcode_saved": "Ampcode 配置已保存",
     "current_status": "当前：{{status}} · 映射 {{count}} 条",
     "status_loaded": "已加载",

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import {
   buildOpenAIDraft,
   buildProviderKeyDraft,
-  buildProviderModelsEndpoint,
   maskApiKey,
   normalizeDiscoveredModels,
 } from "@pages/providers/providers-helpers";
@@ -111,23 +110,6 @@ describe("providers helpers", () => {
         ],
       }),
     ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
-  });
-
-  test("normalizes Claude payloads via models field", () => {
-    expect(
-      normalizeDiscoveredModels({
-        models: [{ id: "claude-sonnet-4-5", display_name: "Sonnet" }],
-      }),
-    ).toEqual([{ id: "claude-sonnet-4-5" }]);
-  });
-
-  test("builds Claude /models endpoints with defaults", () => {
-    expect(buildProviderModelsEndpoint("claude", "")).toBe(
-      "https://api.anthropic.com/v1/models",
-    );
-    expect(buildProviderModelsEndpoint("claude", "https://gw.example/v1")).toBe(
-      "https://gw.example/v1/models",
-    );
   });
 
   test("normalizes discovered models from a JSON string payload", () => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -8,24 +8,16 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
-import {
-  apiCallApi,
-  getApiCallErrorMessage,
-  modelsApi,
-} from "@code-proxy/api-client";
+import { modelsApi } from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
-import { useToast } from "@code-proxy/ui";
 import type { ProviderKeyDraft } from "../providers-helpers";
 import {
-  buildProviderModelsEndpoint,
   excludedModelsFromText,
   hasDisableAllModelsRule,
-  normalizeDiscoveredModels,
 } from "../providers-helpers";
-import { keyValueEntriesToRecord } from "../KeyValueInputList";
 import { createEmptyModelEntry, type ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
@@ -120,7 +112,6 @@ export function ProviderKeyModal({
   maskApiKey,
 }: ProviderKeyModalProps) {
   const { t } = useTranslation();
-  const { notify } = useToast();
   const [modalTab, setModalTab] = useState<ProviderKeyModalTab>("basic");
   const [openCodeModels, setOpenCodeModels] = useState<
     { id: string; owned_by?: string }[]
@@ -130,23 +121,12 @@ export function ProviderKeyModal({
     null,
   );
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
-  // Live /models discovery for Claude & Codex provider keys (issue #492).
-  const [discoveredModels, setDiscoveredModels] = useState<
-    { id: string; owned_by?: string }[]
-  >([]);
-  const [discovering, setDiscovering] = useState(false);
-  const [discoverSelected, setDiscoverSelected] = useState<Set<string>>(
-    () => new Set(),
-  );
 
   const isBedrock = editKeyType === "bedrock";
   const isOpenCodeGo = editKeyType === "opencode-go";
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
-  // Codex must NOT use live /models discovery: ChatGPT/OpenAI catalogs are
-  // incomplete vs our static registry and previously wiped gpt-5.x routing.
-  const supportsLiveDiscovery = editKeyType === "claude";
   const modelAccessProvider: ModelAccessProvider | null = isCline
     ? "cline"
     : isOllamaCloud
@@ -211,116 +191,7 @@ export function ProviderKeyModal({
     setModalTab("basic");
     setOpenCodeModelQuery("");
     setSelectedModelGroup("");
-    setDiscoveredModels([]);
-    setDiscoverSelected(new Set());
-    setDiscovering(false);
   }, [editKeyIndex, editKeyType, open]);
-
-  const discoverModels = useCallback(async () => {
-    if (!supportsLiveDiscovery) return;
-    // Claude only — Codex live discovery is intentionally disabled.
-    const endpoint = buildProviderModelsEndpoint("claude", keyDraft.baseUrl);
-    if (!endpoint) {
-      notify({ type: "info", message: t("providers.fill_base_url_first") });
-      return;
-    }
-
-    setDiscovering(true);
-    setDiscoveredModels([]);
-    setDiscoverSelected(new Set());
-    try {
-      const customHeaders =
-        keyValueEntriesToRecord(keyDraft.headersEntries) ?? {};
-      const headers: Record<string, string> = { ...customHeaders };
-      const apiKey = keyDraft.apiKey.trim();
-
-      // Anthropic official + most compatible gateways accept x-api-key.
-      // Also send Authorization for gateways that only accept Bearer.
-      if (apiKey) {
-        if (
-          !Object.keys(headers).some(
-            (key) => key.toLowerCase() === "x-api-key",
-          )
-        ) {
-          headers["x-api-key"] = apiKey;
-        }
-        if (
-          !Object.keys(headers).some(
-            (key) => key.toLowerCase() === "authorization",
-          )
-        ) {
-          headers.Authorization = `Bearer ${apiKey}`;
-        }
-      }
-      if (
-        !Object.keys(headers).some(
-          (key) => key.toLowerCase() === "anthropic-version",
-        )
-      ) {
-        headers["anthropic-version"] = "2023-06-01";
-      }
-      if (
-        !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
-      ) {
-        headers.Accept = "application/json";
-      }
-
-      const result = await apiCallApi.request({
-        method: "GET",
-        url: endpoint,
-        header: Object.keys(headers).length ? headers : undefined,
-      });
-      if (result.statusCode < 200 || result.statusCode >= 300) {
-        throw new Error(getApiCallErrorMessage(result));
-      }
-      const list = normalizeDiscoveredModels(result.body ?? result.bodyText);
-      setDiscoveredModels(list);
-      setDiscoverSelected(new Set(list.map((model) => model.id)));
-      if (list.length === 0) {
-        notify({ type: "info", message: t("providers.no_discovered_models") });
-      }
-    } catch (err: unknown) {
-      notify({
-        type: "error",
-        message:
-          err instanceof Error ? err.message : t("providers.fetch_models_failed"),
-      });
-    } finally {
-      setDiscovering(false);
-    }
-  }, [
-    keyDraft.apiKey,
-    keyDraft.baseUrl,
-    keyDraft.headersEntries,
-    notify,
-    supportsLiveDiscovery,
-    t,
-  ]);
-
-  const applyDiscoveredModels = useCallback(() => {
-    const selected = new Set(discoverSelected);
-    const picked = discoveredModels.filter((model) => selected.has(model.id));
-    if (picked.length === 0) {
-      notify({ type: "info", message: t("providers.no_models_selected") });
-      return;
-    }
-    setKeyDraft((prev) => {
-      const seen = new Set(
-        prev.modelEntries
-          .map((model) => model.name.trim().toLowerCase())
-          .filter(Boolean),
-      );
-      const merged = [...prev.modelEntries];
-      for (const model of picked) {
-        const key = model.id.toLowerCase();
-        if (seen.has(key)) continue;
-        seen.add(key);
-        merged.push({ ...createEmptyModelEntry(), name: model.id });
-      }
-      return { ...prev, modelEntries: merged };
-    });
-    notify({ type: "success", message: t("providers.models_merged") });
-  }, [discoverSelected, discoveredModels, notify, setKeyDraft, t]);
 
   useEffect(() => {
     if (!open || !showModelsTab) return;
@@ -736,18 +607,6 @@ export function ProviderKeyModal({
                 setKeyDraft={setKeyDraft}
                 editKeyExcludedCount={editKeyExcludedCount}
                 editKeyEnabledToggle={editKeyEnabledToggle}
-                discovering={discovering}
-                discoverModels={
-                  supportsLiveDiscovery ? discoverModels : undefined
-                }
-                applyDiscoveredModels={
-                  supportsLiveDiscovery ? applyDiscoveredModels : undefined
-                }
-                discoveredModels={discoveredModels}
-                discoverSelected={discoverSelected}
-                setDiscoverSelected={
-                  supportsLiveDiscovery ? setDiscoverSelected : undefined
-                }
               />
             </TabsContent>
           ) : null}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -13,7 +13,6 @@ import {
   type ModelEntryDraft,
 } from "../ModelInputList";
 import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
-import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 
 type ModelAccessRow = { id: string; owned_by?: string };
 
@@ -51,13 +50,6 @@ interface ProviderKeyModelsTabProps {
   setKeyDraft: React.Dispatch<React.SetStateAction<ProviderKeyDraft>>;
   editKeyExcludedCount: number;
   editKeyEnabledToggle: (checked: boolean) => void;
-  /** Live /models discovery for Claude & Codex provider keys (aligned with OpenAI). */
-  discovering?: boolean;
-  discoverModels?: () => Promise<void>;
-  applyDiscoveredModels?: () => void;
-  discoveredModels?: { id: string; owned_by?: string }[];
-  discoverSelected?: Set<string>;
-  setDiscoverSelected?: (value: React.SetStateAction<Set<string>>) => void;
 }
 
 export function ProviderKeyModelsTab({
@@ -88,21 +80,10 @@ export function ProviderKeyModelsTab({
   setKeyDraft,
   editKeyExcludedCount,
   editKeyEnabledToggle,
-  discovering = false,
-  discoverModels,
-  applyDiscoveredModels,
-  discoveredModels = [],
-  discoverSelected = new Set(),
-  setDiscoverSelected,
 }: ProviderKeyModelsTabProps) {
   const { t } = useTranslation();
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
-  const supportsLiveDiscovery =
-    editKeyType === "claude" &&
-    typeof discoverModels === "function" &&
-    typeof applyDiscoveredModels === "function" &&
-    typeof setDiscoverSelected === "function";
   const modelAccessTitle = isCline
     ? t("providers.cline_models_title")
     : isOllamaCloud
@@ -372,22 +353,6 @@ export function ProviderKeyModelsTab({
           </p>
         )}
       </SectionCard>
-
-      {supportsLiveDiscovery ? (
-        <SectionCard>
-          <OpenAIModelDiscoveryPanel
-            discovering={discovering}
-            discoverModels={discoverModels!}
-            applyDiscoveredModels={applyDiscoveredModels!}
-            discoveredModels={discoveredModels}
-            discoverSelected={discoverSelected}
-            setDiscoverSelected={setDiscoverSelected!}
-          />
-          <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-            {t("providers.claude_models_discovery_hint")}
-          </p>
-        </SectionCard>
-      ) : null}
 
       <ExcludedModelsEditor
         count={editKeyExcludedCount}

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -74,43 +74,6 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
   return `${normalized}/models`;
 };
 
-/** Default bases when the provider key leaves base URL empty (official endpoints). */
-export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
-export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
-
-/**
- * Build the upstream /models URL for Claude provider keys.
- * Claude uses Anthropic-style `/v1/models`. Codex intentionally has no live
- * discovery path — incomplete upstream catalogs must not replace the static list.
- */
-export const buildProviderModelsEndpoint = (
-  providerType: "claude" | "openai",
-  baseUrl: string,
-): string => {
-  if (providerType === "claude") {
-    const normalized = normalizeOpenAIBaseUrl(baseUrl || DEFAULT_CLAUDE_MODELS_BASE);
-    if (!normalized) return "";
-    const lower = normalized.toLowerCase();
-    if (lower.endsWith("/models") || lower.includes("/models?")) {
-      return normalized;
-    }
-    if (lower.endsWith("/v1")) return `${normalized}/models`;
-    return `${normalized}/v1/models`;
-  }
-  // OpenAI-compatible: prefer /v1/models when base has no path tail.
-  const normalized = normalizeOpenAIBaseUrl(baseUrl);
-  if (!normalized) return "";
-  const lower = normalized.toLowerCase();
-  if (lower.endsWith("/models") || lower.includes("/models?")) {
-    return normalized;
-  }
-  if (lower.endsWith("/v1")) return `${normalized}/models`;
-  if (lower.includes("api.openai.com") && !/\/v\d+(\/|$)/i.test(lower)) {
-    return `${normalized}/v1/models`;
-  }
-  return `${normalized}/models`;
-};
-
 export const normalizeDiscoveredModels = (
   payload: unknown,
 ): { id: string; owned_by?: string }[] => {
@@ -127,18 +90,14 @@ export const normalizeDiscoveredModels = (
     }
   }
   const root = isRecord(payload) ? payload : null;
-  // Codex manifests may nest under data / models / items.
-  const data = root
-    ? (root.data ?? root.models ?? root.items ?? payload)
-    : payload;
+  const data = root ? (root.data ?? root.models ?? payload) : payload;
   if (!Array.isArray(data)) return [];
 
   const seen = new Set<string>();
   const result: { id: string; owned_by?: string }[] = [];
   for (const item of data) {
     if (!isRecord(item)) continue;
-    // Claude: id; Codex: id | slug | name
-    const id = String(item.id ?? item.slug ?? item.name ?? "").trim();
+    const id = String(item.id ?? item.name ?? "").trim();
     if (!id) continue;
     const key = id.toLowerCase();
     if (seen.has(key)) continue;


### PR DESCRIPTION
## Summary

Remove Claude provider-key **Fetch /models** discovery UI and helpers. Incomplete upstream Anthropic catalogs must not replace the static registry list.

OpenAI-compatible discovery is unchanged. Pairs with CliRelay `fix/revert-claude-live-models`.

## Test plan
- [x] `bun run lint` / `design:check` / `build` / `bundle:diff`
- [x] `bun test pages/providers/__tests__/providers-helpers.test.ts`