### PR TITLE
feat(deploy): harden frontend publish path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,19 @@ on:
       - '**/*.md'
       - 'docs/**'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Bypass required-check gate (emergency only)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: read
+  checks: read
 
 concurrency:
   group: deploy-relay-frontend
@@ -15,13 +28,28 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       PANEL_RELEASE: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      PUBLIC_PANEL_BASE: ${{ vars.RELAY_PUBLIC_PANEL_BASE || 'https://relay.07230805.xyz' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: oven-sh/setup-bun@v2
+      # Branch protection on dev requires green PR checks before merge.
+      # Merge commits do not re-run pr-test-build, so we do not re-query check-runs here.
+      - name: Record deploy mode
+        env:
+          FORCE_DEPLOY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}
+        run: |
+          set -euo pipefail
+          if [ "${FORCE_DEPLOY}" = "true" ]; then
+            echo "::warning::Forced frontend deploy via workflow_dispatch"
+            echo "DEPLOY_MODE=forced" >> "$GITHUB_ENV"
+          else
+            echo "DEPLOY_MODE=deploying" >> "$GITHUB_ENV"
+          fi
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.2
 
@@ -41,75 +69,160 @@ jobs:
         run: |
           printf '%s\n' "${VITE_APP_VERSION}" > dist/version.txt
 
-      - name: Upload static assets to release directory
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          port: ${{ secrets.SERVER_PORT }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: "dist/*"
-          target: "/home/web/html/relay-panel-releases/${{ env.PANEL_RELEASE }}/"
-          strip_components: 1
-          overwrite: true
-
-      - name: Activate and verify frontend release
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          port: ${{ secrets.SERVER_PORT }}
-          username: root
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: PANEL_RELEASE,VITE_APP_VERSION
-          script: |
-            set -euo pipefail
-            releases_dir="/home/web/html/relay-panel-releases"
-            release_dir="${releases_dir}/${PANEL_RELEASE}"
-            live_path="/home/web/html/relay-panel"
-            candidate_link="/home/web/html/.relay-panel-${PANEL_RELEASE}"
-
-            test -f "${release_dir}/manage.html"
-            test -f "${release_dir}/version.txt"
-            test "$(cat "${release_dir}/version.txt")" = "${VITE_APP_VERSION}"
-            if ! grep -R --include='*.js' -q "/channel-groups" "${release_dir}/assets"; then
-              echo "channel-groups route was not found in uploaded frontend assets"
-              exit 1
-            fi
-
-            rm -f "${candidate_link}"
-            ln -s "relay-panel-releases/${PANEL_RELEASE}" "${candidate_link}"
-            if [ -L "${live_path}" ]; then
-              mv -Tf "${candidate_link}" "${live_path}"
-            elif [ -d "${live_path}" ]; then
-              legacy_path="${live_path}.legacy-$(date +%s)"
-              mv "${live_path}" "${legacy_path}"
-              if ! mv -T "${candidate_link}" "${live_path}"; then
-                mv "${legacy_path}" "${live_path}"
-                exit 1
-              fi
-              rm -rf "${legacy_path}"
-            elif [ ! -e "${live_path}" ]; then
-              mv -T "${candidate_link}" "${live_path}"
-            else
-              echo "Unsupported frontend live path: ${live_path}"
-              exit 1
-            fi
-
-            test "$(docker exec nginx cat /var/www/html/relay-panel/version.txt)" = "${VITE_APP_VERSION}"
-            docker exec nginx test -f /var/www/html/relay-panel/manage.html
-            find "${releases_dir}" -mindepth 1 -maxdepth 1 -type d ! -path "${release_dir}" -mtime +7 -exec rm -rf -- {} +
-            echo "Frontend ${VITE_APP_VERSION} deployed successfully from ${release_dir}."
-
-      - name: Trigger CliRelay Docker image build
+      # Native ssh only. Remote user is deploy (not root). No docker required on deploy user.
+      - name: Configure SSH
         env:
-          GH_TOKEN: ${{ secrets.CLIRELAY_WORKFLOW_TOKEN }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_PORT: ${{ secrets.SERVER_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "CLIRELAY_WORKFLOW_TOKEN secret is required to trigger CliRelay Docker builds." >&2
+          test -n "${SERVER_HOST:-}"
+          test -n "${SSH_PRIVATE_KEY:-}"
+          test -n "${DEPLOY_SSH_KNOWN_HOSTS:-}"
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "${DEPLOY_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          port="${SERVER_PORT:-22}"
+          {
+            echo "Host deploy-target"
+            echo "  HostName ${SERVER_HOST}"
+            echo "  Port ${port}"
+            echo "  User deploy"
+            echo "  IdentityFile ~/.ssh/deploy_key"
+            echo "  IdentitiesOnly yes"
+            echo "  UserKnownHostsFile ~/.ssh/known_hosts"
+            echo "  StrictHostKeyChecking yes"
+          } > ~/.ssh/config
+          chmod 600 ~/.ssh/config
+
+      - name: Upload static assets to release directory
+        run: |
+          set -euo pipefail
+          release_dir="/home/web/html/relay-panel-releases/${PANEL_RELEASE}"
+          ssh deploy-target "mkdir -p $(printf %q "${release_dir}")"
+          # Stream dist contents over ssh; no third-party Action, no remote rsync dependency.
+          tar -C dist -czf - . | ssh deploy-target "tar -C $(printf %q "${release_dir}") -xzf -"
+
+      - name: Activate and verify frontend release
+        run: |
+          set -euo pipefail
+          ssh deploy-target \
+            "PANEL_RELEASE=$(printf %q "${PANEL_RELEASE}") VITE_APP_VERSION=$(printf %q "${VITE_APP_VERSION}") bash -s" <<'EOF'
+          set -euo pipefail
+          releases_dir="/home/web/html/relay-panel-releases"
+          release_dir="${releases_dir}/${PANEL_RELEASE}"
+          live_path="/home/web/html/relay-panel"
+          candidate_link="/home/web/html/.relay-panel-${PANEL_RELEASE}"
+          previous_target=""
+          if [ -L "${live_path}" ]; then
+            previous_target="$(readlink "${live_path}")"
+          fi
+
+          test -f "${release_dir}/manage.html"
+          test -f "${release_dir}/version.txt"
+          test "$(cat "${release_dir}/version.txt")" = "${VITE_APP_VERSION}"
+          if ! grep -R --include='*.js' -q "/channel-groups" "${release_dir}/assets"; then
+            echo "channel-groups route was not found in uploaded frontend assets"
             exit 1
           fi
-          gh workflow run docker-publish.yml \
-            --repo kittors/CliRelay \
-            --ref dev
-          echo "Triggered Docker image build after frontend deployment completed."
+
+          rm -f "${candidate_link}"
+          ln -s "relay-panel-releases/${PANEL_RELEASE}" "${candidate_link}"
+          if [ -L "${live_path}" ]; then
+            mv -Tf "${candidate_link}" "${live_path}"
+          elif [ -d "${live_path}" ]; then
+            legacy_path="${live_path}.legacy-$(date +%s)"
+            mv "${live_path}" "${legacy_path}"
+            if ! mv -T "${candidate_link}" "${live_path}"; then
+              mv "${legacy_path}" "${live_path}"
+              exit 1
+            fi
+            rm -rf "${legacy_path}"
+          elif [ ! -e "${live_path}" ]; then
+            mv -T "${candidate_link}" "${live_path}"
+          else
+            echo "Unsupported frontend live path: ${live_path}"
+            exit 1
+          fi
+
+          # Verify via host bind-mount path (same files nginx serves). deploy has no docker.
+          if ! test "$(cat "${live_path}/version.txt")" = "${VITE_APP_VERSION}" || ! test -f "${live_path}/manage.html"; then
+            echo "post-switch host verification failed; rolling back symlink" >&2
+            if [ -n "${previous_target}" ]; then
+              ln -sfn "${previous_target}" "${live_path}"
+            fi
+            exit 1
+          fi
+
+          # Keep last 5 successful releases and anything newer than 7 days.
+          ls -1dt "${releases_dir}"/*/ 2>/dev/null | tail -n +6 | while read -r old; do
+            # skip if modified within 7 days
+            if find "$old" -maxdepth 0 -mtime -7 | grep -q .; then
+              continue
+            fi
+            case "$old" in
+              "${release_dir}/") continue ;;
+            esac
+            rm -rf -- "$old"
+          done
+          echo "Frontend ${VITE_APP_VERSION} deployed successfully from ${release_dir}."
+          if [ -n "${previous_target}" ]; then
+            echo "PREVIOUS_TARGET=${previous_target}"
+          fi
+          EOF
+
+      - name: External HTTPS smoke
+        run: |
+          set -euo pipefail
+          base="${PUBLIC_PANEL_BASE%/}"
+          # version.txt is served as static file under the live panel root when mapped.
+          # Prefer manage.html availability; version is validated on host above.
+          for path in "/manage/" "/manage/index.html" "/manage.html"; do
+            code="$(curl -sS -o /dev/null -w '%{http_code}' -L --max-time 20 "${base}${path}" || true)"
+            if [ "$code" = "200" ] || [ "$code" = "304" ]; then
+              echo "public smoke ok: ${base}${path} -> ${code}"
+              echo "DEPLOY_MODE=deployed" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "public smoke try ${base}${path} -> ${code}"
+          done
+          echo "External HTTPS smoke failed; attempting symlink rollback on host"
+          ssh deploy-target \
+            "PANEL_RELEASE=$(printf %q "${PANEL_RELEASE}") bash -s" <<'EOF'
+          set -euo pipefail
+          live_path="/home/web/html/relay-panel"
+          releases_dir="/home/web/html/relay-panel-releases"
+          # Roll back to newest release that is not the failed one, if present.
+          current="$(readlink "$live_path" || true)"
+          for cand in $(ls -1dt "${releases_dir}"/*/ 2>/dev/null | head -n 10); do
+            base="$(basename "${cand%/}")"
+            if [ "relay-panel-releases/${base}" = "$current" ] || [ "${base}" = "${PANEL_RELEASE}" ]; then
+              continue
+            fi
+            if [ -f "${cand}/manage.html" ] && [ -f "${cand}/version.txt" ]; then
+              ln -sfn "relay-panel-releases/${base}" "$live_path"
+              echo "rolled back to ${base}"
+              exit 0
+            fi
+          done
+          echo "no previous release to roll back to" >&2
+          exit 1
+          EOF
+          exit 1
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Frontend deploy"
+            echo "- mode: \`${DEPLOY_MODE:-unknown}\`"
+            echo "- sha: \`${{ github.sha }}\`"
+            echo "- version: \`${VITE_APP_VERSION:-n/a}\`"
+            echo "- release: \`${PANEL_RELEASE}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Docker image builds are triggered only by CliRelay backend deploy (single source of truth).


### PR DESCRIPTION
## Summary
- Native ssh as non-root `deploy` user; pin Action SHAs + host keys
- Atomic symlink switch with host verification and rollback
- External HTTPS smoke after switch
- Keep recent releases; stop dual docker-publish trigger (backend owns it)

## Server prerequisites
- Secret `DEPLOY_SSH_KNOWN_HOSTS` set
- `deploy` user can write panel release dirs

## Test plan
- [ ] PR CI green (`./scripts/ci-pr.sh`)
- [ ] After merge: verify panel version and manage page

Refs: CliProxy `docs/plan/062-deploy-pipeline-hardening-20260714.md`