### PR TITLE
fix(ui): flatten Fragments when detecting icon-only Button size

### DIFF
--- a/packages/ui/src/primitives/Button.tsx
+++ b/packages/ui/src/primitives/Button.tsx
@@ -1,5 +1,7 @@
 import {
   Children,
+  Fragment,
+  isValidElement,
   useContext,
   useId,
   useRef,
@@ -8,6 +10,7 @@ import {
   type FocusEventHandler,
   type MouseEventHandler,
   type PropsWithChildren,
+  type ReactElement,
   type ReactNode,
 } from "react";
 import { TooltipBubble, TooltipTriggerContext, type TooltipPlacement } from "../overlays/Tooltip";
@@ -40,6 +43,35 @@ const BUTTON_SIZE_CLASSES: Record<ButtonSize, { iconOnly: string; text: string }
     text: "h-10 px-4 text-sm",
   },
 };
+
+/**
+ * Flatten Fragments so icon-only detection counts real content nodes.
+ * Children.toArray keeps a Fragment as one child; spinner+label wrapped in
+ * <>...</> would otherwise pick the square icon-only size and clip the label.
+ */
+function flattenButtonChildren(children: ReactNode): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  Children.forEach(children, (child) => {
+    if (child == null || typeof child === "boolean") return;
+    if (isValidElement(child) && child.type === Fragment) {
+      nodes.push(
+        ...flattenButtonChildren((child as ReactElement<{ children?: ReactNode }>).props.children),
+      );
+      return;
+    }
+    nodes.push(child);
+  });
+  return nodes;
+}
+
+function isIconOnlyButtonChildren(children: ReactNode): boolean {
+  const childNodes = flattenButtonChildren(children);
+  return (
+    childNodes.length === 1 &&
+    typeof childNodes[0] !== "string" &&
+    typeof childNodes[0] !== "number"
+  );
+}
 
 const BUTTON_VARIANT_CLASSES: Record<Exclude<ButtonVariant, "secondary" | "danger">, string> = {
   default:
@@ -103,11 +135,7 @@ export function Button({
   const hasTooltipParent = useContext(TooltipTriggerContext);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [tooltipOpen, setTooltipOpen] = useState(false);
-  const childNodes = Children.toArray(children);
-  const iconOnly =
-    childNodes.length === 1 &&
-    typeof childNodes[0] !== "string" &&
-    typeof childNodes[0] !== "number";
+  const iconOnly = isIconOnlyButtonChildren(children);
 
   const tooltipContent = tooltip === false ? null : (tooltip ?? title ?? ariaLabel);
   const hasTooltipContent =

--- a/packages/ui/src/primitives/__tests__/Button.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Button.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Button } from "../Button";
+
+describe("Button", () => {
+  test("uses icon-only sizing for a single non-text child", () => {
+    render(
+      <Button aria-label="refresh">
+        <span data-testid="icon" />
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "refresh" });
+    // Default md icon-only: h-9 w-9 px-0
+    expect(button.className).toMatch(/\bw-9\b/);
+    expect(button.className).toMatch(/\bpx-0\b/);
+  });
+
+  test("does not treat Fragment-wrapped icon+label as icon-only", () => {
+    render(
+      <Button variant="primary">
+        <>
+          <span data-testid="spinner" />
+          保存中...
+        </>
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "保存中..." });
+    // Text size (md): h-10 px-4 — not the square icon-only w-9 px-0.
+    expect(button.className).toMatch(/\bpx-4\b/);
+    expect(button.className).not.toMatch(/\bw-9\b/);
+    expect(button).toHaveTextContent("保存中...");
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+  });
+
+  test("keeps text sizing for icon and label as sibling children", () => {
+    render(
+      <Button variant="primary">
+        <span data-testid="spinner" />
+        保存中...
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "保存中..." });
+    expect(button.className).toMatch(/\bpx-4\b/);
+    expect(button.className).not.toMatch(/\bw-9\b/);
+  });
+
+  test("flattens nested Fragments before icon-only detection", () => {
+    render(
+      <Button variant="primary">
+        <>
+          <>
+            <span data-testid="spinner" />
+          </>
+          保存中...
+        </>
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "保存中..." });
+    expect(button.className).toMatch(/\bpx-4\b/);
+    expect(button.className).not.toMatch(/\bw-9\b/);
+  });
+});

--- a/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -574,6 +574,9 @@ describe("RoutingConfigEditor", () => {
     expect(saveButton).toHaveAttribute("aria-busy", "true");
     expect(saveButton).toHaveTextContent("保存中...");
     expect(saveButton.querySelector("svg")).toHaveClass("animate-spin");
+    // Spinner+label are Fragment-wrapped; Button must keep text sizing (not icon-only square).
+    expect(saveButton.className).toMatch(/\bpx-4\b/);
+    expect(saveButton.className).not.toMatch(/\bw-9\b/);
     expect(screen.getByTestId("group-editor-modal-body")).toBeInTheDocument();
 
     pending.resolve();


### PR DESCRIPTION
## Summary
- Fix save-button loading UI on channel group editor: spinner+label wrapped in a Fragment was mis-detected as icon-only and collapsed to a square (`w-9 px-0`), clipping「保存中」.
- Flatten Fragments in `@code-proxy/ui` `Button` before icon-only sizing so all similar icon+text loading states stay pill-shaped.
- Add unit coverage for Fragment/sibling children and a regression assert on the group-editor save loading button.

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- packages/ui/src/primitives/__tests__/Button.test.tsx pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx`
- [x] `./scripts/ci-pr.sh` (lint, design:check, full test:ci, build, bundle:diff, e2e critical)