### PR TITLE
fix(auth-files): 402 restriction tooltip + card error badge placement

### DIFF
--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1208,15 +1208,27 @@ describe("AuthFilesPage files table", () => {
     const card = title.closest("section");
     expect(card).not.toBeNull();
     expect(within(card as HTMLElement).queryByText("Restricted")).not.toBeInTheDocument();
-    const badge = within(card as HTMLElement).getByText("429 Error");
+    const errorBadges = within(card as HTMLElement).getByTestId("auth-file-card-error-badges");
+    const quota = within(card as HTMLElement).getByTestId("auth-file-card-quota");
+    expect(
+      Boolean(
+        errorBadges.compareDocumentPosition(quota) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ),
+    ).toBe(true);
+    const badge = within(errorBadges).getByText("429 Error");
     const tooltipTrigger = badge.closest("[aria-describedby]") ?? badge;
     fireEvent.mouseEnter(tooltipTrigger);
 
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip).toHaveTextContent("Requests are limited");
-    expect(tooltip).toHaveTextContent("5h");
+    expect(tooltip).toHaveTextContent("Limit window: 5h");
+    expect(tooltip).toHaveTextContent("Reason: usage limit");
+    expect(tooltip).toHaveTextContent("Refresh time:");
     expect(tooltip).toHaveTextContent("Auto recovery in");
     expect(tooltip).not.toHaveTextContent("usage_limit_reached");
+    // Multi-line tooltip: each fact on its own line for scanability.
+    expect(tooltip.textContent?.includes("\n")).toBe(true);
   });
 
   test("supports multi-select delete from the toolbar", async () => {

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1524,6 +1524,29 @@ export function AuthFilesFilesTab({
                     planType,
                   );
                   const subscriptionBadge = renderSubscriptionBadge(file);
+                  const restrictionBadges = renderRestrictionBadges(file);
+                  const claudeOAuthHealthBadges =
+                    renderClaudeOAuthHealthBadges(file);
+                  const quotaErrorBadge =
+                    provider && (state.status === "error" || state.error)
+                      ? renderQuotaErrorBadge(state.error ?? t("common.error"))
+                      : null;
+                  const cardErrorBadges = [
+                    restrictionBadges
+                      ? { key: "restriction", node: restrictionBadges }
+                      : null,
+                    claudeOAuthHealthBadges
+                      ? { key: "claude-oauth", node: claudeOAuthHealthBadges }
+                      : null,
+                    quotaErrorBadge
+                      ? { key: "quota-error", node: quotaErrorBadge }
+                      : null,
+                  ].filter(
+                    (
+                      item,
+                    ): item is { key: string; node: NonNullable<ReactNode> } =>
+                      Boolean(item),
+                  );
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const usageTotalCalls = stats.success + stats.failure;
                   const authIndex = normalizeAuthIndexValue(
@@ -1727,8 +1750,6 @@ export function AuthFilesFilesTab({
                                 : `${successRate.toFixed(1)}%`}
                             </span>
                           </span>
-                          {renderRestrictionBadges(file)}
-                          {renderClaudeOAuthHealthBadges(file)}
                           {subscriptionBadge}
                           {runtimeOnly ? (
                             <span className="inline-flex shrink-0 items-center rounded-full bg-slate-900 px-2 py-0.5 text-2xs font-semibold text-white dark:bg-white dark:text-neutral-950">
@@ -1750,19 +1771,23 @@ export function AuthFilesFilesTab({
                         ) : null}
                       </div>
 
+                      {cardErrorBadges.length > 0 ? (
+                        <div
+                          className="mt-3 min-w-0 flex flex-wrap items-center gap-1.5"
+                          data-testid="auth-file-card-error-badges"
+                        >
+                          {cardErrorBadges.map((item) => (
+                            <div key={item.key} className="min-w-0">
+                              {item.node}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+
                       <div
-                        className="mt-4 min-w-0 touch-pan-y rounded-2xl bg-slate-50/85 px-3 py-3 transition-colors duration-200 ease-out dark:bg-white/[0.03]"
+                        className="mt-3 min-w-0 touch-pan-y rounded-2xl bg-slate-50/85 px-3 py-3 transition-colors duration-200 ease-out dark:bg-white/[0.03]"
                         data-testid="auth-file-card-quota"
                       >
-                        {provider &&
-                        (state.status === "error" || state.error) ? (
-                          <div className="mb-2 min-w-0">
-                            {renderQuotaErrorBadge(
-                              state.error ?? t("common.error"),
-                            )}
-                          </div>
-                        ) : null}
-
                         {!provider && slots.length === 0 ? (
                           <div className="text-xs text-slate-400 dark:text-white/40">
                             --

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1531,22 +1531,26 @@ export function AuthFilesFilesTab({
                     provider && (state.status === "error" || state.error)
                       ? renderQuotaErrorBadge(state.error ?? t("common.error"))
                       : null;
-                  const cardErrorBadges = [
-                    restrictionBadges
-                      ? { key: "restriction", node: restrictionBadges }
-                      : null,
-                    claudeOAuthHealthBadges
-                      ? { key: "claude-oauth", node: claudeOAuthHealthBadges }
-                      : null,
-                    quotaErrorBadge
-                      ? { key: "quota-error", node: quotaErrorBadge }
-                      : null,
-                  ].filter(
-                    (
-                      item,
-                    ): item is { key: string; node: NonNullable<ReactNode> } =>
-                      Boolean(item),
-                  );
+                  const cardErrorBadges: Array<{ key: string; node: ReactNode }> =
+                    [];
+                  if (restrictionBadges) {
+                    cardErrorBadges.push({
+                      key: "restriction",
+                      node: restrictionBadges,
+                    });
+                  }
+                  if (claudeOAuthHealthBadges) {
+                    cardErrorBadges.push({
+                      key: "claude-oauth",
+                      node: claudeOAuthHealthBadges,
+                    });
+                  }
+                  if (quotaErrorBadge) {
+                    cardErrorBadges.push({
+                      key: "quota-error",
+                      node: quotaErrorBadge,
+                    });
+                  }
                   const stats = resolveAuthFileStats(file, usageIndex);
                   const usageTotalCalls = stats.success + stats.failure;
                   const authIndex = normalizeAuthIndexValue(

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -277,11 +277,14 @@ export function useAuthFilesFilesPresentation({
       const quotaWindow = formatRestrictionQuotaWindowLabel(badge);
       // Always surface the upstream reason (parsed status_message / quota reason).
       // Hiding it for quota-limited badges left 429 chips without any error detail.
+      // ponytail: multi-line string; HoverTooltip already uses whitespace-pre-line.
+      const reason =
+        badge.reason === "quota" ? t("auth_files.restriction_quota_label") : badge.reason;
       const parts = [
         badge.quotaLimited ? t("auth_files.restriction_limited") : "",
         quotaWindow ? t("auth_files.restriction_window", { window: quotaWindow }) : "",
         badge.model ? t("auth_files.restriction_model", { model: badge.model }) : "",
-        badge.reason ? t("auth_files.restriction_reason", { reason: badge.reason }) : "",
+        reason ? t("auth_files.restriction_reason", { reason }) : "",
       ].filter(Boolean);
       if (badge.recoverAtMs) {
         const remaining = formatAuthFileRestrictionRemaining(
@@ -298,7 +301,7 @@ export function useAuthFilesFilesPresentation({
       } else {
         parts.push(t("auth_files.restriction_recovery_unknown"));
       }
-      return parts.join(" · ");
+      return parts.join("\n");
     },
     [formatRestrictionQuotaWindowLabel, nowMs, restrictionUnitLabels, t],
   );
@@ -312,6 +315,7 @@ export function useAuthFilesFilesPresentation({
           {badges.map((badge) => (
             <HoverTooltip key={badge.key} content={formatRestrictionTooltip(badge)} placement="top">
               <span
+                data-testid="auth-file-restriction-badge"
                 className={[
                   "inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold tabular-nums",
                   RESTRICTION_TONE_CLASSES[badge.tone],
@@ -360,7 +364,7 @@ export function useAuthFilesFilesPresentation({
               })
             : "",
         ].filter(Boolean);
-        return parts.join(" · ");
+        return parts.join("\n");
       };
 
       return (


### PR DESCRIPTION
## Summary
- 卡片视图所有报错标签（限制 402/429、Claude OAuth 健康、配额拉取失败）统一放到额度进度条阴影区上方
- restriction tooltip 改为多行：限制窗口、原因、刷新时间、剩余恢复倒计时
- 补强 cards view 单测：位置与多行 tooltip

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci 732 / build / bundle:diff）
- [x] 相关 vitest：cards view + restriction tooltip
- [x] Playwright `@critical` 失败项重跑通过（`tenant_scope_forbidden` 首次超时属 flaky）

## Scope
`codeProxy` only — auth-files card presentation