### PR TITLE
fix: honor scoped AllowedModels in plaza and catalog path merge

### DIFF
--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -21,6 +21,7 @@ import {
 } from "@features/visual-config-editor";
 import {
   filterByConfiguredModelAvailability,
+  invalidateConfiguredModelAvailability,
   loadConfiguredModelAvailability,
 } from "@features/model-availability";
 import { Card } from "@code-proxy/ui";
@@ -417,6 +418,9 @@ export function ChannelGroupsPage() {
       setError("");
       try {
         await routingConfigApi.update(serializeRoutingValues(nextValues));
+        // AllowedModels / path routes change plaza + catalog; drop TTL so the
+        // next page load does not keep the previous channel-group allow-list.
+        invalidateConfiguredModelAvailability();
         const [latest, channels] = await Promise.all([
           routingConfigApi.get(),
           loadAvailableChannels().catch(() => ({

--- a/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
+++ b/pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx
@@ -1004,6 +1004,8 @@ describe("ChannelGroupsPage", () => {
     );
   });
 
+
+
   test("shows save button loading while routing-config update is in flight", async () => {
     const user = userEvent.setup();
     const putDeferred = deferred<Record<string, unknown>>();

--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -291,13 +291,20 @@ function mergePlazaModels(
   configuredItems: ModelAvailabilityItem[],
   pathModelIds: string[],
   useMappedOwnerModels: boolean,
+  configuredScoped: boolean,
 ): PlazaModel[] {
   const configuredById = new Map(
     configuredItems.map((item) => [item.id.toLowerCase(), item]),
   );
-  const nextIds = useMappedOwnerModels
-    ? configuredItems.map((item) => item.id)
-    : [...pathModelIds, ...configuredItems.map((item) => item.id)];
+  // When configured-availability is scoped (tenant channel-group allow-list),
+  // it is the source of truth. Path-only IDs used to re-introduce models that
+  // AllowedModels already removed (e.g. xAI live discovery via path-availability).
+  // Mapped-owner mode likewise trusts the configured list only.
+  // Unscoped tenants keep path ∪ configured enrichment.
+  const nextIds =
+    useMappedOwnerModels || configuredScoped
+      ? configuredItems.map((item) => item.id)
+      : [...pathModelIds, ...configuredItems.map((item) => item.id)];
 
   return Array.from(new Set(nextIds))
     .sort((a, b) => a.localeCompare(b))
@@ -340,6 +347,7 @@ export function ModelPlazaPage() {
       ]);
 
       const useMappedOwnerModels = configuredAvailability?.usesMappedOwners === true;
+      const configuredScoped = configuredAvailability?.scoped === true;
       const rootV1ModelIds =
         pathAvailability?.items
           .filter((item) =>
@@ -355,6 +363,7 @@ export function ModelPlazaPage() {
           configuredAvailability?.items ?? [],
           rootV1ModelIds,
           useMappedOwnerModels,
+          configuredScoped,
         ),
       );
     } catch (err: unknown) {

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -320,6 +320,40 @@ describe("ModelPlazaPage", () => {
     expect(within(audioCard).getByText("Audio")).toBeInTheDocument();
   });
 
+  test("does not re-add path-only models when configured availability is scoped", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [{ id: "grok-4.5", description: "Allowed xAI model", owned_by: "xAI" }],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "grok-4.5",
+              owned_by: "xAI",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+            {
+              id: "grok-composer-2.5-fast",
+              owned_by: "xAI",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("grok-4.5")).toBeInTheDocument();
+    expect(screen.queryByText("grok-composer-2.5-fast")).not.toBeInTheDocument();
+  });
+
   test("pins vendor tabs with sticky styles and keeps page overflow open", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });

--- a/pages/models/ModelsPage.tsx
+++ b/pages/models/ModelsPage.tsx
@@ -134,6 +134,11 @@ export function ModelsPage() {
     active: [],
     library: [],
   });
+  // Last configured-availability for the active tab. Secondary path merge must
+  // re-apply scoped AllowedModels; passing null re-adds path-only blocked models.
+  const lastAvailabilityRef = useRef<
+    import("@features/model-availability").ConfiguredModelAvailability | null
+  >(null);
   // After first successful paint (or warm snapshot), keep refreshes non-blocking.
   const warmPaintByScopeRef = useRef<Record<ModelScope, boolean>>({
     active: Boolean(initialActiveSnapshot),
@@ -196,6 +201,10 @@ export function ModelsPage() {
         ]);
         if (!isActive()) return;
 
+        if (scope === "active") {
+          lastAvailabilityRef.current = availability;
+        }
+
         // Reuse last path items for this scope during soft refresh so path-only rows do not vanish.
         const visibleData = mergeConfiguredModelAvailability(
           data,
@@ -220,6 +229,7 @@ export function ModelsPage() {
 
         // Secondary: enrich with path-only models without blanking the table.
         // Merge into the current list (not a stale critical snapshot) so in-flight saves/deletes win.
+        // Keep last configured-availability so scoped allow-lists still apply.
         void loadModelPathAvailability()
           .then((pathAvailability) => {
             if (!isActive()) return;
@@ -227,7 +237,13 @@ export function ModelsPage() {
             pathItemsByScopeRef.current[scope] = pathItems;
             if (!pathItems.length) return;
             const current = modelsRef.current;
-            const merged = mergeConfiguredModelAvailability(current, null, pathItems);
+            const availabilityForMerge =
+              scope === "active" ? lastAvailabilityRef.current : null;
+            const merged = mergeConfiguredModelAvailability(
+              current,
+              availabilityForMerge,
+              pathItems,
+            );
             if (merged.length === current.length) return;
             setModels(merged);
             setModelsPageSnapshot(scope, {

--- a/pages/models/__tests__/modelAvailability.test.ts
+++ b/pages/models/__tests__/modelAvailability.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, test } from "vitest";
 import {
+  emptyModelPricing,
   filterByConfiguredModelAvailability,
   normalizeConfiguredModelAvailability,
+  type ModelPathAvailabilityItem,
 } from "@features/model-availability";
+import { mergeConfiguredModelAvailability } from "../modelsUtils";
+import type { ModelItem } from "../types";
+
+const baseModel = (id: string, ownedBy = "xai"): ModelItem => ({
+  id,
+  owned_by: ownedBy,
+  description: "",
+  enabled: true,
+  source: "config",
+  pricing: emptyModelPricing(),
+  inputModalities: [],
+  outputModalities: [],
+  supportsVision: false,
+});
+
+const pathItem = (id: string, ownedBy: string): ModelPathAvailabilityItem => ({
+  id,
+  owned_by: ownedBy,
+  kind: "path",
+  alias: false,
+  paths: [],
+});
 
 describe("model availability normalization", () => {
   test("preserves an explicit scoped empty availability response", () => {
@@ -51,5 +75,45 @@ describe("model availability normalization", () => {
         clientId: "codex-1",
       },
     ]);
+  });
+});
+
+describe("mergeConfiguredModelAvailability path enrichment", () => {
+  test("does not re-add path-only models blocked by scoped AllowedModels", () => {
+    const availability = normalizeConfiguredModelAvailability({
+      scoped: true,
+      data: [{ id: "grok-4.5", owned_by: "xAI" }],
+    });
+    const pathItems = [
+      pathItem("grok-4.5", "xAI"),
+      pathItem("grok-composer-2.5-fast", "xAI"),
+    ];
+
+    const merged = mergeConfiguredModelAvailability(
+      [baseModel("grok-4.5")],
+      availability,
+      pathItems,
+    );
+
+    expect(merged.map((m) => m.id)).toEqual(["grok-4.5"]);
+  });
+
+  test("still merges path-only models when availability is unscoped", () => {
+    const availability = normalizeConfiguredModelAvailability({
+      scoped: false,
+      data: [{ id: "gpt-5", owned_by: "openai" }],
+    });
+    const pathItems = [
+      pathItem("gpt-5", "openai"),
+      pathItem("path-only-model", "openai"),
+    ];
+
+    const merged = mergeConfiguredModelAvailability(
+      [baseModel("gpt-5", "openai")],
+      availability,
+      pathItems,
+    );
+
+    expect(merged.map((m) => m.id).sort()).toEqual(["gpt-5", "path-only-model"]);
   });
 });

--- a/pages/models/modelsUtils.ts
+++ b/pages/models/modelsUtils.ts
@@ -183,9 +183,13 @@ export function mergeConfiguredModelAvailability(
     visible.push(availabilityItemToModel(item));
     seen.add(key);
   }
+  // Path-only rows enrich discovery when there is no scoped allow-list.
+  // When configured-availability is scoped, AllowedModels already decided the
+  // set — do not re-add path models that were filtered out (xAI live discovery).
   for (const item of pathItems) {
     const key = item.id.toLowerCase();
     if (seen.has(key)) continue;
+    if (availability?.scoped && !availabilityById.has(key)) continue;
     visible.push(
       availabilityItemToModel({
         id: item.id,


### PR DESCRIPTION
## Summary
- Plaza: when configured-availability is `scoped`, use it as source of truth (do not re-add path-only IDs blocked by AllowedModels).
- Catalog: skip path-only rows missing from scoped availability; secondary path merge keeps last configured-availability instead of `null`.
- Channel groups: invalidate configured-availability cache after routing-config save so plaza/catalog refresh the allow-list.
- Unit coverage for scoped path merge and plaza regression.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e critical)
- [x] Targeted: modelAvailability merge tests + ModelPlazaPage scoped path test

Related: CliRelay path-availability filter PR (same topic).