### PR TITLE
fix(auth-files): keep Claude/Codex live model list after refresh

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -699,7 +699,9 @@ const loadAuthFileModelItems = async (
       }
 
       try {
-        const liveModels = await authFilesApi.getModelsForAuthFile(file.name);
+        const { models: liveModels } = await authFilesApi.getModelsForAuthFile(
+          file.name,
+        );
         scoped = true;
         for (const model of liveModels) {
           addModel(

--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -86,11 +86,15 @@ export const authFilesApi = {
   getModelsForAuthFile: async (
     name: string,
     options?: { force?: boolean },
-  ): Promise<{ id: string; display_name?: string; type?: string; owned_by?: string }[]> => {
+  ): Promise<{
+    models: { id: string; display_name?: string; type?: string; owned_by?: string }[];
+    source: "registry" | "upstream" | string;
+  }> => {
     const params: Record<string, string> = { name };
-    // refresh=1 asks the backend to re-fetch live upstream /models for discovery.
-    // xai/antigravity may update the registry; claude/codex return upstream lists
-    // without replacing the static registry catalog.
+    // refresh=1 forces a re-fetch from upstream.
+    // claude/codex: backend keeps a provider-level discovery cache (shared by
+    // same-type accounts); open auto-warms once, force refreshes the cache.
+    // xai/antigravity may also update the runtime registry.
     if (options?.force) {
       params.refresh = "1";
     }
@@ -98,9 +102,17 @@ export const authFilesApi = {
       params,
     });
     const models = data.models ?? data["models"];
-    return Array.isArray(models)
-      ? (models as { id: string; display_name?: string; type?: string; owned_by?: string }[])
-      : [];
+    const sourceRaw = data.source ?? data["source"];
+    const source =
+      typeof sourceRaw === "string" && sourceRaw.trim()
+        ? sourceRaw.trim().toLowerCase()
+        : "registry";
+    return {
+      models: Array.isArray(models)
+        ? (models as { id: string; display_name?: string; type?: string; owned_by?: string }[])
+        : [],
+      source,
+    };
   },
   getModelDefinitions: async (
     channel: string,

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -66,7 +66,10 @@ const mocks = vi.hoisted(() => ({
   deleteFile: vi.fn(async () => ({})),
   downloadText: vi.fn(async () => "{}"),
   patchFields: vi.fn(async () => ({})),
-  getModelsForAuthFile: vi.fn(async () => [{ id: "live-only", owned_by: "runtime" }]),
+  getModelsForAuthFile: vi.fn(async () => ({
+    models: [{ id: "live-only", owned_by: "runtime" }],
+    source: "upstream",
+  })),
   getModelConfigs: vi.fn(async () => [
     { id: "gpt-4.1", owned_by: "openai" },
     { id: "claude-sonnet-4-5", owned_by: "anthropic" },
@@ -254,9 +257,10 @@ describe("AuthFilesPage files table", () => {
     mocks.patchFields.mockReset();
     mocks.patchFields.mockImplementation(async () => ({}));
     mocks.getModelsForAuthFile.mockReset();
-    mocks.getModelsForAuthFile.mockImplementation(async () => [
-      { id: "live-only", owned_by: "runtime" },
-    ]);
+    mocks.getModelsForAuthFile.mockImplementation(async () => ({
+      models: [{ id: "live-only", owned_by: "runtime" }],
+      source: "upstream",
+    }));
     mocks.getModelConfigs.mockReset();
     mocks.getModelConfigs.mockImplementation(async () => [
       { id: "gpt-4.1", owned_by: "openai" },

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -201,7 +201,12 @@ export function useAuthFilesDetailEditors(
 ) {
   const { t } = useTranslation();
   const { notify } = useToast();
+  // Per-auth-file list cache (any provider).
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
+  // Shared live discovery list for claude/codex (same-type accounts reuse).
+  const providerDiscoveryCacheRef = useRef<Map<string, AuthFileModelItem[]>>(
+    new Map(),
+  );
   const detailTrendInFlightRef = useRef<Map<string, Promise<void>>>(new Map());
   const identityFingerprintDetailKeyRef = useRef("");
 
@@ -248,25 +253,50 @@ export function useAuthFilesDetailEditors(
   const loadModelsForDetail = useCallback(
     async (file: AuthFileItem, options?: { force?: boolean }) => {
       const force = Boolean(options?.force);
-      setModelsFileType(resolveFileType(file));
-      setModelsLoading(true);
-      setModelsList([]);
+      const fileType = resolveFileType(file);
+      const provider = normalizeProviderKey(fileType);
+      const sharedDiscovery = provider === "claude" || provider === "codex";
+      setModelsFileType(fileType);
       setModelsError(null);
 
-      if (!force) {
-        const cached = modelsCacheRef.current.get(file.name);
-        if (cached) {
-          setModelsList(cached);
+      // Prefer shared provider discovery cache so reopening the modal keeps the
+      // live list (not the static registry) after a successful warm/refresh.
+      if (!force && sharedDiscovery) {
+        const providerCached = providerDiscoveryCacheRef.current.get(provider);
+        if (providerCached && providerCached.length > 0) {
+          setModelsList(providerCached);
           setModelsLoading(false);
           return;
         }
       }
 
+      if (!force) {
+        const cached = modelsCacheRef.current.get(file.name);
+        if (cached && cached.length > 0) {
+          setModelsList(cached);
+          // For non-discovery providers, file cache is enough.
+          // For claude/codex, still call the API so backend can auto-warm the
+          // shared provider cache; keep showing the file cache meanwhile.
+          if (!sharedDiscovery) {
+            setModelsLoading(false);
+            return;
+          }
+        } else {
+          setModelsList([]);
+        }
+      }
+
+      setModelsLoading(true);
+
       try {
-        const list = await authFilesApi.getModelsForAuthFile(file.name, {
-          force,
-        });
+        const { models: list, source } = await authFilesApi.getModelsForAuthFile(
+          file.name,
+          { force },
+        );
         modelsCacheRef.current.set(file.name, list);
+        if (sharedDiscovery && source === "upstream" && list.length > 0) {
+          providerDiscoveryCacheRef.current.set(provider, list);
+        }
         setModelsList(list);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "";

--- a/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -76,7 +76,11 @@ vi.mock("@code-proxy/api-client", () => ({
       const payload = await apiMocks.get("/auth-files/models", { params: { name } });
       const record =
         payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-      return Array.isArray(record.models) ? record.models : [];
+      return {
+        models: Array.isArray(record.models) ? record.models : [],
+        source:
+          typeof record.source === "string" ? String(record.source) : "registry",
+      };
     },
     getModelDefinitions: async (channel: string) => {
       const normalizedChannel = String(channel ?? "")

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -22,7 +22,11 @@ vi.mock("@code-proxy/api-client", () => ({
       const payload = await mocks.apiGet("/auth-files/models", { params: { name } });
       const record =
         payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-      return Array.isArray(record.models) ? record.models : [];
+      return {
+        models: Array.isArray(record.models) ? record.models : [],
+        source:
+          typeof record.source === "string" ? String(record.source) : "registry",
+      };
     },
   },
   providersApi: {

--- a/pages/models/__tests__/ModelsPage.test.tsx
+++ b/pages/models/__tests__/ModelsPage.test.tsx
@@ -35,7 +35,11 @@ vi.mock("@code-proxy/api-client", () => ({
       const payload = await mocks.apiGet("/auth-files/models", { params: { name } });
       const record =
         payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-      return Array.isArray(record.models) ? record.models : [];
+      return {
+        models: Array.isArray(record.models) ? record.models : [],
+        source:
+          typeof record.source === "string" ? String(record.source) : "registry",
+      };
     },
     getModelDefinitions: async (channel: string) => {
       const normalizedChannel = String(channel ?? "")


### PR DESCRIPTION
## Summary
- `getModelsForAuthFile` now returns `{ models, source }` so the UI can tell registry vs upstream discovery.
- Auth-files detail editor keeps a **provider-level** discovery cache for claude/codex; after a successful warm/manual refresh, reopening the modal shows the live list instead of snapping back to the static registry catalog.
- Same-type accounts reuse the shared list (no redundant client-side re-fetch of the static path).

Pairs with CliRelay #677 (provider discovery cache + auto-warm on open).

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci 725, build, bundle:diff PASS, e2e critical 9)
- [ ] Deploy Frontend then hard-refresh panel: open Codex models → live list; close/reopen → still live; open another Codex account → shared list; manual refresh still works

## Local CI
```
bun install --frozen-lockfile
bun run lint
bun run design:check
bun run test:ci
bun run build
bun run bundle:diff
playwright e2e @critical
```