### PR TITLE
fix(data-table): viewport-fixed header chrome and split module

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -219,9 +219,7 @@ test("API Keys: limited model summary truncates inside the rounded pill", async 
   expect(Number.parseFloat(summaryState.borderTopRightRadius)).toBeGreaterThan(0);
 });
 
-test("API Keys: dark hover keeps fixed columns opaque above scrolled content", async ({
-  page,
-}) => {
+test("API Keys: dark hover keeps fixed columns opaque above scrolled content", async ({ page }) => {
   await page.setViewportSize({ width: 1360, height: 980 });
   await setAuthed(page);
   await page.addInitScript(() => {
@@ -533,10 +531,7 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
   await mockApiKeysApis(page);
 
   await page.goto("/#/api-keys");
-  await page
-    .locator('td[data-vt-column-key="createdAt"]')
-    .first()
-    .waitFor({ state: "visible" });
+  await page.locator('td[data-vt-column-key="createdAt"]').first().waitFor({ state: "visible" });
   await expect(page.getByText(/All 9 records loaded|已加载全部 9 条记录/)).toHaveCount(0);
 
   const states = await page.evaluate(async () => {
@@ -608,9 +603,7 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
       const nameCell = document.querySelector<HTMLElement>('td[data-vt-column-key="name"]');
       const startRail = document.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
       const endRail = document.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
-      const startBoundary = document.querySelector<HTMLElement>(
-        "[data-vt-sticky-start-boundary]",
-      );
+      const startBoundary = document.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
       const endBoundary = document.querySelector<HTMLElement>("[data-vt-sticky-end-boundary]");
       if (
         !createdAt ||
@@ -701,13 +694,9 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
           actionsHeaderStyle.borderBottomRightRadius,
         ),
         headerChromeTopLeftRadius: Number.parseFloat(headerChromeStyle.borderTopLeftRadius),
-        headerChromeBottomLeftRadius: Number.parseFloat(
-          headerChromeStyle.borderBottomLeftRadius,
-        ),
+        headerChromeBottomLeftRadius: Number.parseFloat(headerChromeStyle.borderBottomLeftRadius),
         headerChromeTopRightRadius: Number.parseFloat(headerChromeStyle.borderTopRightRadius),
-        headerChromeBottomRightRadius: Number.parseFloat(
-          headerChromeStyle.borderBottomRightRadius,
-        ),
+        headerChromeBottomRightRadius: Number.parseFloat(headerChromeStyle.borderBottomRightRadius),
         headerGutterTopRightRadius: headerGutterStyle
           ? Number.parseFloat(headerGutterStyle.borderTopRightRadius)
           : null,
@@ -767,13 +756,8 @@ test("API Keys: fixed columns do not cover the created time at the right edge", 
     expect(state.endRailBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.startBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
     expect(state.endBoundaryBottom).toBeGreaterThanOrEqual(state.fixedRailBottom - 1);
-    // Outer sticky headers keep full side radius (top+bottom) at every scroll
-    // offset. Header chrome fills corner wedges so mid-scroll columns cannot
-    // square them off.
-    expect(state.selectHeaderTopLeftRadius).toBeGreaterThan(0);
-    expect(state.selectHeaderBottomLeftRadius).toBeGreaterThan(0);
-    expect(state.actionsHeaderTopRightRadius).toBeGreaterThan(0);
-    expect(state.actionsHeaderBottomRightRadius).toBeGreaterThan(0);
+    // Viewport-fixed header chrome owns the rounded plate; root overflow clips
+    // sticky th cells. Per-cell header radius is intentionally not required.
     expect(state.headerChromeTopLeftRadius).toBeGreaterThan(0);
     expect(state.headerChromeBottomLeftRadius).toBeGreaterThan(0);
     if (state.headerGutterTopRightRadius === null) {

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -5,18 +5,11 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import {
-  ArrowDown,
-  ArrowUp,
-  ArrowUpDown,
-  Check,
-  GripVertical,
-} from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Check, GripVertical } from "lucide-react";
 import { EmptyState } from "../feedback/EmptyState";
 import { DropdownMenu } from "../primitives/DropdownMenu";
 import { TableCellOverflowTooltip } from "./TableCellOverflowTooltip";
@@ -35,996 +28,85 @@ import type {
   DataTableProps,
   DataTableSortDirection,
   DataTableSortState,
-  DataTableSortValue,
 } from "./DataTable.types";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-const DEFAULT_ROW_HEIGHT = 44;
-const DEFAULT_OVERSCAN = 12;
-const DEFAULT_SCROLL_THRESHOLD = 100;
-const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
-const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v1";
-const COLUMN_RESIZE_DEBUG_STORAGE_KEY = "codeProxy.dataTable.debugResize";
-const DEFAULT_MIN_COLUMN_WIDTH = 72;
-const DEFAULT_MAX_COLUMN_WIDTH = 640;
-const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
-const STICKY_EDGE_SHADOW_WIDTH = 28;
-
-function getStickyEdgeShadowOpacity(
-  metrics: ScrollMetrics,
-  edge: "start" | "end",
-) {
-  const maxScrollLeft = Math.max(0, metrics.scrollWidth - metrics.clientWidth);
-  if (maxScrollLeft <= 1) return 0;
-  if (edge === "start") return metrics.scrollLeft > 1 ? 1 : 0;
-  return metrics.scrollLeft < maxScrollLeft - 1 ? 1 : 0;
-}
-const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
-const TAILWIND_SPACING_UNIT_PX = 4;
-
-// ---------------------------------------------------------------------------
-// Column Reorder
-// ---------------------------------------------------------------------------
-const COLUMN_ORDER_STORAGE_PREFIX = "codeProxy.dataTable.columnOrder.v1";
-const COLUMN_REORDER_ACTIVATION_DELAY_MS = 90;
-const COLUMN_REORDER_MIN_DRAG_DISTANCE_PX = 4;
-const COLUMN_REORDER_AUTOSCROLL_EDGE_PX = 72;
-const COLUMN_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME = 22;
-const COLUMN_REORDER_SHIFT_TRANSITION =
-  "transform 72ms cubic-bezier(0.2, 0, 0, 1)";
-const COLUMN_REORDER_SETTLE_CLEANUP_MS = 110;
-const COLUMN_REORDER_SETTLE_FEEDBACK_MS = 900;
-const NON_REORDERABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
-
-const ROW_REORDER_COLUMN_KEY = "__data-table-row-reorder__";
-const ROW_REORDER_MIN_DRAG_DISTANCE_PX = 4;
-const ROW_REORDER_AUTOSCROLL_EDGE_PX = 56;
-const ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME = 18;
-
-type ColumnOrder = string[];
-
-interface ColumnReorderGeometry {
-  key: string;
-  index: number;
-  left: number;
-  width: number;
-  elements: HTMLElement[];
-  appliedDragging: boolean;
-  appliedShift: number | null;
-  appliedTransform: string;
-}
-
-interface ColumnReorderState {
-  pointerId: number;
-  columnKey: string;
-  originIndex: number;
-  currentToIndex: number;
-  startClientX: number;
-  startClientY: number;
-  startScrollLeft: number;
-  lastClientX: number;
-  lastClientY: number;
-  activated: boolean;
-  activationTimer: number | null;
-  allowedMinIndex: number;
-  allowedMaxIndex: number;
-  columns: ColumnReorderGeometry[];
-  draggedWidth: number;
-}
-
-interface RowReorderGeometry {
-  index: number;
-  element: HTMLTableRowElement;
-  appliedShift: number;
-}
-
-interface RowReorderState {
-  pointerId: number;
-  fromIndex: number;
-  insertionIndex: number;
-  startClientY: number;
-  lastClientY: number;
-  activated: boolean;
-  scrollContainer: HTMLElement | null;
-  sourceRow: HTMLTableRowElement | null;
-  previewElement: HTMLDivElement | null;
-  grabOffsetY: number;
-  previewHeight: number;
-  sourceHeight: number;
-  rows: RowReorderGeometry[];
-}
-
-type ColumnWidthMap = Record<string, number>;
-
-interface ColumnResizeState {
-  pointerId: number;
-  columnKey: string;
-  startLeftClientX: number;
-  pointerBoundaryOffsetClientX: number;
-  minWidth: number;
-  maxWidth: number;
-  previewTop: number;
-  previewBottom: number;
-  previewMinClientX: number;
-  previewMaxClientX: number;
-  currentWidth: number;
-  lastDebugAtMs: number;
-  debugEnabled: boolean;
-}
-
-interface ColumnResizePreview {
-  width: number;
-  left: number;
-  top: number;
-  height: number;
-  tooltipTop: number;
-  visible: boolean;
-}
-
-interface ScrollMetrics {
-  scrollTop: number;
-  scrollLeft: number;
-  scrollHeight: number;
-  scrollWidth: number;
-  clientHeight: number;
-  clientWidth: number;
-}
-
-type StickyColumnPlacement = {
-  edge: "start" | "end";
-  offset: number;
-};
-
-type DataTableColumnStyle = CSSProperties & {
-  "--vt-sticky-left"?: string;
-  "--vt-sticky-right"?: string;
-};
-
-function hasHorizontalOverflow(metrics: ScrollMetrics) {
-  return metrics.scrollWidth > metrics.clientWidth + 1;
-}
-
-function hasVerticalOverflow(metrics: ScrollMetrics, headerHeight: number) {
-  const effectiveViewportY = Math.max(0, metrics.clientHeight - headerHeight);
-  const effectiveContentY = Math.max(
-    effectiveViewportY,
-    metrics.scrollHeight - headerHeight,
-  );
-  return effectiveContentY > effectiveViewportY + 1;
-}
-
-function calculateScrollbarThumbs(
-  scrollMetrics: ScrollMetrics,
-  headerHeight: number,
-) {
-  const trackInset = 8; // matches `inset-y-2` / `inset-x-2` (8px)
-  const effectiveViewportY = Math.max(
-    0,
-    scrollMetrics.clientHeight - headerHeight,
-  );
-  const effectiveContentY = Math.max(
-    effectiveViewportY,
-    scrollMetrics.scrollHeight - headerHeight,
-  );
-  const hasV = hasVerticalOverflow(scrollMetrics, headerHeight);
-  const hasH = hasHorizontalOverflow(scrollMetrics);
-
-  const v = (() => {
-    if (!hasV) return null;
-    const trackLength = Math.max(
-      0,
-      scrollMetrics.clientHeight - headerHeight - trackInset * 2,
-    );
-    const viewport = Math.max(1, effectiveViewportY);
-    const content = Math.max(viewport, effectiveContentY);
-    const thumbLength = Math.max(
-      28,
-      Math.round((viewport / content) * trackLength),
-    );
-    const maxThumbOffset = Math.max(0, trackLength - thumbLength);
-    const scrollRange = Math.max(
-      1,
-      scrollMetrics.scrollHeight - scrollMetrics.clientHeight,
-    );
-    const offset = Math.min(
-      maxThumbOffset,
-      Math.max(
-        0,
-        Math.round((scrollMetrics.scrollTop / scrollRange) * maxThumbOffset),
-      ),
-    );
-    return { top: offset, height: thumbLength };
-  })();
-
-  const h = (() => {
-    if (!hasH) return null;
-    const trackLength = Math.max(0, scrollMetrics.clientWidth - trackInset * 2);
-    const viewport = scrollMetrics.clientWidth;
-    const content = scrollMetrics.scrollWidth;
-    const thumbLength = Math.max(
-      28,
-      Math.round((viewport / content) * trackLength),
-    );
-    const maxThumbOffset = Math.max(0, trackLength - thumbLength);
-    const scrollRange = Math.max(1, content - viewport);
-    const offset = Math.min(
-      maxThumbOffset,
-      Math.max(
-        0,
-        Math.round((scrollMetrics.scrollLeft / scrollRange) * maxThumbOffset),
-      ),
-    );
-    return { left: offset, width: thumbLength };
-  })();
-
-  return { vThumb: v, hThumb: h };
-}
-
-function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
-  const minWidth = resolveColumnMinWidth(column);
-  const maxWidth = resolveColumnMaxWidth(column, minWidth);
-  return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
-}
-
-function parseTailwindSizePx(token: string) {
-  const arbitrary = token.match(/^\[(\d+(?:\.\d+)?)(px|rem)\]$/);
-  if (arbitrary) {
-    const value = Number(arbitrary[1]);
-    if (!Number.isFinite(value)) return null;
-    return arbitrary[2] === "rem" ? Math.round(value * 16) : Math.round(value);
-  }
-
-  if (token === "px") return 1;
-
-  const numeric = Number(token);
-  if (!Number.isFinite(numeric)) return null;
-  return Math.round(numeric * TAILWIND_SPACING_UNIT_PX);
-}
-
-function resolveWidthClassPx(width: string | undefined, prefix: string) {
-  if (!width) return null;
-  const classes = width.split(/\s+/).filter(Boolean).reverse();
-  for (const className of classes) {
-    if (!className.startsWith(`${prefix}-`)) continue;
-    const parsed = parseTailwindSizePx(className.slice(prefix.length + 1));
-    if (parsed !== null) return parsed;
-  }
-  return null;
-}
-
-function resolveColumnMinWidth<T>(column: DataTableColumn<T>) {
-  return (
-    column.minWidthPx ??
-    resolveWidthClassPx(column.width, "min-w") ??
-    DEFAULT_MIN_COLUMN_WIDTH
-  );
-}
-
-function resolveColumnMaxWidth<T>(
-  column: DataTableColumn<T>,
-  minWidth = resolveColumnMinWidth(column),
-) {
-  return Math.max(minWidth, column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH);
-}
-
-function hasStickyColumnClass<T>(column: DataTableColumn<T>) {
-  return `${column.headerClassName ?? ""} ${column.cellClassName ?? ""}`
-    .split(/\s+/)
-    .some(
-      (className) => className === "sticky" || className.endsWith(":sticky"),
-    );
-}
-
-/**
- * Map Tailwind text-align utilities on the header cell to flex justify on the
- * header content row. `th` may carry `text-center` / `text-right`, but the label
- * wrapper is `display: flex`, so text-align alone never centers/right-aligns it.
- */
-function resolveHeaderContentJustifyClass(headerClassName?: string) {
-  let justifyClass = "";
-  for (const className of (headerClassName ?? "").split(/\s+/).filter(Boolean)) {
-    if (/(?:^|:)text-center$/.test(className)) {
-      justifyClass = "justify-center";
-      continue;
-    }
-    if (/(?:^|:)text-right$/.test(className)) {
-      justifyClass = "justify-end";
-      continue;
-    }
-    if (/(?:^|:)text-left$/.test(className)) {
-      justifyClass = "justify-start";
-    }
-  }
-  return justifyClass;
-}
-
-function resolveColumnLayoutWidth<T>(
-  column: DataTableColumn<T>,
-  widths: ColumnWidthMap,
-) {
-  const resizedWidth = widths[column.key];
-  return resizedWidth
-    ? clampColumnWidth(column, resizedWidth)
-    : resolveColumnMinWidth(column);
-}
-
-function resolveStickyRailWidth<T>(
-  columns: DataTableColumn<T>[],
-  widths: ColumnWidthMap,
-  edge: "start" | "end",
-) {
-  const edgeColumns = edge === "start" ? columns : [...columns].reverse();
-  let width = 0;
-
-  for (const column of edgeColumns) {
-    if (
-      resolveColumnOrderLock(column) !== edge ||
-      !hasStickyColumnClass(column)
-    )
-      break;
-    width += resolveColumnLayoutWidth(column, widths);
-  }
-
-  return width;
-}
-
-function resolveStickyColumnPlacements<T>(
-  columns: DataTableColumn<T>[],
-  widths: ColumnWidthMap,
-) {
-  const placements: Record<string, StickyColumnPlacement> = {};
-
-  let startOffset = 0;
-  for (const column of columns) {
-    if (
-      resolveColumnOrderLock(column) !== "start" ||
-      !hasStickyColumnClass(column)
-    )
-      break;
-    placements[column.key] = { edge: "start", offset: startOffset };
-    startOffset += resolveColumnLayoutWidth(column, widths);
-  }
-
-  let endOffset = 0;
-  for (const column of [...columns].reverse()) {
-    if (
-      resolveColumnOrderLock(column) !== "end" ||
-      !hasStickyColumnClass(column)
-    )
-      break;
-    placements[column.key] = { edge: "end", offset: endOffset };
-    endOffset += resolveColumnLayoutWidth(column, widths);
-  }
-
-  return placements;
-}
-
-function normalizeColumnWidths<T>(
-  columns: DataTableColumn<T>[],
-  widths: ColumnWidthMap,
-) {
-  const next: ColumnWidthMap = {};
-  columns.forEach((column) => {
-    const width = widths[column.key];
-    if (width !== undefined) next[column.key] = clampColumnWidth(column, width);
-  });
-  return next;
-}
-
-function areColumnWidthMapsEqual(left: ColumnWidthMap, right: ColumnWidthMap) {
-  const leftKeys = Object.keys(left);
-  const rightKeys = Object.keys(right);
-  if (leftKeys.length !== rightKeys.length) return false;
-  return leftKeys.every((key) => left[key] === right[key]);
-}
-
-function getColumnWidthStorageKey(tableId?: string) {
-  const trimmed = tableId?.trim();
-  return trimmed ? `${COLUMN_WIDTH_STORAGE_PREFIX}.${trimmed}` : null;
-}
-
-function readStoredColumnWidths(tableId?: string): ColumnWidthMap {
-  const key = getColumnWidthStorageKey(tableId);
-  if (!key || typeof window === "undefined") return {};
-
-  try {
-    const raw = window.localStorage.getItem(key);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-      return {};
-
-    return Object.fromEntries(
-      Object.entries(parsed as Record<string, unknown>)
-        .filter(
-          ([, value]) => typeof value === "number" && Number.isFinite(value),
-        )
-        .map(([columnKey, value]) => [columnKey, Math.round(value as number)]),
-    );
-  } catch {
-    return {};
-  }
-}
-
-function writeStoredColumnWidths(
-  tableId: string | undefined,
-  widths: ColumnWidthMap,
-) {
-  const key = getColumnWidthStorageKey(tableId);
-  if (!key || typeof window === "undefined") return;
-
-  try {
-    const normalized = Object.fromEntries(
-      Object.entries(widths).filter(
-        ([, value]) => Number.isFinite(value) && value > 0,
-      ),
-    );
-    window.localStorage.setItem(key, JSON.stringify(normalized));
-  } catch {
-    // localStorage can be unavailable in private browsing or embedded contexts.
-  }
-}
-
-function shouldDebugColumnResize() {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(COLUMN_RESIZE_DEBUG_STORAGE_KEY) === "1";
-}
-
-function logColumnResizeDebug(event: string, payload: Record<string, unknown>) {
-  if (!shouldDebugColumnResize()) return;
-  // eslint-disable-next-line no-console
-  console.debug("[DataTable resize]", event, payload);
-}
-
-function resolveColumnResizeWidth(
-  active: ColumnResizeState,
-  pointerClientX: number,
-) {
-  const rawBoundaryClientX =
-    pointerClientX + active.pointerBoundaryOffsetClientX;
-  return Math.max(
-    active.minWidth,
-    Math.min(
-      active.maxWidth,
-      Math.round(rawBoundaryClientX - active.startLeftClientX),
-    ),
-  );
-}
-
-function shouldAllowColumnResize<T>(
-  column: DataTableColumn<T>,
-  columnIndex: number,
-  columns: DataTableColumn<T>[],
-) {
-  if (columnIndex >= columns.length - 1) return false;
-  if (column.resizable !== undefined) return column.resizable;
-  return !NON_RESIZABLE_COLUMN_KEYS.has(column.key);
-}
-
-function resolveCellOverflowTooltip<T>(
-  column: DataTableColumn<T>,
-  row: T,
-  index: number,
-) {
-  if (column.overflowTooltip === false) return false;
-
-  if (typeof column.overflowTooltip === "function") {
-    const value = column.overflowTooltip(row, index);
-    return value === null || value === undefined ? null : String(value);
-  }
-
-  return undefined;
-}
-
-function safeSetPointerCapture(element: Element, pointerId: number) {
-  try {
-    if ("setPointerCapture" in element) {
-      element.setPointerCapture(pointerId);
-    }
-  } catch {
-    // Synthetic pointer events in automated checks may not create an active browser pointer.
-  }
-}
-
-function isEmptySortValue(value: DataTableSortValue) {
-  return (
-    value === null ||
-    value === undefined ||
-    (typeof value === "string" && !value.trim())
-  );
-}
-
-function compareSortValues(
-  left: DataTableSortValue,
-  right: DataTableSortValue,
-  collator: Intl.Collator,
-) {
-  const leftEmpty = isEmptySortValue(left);
-  const rightEmpty = isEmptySortValue(right);
-  if (leftEmpty || rightEmpty) {
-    if (leftEmpty && rightEmpty) return 0;
-    return leftEmpty ? 1 : -1;
-  }
-  if (typeof left === "number" && typeof right === "number") {
-    return left - right;
-  }
-  return collator.compare(String(left), String(right));
-}
-
-function moveRow<T>(
-  rows: readonly T[],
-  fromIndex: number,
-  toIndex: number,
-): T[] {
-  const next = Array.from(rows);
-  const [moved] = next.splice(fromIndex, 1);
-  if (moved === undefined) return next;
-  next.splice(toIndex, 0, moved);
-  return next;
-}
-
-function findVerticalScrollContainer(
-  element: HTMLElement | null,
-): HTMLElement | null {
-  let current = element?.parentElement ?? null;
-  while (current) {
-    const overflowY = window.getComputedStyle(current).overflowY;
-    if (
-      /(auto|scroll)/.test(overflowY) &&
-      current.scrollHeight > current.clientHeight
-    ) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  const scrollingElement = document.scrollingElement;
-  return scrollingElement instanceof HTMLElement ? scrollingElement : null;
-}
-
-function findVerticalScrollTarget(
-  element: HTMLElement,
-  deltaY: number,
-): HTMLElement | null {
-  let current = element.parentElement;
-  while (current) {
-    const overflowY = window.getComputedStyle(current).overflowY;
-    const maxScrollTop = Math.max(
-      0,
-      current.scrollHeight - current.clientHeight,
-    );
-    const canMove =
-      /(auto|scroll)/.test(overflowY) &&
-      ((deltaY < 0 && current.scrollTop > 0) ||
-        (deltaY > 0 && current.scrollTop < maxScrollTop));
-    if (canMove) return current;
-    current = current.parentElement;
-  }
-
-  const scrollingElement = document.scrollingElement;
-  if (!(scrollingElement instanceof HTMLElement)) return null;
-  const maxScrollTop = Math.max(
-    0,
-    scrollingElement.scrollHeight - scrollingElement.clientHeight,
-  );
-  return (deltaY < 0 && scrollingElement.scrollTop > 0) ||
-    (deltaY > 0 && scrollingElement.scrollTop < maxScrollTop)
-    ? scrollingElement
-    : null;
-}
-
-function syncClonedFormControlState(
-  sourceRow: HTMLTableRowElement,
-  clonedRow: HTMLTableRowElement,
-) {
-  const sourceControls = sourceRow.querySelectorAll<
-    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-  >("input, textarea, select");
-  const clonedControls = clonedRow.querySelectorAll<
-    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-  >("input, textarea, select");
-
-  clonedControls.forEach((clonedControl, index) => {
-    const sourceControl = sourceControls[index];
-    if (sourceControl) {
-      clonedControl.value = sourceControl.value;
-      if (
-        sourceControl instanceof HTMLInputElement &&
-        clonedControl instanceof HTMLInputElement
-      ) {
-        clonedControl.checked = sourceControl.checked;
-      }
-    }
-    clonedControl.tabIndex = -1;
-  });
-}
-
-// Clone the rendered row so form controls keep their exact current appearance without re-running cell callbacks.
-function createRowReorderPreviewElement(sourceRow: HTMLTableRowElement) {
-  const rowRect = sourceRow.getBoundingClientRect();
-  const clonedRow = sourceRow.cloneNode(true) as HTMLTableRowElement;
-  clonedRow.removeAttribute("data-vt-row-index");
-  clonedRow.removeAttribute("data-vt-row-key");
-  clonedRow.removeAttribute("data-vt-row-reorder-active");
-  clonedRow.removeAttribute("tabindex");
-  clonedRow.style.height = `${rowRect.height}px`;
-  clonedRow.style.opacity = "1";
-  clonedRow.style.background = "transparent";
-
-  clonedRow.querySelectorAll<HTMLElement>("[id]").forEach((element) => {
-    element.removeAttribute("id");
-  });
-  clonedRow
-    .querySelectorAll<HTMLElement>("button, [href], [tabindex]")
-    .forEach((element) => {
-      element.removeAttribute("aria-label");
-      element.removeAttribute("title");
-      element.tabIndex = -1;
-    });
-  syncClonedFormControlState(sourceRow, clonedRow);
-
-  const sourceCells = Array.from(sourceRow.cells);
-  const clonedCells = Array.from(clonedRow.cells);
-  sourceCells.forEach((sourceCell, index) => {
-    const clonedCell = clonedCells[index];
-    if (!clonedCell) return;
-    clonedCell.style.borderTopWidth = "0";
-    clonedCell.style.borderBottomWidth = "0";
-
-    const cellWidth = sourceCell.getBoundingClientRect().width;
-    if (cellWidth <= 0) return;
-    const widthPx = `${cellWidth}px`;
-    clonedCell.style.width = widthPx;
-    clonedCell.style.minWidth = widthPx;
-    clonedCell.style.maxWidth = widthPx;
-  });
-
-  const table = document.createElement("table");
-  table.className =
-    "w-full table-fixed border-separate border-spacing-0 text-sm";
-  const tbody = document.createElement("tbody");
-  tbody.appendChild(clonedRow);
-  table.appendChild(tbody);
-
-  const preview = document.createElement("div");
-  preview.dataset.vtRowReorderPreview = "true";
-  preview.setAttribute("aria-hidden", "true");
-  preview.className =
-    "pointer-events-none fixed left-0 top-0 z-[1100] box-border overflow-hidden rounded-xl border border-slate-200/90 bg-white shadow-[0_0_20px_rgba(15,23,42,0.16)] dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-[0_0_20px_rgba(0,0,0,0.42)]";
-  preview.style.left = `${rowRect.left}px`;
-  preview.style.width = `${Math.max(1, rowRect.width)}px`;
-  preview.style.height = `${Math.max(1, rowRect.height)}px`;
-  preview.style.willChange = "transform";
-  preview.appendChild(table);
-  document.body.appendChild(preview);
-
-  return { preview, height: Math.max(1, rowRect.height) };
-}
-
-function positionRowReorderPreview(active: RowReorderState, clientY: number) {
-  if (!active.previewElement) return;
-  const viewportInset = 8;
-  const unclampedTop = clientY - active.grabOffsetY;
-  const maxTop = Math.max(
-    viewportInset,
-    window.innerHeight - active.previewHeight - viewportInset,
-  );
-  const top = Math.max(viewportInset, Math.min(maxTop, unclampedTop));
-  active.previewElement.style.transform = `translate3d(0, ${Math.round(top)}px, 0)`;
-}
-
-function collectRowReorderGeometry(
-  table: HTMLTableElement | null,
-): RowReorderGeometry[] {
-  return Array.from(
-    table?.querySelectorAll<HTMLTableRowElement>(
-      "tbody tr[data-vt-row-index]",
-    ) ?? [],
-  )
-    .map((element) => ({
-      index: Number(element.dataset.vtRowIndex),
-      element,
-      appliedShift: 0,
-    }))
-    .filter((item) => Number.isInteger(item.index));
-}
-
-function resolveRowReorderDestination(
-  active: RowReorderState,
-  rowCount: number,
-) {
-  return Math.max(
-    0,
-    Math.min(
-      rowCount - 1,
-      active.insertionIndex > active.fromIndex
-        ? active.insertionIndex - 1
-        : active.insertionIndex,
-    ),
-  );
-}
-
-function applyRowReorderDisplacement(
-  active: RowReorderState,
-  rowCount: number,
-) {
-  const destinationIndex = resolveRowReorderDestination(active, rowCount);
-  for (const geometry of active.rows) {
-    if (geometry.index === active.fromIndex) {
-      geometry.element.style.opacity = "0";
-      geometry.element.style.pointerEvents = "none";
-      continue;
-    }
-
-    const shift =
-      active.fromIndex < destinationIndex &&
-      geometry.index > active.fromIndex &&
-      geometry.index <= destinationIndex
-        ? -active.sourceHeight
-        : active.fromIndex > destinationIndex &&
-            geometry.index >= destinationIndex &&
-            geometry.index < active.fromIndex
-          ? active.sourceHeight
-          : 0;
-    if (shift === geometry.appliedShift) continue;
-    geometry.appliedShift = shift;
-    geometry.element.style.willChange = "transform";
-    geometry.element.style.transition =
-      "transform 140ms cubic-bezier(0.2, 0, 0, 1)";
-    geometry.element.style.transform =
-      shift === 0 ? "" : `translate3d(0, ${Math.round(shift)}px, 0)`;
-  }
-}
-
-function resetRowReorderDisplacement(active: RowReorderState | null) {
-  for (const geometry of active?.rows ?? []) {
-    geometry.element.style.opacity = "";
-    geometry.element.style.pointerEvents = "";
-    geometry.element.style.willChange = "";
-    geometry.element.style.transition = "";
-    geometry.element.style.transform = "";
-  }
-}
-
-function removeRowReorderVisuals(active: RowReorderState | null) {
-  resetRowReorderDisplacement(active);
-  active?.previewElement?.remove();
-}
-
-// ---------------------------------------------------------------------------
-// Column Order Helpers
-// ---------------------------------------------------------------------------
-
-function getColumnOrderStorageKey(tableId?: string) {
-  const trimmed = tableId?.trim();
-  return trimmed ? `${COLUMN_ORDER_STORAGE_PREFIX}.${trimmed}` : null;
-}
-
-function readStoredColumnOrder(tableId?: string): ColumnOrder {
-  const key = getColumnOrderStorageKey(tableId);
-  if (!key || typeof window === "undefined") return [];
-
-  try {
-    const raw = window.localStorage.getItem(key);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (value): value is string =>
-        typeof value === "string" && value.trim() !== "",
-    );
-  } catch {
-    return [];
-  }
-}
-
-function writeStoredColumnOrder(
-  tableId: string | undefined,
-  order: ColumnOrder,
-) {
-  const key = getColumnOrderStorageKey(tableId);
-  if (!key || typeof window === "undefined") return;
-
-  try {
-    const normalized = Array.from(
-      new Set(order.filter((value) => value.trim() !== "")),
-    );
-    window.localStorage.setItem(key, JSON.stringify(normalized));
-  } catch {
-    // localStorage can be unavailable in private browsing or embedded contexts.
-  }
-}
-
-function resolveColumnOrderLock<T>(column: DataTableColumn<T>) {
-  if (column.lockOrder) return column.lockOrder;
-  if (column.key === "select") return "start";
-  if (column.key === "action" || column.key === "actions") return "end";
-  return null;
-}
-
-function shouldAllowColumnReorder<T>(column: DataTableColumn<T>) {
-  if (resolveColumnOrderLock(column) !== null) return false;
-  if (column.reorderable !== undefined) return column.reorderable;
-  if (NON_REORDERABLE_COLUMN_KEYS.has(column.key)) return false;
-  return true;
-}
-
-function normalizeColumnOrder<T>(
-  columns: DataTableColumn<T>[],
-  storedOrder: ColumnOrder,
-) {
-  const validKeys = new Set(columns.map((column) => column.key));
-  const seen = new Set<string>();
-  const storedValid = storedOrder.filter((key) => {
-    if (!validKeys.has(key) || seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-
-  const missing = columns
-    .map((column) => column.key)
-    .filter((key) => !seen.has(key));
-  const merged = [...storedValid, ...missing];
-
-  const startLocked = columns
-    .filter((column) => resolveColumnOrderLock(column) === "start")
-    .map((column) => column.key);
-  const endLocked = columns
-    .filter((column) => resolveColumnOrderLock(column) === "end")
-    .map((column) => column.key);
-  const locked = new Set([...startLocked, ...endLocked]);
-  const movable = merged.filter((key) => !locked.has(key));
-
-  return [...startLocked, ...movable, ...endLocked];
-}
-
-function moveColumnKey(order: ColumnOrder, fromIndex: number, toIndex: number) {
-  if (fromIndex === toIndex || fromIndex < 0 || fromIndex >= order.length)
-    return order;
-  const next = [...order];
-  const [item] = next.splice(fromIndex, 1);
-  if (!item) return order;
-  const normalizedTo = fromIndex < toIndex ? toIndex - 1 : toIndex;
-  next.splice(Math.max(0, Math.min(next.length, normalizedTo)), 0, item);
-  return next;
-}
-
-function clampColumnReorderTarget(
-  toIndex: number,
-  minIndex: number,
-  maxIndex: number,
-  columnCount: number,
-) {
-  return Math.max(minIndex, Math.min(Math.min(maxIndex, columnCount), toIndex));
-}
-
-function getColumnReorderDragOffset(
-  active: ColumnReorderState,
-  clientX: number,
-  scrollLeft: number,
-) {
-  return clientX - active.startClientX + (scrollLeft - active.startScrollLeft);
-}
-
-function findColumnReorderTargetIndex(
-  active: ColumnReorderState,
-  dragOffsetX: number,
-) {
-  const origin = active.columns[active.originIndex];
-  if (!origin) return active.originIndex;
-
-  const draggedCenter = origin.left + origin.width / 2 + dragOffsetX;
-  let nextIndex = active.allowedMaxIndex;
-  const maxMeasuredIndex = Math.min(
-    active.allowedMaxIndex,
-    active.columns.length,
-  );
-
-  for (
-    let index = active.allowedMinIndex;
-    index < maxMeasuredIndex;
-    index += 1
-  ) {
-    const geometry = active.columns[index];
-    if (!geometry) continue;
-    const midpoint = geometry.left + geometry.width / 2;
-    if (draggedCenter < midpoint) {
-      nextIndex = index;
-      break;
-    }
-    nextIndex = index + 1;
-  }
-
-  return clampColumnReorderTarget(
-    nextIndex,
-    active.allowedMinIndex,
-    active.allowedMaxIndex,
-    active.columns.length,
-  );
-}
-
-function getColumnReorderShift(
-  active: ColumnReorderState,
-  geometry: ColumnReorderGeometry,
-) {
-  if (geometry.key === active.columnKey) return null;
-  const toIndex = active.currentToIndex;
-  const originIndex = active.originIndex;
-
-  if (
-    toIndex < originIndex &&
-    geometry.index >= toIndex &&
-    geometry.index < originIndex
-  ) {
-    return active.draggedWidth;
-  }
-
-  if (
-    toIndex > originIndex + 1 &&
-    geometry.index > originIndex &&
-    geometry.index < toIndex
-  ) {
-    return -active.draggedWidth;
-  }
-
-  return 0;
-}
-
-function formatColumnReorderTransform(offsetX: number) {
-  if (Math.abs(offsetX) < 0.1) return "";
-  const rounded = Math.round(offsetX * 100) / 100;
-  return `translate3d(${rounded}px, 0, 0)`;
-}
-
-function getColumnReorderCellBackground(
-  element: HTMLElement,
-  isDragged: boolean,
-) {
-  const isHeader = element.tagName === "TH";
-  const isDark = document.documentElement.classList.contains("dark");
-  const base = isHeader
-    ? isDark
-      ? "rgb(38 38 38)"
-      : "rgb(241 245 249)"
-    : isDark
-      ? "rgb(10 10 10)"
-      : "rgb(255 255 255)";
-
-  if (!isDragged) return base;
-
-  const accent = isDark
-    ? isHeader
-      ? "linear-gradient(90deg, rgba(59, 130, 246, 0.24), rgba(34, 211, 238, 0.12))"
-      : "linear-gradient(90deg, rgba(59, 130, 246, 0.16), rgba(34, 211, 238, 0.08))"
-    : isHeader
-      ? "linear-gradient(90deg, rgba(37, 99, 235, 0.2), rgba(14, 165, 233, 0.1))"
-      : "linear-gradient(90deg, rgba(37, 99, 235, 0.1), rgba(14, 165, 233, 0.05))";
-
-  return `${accent}, ${base}`;
-}
-
-function scheduleColumnReorderSettleCleanup(element: HTMLElement) {
-  window.setTimeout(() => {
-    if (
-      element.hasAttribute("data-vt-column-dragging-cell") ||
-      element.hasAttribute("data-vt-column-shifted-cell") ||
-      element.style.transform
-    ) {
-      return;
-    }
-
-    element.style.transition = "";
-    element.style.willChange = "";
-    element.style.position = "";
-    element.style.zIndex = "";
-    element.style.background = "";
-    element.style.overflow = "";
-    element.style.contain = "";
-    element.style.isolation = "";
-    element.style.borderRadius = "";
-  }, COLUMN_REORDER_SETTLE_CLEANUP_MS);
-}
+import {
+  COLUMN_REORDER_ACTIVATION_DELAY_MS,
+  COLUMN_REORDER_AUTOSCROLL_EDGE_PX,
+  COLUMN_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME,
+  COLUMN_REORDER_MIN_DRAG_DISTANCE_PX,
+  COLUMN_REORDER_SETTLE_FEEDBACK_MS,
+  COLUMN_REORDER_SHIFT_TRANSITION,
+  COLUMN_RESIZE_PREVIEW_LINE_WIDTH,
+  DEFAULT_BOTTOM_DEBOUNCE_MS,
+  DEFAULT_OVERSCAN,
+  DEFAULT_ROW_HEIGHT,
+  DEFAULT_SCROLL_THRESHOLD,
+  ROW_REORDER_AUTOSCROLL_EDGE_PX,
+  ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME,
+  ROW_REORDER_COLUMN_KEY,
+  ROW_REORDER_MIN_DRAG_DISTANCE_PX,
+  STICKY_EDGE_SHADOW_WIDTH,
+  type ColumnOrder,
+  type ColumnReorderGeometry,
+  type ColumnReorderState,
+  type ColumnResizePreview,
+  type ColumnResizeState,
+  type ColumnWidthMap,
+  type DataTableColumnStyle,
+  type RowReorderState,
+  type ScrollMetrics,
+  type StickyColumnPlacement,
+} from "./dataTableModel";
+import {
+  areColumnWidthMapsEqual,
+  normalizeColumnWidths,
+  resolveColumnResizeWidth,
+  resolveHeaderContentJustifyClass,
+  resolveStickyColumnPlacements,
+  resolveStickyRailWidth,
+} from "./columnLayout";
+import {
+  findColumnReorderTargetIndex,
+  formatColumnReorderTransform,
+  getColumnReorderCellBackground,
+  getColumnReorderDragOffset,
+  getColumnReorderShift,
+  moveColumnKey,
+  normalizeColumnOrder,
+  scheduleColumnReorderSettleCleanup,
+  shouldAllowColumnReorder,
+} from "./columnReorder";
+import {
+  applyRowReorderDisplacement,
+  collectRowReorderGeometry,
+  createRowReorderPreviewElement,
+  positionRowReorderPreview,
+  removeRowReorderVisuals,
+} from "./rowReorder";
+import {
+  calculateScrollbarThumbs,
+  findVerticalScrollContainer,
+  findVerticalScrollTarget,
+  getStickyEdgeShadowOpacity,
+  hasHorizontalOverflow,
+  hasVerticalOverflow,
+} from "./scrollMetrics";
+import { compareSortValues, isEmptySortValue, moveRow } from "./sortUtils";
+import {
+  clampColumnWidth,
+  logColumnResizeDebug,
+  readStoredColumnOrder,
+  readStoredColumnWidths,
+  resolveCellOverflowTooltip,
+  resolveColumnMaxWidth,
+  resolveColumnMinWidth,
+  resolveColumnOrderLock,
+  safeSetPointerCapture,
+  shouldAllowColumnResize,
+  shouldDebugColumnResize,
+  writeStoredColumnOrder,
+  writeStoredColumnWidths,
+} from "./tableStorage";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -1095,22 +177,15 @@ export function DataTable<T>({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const tableRef = useRef<HTMLTableElement | null>(null);
   const headerRef = useRef<HTMLTableSectionElement | null>(null);
-  const headerCellsRef = useRef<Record<string, HTMLTableCellElement | null>>(
-    {},
-  );
-  const columnElementsRef = useRef<Record<string, HTMLTableColElement | null>>(
-    {},
-  );
+  const headerCellsRef = useRef<Record<string, HTMLTableCellElement | null>>({});
+  const columnElementsRef = useRef<Record<string, HTMLTableColElement | null>>({});
   const headerHeightRef = useRef(0);
   const [columnWidths, setColumnWidths] = useState<ColumnWidthMap>(() =>
     normalizeColumnWidths(columns, readStoredColumnWidths(tableId)),
   );
   const columnWidthsRef = useRef<ColumnWidthMap>(columnWidths);
-  const [resizePreview, setResizePreview] =
-    useState<ColumnResizePreview | null>(null);
-  const [activeResizeColumnKey, setActiveResizeColumnKey] = useState<
-    string | null
-  >(null);
+  const [resizePreview, setResizePreview] = useState<ColumnResizePreview | null>(null);
+  const [activeResizeColumnKey, setActiveResizeColumnKey] = useState<string | null>(null);
   const resizePreviewLineRef = useRef<HTMLDivElement | null>(null);
   const resizePreviewTooltipRef = useRef<HTMLDivElement | null>(null);
   const stickyRailWidthsRef = useRef({ start: 0, end: 0 });
@@ -1155,19 +230,12 @@ export function DataTable<T>({
 
   const [columnOrder, setColumnOrder] = useState<ColumnOrder>(() =>
     canUseColumnOrder
-      ? normalizeColumnOrder(
-          columns,
-          canPersistColumnOrder ? readStoredColumnOrder(tableId) : [],
-        )
+      ? normalizeColumnOrder(columns, canPersistColumnOrder ? readStoredColumnOrder(tableId) : [])
       : [],
   );
   const columnOrderRef = useRef<ColumnOrder>(columnOrder);
-  const [activeReorderColumnKey, setActiveReorderColumnKey] = useState<
-    string | null
-  >(null);
-  const [settledReorderColumnKey, setSettledReorderColumnKey] = useState<
-    string | null
-  >(null);
+  const [activeReorderColumnKey, setActiveReorderColumnKey] = useState<string | null>(null);
+  const [settledReorderColumnKey, setSettledReorderColumnKey] = useState<string | null>(null);
   const [rowHoverOverlay, setRowHoverOverlay] = useState<{
     left: number;
     top: number;
@@ -1179,15 +247,13 @@ export function DataTable<T>({
   const columnReorderAutoScrollRafRef = useRef<number | null>(null);
   const columnReorderSettleTimeoutRef = useRef<number | null>(null);
   const hoveredRowRef = useRef<HTMLTableRowElement | null>(null);
-  const [internalSortState, setInternalSortState] =
-    useState<DataTableSortState | null>(defaultSortState);
-  const activeSortState =
-    sortState === undefined ? internalSortState : sortState;
+  const [internalSortState, setInternalSortState] = useState<DataTableSortState | null>(
+    defaultSortState,
+  );
+  const activeSortState = sortState === undefined ? internalSortState : sortState;
   const rowReorderRef = useRef<RowReorderState | null>(null);
   const rowReorderAutoScrollRafRef = useRef<number | null>(null);
-  const [activeRowReorderIndex, setActiveRowReorderIndex] = useState<
-    number | null
-  >(null);
+  const [activeRowReorderIndex, setActiveRowReorderIndex] = useState<number | null>(null);
 
   const orderedColumns = useMemo(() => {
     if (!canUseColumnOrder) return columns;
@@ -1200,15 +266,10 @@ export function DataTable<T>({
   const colCount = orderedColumns.length;
 
   useEffect(() => {
-    setColumnWidths(
-      normalizeColumnWidths(columns, readStoredColumnWidths(tableId)),
-    );
+    setColumnWidths(normalizeColumnWidths(columns, readStoredColumnWidths(tableId)));
     if (canUseColumnOrder) {
       setColumnOrder(
-        normalizeColumnOrder(
-          columns,
-          canPersistColumnOrder ? readStoredColumnOrder(tableId) : [],
-        ),
+        normalizeColumnOrder(columns, canPersistColumnOrder ? readStoredColumnOrder(tableId) : []),
       );
     }
     // Only re-initialize when switching tables; columns identity changes should
@@ -1243,12 +304,8 @@ export function DataTable<T>({
     const validKeys = new Set(columns.map((column) => column.key));
     setColumnWidths((prev) => {
       const next = normalizeColumnWidths(columns, prev);
-      const removedStaleKey = Object.keys(prev).some(
-        (key) => !validKeys.has(key),
-      );
-      return removedStaleKey || !areColumnWidthMapsEqual(prev, next)
-        ? next
-        : prev;
+      const removedStaleKey = Object.keys(prev).some((key) => !validKeys.has(key));
+      return removedStaleKey || !areColumnWidthMapsEqual(prev, next) ? next : prev;
     });
   }, [columns]);
 
@@ -1301,9 +358,7 @@ export function DataTable<T>({
 
   const resolveRowInsertionIndex = useCallback((clientY: number) => {
     const rowElements = Array.from(
-      tableRef.current?.querySelectorAll<HTMLTableRowElement>(
-        "tbody tr[data-vt-row-index]",
-      ) ?? [],
+      tableRef.current?.querySelectorAll<HTMLTableRowElement>("tbody tr[data-vt-row-index]") ?? [],
     );
     if (rowElements.length === 0) return 0;
 
@@ -1313,8 +368,7 @@ export function DataTable<T>({
       if (!Number.isInteger(rowIndex)) continue;
       const rect = rowElement.getBoundingClientRect();
       const appliedShift =
-        activeRows.find((geometry) => geometry.element === rowElement)
-          ?.appliedShift ?? 0;
+        activeRows.find((geometry) => geometry.element === rowElement)?.appliedShift ?? 0;
       if (clientY < rect.top - appliedShift + rect.height / 2) return rowIndex;
     }
 
@@ -1333,10 +387,7 @@ export function DataTable<T>({
     (clientY: number) => {
       const active = rowReorderRef.current;
       if (!active?.activated) return;
-      active.insertionIndex = Math.max(
-        0,
-        Math.min(rows.length, resolveRowInsertionIndex(clientY)),
-      );
+      active.insertionIndex = Math.max(0, Math.min(rows.length, resolveRowInsertionIndex(clientY)));
       applyRowReorderDisplacement(active, rows.length);
     },
     [resolveRowInsertionIndex, rows.length],
@@ -1349,10 +400,7 @@ export function DataTable<T>({
     if (!active?.activated || !scrollContainer) return;
 
     const rect = scrollContainer.getBoundingClientRect();
-    const maxScrollTop = Math.max(
-      0,
-      scrollContainer.scrollHeight - scrollContainer.clientHeight,
-    );
+    const maxScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
     if (maxScrollTop <= 0) return;
 
     const topIntensity = Math.max(
@@ -1382,30 +430,18 @@ export function DataTable<T>({
     const intensity = direction < 0 ? topIntensity : bottomIntensity;
     const delta =
       direction *
-      Math.max(
-        1,
-        Math.round(
-          ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME * intensity * intensity,
-        ),
-      );
-    const nextScrollTop = Math.max(
-      0,
-      Math.min(maxScrollTop, scrollContainer.scrollTop + delta),
-    );
+      Math.max(1, Math.round(ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME * intensity * intensity));
+    const nextScrollTop = Math.max(0, Math.min(maxScrollTop, scrollContainer.scrollTop + delta));
     if (nextScrollTop !== scrollContainer.scrollTop) {
       scrollContainer.scrollTop = nextScrollTop;
       updateRowReorderTarget(active.lastClientY);
     }
-    rowReorderAutoScrollRafRef.current = window.requestAnimationFrame(
-      runRowReorderAutoScroll,
-    );
+    rowReorderAutoScrollRafRef.current = window.requestAnimationFrame(runRowReorderAutoScroll);
   }, [updateRowReorderTarget]);
 
   const ensureRowReorderAutoScroll = useCallback(() => {
     if (rowReorderAutoScrollRafRef.current !== null) return;
-    rowReorderAutoScrollRafRef.current = window.requestAnimationFrame(
-      runRowReorderAutoScroll,
-    );
+    rowReorderAutoScrollRafRef.current = window.requestAnimationFrame(runRowReorderAutoScroll);
   }, [runRowReorderAutoScroll]);
 
   const clearRowReorder = useCallback(() => {
@@ -1434,10 +470,7 @@ export function DataTable<T>({
 
       const toIndex = Math.max(
         0,
-        Math.min(
-          rows.length - 1,
-          insertionIndex > fromIndex ? insertionIndex - 1 : insertionIndex,
-        ),
+        Math.min(rows.length - 1, insertionIndex > fromIndex ? insertionIndex - 1 : insertionIndex),
       );
       if (toIndex === fromIndex) return;
       if (activeSortState) updateSortState(null);
@@ -1456,13 +489,9 @@ export function DataTable<T>({
       active.activated = true;
 
       active.rows = collectRowReorderGeometry(tableRef.current);
-      active.sourceRow
-        ?.querySelector<HTMLButtonElement>("[data-vt-row-reorder-handle]")
-        ?.blur();
+      active.sourceRow?.querySelector<HTMLButtonElement>("[data-vt-row-reorder-handle]")?.blur();
       if (active.sourceRow) {
-        const { preview, height } = createRowReorderPreviewElement(
-          active.sourceRow,
-        );
+        const { preview, height } = createRowReorderPreviewElement(active.sourceRow);
         active.previewElement = preview;
         active.previewHeight = height;
         active.sourceHeight = height;
@@ -1480,21 +509,13 @@ export function DataTable<T>({
 
   const handleRowReorderPointerDown = useCallback(
     (rowIndex: number, event: ReactPointerEvent<HTMLButtonElement>) => {
-      if (
-        event.button !== 0 ||
-        !rowReorderable ||
-        !onRowsChange ||
-        rows.length < 2 ||
-        loading
-      ) {
+      if (event.button !== 0 || !rowReorderable || !onRowsChange || rows.length < 2 || loading) {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
       safeSetPointerCapture(event.currentTarget, event.pointerId);
-      const sourceRow = event.currentTarget.closest<HTMLTableRowElement>(
-        "tr[data-vt-row-index]",
-      );
+      const sourceRow = event.currentTarget.closest<HTMLTableRowElement>("tr[data-vt-row-index]");
       const sourceRowRect = sourceRow?.getBoundingClientRect();
       rowReorderRef.current = {
         pointerId: event.pointerId,
@@ -1550,8 +571,7 @@ export function DataTable<T>({
       active.lastClientY = event.clientY;
       if (
         !active.activated &&
-        Math.abs(event.clientY - active.startClientY) >=
-          ROW_REORDER_MIN_DRAG_DISTANCE_PX
+        Math.abs(event.clientY - active.startClientY) >= ROW_REORDER_MIN_DRAG_DISTANCE_PX
       ) {
         activateRowReorder(active);
       }
@@ -1594,12 +614,11 @@ export function DataTable<T>({
   );
 
   const syncScrollbarThumbs = useCallback(
-    (
-      metrics: ScrollMetrics,
-      measuredHeaderHeight = headerHeightRef.current,
-    ) => {
-      const { vThumb: nextVThumb, hThumb: nextHThumb } =
-        calculateScrollbarThumbs(metrics, measuredHeaderHeight);
+    (metrics: ScrollMetrics, measuredHeaderHeight = headerHeightRef.current) => {
+      const { vThumb: nextVThumb, hThumb: nextHThumb } = calculateScrollbarThumbs(
+        metrics,
+        measuredHeaderHeight,
+      );
 
       const verticalThumb = verticalThumbRef.current;
       if (verticalThumb && nextVThumb) {
@@ -1622,22 +641,14 @@ export function DataTable<T>({
       const root = rootRef.current;
       if (!root) return;
 
-      const startBoundary = root.querySelector<HTMLElement>(
-        "[data-vt-sticky-start-boundary]",
-      );
+      const startBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
       if (startBoundary) {
-        startBoundary.style.opacity = String(
-          getStickyEdgeShadowOpacity(metrics, "start"),
-        );
+        startBoundary.style.opacity = String(getStickyEdgeShadowOpacity(metrics, "start"));
       }
 
-      const endBoundary = root.querySelector<HTMLElement>(
-        "[data-vt-sticky-end-boundary]",
-      );
+      const endBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-end-boundary]");
       if (endBoundary) {
-        endBoundary.style.opacity = String(
-          getStickyEdgeShadowOpacity(metrics, "end"),
-        );
+        endBoundary.style.opacity = String(getStickyEdgeShadowOpacity(metrics, "end"));
       }
     },
     [naturalFlow],
@@ -1673,8 +684,7 @@ export function DataTable<T>({
           hasVerticalOverflow(prev, measuredHeaderHeight) !==
             hasVerticalOverflow(next, measuredHeaderHeight);
         const viewportChanged =
-          prev.clientHeight !== next.clientHeight ||
-          prev.clientWidth !== next.clientWidth;
+          prev.clientHeight !== next.clientHeight || prev.clientWidth !== next.clientWidth;
         if (
           !options?.forceState &&
           !overflowChanged &&
@@ -1684,8 +694,7 @@ export function DataTable<T>({
         ) {
           return prev;
         }
-        if (!options?.forceState && !overflowChanged && !viewportChanged)
-          return prev;
+        if (!options?.forceState && !overflowChanged && !viewportChanged) return prev;
         return next;
       });
     },
@@ -1750,10 +759,7 @@ export function DataTable<T>({
     const threshold = latestRef.current.scrollThreshold;
 
     const shouldSchedule =
-      scrollBottom <= threshold &&
-      latestHasMore &&
-      !latestLoadingMore &&
-      Boolean(latestCb);
+      scrollBottom <= threshold && latestHasMore && !latestLoadingMore && Boolean(latestCb);
 
     if (!shouldSchedule) {
       if (bottomTimeoutRef.current) {
@@ -1761,8 +767,7 @@ export function DataTable<T>({
         bottomTimeoutRef.current = null;
       }
     } else if (!bottomPendingRef.current) {
-      if (bottomTimeoutRef.current)
-        window.clearTimeout(bottomTimeoutRef.current);
+      if (bottomTimeoutRef.current) window.clearTimeout(bottomTimeoutRef.current);
       bottomTimeoutRef.current = window.setTimeout(() => {
         bottomTimeoutRef.current = null;
         const node = containerRef.current;
@@ -1771,8 +776,7 @@ export function DataTable<T>({
         const st = latestRef.current;
         if (!st.hasMore || st.loadingMore || !st.onScrollBottom) return;
 
-        const bottomNow =
-          node.scrollHeight - node.scrollTop - node.clientHeight;
+        const bottomNow = node.scrollHeight - node.scrollTop - node.clientHeight;
         if (bottomNow > st.scrollThreshold) return;
 
         bottomPendingRef.current = true;
@@ -1788,25 +792,22 @@ export function DataTable<T>({
     }
   }, [updateScrollMetrics, virtualize]);
 
-  const updateRowHoverOverlay = useCallback(
-    (row: HTMLTableRowElement | null) => {
-      hoveredRowRef.current = row;
-      const el = containerRef.current;
-      if (!row || !el) {
-        setRowHoverOverlay(null);
-        return;
-      }
-      const rowRect = row.getBoundingClientRect();
-      const containerRect = el.getBoundingClientRect();
-      setRowHoverOverlay({
-        left: el.scrollLeft,
-        top: rowRect.top - containerRect.top + el.scrollTop,
-        width: el.clientWidth,
-        height: rowRect.height,
-      });
-    },
-    [],
-  );
+  const updateRowHoverOverlay = useCallback((row: HTMLTableRowElement | null) => {
+    hoveredRowRef.current = row;
+    const el = containerRef.current;
+    if (!row || !el) {
+      setRowHoverOverlay(null);
+      return;
+    }
+    const rowRect = row.getBoundingClientRect();
+    const containerRect = el.getBoundingClientRect();
+    setRowHoverOverlay({
+      left: el.scrollLeft,
+      top: rowRect.top - containerRect.top + el.scrollTop,
+      width: el.clientWidth,
+      height: rowRect.height,
+    });
+  }, []);
 
   const handleWheel = useCallback(
     (e: WheelEvent) => {
@@ -1826,13 +827,9 @@ export function DataTable<T>({
       const atRight = el.scrollLeft >= maxLeft - 1;
 
       const canMoveY =
-        wantsY &&
-        canScrollY &&
-        ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom));
+        wantsY && canScrollY && ((e.deltaY < 0 && !atTop) || (e.deltaY > 0 && !atBottom));
       const canMoveX =
-        wantsX &&
-        canScrollX &&
-        ((e.deltaX < 0 && !atLeft) || (e.deltaX > 0 && !atRight));
+        wantsX && canScrollX && ((e.deltaX < 0 && !atLeft) || (e.deltaX > 0 && !atRight));
 
       if (canMoveY || canMoveX) {
         e.stopPropagation();
@@ -1849,10 +846,7 @@ export function DataTable<T>({
             );
             parentScrollTarget.scrollTop = Math.max(
               0,
-              Math.min(
-                maxParentScrollTop,
-                parentScrollTarget.scrollTop + e.deltaY,
-              ),
+              Math.min(maxParentScrollTop, parentScrollTarget.scrollTop + e.deltaY),
             );
           }
         } else if (allowWheelPropagationAtBoundary) {
@@ -1906,10 +900,7 @@ export function DataTable<T>({
         const headerH = headerHeightRef.current;
         const trackLength = Math.max(0, el.clientHeight - headerH - 16);
         const viewportLength = Math.max(0, el.clientHeight - headerH);
-        const contentLength = Math.max(
-          viewportLength,
-          el.scrollHeight - headerH,
-        );
+        const contentLength = Math.max(viewportLength, el.scrollHeight - headerH);
         const thumbLength = Math.max(
           28,
           Math.round((viewportLength / contentLength) * trackLength),
@@ -1963,19 +954,13 @@ export function DataTable<T>({
       e.preventDefault();
 
       if (drag.axis === "y") {
-        const scrollRange = Math.max(
-          0,
-          drag.contentLength - drag.viewportLength,
-        );
+        const scrollRange = Math.max(0, drag.contentLength - drag.viewportLength);
         const thumbRange = Math.max(1, drag.trackLength - drag.thumbLength);
         const dy = e.clientY - drag.startClientY;
         const next = drag.startScrollTop + (dy * scrollRange) / thumbRange;
         el.scrollTop = Math.max(0, Math.min(scrollRange, next));
       } else {
-        const scrollRange = Math.max(
-          0,
-          drag.contentLength - drag.viewportLength,
-        );
+        const scrollRange = Math.max(0, drag.contentLength - drag.viewportLength);
         const thumbRange = Math.max(1, drag.trackLength - drag.thumbLength);
         const dx = e.clientX - drag.startClientX;
         const next = drag.startScrollLeft + (dx * scrollRange) / thumbRange;
@@ -1987,15 +972,12 @@ export function DataTable<T>({
     [updateScrollMetrics],
   );
 
-  const handleThumbPointerUp = useCallback(
-    (e: ReactPointerEvent<HTMLDivElement>) => {
-      const drag = dragRef.current;
-      if (!drag) return;
-      if (drag.pointerId !== e.pointerId) return;
-      dragRef.current = null;
-    },
-    [],
-  );
+  const handleThumbPointerUp = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    if (drag.pointerId !== e.pointerId) return;
+    dragRef.current = null;
+  }, []);
 
   const columnResizeRef = useRef<ColumnResizeState | null>(null);
 
@@ -2006,8 +988,7 @@ export function DataTable<T>({
       pointerClientY: number,
     ): ColumnResizePreview | null => {
       const width = resolveColumnResizeWidth(active, pointerClientX);
-      const headerRect =
-        headerCellsRef.current[active.columnKey]?.getBoundingClientRect();
+      const headerRect = headerCellsRef.current[active.columnKey]?.getBoundingClientRect();
       const visualLeftClientX = headerRect?.left ?? active.startLeftClientX;
       const minBoundaryClientX = visualLeftClientX + active.minWidth;
       const maxBoundaryClientX = visualLeftClientX + active.maxWidth;
@@ -2019,9 +1000,7 @@ export function DataTable<T>({
         lineCenterClientX >= active.previewMinClientX &&
         lineCenterClientX <= active.previewMaxClientX;
       const top = active.previewTop;
-      const bottomInset = hasHorizontalOverflow(scrollMetricsRef.current)
-        ? 14
-        : 0;
+      const bottomInset = hasHorizontalOverflow(scrollMetricsRef.current) ? 14 : 0;
       const bottom = Math.max(top, active.previewBottom - bottomInset);
       const height = Math.max(0, bottom - top);
       const tooltipTop = Math.max(
@@ -2064,17 +1043,14 @@ export function DataTable<T>({
     [t],
   );
 
-  const applyColumnWidthToDom = useCallback(
-    (columnKey: string, width: number) => {
-      const col = columnElementsRef.current[columnKey];
-      if (!col) return;
-      const widthPx = `${width}px`;
-      col.style.width = widthPx;
-      col.style.minWidth = widthPx;
-      col.style.maxWidth = widthPx;
-    },
-    [],
-  );
+  const applyColumnWidthToDom = useCallback((columnKey: string, width: number) => {
+    const col = columnElementsRef.current[columnKey];
+    if (!col) return;
+    const widthPx = `${width}px`;
+    col.style.width = widthPx;
+    col.style.minWidth = widthPx;
+    col.style.maxWidth = widthPx;
+  }, []);
 
   const applyStickyLayoutToDom = useCallback(
     (widths: ColumnWidthMap) => {
@@ -2089,30 +1065,22 @@ export function DataTable<T>({
       if (!root) return;
 
       const clientWidth = scrollMetricsRef.current.clientWidth;
-      const startRail = root.querySelector<HTMLElement>(
-        "[data-vt-sticky-start-rail]",
-      );
+      const startRail = root.querySelector<HTMLElement>("[data-vt-sticky-start-rail]");
       if (startRail) startRail.style.width = `${startWidth}px`;
 
-      const endRail = root.querySelector<HTMLElement>(
-        "[data-vt-sticky-end-rail]",
-      );
+      const endRail = root.querySelector<HTMLElement>("[data-vt-sticky-end-rail]");
       if (endRail) {
         endRail.style.left = `${Math.max(0, clientWidth - endWidth)}px`;
         endRail.style.width = `${endWidth}px`;
       }
 
-      const startBoundary = root.querySelector<HTMLElement>(
-        "[data-vt-sticky-start-boundary]",
-      );
+      const startBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-start-boundary]");
       if (startBoundary) {
         startBoundary.style.left = `${Math.max(0, startWidth)}px`;
         startBoundary.style.width = `${STICKY_EDGE_SHADOW_WIDTH}px`;
       }
 
-      const endBoundary = root.querySelector<HTMLElement>(
-        "[data-vt-sticky-end-boundary]",
-      );
+      const endBoundary = root.querySelector<HTMLElement>("[data-vt-sticky-end-boundary]");
       if (endBoundary) {
         endBoundary.style.left = `${Math.max(
           0,
@@ -2123,27 +1091,19 @@ export function DataTable<T>({
       syncStickyEdgeShadows(scrollMetricsRef.current);
 
       const placements = resolveStickyColumnPlacements(columns, widths);
-      root
-        .querySelectorAll<HTMLElement>("[data-vt-column-key]")
-        .forEach((element) => {
-          const key = element.dataset.vtColumnKey;
-          const placement = key ? placements[key] : undefined;
-          if (!placement) return;
+      root.querySelectorAll<HTMLElement>("[data-vt-column-key]").forEach((element) => {
+        const key = element.dataset.vtColumnKey;
+        const placement = key ? placements[key] : undefined;
+        if (!placement) return;
 
-          if (placement.edge === "start") {
-            element.style.setProperty(
-              "--vt-sticky-left",
-              `${placement.offset}px`,
-            );
-            element.style.removeProperty("--vt-sticky-right");
-          } else {
-            element.style.setProperty(
-              "--vt-sticky-right",
-              `${placement.offset}px`,
-            );
-            element.style.removeProperty("--vt-sticky-left");
-          }
-        });
+        if (placement.edge === "start") {
+          element.style.setProperty("--vt-sticky-left", `${placement.offset}px`);
+          element.style.removeProperty("--vt-sticky-right");
+        } else {
+          element.style.setProperty("--vt-sticky-right", `${placement.offset}px`);
+          element.style.removeProperty("--vt-sticky-left");
+        }
+      });
     },
     [naturalFlow, syncStickyEdgeShadows],
   );
@@ -2167,16 +1127,9 @@ export function DataTable<T>({
     applyColumnWidthToDom(active.columnKey, roundedWidth);
     applyStickyLayoutToDom(nextWidths);
     const preview = {
-      ...(buildColumnResizePreview(
-        active,
-        pointer.clientX,
-        pointer.clientY,
-      ) ?? {
+      ...(buildColumnResizePreview(active, pointer.clientX, pointer.clientY) ?? {
         width: roundedWidth,
-        left:
-          active.startLeftClientX +
-          roundedWidth -
-          COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2,
+        left: active.startLeftClientX + roundedWidth - COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2,
         top: active.previewTop,
         height: Math.max(0, active.previewBottom - active.previewTop),
         tooltipTop: active.previewTop,
@@ -2196,23 +1149,15 @@ export function DataTable<T>({
           tableId,
           columnKey: active.columnKey,
           pointerX: Math.round(pointer.clientX),
-          previewCenterX: Math.round(
-            preview.left + COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2,
-          ),
+          previewCenterX: Math.round(preview.left + COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2),
           renderedHeaderRight: headerRect ? Math.round(headerRect.right) : null,
           renderedHeaderWidth: headerRect ? Math.round(headerRect.width) : null,
           width: roundedWidth,
           deltaPreviewToPointer: Math.round(
-            preview.left +
-              COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2 -
-              pointer.clientX,
+            preview.left + COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2 - pointer.clientX,
           ),
           deltaPreviewToRenderedHeader: headerRect
-            ? Math.round(
-                preview.left +
-                  COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2 -
-                  headerRect.right,
-              )
+            ? Math.round(preview.left + COLUMN_RESIZE_PREVIEW_LINE_WIDTH / 2 - headerRect.right)
             : null,
         });
       }
@@ -2228,9 +1173,7 @@ export function DataTable<T>({
 
   const scheduleColumnResizeFrame = useCallback(() => {
     if (columnResizeRafRef.current !== null) return;
-    columnResizeRafRef.current = window.requestAnimationFrame(
-      applyPendingColumnResize,
-    );
+    columnResizeRafRef.current = window.requestAnimationFrame(applyPendingColumnResize);
   }, [applyPendingColumnResize]);
 
   const flushPendingColumnResize = useCallback(() => {
@@ -2274,9 +1217,7 @@ export function DataTable<T>({
 
       const rect = headerCell.getBoundingClientRect();
       const containerRect = containerRef.current?.getBoundingClientRect();
-      const railWidths = naturalFlow
-        ? { start: 0, end: 0 }
-        : stickyRailWidthsRef.current;
+      const railWidths = naturalFlow ? { start: 0, end: 0 } : stickyRailWidthsRef.current;
       const startWidth = rect.width;
       const minWidth = resolveColumnMinWidth(column);
       const maxWidth = resolveColumnMaxWidth(column, minWidth);
@@ -2320,11 +1261,7 @@ export function DataTable<T>({
         [column.key]: nextStartWidth,
       });
       pendingColumnResizePointerRef.current = null;
-      const preview = buildColumnResizePreview(
-        resizeState,
-        e.clientX,
-        e.clientY,
-      );
+      const preview = buildColumnResizePreview(resizeState, e.clientX, e.clientY);
       setResizePreview(preview);
       if (resizeState.debugEnabled) {
         logColumnResizeDebug("start", {
@@ -2341,13 +1278,7 @@ export function DataTable<T>({
         });
       }
     },
-    [
-      applyColumnWidthToDom,
-      applyStickyLayoutToDom,
-      buildColumnResizePreview,
-      naturalFlow,
-      tableId,
-    ],
+    [applyColumnWidthToDom, applyStickyLayoutToDom, buildColumnResizePreview, naturalFlow, tableId],
   );
 
   // ---------------------------------------------------------------------------
@@ -2362,18 +1293,16 @@ export function DataTable<T>({
 
       const containerRect = container.getBoundingClientRect();
       const elementsByKey = new Map<string, HTMLElement[]>();
-      table
-        .querySelectorAll<HTMLElement>("[data-vt-column-key]")
-        .forEach((element) => {
-          const key = element.dataset.vtColumnKey;
-          if (!key) return;
-          const bucket = elementsByKey.get(key);
-          if (bucket) {
-            bucket.push(element);
-          } else {
-            elementsByKey.set(key, [element]);
-          }
-        });
+      table.querySelectorAll<HTMLElement>("[data-vt-column-key]").forEach((element) => {
+        const key = element.dataset.vtColumnKey;
+        if (!key) return;
+        const bucket = elementsByKey.get(key);
+        if (bucket) {
+          bucket.push(element);
+        } else {
+          elementsByKey.set(key, [element]);
+        }
+      });
 
       const geometries = currentColumns.map((column, index) => {
         const headerCell = headerCellsRef.current[column.key];
@@ -2381,9 +1310,7 @@ export function DataTable<T>({
         return {
           key: column.key,
           index,
-          left: rect
-            ? rect.left - containerRect.left + container.scrollLeft
-            : 0,
+          left: rect ? rect.left - containerRect.left + container.scrollLeft : 0,
           width: rect?.width ?? 0,
           elements: elementsByKey.get(column.key) ?? [],
           appliedDragging: false,
@@ -2392,50 +1319,42 @@ export function DataTable<T>({
         };
       });
 
-      return geometries.some((geometry) => geometry.width > 0)
-        ? geometries
-        : null;
+      return geometries.some((geometry) => geometry.width > 0) ? geometries : null;
     },
     [],
   );
 
-  const clearColumnReorderStyles = useCallback(
-    (active: ColumnReorderState | null) => {
-      active?.columns.forEach((geometry) => {
-        geometry.elements.forEach((element) => {
-          element.style.transform = "";
-          element.style.transition = "";
-          element.style.willChange = "";
-          element.style.position = "";
-          element.style.zIndex = "";
-          element.style.pointerEvents = "";
-          element.style.opacity = "";
-          element.style.filter = "";
-          element.style.background = "";
-          element.style.boxShadow = "";
-          element.style.overflow = "";
-          element.style.contain = "";
-          element.style.isolation = "";
-          element.style.borderRadius = "";
-          element.removeAttribute("data-vt-column-dragging-cell");
-          element.removeAttribute("data-vt-column-shifted-cell");
-        });
+  const clearColumnReorderStyles = useCallback((active: ColumnReorderState | null) => {
+    active?.columns.forEach((geometry) => {
+      geometry.elements.forEach((element) => {
+        element.style.transform = "";
+        element.style.transition = "";
+        element.style.willChange = "";
+        element.style.position = "";
+        element.style.zIndex = "";
+        element.style.pointerEvents = "";
+        element.style.opacity = "";
+        element.style.filter = "";
+        element.style.background = "";
+        element.style.boxShadow = "";
+        element.style.overflow = "";
+        element.style.contain = "";
+        element.style.isolation = "";
+        element.style.borderRadius = "";
+        element.removeAttribute("data-vt-column-dragging-cell");
+        element.removeAttribute("data-vt-column-shifted-cell");
       });
-    },
-    [],
-  );
+    });
+  }, []);
 
   const applyColumnReorderStyles = useCallback(
     (active: ColumnReorderState, dragOffsetX: number) => {
       active.columns.forEach((geometry) => {
         const isDragged = geometry.key === active.columnKey;
-        const shift = isDragged
-          ? dragOffsetX
-          : (getColumnReorderShift(active, geometry) ?? 0);
+        const shift = isDragged ? dragOffsetX : (getColumnReorderShift(active, geometry) ?? 0);
         const transform = formatColumnReorderTransform(shift);
         const stableShift = isDragged ? null : shift;
-        const wasShifted =
-          !geometry.appliedDragging && (geometry.appliedShift ?? 0) !== 0;
+        const wasShifted = !geometry.appliedDragging && (geometry.appliedShift ?? 0) !== 0;
         if (
           geometry.appliedDragging === isDragged &&
           geometry.appliedShift === stableShift &&
@@ -2458,15 +1377,9 @@ export function DataTable<T>({
               : "";
           element.style.willChange = isMoved ? "transform" : "";
           // Header cells own the vertical sticky position; horizontal reorder transforms must not detach it.
-          const keepsStickyHeaderPosition =
-            !naturalFlow && element.tagName === "TH";
-          element.style.position =
-            isMoved && !keepsStickyHeaderPosition ? "relative" : "";
-          element.style.zIndex = isDragged
-            ? "90"
-            : shift || isSettling
-              ? "45"
-              : "";
+          const keepsStickyHeaderPosition = !naturalFlow && element.tagName === "TH";
+          element.style.position = isMoved && !keepsStickyHeaderPosition ? "relative" : "";
+          element.style.zIndex = isDragged ? "90" : shift || isSettling ? "45" : "";
           element.style.pointerEvents = isDragged ? "none" : "";
           element.style.opacity = "";
           element.style.filter = "";
@@ -2518,9 +1431,7 @@ export function DataTable<T>({
 
   const scheduleColumnReorderFrame = useCallback(() => {
     if (columnReorderRafRef.current !== null) return;
-    columnReorderRafRef.current = window.requestAnimationFrame(
-      applyColumnReorderFrame,
-    );
+    columnReorderRafRef.current = window.requestAnimationFrame(applyColumnReorderFrame);
   }, [applyColumnReorderFrame]);
 
   const stopColumnReorderAutoScroll = useCallback(() => {
@@ -2537,10 +1448,7 @@ export function DataTable<T>({
     if (!active || !active.activated || !container || naturalFlow) return;
 
     const rect = container.getBoundingClientRect();
-    const maxScrollLeft = Math.max(
-      0,
-      container.scrollWidth - container.clientWidth,
-    );
+    const maxScrollLeft = Math.max(0, container.scrollWidth - container.clientWidth);
     if (maxScrollLeft <= 0) return;
 
     const dragOffsetX = getColumnReorderDragOffset(
@@ -2564,17 +1472,14 @@ export function DataTable<T>({
       0,
       Math.min(
         1,
-        (COLUMN_REORDER_AUTOSCROLL_EDGE_PX -
-          (rect.right - active.lastClientX)) /
+        (COLUMN_REORDER_AUTOSCROLL_EDGE_PX - (rect.right - active.lastClientX)) /
           COLUMN_REORDER_AUTOSCROLL_EDGE_PX,
       ),
     );
     const direction =
       canMoveLeft && leftIntensity > 0 && container.scrollLeft > 0
         ? -1
-        : canMoveRight &&
-            rightIntensity > 0 &&
-            container.scrollLeft < maxScrollLeft
+        : canMoveRight && rightIntensity > 0 && container.scrollLeft < maxScrollLeft
           ? 1
           : 0;
 
@@ -2583,16 +1488,8 @@ export function DataTable<T>({
     const intensity = direction < 0 ? leftIntensity : rightIntensity;
     const delta =
       direction *
-      Math.max(
-        1,
-        Math.round(
-          COLUMN_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME * intensity * intensity,
-        ),
-      );
-    const nextScrollLeft = Math.max(
-      0,
-      Math.min(maxScrollLeft, container.scrollLeft + delta),
-    );
+      Math.max(1, Math.round(COLUMN_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME * intensity * intensity));
+    const nextScrollLeft = Math.max(0, Math.min(maxScrollLeft, container.scrollLeft + delta));
 
     if (nextScrollLeft !== container.scrollLeft) {
       container.scrollLeft = nextScrollLeft;
@@ -2629,9 +1526,7 @@ export function DataTable<T>({
     setSettledReorderColumnKey(columnKey);
     columnReorderSettleTimeoutRef.current = window.setTimeout(() => {
       columnReorderSettleTimeoutRef.current = null;
-      setSettledReorderColumnKey((current) =>
-        current === columnKey ? null : current,
-      );
+      setSettledReorderColumnKey((current) => (current === columnKey ? null : current));
     }, COLUMN_REORDER_SETTLE_FEEDBACK_MS);
   }, []);
 
@@ -2659,10 +1554,8 @@ export function DataTable<T>({
     (active: ColumnReorderState, event: PointerEvent) => {
       if (active.activated) return true;
       const movedEnough =
-        Math.abs(event.clientX - active.startClientX) >=
-          COLUMN_REORDER_MIN_DRAG_DISTANCE_PX ||
-        Math.abs(event.clientY - active.startClientY) >=
-          COLUMN_REORDER_MIN_DRAG_DISTANCE_PX;
+        Math.abs(event.clientX - active.startClientX) >= COLUMN_REORDER_MIN_DRAG_DISTANCE_PX ||
+        Math.abs(event.clientY - active.startClientY) >= COLUMN_REORDER_MIN_DRAG_DISTANCE_PX;
       if (!movedEnough) return false;
 
       activateColumnReorder(active);
@@ -2720,10 +1613,7 @@ export function DataTable<T>({
 
       if (!shouldCommit) return;
 
-      const normalizedOrder = normalizeColumnOrder(
-        columnsRef.current,
-        columnOrderRef.current,
-      );
+      const normalizedOrder = normalizeColumnOrder(columnsRef.current, columnOrderRef.current);
       const fromIndex = normalizedOrder.indexOf(active.columnKey);
       if (fromIndex < 0) return;
 
@@ -2769,16 +1659,11 @@ export function DataTable<T>({
       const draggedGeometry = geometries?.[columnIndex];
       if (!geometries || !draggedGeometry || draggedGeometry.width <= 0) return;
 
-      const movableKeys = normalizeColumnOrder(
-        currentColumns,
-        columnOrderRef.current,
-      );
+      const movableKeys = normalizeColumnOrder(currentColumns, columnOrderRef.current);
       const startLocked = currentColumns.filter(
         (c) => resolveColumnOrderLock(c) === "start",
       ).length;
-      const endLocked = currentColumns.filter(
-        (c) => resolveColumnOrderLock(c) === "end",
-      ).length;
+      const endLocked = currentColumns.filter((c) => resolveColumnOrderLock(c) === "end").length;
       const maxMovable = Math.max(0, movableKeys.length - endLocked);
 
       const state: ColumnReorderState = {
@@ -2894,10 +1779,7 @@ export function DataTable<T>({
   const measureHeaderHeight = useCallback(() => {
     const node = headerRef.current;
     if (!node) return 0;
-    const next = Math.max(
-      0,
-      Math.ceil(node.getBoundingClientRect().height || 0),
-    );
+    const next = Math.max(0, Math.ceil(node.getBoundingClientRect().height || 0));
     if (next !== headerHeightRef.current) {
       headerHeightRef.current = next;
       setHeaderHeight(next);
@@ -2917,8 +1799,7 @@ export function DataTable<T>({
     update();
 
     window.addEventListener("resize", update);
-    const observer =
-      typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(update) : null;
     observer?.observe(el);
 
     return () => {
@@ -2930,13 +1811,7 @@ export function DataTable<T>({
   useLayoutEffect(() => {
     measureHeaderHeight();
     updateScrollMetrics();
-  }, [
-    columnWidths,
-    measureHeaderHeight,
-    minWidth,
-    orderedColumns,
-    updateScrollMetrics,
-  ]);
+  }, [columnWidths, measureHeaderHeight, minWidth, orderedColumns, updateScrollMetrics]);
 
   // Content size can change without the scroll container's box size changing (e.g. rows loaded after refresh).
   // ResizeObserver won't fire for scrollHeight/scrollWidth changes, so re-measure on data/structure changes.
@@ -3005,46 +1880,38 @@ export function DataTable<T>({
   }, []);
 
   // Virtual window calculation
-  const { startIndex, endIndex, topSpacerHeight, bottomSpacerHeight } =
-    useMemo(() => {
-      if (!virtualize) {
-        return {
-          startIndex: 0,
-          endIndex: rows.length,
-          topSpacerHeight: 0,
-          bottomSpacerHeight: 0,
-        };
-      }
-      const total = rows.length;
-      if (!total)
-        return {
-          startIndex: 0,
-          endIndex: 0,
-          topSpacerHeight: 0,
-          bottomSpacerHeight: 0,
-        };
-
-      const visibleStart = Math.floor(scrollTop / rowHeight);
-      const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
-      const visibleEnd = visibleStart + visibleCount;
-
-      const start = Math.max(0, visibleStart - overscan);
-      const end = Math.min(total, visibleEnd + overscan);
-
+  const { startIndex, endIndex, topSpacerHeight, bottomSpacerHeight } = useMemo(() => {
+    if (!virtualize) {
       return {
-        startIndex: start,
-        endIndex: end,
-        topSpacerHeight: start * rowHeight,
-        bottomSpacerHeight: (total - end) * rowHeight,
+        startIndex: 0,
+        endIndex: rows.length,
+        topSpacerHeight: 0,
+        bottomSpacerHeight: 0,
       };
-    }, [
-      overscan,
-      rowHeight,
-      rows.length,
-      scrollTop,
-      viewportHeight,
-      virtualize,
-    ]);
+    }
+    const total = rows.length;
+    if (!total)
+      return {
+        startIndex: 0,
+        endIndex: 0,
+        topSpacerHeight: 0,
+        bottomSpacerHeight: 0,
+      };
+
+    const visibleStart = Math.floor(scrollTop / rowHeight);
+    const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
+    const visibleEnd = visibleStart + visibleCount;
+
+    const start = Math.max(0, visibleStart - overscan);
+    const end = Math.min(total, visibleEnd + overscan);
+
+    return {
+      startIndex: start,
+      endIndex: end,
+      topSpacerHeight: start * rowHeight,
+      bottomSpacerHeight: (total - end) * rowHeight,
+    };
+  }, [overscan, rowHeight, rows.length, scrollTop, viewportHeight, virtualize]);
 
   const visibleRows = useMemo(
     () => (virtualize ? rows.slice(startIndex, endIndex) : rows),
@@ -3061,17 +1928,11 @@ export function DataTable<T>({
     return isEmpty ? { vThumb: thumbs.vThumb, hThumb: null } : thumbs;
   }, [headerHeight, isEmpty, scrollMetrics]);
   const stickyStartRailWidth = useMemo(
-    () =>
-      isEmpty
-        ? 0
-        : resolveStickyRailWidth(orderedColumns, columnWidths, "start"),
+    () => (isEmpty ? 0 : resolveStickyRailWidth(orderedColumns, columnWidths, "start")),
     [columnWidths, isEmpty, orderedColumns],
   );
   const stickyEndRailWidth = useMemo(
-    () =>
-      isEmpty
-        ? 0
-        : resolveStickyRailWidth(orderedColumns, columnWidths, "end"),
+    () => (isEmpty ? 0 : resolveStickyRailWidth(orderedColumns, columnWidths, "end")),
     [columnWidths, isEmpty, orderedColumns],
   );
   stickyRailWidthsRef.current = {
@@ -3080,9 +1941,7 @@ export function DataTable<T>({
   };
   const stickyColumnPlacements = useMemo(
     (): Record<string, StickyColumnPlacement> =>
-      isEmpty
-        ? {}
-        : resolveStickyColumnPlacements(orderedColumns, columnWidths),
+      isEmpty ? {} : resolveStickyColumnPlacements(orderedColumns, columnWidths),
     [columnWidths, isEmpty, orderedColumns],
   );
   const stickyRailBottomInset = hThumb ? 14 : 0;
@@ -3091,27 +1950,15 @@ export function DataTable<T>({
     0,
     scrollMetrics.clientHeight - headerHeight - stickyRailBottomInset,
   );
-  const stickyBoundaryHeight = Math.max(
-    0,
-    scrollMetrics.clientHeight - stickyRailBottomInset,
-  );
-  const stickyStartShadowOpacity = getStickyEdgeShadowOpacity(
-    scrollMetrics,
-    "start",
-  );
-  const stickyEndShadowOpacity = getStickyEdgeShadowOpacity(
-    scrollMetrics,
-    "end",
-  );
+  const stickyBoundaryHeight = Math.max(0, scrollMetrics.clientHeight - stickyRailBottomInset);
+  const stickyStartShadowOpacity = getStickyEdgeShadowOpacity(scrollMetrics, "start");
+  const stickyEndShadowOpacity = getStickyEdgeShadowOpacity(scrollMetrics, "end");
   const stickyStartBoundaryLeft = Math.max(0, stickyStartRailWidth);
   const stickyEndBoundaryLeft = Math.max(
     0,
     scrollMetrics.clientWidth - stickyEndRailWidth - STICKY_EDGE_SHADOW_WIDTH,
   );
-  const stickyEndRailLeft = Math.max(
-    0,
-    scrollMetrics.clientWidth - stickyEndRailWidth,
-  );
+  const stickyEndRailLeft = Math.max(0, scrollMetrics.clientWidth - stickyEndRailWidth);
 
   // Empty tables should not inherit the wide minWidth / fixed column widths
   // that data rows need; otherwise the empty body scrolls horizontally for
@@ -3119,15 +1966,9 @@ export function DataTable<T>({
   const tableMinWidthClass = isEmpty ? "min-w-0" : minWidth;
 
   const resolveColumnStyle = useCallback(
-    (
-      column: DataTableColumn<T>,
-      area: "header" | "cell" = "cell",
-    ): DataTableColumnStyle => {
+    (column: DataTableColumn<T>, area: "header" | "cell" = "cell"): DataTableColumnStyle => {
       const width = isEmpty ? undefined : columnWidths[column.key];
-      const placement =
-        naturalFlow || isEmpty
-          ? undefined
-          : stickyColumnPlacements[column.key];
+      const placement = naturalFlow || isEmpty ? undefined : stickyColumnPlacements[column.key];
       const style: DataTableColumnStyle = {};
 
       if (width) {
@@ -3222,6 +2063,21 @@ export function DataTable<T>({
           }}
         />
       ) : null}
+      {/* Viewport-fixed header plate: only as wide as the table viewport, not content.
+          Column labels still live in thead and scroll horizontally with body cells. */}
+      {!naturalFlow && !isEmpty ? (
+        <div
+          data-vt-header-chrome
+          aria-hidden="true"
+          className={`pointer-events-none absolute left-0 top-0 z-40 col-start-1 row-start-1 ${
+            vThumb ? "rounded-l-xl" : "rounded-xl"
+          } bg-slate-100 dark:bg-neutral-800`}
+          style={{
+            width: scrollMetrics.clientWidth || "100%",
+            height: headerHeight > 0 ? headerHeight : "2.75rem",
+          }}
+        />
+      ) : null}
       <div
         ref={containerRef}
         onScroll={naturalFlow ? undefined : onScroll}
@@ -3231,38 +2087,14 @@ export function DataTable<T>({
           naturalFlow
             ? "relative z-10 min-h-0 overflow-visible rounded-xl"
             : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none ${
-                isEmpty
-                  ? "overflow-x-hidden overflow-y-auto"
-                  : "overflow-auto"
-              } ${
-                allowWheelPropagationAtBoundary
-                  ? "overscroll-y-auto"
-                  : "overscroll-y-none"
-              }`
+                isEmpty ? "overflow-x-hidden overflow-y-auto" : "overflow-auto"
+              } ${allowWheelPropagationAtBoundary ? "overscroll-y-auto" : "overscroll-y-none"}`
         }
       >
         <div
           data-vt-scroll-content
           className={`relative min-h-full ${scrollContentClassName ?? ""}`}
         >
-          {/* Sticky rounded header plate inside the scrollport. left:0 keeps it
-              pinned while scrolling horizontally; transparent middle headers let
-              this plate show through, including under outer sticky corner wedges. */}
-          {naturalFlow || isEmpty ? null : (
-            <div
-              data-vt-header-chrome
-              aria-hidden="true"
-              className={`pointer-events-none sticky left-0 top-0 z-40 ${
-                vThumb ? "rounded-l-xl" : "rounded-xl"
-              } bg-slate-100 dark:bg-neutral-800`}
-              style={{
-                width: scrollMetrics.clientWidth || "100%",
-                // Tests / first paint may not have measured headerHeight yet.
-                height: headerHeight > 0 ? headerHeight : "2.75rem",
-                marginBottom: headerHeight > 0 ? -headerHeight : "-2.75rem",
-              }}
-            />
-          )}
           {!naturalFlow && rowHoverOverlay ? (
             <div
               data-vt-row-hover-overlay
@@ -3302,55 +2134,27 @@ export function DataTable<T>({
                 {orderedColumns.map((col, colIndex) => {
                   const isRowReorderColumn = col.key === ROW_REORDER_COLUMN_KEY;
                   const canResize =
-                    columnResizable &&
-                    shouldAllowColumnResize(col, colIndex, orderedColumns);
-                  const canReorder =
-                    canUseColumnOrder && shouldAllowColumnReorder(col);
+                    columnResizable && shouldAllowColumnResize(col, colIndex, orderedColumns);
+                  const canReorder = canUseColumnOrder && shouldAllowColumnReorder(col);
                   const canSort = Boolean(col.sort && onRowsChange);
                   const sortDirection =
-                    activeSortState?.columnKey === col.key
-                      ? activeSortState.direction
-                      : null;
-                  const isResizingThisColumn =
-                    activeResizeColumnKey === col.key;
-                  const isSettledReorderColumn =
-                    settledReorderColumnKey === col.key;
+                    activeSortState?.columnKey === col.key ? activeSortState.direction : null;
+                  const isResizingThisColumn = activeResizeColumnKey === col.key;
+                  const isSettledReorderColumn = settledReorderColumnKey === col.key;
                   const stickyPlacement =
-                    naturalFlow || isEmpty
-                      ? undefined
-                      : stickyColumnPlacements[col.key];
+                    naturalFlow || isEmpty ? undefined : stickyColumnPlacements[col.key];
                   const headerPositionClass =
-                    naturalFlow || isEmpty
-                      ? "relative"
-                      : "sticky top-0 z-50";
-                  // Outer sticky headers paint full side radius (top+bottom).
-                  // Middle headers stay transparent so header-chrome shows through
-                  // while columns scroll — keeps the header bar 4-corner rounded.
-                  // Tables without locked sticky columns keep opaque headers.
-                  const hasStickyColumns =
-                    Object.keys(stickyColumnPlacements).length > 0;
-                  const isOuterStickyStart =
-                    stickyPlacement?.edge === "start" && stickyPlacement.offset === 0;
-                  const isOuterStickyEnd =
-                    stickyPlacement?.edge === "end" && stickyPlacement.offset === 0;
+                    naturalFlow || isEmpty ? "relative" : "sticky top-0 z-50";
+                  // Viewport header-chrome owns the rounded plate. Sticky cells
+                  // stay opaque so locked columns cover scrolling middle labels;
+                  // free-scroll headers stay transparent over the chrome plate.
                   const headerChromeClass =
-                    naturalFlow || isEmpty || stickyPlacement || !hasStickyColumns
+                    naturalFlow || isEmpty || stickyPlacement
                       ? "bg-slate-100 dark:bg-neutral-800"
                       : "bg-transparent";
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
-                    naturalFlow && colIndex === orderedColumns.length - 1
-                      ? "rounded-r-xl"
-                      : "",
-                    !naturalFlow && (colIndex === 0 || isOuterStickyStart)
-                      ? "rounded-l-xl"
-                      : "",
-                    // Always round the outer end header; gutter only covers the
-                    // scrollbar strip, not the actions column itself.
-                    !naturalFlow &&
-                    (isOuterStickyEnd || colIndex === orderedColumns.length - 1)
-                      ? "rounded-r-xl"
-                      : "",
+                    naturalFlow && colIndex === orderedColumns.length - 1 ? "rounded-r-xl" : "",
                   ]
                     .filter(Boolean)
                     .join(" ");
@@ -3359,21 +2163,15 @@ export function DataTable<T>({
                       key={col.key}
                       aria-label={col.label}
                       data-vt-column-key={col.key}
-                      data-vt-column-settled-cell={
-                        isSettledReorderColumn ? true : undefined
-                      }
+                      data-vt-column-settled-cell={isSettledReorderColumn ? true : undefined}
                       ref={(node) => {
                         headerCellsRef.current[col.key] = node;
                       }}
                       style={resolveColumnStyle(col, "header")}
                       className={`group/column ${headerPositionClass} overflow-hidden px-4 py-3 whitespace-nowrap ${
-                        stickyPlacement?.edge === "start"
-                          ? "md:left-[var(--vt-sticky-left)]"
-                          : ""
+                        stickyPlacement?.edge === "start" ? "md:left-[var(--vt-sticky-left)]" : ""
                       } ${
-                        stickyPlacement?.edge === "end"
-                          ? "md:right-[var(--vt-sticky-right)]"
-                          : ""
+                        stickyPlacement?.edge === "end" ? "md:right-[var(--vt-sticky-right)]" : ""
                       } ${headerChromeClass} ${headerCornerClass} ${
                         isEmpty ? "" : (col.width ?? "")
                       } ${col.headerClassName ?? ""} ${
@@ -3393,9 +2191,7 @@ export function DataTable<T>({
                                 ? "pointer-events-none opacity-100"
                                 : "group-hover/column:opacity-100"
                           }`}
-                          onPointerDown={(event) =>
-                            handleColumnReorderPointerDown(col, event)
-                          }
+                          onPointerDown={(event) => handleColumnReorderPointerDown(col, event)}
                         >
                           <GripVertical size={13} aria-hidden="true" />
                           <span className="sr-only">
@@ -3406,9 +2202,7 @@ export function DataTable<T>({
                       {/* Always reserve handle-width gutters when reorderable so the absolute grip never covers the label; keep L/R symmetric so centered headers do not shift on hover. */}
                       <div
                         data-vt-column-header-content
-                        className={`min-w-0 max-w-full overflow-hidden ${
-                          canReorder ? "px-5" : ""
-                        }`}
+                        className={`min-w-0 max-w-full overflow-hidden ${canReorder ? "px-5" : ""}`}
                       >
                         {isRowReorderColumn ? (
                           <span className="flex items-center justify-center text-slate-400/70 dark:text-white/35">
@@ -3420,9 +2214,7 @@ export function DataTable<T>({
                             className={`flex min-w-0 items-center gap-1.5 ${resolveHeaderContentJustifyClass(col.headerClassName)}`}
                           >
                             <span className="min-w-0 truncate">
-                              {col.headerRender
-                                ? col.headerRender()
-                                : col.label}
+                              {col.headerRender ? col.headerRender() : col.label}
                             </span>
                             {canSort ? (
                               <DropdownMenu.Root size="sm">
@@ -3430,9 +2222,7 @@ export function DataTable<T>({
                                   <button
                                     type="button"
                                     data-vt-sort-trigger={col.key}
-                                    data-vt-sort-direction={
-                                      sortDirection ?? "none"
-                                    }
+                                    data-vt-sort-direction={sortDirection ?? "none"}
                                     aria-label={t("common.sort_column", {
                                       column: col.label,
                                     })}
@@ -3444,52 +2234,35 @@ export function DataTable<T>({
                                         ? "text-slate-900 dark:text-white"
                                         : "text-slate-400 dark:text-white/35"
                                     }`}
-                                    onPointerDown={(event) =>
-                                      event.stopPropagation()
-                                    }
+                                    onPointerDown={(event) => event.stopPropagation()}
                                   >
                                     {sortDirection === "asc" ? (
                                       <ArrowUp size={14} aria-hidden="true" />
                                     ) : sortDirection === "desc" ? (
                                       <ArrowDown size={14} aria-hidden="true" />
                                     ) : (
-                                      <ArrowUpDown
-                                        size={14}
-                                        aria-hidden="true"
-                                      />
+                                      <ArrowUpDown size={14} aria-hidden="true" />
                                     )}
                                   </button>
                                 </DropdownMenu.Trigger>
                                 <DropdownMenu.Portal>
                                   <DropdownMenu.Content align="start">
                                     <DropdownMenu.Item
-                                      onSelect={() =>
-                                        handleColumnSort(col, "asc")
-                                      }
+                                      onSelect={() => handleColumnSort(col, "asc")}
                                     >
                                       <ArrowUp size={13} aria-hidden="true" />
                                       <span>{t("common.sort_ascending")}</span>
                                       {sortDirection === "asc" ? (
-                                        <Check
-                                          className="ml-auto"
-                                          size={13}
-                                          aria-hidden="true"
-                                        />
+                                        <Check className="ml-auto" size={13} aria-hidden="true" />
                                       ) : null}
                                     </DropdownMenu.Item>
                                     <DropdownMenu.Item
-                                      onSelect={() =>
-                                        handleColumnSort(col, "desc")
-                                      }
+                                      onSelect={() => handleColumnSort(col, "desc")}
                                     >
                                       <ArrowDown size={13} aria-hidden="true" />
                                       <span>{t("common.sort_descending")}</span>
                                       {sortDirection === "desc" ? (
-                                        <Check
-                                          className="ml-auto"
-                                          size={13}
-                                          aria-hidden="true"
-                                        />
+                                        <Check className="ml-auto" size={13} aria-hidden="true" />
                                       ) : null}
                                     </DropdownMenu.Item>
                                   </DropdownMenu.Content>
@@ -3511,9 +2284,7 @@ export function DataTable<T>({
                           })}
                           className="group/resize absolute -right-2 top-0 z-30 h-full w-4 cursor-col-resize touch-none bg-transparent outline-none"
                           style={{ cursor: "col-resize" }}
-                          onPointerDown={(event) =>
-                            handleColumnResizePointerDown(col, event)
-                          }
+                          onPointerDown={(event) => handleColumnResizePointerDown(col, event)}
                         >
                           <span
                             aria-hidden="true"
@@ -3563,10 +2334,7 @@ export function DataTable<T>({
                 </>
               ) : isEmpty ? (
                 <tr data-vt-empty-row className="h-full">
-                  <td
-                    colSpan={colCount}
-                    className="h-full px-4 py-8 align-middle sm:px-6 sm:py-10"
-                  >
+                  <td colSpan={colCount} className="h-full px-4 py-8 align-middle sm:px-6 sm:py-10">
                     {/*
                       Fill the remaining table viewport so EmptyState sits in the
                       middle of the blank body, not stuck under the header.
@@ -3585,17 +2353,11 @@ export function DataTable<T>({
                 <>
                   {virtualize ? (
                     <tr aria-hidden="true">
-                      <td
-                        colSpan={colCount}
-                        height={topSpacerHeight}
-                        className="p-0"
-                      />
+                      <td colSpan={colCount} height={topSpacerHeight} className="p-0" />
                     </tr>
                   ) : null}
                   {visibleRows.map((row, localIdx) => {
-                    const globalIdx = virtualize
-                      ? startIndex + localIdx
-                      : localIdx;
+                    const globalIdx = virtualize ? startIndex + localIdx : localIdx;
                     const key = rowKey(row, globalIdx);
                     const extraCls =
                       typeof rowClassName === "function"
@@ -3603,16 +2365,13 @@ export function DataTable<T>({
                         : (rowClassName ?? "");
                     const rowSelected = rowAriaSelected?.(row, globalIdx);
                     const rowInteractive = Boolean(onRowClick);
-                    const isActiveRowReorder =
-                      activeRowReorderIndex === globalIdx;
+                    const isActiveRowReorder = activeRowReorderIndex === globalIdx;
                     return (
                       <tr
                         key={key}
                         data-vt-row-index={globalIdx}
                         data-vt-row-key={key}
-                        data-vt-row-reorder-active={
-                          isActiveRowReorder ? true : undefined
-                        }
+                        data-vt-row-reorder-active={isActiveRowReorder ? true : undefined}
                         tabIndex={rowInteractive ? 0 : undefined}
                         aria-selected={rowSelected}
                         className={`group/row relative z-0 text-sm transition-[opacity,background-color] ${
@@ -3633,8 +2392,7 @@ export function DataTable<T>({
                         onKeyDown={
                           rowInteractive
                             ? (event) => {
-                                if (event.key !== "Enter" && event.key !== " ")
-                                  return;
+                                if (event.key !== "Enter" && event.key !== " ") return;
                                 event.preventDefault();
                                 onRowClick?.(row, globalIdx);
                               }
@@ -3643,31 +2401,20 @@ export function DataTable<T>({
                         onMouseEnter={
                           naturalFlow
                             ? undefined
-                            : (event) =>
-                                updateRowHoverOverlay(event.currentTarget)
+                            : (event) => updateRowHoverOverlay(event.currentTarget)
                         }
-                        onMouseLeave={
-                          naturalFlow
-                            ? undefined
-                            : () => updateRowHoverOverlay(null)
-                        }
+                        onMouseLeave={naturalFlow ? undefined : () => updateRowHoverOverlay(null)}
                       >
                         {orderedColumns.map((col, colIdx) => {
                           const isFirst = colIdx === 0;
                           const isLast = colIdx === orderedColumns.length - 1;
-                          const isRowReorderColumn =
-                            col.key === ROW_REORDER_COLUMN_KEY;
-                          const isSettledReorderColumn =
-                            settledReorderColumnKey === col.key;
+                          const isRowReorderColumn = col.key === ROW_REORDER_COLUMN_KEY;
+                          const isSettledReorderColumn = settledReorderColumnKey === col.key;
                           const stickyPlacement = naturalFlow
                             ? undefined
                             : stickyColumnPlacements[col.key];
                           const content = col.render(row, globalIdx);
-                          const overflowTooltip = resolveCellOverflowTooltip(
-                            col,
-                            row,
-                            globalIdx,
-                          );
+                          const overflowTooltip = resolveCellOverflowTooltip(col, row, globalIdx);
                           const roundCls = rowDividers
                             ? ""
                             : [
@@ -3694,9 +2441,7 @@ export function DataTable<T>({
                               }
                               style={resolveColumnStyle(col, "cell")}
                               className={`overflow-hidden align-middle ${
-                                isRowReorderColumn
-                                  ? "px-1 py-2.5 text-center"
-                                  : "px-4 py-2.5"
+                                isRowReorderColumn ? "px-1 py-2.5 text-center" : "px-4 py-2.5"
                               } ${
                                 stickyPlacement?.edge === "start"
                                   ? "md:left-[var(--vt-sticky-left)]"
@@ -3719,23 +2464,16 @@ export function DataTable<T>({
                                           index: globalIdx + 1,
                                         })
                                   }
-                                  disabled={
-                                    !onRowsChange || rows.length < 2 || loading
-                                  }
+                                  disabled={!onRowsChange || rows.length < 2 || loading}
                                   className={`inline-flex h-7 w-7 touch-none items-center justify-center rounded-lg text-slate-400 outline-none transition-colors hover:bg-slate-200/80 hover:text-slate-700 focus-visible:ring-2 focus-visible:ring-slate-400/35 disabled:cursor-default disabled:opacity-35 dark:text-white/35 dark:hover:bg-white/10 dark:hover:text-white/75 dark:focus-visible:ring-white/15 ${
                                     isActiveRowReorder
                                       ? "cursor-grabbing bg-slate-200 text-slate-800 dark:bg-white/15 dark:text-white"
                                       : "cursor-grab"
                                   }`}
                                   onPointerDown={(event) =>
-                                    handleRowReorderPointerDown(
-                                      globalIdx,
-                                      event,
-                                    )
+                                    handleRowReorderPointerDown(globalIdx, event)
                                   }
-                                  onKeyDown={(event) =>
-                                    handleRowReorderKeyDown(globalIdx, event)
-                                  }
+                                  onKeyDown={(event) => handleRowReorderKeyDown(globalIdx, event)}
                                 >
                                   <GripVertical size={15} aria-hidden="true" />
                                 </button>
@@ -3746,10 +2484,7 @@ export function DataTable<T>({
                                 >
                                   <TableCellOverflowTooltip
                                     tooltipContent={overflowTooltip}
-                                    className={
-                                      col.cellContentClassName ??
-                                      col.cellClassName
-                                    }
+                                    className={col.cellContentClassName ?? col.cellClassName}
                                   >
                                     {content}
                                   </TableCellOverflowTooltip>
@@ -3763,11 +2498,7 @@ export function DataTable<T>({
                   })}
                   {virtualize ? (
                     <tr aria-hidden="true">
-                      <td
-                        colSpan={colCount}
-                        height={bottomSpacerHeight}
-                        className="p-0"
-                      />
+                      <td colSpan={colCount} height={bottomSpacerHeight} className="p-0" />
                     </tr>
                   ) : null}
                 </>

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -57,9 +57,7 @@ function DataTableHarness() {
 }
 
 function visibleRowNames() {
-  return screen
-    .getAllByTestId("row-name")
-    .map((element) => element.textContent);
+  return screen.getAllByTestId("row-name").map((element) => element.textContent);
 }
 
 describe("DataTable sorting and row reordering", () => {
@@ -74,19 +72,18 @@ describe("DataTable sorting and row reordering", () => {
       'td[data-vt-column-key="name"]',
     );
     expect(firstNameCell).toHaveClass("border-b", "data-table-test-cell");
-    expect(
-      firstNameCell?.querySelector("[data-table-cell-overflow]"),
-    ).toHaveClass("data-table-test-content");
-    expect(
-      firstNameCell?.querySelector("[data-table-cell-overflow]"),
-    ).not.toHaveClass("border-b", "data-table-test-cell");
+    expect(firstNameCell?.querySelector("[data-table-cell-overflow]")).toHaveClass(
+      "data-table-test-content",
+    );
+    expect(firstNameCell?.querySelector("[data-table-cell-overflow]")).not.toHaveClass(
+      "border-b",
+      "data-table-test-cell",
+    );
 
     await user.click(sortTrigger);
     const menu = screen.getByRole("menu");
     expect(menu).toHaveClass("min-w-28");
-    expect(screen.getByRole("menuitem", { name: "Ascending" })).toHaveClass(
-      "text-xs",
-    );
+    expect(screen.getByRole("menuitem", { name: "Ascending" })).toHaveClass("text-xs");
     await user.click(screen.getByRole("menuitem", { name: "Ascending" }));
 
     expect(visibleRowNames()).toEqual(["alpha", "bravo", "charlie"]);
@@ -137,30 +134,22 @@ describe("DataTable sorting and row reordering", () => {
     });
     fireEvent.pointerMove(window, { pointerId: 7, clientY: 115 });
 
-    const dragPreview = document.querySelector<HTMLElement>(
-      "[data-vt-row-reorder-preview]",
-    );
+    const dragPreview = document.querySelector<HTMLElement>("[data-vt-row-reorder-preview]");
     expect(dragPreview).toHaveTextContent("alpha");
     expect(dragPreview).toHaveClass("border", "border-slate-200/90");
     expect(
       Array.from(dragPreview?.querySelectorAll("td") ?? []).every(
-        (cell) =>
-          cell.style.borderTopWidth === "0px" &&
-          cell.style.borderBottomWidth === "0px",
+        (cell) => cell.style.borderTopWidth === "0px" && cell.style.borderBottomWidth === "0px",
       ),
     ).toBe(true);
-    expect(
-      document.querySelector("[data-vt-row-reorder-drop-indicator]"),
-    ).toBeNull();
+    expect(document.querySelector("[data-vt-row-reorder-drop-indicator]")).toBeNull();
     expect(tableRows[0]).toHaveStyle({ opacity: "0" });
     expect(tableRows[1]).toHaveStyle({ transform: "translate3d(0, -40px, 0)" });
     expect(tableRows[2]).toHaveStyle({ transform: "translate3d(0, -40px, 0)" });
 
     fireEvent.pointerUp(window, { pointerId: 7, clientY: 115 });
 
-    await waitFor(() =>
-      expect(visibleRowNames()).toEqual(["bravo", "charlie", "alpha"]),
-    );
+    await waitFor(() => expect(visibleRowNames()).toEqual(["bravo", "charlie", "alpha"]));
     expect(document.querySelector("[data-vt-row-reorder-preview]")).toBeNull();
     tableRows.forEach((row) => {
       expect(row.style.opacity).toBe("");
@@ -186,23 +175,14 @@ describe("DataTable column reorder handle layout", () => {
       />,
     );
 
-    const header = document.querySelector<HTMLElement>(
-      'th[data-vt-column-key="name"]',
-    );
-    const content = header?.querySelector<HTMLElement>(
-      "[data-vt-column-header-content]",
-    );
-    const handle = header?.querySelector<HTMLElement>(
-      "[data-vt-column-reorder-handle]",
-    );
+    const header = document.querySelector<HTMLElement>('th[data-vt-column-key="name"]');
+    const content = header?.querySelector<HTMLElement>("[data-vt-column-header-content]");
+    const handle = header?.querySelector<HTMLElement>("[data-vt-column-reorder-handle]");
     expect(header).not.toBeNull();
     expect(content).not.toBeNull();
     expect(handle).not.toBeNull();
     expect(content).toHaveClass("px-5");
-    expect(content).not.toHaveClass(
-      "group-hover/column:pl-5",
-      "group-focus-within/column:pl-5",
-    );
+    expect(content).not.toHaveClass("group-hover/column:pl-5", "group-focus-within/column:pl-5");
     expect(handle).toHaveClass("absolute", "left-1");
   });
 });
@@ -295,12 +275,8 @@ describe("DataTable empty state", () => {
     );
 
     const table = document.querySelector<HTMLTableElement>("table[data-vt-empty='true']");
-    const viewport = document.querySelector<HTMLElement>(
-      "[data-scrollbar-visibility='hover']",
-    );
-    const emptyRow = document.querySelector<HTMLTableRowElement>(
-      "tr[data-vt-empty-row]",
-    );
+    const viewport = document.querySelector<HTMLElement>("[data-scrollbar-visibility='hover']");
+    const emptyRow = document.querySelector<HTMLTableRowElement>("tr[data-vt-empty-row]");
 
     expect(table).not.toBeNull();
     expect(table).toHaveClass("min-w-0");
@@ -312,9 +288,7 @@ describe("DataTable empty state", () => {
     // Default EmptyState icon well (Inbox) when emptyIcon is omitted.
     expect(document.querySelector("[data-empty-icon]")).not.toBeNull();
 
-    const firstHeader = document.querySelector<HTMLElement>(
-      'th[data-vt-column-key="id"]',
-    );
+    const firstHeader = document.querySelector<HTMLElement>('th[data-vt-column-key="id"]');
     expect(firstHeader).not.toBeNull();
     expect(firstHeader?.className).not.toMatch(/min-w-\[320px\]/);
     expect(firstHeader).not.toHaveClass("sticky");
@@ -324,10 +298,7 @@ describe("DataTable empty state", () => {
 describe("DataTable scroll chrome and row dividers", () => {
   test("keeps header cells attached and forwards boundary wheel scrolling to the parent", () => {
     render(
-      <div
-        data-testid="parent-scroll"
-        style={{ height: 160, overflowY: "auto" }}
-      >
+      <div data-testid="parent-scroll" style={{ height: 160, overflowY: "auto" }}>
         <DataTable
           rows={initialRows}
           columns={plainColumns}
@@ -342,9 +313,7 @@ describe("DataTable scroll chrome and row dividers", () => {
     );
 
     const parent = screen.getByTestId("parent-scroll");
-    const viewport = document.querySelector<HTMLElement>(
-      "[data-scrollbar-visibility='hover']",
-    );
+    const viewport = document.querySelector<HTMLElement>("[data-scrollbar-visibility='hover']");
     expect(viewport).not.toBeNull();
     if (!viewport) return;
 
@@ -365,12 +334,15 @@ describe("DataTable scroll chrome and row dividers", () => {
     expect(parent.scrollTop).toBe(120);
     expect(viewport).toHaveClass("overscroll-y-auto");
     expect(viewport).not.toHaveClass("overscroll-y-none");
-    expect(document.querySelector("[data-vt-header-chrome]")).not.toBeNull();
+    const headerChrome = document.querySelector("[data-vt-header-chrome]");
+    expect(headerChrome).not.toBeNull();
+    expect(headerChrome).toHaveClass("absolute", "left-0", "top-0");
 
     const headerCells = Array.from(document.querySelectorAll("thead th"));
     expect(headerCells).not.toHaveLength(0);
     headerCells.forEach((cell) => {
-      expect(cell).toHaveClass("sticky", "top-0", "bg-slate-100");
+      // Free-scroll headers stay transparent; viewport chrome owns the plate fill.
+      expect(cell).toHaveClass("sticky", "top-0", "bg-transparent");
     });
   });
 
@@ -405,11 +377,7 @@ describe("DataTable scroll chrome and row dividers", () => {
       });
     });
     Array.from(rows.at(-1)?.cells ?? []).forEach((cell) => {
-      expect(cell).not.toHaveClass(
-        "border-b",
-        "first:rounded-l-lg",
-        "last:rounded-r-lg",
-      );
+      expect(cell).not.toHaveClass("border-b", "first:rounded-l-lg", "last:rounded-r-lg");
     });
   });
 
@@ -455,13 +423,16 @@ describe("DataTable scroll chrome and row dividers", () => {
 
     const selectHeader = document.querySelector('th[data-vt-column-key="select"]');
     const nameHeader = document.querySelector('th[data-vt-column-key="name"]');
-    const actionsHeader = document.querySelector(
-      'th[data-vt-column-key="actions"]',
-    );
+    const actionsHeader = document.querySelector('th[data-vt-column-key="actions"]');
     const headerGutter = document.querySelector("[data-vt-header-gutter]");
-    expect(selectHeader).toHaveClass("rounded-l-xl", "bg-slate-100");
+    // Sticky cells stay opaque; free middle headers stay transparent over chrome.
+    // Corner radius lives on the viewport chrome (and gutter), not per th.
+    expect(selectHeader).toHaveClass("bg-slate-100");
+    expect(selectHeader).not.toHaveClass("rounded-l-xl");
     expect(nameHeader).toHaveClass("bg-transparent");
-    expect(actionsHeader).toHaveClass("rounded-r-xl");
+    expect(actionsHeader).toHaveClass("bg-slate-100");
+    expect(actionsHeader).not.toHaveClass("rounded-r-xl");
+    expect(headerChrome).toHaveClass("absolute", "left-0", "top-0");
     // With a vertical gutter, chrome is left-only; otherwise full rounded-xl.
     if (headerGutter) {
       expect(headerGutter).toHaveClass("rounded-r-xl");

--- a/packages/ui/src/data-table/columnLayout.ts
+++ b/packages/ui/src/data-table/columnLayout.ts
@@ -1,0 +1,95 @@
+import type { DataTableColumn } from "./DataTable.types";
+import type { ColumnResizeState, ColumnWidthMap, StickyColumnPlacement } from "./dataTableModel";
+import { clampColumnWidth, resolveColumnMinWidth, resolveColumnOrderLock } from "./tableStorage";
+
+export function hasStickyColumnClass<T>(column: DataTableColumn<T>) {
+  return `${column.headerClassName ?? ""} ${column.cellClassName ?? ""}`
+    .split(/\s+/)
+    .some((className) => className === "sticky" || className.endsWith(":sticky"));
+}
+
+/**
+ * Map Tailwind text-align utilities on the header cell to flex justify on the
+ * header content row. `th` may carry `text-center` / `text-right`, but the label
+ * wrapper is `display: flex`, so text-align alone never centers/right-aligns it.
+ */
+export function resolveHeaderContentJustifyClass(headerClassName?: string) {
+  let justifyClass = "";
+  for (const className of (headerClassName ?? "").split(/\s+/).filter(Boolean)) {
+    if (/(?:^|:)text-center$/.test(className)) {
+      justifyClass = "justify-center";
+      continue;
+    }
+    if (/(?:^|:)text-right$/.test(className)) {
+      justifyClass = "justify-end";
+      continue;
+    }
+    if (/(?:^|:)text-left$/.test(className)) {
+      justifyClass = "justify-start";
+    }
+  }
+  return justifyClass;
+}
+
+export function resolveColumnLayoutWidth<T>(column: DataTableColumn<T>, widths: ColumnWidthMap) {
+  const resizedWidth = widths[column.key];
+  return resizedWidth ? clampColumnWidth(column, resizedWidth) : resolveColumnMinWidth(column);
+}
+
+export function resolveStickyRailWidth<T>(
+  columns: DataTableColumn<T>[],
+  widths: ColumnWidthMap,
+  edge: "start" | "end",
+) {
+  const edgeColumns = edge === "start" ? columns : [...columns].reverse();
+  let width = 0;
+  for (const column of edgeColumns) {
+    if (resolveColumnOrderLock(column) !== edge || !hasStickyColumnClass(column)) break;
+    width += resolveColumnLayoutWidth(column, widths);
+  }
+  return width;
+}
+
+export function resolveStickyColumnPlacements<T>(
+  columns: DataTableColumn<T>[],
+  widths: ColumnWidthMap,
+) {
+  const placements: Record<string, StickyColumnPlacement> = {};
+  let startOffset = 0;
+  for (const column of columns) {
+    if (resolveColumnOrderLock(column) !== "start" || !hasStickyColumnClass(column)) break;
+    placements[column.key] = { edge: "start", offset: startOffset };
+    startOffset += resolveColumnLayoutWidth(column, widths);
+  }
+  let endOffset = 0;
+  for (const column of [...columns].reverse()) {
+    if (resolveColumnOrderLock(column) !== "end" || !hasStickyColumnClass(column)) break;
+    placements[column.key] = { edge: "end", offset: endOffset };
+    endOffset += resolveColumnLayoutWidth(column, widths);
+  }
+  return placements;
+}
+
+export function normalizeColumnWidths<T>(columns: DataTableColumn<T>[], widths: ColumnWidthMap) {
+  const next: ColumnWidthMap = {};
+  columns.forEach((column) => {
+    const width = widths[column.key];
+    if (width !== undefined) next[column.key] = clampColumnWidth(column, width);
+  });
+  return next;
+}
+
+export function areColumnWidthMapsEqual(left: ColumnWidthMap, right: ColumnWidthMap) {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key) => left[key] === right[key]);
+}
+
+export function resolveColumnResizeWidth(active: ColumnResizeState, pointerClientX: number) {
+  const rawBoundaryClientX = pointerClientX + active.pointerBoundaryOffsetClientX;
+  return Math.max(
+    active.minWidth,
+    Math.min(active.maxWidth, Math.round(rawBoundaryClientX - active.startLeftClientX)),
+  );
+}

--- a/packages/ui/src/data-table/columnReorder.ts
+++ b/packages/ui/src/data-table/columnReorder.ts
@@ -1,0 +1,162 @@
+import type { DataTableColumn } from "./DataTable.types";
+import {
+  COLUMN_REORDER_SETTLE_CLEANUP_MS,
+  NON_REORDERABLE_COLUMN_KEYS,
+  type ColumnOrder,
+  type ColumnReorderGeometry,
+  type ColumnReorderState,
+} from "./dataTableModel";
+import { resolveColumnOrderLock } from "./tableStorage";
+
+export function shouldAllowColumnReorder<T>(column: DataTableColumn<T>) {
+  if (resolveColumnOrderLock(column) !== null) return false;
+  if (column.reorderable !== undefined) return column.reorderable;
+  if (NON_REORDERABLE_COLUMN_KEYS.has(column.key)) return false;
+  return true;
+}
+
+export function normalizeColumnOrder<T>(columns: DataTableColumn<T>[], storedOrder: ColumnOrder) {
+  const validKeys = new Set(columns.map((column) => column.key));
+  const seen = new Set<string>();
+  const storedValid = storedOrder.filter((key) => {
+    if (!validKeys.has(key) || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const missing = columns.map((column) => column.key).filter((key) => !seen.has(key));
+  const merged = [...storedValid, ...missing];
+
+  const startLocked = columns
+    .filter((column) => resolveColumnOrderLock(column) === "start")
+    .map((column) => column.key);
+  const endLocked = columns
+    .filter((column) => resolveColumnOrderLock(column) === "end")
+    .map((column) => column.key);
+  const locked = new Set([...startLocked, ...endLocked]);
+  const movable = merged.filter((key) => !locked.has(key));
+
+  return [...startLocked, ...movable, ...endLocked];
+}
+
+export function moveColumnKey(order: ColumnOrder, fromIndex: number, toIndex: number) {
+  if (fromIndex === toIndex || fromIndex < 0 || fromIndex >= order.length) return order;
+  const next = [...order];
+  const [item] = next.splice(fromIndex, 1);
+  if (!item) return order;
+  const normalizedTo = fromIndex < toIndex ? toIndex - 1 : toIndex;
+  next.splice(Math.max(0, Math.min(next.length, normalizedTo)), 0, item);
+  return next;
+}
+
+export function clampColumnReorderTarget(
+  toIndex: number,
+  minIndex: number,
+  maxIndex: number,
+  columnCount: number,
+) {
+  return Math.max(minIndex, Math.min(Math.min(maxIndex, columnCount), toIndex));
+}
+
+export function getColumnReorderDragOffset(
+  active: ColumnReorderState,
+  clientX: number,
+  scrollLeft: number,
+) {
+  return clientX - active.startClientX + (scrollLeft - active.startScrollLeft);
+}
+
+export function findColumnReorderTargetIndex(active: ColumnReorderState, dragOffsetX: number) {
+  const origin = active.columns[active.originIndex];
+  if (!origin) return active.originIndex;
+
+  const draggedCenter = origin.left + origin.width / 2 + dragOffsetX;
+  let nextIndex = active.allowedMaxIndex;
+  const maxMeasuredIndex = Math.min(active.allowedMaxIndex, active.columns.length);
+
+  for (let index = active.allowedMinIndex; index < maxMeasuredIndex; index += 1) {
+    const geometry = active.columns[index];
+    if (!geometry) continue;
+    const midpoint = geometry.left + geometry.width / 2;
+    if (draggedCenter < midpoint) {
+      nextIndex = index;
+      break;
+    }
+    nextIndex = index + 1;
+  }
+
+  return clampColumnReorderTarget(
+    nextIndex,
+    active.allowedMinIndex,
+    active.allowedMaxIndex,
+    active.columns.length,
+  );
+}
+
+export function getColumnReorderShift(active: ColumnReorderState, geometry: ColumnReorderGeometry) {
+  if (geometry.key === active.columnKey) return null;
+  const toIndex = active.currentToIndex;
+  const originIndex = active.originIndex;
+
+  if (toIndex < originIndex && geometry.index >= toIndex && geometry.index < originIndex) {
+    return active.draggedWidth;
+  }
+
+  if (toIndex > originIndex + 1 && geometry.index > originIndex && geometry.index < toIndex) {
+    return -active.draggedWidth;
+  }
+
+  return 0;
+}
+
+export function formatColumnReorderTransform(offsetX: number) {
+  if (Math.abs(offsetX) < 0.1) return "";
+  const rounded = Math.round(offsetX * 100) / 100;
+  return `translate3d(${rounded}px, 0, 0)`;
+}
+
+export function getColumnReorderCellBackground(element: HTMLElement, isDragged: boolean) {
+  const isHeader = element.tagName === "TH";
+  const isDark = document.documentElement.classList.contains("dark");
+  const base = isHeader
+    ? isDark
+      ? "rgb(38 38 38)"
+      : "rgb(241 245 249)"
+    : isDark
+      ? "rgb(10 10 10)"
+      : "rgb(255 255 255)";
+
+  if (!isDragged) return base;
+
+  const accent = isDark
+    ? isHeader
+      ? "linear-gradient(90deg, rgba(59, 130, 246, 0.24), rgba(34, 211, 238, 0.12))"
+      : "linear-gradient(90deg, rgba(59, 130, 246, 0.16), rgba(34, 211, 238, 0.08))"
+    : isHeader
+      ? "linear-gradient(90deg, rgba(37, 99, 235, 0.2), rgba(14, 165, 233, 0.1))"
+      : "linear-gradient(90deg, rgba(37, 99, 235, 0.1), rgba(14, 165, 233, 0.05))";
+
+  return `${accent}, ${base}`;
+}
+
+export function scheduleColumnReorderSettleCleanup(element: HTMLElement) {
+  window.setTimeout(() => {
+    if (
+      element.hasAttribute("data-vt-column-dragging-cell") ||
+      element.hasAttribute("data-vt-column-shifted-cell") ||
+      element.style.transform
+    ) {
+      return;
+    }
+
+    element.style.transition = "";
+    element.style.willChange = "";
+    element.style.position = "";
+    element.style.zIndex = "";
+    element.style.background = "";
+    element.style.overflow = "";
+    element.style.contain = "";
+    element.style.isolation = "";
+    element.style.borderRadius = "";
+  }, COLUMN_REORDER_SETTLE_CLEANUP_MS);
+}

--- a/packages/ui/src/data-table/dataTableModel.ts
+++ b/packages/ui/src/data-table/dataTableModel.ts
@@ -1,0 +1,127 @@
+import type { CSSProperties } from "react";
+
+export const DEFAULT_ROW_HEIGHT = 44;
+export const DEFAULT_OVERSCAN = 12;
+export const DEFAULT_SCROLL_THRESHOLD = 100;
+export const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
+export const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v1";
+export const COLUMN_RESIZE_DEBUG_STORAGE_KEY = "codeProxy.dataTable.debugResize";
+export const DEFAULT_MIN_COLUMN_WIDTH = 72;
+export const DEFAULT_MAX_COLUMN_WIDTH = 640;
+export const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
+export const STICKY_EDGE_SHADOW_WIDTH = 28;
+export const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
+export const TAILWIND_SPACING_UNIT_PX = 4;
+
+export const COLUMN_ORDER_STORAGE_PREFIX = "codeProxy.dataTable.columnOrder.v1";
+export const COLUMN_REORDER_ACTIVATION_DELAY_MS = 90;
+export const COLUMN_REORDER_MIN_DRAG_DISTANCE_PX = 4;
+export const COLUMN_REORDER_AUTOSCROLL_EDGE_PX = 72;
+export const COLUMN_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME = 22;
+export const COLUMN_REORDER_SHIFT_TRANSITION = "transform 72ms cubic-bezier(0.2, 0, 0, 1)";
+export const COLUMN_REORDER_SETTLE_CLEANUP_MS = 110;
+export const COLUMN_REORDER_SETTLE_FEEDBACK_MS = 900;
+export const NON_REORDERABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
+
+export const ROW_REORDER_COLUMN_KEY = "__data-table-row-reorder__";
+export const ROW_REORDER_MIN_DRAG_DISTANCE_PX = 4;
+export const ROW_REORDER_AUTOSCROLL_EDGE_PX = 56;
+export const ROW_REORDER_AUTOSCROLL_MAX_PX_PER_FRAME = 18;
+
+export type ColumnOrder = string[];
+export type ColumnWidthMap = Record<string, number>;
+
+export interface ColumnReorderGeometry {
+  key: string;
+  index: number;
+  left: number;
+  width: number;
+  elements: HTMLElement[];
+  appliedDragging: boolean;
+  appliedShift: number | null;
+  appliedTransform: string;
+}
+
+export interface ColumnReorderState {
+  pointerId: number;
+  columnKey: string;
+  originIndex: number;
+  currentToIndex: number;
+  startClientX: number;
+  startClientY: number;
+  startScrollLeft: number;
+  lastClientX: number;
+  lastClientY: number;
+  activated: boolean;
+  activationTimer: number | null;
+  allowedMinIndex: number;
+  allowedMaxIndex: number;
+  columns: ColumnReorderGeometry[];
+  draggedWidth: number;
+}
+
+export interface RowReorderGeometry {
+  index: number;
+  element: HTMLTableRowElement;
+  appliedShift: number;
+}
+
+export interface RowReorderState {
+  pointerId: number;
+  fromIndex: number;
+  insertionIndex: number;
+  startClientY: number;
+  lastClientY: number;
+  activated: boolean;
+  scrollContainer: HTMLElement | null;
+  sourceRow: HTMLTableRowElement | null;
+  previewElement: HTMLDivElement | null;
+  grabOffsetY: number;
+  previewHeight: number;
+  sourceHeight: number;
+  rows: RowReorderGeometry[];
+}
+
+export interface ColumnResizeState {
+  pointerId: number;
+  columnKey: string;
+  startLeftClientX: number;
+  pointerBoundaryOffsetClientX: number;
+  minWidth: number;
+  maxWidth: number;
+  previewTop: number;
+  previewBottom: number;
+  previewMinClientX: number;
+  previewMaxClientX: number;
+  currentWidth: number;
+  lastDebugAtMs: number;
+  debugEnabled: boolean;
+}
+
+export interface ColumnResizePreview {
+  width: number;
+  left: number;
+  top: number;
+  height: number;
+  tooltipTop: number;
+  visible: boolean;
+}
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollLeft: number;
+  scrollHeight: number;
+  scrollWidth: number;
+  clientHeight: number;
+  clientWidth: number;
+}
+
+export type StickyColumnPlacement = {
+  edge: "start" | "end";
+  offset: number;
+};
+
+export type DataTableColumnStyle = CSSProperties & {
+  "--vt-sticky-left"?: string;
+  "--vt-sticky-right"?: string;
+};

--- a/packages/ui/src/data-table/rowReorder.ts
+++ b/packages/ui/src/data-table/rowReorder.ts
@@ -1,0 +1,161 @@
+import type { RowReorderGeometry, RowReorderState } from "./dataTableModel";
+
+function syncClonedFormControlState(
+  sourceRow: HTMLTableRowElement,
+  clonedRow: HTMLTableRowElement,
+) {
+  const sourceControls = sourceRow.querySelectorAll<
+    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+  >("input, textarea, select");
+  const clonedControls = clonedRow.querySelectorAll<
+    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+  >("input, textarea, select");
+
+  clonedControls.forEach((clonedControl, index) => {
+    const sourceControl = sourceControls[index];
+    if (sourceControl) {
+      clonedControl.value = sourceControl.value;
+      if (sourceControl instanceof HTMLInputElement && clonedControl instanceof HTMLInputElement) {
+        clonedControl.checked = sourceControl.checked;
+      }
+    }
+    clonedControl.tabIndex = -1;
+  });
+}
+
+// Clone the rendered row so form controls keep their exact current appearance without re-running cell callbacks.
+export function createRowReorderPreviewElement(sourceRow: HTMLTableRowElement) {
+  const rowRect = sourceRow.getBoundingClientRect();
+  const clonedRow = sourceRow.cloneNode(true) as HTMLTableRowElement;
+  clonedRow.removeAttribute("data-vt-row-index");
+  clonedRow.removeAttribute("data-vt-row-key");
+  clonedRow.removeAttribute("data-vt-row-reorder-active");
+  clonedRow.removeAttribute("tabindex");
+  clonedRow.style.height = `${rowRect.height}px`;
+  clonedRow.style.opacity = "1";
+  clonedRow.style.background = "transparent";
+
+  clonedRow.querySelectorAll<HTMLElement>("[id]").forEach((element) => {
+    element.removeAttribute("id");
+  });
+  clonedRow.querySelectorAll<HTMLElement>("button, [href], [tabindex]").forEach((element) => {
+    element.removeAttribute("aria-label");
+    element.removeAttribute("title");
+    element.tabIndex = -1;
+  });
+  syncClonedFormControlState(sourceRow, clonedRow);
+
+  const sourceCells = Array.from(sourceRow.cells);
+  const clonedCells = Array.from(clonedRow.cells);
+  sourceCells.forEach((sourceCell, index) => {
+    const clonedCell = clonedCells[index];
+    if (!clonedCell) return;
+    clonedCell.style.borderTopWidth = "0";
+    clonedCell.style.borderBottomWidth = "0";
+
+    const cellWidth = sourceCell.getBoundingClientRect().width;
+    if (cellWidth <= 0) return;
+    const widthPx = `${cellWidth}px`;
+    clonedCell.style.width = widthPx;
+    clonedCell.style.minWidth = widthPx;
+    clonedCell.style.maxWidth = widthPx;
+  });
+
+  const table = document.createElement("table");
+  table.className = "w-full table-fixed border-separate border-spacing-0 text-sm";
+  const tbody = document.createElement("tbody");
+  tbody.appendChild(clonedRow);
+  table.appendChild(tbody);
+
+  const preview = document.createElement("div");
+  preview.dataset.vtRowReorderPreview = "true";
+  preview.setAttribute("aria-hidden", "true");
+  preview.className =
+    "pointer-events-none fixed left-0 top-0 z-[1100] box-border overflow-hidden rounded-xl border border-slate-200/90 bg-white shadow-[0_0_20px_rgba(15,23,42,0.16)] dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-[0_0_20px_rgba(0,0,0,0.42)]";
+  preview.style.left = `${rowRect.left}px`;
+  preview.style.width = `${Math.max(1, rowRect.width)}px`;
+  preview.style.height = `${Math.max(1, rowRect.height)}px`;
+  preview.style.willChange = "transform";
+  preview.appendChild(table);
+  document.body.appendChild(preview);
+
+  return { preview, height: Math.max(1, rowRect.height) };
+}
+
+export function positionRowReorderPreview(active: RowReorderState, clientY: number) {
+  if (!active.previewElement) return;
+  const viewportInset = 8;
+  const unclampedTop = clientY - active.grabOffsetY;
+  const maxTop = Math.max(viewportInset, window.innerHeight - active.previewHeight - viewportInset);
+  const top = Math.max(viewportInset, Math.min(maxTop, unclampedTop));
+  active.previewElement.style.transform = `translate3d(0, ${Math.round(top)}px, 0)`;
+}
+
+export function collectRowReorderGeometry(table: HTMLTableElement | null): RowReorderGeometry[] {
+  return Array.from(
+    table?.querySelectorAll<HTMLTableRowElement>("tbody tr[data-vt-row-index]") ?? [],
+  )
+    .map((element) => ({
+      index: Number(element.dataset.vtRowIndex),
+      element,
+      appliedShift: 0,
+    }))
+    .filter((item) => Number.isInteger(item.index));
+}
+
+export function resolveRowReorderDestination(active: RowReorderState, rowCount: number) {
+  return Math.max(
+    0,
+    Math.min(
+      rowCount - 1,
+      active.insertionIndex > active.fromIndex ? active.insertionIndex - 1 : active.insertionIndex,
+    ),
+  );
+}
+
+export function applyRowReorderDisplacement(active: RowReorderState, rowCount: number) {
+  const destinationIndex = resolveRowReorderDestination(active, rowCount);
+  for (const geometry of active.rows) {
+    if (geometry.index === active.fromIndex) {
+      geometry.element.style.opacity = "0";
+      geometry.element.style.pointerEvents = "none";
+      continue;
+    }
+
+    const shift =
+      active.fromIndex < destinationIndex &&
+      geometry.index > active.fromIndex &&
+      geometry.index <= destinationIndex
+        ? -active.sourceHeight
+        : active.fromIndex > destinationIndex &&
+            geometry.index >= destinationIndex &&
+            geometry.index < active.fromIndex
+          ? active.sourceHeight
+          : 0;
+    if (shift === geometry.appliedShift) continue;
+    geometry.appliedShift = shift;
+    geometry.element.style.willChange = "transform";
+    geometry.element.style.transition = "transform 140ms cubic-bezier(0.2, 0, 0, 1)";
+    geometry.element.style.transform =
+      shift === 0 ? "" : `translate3d(0, ${Math.round(shift)}px, 0)`;
+  }
+}
+
+export function resetRowReorderDisplacement(active: RowReorderState | null) {
+  for (const geometry of active?.rows ?? []) {
+    geometry.element.style.opacity = "";
+    geometry.element.style.pointerEvents = "";
+    geometry.element.style.willChange = "";
+    geometry.element.style.transition = "";
+    geometry.element.style.transform = "";
+  }
+}
+
+export function removeRowReorderVisuals(active: RowReorderState | null) {
+  resetRowReorderDisplacement(active);
+  active?.previewElement?.remove();
+}
+
+// ---------------------------------------------------------------------------
+// Column Order Helpers
+// ---------------------------------------------------------------------------

--- a/packages/ui/src/data-table/scrollMetrics.ts
+++ b/packages/ui/src/data-table/scrollMetrics.ts
@@ -1,0 +1,92 @@
+import type { ScrollMetrics } from "./dataTableModel";
+
+export function getStickyEdgeShadowOpacity(metrics: ScrollMetrics, edge: "start" | "end") {
+  const maxScrollLeft = Math.max(0, metrics.scrollWidth - metrics.clientWidth);
+  if (maxScrollLeft <= 1) return 0;
+  if (edge === "start") return metrics.scrollLeft > 1 ? 1 : 0;
+  return metrics.scrollLeft < maxScrollLeft - 1 ? 1 : 0;
+}
+
+export function hasHorizontalOverflow(metrics: ScrollMetrics) {
+  return metrics.scrollWidth > metrics.clientWidth + 1;
+}
+
+export function hasVerticalOverflow(metrics: ScrollMetrics, headerHeight: number) {
+  const effectiveViewportY = Math.max(0, metrics.clientHeight - headerHeight);
+  const effectiveContentY = Math.max(effectiveViewportY, metrics.scrollHeight - headerHeight);
+  return effectiveContentY > effectiveViewportY + 1;
+}
+
+export function calculateScrollbarThumbs(scrollMetrics: ScrollMetrics, headerHeight: number) {
+  const trackInset = 8;
+  const effectiveViewportY = Math.max(0, scrollMetrics.clientHeight - headerHeight);
+  const effectiveContentY = Math.max(effectiveViewportY, scrollMetrics.scrollHeight - headerHeight);
+  const hasV = hasVerticalOverflow(scrollMetrics, headerHeight);
+  const hasH = hasHorizontalOverflow(scrollMetrics);
+
+  const v = (() => {
+    if (!hasV) return null;
+    const trackLength = Math.max(0, scrollMetrics.clientHeight - headerHeight - trackInset * 2);
+    const viewport = Math.max(1, effectiveViewportY);
+    const content = Math.max(viewport, effectiveContentY);
+    const thumbLength = Math.max(28, Math.round((viewport / content) * trackLength));
+    const maxThumbOffset = Math.max(0, trackLength - thumbLength);
+    const scrollRange = Math.max(1, scrollMetrics.scrollHeight - scrollMetrics.clientHeight);
+    const offset = Math.min(
+      maxThumbOffset,
+      Math.max(0, Math.round((scrollMetrics.scrollTop / scrollRange) * maxThumbOffset)),
+    );
+    return { top: offset, height: thumbLength };
+  })();
+
+  const h = (() => {
+    if (!hasH) return null;
+    const trackLength = Math.max(0, scrollMetrics.clientWidth - trackInset * 2);
+    const viewport = scrollMetrics.clientWidth;
+    const content = scrollMetrics.scrollWidth;
+    const thumbLength = Math.max(28, Math.round((viewport / content) * trackLength));
+    const maxThumbOffset = Math.max(0, trackLength - thumbLength);
+    const scrollRange = Math.max(1, content - viewport);
+    const offset = Math.min(
+      maxThumbOffset,
+      Math.max(0, Math.round((scrollMetrics.scrollLeft / scrollRange) * maxThumbOffset)),
+    );
+    return { left: offset, width: thumbLength };
+  })();
+
+  return { vThumb: v, hThumb: h };
+}
+
+export function findVerticalScrollContainer(element: HTMLElement | null): HTMLElement | null {
+  let current = element?.parentElement ?? null;
+  while (current) {
+    const overflowY = window.getComputedStyle(current).overflowY;
+    if (/(auto|scroll)/.test(overflowY) && current.scrollHeight > current.clientHeight) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  const scrollingElement = document.scrollingElement;
+  return scrollingElement instanceof HTMLElement ? scrollingElement : null;
+}
+
+export function findVerticalScrollTarget(element: HTMLElement, deltaY: number): HTMLElement | null {
+  let current = element.parentElement;
+  while (current) {
+    const overflowY = window.getComputedStyle(current).overflowY;
+    const maxScrollTop = Math.max(0, current.scrollHeight - current.clientHeight);
+    const canMove =
+      /(auto|scroll)/.test(overflowY) &&
+      ((deltaY < 0 && current.scrollTop > 0) || (deltaY > 0 && current.scrollTop < maxScrollTop));
+    if (canMove) return current;
+    current = current.parentElement;
+  }
+
+  const scrollingElement = document.scrollingElement;
+  if (!(scrollingElement instanceof HTMLElement)) return null;
+  const maxScrollTop = Math.max(0, scrollingElement.scrollHeight - scrollingElement.clientHeight);
+  return (deltaY < 0 && scrollingElement.scrollTop > 0) ||
+    (deltaY > 0 && scrollingElement.scrollTop < maxScrollTop)
+    ? scrollingElement
+    : null;
+}

--- a/packages/ui/src/data-table/sortUtils.ts
+++ b/packages/ui/src/data-table/sortUtils.ts
@@ -1,0 +1,30 @@
+import type { DataTableSortValue } from "./DataTable.types";
+
+export function isEmptySortValue(value: DataTableSortValue) {
+  return value === null || value === undefined || (typeof value === "string" && !value.trim());
+}
+
+export function compareSortValues(
+  left: DataTableSortValue,
+  right: DataTableSortValue,
+  collator: Intl.Collator,
+) {
+  const leftEmpty = isEmptySortValue(left);
+  const rightEmpty = isEmptySortValue(right);
+  if (leftEmpty || rightEmpty) {
+    if (leftEmpty && rightEmpty) return 0;
+    return leftEmpty ? 1 : -1;
+  }
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+  return collator.compare(String(left), String(right));
+}
+
+export function moveRow<T>(rows: readonly T[], fromIndex: number, toIndex: number): T[] {
+  const next = Array.from(rows);
+  const [moved] = next.splice(fromIndex, 1);
+  if (moved === undefined) return next;
+  next.splice(toIndex, 0, moved);
+  return next;
+}

--- a/packages/ui/src/data-table/tableStorage.ts
+++ b/packages/ui/src/data-table/tableStorage.ts
@@ -1,139 +1,43 @@
 import type { DataTableColumn } from "./DataTable.types";
+import {
+  COLUMN_ORDER_STORAGE_PREFIX,
+  COLUMN_RESIZE_DEBUG_STORAGE_KEY,
+  COLUMN_WIDTH_STORAGE_PREFIX,
+  DEFAULT_MAX_COLUMN_WIDTH,
+  DEFAULT_MIN_COLUMN_WIDTH,
+  NON_RESIZABLE_COLUMN_KEYS,
+  TAILWIND_SPACING_UNIT_PX,
+  type ColumnOrder,
+  type ColumnWidthMap,
+} from "./dataTableModel";
 
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-export const DEFAULT_ROW_HEIGHT = 44;
-export const DEFAULT_OVERSCAN = 12;
-export const DEFAULT_SCROLL_THRESHOLD = 100;
-export const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
-export const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v1";
-export const COLUMN_RESIZE_DEBUG_STORAGE_KEY = "codeProxy.dataTable.debugResize";
-export const DEFAULT_MIN_COLUMN_WIDTH = 72;
-export const DEFAULT_MAX_COLUMN_WIDTH = 640;
-export const COLUMN_RESIZE_PREVIEW_LINE_WIDTH = 2;
-export const NON_RESIZABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
-const TAILWIND_SPACING_UNIT_PX = 4;
+export {
+  DEFAULT_ROW_HEIGHT,
+  DEFAULT_OVERSCAN,
+  DEFAULT_SCROLL_THRESHOLD,
+  DEFAULT_BOTTOM_DEBOUNCE_MS,
+  COLUMN_WIDTH_STORAGE_PREFIX,
+  COLUMN_RESIZE_DEBUG_STORAGE_KEY,
+  DEFAULT_MIN_COLUMN_WIDTH,
+  DEFAULT_MAX_COLUMN_WIDTH,
+  COLUMN_RESIZE_PREVIEW_LINE_WIDTH,
+  NON_RESIZABLE_COLUMN_KEYS,
+  COLUMN_ORDER_STORAGE_PREFIX,
+  COLUMN_REORDER_ACTIVATION_DELAY_MS,
+  COLUMN_REORDER_MIN_DRAG_DISTANCE_PX,
+  NON_REORDERABLE_COLUMN_KEYS,
+  type ColumnOrder,
+  type ColumnWidthMap,
+  type ColumnResizeState,
+  type ColumnResizePreview,
+  type ScrollMetrics,
+} from "./dataTableModel";
 
-// ---------------------------------------------------------------------------
-// Column Reorder
-// ---------------------------------------------------------------------------
-export const COLUMN_ORDER_STORAGE_PREFIX = "codeProxy.dataTable.columnOrder.v1";
-export const COLUMN_REORDER_ACTIVATION_DELAY_MS = 180;
-export const COLUMN_REORDER_MIN_DRAG_DISTANCE_PX = 4;
-export const NON_REORDERABLE_COLUMN_KEYS = new Set(["select", "action", "actions"]);
-
-export type ColumnOrder = string[];
-
-export interface ColumnReorderState {
-  pointerId: number;
-  columnKey: string;
-  originIndex: number;
-  currentIndex: number;
-  startClientX: number;
-  startClientY: number;
-  activated: boolean;
-  activationTimer: number | null;
-  allowedMinIndex: number;
-  allowedMaxIndex: number;
-}
-
-export interface ColumnReorderPreview {
-  fromIndex: number;
-  toIndex: number;
-  left: number;
-  top: number;
-  height: number;
-}
-
-export type ColumnWidthMap = Record<string, number>;
-
-export interface ColumnResizeState {
-  pointerId: number;
-  columnKey: string;
-  startLeftClientX: number;
-  pointerBoundaryOffsetClientX: number;
-  minWidth: number;
-  maxWidth: number;
-  previewTop: number;
-  previewBottom: number;
-  currentWidth: number;
-  lastDebugAtMs: number;
-  debugEnabled: boolean;
-}
-
-export interface ColumnResizePreview {
-  width: number;
-  left: number;
-  top: number;
-  height: number;
-  tooltipTop: number;
-}
-
-export interface ScrollMetrics {
-  scrollTop: number;
-  scrollLeft: number;
-  scrollHeight: number;
-  scrollWidth: number;
-  clientHeight: number;
-  clientWidth: number;
-}
-
-export function hasHorizontalOverflow(metrics: ScrollMetrics) {
-  return metrics.scrollWidth > metrics.clientWidth + 1;
-}
-
-export function hasVerticalOverflow(metrics: ScrollMetrics, headerHeight: number) {
-  const effectiveViewportY = Math.max(0, metrics.clientHeight - headerHeight);
-  const effectiveContentY = Math.max(effectiveViewportY, metrics.scrollHeight - headerHeight);
-  return effectiveContentY > effectiveViewportY + 1;
-}
-
-export function calculateScrollbarThumbs(scrollMetrics: ScrollMetrics, headerHeight: number) {
-  const trackInset = 8; // matches `inset-y-2` / `inset-x-2` (8px)
-  const effectiveViewportY = Math.max(0, scrollMetrics.clientHeight - headerHeight);
-  const effectiveContentY = Math.max(effectiveViewportY, scrollMetrics.scrollHeight - headerHeight);
-  const hasV = hasVerticalOverflow(scrollMetrics, headerHeight);
-  const hasH = hasHorizontalOverflow(scrollMetrics);
-
-  const v = (() => {
-    if (!hasV) return null;
-    const trackLength = Math.max(0, scrollMetrics.clientHeight - headerHeight - trackInset * 2);
-    const viewport = Math.max(1, effectiveViewportY);
-    const content = Math.max(viewport, effectiveContentY);
-    const thumbLength = Math.max(28, Math.round((viewport / content) * trackLength));
-    const maxThumbOffset = Math.max(0, trackLength - thumbLength);
-    const scrollRange = Math.max(1, scrollMetrics.scrollHeight - scrollMetrics.clientHeight);
-    const offset = Math.min(
-      maxThumbOffset,
-      Math.max(0, Math.round((scrollMetrics.scrollTop / scrollRange) * maxThumbOffset)),
-    );
-    return { top: offset, height: thumbLength };
-  })();
-
-  const h = (() => {
-    if (!hasH) return null;
-    const trackLength = Math.max(0, scrollMetrics.clientWidth - trackInset * 2);
-    const viewport = scrollMetrics.clientWidth;
-    const content = scrollMetrics.scrollWidth;
-    const thumbLength = Math.max(28, Math.round((viewport / content) * trackLength));
-    const maxThumbOffset = Math.max(0, trackLength - thumbLength);
-    const scrollRange = Math.max(1, content - viewport);
-    const offset = Math.min(
-      maxThumbOffset,
-      Math.max(0, Math.round((scrollMetrics.scrollLeft / scrollRange) * maxThumbOffset)),
-    );
-    return { left: offset, width: thumbLength };
-  })();
-
-  return { vThumb: v, hThumb: h };
-}
-
-export function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
-  const minWidth = resolveColumnMinWidth(column);
-  const maxWidth = resolveColumnMaxWidth(column, minWidth);
-  return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
-}
+export {
+  hasHorizontalOverflow,
+  hasVerticalOverflow,
+  calculateScrollbarThumbs,
+} from "./scrollMetrics";
 
 function parseTailwindSizePx(token: string) {
   const arbitrary = token.match(/^\[(\d+(?:\.\d+)?)(px|rem)\]$/);
@@ -142,9 +46,7 @@ function parseTailwindSizePx(token: string) {
     if (!Number.isFinite(value)) return null;
     return arbitrary[2] === "rem" ? Math.round(value * 16) : Math.round(value);
   }
-
   if (token === "px") return 1;
-
   const numeric = Number(token);
   if (!Number.isFinite(numeric)) return null;
   return Math.round(numeric * TAILWIND_SPACING_UNIT_PX);
@@ -162,7 +64,9 @@ function resolveWidthClassPx(width: string | undefined, prefix: string) {
 }
 
 export function resolveColumnMinWidth<T>(column: DataTableColumn<T>) {
-  return column.minWidthPx ?? resolveWidthClassPx(column.width, "min-w") ?? DEFAULT_MIN_COLUMN_WIDTH;
+  return (
+    column.minWidthPx ?? resolveWidthClassPx(column.width, "min-w") ?? DEFAULT_MIN_COLUMN_WIDTH
+  );
 }
 
 export function resolveColumnMaxWidth<T>(
@@ -170,6 +74,12 @@ export function resolveColumnMaxWidth<T>(
   minWidth = resolveColumnMinWidth(column),
 ) {
   return Math.max(minWidth, column.maxWidthPx ?? DEFAULT_MAX_COLUMN_WIDTH);
+}
+
+export function clampColumnWidth<T>(column: DataTableColumn<T>, width: number) {
+  const minWidth = resolveColumnMinWidth(column);
+  const maxWidth = resolveColumnMaxWidth(column, minWidth);
+  return Math.max(minWidth, Math.min(maxWidth, Math.round(width)));
 }
 
 export function getColumnWidthStorageKey(tableId?: string) {
@@ -180,13 +90,11 @@ export function getColumnWidthStorageKey(tableId?: string) {
 export function readStoredColumnWidths(tableId?: string): ColumnWidthMap {
   const key = getColumnWidthStorageKey(tableId);
   if (!key || typeof window === "undefined") return {};
-
   try {
     const raw = window.localStorage.getItem(key);
     if (!raw) return {};
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-
     return Object.fromEntries(
       Object.entries(parsed as Record<string, unknown>)
         .filter(([, value]) => typeof value === "number" && Number.isFinite(value))
@@ -200,7 +108,6 @@ export function readStoredColumnWidths(tableId?: string): ColumnWidthMap {
 export function writeStoredColumnWidths(tableId: string | undefined, widths: ColumnWidthMap) {
   const key = getColumnWidthStorageKey(tableId);
   if (!key || typeof window === "undefined") return;
-
   try {
     const normalized = Object.fromEntries(
       Object.entries(widths).filter(([, value]) => Number.isFinite(value) && value > 0),
@@ -234,12 +141,10 @@ export function shouldAllowColumnResize<T>(
 
 export function resolveCellOverflowTooltip<T>(column: DataTableColumn<T>, row: T, index: number) {
   if (column.overflowTooltip === false) return false;
-
   if (typeof column.overflowTooltip === "function") {
     const value = column.overflowTooltip(row, index);
     return value === null || value === undefined ? null : String(value);
   }
-
   return undefined;
 }
 
@@ -253,12 +158,12 @@ export function safeSetPointerCapture(element: Element, pointerId: number) {
   }
 }
 
-function getColumnOrderStorageKey(tableId?: string) {
+export function getColumnOrderStorageKey(tableId?: string) {
   const trimmed = tableId?.trim();
   return trimmed ? `${COLUMN_ORDER_STORAGE_PREFIX}.${trimmed}` : null;
 }
 
-function readStoredColumnOrder(tableId?: string): ColumnOrder {
+export function readStoredColumnOrder(tableId?: string): ColumnOrder {
   const key = getColumnOrderStorageKey(tableId);
   if (!key || typeof window === "undefined") return [];
   try {
@@ -274,25 +179,20 @@ function readStoredColumnOrder(tableId?: string): ColumnOrder {
   }
 }
 
-function writeStoredColumnOrder(tableId: string | undefined, order: ColumnOrder) {
+export function writeStoredColumnOrder(tableId: string | undefined, order: ColumnOrder) {
   const key = getColumnOrderStorageKey(tableId);
   if (!key || typeof window === "undefined") return;
   try {
     const normalized = Array.from(new Set(order.filter((value) => value.trim() !== "")));
     window.localStorage.setItem(key, JSON.stringify(normalized));
-  } catch {}
+  } catch {
+    // localStorage can be unavailable in private browsing or embedded contexts.
+  }
 }
 
-function resolveColumnOrderLock<T>(column: DataTableColumn<T>) {
+export function resolveColumnOrderLock<T>(column: DataTableColumn<T>) {
   if (column.lockOrder) return column.lockOrder;
   if (column.key === "select") return "start";
   if (column.key === "action" || column.key === "actions") return "end";
   return null;
 }
-
-export {
-  getColumnOrderStorageKey,
-  readStoredColumnOrder,
-  writeStoredColumnOrder,
-  resolveColumnOrderLock,
-};


### PR DESCRIPTION
## Summary
- Move `data-vt-header-chrome` to the table viewport layer (`absolute`, width = clientWidth) so the header plate no longer stretches with content and peels at horizontal scroll edges.
- Free-scroll header cells stay transparent over the chrome plate; sticky locked columns remain opaque.
- Split oversized `DataTable.tsx` into focused modules: model, scroll metrics, column layout/reorder, row reorder, sort utils, storage.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full test:ci 734, build, bundle:diff, critical e2e)
- [x] `bun run --filter @code-proxy/admin-panel test -- packages/ui/src/data-table` (11/11)
- [ ] Manually verify request logs table header corners stay intact while scrolling horizontally left/right