### PR TITLE
fix(data-table): sticky 表头横向滚动圆角裁切

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -588,6 +588,9 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       selectHeaderBottomLeftRadius: number;
       actionsHeaderTopRightRadius: number;
       actionsHeaderBottomRightRadius: number;
+      scrollportTopLeftRadius: number;
+      scrollportTopRightRadius: number;
+      headerGutterTopRightRadius: number | null;
     }> = [];
     for (const scrollLeft of positions) {
       container.scrollLeft = scrollLeft;
@@ -637,6 +640,9 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       const endBoundaryRect = endBoundary.getBoundingClientRect();
       const selectHeaderStyle = getComputedStyle(selectHeader);
       const actionsHeaderStyle = getComputedStyle(actionsHeader);
+      const scrollportStyle = getComputedStyle(container);
+      const headerGutter = document.querySelector<HTMLElement>("[data-vt-header-gutter]");
+      const headerGutterStyle = headerGutter ? getComputedStyle(headerGutter) : null;
       const nameHeaderHit = document.elementFromPoint(
         nameHeaderRect.right - 8,
         nameHeaderRect.top + nameHeaderRect.height / 2,
@@ -690,6 +696,11 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
         actionsHeaderBottomRightRadius: Number.parseFloat(
           actionsHeaderStyle.borderBottomRightRadius,
         ),
+        scrollportTopLeftRadius: Number.parseFloat(scrollportStyle.borderTopLeftRadius),
+        scrollportTopRightRadius: Number.parseFloat(scrollportStyle.borderTopRightRadius),
+        headerGutterTopRightRadius: headerGutterStyle
+          ? Number.parseFloat(headerGutterStyle.borderTopRightRadius)
+          : null,
       });
     }
 
@@ -746,10 +757,18 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
     expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.startBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.endBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
-    expect(state.selectHeaderTopLeftRadius).toBeGreaterThan(0);
-    expect(state.selectHeaderBottomLeftRadius).toBeGreaterThan(0);
-    expect(state.actionsHeaderTopRightRadius).toBeGreaterThan(0);
-    expect(state.actionsHeaderBottomRightRadius).toBeGreaterThan(0);
+    // Sticky header cells stay square so mid-scroll under-paint cannot square
+    // the corners; the scrollport (and optional header gutter) owns the radius.
+    expect(state.selectHeaderTopLeftRadius).toBe(0);
+    expect(state.selectHeaderBottomLeftRadius).toBe(0);
+    expect(state.actionsHeaderTopRightRadius).toBe(0);
+    expect(state.actionsHeaderBottomRightRadius).toBe(0);
+    expect(state.scrollportTopLeftRadius).toBeGreaterThan(0);
+    if (state.headerGutterTopRightRadius === null) {
+      expect(state.scrollportTopRightRadius).toBeGreaterThan(0);
+    } else {
+      expect(state.headerGutterTopRightRadius).toBeGreaterThan(0);
+    }
   }
 
   const maxScrollState = states.at(-1);

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -3230,7 +3230,12 @@ export function DataTable<T>({
         className={
           naturalFlow
             ? "relative z-10 min-h-0 overflow-visible rounded-xl"
-            : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none ${
+            : // Clip sticky headers to the scrollport radius so middle columns
+              // cannot square off the visible left/right header corners while
+              // scrolling. Keep left always rounded; right only when no v-gutter.
+              `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none rounded-l-xl ${
+                vThumb ? "" : "rounded-r-xl"
+              } ${
                 isEmpty
                   ? "overflow-x-hidden overflow-y-auto"
                   : "overflow-auto"
@@ -3306,15 +3311,12 @@ export function DataTable<T>({
                       ? "relative"
                       : "sticky top-0 z-50";
                   const headerChromeClass = "bg-slate-100 dark:bg-neutral-800";
+                  // Only naturalFlow paints radius on th cells. Sticky tables keep
+                  // square header cells so mid-scroll columns cannot fill the
+                  // transparent corner wedges; the scrollport radius clips instead.
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
                     naturalFlow && colIndex === orderedColumns.length - 1
-                      ? "rounded-r-xl"
-                      : "",
-                    !naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
-                    !naturalFlow &&
-                    !vThumb &&
-                    colIndex === orderedColumns.length - 1
                       ? "rounded-r-xl"
                       : "",
                   ]

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -412,4 +412,61 @@ describe("DataTable scroll chrome and row dividers", () => {
       );
     });
   });
+
+  test("clips sticky header corners on the scrollport instead of sticky header cells", () => {
+    const stickyColumns: DataTableColumn<TestRow>[] = [
+      {
+        key: "select",
+        label: "Select",
+        lockOrder: "start",
+        headerClassName: "md:sticky",
+        cellClassName: "md:sticky",
+        render: () => null,
+      },
+      {
+        key: "name",
+        label: "Name",
+        render: (row) => <span>{row.name}</span>,
+      },
+      {
+        key: "actions",
+        label: "Actions",
+        lockOrder: "end",
+        headerClassName: "md:sticky",
+        cellClassName: "md:sticky",
+        render: () => null,
+      },
+    ];
+
+    render(
+      <DataTable
+        rows={initialRows}
+        columns={stickyColumns}
+        rowKey={(row) => row.id}
+        height="h-[240px]"
+        minHeight="min-h-[240px]"
+        minWidth="min-w-[960px]"
+        showAllLoadedMessage={false}
+      />,
+    );
+
+    const viewport = document.querySelector<HTMLElement>(
+      "[data-scrollbar-visibility='hover']",
+    );
+    expect(viewport).not.toBeNull();
+    expect(viewport).toHaveClass("rounded-l-xl");
+
+    const selectHeader = document.querySelector('th[data-vt-column-key="select"]');
+    const actionsHeader = document.querySelector(
+      'th[data-vt-column-key="actions"]',
+    );
+    const headerGutter = document.querySelector("[data-vt-header-gutter]");
+    expect(selectHeader).not.toHaveClass("rounded-l-xl");
+    expect(actionsHeader).not.toHaveClass("rounded-r-xl");
+    if (headerGutter) {
+      expect(headerGutter).toHaveClass("rounded-r-xl");
+    } else {
+      expect(viewport).toHaveClass("rounded-r-xl");
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- sticky 表头单元格圆角透明角在横向滚动时会被中间列透出，端点看起来像直角
- 改为滚动容器裁切圆角；sticky 表头保持直角，右侧圆角由 header gutter（有纵向滚动条时）或 scrollport 承担

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] DataTable interactions unit test for scrollport radius
- [x] e2e api-keys-table radius assertions updated

## Scope
`codeProxy` only — `packages/ui/src/data-table/DataTable.tsx`