### PR TITLE
fix(data-table): keep free header labels above chrome plate

### DIFF
--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2143,16 +2143,16 @@ export function DataTable<T>({
                   const isSettledReorderColumn = settledReorderColumnKey === col.key;
                   const stickyPlacement =
                     naturalFlow || isEmpty ? undefined : stickyColumnPlacements[col.key];
-                  // All headers stick vertically. Free headers stay low z so they
-                  // scroll under locked headers; locked headers use z-[70] (also set
-                  // inline in resolveColumnStyle) above free z-10 and chrome z-40.
+                  // Stack: chrome z-40 < free headers z-50 < locked headers z-70.
+                  // Free must sit above chrome so labels stay visible; locked must
+                  // sit above free so horizontal scroll cannot overlay titles.
                   // headerClassName may ship md:z-40 — put our z after it.
                   const headerPositionClass =
                     naturalFlow || isEmpty
                       ? "relative"
                       : stickyPlacement
                         ? "sticky top-0"
-                        : "sticky top-0 z-10";
+                        : "sticky top-0 z-50";
                   // Viewport header-chrome owns the top plate. Opaque sticky
                   // headers cover scrolling middle labels; outer sticky cells
                   // still need side radius so bottom corners aren't squared off.

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -427,10 +427,10 @@ describe("DataTable scroll chrome and row dividers", () => {
     const headerGutter = document.querySelector("[data-vt-header-gutter]");
     // Sticky cells stay opaque; free middle headers stay transparent over chrome.
     // Outer sticky headers own side radius (top+bottom) so fixed columns don't square corners.
-    // Locked headers (z-70) stack above free headers (z-10) during horizontal scroll.
+    // Stack: chrome z-40 < free z-50 < locked z-70.
     expect(selectHeader).toHaveClass("bg-slate-100", "rounded-l-xl", "z-[70]");
     expect(selectHeader).toHaveStyle({ zIndex: "70" });
-    expect(nameHeader).toHaveClass("bg-transparent", "z-10");
+    expect(nameHeader).toHaveClass("bg-transparent", "z-50");
     expect(nameHeader).not.toHaveClass("rounded-l-xl", "rounded-r-xl", "z-[70]");
     expect(actionsHeader).toHaveClass("bg-slate-100", "rounded-r-xl", "z-[70]");
     expect(actionsHeader).toHaveStyle({ zIndex: "70" });


### PR DESCRIPTION
## Summary
- #711 把自由列表头降到 z-10，导致中间列名被 header chrome（z-40）盖住
- 恢复自由列表头为 z-50：chrome z-40 < free z-50 < locked z-70
- 固定列仍 z-70，横向滚动不叠字

## Test plan
- [x] DataTable.interactions 8/8
- [ ] API Keys：中间列名可见；横向滚动固定列不叠字