### PR TITLE
fix(auth-files): include xAI/Grok in shared live model discovery cache

### DIFF
--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -92,9 +92,9 @@ export const authFilesApi = {
   }> => {
     const params: Record<string, string> = { name };
     // refresh=1 forces a re-fetch from upstream.
-    // claude/codex: backend keeps a provider-level discovery cache (shared by
-    // same-type accounts); open auto-warms once, force refreshes the cache.
-    // xai/antigravity may also update the runtime registry.
+    // claude/codex/xai: backend keeps a provider-level discovery cache (shared
+    // by same-type accounts); open auto-warms once, force refreshes the cache.
+    // antigravity may still update the runtime registry on force refresh.
     if (options?.force) {
       params.refresh = "1";
     }

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -203,7 +203,7 @@ export function useAuthFilesDetailEditors(
   const { notify } = useToast();
   // Per-auth-file list cache (any provider).
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
-  // Shared live discovery list for claude/codex (same-type accounts reuse).
+  // Shared live discovery list for claude/codex/xai (same-type accounts reuse).
   const providerDiscoveryCacheRef = useRef<Map<string, AuthFileModelItem[]>>(
     new Map(),
   );
@@ -255,14 +255,21 @@ export function useAuthFilesDetailEditors(
       const force = Boolean(options?.force);
       const fileType = resolveFileType(file);
       const provider = normalizeProviderKey(fileType);
-      const sharedDiscovery = provider === "claude" || provider === "codex";
+      // Align with backend normalizeDiscoveryProvider (x-ai/grok → xai).
+      const discoveryProvider =
+        provider === "x-ai" || provider === "grok" ? "xai" : provider;
+      const sharedDiscovery =
+        discoveryProvider === "claude" ||
+        discoveryProvider === "codex" ||
+        discoveryProvider === "xai";
       setModelsFileType(fileType);
       setModelsError(null);
 
       // Prefer shared provider discovery cache so reopening the modal keeps the
       // live list (not the static registry) after a successful warm/refresh.
       if (!force && sharedDiscovery) {
-        const providerCached = providerDiscoveryCacheRef.current.get(provider);
+        const providerCached =
+          providerDiscoveryCacheRef.current.get(discoveryProvider);
         if (providerCached && providerCached.length > 0) {
           setModelsList(providerCached);
           setModelsLoading(false);
@@ -275,7 +282,7 @@ export function useAuthFilesDetailEditors(
         if (cached && cached.length > 0) {
           setModelsList(cached);
           // For non-discovery providers, file cache is enough.
-          // For claude/codex, still call the API so backend can auto-warm the
+          // For claude/codex/xai, still call the API so backend can auto-warm the
           // shared provider cache; keep showing the file cache meanwhile.
           if (!sharedDiscovery) {
             setModelsLoading(false);
@@ -295,7 +302,7 @@ export function useAuthFilesDetailEditors(
         );
         modelsCacheRef.current.set(file.name, list);
         if (sharedDiscovery && source === "upstream" && list.length > 0) {
-          providerDiscoveryCacheRef.current.set(provider, list);
+          providerDiscoveryCacheRef.current.set(discoveryProvider, list);
         }
         setModelsList(list);
       } catch (err: unknown) {


### PR DESCRIPTION
## Summary
前端把 **xAI / Grok** 纳入与 Claude/Codex 相同的 provider discovery 缓存：

- `sharedDiscovery` 包含 `xai`（`x-ai` / `grok` 归一到 `xai`）
- 重开弹窗保留 live 列表；同类型账号复用
- 配对 CliRelay #679

## Test plan
- [ ] `./scripts/ci-pr.sh`
- [ ] Deploy 后打开 Grok 账号模型 → live；再开另一 xAI 账号 → 共享缓存

## Local CI
Running `./scripts/ci-pr.sh` in worktree.