### PR TITLE
feat(auth-files): AI account card style + distinct membership badges

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -1279,6 +1279,55 @@ export const TYPE_BADGE_CLASSES: Record<string, string> = {
   unknown: "bg-slate-50 text-slate-600 dark:bg-white/10 dark:text-white/70",
 };
 
+/** Membership plan pills: solid/gradient chips, never the soft sky/amber tag look. */
+export const PLAN_BADGE_CLASSES: Record<string, string> = {
+  free: "bg-slate-100 text-slate-600 ring-1 ring-inset ring-slate-200/80 dark:bg-white/10 dark:text-white/65 dark:ring-white/10",
+  plus: "bg-gradient-to-r from-sky-500 to-blue-600 text-white shadow-sm shadow-sky-500/25 dark:from-sky-400 dark:to-blue-500",
+  pro: "bg-gradient-to-r from-amber-400 via-orange-500 to-rose-500 text-white shadow-sm shadow-orange-500/30 dark:from-amber-300 dark:via-orange-400 dark:to-rose-400",
+  team: "bg-gradient-to-r from-violet-500 to-indigo-600 text-white shadow-sm shadow-violet-500/25 dark:from-violet-400 dark:to-indigo-500",
+  premium: "bg-gradient-to-r from-fuchsia-500 to-purple-600 text-white shadow-sm shadow-fuchsia-500/25 dark:from-fuchsia-400 dark:to-purple-500",
+  business: "bg-gradient-to-r from-slate-700 to-slate-900 text-white shadow-sm shadow-slate-900/20 dark:from-slate-500 dark:to-slate-700",
+  enterprise: "bg-gradient-to-r from-zinc-800 via-slate-900 to-black text-amber-100 shadow-sm shadow-black/20 dark:from-zinc-600 dark:via-slate-700 dark:to-zinc-900",
+  supergrok:
+    "bg-gradient-to-r from-neutral-900 to-emerald-700 text-emerald-50 shadow-sm shadow-emerald-900/30 dark:from-neutral-800 dark:to-emerald-600",
+  "supergrok-heavy":
+    "bg-gradient-to-r from-black via-emerald-900 to-teal-700 text-emerald-50 shadow-sm shadow-emerald-950/40 dark:from-black dark:via-emerald-800 dark:to-teal-600",
+  supergrok_heavy:
+    "bg-gradient-to-r from-black via-emerald-900 to-teal-700 text-emerald-50 shadow-sm shadow-emerald-950/40 dark:from-black dark:via-emerald-800 dark:to-teal-600",
+  supergrokheavy:
+    "bg-gradient-to-r from-black via-emerald-900 to-teal-700 text-emerald-50 shadow-sm shadow-emerald-950/40 dark:from-black dark:via-emerald-800 dark:to-teal-600",
+  unknown:
+    "bg-gradient-to-r from-orange-400 to-amber-500 text-white shadow-sm shadow-orange-500/25 dark:from-orange-400 dark:to-amber-400",
+};
+
+export const resolvePlanBadgeClass = (planType: string | null | undefined): string => {
+  const normalized = normalizeTagValue(planType);
+  if (!normalized) return PLAN_BADGE_CLASSES.unknown;
+  return PLAN_BADGE_CLASSES[normalized] ?? PLAN_BADGE_CLASSES.unknown;
+};
+
+/** Short membership chip copy (PRO / PLUS), distinct from soft info tags. */
+export const formatPlanBadgeLabel = (planType: string | null | undefined): string => {
+  const normalized = normalizeTagValue(planType);
+  if (!normalized) return "";
+  if (
+    normalized === "supergrok-heavy" ||
+    normalized === "supergrok_heavy" ||
+    normalized === "supergrokheavy"
+  ) {
+    return "SUPERGROK HEAVY";
+  }
+  if (normalized === "supergrok") return "SUPERGROK";
+  if (normalized === "free") return "FREE";
+  if (normalized === "plus") return "PLUS";
+  if (normalized === "pro") return "PRO";
+  if (normalized === "team") return "TEAM";
+  if (normalized === "premium") return "PREMIUM";
+  if (normalized === "business") return "BUSINESS";
+  if (normalized === "enterprise") return "ENTERPRISE";
+  return normalized.replace(/[-_]+/g, " ").toUpperCase();
+};
+
 const KNOWN_AUTH_FILE_PROVIDER_KEYS = Object.keys(TYPE_BADGE_CLASSES)
   .filter((key) => key !== "empty" && key !== "unknown")
   .sort((left, right) => right.length - left.length);

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1393,7 +1393,7 @@ describe("AuthFilesPage files table", () => {
       expect(quota).toHaveTextContent("$40.00 / $50.00");
       expect(quota).toHaveTextContent("Monthly credits");
       expect(quota).toHaveTextContent("$130.00 / $150.00");
-      expect(card as HTMLElement).toHaveTextContent("Plan SuperGrok");
+      expect(card as HTMLElement).toHaveTextContent("SUPERGROK");
     });
     expect(quota).not.toHaveTextContent("Used");
     expect(quota).not.toHaveTextContent("Requests");
@@ -1811,7 +1811,11 @@ describe("AuthFilesPage files table", () => {
     expect(card).not.toBeNull();
     expect(within(card as HTMLElement).getByText("vip-team")).toBeInTheDocument();
     expect(within(card as HTMLElement).getAllByText(/^codex$/i)).toHaveLength(1);
-    expect(within(card as HTMLElement).queryByText(/^pro$/i)).not.toBeInTheDocument();
+    // Membership chip is PRO (not soft sky "pro" tag); only one membership badge.
+    expect(within(card as HTMLElement).getByTestId("auth-file-plan-badge")).toHaveTextContent(
+      "PRO",
+    );
+    expect(within(card as HTMLElement).queryByText("pro")).not.toBeInTheDocument();
   });
 
   test("cards view shows the auth-file success rate beside call volume", async () => {
@@ -1982,7 +1986,7 @@ describe("AuthFilesPage files table", () => {
     expect(card).not.toBeNull();
     // Prefer request_total over a misleading cycle_request_total of 0 when cycle_known is false.
     expect(await within(card as HTMLElement).findByText("116 calls")).toBeInTheDocument();
-    expect(within(card as HTMLElement).getByText("Plan SuperGrok")).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText("SUPERGROK")).toBeInTheDocument();
     expect(mocks.getAuthFileTrend).toHaveBeenCalledWith("xai-auth", { days: 7, hours: 5 });
   });
 
@@ -2771,9 +2775,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getAllByText("Beta Channel").length).toBeGreaterThan(0);
     expect(screen.queryByText("z-last.json")).not.toBeInTheDocument();
     expect(screen.queryByText("codex-prod.json")).not.toBeInTheDocument();
-    expect(
-      screen.getAllByText((_, node) => node?.textContent?.includes("Plan Plus") ?? false).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("PLUS").length).toBeGreaterThan(0);
     expect(screen.getByText("9 calls")).toBeInTheDocument();
 
     const cards = screen.getByTestId("auth-files-cards");
@@ -4883,10 +4885,7 @@ describe("AuthFilesPage files table", () => {
       "codex",
       expect.objectContaining({ name: "codex.json" }),
     );
-    expect(
-      (await screen.findAllByText((_, node) => node?.textContent?.includes("Plan Plus") ?? false))
-        .length,
-    ).toBeGreaterThan(0);
+    expect((await screen.findAllByText("PLUS")).length).toBeGreaterThan(0);
 
     await waitFor(() => {
       const raw = window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY);
@@ -5024,8 +5023,8 @@ describe("AuthFilesPage files table", () => {
     );
 
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    expect(screen.getByText("Plan Free")).toBeInTheDocument();
-    expect(screen.queryByText("Plan Plus")).not.toBeInTheDocument();
+    expect(screen.getByText("FREE")).toBeInTheDocument();
+    expect(screen.queryByText("PLUS")).not.toBeInTheDocument();
   });
 
   test("cards view exposes quota refresh for Anthropic OAuth files", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -16,11 +16,13 @@ import {
   resolveAuthFileDisplayName,
   resolveAuthFileRestrictionBadges,
   resolveAuthFileDisplayTags,
+  formatPlanBadgeLabel,
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
   resolveAuthFileStats,
+  resolvePlanBadgeClass,
   sanitizeAuthFilesForCache,
   setActiveCacheTenantId,
   setCacheTenantResolver,
@@ -479,6 +481,19 @@ describe("Auth Files helper coverage", () => {
         "codex",
       ),
     ).toBe(true);
+  });
+
+  test("membership plan badges use distinct solid styles and short labels", () => {
+    expect(formatPlanBadgeLabel("pro")).toBe("PRO");
+    expect(formatPlanBadgeLabel("plus")).toBe("PLUS");
+    expect(formatPlanBadgeLabel("team")).toBe("TEAM");
+    expect(formatPlanBadgeLabel("supergrok-heavy")).toBe("SUPERGROK HEAVY");
+    expect(resolvePlanBadgeClass("pro")).toContain("from-amber-400");
+    expect(resolvePlanBadgeClass("plus")).toContain("from-sky-500");
+    expect(resolvePlanBadgeClass("team")).toContain("from-violet-500");
+    // Soft info tags use sky-50; membership chips must not.
+    expect(resolvePlanBadgeClass("pro")).not.toContain("bg-sky-50");
+    expect(resolvePlanBadgeClass("pro")).not.toContain("bg-amber-50");
   });
 
   test("always shows quota-derived plan badges even when display tags omit them", () => {

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -52,6 +52,7 @@ import {
   AUTH_FILES_PAGE_SIZE,
   AUTH_FILE_STATUS_FILTERS,
   TYPE_BADGE_CLASSES,
+  formatPlanBadgeLabel,
   isRuntimeOnlyAuthFile,
   normalizeAuthIndexValue,
   normalizeProviderKey,
@@ -60,6 +61,7 @@ import {
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveFileType,
+  resolvePlanBadgeClass,
   shouldShowAuthFileDisplayTag,
   shouldShowAuthFilePlanBadge,
 } from "@code-proxy/domain";
@@ -1626,7 +1628,7 @@ export function AuthFilesFilesTab({
                       padding="default"
                       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[
-                        "group/card flex h-full w-full max-w-[34rem] flex-col transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+                        "group/card flex h-full w-full max-w-[34rem] flex-col rounded-3xl border-slate-200/80 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
                         fileSelected
                           ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                           : "",
@@ -1636,12 +1638,24 @@ export function AuthFilesFilesTab({
                         .filter(Boolean)
                         .join(" ")}
                     >
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="min-w-0 flex items-center gap-2">
-                            <span className="min-w-0 truncate text-sm font-semibold text-slate-900 dark:text-white">
+                      <div className="space-y-2.5">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex flex-1 items-center gap-2">
+                            <span className="min-w-0 truncate text-sm font-semibold tracking-tight text-slate-900 dark:text-white">
                               {displayTitle}
                             </span>
+                            {showPlanBadge && planType ? (
+                              <span
+                                data-testid="auth-file-plan-badge"
+                                className={[
+                                  "inline-flex shrink-0 items-center rounded-md px-2 py-0.5 text-2xs font-bold tracking-wide",
+                                  resolvePlanBadgeClass(planType),
+                                ].join(" ")}
+                              >
+                                {formatPlanTypeLabel(planType) ||
+                                  formatPlanBadgeLabel(planType)}
+                              </span>
+                            ) : null}
                           </div>
 
                           <div className="flex shrink-0 items-center gap-2">
@@ -1694,7 +1708,7 @@ export function AuthFilesFilesTab({
                           </div>
                         </div>
 
-                        <div className="min-w-0 flex flex-wrap items-center gap-2">
+                        <div className="min-w-0 flex flex-wrap items-center gap-1.5">
                           {showTypeBadge ? (
                             <span
                               className={[
@@ -1703,12 +1717,6 @@ export function AuthFilesFilesTab({
                               ].join(" ")}
                             >
                               {typeKey}
-                            </span>
-                          ) : null}
-                          {showPlanBadge && planType ? (
-                            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-2xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
-                              {t("codex_quota.plan_label")}{" "}
-                              {formatPlanTypeLabel(planType)}
                             </span>
                           ) : null}
                           {provider === "codex" ? (
@@ -1789,7 +1797,7 @@ export function AuthFilesFilesTab({
                       ) : null}
 
                       <div
-                        className="mt-3 min-w-0 touch-pan-y rounded-2xl bg-slate-50/85 px-3 py-3 transition-colors duration-200 ease-out dark:bg-white/[0.03]"
+                        className="mt-3 min-w-0 touch-pan-y space-y-3 px-0.5 py-1"
                         data-testid="auth-file-card-quota"
                       >
                         {!provider && slots.length === 0 ? (
@@ -1797,7 +1805,7 @@ export function AuthFilesFilesTab({
                             --
                           </div>
                         ) : slots.length > 0 ? (
-                          <div className="space-y-2.5">
+                          <div className="space-y-3">
                             {slots.map((slot) =>
                               renderQuotaBar(slot.label, slot.item),
                             )}
@@ -1809,7 +1817,7 @@ export function AuthFilesFilesTab({
                         )}
                       </div>
 
-                      <div className="mt-auto flex items-center justify-between gap-2 pt-3">
+                      <div className="mt-auto flex items-center justify-between gap-2 border-t border-slate-100 pt-3 dark:border-white/[0.06]">
                         <div className="inline-flex items-center gap-1">
                           {provider ? (
                             <HoverTooltip content={t("common.refresh")}>

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   AlertTriangle,
   CalendarClock,
+  Clock,
   Download,
   Eye,
   Gauge,
@@ -29,6 +30,7 @@ import {
   formatAuthFileRestrictionRemaining,
   formatFileSize,
   formatModified,
+  formatPlanBadgeLabel,
   resolveClaudeOAuthHealthBadges,
   isRuntimeOnlyAuthFile,
   parseAdditionalQuotaWindowLabel,
@@ -41,6 +43,7 @@ import {
   resolveAuthFileStatusBar,
   resolveAuthFileSubscriptionStatus,
   resolveFileType,
+  resolvePlanBadgeClass,
   shouldShowAuthFileDisplayTag,
   shouldShowAuthFilePlanBadge,
 } from "@code-proxy/domain";
@@ -219,25 +222,7 @@ export function useAuthFilesFilesPresentation({
     [t],
   );
 
-  const formatPlanTypeLabel = useCallback(
-    (planType: string) => {
-      const normalized = planType.trim().toLowerCase();
-      if (!normalized) return "";
-      if (normalized === "plus" || normalized === "team" || normalized === "free") {
-        return t(`codex_quota.plan_${normalized}`);
-      }
-      if (normalized === "supergrok") return t("xai_quota.plan_supergrok");
-      if (
-        normalized === "supergrok-heavy" ||
-        normalized === "supergrok_heavy" ||
-        normalized === "supergrokheavy"
-      ) {
-        return t("xai_quota.plan_supergrok_heavy");
-      }
-      return normalized.charAt(0).toUpperCase() + normalized.slice(1);
-    },
-    [t],
-  );
+  const formatPlanTypeLabel = useCallback((planType: string) => formatPlanBadgeLabel(planType), []);
 
   const restrictionUnitLabels = useMemo(
     () => ({
@@ -620,10 +605,11 @@ export function useAuthFilesFilesPresentation({
       const detailText = formatQuotaItemDetailText(item);
 
       return (
-        <div key={label} className="space-y-1">
+        <div key={label} className="space-y-1.5">
           <div className="flex items-center justify-between gap-2">
-            <span className="min-w-0 truncate text-xs font-semibold text-slate-700 dark:text-white/80">
-              {translateQuotaText(label)}
+            <span className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium text-slate-600 dark:text-white/70">
+              <Clock size={12} className="shrink-0 text-slate-400 dark:text-white/40" aria-hidden />
+              <span className="min-w-0 truncate">{translateQuotaText(label)}</span>
             </span>
             <span
               className={[
@@ -634,14 +620,14 @@ export function useAuthFilesFilesPresentation({
               {percentText}
             </span>
           </div>
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
+          <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-white/10">
             <div
               className={["h-full rounded-full", tone.fillClass].join(" ")}
               style={{ width: `${normalized ?? 0}%` }}
               aria-hidden="true"
             />
           </div>
-          <div className="min-h-[14px] truncate text-2xs tabular-nums text-slate-500 dark:text-white/45">
+          <div className="min-h-[14px] truncate text-right text-2xs tabular-nums text-slate-400 dark:text-white/40">
             {detailText ?? "\u00A0"}
           </div>
         </div>
@@ -752,8 +738,14 @@ export function useAuthFilesFilesPresentation({
                   </span>
                 ) : null}
                 {showPlanBadge && planType ? (
-                  <span className="inline-flex rounded-lg bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
-                    {t("codex_quota.plan_label")} {formatPlanTypeLabel(planType)}
+                  <span
+                    data-testid="auth-file-plan-badge"
+                    className={[
+                      "inline-flex items-center rounded-md px-2 py-0.5 text-2xs font-bold tracking-wide",
+                      resolvePlanBadgeClass(planType),
+                    ].join(" ")}
+                  >
+                    {formatPlanTypeLabel(planType)}
                   </span>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary
- Redesign AI account cards: softer shadow, title-row membership chip, cleaner quota section
- Membership plan badges use solid/gradient styles (`PRO` / `PLUS` / `TEAM` / …) distinct from soft sky/provider tags
- Quota bars gain clock icon, thicker track, right-aligned reset meta

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full vitest, build, bundle:diff, critical e2e)
- [x] Auth-files cards tests for plan badge / non-duplicated tags
- [ ] Visual check on `/manage/access/ai-accounts` after deploy

## Local verification
```bash
./scripts/ci-pr.sh
```