### PR TITLE
fix(data-table): sticky 表头横向滚动保持四角圆角

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -588,8 +588,10 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       selectHeaderBottomLeftRadius: number;
       actionsHeaderTopRightRadius: number;
       actionsHeaderBottomRightRadius: number;
-      scrollportTopLeftRadius: number;
-      scrollportTopRightRadius: number;
+      headerChromeTopLeftRadius: number;
+      headerChromeBottomLeftRadius: number;
+      headerChromeTopRightRadius: number;
+      headerChromeBottomRightRadius: number;
       headerGutterTopRightRadius: number | null;
     }> = [];
     for (const scrollLeft of positions) {
@@ -640,7 +642,9 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       const endBoundaryRect = endBoundary.getBoundingClientRect();
       const selectHeaderStyle = getComputedStyle(selectHeader);
       const actionsHeaderStyle = getComputedStyle(actionsHeader);
-      const scrollportStyle = getComputedStyle(container);
+      const headerChrome = document.querySelector<HTMLElement>("[data-vt-header-chrome]");
+      if (!headerChrome) throw new Error("Missing header chrome");
+      const headerChromeStyle = getComputedStyle(headerChrome);
       const headerGutter = document.querySelector<HTMLElement>("[data-vt-header-gutter]");
       const headerGutterStyle = headerGutter ? getComputedStyle(headerGutter) : null;
       const nameHeaderHit = document.elementFromPoint(
@@ -696,8 +700,14 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
         actionsHeaderBottomRightRadius: Number.parseFloat(
           actionsHeaderStyle.borderBottomRightRadius,
         ),
-        scrollportTopLeftRadius: Number.parseFloat(scrollportStyle.borderTopLeftRadius),
-        scrollportTopRightRadius: Number.parseFloat(scrollportStyle.borderTopRightRadius),
+        headerChromeTopLeftRadius: Number.parseFloat(headerChromeStyle.borderTopLeftRadius),
+        headerChromeBottomLeftRadius: Number.parseFloat(
+          headerChromeStyle.borderBottomLeftRadius,
+        ),
+        headerChromeTopRightRadius: Number.parseFloat(headerChromeStyle.borderTopRightRadius),
+        headerChromeBottomRightRadius: Number.parseFloat(
+          headerChromeStyle.borderBottomRightRadius,
+        ),
         headerGutterTopRightRadius: headerGutterStyle
           ? Number.parseFloat(headerGutterStyle.borderTopRightRadius)
           : null,
@@ -757,15 +767,18 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
     expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.startBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.endBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
-    // Sticky header cells stay square so mid-scroll under-paint cannot square
-    // the corners; the scrollport (and optional header gutter) owns the radius.
-    expect(state.selectHeaderTopLeftRadius).toBe(0);
-    expect(state.selectHeaderBottomLeftRadius).toBe(0);
-    expect(state.actionsHeaderTopRightRadius).toBe(0);
-    expect(state.actionsHeaderBottomRightRadius).toBe(0);
-    expect(state.scrollportTopLeftRadius).toBeGreaterThan(0);
+    // Outer sticky headers keep full side radius (top+bottom) at every scroll
+    // offset. Header chrome fills corner wedges so mid-scroll columns cannot
+    // square them off.
+    expect(state.selectHeaderTopLeftRadius).toBeGreaterThan(0);
+    expect(state.selectHeaderBottomLeftRadius).toBeGreaterThan(0);
+    expect(state.actionsHeaderTopRightRadius).toBeGreaterThan(0);
+    expect(state.actionsHeaderBottomRightRadius).toBeGreaterThan(0);
+    expect(state.headerChromeTopLeftRadius).toBeGreaterThan(0);
+    expect(state.headerChromeBottomLeftRadius).toBeGreaterThan(0);
     if (state.headerGutterTopRightRadius === null) {
-      expect(state.scrollportTopRightRadius).toBeGreaterThan(0);
+      expect(state.headerChromeTopRightRadius).toBeGreaterThan(0);
+      expect(state.headerChromeBottomRightRadius).toBeGreaterThan(0);
     } else {
       expect(state.headerGutterTopRightRadius).toBeGreaterThan(0);
     }

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -3230,12 +3230,7 @@ export function DataTable<T>({
         className={
           naturalFlow
             ? "relative z-10 min-h-0 overflow-visible rounded-xl"
-            : // Clip sticky headers to the scrollport radius so middle columns
-              // cannot square off the visible left/right header corners while
-              // scrolling. Keep left always rounded; right only when no v-gutter.
-              `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none rounded-l-xl ${
-                vThumb ? "" : "rounded-r-xl"
-              } ${
+            : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none ${
                 isEmpty
                   ? "overflow-x-hidden overflow-y-auto"
                   : "overflow-auto"
@@ -3250,6 +3245,24 @@ export function DataTable<T>({
           data-vt-scroll-content
           className={`relative min-h-full ${scrollContentClassName ?? ""}`}
         >
+          {/* Sticky rounded header plate inside the scrollport. left:0 keeps it
+              pinned while scrolling horizontally; transparent middle headers let
+              this plate show through, including under outer sticky corner wedges. */}
+          {naturalFlow || isEmpty ? null : (
+            <div
+              data-vt-header-chrome
+              aria-hidden="true"
+              className={`pointer-events-none sticky left-0 top-0 z-40 ${
+                vThumb ? "rounded-l-xl" : "rounded-xl"
+              } bg-slate-100 dark:bg-neutral-800`}
+              style={{
+                width: scrollMetrics.clientWidth || "100%",
+                // Tests / first paint may not have measured headerHeight yet.
+                height: headerHeight > 0 ? headerHeight : "2.75rem",
+                marginBottom: headerHeight > 0 ? -headerHeight : "-2.75rem",
+              }}
+            />
+          )}
           {!naturalFlow && rowHoverOverlay ? (
             <div
               data-vt-row-hover-overlay
@@ -3310,13 +3323,32 @@ export function DataTable<T>({
                     naturalFlow || isEmpty
                       ? "relative"
                       : "sticky top-0 z-50";
-                  const headerChromeClass = "bg-slate-100 dark:bg-neutral-800";
-                  // Only naturalFlow paints radius on th cells. Sticky tables keep
-                  // square header cells so mid-scroll columns cannot fill the
-                  // transparent corner wedges; the scrollport radius clips instead.
+                  // Outer sticky headers paint full side radius (top+bottom).
+                  // Middle headers stay transparent so header-chrome shows through
+                  // while columns scroll — keeps the header bar 4-corner rounded.
+                  // Tables without locked sticky columns keep opaque headers.
+                  const hasStickyColumns =
+                    Object.keys(stickyColumnPlacements).length > 0;
+                  const isOuterStickyStart =
+                    stickyPlacement?.edge === "start" && stickyPlacement.offset === 0;
+                  const isOuterStickyEnd =
+                    stickyPlacement?.edge === "end" && stickyPlacement.offset === 0;
+                  const headerChromeClass =
+                    naturalFlow || isEmpty || stickyPlacement || !hasStickyColumns
+                      ? "bg-slate-100 dark:bg-neutral-800"
+                      : "bg-transparent";
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
                     naturalFlow && colIndex === orderedColumns.length - 1
+                      ? "rounded-r-xl"
+                      : "",
+                    !naturalFlow && (colIndex === 0 || isOuterStickyStart)
+                      ? "rounded-l-xl"
+                      : "",
+                    // Always round the outer end header; gutter only covers the
+                    // scrollbar strip, not the actions column itself.
+                    !naturalFlow &&
+                    (isOuterStickyEnd || colIndex === orderedColumns.length - 1)
                       ? "rounded-r-xl"
                       : "",
                   ]

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -365,7 +365,7 @@ describe("DataTable scroll chrome and row dividers", () => {
     expect(parent.scrollTop).toBe(120);
     expect(viewport).toHaveClass("overscroll-y-auto");
     expect(viewport).not.toHaveClass("overscroll-y-none");
-    expect(document.querySelector("[data-vt-header-chrome]")).toBeNull();
+    expect(document.querySelector("[data-vt-header-chrome]")).not.toBeNull();
 
     const headerCells = Array.from(document.querySelectorAll("thead th"));
     expect(headerCells).not.toHaveLength(0);
@@ -413,7 +413,7 @@ describe("DataTable scroll chrome and row dividers", () => {
     });
   });
 
-  test("clips sticky header corners on the scrollport instead of sticky header cells", () => {
+  test("keeps sticky header corners rounded via header chrome and outer sticky cells", () => {
     const stickyColumns: DataTableColumn<TestRow>[] = [
       {
         key: "select",
@@ -450,23 +450,24 @@ describe("DataTable scroll chrome and row dividers", () => {
       />,
     );
 
-    const viewport = document.querySelector<HTMLElement>(
-      "[data-scrollbar-visibility='hover']",
-    );
-    expect(viewport).not.toBeNull();
-    expect(viewport).toHaveClass("rounded-l-xl");
+    const headerChrome = document.querySelector("[data-vt-header-chrome]");
+    expect(headerChrome).not.toBeNull();
 
     const selectHeader = document.querySelector('th[data-vt-column-key="select"]');
+    const nameHeader = document.querySelector('th[data-vt-column-key="name"]');
     const actionsHeader = document.querySelector(
       'th[data-vt-column-key="actions"]',
     );
     const headerGutter = document.querySelector("[data-vt-header-gutter]");
-    expect(selectHeader).not.toHaveClass("rounded-l-xl");
-    expect(actionsHeader).not.toHaveClass("rounded-r-xl");
+    expect(selectHeader).toHaveClass("rounded-l-xl", "bg-slate-100");
+    expect(nameHeader).toHaveClass("bg-transparent");
+    expect(actionsHeader).toHaveClass("rounded-r-xl");
+    // With a vertical gutter, chrome is left-only; otherwise full rounded-xl.
     if (headerGutter) {
       expect(headerGutter).toHaveClass("rounded-r-xl");
+      expect(headerChrome).toHaveClass("rounded-l-xl");
     } else {
-      expect(viewport).toHaveClass("rounded-r-xl");
+      expect(headerChrome).toHaveClass("rounded-xl");
     }
   });
 });

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -1388,10 +1388,10 @@ describe("CcSwitchImportSettingsPage", () => {
       tableViewport?.querySelectorAll("thead th") ?? [],
     );
     expect(headerCells).not.toHaveLength(0);
-    headerCells.forEach((cell) =>
-      expect(cell).toHaveClass("sticky", "top-0", "bg-slate-100"),
-    );
-    expect(mappingTable.querySelector("[data-vt-header-chrome]")).toBeNull();
+    headerCells.forEach((cell) => expect(cell).toHaveClass("sticky", "top-0"));
+    // rowReorderable injects a sticky start column, so DataTable paints a rounded
+    // header-chrome plate and keeps non-sticky middle headers transparent.
+    expect(mappingTable.querySelector("[data-vt-header-chrome]")).not.toBeNull();
     expect(mappingTable.querySelector("[data-vt-column-resizer]")).toBeNull();
 
     const mappingRows = Array.from(


### PR DESCRIPTION
## Summary
- 表头应始终四角圆角，横向滚动时也不能变成直角
- 恢复 sticky `header-chrome` 底板；两端 sticky 表头保留完整侧圆角（上下都圆）
- 中间表头透明，让 chrome 透过圆角透明区，避免中间列“填成直角”

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] DataTable interactions unit tests
- [x] e2e radius assertions for API keys sticky headers
- [x] CcSwitch mapping table header chrome assertion update

## Scope
`codeProxy` only — `packages/ui/src/data-table/DataTable.tsx`