### PR TITLE
fix(auth-files): use weekly_limit reset for xAI week restriction recovery

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -697,6 +697,38 @@ export type AuthFileRestrictionBadge = {
 const readRestrictionDateMs = (restriction: AuthFileRestriction): number | null =>
   parseDateLikeMs(restriction.next_retry_after) ?? parseDateLikeMs(restriction.next_recover_at);
 
+// Grok/xAI weekly 402: user-facing recovery is the weekly period end (quota preview
+// weekly_limit.resetAtMs), not short local probe NextRetryAfter when upstream omits reset.
+const resolveRestrictionRecoverAtMs = (
+  restriction: AuthFileRestriction,
+  nowMs: number,
+  weeklyResetAtMs?: number | null,
+): number | null => {
+  const quotaWindow = normalizeRestrictionQuotaWindow(restriction);
+  const weekly =
+    typeof weeklyResetAtMs === "number" && Number.isFinite(weeklyResetAtMs) && weeklyResetAtMs > nowMs
+      ? weeklyResetAtMs
+      : null;
+  if (quotaWindow === "week" && weekly !== null) {
+    return weekly;
+  }
+  return readRestrictionDateMs(restriction);
+};
+
+export const resolveAuthFileWeeklyQuotaResetAtMs = (
+  items: Array<{ key?: string; label?: string; resetAtMs?: number }> | null | undefined,
+): number | null => {
+  if (!Array.isArray(items) || items.length === 0) return null;
+  const weekly = items.find((item) => {
+    const key = normalizeTagValue(item.key);
+    if (key === "weekly_limit" || key === "week" || key.includes("weekly")) return true;
+    const label = normalizeQuotaLabel(item.label ?? "");
+    return label.includes("weekly") || label.includes("week") || label.includes("周");
+  });
+  const resetAtMs = weekly?.resetAtMs;
+  return typeof resetAtMs === "number" && Number.isFinite(resetAtMs) ? resetAtMs : null;
+};
+
 const isLegacyAuthRestrictionActive = (file: AuthFileItem): boolean => {
   if (file.unavailable === true) return true;
   const status = normalizeTagValue(file.status);
@@ -996,6 +1028,7 @@ const resolveRestrictionReason = (restriction: AuthFileRestriction): string => {
 export const resolveAuthFileRestrictionBadges = (
   file: AuthFileItem,
   nowMs = Date.now(),
+  weeklyResetAtMs?: number | null,
 ): AuthFileRestrictionBadge[] => {
   const rawRestrictions = Array.isArray(file.restrictions) ? file.restrictions : [];
   const displayableRawRestrictions = rawRestrictions.filter((restriction) => {
@@ -1022,11 +1055,11 @@ export const resolveAuthFileRestrictionBadges = (
 
   return restrictions
     .map((restriction): AuthFileRestrictionBadge | null => {
-      const recoverAtMs = readRestrictionDateMs(restriction);
+      const recoverAtMs = resolveRestrictionRecoverAtMs(restriction, nowMs, weeklyResetAtMs);
       if (recoverAtMs !== null && recoverAtMs <= nowMs) return null;
       const model = typeof restriction.model === "string" ? restriction.model.trim() : "";
       const reason = resolveRestrictionReason(restriction);
-      const dateKey =
+      const restrictionDateKey =
         typeof restriction.next_retry_after === "string" ||
         typeof restriction.next_retry_after === "number"
           ? String(restriction.next_retry_after)
@@ -1034,6 +1067,9 @@ export const resolveAuthFileRestrictionBadges = (
               typeof restriction.next_recover_at === "number"
             ? String(restriction.next_recover_at)
             : "";
+      // Prefer raw restriction timestamps for key stability; weekly_limit only fills gaps.
+      const dateKey =
+        restrictionDateKey || (recoverAtMs !== null ? String(recoverAtMs) : "");
       const status = Number(restriction.http_status);
       const statusKey = Number.isFinite(status) && status > 0 ? String(Math.round(status)) : "";
       const quotaWindow = normalizeRestrictionQuotaWindow(restriction);

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -688,6 +688,36 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
     ]);
   });
 
+  test("xAI week restriction uses weekly_limit resetAtMs as recovery time", () => {
+    const nowMs = Date.parse("2026-07-14T08:00:00.000Z");
+    const weeklyResetAtMs = Date.parse("2026-07-16T07:38:00.000Z");
+    const file = {
+      name: "xai.json",
+      restrictions: [
+        {
+          scope: "auth",
+          http_status: 402,
+          quota_exceeded: true,
+          reason: "quota",
+          quota_window: "week",
+          quota_window_minutes: 10080,
+          status_message: "Grok Build usage balance exhausted",
+          // short local probe cooldown — not user-facing weekly recovery
+          next_retry_after: "2026-07-14T08:01:00.000Z",
+        },
+      ],
+    } as AuthFileItem;
+
+    expect(resolveAuthFileRestrictionBadges(file, nowMs, weeklyResetAtMs)).toEqual([
+      expect.objectContaining({
+        label: "402 Error",
+        quotaWindow: "week",
+        quotaLimited: true,
+        recoverAtMs: weeklyResetAtMs,
+      }),
+    ]);
+  });
+
   test("does not derive restriction badges from normal auth status", () => {
     expect(
       resolveAuthFileRestrictionBadges({

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -35,6 +35,7 @@ import {
   resolveAuthFileDisplayName,
   resolveAuthFilePlanType,
   resolveAuthFileRestrictionBadges,
+  resolveAuthFileWeeklyQuotaResetAtMs,
   resolveAuthFileSupplementalTags,
   resolveAuthFileStats,
   resolveAuthFileStatusBar,
@@ -308,7 +309,11 @@ export function useAuthFilesFilesPresentation({
 
   const renderRestrictionBadges = useCallback(
     (file: AuthFileItem): ReactNode | null => {
-      const badges = resolveAuthFileRestrictionBadges(file, nowMs);
+      // xAI week restriction recovery is the account weekly_limit reset, not probe cooldown.
+      const weeklyResetAtMs = resolveAuthFileWeeklyQuotaResetAtMs(
+        quotaByFileName[file.name]?.items,
+      );
+      const badges = resolveAuthFileRestrictionBadges(file, nowMs, weeklyResetAtMs);
       if (badges.length === 0) return null;
       return (
         <div className="flex min-w-0 flex-wrap gap-1.5">
@@ -329,7 +334,7 @@ export function useAuthFilesFilesPresentation({
         </div>
       );
     },
-    [formatRestrictionBadgeLabel, formatRestrictionTooltip, nowMs],
+    [formatRestrictionBadgeLabel, formatRestrictionTooltip, nowMs, quotaByFileName],
   );
 
   const renderClaudeOAuthHealthBadges = useCallback(


### PR DESCRIPTION
## Summary
- Grok/xAI OAuth 周限制（402 + `quota_window=week`）的自动恢复时间使用账号周限额 `weekly_limit.resetAtMs`
- 避免上游未给 reset、restriction 只有短 probe cooldown 时 tooltip 显示「暂无自动恢复时间」
- 卡片渲染时从已有 quota preview items 取周重置时间传入 badge 解析

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / e2e critical）
- [x] `auth-files-helpers` 新增：402 week + 短 `next_retry_after` → `recoverAtMs` 等于 `weekly_limit` 重置时间
- [ ] 管理端 auth-files 卡片：xAI 402 周限制 tooltip 显示与周限额相同的「还有 X 天…」倒计时