### PR TITLE
fix(data-table): keep locked headers above free-scroll labels

### DIFF
--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2143,8 +2143,16 @@ export function DataTable<T>({
                   const isSettledReorderColumn = settledReorderColumnKey === col.key;
                   const stickyPlacement =
                     naturalFlow || isEmpty ? undefined : stickyColumnPlacements[col.key];
+                  // All headers stick vertically. Free headers stay low z so they
+                  // scroll under locked headers; locked headers use z-[70] (also set
+                  // inline in resolveColumnStyle) above free z-10 and chrome z-40.
+                  // headerClassName may ship md:z-40 — put our z after it.
                   const headerPositionClass =
-                    naturalFlow || isEmpty ? "relative" : "sticky top-0 z-50";
+                    naturalFlow || isEmpty
+                      ? "relative"
+                      : stickyPlacement
+                        ? "sticky top-0"
+                        : "sticky top-0 z-10";
                   // Viewport header-chrome owns the top plate. Opaque sticky
                   // headers cover scrolling middle labels; outer sticky cells
                   // still need side radius so bottom corners aren't squared off.
@@ -2186,6 +2194,8 @@ export function DataTable<T>({
                       } ${headerChromeClass} ${headerCornerClass} ${
                         isEmpty ? "" : (col.width ?? "")
                       } ${col.headerClassName ?? ""} ${
+                        stickyPlacement ? "z-[70]" : ""
+                      } ${
                         activeReorderColumnKey === col.key
                           ? "cursor-grabbing bg-slate-100 text-slate-700 shadow-[inset_2px_0_0_rgba(37,99,235,0.42),inset_-2px_0_0_rgba(14,165,233,0.28)] dark:bg-neutral-800 dark:text-white/80"
                           : ""

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -427,10 +427,13 @@ describe("DataTable scroll chrome and row dividers", () => {
     const headerGutter = document.querySelector("[data-vt-header-gutter]");
     // Sticky cells stay opaque; free middle headers stay transparent over chrome.
     // Outer sticky headers own side radius (top+bottom) so fixed columns don't square corners.
-    expect(selectHeader).toHaveClass("bg-slate-100", "rounded-l-xl");
-    expect(nameHeader).toHaveClass("bg-transparent");
-    expect(nameHeader).not.toHaveClass("rounded-l-xl", "rounded-r-xl");
-    expect(actionsHeader).toHaveClass("bg-slate-100", "rounded-r-xl");
+    // Locked headers (z-70) stack above free headers (z-10) during horizontal scroll.
+    expect(selectHeader).toHaveClass("bg-slate-100", "rounded-l-xl", "z-[70]");
+    expect(selectHeader).toHaveStyle({ zIndex: "70" });
+    expect(nameHeader).toHaveClass("bg-transparent", "z-10");
+    expect(nameHeader).not.toHaveClass("rounded-l-xl", "rounded-r-xl", "z-[70]");
+    expect(actionsHeader).toHaveClass("bg-slate-100", "rounded-r-xl", "z-[70]");
+    expect(actionsHeader).toHaveStyle({ zIndex: "70" });
     expect(headerChrome).toHaveClass("absolute", "left-0", "top-0");
     // With a vertical gutter, chrome is left-only; otherwise full rounded-xl.
     if (headerGutter) {


### PR DESCRIPTION
## Summary
- 横向滚动时中间列表头盖住固定列表头（名称/操作叠字）
- 根因：自由列表头 `z-50` 高于页面 sticky 列的 `md:z-40`
- 自由列表头降为 `z-10`，锁定列表头在 `headerClassName` 后强制 `z-[70]`（与 `resolveColumnStyle` 一致）

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx`（15/15）
- [ ] API Keys 横向滚动：固定列「名称」「操作」不再与中间列名重叠