### PR TITLE
fix(api-keys): usage modal uses shared DataTable empty state

### DIFF
--- a/pages/api-keys/components/ApiKeyUsageModal.tsx
+++ b/pages/api-keys/components/ApiKeyUsageModal.tsx
@@ -1,9 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { RefreshCw } from "lucide-react";
-import { Modal } from "@code-proxy/ui";
-import { SearchableSelect } from "@code-proxy/ui";
-import { Select } from "@code-proxy/ui";
-import { TableCellOverflowTooltip } from "@code-proxy/ui";
+import { DataTable, Modal, SearchableSelect, Select } from "@code-proxy/ui";
 import {
   RequestLogsPaginationBar,
   RequestLogsTimeRangeSelector,
@@ -160,75 +157,20 @@ export function ApiKeyUsageModal({
         </div>
 
         <div className="relative min-h-[320px] flex-1 overflow-hidden pt-3">
-          <div className="h-full overflow-auto">
-            <table className="w-full min-w-[1320px] table-fixed border-separate border-spacing-0 text-sm">
-              <caption className="sr-only">{t("api_keys_page.usage_table_caption")}</caption>
-              <thead className="sticky top-0 z-10">
-                <tr className="text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-white/55">
-                  {usageLogColumns.map((col, index) => {
-                    const isFirst = index === 0;
-                    const isLast = index === usageLogColumns.length - 1;
-                    const roundCls = [
-                      isFirst ? "first:rounded-l-xl" : "",
-                      isLast ? "last:rounded-r-xl" : "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ");
-                    return (
-                      <th
-                        key={col.key}
-                        className={`whitespace-nowrap bg-slate-100 px-4 py-3 dark:bg-neutral-800 ${col.width ?? ""} ${col.headerClassName ?? ""} ${roundCls}`}
-                      >
-                        {col.label}
-                      </th>
-                    );
-                  })}
-                </tr>
-              </thead>
-              <tbody className="text-slate-900 dark:text-white">
-                {!usageLoading && usageRows.length === 0 ? (
-                  <tr>
-                    <td
-                      colSpan={usageLogColumns.length}
-                      className="px-4 py-12 text-center text-sm text-slate-600 dark:text-white/70"
-                    >
-                      {t("api_keys_page.no_usage_records")}
-                    </td>
-                  </tr>
-                ) : (
-                  usageRows.map((row, rowIndex) => (
-                    <tr
-                      key={row.id}
-                      className="text-sm transition-colors hover:bg-slate-50 dark:hover:bg-white/[0.04]"
-                      style={{ height: 44 }}
-                    >
-                      {usageLogColumns.map((col, colIndex) => {
-                        const isFirst = colIndex === 0;
-                        const isLast = colIndex === usageLogColumns.length - 1;
-                        const roundCls = [
-                          isFirst ? "first:rounded-l-lg" : "",
-                          isLast ? "last:rounded-r-lg" : "",
-                        ]
-                          .filter(Boolean)
-                          .join(" ");
-                        return (
-                          <td
-                            key={col.key}
-                            className={`px-4 py-2.5 align-middle ${col.cellClassName ?? ""} ${roundCls}`}
-                          >
-                            <TableCellOverflowTooltip className={col.cellClassName}>
-                              {col.render(row, rowIndex)}
-                            </TableCellOverflowTooltip>
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-
+          <DataTable
+            tableId="api-key-usage-logs"
+            rows={usageRows}
+            columns={usageLogColumns}
+            rowKey={(row) => row.id}
+            loading={usageLoading}
+            virtualize={false}
+            minWidth="min-w-[1320px]"
+            height="h-full"
+            minHeight="min-h-full"
+            caption={t("api_keys_page.usage_table_caption")}
+            emptyText={t("api_keys_page.no_usage_records")}
+            showAllLoadedMessage={false}
+          />
           {usageLoading ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
               <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">

--- a/pages/api-keys/components/__tests__/ApiKeyUsageModal.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyUsageModal.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { ThemeProvider } from "@code-proxy/ui";
+import { ApiKeyUsageModal } from "../ApiKeyUsageModal";
+
+describe("ApiKeyUsageModal", () => {
+  test("uses shared DataTable empty state when there are no usage rows", async () => {
+    await i18n.changeLanguage("en");
+
+    render(
+      <ThemeProvider>
+        <ApiKeyUsageModal
+          open
+          onClose={vi.fn()}
+          usageViewName="Demo Key"
+          maskedKey="sk-***demo"
+          usageTotalCount={0}
+          usageTimeRange={7}
+          setUsageTimeRange={vi.fn()}
+          fetchUsageLogs={vi.fn(async () => undefined)}
+          usagePageSize={50}
+          usageLoading={false}
+          usageLastUpdatedText="Updated 00:00:00"
+          usageChannelGroupQuery=""
+          setUsageChannelGroupQuery={vi.fn()}
+          setUsageChannelQuery={vi.fn()}
+          usageChannelGroupOptions={[]}
+          usageChannelQuery=""
+          setUsageChannelQueryDirect={vi.fn()}
+          usageChannelOptions={[]}
+          usageModelQuery=""
+          setUsageModelQuery={vi.fn()}
+          usageModelOptions={[]}
+          usageStatusFilter=""
+          setUsageStatusFilter={vi.fn()}
+          usageLogColumns={[
+            {
+              key: "id",
+              label: "ID",
+              render: (row) => row.id,
+            },
+          ]}
+          usageRows={[]}
+          usageCurrentPage={1}
+          usageTotalPages={1}
+          setUsagePageSize={vi.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(await screen.findByText("No usage records")).toBeInTheDocument();
+    expect(document.querySelector("[data-empty-state]")).not.toBeNull();
+    expect(document.querySelector("table[data-vt-empty='true']")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- API Key 用量弹窗不再手写 `<table>` 空态文案行
- 改为共享 `DataTable`，空列表走统一 `EmptyState`（与 request logs / 其它管理表格一致）

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] `ApiKeyUsageModal.test.tsx` empty state

## Scope
`codeProxy` only — `pages/api-keys/components/ApiKeyUsageModal.tsx`