### PR TITLE
Release: merge dev into main for v0.4.14

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -699,7 +699,9 @@ const loadAuthFileModelItems = async (
       }
 
       try {
-        const liveModels = await authFilesApi.getModelsForAuthFile(file.name);
+        const { models: liveModels } = await authFilesApi.getModelsForAuthFile(
+          file.name,
+        );
         scoped = true;
         for (const model of liveModels) {
           addModel(

--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -85,9 +85,16 @@ export const authFilesApi = {
 
   getModelsForAuthFile: async (
     name: string,
+    options?: { force?: boolean },
   ): Promise<{ id: string; display_name?: string; type?: string; owned_by?: string }[]> => {
+    const params: Record<string, string> = { name };
+    // refresh=1 asks the backend to re-fetch live upstream /models for
+    // claude/codex (and other live-capable providers) and update the registry.
+    if (options?.force) {
+      params.refresh = "1";
+    }
     const data = await apiClient.get<Record<string, unknown>>("/auth-files/models", {
-      params: { name },
+      params,
     });
     const models = data.models ?? data["models"];
     return Array.isArray(models)

--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -88,8 +88,9 @@ export const authFilesApi = {
     options?: { force?: boolean },
   ): Promise<{ id: string; display_name?: string; type?: string; owned_by?: string }[]> => {
     const params: Record<string, string> = { name };
-    // refresh=1 asks the backend to re-fetch live upstream /models for
-    // claude/codex (and other live-capable providers) and update the registry.
+    // refresh=1 asks the backend to re-fetch live upstream /models for discovery.
+    // xai/antigravity may update the registry; claude/codex return upstream lists
+    // without replacing the static registry catalog.
     if (options?.force) {
       params.refresh = "1";
     }

--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -86,11 +86,15 @@ export const authFilesApi = {
   getModelsForAuthFile: async (
     name: string,
     options?: { force?: boolean },
-  ): Promise<{ id: string; display_name?: string; type?: string; owned_by?: string }[]> => {
+  ): Promise<{
+    models: { id: string; display_name?: string; type?: string; owned_by?: string }[];
+    source: "registry" | "upstream" | string;
+  }> => {
     const params: Record<string, string> = { name };
-    // refresh=1 asks the backend to re-fetch live upstream /models for discovery.
-    // xai/antigravity may update the registry; claude/codex return upstream lists
-    // without replacing the static registry catalog.
+    // refresh=1 forces a re-fetch from upstream.
+    // claude/codex: backend keeps a provider-level discovery cache (shared by
+    // same-type accounts); open auto-warms once, force refreshes the cache.
+    // xai/antigravity may also update the runtime registry.
     if (options?.force) {
       params.refresh = "1";
     }
@@ -98,9 +102,17 @@ export const authFilesApi = {
       params,
     });
     const models = data.models ?? data["models"];
-    return Array.isArray(models)
-      ? (models as { id: string; display_name?: string; type?: string; owned_by?: string }[])
-      : [];
+    const sourceRaw = data.source ?? data["source"];
+    const source =
+      typeof sourceRaw === "string" && sourceRaw.trim()
+        ? sourceRaw.trim().toLowerCase()
+        : "registry";
+    return {
+      models: Array.isArray(models)
+        ? (models as { id: string; display_name?: string; type?: string; owned_by?: string }[])
+        : [],
+      source,
+    };
   },
   getModelDefinitions: async (
     channel: string,

--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -92,9 +92,9 @@ export const authFilesApi = {
   }> => {
     const params: Record<string, string> = { name };
     // refresh=1 forces a re-fetch from upstream.
-    // claude/codex: backend keeps a provider-level discovery cache (shared by
-    // same-type accounts); open auto-warms once, force refreshes the cache.
-    // xai/antigravity may also update the runtime registry.
+    // claude/codex/xai: backend keeps a provider-level discovery cache (shared
+    // by same-type accounts); open auto-warms once, force refreshes the cache.
+    // antigravity may still update the runtime registry on force refresh.
     if (options?.force) {
       params.refresh = "1";
     }

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3592,7 +3592,6 @@
     "no_models_selected": "No models selected",
     "models_merged": "Model list merged",
     "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
-    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead.",
     "ampcode_saved": "Ampcode configuration saved",
     "current_status": "Current: {{status}} · {{count}} mappings",
     "status_loaded": "Loaded",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3616,7 +3616,9 @@
     "test_model_placeholder": "e.g. gpt-4.1",
     "api_key_placeholder": "Paste API key",
     "anthropic_processing_label": "Anthropic Processing",
-    "anthropic_processing_hint": "When enabled, applies Anthropic-specific processing (cloaking, cache control, tool prefix). Disable for third-party Claude-compatible APIs (e.g. Kimi) to improve performance."
+    "anthropic_processing_hint": "When enabled, applies Anthropic-specific processing (cloaking, cache control, tool prefix). Disable for third-party Claude-compatible APIs (e.g. Kimi) to improve performance.",
+    "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
+    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead."
   },
   "logs_page": {
     "error_log_files": "Error Log Files",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3591,6 +3591,8 @@
     "fetch_models_failed": "Failed to fetch models",
     "no_models_selected": "No models selected",
     "models_merged": "Model list merged",
+    "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
+    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead.",
     "ampcode_saved": "Ampcode configuration saved",
     "current_status": "Current: {{status}} · {{count}} mappings",
     "status_loaded": "Loaded",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3591,7 +3591,6 @@
     "fetch_models_failed": "Failed to fetch models",
     "no_models_selected": "No models selected",
     "models_merged": "Model list merged",
-    "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
     "ampcode_saved": "Ampcode configuration saved",
     "current_status": "Current: {{status}} · {{count}} mappings",
     "status_loaded": "Loaded",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2852,7 +2852,6 @@
     "no_models_selected": "未选择任何模型",
     "models_merged": "模型列表已合并",
     "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
-    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。",
     "ampcode_saved": "Ampcode 配置已保存",
     "current_status": "当前：{{status}} · 映射 {{count}} 条",
     "status_loaded": "已加载",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2876,7 +2876,9 @@
     "test_model_placeholder": "例如 gpt-4.1",
     "api_key_placeholder": "粘贴 API 密钥",
     "anthropic_processing_label": "Anthropic 专有处理",
-    "anthropic_processing_hint": "开启时将执行 Anthropic 专有处理（伪装、缓存控制、工具前缀等）。如 Base URL 指向第三方 Claude 兼容 API（如 Kimi），建议关闭以提升性能。"
+    "anthropic_processing_hint": "开启时将执行 Anthropic 专有处理（伪装、缓存控制、工具前缀等）。如 Base URL 指向第三方 Claude 兼容 API（如 Kimi），建议关闭以提升性能。",
+    "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
+    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。"
   },
   "request_logs": {
     "title": "请求日志",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2851,7 +2851,6 @@
     "fetch_models_failed": "获取模型失败",
     "no_models_selected": "未选择任何模型",
     "models_merged": "模型列表已合并",
-    "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
     "ampcode_saved": "Ampcode 配置已保存",
     "current_status": "当前：{{status}} · 映射 {{count}} 条",
     "status_loaded": "已加载",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2851,6 +2851,8 @@
     "fetch_models_failed": "获取模型失败",
     "no_models_selected": "未选择任何模型",
     "models_merged": "模型列表已合并",
+    "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
+    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。",
     "ampcode_saved": "Ampcode 配置已保存",
     "current_status": "当前：{{status}} · 映射 {{count}} 条",
     "status_loaded": "已加载",

--- a/packages/ui/src/overlays/Modal.tsx
+++ b/packages/ui/src/overlays/Modal.tsx
@@ -1,8 +1,17 @@
 import { createPortal } from "react-dom";
-import { useEffect, useId, useRef, useState, type PropsWithChildren, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
 import { X } from "lucide-react";
 
-const ANIMATION_MS = 180;
+/** Exit animation duration — keep content mounted until this finishes. */
+const ANIMATION_MS = 220;
+const EASE = "cubic-bezier(0.16, 1, 0.3, 1)";
 
 export function Modal({
   open,
@@ -38,6 +47,25 @@ export function Modal({
   const [visible, setVisible] = useState(open);
   const timeoutRef = useRef<number | null>(null);
   const titleId = useId();
+  // Snapshot title/description/footer/children while open so parents can clear
+  // props immediately without collapsing the panel mid-exit animation.
+  const contentRef = useRef({
+    title,
+    titleAccessory,
+    description,
+    footer,
+    children,
+  });
+  if (open) {
+    contentRef.current = {
+      title,
+      titleAccessory,
+      description,
+      footer,
+      children,
+    };
+  }
+  const snapshot = contentRef.current;
 
   useEffect(() => {
     if (open) {
@@ -46,8 +74,15 @@ export function Modal({
         timeoutRef.current = null;
       }
       setMounted(true);
-      const raf = window.requestAnimationFrame(() => setVisible(true));
-      return () => window.cancelAnimationFrame(raf);
+      // Double rAF ensures the browser paints the "hidden" frame before animating in.
+      let raf2 = 0;
+      const raf1 = window.requestAnimationFrame(() => {
+        raf2 = window.requestAnimationFrame(() => setVisible(true));
+      });
+      return () => {
+        window.cancelAnimationFrame(raf1);
+        if (raf2) window.cancelAnimationFrame(raf2);
+      };
     }
 
     setVisible(false);
@@ -82,6 +117,10 @@ export function Modal({
 
   const bodyHeightCls = bodyHeightClassName ?? "max-h-[70vh]";
   const bodyOverflowCls = bodyOverflowClassName ?? "overflow-y-auto";
+  const transitionStyle = {
+    transitionDuration: `${ANIMATION_MS}ms`,
+    transitionTimingFunction: EASE,
+  } as const;
 
   return createPortal(
     <div className="fixed inset-0 z-[200] flex items-center justify-center p-4">
@@ -92,9 +131,10 @@ export function Modal({
           onClose();
         }}
         aria-label="close"
+        style={transitionStyle}
         className={[
           "absolute inset-0 cursor-default bg-slate-900/40 backdrop-blur-sm dark:bg-black/50",
-          "transition-opacity duration-200 ease-out motion-reduce:transition-none",
+          "transition-opacity motion-reduce:transition-none",
           visible ? "opacity-100" : "opacity-0",
         ].join(" ")}
       />
@@ -102,12 +142,16 @@ export function Modal({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label={hideHeader ? title : undefined}
+        aria-label={hideHeader ? snapshot.title : undefined}
         aria-labelledby={hideHeader ? undefined : titleId}
+        style={transitionStyle}
         className={[
           `relative z-10 w-full ${maxWidth} overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-950`,
-          "transition-all duration-200 ease-out motion-reduce:transition-none",
-          visible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-95",
+          // Animate opacity + subtle rise only — avoid scale that makes height feel like it collapses.
+          "transition-[opacity,transform] will-change-transform motion-reduce:transition-none motion-reduce:transform-none",
+          visible
+            ? "opacity-100 translate-y-0"
+            : "opacity-0 translate-y-3",
           panelClassName,
         ].join(" ")}
       >
@@ -126,16 +170,18 @@ export function Modal({
             <div className="min-w-0">
               <h2 className="flex min-w-0 items-center gap-2 text-base font-semibold tracking-tight text-slate-900 dark:text-white">
                 <span id={titleId} className="min-w-0 truncate">
-                  {title}
+                  {snapshot.title}
                 </span>
-                {titleAccessory ? (
+                {snapshot.titleAccessory ? (
                   <span className="shrink-0" aria-hidden="true">
-                    {titleAccessory}
+                    {snapshot.titleAccessory}
                   </span>
                 ) : null}
               </h2>
-              {description ? (
-                <p className="mt-1 text-sm text-slate-600 dark:text-white/65">{description}</p>
+              {snapshot.description ? (
+                <p className="mt-1 text-sm text-slate-600 dark:text-white/65">
+                  {snapshot.description}
+                </p>
               ) : null}
             </div>
             <button
@@ -154,12 +200,12 @@ export function Modal({
           data-testid={bodyTestId}
           className={`${bodyHeightCls} ${bodyOverflowCls} overscroll-contain px-5 py-4 ${bodyClassName ?? ""}`}
         >
-          {children}
+          {snapshot.children}
         </div>
 
-        {footer ? (
+        {snapshot.footer ? (
           <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 px-5 py-4 dark:border-neutral-800">
-            {footer}
+            {snapshot.footer}
           </div>
         ) : null}
       </div>

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -425,6 +425,47 @@ describe("AuthFileDetailModal", () => {
     expectSummaryCard("Current weekly cycle", "116");
     // Remaining snapshot percent 75% => used 25%.
     expectSummaryCard("Weekly quota used", "25%");
+    // xAI shows weekly prediction (zero when cycle cost is missing), never the Codex 5h card.
+    expectSummaryCard("Predicted weekly window quota", "$0.0000");
+    expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
+  });
+
+  test("predicts xAI weekly window quota from cycle cost and used percent", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "xai-user.json",
+        label: "xAI Grok",
+        type: "xai",
+        provider: "xai",
+        size: 256,
+      },
+      modelsFileType: "xai",
+      quotaState: {
+        status: "success",
+        planType: "supergrok-heavy",
+        items: [],
+        updatedAt: Date.now(),
+      },
+      detailTrend: {
+        auth_index: "xai-auth",
+        days: 7,
+        hours: 5,
+        request_total: 180,
+        cycle_request_total: 180,
+        cycle_cost_total: 7.352,
+        weekly_quota_used_percent: 6,
+        cycle_known: true,
+        cycle_start: "2026-07-12T05:05:02Z",
+        daily_usage: [],
+        hourly_usage: [],
+        quota_series: [],
+      },
+    });
+
+    expectSummaryCard("Current cycle cost", "$7.3520");
+    expectSummaryCard("Weekly quota used", "6%");
+    // $7.352 / 6% ≈ $122.5333 full weekly window budget.
+    expectSummaryCard("Predicted weekly window quota", "$122.5333");
     expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
   });
 

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -66,7 +66,10 @@ const mocks = vi.hoisted(() => ({
   deleteFile: vi.fn(async () => ({})),
   downloadText: vi.fn(async () => "{}"),
   patchFields: vi.fn(async () => ({})),
-  getModelsForAuthFile: vi.fn(async () => [{ id: "live-only", owned_by: "runtime" }]),
+  getModelsForAuthFile: vi.fn(async () => ({
+    models: [{ id: "live-only", owned_by: "runtime" }],
+    source: "upstream",
+  })),
   getModelConfigs: vi.fn(async () => [
     { id: "gpt-4.1", owned_by: "openai" },
     { id: "claude-sonnet-4-5", owned_by: "anthropic" },
@@ -254,9 +257,10 @@ describe("AuthFilesPage files table", () => {
     mocks.patchFields.mockReset();
     mocks.patchFields.mockImplementation(async () => ({}));
     mocks.getModelsForAuthFile.mockReset();
-    mocks.getModelsForAuthFile.mockImplementation(async () => [
-      { id: "live-only", owned_by: "runtime" },
-    ]);
+    mocks.getModelsForAuthFile.mockImplementation(async () => ({
+      models: [{ id: "live-only", owned_by: "runtime" }],
+      source: "upstream",
+    }));
     mocks.getModelConfigs.mockReset();
     mocks.getModelConfigs.mockImplementation(async () => [
       { id: "gpt-4.1", owned_by: "openai" },

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -1102,10 +1102,12 @@ export function AuthFileDetailModal({
 
   const renderUsageTrend = () => {
     const isCodexDetail = detailProviderKey === "codex";
-    const summaryGridClassName = isCodexDetail
+    // xAI only has a weekly window (no Codex 5h slot); still show predicted weekly quota like Codex.
+    const showPredictedWeeklyQuota = isCodexDetail || detailProviderKey === "xai";
+    const summaryGridClassName = showPredictedWeeklyQuota
       ? "grid gap-3 sm:grid-cols-2 xl:grid-cols-6"
       : "grid gap-3 sm:grid-cols-2 xl:grid-cols-5";
-    const summarySkeletonCount = isCodexDetail ? 6 : 5;
+    const summarySkeletonCount = showPredictedWeeklyQuota ? 6 : 5;
 
     if (detailTrendLoading && !detailTrend) {
       const skeletonClass = "animate-pulse rounded-lg bg-slate-100/80 dark:bg-white/[0.06]";
@@ -1208,20 +1210,20 @@ export function AuthFileDetailModal({
             <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(displayCycleCostTotal)}</p>
           </div>
           {isCodexDetail ? (
-            <>
-              <div className={SUMMARY_CARD_CLASS_NAME}>
-                <p className={SUMMARY_LABEL_CLASS_NAME}>
-                  {t("auth_files.trend_predicted_5h_window_quota")}
-                </p>
-                <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedFiveHourQuota)}</p>
-              </div>
-              <div className={SUMMARY_CARD_CLASS_NAME}>
-                <p className={SUMMARY_LABEL_CLASS_NAME}>
-                  {t("auth_files.trend_predicted_week_window_quota")}
-                </p>
-                <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
-              </div>
-            </>
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>
+                {t("auth_files.trend_predicted_5h_window_quota")}
+              </p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedFiveHourQuota)}</p>
+            </div>
+          ) : null}
+          {showPredictedWeeklyQuota ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>
+                {t("auth_files.trend_predicted_week_window_quota")}
+              </p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
+            </div>
           ) : null}
           <div className={SUMMARY_CARD_CLASS_NAME}>
             <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_weekly_quota_used")}</p>

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -203,7 +203,7 @@ export function useAuthFilesDetailEditors(
   const { notify } = useToast();
   // Per-auth-file list cache (any provider).
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
-  // Shared live discovery list for claude/codex (same-type accounts reuse).
+  // Shared live discovery list for claude/codex/xai (same-type accounts reuse).
   const providerDiscoveryCacheRef = useRef<Map<string, AuthFileModelItem[]>>(
     new Map(),
   );
@@ -255,14 +255,21 @@ export function useAuthFilesDetailEditors(
       const force = Boolean(options?.force);
       const fileType = resolveFileType(file);
       const provider = normalizeProviderKey(fileType);
-      const sharedDiscovery = provider === "claude" || provider === "codex";
+      // Align with backend normalizeDiscoveryProvider (x-ai/grok → xai).
+      const discoveryProvider =
+        provider === "x-ai" || provider === "grok" ? "xai" : provider;
+      const sharedDiscovery =
+        discoveryProvider === "claude" ||
+        discoveryProvider === "codex" ||
+        discoveryProvider === "xai";
       setModelsFileType(fileType);
       setModelsError(null);
 
       // Prefer shared provider discovery cache so reopening the modal keeps the
       // live list (not the static registry) after a successful warm/refresh.
       if (!force && sharedDiscovery) {
-        const providerCached = providerDiscoveryCacheRef.current.get(provider);
+        const providerCached =
+          providerDiscoveryCacheRef.current.get(discoveryProvider);
         if (providerCached && providerCached.length > 0) {
           setModelsList(providerCached);
           setModelsLoading(false);
@@ -275,7 +282,7 @@ export function useAuthFilesDetailEditors(
         if (cached && cached.length > 0) {
           setModelsList(cached);
           // For non-discovery providers, file cache is enough.
-          // For claude/codex, still call the API so backend can auto-warm the
+          // For claude/codex/xai, still call the API so backend can auto-warm the
           // shared provider cache; keep showing the file cache meanwhile.
           if (!sharedDiscovery) {
             setModelsLoading(false);
@@ -295,7 +302,7 @@ export function useAuthFilesDetailEditors(
         );
         modelsCacheRef.current.set(file.name, list);
         if (sharedDiscovery && source === "upstream" && list.length > 0) {
-          providerDiscoveryCacheRef.current.set(provider, list);
+          providerDiscoveryCacheRef.current.set(discoveryProvider, list);
         }
         setModelsList(list);
       } catch (err: unknown) {

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -263,7 +263,9 @@ export function useAuthFilesDetailEditors(
       }
 
       try {
-        const list = await authFilesApi.getModelsForAuthFile(file.name);
+        const list = await authFilesApi.getModelsForAuthFile(file.name, {
+          force,
+        });
         modelsCacheRef.current.set(file.name, list);
         setModelsList(list);
       } catch (err: unknown) {

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -201,7 +201,12 @@ export function useAuthFilesDetailEditors(
 ) {
   const { t } = useTranslation();
   const { notify } = useToast();
+  // Per-auth-file list cache (any provider).
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
+  // Shared live discovery list for claude/codex (same-type accounts reuse).
+  const providerDiscoveryCacheRef = useRef<Map<string, AuthFileModelItem[]>>(
+    new Map(),
+  );
   const detailTrendInFlightRef = useRef<Map<string, Promise<void>>>(new Map());
   const identityFingerprintDetailKeyRef = useRef("");
 
@@ -248,25 +253,50 @@ export function useAuthFilesDetailEditors(
   const loadModelsForDetail = useCallback(
     async (file: AuthFileItem, options?: { force?: boolean }) => {
       const force = Boolean(options?.force);
-      setModelsFileType(resolveFileType(file));
-      setModelsLoading(true);
-      setModelsList([]);
+      const fileType = resolveFileType(file);
+      const provider = normalizeProviderKey(fileType);
+      const sharedDiscovery = provider === "claude" || provider === "codex";
+      setModelsFileType(fileType);
       setModelsError(null);
 
-      if (!force) {
-        const cached = modelsCacheRef.current.get(file.name);
-        if (cached) {
-          setModelsList(cached);
+      // Prefer shared provider discovery cache so reopening the modal keeps the
+      // live list (not the static registry) after a successful warm/refresh.
+      if (!force && sharedDiscovery) {
+        const providerCached = providerDiscoveryCacheRef.current.get(provider);
+        if (providerCached && providerCached.length > 0) {
+          setModelsList(providerCached);
           setModelsLoading(false);
           return;
         }
       }
 
+      if (!force) {
+        const cached = modelsCacheRef.current.get(file.name);
+        if (cached && cached.length > 0) {
+          setModelsList(cached);
+          // For non-discovery providers, file cache is enough.
+          // For claude/codex, still call the API so backend can auto-warm the
+          // shared provider cache; keep showing the file cache meanwhile.
+          if (!sharedDiscovery) {
+            setModelsLoading(false);
+            return;
+          }
+        } else {
+          setModelsList([]);
+        }
+      }
+
+      setModelsLoading(true);
+
       try {
-        const list = await authFilesApi.getModelsForAuthFile(file.name, {
-          force,
-        });
+        const { models: list, source } = await authFilesApi.getModelsForAuthFile(
+          file.name,
+          { force },
+        );
         modelsCacheRef.current.set(file.name, list);
+        if (sharedDiscovery && source === "upstream" && list.length > 0) {
+          providerDiscoveryCacheRef.current.set(provider, list);
+        }
         setModelsList(list);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "";

--- a/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -76,7 +76,11 @@ vi.mock("@code-proxy/api-client", () => ({
       const payload = await apiMocks.get("/auth-files/models", { params: { name } });
       const record =
         payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-      return Array.isArray(record.models) ? record.models : [];
+      return {
+        models: Array.isArray(record.models) ? record.models : [],
+        source:
+          typeof record.source === "string" ? String(record.source) : "registry",
+      };
     },
     getModelDefinitions: async (channel: string) => {
       const normalizedChannel = String(channel ?? "")

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -22,7 +22,11 @@ vi.mock("@code-proxy/api-client", () => ({
       const payload = await mocks.apiGet("/auth-files/models", { params: { name } });
       const record =
         payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-      return Array.isArray(record.models) ? record.models : [];
+      return {
+        models: Array.isArray(record.models) ? record.models : [],
+        source:
+          typeof record.source === "string" ? String(record.source) : "registry",
+      };
     },
   },
   providersApi: {

--- a/pages/models/__tests__/ModelTestModal.test.tsx
+++ b/pages/models/__tests__/ModelTestModal.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { ThemeProvider } from "@code-proxy/ui";
+import {
+  buildChannelOptions,
+  isBareProviderOnlySource,
+  ModelTestModal,
+} from "../components/ModelTestModal";
+import type { ModelItem } from "../types";
+
+const baseModel: ModelItem = {
+  id: "grok-4.5",
+  owned_by: "xai",
+  description: "test",
+  enabled: true,
+  source: "oauth",
+  pricing: {
+    mode: "token",
+    inputPricePerMillion: 0,
+    outputPricePerMillion: 0,
+    cachedPricePerMillion: 0,
+    cacheReadPricePerMillion: 0,
+    cacheWritePricePerMillion: 0,
+    pricePerCall: 0,
+  },
+  inputModalities: ["text"],
+  outputModalities: ["text"],
+  supportsVision: false,
+  sources: [
+    {
+      label: "xai · GinofkFerraiuolo@hotmail.com",
+      provider: "xai",
+      channel: "GinofkFerraiuolo@hotmail.com",
+      clientId: "xai-1",
+    },
+    {
+      label: "xai · LatoriaqcDarr@hotmail.com",
+      provider: "xai",
+      channel: "LatoriaqcDarr@hotmail.com",
+      clientId: "xai-2",
+    },
+    {
+      // Incomplete auth: no email/label beyond provider name (the blank "xai" row).
+      label: "xai",
+      provider: "xai",
+      clientId: "xai-orphan",
+    },
+    {
+      label: "xai",
+      provider: "xai",
+      channel: "xai",
+      clientId: "xai-orphan-2",
+    },
+  ],
+};
+
+describe("buildChannelOptions / isBareProviderOnlySource", () => {
+  test("filters bare provider-only sources like orphan xai rows", () => {
+    expect(
+      isBareProviderOnlySource({ label: "xai", provider: "xai", clientId: "x" }),
+    ).toBe(true);
+    expect(
+      isBareProviderOnlySource({
+        label: "xai",
+        provider: "xai",
+        channel: "xai",
+      }),
+    ).toBe(true);
+    expect(
+      isBareProviderOnlySource({
+        label: "xai · user@example.com",
+        provider: "xai",
+        channel: "user@example.com",
+      }),
+    ).toBe(false);
+    expect(
+      isBareProviderOnlySource({
+        label: "openai · Primary OpenAI",
+        provider: "openai",
+        channel: "Primary OpenAI",
+      }),
+    ).toBe(false);
+
+    const options = buildChannelOptions(baseModel);
+    expect(options.map((o) => o.channel)).toEqual([
+      "GinofkFerraiuolo@hotmail.com",
+      "LatoriaqcDarr@hotmail.com",
+    ]);
+    expect(options.some((o) => o.label === "xai" || o.channel === "xai")).toBe(
+      false,
+    );
+  });
+
+  test("keeps bare provider source only when it is the sole option", () => {
+    const options = buildChannelOptions({
+      ...baseModel,
+      sources: [
+        { label: "xai", provider: "xai", channel: "xai", clientId: "orphan" },
+      ],
+    });
+    expect(options).toEqual([
+      { value: "xai", label: "xai", channel: "xai" },
+    ]);
+  });
+});
+
+describe("ModelTestModal", () => {
+  test("renders success response in green and hides bare channels", async () => {
+    await i18n.changeLanguage("en");
+    const onRun = vi.fn();
+    render(
+      <ThemeProvider>
+        <ModelTestModal
+          model={baseModel}
+          running={false}
+          resultText="I'll check the weather."
+          errorText={null}
+          onClose={() => undefined}
+          onRun={onRun}
+        />
+      </ThemeProvider>,
+    );
+
+    const success = screen.getByTestId("model-test-success");
+    expect(success).toHaveTextContent("I'll check the weather.");
+    expect(success.querySelector("pre")?.className).toMatch(/emerald/);
+
+    // Open channel select and ensure bare "xai" is not listed.
+    const channelTrigger = screen.getByLabelText(/channel/i);
+    await userEvent.click(channelTrigger);
+    await waitFor(() => {
+      expect(screen.queryByRole("option", { name: /^xai$/i })).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("option", { name: /GinofkFerraiuolo@hotmail.com/i }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders error response in red", async () => {
+    await i18n.changeLanguage("en");
+    render(
+      <ThemeProvider>
+        <ModelTestModal
+          model={baseModel}
+          running={false}
+          resultText={null}
+          errorText="upstream timeout"
+          onClose={() => undefined}
+          onRun={() => undefined}
+        />
+      </ThemeProvider>,
+    );
+
+    const error = screen.getByTestId("model-test-error");
+    expect(error).toHaveTextContent("upstream timeout");
+    expect(error.querySelector("[role='alert']")?.className).toMatch(/rose/);
+  });
+});

--- a/pages/models/__tests__/ModelsPage.test.tsx
+++ b/pages/models/__tests__/ModelsPage.test.tsx
@@ -35,7 +35,11 @@ vi.mock("@code-proxy/api-client", () => ({
       const payload = await mocks.apiGet("/auth-files/models", { params: { name } });
       const record =
         payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-      return Array.isArray(record.models) ? record.models : [];
+      return {
+        models: Array.isArray(record.models) ? record.models : [],
+        source:
+          typeof record.source === "string" ? String(record.source) : "registry",
+      };
     },
     getModelDefinitions: async (channel: string) => {
       const normalizedChannel = String(channel ?? "")

--- a/pages/models/components/ModelTestModal.tsx
+++ b/pages/models/components/ModelTestModal.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_MODEL_TEST_PROMPT,
   formatModelSourceLabel,
 } from "../modelsUtils";
-import type { ModelItem } from "../types";
+import type { ModelAvailabilitySource, ModelItem } from "../types";
 
 export type ModelTestChannelOption = {
   value: string;
@@ -14,26 +14,83 @@ export type ModelTestChannelOption = {
   channel: string;
 };
 
-function buildChannelOptions(model: ModelItem | null): ModelTestChannelOption[] {
+function equalsIgnoreCase(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/**
+ * Incomplete auth sources often surface as bare provider names (e.g. "xai")
+ * when Label/email metadata is missing. Those are not usable test channels.
+ *
+ * Real channels look like:
+ * - "user@example.com"
+ * - "xai · user@example.com"
+ * - "Primary OpenAI" (distinct from provider "openai")
+ */
+export function isBareProviderOnlySource(source: ModelAvailabilitySource): boolean {
+  const provider = String(source.provider ?? "").trim();
+  const channel = String(source.channel ?? "").trim();
+  const label = String(source.label ?? "").trim();
+
+  // Email identity is always a real account channel.
+  if (channel.includes("@") || label.includes("@")) return false;
+
+  const channelIsBare =
+    !channel || (Boolean(provider) && equalsIgnoreCase(channel, provider));
+
+  const normalizedLabel = label.replace(/\s*·\s*/g, " · ");
+  const labelIsBare =
+    !label ||
+    (Boolean(provider) &&
+      (equalsIgnoreCase(label, provider) ||
+        equalsIgnoreCase(normalizedLabel, `${provider} · ${provider}`)));
+
+  // Both channel and label collapse to the provider (or are empty) → incomplete source.
+  return channelIsBare && labelIsBare;
+}
+
+function sourceToOption(source: ModelAvailabilitySource): ModelTestChannelOption | null {
+  const channel =
+    String(source.channel ?? "").trim() ||
+    String(source.label ?? "").trim() ||
+    String(source.clientId ?? "").trim();
+  if (!channel) return null;
+  return {
+    value: channel,
+    label: formatModelSourceLabel(source),
+    channel,
+  };
+}
+
+export function buildChannelOptions(model: ModelItem | null): ModelTestChannelOption[] {
   if (!model?.sources?.length) return [];
+
+  const rich: ModelTestChannelOption[] = [];
+  const bare: ModelTestChannelOption[] = [];
   const seen = new Set<string>();
-  const options: ModelTestChannelOption[] = [];
-  for (const source of model.sources) {
-    const channel =
-      String(source.channel ?? "").trim() ||
-      String(source.label ?? "").trim() ||
-      String(source.clientId ?? "").trim();
-    if (!channel) continue;
-    const key = channel.toLowerCase();
-    if (seen.has(key)) continue;
+
+  const pushUnique = (
+    list: ModelTestChannelOption[],
+    option: ModelTestChannelOption,
+  ) => {
+    const key = option.channel.toLowerCase();
+    if (seen.has(key)) return;
     seen.add(key);
-    options.push({
-      value: channel,
-      label: formatModelSourceLabel(source),
-      channel,
-    });
+    list.push(option);
+  };
+
+  for (const source of model.sources) {
+    const option = sourceToOption(source);
+    if (!option) continue;
+    if (isBareProviderOnlySource(source)) {
+      pushUnique(bare, option);
+    } else {
+      pushUnique(rich, option);
+    }
   }
-  return options;
+
+  // Prefer account-level sources; only fall back to bare provider rows when nothing else exists.
+  return rich.length > 0 ? rich : bare;
 }
 
 export interface ModelTestModalProps {
@@ -54,7 +111,22 @@ export function ModelTestModal({
   onRun,
 }: ModelTestModalProps) {
   const { t } = useTranslation();
-  const channelOptions = useMemo(() => buildChannelOptions(model), [model]);
+  // Keep last model/result during Modal exit animation so the panel does not collapse.
+  const [displayModel, setDisplayModel] = useState<ModelItem | null>(model);
+  const [displayResult, setDisplayResult] = useState<string | null>(resultText);
+  const [displayError, setDisplayError] = useState<string | null>(errorText);
+
+  useEffect(() => {
+    if (!model) return;
+    setDisplayModel(model);
+    setDisplayResult(resultText);
+    setDisplayError(errorText);
+  }, [model, resultText, errorText]);
+
+  const channelOptions = useMemo(
+    () => buildChannelOptions(displayModel),
+    [displayModel],
+  );
   const [channel, setChannel] = useState("");
   const [prompt, setPrompt] = useState(DEFAULT_MODEL_TEST_PROMPT);
 
@@ -65,17 +137,20 @@ export function ModelTestModal({
     setPrompt(DEFAULT_MODEL_TEST_PROMPT);
   }, [model]);
 
+  const open = model !== null;
   const canRun = Boolean(model && channel && prompt.trim() && !running);
-  const noChannels = Boolean(model) && channelOptions.length === 0;
+  const noChannels = Boolean(displayModel) && channelOptions.length === 0;
+  const showSuccess = Boolean(displayResult) && !displayError;
+  const showError = Boolean(displayError);
 
   return (
     <Modal
-      open={model !== null}
+      open={open}
       onClose={onClose}
       title={t("models_page.test_model_title")}
       description={
-        model
-          ? t("models_page.test_model_desc", { model: model.id })
+        displayModel
+          ? t("models_page.test_model_desc", { model: displayModel.id })
           : undefined
       }
       maxWidth="max-w-xl"
@@ -97,7 +172,7 @@ export function ModelTestModal({
         </>
       }
     >
-      {model ? (
+      {displayModel ? (
         <div className="space-y-4">
           <div>
             <label
@@ -142,25 +217,43 @@ export function ModelTestModal({
             />
           </div>
 
-          {errorText ? (
-            <div
-              role="alert"
-              className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200"
-            >
-              {errorText}
-            </div>
-          ) : null}
+          {/* Always reserve the response slot while open so success/error swaps don't collapse height. */}
+          <div
+            className={[
+              "grid transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+              showError || showSuccess
+                ? "grid-rows-[1fr] opacity-100"
+                : "grid-rows-[0fr] opacity-0",
+            ].join(" ")}
+            aria-live="polite"
+          >
+            <div className="min-h-0 overflow-hidden">
+              {showError ? (
+                <div data-testid="model-test-error">
+                  <div className="mb-1 text-sm font-medium text-rose-700 dark:text-rose-300">
+                    {t("models_page.test_response")}
+                  </div>
+                  <div
+                    role="alert"
+                    className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200"
+                  >
+                    {displayError}
+                  </div>
+                </div>
+              ) : null}
 
-          {resultText ? (
-            <div>
-              <div className="mb-1 text-sm font-medium text-slate-700 dark:text-white/80">
-                {t("models_page.test_response")}
-              </div>
-              <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-800 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/80">
-                {resultText}
-              </pre>
+              {showSuccess ? (
+                <div data-testid="model-test-success">
+                  <div className="mb-1 text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                    {t("models_page.test_response")}
+                  </div>
+                  <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+                    {displayResult}
+                  </pre>
+                </div>
+              ) : null}
             </div>
-          ) : null}
+          </div>
         </div>
       ) : null}
     </Modal>

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   buildOpenAIDraft,
   buildProviderKeyDraft,
+  buildProviderModelsEndpoint,
   maskApiKey,
   normalizeDiscoveredModels,
 } from "@pages/providers/providers-helpers";
@@ -110,6 +111,34 @@ describe("providers helpers", () => {
         ],
       }),
     ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
+  });
+
+  test("normalizes Claude/Codex payloads via models, items, and slug fields", () => {
+    expect(
+      normalizeDiscoveredModels({
+        models: [{ id: "claude-sonnet-4-5", display_name: "Sonnet" }],
+      }),
+    ).toEqual([{ id: "claude-sonnet-4-5" }]);
+    expect(
+      normalizeDiscoveredModels({
+        items: [{ slug: "gpt-5.1-codex", title: "Codex" }],
+      }),
+    ).toEqual([{ id: "gpt-5.1-codex" }]);
+  });
+
+  test("builds Claude and Codex /models endpoints with defaults", () => {
+    expect(buildProviderModelsEndpoint("claude", "")).toBe(
+      "https://api.anthropic.com/v1/models",
+    );
+    expect(buildProviderModelsEndpoint("claude", "https://gw.example/v1")).toBe(
+      "https://gw.example/v1/models",
+    );
+    expect(buildProviderModelsEndpoint("codex", "")).toBe(
+      "https://api.openai.com/v1/models",
+    );
+    expect(
+      buildProviderModelsEndpoint("codex", "https://api.openai.com/v1"),
+    ).toBe("https://api.openai.com/v1/models");
   });
 
   test("normalizes discovered models from a JSON string payload", () => {

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -4,6 +4,9 @@ import {
   buildProviderKeyDraft,
   maskApiKey,
   normalizeDiscoveredModels,
+  buildProviderModelsEndpoint,
+  DEFAULT_CLAUDE_MODELS_BASE,
+  DEFAULT_CODEX_MODELS_BASE,
 } from "@pages/providers/providers-helpers";
 import {
   buildCandidateUsageSourceIds,
@@ -147,4 +150,35 @@ describe("providers helpers", () => {
     expect(candidates.some((entry) => entry === normalized)).toBe(true);
     expect(normalizeUsageSourceId(masked, maskApiKey)).toBe(`m:${masked}`);
   });
+
+  test("builds Claude and Codex /models endpoints with defaults", () => {
+    expect(buildProviderModelsEndpoint("claude", "")).toBe(
+      `${DEFAULT_CLAUDE_MODELS_BASE}/v1/models`,
+    );
+    expect(buildProviderModelsEndpoint("codex", "")).toBe(
+      `${DEFAULT_CODEX_MODELS_BASE}/v1/models`,
+    );
+    expect(buildProviderModelsEndpoint("claude", "https://proxy.example/v1")).toBe(
+      "https://proxy.example/v1/models",
+    );
+    expect(buildProviderModelsEndpoint("codex", "https://gateway.example")).toBe(
+      "https://gateway.example/v1/models",
+    );
+  });
+
+  test("normalizes discovered models from id and slug payloads", () => {
+    expect(
+      normalizeDiscoveredModels({
+        models: [
+          { slug: "gpt-5.6-sol", owned_by: "openai" },
+          { id: "claude-sonnet-4", owned_by: "anthropic" },
+          { id: "gpt-5.6-sol" },
+        ],
+      }),
+    ).toEqual([
+      { id: "gpt-5.6-sol", owned_by: "openai" },
+      { id: "claude-sonnet-4", owned_by: "anthropic" },
+    ]);
+  });
+
 });

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import {
   buildOpenAIDraft,
   buildProviderKeyDraft,
-  buildProviderModelsEndpoint,
   maskApiKey,
   normalizeDiscoveredModels,
 } from "@pages/providers/providers-helpers";
@@ -111,23 +110,6 @@ describe("providers helpers", () => {
         ],
       }),
     ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
-  });
-
-  test("normalizes Claude payloads via models field", () => {
-    expect(
-      normalizeDiscoveredModels({
-        models: [{ id: "claude-sonnet-4-5", display_name: "Sonnet" }],
-      }),
-    ).toEqual([{ id: "claude-sonnet-4-5" }]);
-  });
-
-  test("builds Claude /models endpoints with defaults", () => {
-    expect(buildProviderModelsEndpoint("claude", "")).toBe(
-      "https://api.anthropic.com/v1/models",
-    );
-    expect(buildProviderModelsEndpoint("claude", "https://gw.example/v1")).toBe(
-      "https://gw.example/v1/models",
-    );
   });
 
   test("normalizes discovered models from a JSON string payload", () => {

--- a/pages/providers/__tests__/providers-helpers.test.ts
+++ b/pages/providers/__tests__/providers-helpers.test.ts
@@ -113,32 +113,21 @@ describe("providers helpers", () => {
     ).toEqual([{ id: "gpt-4.1", owned_by: "openai" }, { id: "gpt-4o-mini" }]);
   });
 
-  test("normalizes Claude/Codex payloads via models, items, and slug fields", () => {
+  test("normalizes Claude payloads via models field", () => {
     expect(
       normalizeDiscoveredModels({
         models: [{ id: "claude-sonnet-4-5", display_name: "Sonnet" }],
       }),
     ).toEqual([{ id: "claude-sonnet-4-5" }]);
-    expect(
-      normalizeDiscoveredModels({
-        items: [{ slug: "gpt-5.1-codex", title: "Codex" }],
-      }),
-    ).toEqual([{ id: "gpt-5.1-codex" }]);
   });
 
-  test("builds Claude and Codex /models endpoints with defaults", () => {
+  test("builds Claude /models endpoints with defaults", () => {
     expect(buildProviderModelsEndpoint("claude", "")).toBe(
       "https://api.anthropic.com/v1/models",
     );
     expect(buildProviderModelsEndpoint("claude", "https://gw.example/v1")).toBe(
       "https://gw.example/v1/models",
     );
-    expect(buildProviderModelsEndpoint("codex", "")).toBe(
-      "https://api.openai.com/v1/models",
-    );
-    expect(
-      buildProviderModelsEndpoint("codex", "https://api.openai.com/v1"),
-    ).toBe("https://api.openai.com/v1/models");
   });
 
   test("normalizes discovered models from a JSON string payload", () => {

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -8,24 +8,16 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
-import {
-  apiCallApi,
-  getApiCallErrorMessage,
-  modelsApi,
-} from "@code-proxy/api-client";
+import { modelsApi } from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
-import { useToast } from "@code-proxy/ui";
 import type { ProviderKeyDraft } from "../providers-helpers";
 import {
-  buildProviderModelsEndpoint,
   excludedModelsFromText,
   hasDisableAllModelsRule,
-  normalizeDiscoveredModels,
 } from "../providers-helpers";
-import { keyValueEntriesToRecord } from "../KeyValueInputList";
 import { createEmptyModelEntry, type ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
@@ -120,7 +112,6 @@ export function ProviderKeyModal({
   maskApiKey,
 }: ProviderKeyModalProps) {
   const { t } = useTranslation();
-  const { notify } = useToast();
   const [modalTab, setModalTab] = useState<ProviderKeyModalTab>("basic");
   const [openCodeModels, setOpenCodeModels] = useState<
     { id: string; owned_by?: string }[]
@@ -130,23 +121,12 @@ export function ProviderKeyModal({
     null,
   );
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
-  // Live /models discovery for Claude & Codex provider keys (issue #492).
-  const [discoveredModels, setDiscoveredModels] = useState<
-    { id: string; owned_by?: string }[]
-  >([]);
-  const [discovering, setDiscovering] = useState(false);
-  const [discoverSelected, setDiscoverSelected] = useState<Set<string>>(
-    () => new Set(),
-  );
 
   const isBedrock = editKeyType === "bedrock";
   const isOpenCodeGo = editKeyType === "opencode-go";
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
-  // Codex must NOT use live /models discovery: ChatGPT/OpenAI catalogs are
-  // incomplete vs our static registry and previously wiped gpt-5.x routing.
-  const supportsLiveDiscovery = editKeyType === "claude";
   const modelAccessProvider: ModelAccessProvider | null = isCline
     ? "cline"
     : isOllamaCloud
@@ -211,116 +191,7 @@ export function ProviderKeyModal({
     setModalTab("basic");
     setOpenCodeModelQuery("");
     setSelectedModelGroup("");
-    setDiscoveredModels([]);
-    setDiscoverSelected(new Set());
-    setDiscovering(false);
   }, [editKeyIndex, editKeyType, open]);
-
-  const discoverModels = useCallback(async () => {
-    if (!supportsLiveDiscovery) return;
-    // Claude only — Codex live discovery is intentionally disabled.
-    const endpoint = buildProviderModelsEndpoint("claude", keyDraft.baseUrl);
-    if (!endpoint) {
-      notify({ type: "info", message: t("providers.fill_base_url_first") });
-      return;
-    }
-
-    setDiscovering(true);
-    setDiscoveredModels([]);
-    setDiscoverSelected(new Set());
-    try {
-      const customHeaders =
-        keyValueEntriesToRecord(keyDraft.headersEntries) ?? {};
-      const headers: Record<string, string> = { ...customHeaders };
-      const apiKey = keyDraft.apiKey.trim();
-
-      // Anthropic official + most compatible gateways accept x-api-key.
-      // Also send Authorization for gateways that only accept Bearer.
-      if (apiKey) {
-        if (
-          !Object.keys(headers).some(
-            (key) => key.toLowerCase() === "x-api-key",
-          )
-        ) {
-          headers["x-api-key"] = apiKey;
-        }
-        if (
-          !Object.keys(headers).some(
-            (key) => key.toLowerCase() === "authorization",
-          )
-        ) {
-          headers.Authorization = `Bearer ${apiKey}`;
-        }
-      }
-      if (
-        !Object.keys(headers).some(
-          (key) => key.toLowerCase() === "anthropic-version",
-        )
-      ) {
-        headers["anthropic-version"] = "2023-06-01";
-      }
-      if (
-        !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
-      ) {
-        headers.Accept = "application/json";
-      }
-
-      const result = await apiCallApi.request({
-        method: "GET",
-        url: endpoint,
-        header: Object.keys(headers).length ? headers : undefined,
-      });
-      if (result.statusCode < 200 || result.statusCode >= 300) {
-        throw new Error(getApiCallErrorMessage(result));
-      }
-      const list = normalizeDiscoveredModels(result.body ?? result.bodyText);
-      setDiscoveredModels(list);
-      setDiscoverSelected(new Set(list.map((model) => model.id)));
-      if (list.length === 0) {
-        notify({ type: "info", message: t("providers.no_discovered_models") });
-      }
-    } catch (err: unknown) {
-      notify({
-        type: "error",
-        message:
-          err instanceof Error ? err.message : t("providers.fetch_models_failed"),
-      });
-    } finally {
-      setDiscovering(false);
-    }
-  }, [
-    keyDraft.apiKey,
-    keyDraft.baseUrl,
-    keyDraft.headersEntries,
-    notify,
-    supportsLiveDiscovery,
-    t,
-  ]);
-
-  const applyDiscoveredModels = useCallback(() => {
-    const selected = new Set(discoverSelected);
-    const picked = discoveredModels.filter((model) => selected.has(model.id));
-    if (picked.length === 0) {
-      notify({ type: "info", message: t("providers.no_models_selected") });
-      return;
-    }
-    setKeyDraft((prev) => {
-      const seen = new Set(
-        prev.modelEntries
-          .map((model) => model.name.trim().toLowerCase())
-          .filter(Boolean),
-      );
-      const merged = [...prev.modelEntries];
-      for (const model of picked) {
-        const key = model.id.toLowerCase();
-        if (seen.has(key)) continue;
-        seen.add(key);
-        merged.push({ ...createEmptyModelEntry(), name: model.id });
-      }
-      return { ...prev, modelEntries: merged };
-    });
-    notify({ type: "success", message: t("providers.models_merged") });
-  }, [discoverSelected, discoveredModels, notify, setKeyDraft, t]);
 
   useEffect(() => {
     if (!open || !showModelsTab) return;
@@ -736,18 +607,6 @@ export function ProviderKeyModal({
                 setKeyDraft={setKeyDraft}
                 editKeyExcludedCount={editKeyExcludedCount}
                 editKeyEnabledToggle={editKeyEnabledToggle}
-                discovering={discovering}
-                discoverModels={
-                  supportsLiveDiscovery ? discoverModels : undefined
-                }
-                applyDiscoveredModels={
-                  supportsLiveDiscovery ? applyDiscoveredModels : undefined
-                }
-                discoveredModels={discoveredModels}
-                discoverSelected={discoverSelected}
-                setDiscoverSelected={
-                  supportsLiveDiscovery ? setDiscoverSelected : undefined
-                }
               />
             </TabsContent>
           ) : null}

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -144,8 +144,9 @@ export function ProviderKeyModal({
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
-  const supportsLiveDiscovery =
-    editKeyType === "claude" || editKeyType === "codex";
+  // Codex must NOT use live /models discovery: ChatGPT/OpenAI catalogs are
+  // incomplete vs our static registry and previously wiped gpt-5.x routing.
+  const supportsLiveDiscovery = editKeyType === "claude";
   const modelAccessProvider: ModelAccessProvider | null = isCline
     ? "cline"
     : isOllamaCloud
@@ -217,11 +218,8 @@ export function ProviderKeyModal({
 
   const discoverModels = useCallback(async () => {
     if (!supportsLiveDiscovery) return;
-    const providerType = editKeyType === "claude" ? "claude" : "codex";
-    const endpoint = buildProviderModelsEndpoint(
-      providerType,
-      keyDraft.baseUrl,
-    );
+    // Claude only — Codex live discovery is intentionally disabled.
+    const endpoint = buildProviderModelsEndpoint("claude", keyDraft.baseUrl);
     if (!endpoint) {
       notify({ type: "info", message: t("providers.fill_base_url_first") });
       return;
@@ -236,52 +234,35 @@ export function ProviderKeyModal({
       const headers: Record<string, string> = { ...customHeaders };
       const apiKey = keyDraft.apiKey.trim();
 
-      if (providerType === "claude") {
-        // Anthropic official + most compatible gateways accept x-api-key.
-        // Also send Authorization for gateways that only accept Bearer.
-        if (apiKey) {
-          if (
-            !Object.keys(headers).some(
-              (key) => key.toLowerCase() === "x-api-key",
-            )
-          ) {
-            headers["x-api-key"] = apiKey;
-          }
-          if (
-            !Object.keys(headers).some(
-              (key) => key.toLowerCase() === "authorization",
-            )
-          ) {
-            headers.Authorization = `Bearer ${apiKey}`;
-          }
-        }
+      // Anthropic official + most compatible gateways accept x-api-key.
+      // Also send Authorization for gateways that only accept Bearer.
+      if (apiKey) {
         if (
           !Object.keys(headers).some(
-            (key) => key.toLowerCase() === "anthropic-version",
+            (key) => key.toLowerCase() === "x-api-key",
           )
         ) {
-          headers["anthropic-version"] = "2023-06-01";
+          headers["x-api-key"] = apiKey;
         }
         if (
-          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
-        ) {
-          headers.Accept = "application/json";
-        }
-      } else {
-        // Codex / OpenAI-compatible: Bearer API key.
-        if (
-          apiKey &&
           !Object.keys(headers).some(
             (key) => key.toLowerCase() === "authorization",
           )
         ) {
           headers.Authorization = `Bearer ${apiKey}`;
         }
-        if (
-          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
-        ) {
-          headers.Accept = "application/json";
-        }
+      }
+      if (
+        !Object.keys(headers).some(
+          (key) => key.toLowerCase() === "anthropic-version",
+        )
+      ) {
+        headers["anthropic-version"] = "2023-06-01";
+      }
+      if (
+        !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
+      ) {
+        headers.Accept = "application/json";
       }
 
       const result = await apiCallApi.request({
@@ -308,7 +289,6 @@ export function ProviderKeyModal({
       setDiscovering(false);
     }
   }, [
-    editKeyType,
     keyDraft.apiKey,
     keyDraft.baseUrl,
     keyDraft.headersEntries,

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -8,16 +8,24 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
-import { modelsApi } from "@code-proxy/api-client";
+import {
+  apiCallApi,
+  getApiCallErrorMessage,
+  modelsApi,
+} from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
+import { useToast } from "@code-proxy/ui";
 import type { ProviderKeyDraft } from "../providers-helpers";
 import {
+  buildProviderModelsEndpoint,
   excludedModelsFromText,
   hasDisableAllModelsRule,
+  normalizeDiscoveredModels,
 } from "../providers-helpers";
+import { keyValueEntriesToRecord } from "../KeyValueInputList";
 import { createEmptyModelEntry, type ModelEntryDraft } from "../ModelInputList";
 import { ProviderKeyStatusBadges } from "./ProviderKeyStatusBadges";
 import { ProviderKeyBasicTab } from "./ProviderKeyBasicTab";
@@ -112,6 +120,7 @@ export function ProviderKeyModal({
   maskApiKey,
 }: ProviderKeyModalProps) {
   const { t } = useTranslation();
+  const { notify } = useToast();
   const [modalTab, setModalTab] = useState<ProviderKeyModalTab>("basic");
   const [openCodeModels, setOpenCodeModels] = useState<
     { id: string; owned_by?: string }[]
@@ -121,12 +130,22 @@ export function ProviderKeyModal({
     null,
   );
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
+  // Live /models discovery for Claude & Codex provider keys (issue #492).
+  const [discoveredModels, setDiscoveredModels] = useState<
+    { id: string; owned_by?: string }[]
+  >([]);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverSelected, setDiscoverSelected] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const isBedrock = editKeyType === "bedrock";
   const isOpenCodeGo = editKeyType === "opencode-go";
   const isCline = editKeyType === "cline";
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
+  const supportsLiveDiscovery =
+    editKeyType === "claude" || editKeyType === "codex";
   const modelAccessProvider: ModelAccessProvider | null = isCline
     ? "cline"
     : isOllamaCloud
@@ -191,7 +210,137 @@ export function ProviderKeyModal({
     setModalTab("basic");
     setOpenCodeModelQuery("");
     setSelectedModelGroup("");
+    setDiscoveredModels([]);
+    setDiscoverSelected(new Set());
+    setDiscovering(false);
   }, [editKeyIndex, editKeyType, open]);
+
+  const discoverModels = useCallback(async () => {
+    if (!supportsLiveDiscovery) return;
+    const providerType = editKeyType === "claude" ? "claude" : "codex";
+    const endpoint = buildProviderModelsEndpoint(
+      providerType,
+      keyDraft.baseUrl,
+    );
+    if (!endpoint) {
+      notify({ type: "info", message: t("providers.fill_base_url_first") });
+      return;
+    }
+
+    setDiscovering(true);
+    setDiscoveredModels([]);
+    setDiscoverSelected(new Set());
+    try {
+      const customHeaders =
+        keyValueEntriesToRecord(keyDraft.headersEntries) ?? {};
+      const headers: Record<string, string> = { ...customHeaders };
+      const apiKey = keyDraft.apiKey.trim();
+
+      if (providerType === "claude") {
+        // Anthropic official + most compatible gateways accept x-api-key.
+        // Also send Authorization for gateways that only accept Bearer.
+        if (apiKey) {
+          if (
+            !Object.keys(headers).some(
+              (key) => key.toLowerCase() === "x-api-key",
+            )
+          ) {
+            headers["x-api-key"] = apiKey;
+          }
+          if (
+            !Object.keys(headers).some(
+              (key) => key.toLowerCase() === "authorization",
+            )
+          ) {
+            headers.Authorization = `Bearer ${apiKey}`;
+          }
+        }
+        if (
+          !Object.keys(headers).some(
+            (key) => key.toLowerCase() === "anthropic-version",
+          )
+        ) {
+          headers["anthropic-version"] = "2023-06-01";
+        }
+        if (
+          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
+        ) {
+          headers.Accept = "application/json";
+        }
+      } else {
+        // Codex / OpenAI-compatible: Bearer API key.
+        if (
+          apiKey &&
+          !Object.keys(headers).some(
+            (key) => key.toLowerCase() === "authorization",
+          )
+        ) {
+          headers.Authorization = `Bearer ${apiKey}`;
+        }
+        if (
+          !Object.keys(headers).some((key) => key.toLowerCase() === "accept")
+        ) {
+          headers.Accept = "application/json";
+        }
+      }
+
+      const result = await apiCallApi.request({
+        method: "GET",
+        url: endpoint,
+        header: Object.keys(headers).length ? headers : undefined,
+      });
+      if (result.statusCode < 200 || result.statusCode >= 300) {
+        throw new Error(getApiCallErrorMessage(result));
+      }
+      const list = normalizeDiscoveredModels(result.body ?? result.bodyText);
+      setDiscoveredModels(list);
+      setDiscoverSelected(new Set(list.map((model) => model.id)));
+      if (list.length === 0) {
+        notify({ type: "info", message: t("providers.no_discovered_models") });
+      }
+    } catch (err: unknown) {
+      notify({
+        type: "error",
+        message:
+          err instanceof Error ? err.message : t("providers.fetch_models_failed"),
+      });
+    } finally {
+      setDiscovering(false);
+    }
+  }, [
+    editKeyType,
+    keyDraft.apiKey,
+    keyDraft.baseUrl,
+    keyDraft.headersEntries,
+    notify,
+    supportsLiveDiscovery,
+    t,
+  ]);
+
+  const applyDiscoveredModels = useCallback(() => {
+    const selected = new Set(discoverSelected);
+    const picked = discoveredModels.filter((model) => selected.has(model.id));
+    if (picked.length === 0) {
+      notify({ type: "info", message: t("providers.no_models_selected") });
+      return;
+    }
+    setKeyDraft((prev) => {
+      const seen = new Set(
+        prev.modelEntries
+          .map((model) => model.name.trim().toLowerCase())
+          .filter(Boolean),
+      );
+      const merged = [...prev.modelEntries];
+      for (const model of picked) {
+        const key = model.id.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        merged.push({ ...createEmptyModelEntry(), name: model.id });
+      }
+      return { ...prev, modelEntries: merged };
+    });
+    notify({ type: "success", message: t("providers.models_merged") });
+  }, [discoverSelected, discoveredModels, notify, setKeyDraft, t]);
 
   useEffect(() => {
     if (!open || !showModelsTab) return;
@@ -607,6 +756,18 @@ export function ProviderKeyModal({
                 setKeyDraft={setKeyDraft}
                 editKeyExcludedCount={editKeyExcludedCount}
                 editKeyEnabledToggle={editKeyEnabledToggle}
+                discovering={discovering}
+                discoverModels={
+                  supportsLiveDiscovery ? discoverModels : undefined
+                }
+                applyDiscoveredModels={
+                  supportsLiveDiscovery ? applyDiscoveredModels : undefined
+                }
+                discoveredModels={discoveredModels}
+                discoverSelected={discoverSelected}
+                setDiscoverSelected={
+                  supportsLiveDiscovery ? setDiscoverSelected : undefined
+                }
               />
             </TabsContent>
           ) : null}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -99,7 +99,7 @@ export function ProviderKeyModelsTab({
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
   const supportsLiveDiscovery =
-    (editKeyType === "claude" || editKeyType === "codex") &&
+    editKeyType === "claude" &&
     typeof discoverModels === "function" &&
     typeof applyDiscoveredModels === "function" &&
     typeof setDiscoverSelected === "function";
@@ -384,9 +384,7 @@ export function ProviderKeyModelsTab({
             setDiscoverSelected={setDiscoverSelected!}
           />
           <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-            {editKeyType === "claude"
-              ? t("providers.claude_models_discovery_hint")
-              : t("providers.codex_models_discovery_hint")}
+            {t("providers.claude_models_discovery_hint")}
           </p>
         </SectionCard>
       ) : null}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -13,7 +13,6 @@ import {
   type ModelEntryDraft,
 } from "../ModelInputList";
 import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
-import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 
 type ModelAccessRow = { id: string; owned_by?: string };
 
@@ -51,13 +50,6 @@ interface ProviderKeyModelsTabProps {
   setKeyDraft: React.Dispatch<React.SetStateAction<ProviderKeyDraft>>;
   editKeyExcludedCount: number;
   editKeyEnabledToggle: (checked: boolean) => void;
-  /** Live /models discovery for Claude & Codex provider keys (aligned with OpenAI). */
-  discovering?: boolean;
-  discoverModels?: () => Promise<void>;
-  applyDiscoveredModels?: () => void;
-  discoveredModels?: { id: string; owned_by?: string }[];
-  discoverSelected?: Set<string>;
-  setDiscoverSelected?: (value: React.SetStateAction<Set<string>>) => void;
 }
 
 export function ProviderKeyModelsTab({
@@ -88,21 +80,10 @@ export function ProviderKeyModelsTab({
   setKeyDraft,
   editKeyExcludedCount,
   editKeyEnabledToggle,
-  discovering = false,
-  discoverModels,
-  applyDiscoveredModels,
-  discoveredModels = [],
-  discoverSelected = new Set(),
-  setDiscoverSelected,
 }: ProviderKeyModelsTabProps) {
   const { t } = useTranslation();
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
-  const supportsLiveDiscovery =
-    editKeyType === "claude" &&
-    typeof discoverModels === "function" &&
-    typeof applyDiscoveredModels === "function" &&
-    typeof setDiscoverSelected === "function";
   const modelAccessTitle = isCline
     ? t("providers.cline_models_title")
     : isOllamaCloud
@@ -372,22 +353,6 @@ export function ProviderKeyModelsTab({
           </p>
         )}
       </SectionCard>
-
-      {supportsLiveDiscovery ? (
-        <SectionCard>
-          <OpenAIModelDiscoveryPanel
-            discovering={discovering}
-            discoverModels={discoverModels!}
-            applyDiscoveredModels={applyDiscoveredModels!}
-            discoveredModels={discoveredModels}
-            discoverSelected={discoverSelected}
-            setDiscoverSelected={setDiscoverSelected!}
-          />
-          <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
-            {t("providers.claude_models_discovery_hint")}
-          </p>
-        </SectionCard>
-      ) : null}
 
       <ExcludedModelsEditor
         count={editKeyExcludedCount}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -13,6 +13,7 @@ import {
   type ModelEntryDraft,
 } from "../ModelInputList";
 import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
+import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 
 type ModelAccessRow = { id: string; owned_by?: string };
 
@@ -50,6 +51,13 @@ interface ProviderKeyModelsTabProps {
   setKeyDraft: React.Dispatch<React.SetStateAction<ProviderKeyDraft>>;
   editKeyExcludedCount: number;
   editKeyEnabledToggle: (checked: boolean) => void;
+  /** Live /models discovery for Claude & Codex provider keys (aligned with OpenAI). */
+  discovering?: boolean;
+  discoverModels?: () => Promise<void>;
+  applyDiscoveredModels?: () => void;
+  discoveredModels?: { id: string; owned_by?: string }[];
+  discoverSelected?: Set<string>;
+  setDiscoverSelected?: (value: React.SetStateAction<Set<string>>) => void;
 }
 
 export function ProviderKeyModelsTab({
@@ -80,10 +88,21 @@ export function ProviderKeyModelsTab({
   setKeyDraft,
   editKeyExcludedCount,
   editKeyEnabledToggle,
+  discovering = false,
+  discoverModels,
+  applyDiscoveredModels,
+  discoveredModels = [],
+  discoverSelected = new Set(),
+  setDiscoverSelected,
 }: ProviderKeyModelsTabProps) {
   const { t } = useTranslation();
   const isOllamaCloud = editKeyType === "ollama-cloud";
   const isModelAccessProvider = isOpenCodeGo || isCline || isOllamaCloud;
+  const supportsLiveDiscovery =
+    (editKeyType === "claude" || editKeyType === "codex") &&
+    typeof discoverModels === "function" &&
+    typeof applyDiscoveredModels === "function" &&
+    typeof setDiscoverSelected === "function";
   const modelAccessTitle = isCline
     ? t("providers.cline_models_title")
     : isOllamaCloud
@@ -353,6 +372,24 @@ export function ProviderKeyModelsTab({
           </p>
         )}
       </SectionCard>
+
+      {supportsLiveDiscovery ? (
+        <SectionCard>
+          <OpenAIModelDiscoveryPanel
+            discovering={discovering}
+            discoverModels={discoverModels!}
+            applyDiscoveredModels={applyDiscoveredModels!}
+            discoveredModels={discoveredModels}
+            discoverSelected={discoverSelected}
+            setDiscoverSelected={setDiscoverSelected!}
+          />
+          <p className="mt-2 text-xs text-slate-500 dark:text-white/55">
+            {editKeyType === "claude"
+              ? t("providers.claude_models_discovery_hint")
+              : t("providers.codex_models_discovery_hint")}
+          </p>
+        </SectionCard>
+      ) : null}
 
       <ExcludedModelsEditor
         count={editKeyExcludedCount}

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -76,41 +76,37 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
 
 /** Default bases when the provider key leaves base URL empty (official endpoints). */
 export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
-export const DEFAULT_CODEX_MODELS_BASE = "https://api.openai.com";
 export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
 
 /**
- * Build the upstream /models URL for a provider key type.
- * Claude uses Anthropic-style `/v1/models`; Codex/OpenAI-compatible use `/models`
- * (or `/v1/models` when the base already ends with `/v1`).
+ * Build the upstream /models URL for Claude provider keys.
+ * Claude uses Anthropic-style `/v1/models`. Codex intentionally has no live
+ * discovery path — incomplete upstream catalogs must not replace the static list.
  */
 export const buildProviderModelsEndpoint = (
-  providerType: "claude" | "codex" | "openai",
+  providerType: "claude" | "openai",
   baseUrl: string,
 ): string => {
-  const fallback =
-    providerType === "claude"
-      ? DEFAULT_CLAUDE_MODELS_BASE
-      : providerType === "codex"
-        ? DEFAULT_CODEX_MODELS_BASE
-        : "";
-  const normalized = normalizeOpenAIBaseUrl(baseUrl || fallback);
+  if (providerType === "claude") {
+    const normalized = normalizeOpenAIBaseUrl(baseUrl || DEFAULT_CLAUDE_MODELS_BASE);
+    if (!normalized) return "";
+    const lower = normalized.toLowerCase();
+    if (lower.endsWith("/models") || lower.includes("/models?")) {
+      return normalized;
+    }
+    if (lower.endsWith("/v1")) return `${normalized}/models`;
+    return `${normalized}/v1/models`;
+  }
+  // OpenAI-compatible: prefer /v1/models when base has no path tail.
+  const normalized = normalizeOpenAIBaseUrl(baseUrl);
   if (!normalized) return "";
   const lower = normalized.toLowerCase();
   if (lower.endsWith("/models") || lower.includes("/models?")) {
     return normalized;
   }
-  if (providerType === "claude") {
-    if (lower.endsWith("/v1")) return `${normalized}/models`;
-    return `${normalized}/v1/models`;
-  }
-  // Codex / OpenAI-compatible: prefer /v1/models when base has no path tail.
   if (lower.endsWith("/v1")) return `${normalized}/models`;
-  if (lower.includes("api.openai.com") || providerType === "codex") {
-    // Official OpenAI and typical Codex API-key bases expect /v1/models.
-    if (!/\/v\d+(\/|$)/i.test(lower)) {
-      return `${normalized}/v1/models`;
-    }
+  if (lower.includes("api.openai.com") && !/\/v\d+(\/|$)/i.test(lower)) {
+    return `${normalized}/v1/models`;
   }
   return `${normalized}/models`;
 };

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -74,43 +74,6 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
   return `${normalized}/models`;
 };
 
-/** Default bases when the provider key leaves base URL empty (official endpoints). */
-export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
-export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
-
-/**
- * Build the upstream /models URL for Claude provider keys.
- * Claude uses Anthropic-style `/v1/models`. Codex intentionally has no live
- * discovery path — incomplete upstream catalogs must not replace the static list.
- */
-export const buildProviderModelsEndpoint = (
-  providerType: "claude" | "openai",
-  baseUrl: string,
-): string => {
-  if (providerType === "claude") {
-    const normalized = normalizeOpenAIBaseUrl(baseUrl || DEFAULT_CLAUDE_MODELS_BASE);
-    if (!normalized) return "";
-    const lower = normalized.toLowerCase();
-    if (lower.endsWith("/models") || lower.includes("/models?")) {
-      return normalized;
-    }
-    if (lower.endsWith("/v1")) return `${normalized}/models`;
-    return `${normalized}/v1/models`;
-  }
-  // OpenAI-compatible: prefer /v1/models when base has no path tail.
-  const normalized = normalizeOpenAIBaseUrl(baseUrl);
-  if (!normalized) return "";
-  const lower = normalized.toLowerCase();
-  if (lower.endsWith("/models") || lower.includes("/models?")) {
-    return normalized;
-  }
-  if (lower.endsWith("/v1")) return `${normalized}/models`;
-  if (lower.includes("api.openai.com") && !/\/v\d+(\/|$)/i.test(lower)) {
-    return `${normalized}/v1/models`;
-  }
-  return `${normalized}/models`;
-};
-
 export const normalizeDiscoveredModels = (
   payload: unknown,
 ): { id: string; owned_by?: string }[] => {
@@ -127,18 +90,14 @@ export const normalizeDiscoveredModels = (
     }
   }
   const root = isRecord(payload) ? payload : null;
-  // Codex manifests may nest under data / models / items.
-  const data = root
-    ? (root.data ?? root.models ?? root.items ?? payload)
-    : payload;
+  const data = root ? (root.data ?? root.models ?? payload) : payload;
   if (!Array.isArray(data)) return [];
 
   const seen = new Set<string>();
   const result: { id: string; owned_by?: string }[] = [];
   for (const item of data) {
     if (!isRecord(item)) continue;
-    // Claude: id; Codex: id | slug | name
-    const id = String(item.id ?? item.slug ?? item.name ?? "").trim();
+    const id = String(item.id ?? item.name ?? "").trim();
     if (!id) continue;
     const key = id.toLowerCase();
     if (seen.has(key)) continue;

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -74,6 +74,47 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
   return `${normalized}/models`;
 };
 
+/** Default bases when the provider key leaves base URL empty (official endpoints). */
+export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
+export const DEFAULT_CODEX_MODELS_BASE = "https://api.openai.com";
+export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
+
+/**
+ * Build the upstream /models URL for a provider key type.
+ * Claude uses Anthropic-style `/v1/models`; Codex/OpenAI-compatible use `/models`
+ * (or `/v1/models` when the base already ends with `/v1`).
+ */
+export const buildProviderModelsEndpoint = (
+  providerType: "claude" | "codex" | "openai",
+  baseUrl: string,
+): string => {
+  const fallback =
+    providerType === "claude"
+      ? DEFAULT_CLAUDE_MODELS_BASE
+      : providerType === "codex"
+        ? DEFAULT_CODEX_MODELS_BASE
+        : "";
+  const normalized = normalizeOpenAIBaseUrl(baseUrl || fallback);
+  if (!normalized) return "";
+  const lower = normalized.toLowerCase();
+  if (lower.endsWith("/models") || lower.includes("/models?")) {
+    return normalized;
+  }
+  if (providerType === "claude") {
+    if (lower.endsWith("/v1")) return `${normalized}/models`;
+    return `${normalized}/v1/models`;
+  }
+  // Codex / OpenAI-compatible: prefer /v1/models when base has no path tail.
+  if (lower.endsWith("/v1")) return `${normalized}/models`;
+  if (lower.includes("api.openai.com") || providerType === "codex") {
+    // Official OpenAI and typical Codex API-key bases expect /v1/models.
+    if (!/\/v\d+(\/|$)/i.test(lower)) {
+      return `${normalized}/v1/models`;
+    }
+  }
+  return `${normalized}/models`;
+};
+
 export const normalizeDiscoveredModels = (
   payload: unknown,
 ): { id: string; owned_by?: string }[] => {
@@ -90,14 +131,18 @@ export const normalizeDiscoveredModels = (
     }
   }
   const root = isRecord(payload) ? payload : null;
-  const data = root ? (root.data ?? root.models ?? payload) : payload;
+  // Codex manifests may nest under data / models / items.
+  const data = root
+    ? (root.data ?? root.models ?? root.items ?? payload)
+    : payload;
   if (!Array.isArray(data)) return [];
 
   const seen = new Set<string>();
   const result: { id: string; owned_by?: string }[] = [];
   for (const item of data) {
     if (!isRecord(item)) continue;
-    const id = String(item.id ?? item.name ?? "").trim();
+    // Claude: id; Codex ChatGPT manifest: slug is the callable id (prefer over opaque id).
+    const id = String(item.slug ?? item.id ?? item.name ?? "").trim();
     if (!id) continue;
     const key = id.toLowerCase();
     if (seen.has(key)) continue;

--- a/pages/providers/providers-helpers.ts
+++ b/pages/providers/providers-helpers.ts
@@ -74,6 +74,47 @@ export const buildModelsEndpoint = (baseUrl: string): string => {
   return `${normalized}/models`;
 };
 
+/** Default bases when the provider key leaves base URL empty (official endpoints). */
+export const DEFAULT_CLAUDE_MODELS_BASE = "https://api.anthropic.com";
+export const DEFAULT_CODEX_MODELS_BASE = "https://api.openai.com";
+export const DEFAULT_CLAUDE_ANTHROPIC_VERSION = "2023-06-01";
+
+/**
+ * Build the upstream /models URL for a provider key type.
+ * Claude uses Anthropic-style `/v1/models`; Codex/OpenAI-compatible use `/models`
+ * (or `/v1/models` when the base already ends with `/v1`).
+ */
+export const buildProviderModelsEndpoint = (
+  providerType: "claude" | "codex" | "openai",
+  baseUrl: string,
+): string => {
+  const fallback =
+    providerType === "claude"
+      ? DEFAULT_CLAUDE_MODELS_BASE
+      : providerType === "codex"
+        ? DEFAULT_CODEX_MODELS_BASE
+        : "";
+  const normalized = normalizeOpenAIBaseUrl(baseUrl || fallback);
+  if (!normalized) return "";
+  const lower = normalized.toLowerCase();
+  if (lower.endsWith("/models") || lower.includes("/models?")) {
+    return normalized;
+  }
+  if (providerType === "claude") {
+    if (lower.endsWith("/v1")) return `${normalized}/models`;
+    return `${normalized}/v1/models`;
+  }
+  // Codex / OpenAI-compatible: prefer /v1/models when base has no path tail.
+  if (lower.endsWith("/v1")) return `${normalized}/models`;
+  if (lower.includes("api.openai.com") || providerType === "codex") {
+    // Official OpenAI and typical Codex API-key bases expect /v1/models.
+    if (!/\/v\d+(\/|$)/i.test(lower)) {
+      return `${normalized}/v1/models`;
+    }
+  }
+  return `${normalized}/models`;
+};
+
 export const normalizeDiscoveredModels = (
   payload: unknown,
 ): { id: string; owned_by?: string }[] => {
@@ -90,14 +131,18 @@ export const normalizeDiscoveredModels = (
     }
   }
   const root = isRecord(payload) ? payload : null;
-  const data = root ? (root.data ?? root.models ?? payload) : payload;
+  // Codex manifests may nest under data / models / items.
+  const data = root
+    ? (root.data ?? root.models ?? root.items ?? payload)
+    : payload;
   if (!Array.isArray(data)) return [];
 
   const seen = new Set<string>();
   const result: { id: string; owned_by?: string }[] = [];
   for (const item of data) {
     if (!isRecord(item)) continue;
-    const id = String(item.id ?? item.name ?? "").trim();
+    // Claude: id; Codex: id | slug | name
+    const id = String(item.id ?? item.slug ?? item.name ?? "").trim();
     if (!id) continue;
     const key = id.toLowerCase();
     if (seen.has(key)) continue;


### PR DESCRIPTION
## Summary

Promote the verified `dev` branch to `main` for codeProxy **v0.4.14**.

### Highlights

- Claude / Codex live `/models` discovery with pin-to-models UX (safe path after temporary reverts)
- Shared live model discovery cache for xAI / Grok on auth-files
- Keep Claude / Codex live model list after refresh
- Predicted weekly quota in xAI usage modal
- Model-test modal UX: color results and drop bare channel rows

### Verification (local release worktree)

```bash
./scripts/ci-pr.sh
```

lint, design:check, full test:ci, build, bundle:diff, and critical e2e smoke all passed.

## Test plan

- [x] `./scripts/ci-pr.sh` green in release worktree
- [ ] GitHub PR `test-build` green
- [ ] Merge to `main`, then open `main → dev` sync PR
- [ ] Tag `v0.4.14` and publish bilingual release notes