### PR TITLE
fix(channel-groups): load full channel-servable models in editor

### DIFF
--- a/features/model-availability/modelAvailability.ts
+++ b/features/model-availability/modelAvailability.ts
@@ -1008,10 +1008,13 @@ export { invalidateConfiguredModelAvailability };
 
 export const loadConfiguredModelAvailability = async (options?: {
   allowedChannelGroups?: string[];
+  /** Channel-group editor: list every channel-servable model, not only AllowedModels. */
+  ignoreGroupAllowedModels?: boolean;
 }): Promise<ConfiguredModelAvailability> => {
   const validGroups = (options?.allowedChannelGroups ?? [])
     .map((g) => String(g ?? "").trim())
     .filter(Boolean);
+  const ignoreGroupAllowedModels = Boolean(options?.ignoreGroupAllowedModels);
   const loadFallback = async () =>
     loadConfiguredModelAvailabilityFallback(
       await loadAuthGroupOwnerMappingMap(),
@@ -1019,7 +1022,10 @@ export const loadConfiguredModelAvailability = async (options?: {
   const tenantId = tenantCacheKey();
 
   if (validGroups.length > 0) {
-    const cacheKey = validGroups.join(",");
+    // Separate cache keys so editor (ignore) and plaza (enforce) never share.
+    const cacheKey = ignoreGroupAllowedModels
+      ? `${validGroups.join(",")}|ignore_allowed`
+      : validGroups.join(",");
     const now = Date.now();
     const cacheVersion = getConfiguredAvailabilityCacheVersion();
     let tenantGroupCache = groupAvailabilityByTenant.get(tenantId);
@@ -1037,8 +1043,13 @@ export const loadConfiguredModelAvailability = async (options?: {
     }
     const promise = (async (): Promise<ConfiguredModelAvailability> => {
       try {
+        const params = new URLSearchParams();
+        params.set("allowed_channel_groups", validGroups.join(","));
+        if (ignoreGroupAllowedModels) {
+          params.set("ignore_group_allowed_models", "1");
+        }
         const result = await loadConfiguredAvailabilityEndpoint(
-          `/models/configured-availability?allowed_channel_groups=${encodeURIComponent(cacheKey)}`,
+          `/models/configured-availability?${params.toString()}`,
         );
         if (!result) return loadFallback();
         const current = groupAvailabilityByTenant.get(tenantId) ?? new Map();
@@ -1054,6 +1065,50 @@ export const loadConfiguredModelAvailability = async (options?: {
       }
     })();
     tenantGroupCache.set(cacheKey, {
+      expiresAt: now + GROUP_AVAILABILITY_TTL_MS,
+      cacheVersion,
+      promise,
+    });
+    return promise;
+  }
+
+  // Unscoped editor path (e.g. default group): still request full channel set.
+  if (ignoreGroupAllowedModels) {
+    const editorCacheKey = "__ignore_allowed__";
+    const now = Date.now();
+    const cacheVersion = getConfiguredAvailabilityCacheVersion();
+    let tenantGroupCache = groupAvailabilityByTenant.get(tenantId);
+    if (!tenantGroupCache) {
+      tenantGroupCache = new Map();
+      groupAvailabilityByTenant.set(tenantId, tenantGroupCache);
+    }
+    const cached = tenantGroupCache.get(editorCacheKey);
+    if (
+      cached &&
+      cached.cacheVersion === cacheVersion &&
+      now < cached.expiresAt
+    ) {
+      return cached.promise;
+    }
+    const promise = (async (): Promise<ConfiguredModelAvailability> => {
+      try {
+        const result = await loadConfiguredAvailabilityEndpoint(
+          "/models/configured-availability?ignore_group_allowed_models=1",
+        );
+        if (!result) return loadFallback();
+        const current = groupAvailabilityByTenant.get(tenantId) ?? new Map();
+        current.set(editorCacheKey, {
+          expiresAt: Date.now() + GROUP_AVAILABILITY_TTL_MS,
+          cacheVersion,
+          promise: Promise.resolve(result),
+        });
+        groupAvailabilityByTenant.set(tenantId, current);
+        return result;
+      } catch {
+        return loadFallback();
+      }
+    })();
+    tenantGroupCache.set(editorCacheKey, {
       expiresAt: now + GROUP_AVAILABILITY_TTL_MS,
       cacheVersion,
       promise,

--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -299,6 +299,9 @@ export function ChannelGroupsPage() {
       if (normalizedGroup) {
         params.set("allowed_channel_groups", normalizedGroup);
       }
+      // Editor picker must show every model the group's channels can serve so
+      // operators can (un)check AllowedModels. Plaza/catalog keep enforcement.
+      params.set("ignore_group_allowed_models", "1");
       const data = await apiClient.get<{ data?: Array<{ id?: string }> }>(
         `/models?${params.toString()}`,
       );
@@ -307,10 +310,14 @@ export function ChannelGroupsPage() {
         : [];
       // Group editors must use the same scope as the channel group; default
       // availability can be narrower and would drop owner-mapped catalog models.
+      // Always ignore AllowedModels here — that list is what this UI edits.
       const availability =
         normalizedGroup && normalizedGroup !== "default"
-          ? await loadConfiguredModelAvailability({ allowedChannelGroups: [normalizedGroup] })
-          : await loadConfiguredModelAvailability();
+          ? await loadConfiguredModelAvailability({
+              allowedChannelGroups: [normalizedGroup],
+              ignoreGroupAllowedModels: true,
+            })
+          : await loadConfiguredModelAvailability({ ignoreGroupAllowedModels: true });
       const detailsForGroup =
         (normalizedGroup ? availableChannelDetailsByGroup[normalizedGroup.toLowerCase()] : undefined) ??
         availableChannelDetails;

--- a/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -478,7 +478,7 @@ describe("ChannelGroupsPage", () => {
       }
       if (
         path ===
-        "/models/configured-availability?allowed_channel_groups=deepseekv4flash%2Bchatgpt"
+        "/models/configured-availability?allowed_channel_groups=deepseekv4flash%2Bchatgpt&ignore_group_allowed_models=1"
       ) {
         return Promise.resolve({
           scoped: true,
@@ -562,7 +562,7 @@ describe("ChannelGroupsPage", () => {
     expect(within(table).getByLabelText("gpt-5.6-ultra")).toBeInTheDocument();
     expect(within(table).queryByLabelText("gpt-5.5")).not.toBeInTheDocument();
     expect(mockedApiGet).toHaveBeenCalledWith(
-      "/models/configured-availability?allowed_channel_groups=deepseekv4flash%2Bchatgpt",
+      "/models/configured-availability?allowed_channel_groups=deepseekv4flash%2Bchatgpt&ignore_group_allowed_models=1",
     );
   });
 


### PR DESCRIPTION
## Summary
- Channel-group editor model tab now requests `ignore_group_allowed_models=1` on `/models` and configured-availability so the checkbox list shows every channel-servable model.
- Plaza/catalog continue calling availability without the flag, so `AllowedModels` still controls display.
- Cache keys separate editor (ignore) vs plaza (enforce) responses.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e)
- [x] ChannelGroupsPage + RoutingConfigEditor unit tests

## Depends on
CliRelay PR that implements `ignore_group_allowed_models` on management model endpoints.