### PR TITLE
fix(data-table): restore outer sticky header side radius

### DIFF
--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2145,9 +2145,14 @@ export function DataTable<T>({
                     naturalFlow || isEmpty ? undefined : stickyColumnPlacements[col.key];
                   const headerPositionClass =
                     naturalFlow || isEmpty ? "relative" : "sticky top-0 z-50";
-                  // Viewport header-chrome owns the rounded plate. Sticky cells
-                  // stay opaque so locked columns cover scrolling middle labels;
-                  // free-scroll headers stay transparent over the chrome plate.
+                  // Viewport header-chrome owns the top plate. Opaque sticky
+                  // headers cover scrolling middle labels; outer sticky cells
+                  // still need side radius so bottom corners aren't squared off.
+                  // Free-scroll headers stay transparent over the chrome plate.
+                  const isOuterStickyStart =
+                    stickyPlacement?.edge === "start" && stickyPlacement.offset === 0;
+                  const isOuterStickyEnd =
+                    stickyPlacement?.edge === "end" && stickyPlacement.offset === 0;
                   const headerChromeClass =
                     naturalFlow || isEmpty || stickyPlacement
                       ? "bg-slate-100 dark:bg-neutral-800"
@@ -2155,6 +2160,12 @@ export function DataTable<T>({
                   const headerCornerClass = [
                     naturalFlow && colIndex === 0 ? "rounded-l-xl" : "",
                     naturalFlow && colIndex === orderedColumns.length - 1 ? "rounded-r-xl" : "",
+                    !naturalFlow && (colIndex === 0 || isOuterStickyStart) ? "rounded-l-xl" : "",
+                    // Gutter only paints the scrollbar strip; actions column owns right radius.
+                    !naturalFlow &&
+                    (isOuterStickyEnd || colIndex === orderedColumns.length - 1)
+                      ? "rounded-r-xl"
+                      : "",
                   ]
                     .filter(Boolean)
                     .join(" ");

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -426,12 +426,11 @@ describe("DataTable scroll chrome and row dividers", () => {
     const actionsHeader = document.querySelector('th[data-vt-column-key="actions"]');
     const headerGutter = document.querySelector("[data-vt-header-gutter]");
     // Sticky cells stay opaque; free middle headers stay transparent over chrome.
-    // Corner radius lives on the viewport chrome (and gutter), not per th.
-    expect(selectHeader).toHaveClass("bg-slate-100");
-    expect(selectHeader).not.toHaveClass("rounded-l-xl");
+    // Outer sticky headers own side radius (top+bottom) so fixed columns don't square corners.
+    expect(selectHeader).toHaveClass("bg-slate-100", "rounded-l-xl");
     expect(nameHeader).toHaveClass("bg-transparent");
-    expect(actionsHeader).toHaveClass("bg-slate-100");
-    expect(actionsHeader).not.toHaveClass("rounded-r-xl");
+    expect(nameHeader).not.toHaveClass("rounded-l-xl", "rounded-r-xl");
+    expect(actionsHeader).toHaveClass("bg-slate-100", "rounded-r-xl");
     expect(headerChrome).toHaveClass("absolute", "left-0", "top-0");
     // With a vertical gutter, chrome is left-only; otherwise full rounded-xl.
     if (headerGutter) {


### PR DESCRIPTION
## Summary
- 固定列存在时，不透明 sticky 表头盖住 viewport chrome 底板，导致表头左右下角变直角
- 恢复外层 sticky `th` 的 `rounded-l-xl` / `rounded-r-xl` 侧圆角
- 同步更新 DataTable 交互测试断言

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx`（8/8 通过）
- [ ] API Keys 页有固定列时，表头左右下角应为圆角