### PR TITLE
fix(security): default scheme-less API bases to https

### DIFF
--- a/packages/api-client/src/client/__tests__/client.test.ts
+++ b/packages/api-client/src/client/__tests__/client.test.ts
@@ -23,6 +23,16 @@ describe("API base normalization", () => {
       "https://example.com/relay/v0/management",
     );
   });
+
+  test("defaults scheme-less remote hosts to https and loopback to http", () => {
+    expect(normalizeApiBase("relay.example.com")).toBe("https://relay.example.com");
+    expect(normalizeApiBase("relay.example.com/manage/login")).toBe("https://relay.example.com");
+    expect(normalizeApiBase("localhost:8317")).toBe("http://localhost:8317");
+    expect(normalizeApiBase("127.0.0.1:8317")).toBe("http://127.0.0.1:8317");
+    expect(normalizeApiBase("[::1]:8317")).toBe("http://[::1]:8317");
+    // Explicit remote http is preserved for controlled intranet use.
+    expect(normalizeApiBase("http://relay.example.com")).toBe("http://relay.example.com");
+  });
 });
 
 describe("ApiClient request standardization", () => {

--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -6,13 +6,38 @@ export const AUTH_PERSIST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 export const VERSION_HEADER_KEYS = ["x-cpa-version", "x-server-version"];
 export const BUILD_DATE_HEADER_KEYS = ["x-cpa-build-date", "x-server-build-date"];
 
+const isLoopbackHost = (host: string): boolean => {
+  const normalized = host.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1"
+  );
+};
+
+// Scheme-less remote hosts default to https so admin passwords are not sent in cleartext.
+// Loopback keeps http for local dev (vite / native binary on 8317).
+const withDefaultScheme = (input: string): string => {
+  if (/^https?:\/\//i.test(input)) return input;
+  // Parse host from authority without inventing a scheme first (IPv6: [::1]:8317).
+  const authority = input.split("/")[0] ?? "";
+  let host = authority;
+  if (authority.startsWith("[")) {
+    const end = authority.indexOf("]");
+    host = end >= 0 ? authority.slice(1, end) : authority;
+  } else {
+    host = authority.split(":")[0] ?? "";
+  }
+  const scheme = isLoopbackHost(host) ? "http" : "https";
+  return `${scheme}://${input}`;
+};
+
 export const normalizeApiBase = (input: string): string => {
   let base = input.trim();
   if (!base) return "";
 
-  if (!/^https?:\/\//i.test(base)) {
-    base = `http://${base}`;
-  }
+  base = withDefaultScheme(base);
 
   try {
     const url = new URL(base);


### PR DESCRIPTION
## Summary
- Scheme-less remote API bases (e.g. `relay.example.com`) now become `https://...`
- Loopback (`localhost` / `127.0.0.1` / `::1`) still defaults to `http://` for local dev
- Explicit `http://` / `https://` inputs are unchanged

## Risk
Frontend-only. Does not change backend, nginx, or deploy. Production `/manage` already runs on HTTPS and auto-detects page protocol.

## Test plan
- [x] `bun test packages/api-client/src/client/__tests__/client.test.ts -t "API base normalization"`
- [ ] PR CI full `./scripts/ci-pr.sh`