### PR TITLE
feat(auth-files): tiered plan badge colors + Codex Pro 5X/20X

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -1281,13 +1281,36 @@ export const TYPE_BADGE_CLASSES: Record<string, string> = {
 
 /** Membership plan pills: solid/gradient chips, never the soft sky/amber tag look. */
 export const PLAN_BADGE_CLASSES: Record<string, string> = {
+  // Codex Plus: silver / platinum
+  plus: "bg-gradient-to-r from-slate-100 via-zinc-200 to-slate-300 text-slate-800 ring-1 ring-inset ring-slate-300/70 shadow-sm shadow-slate-400/20 dark:from-zinc-300 dark:via-slate-400 dark:to-zinc-500 dark:text-slate-950 dark:ring-white/20",
+  // Codex Pro family: gold scale (base / 5X / 20X)
+  pro: "bg-gradient-to-r from-amber-300 via-yellow-400 to-amber-500 text-amber-950 shadow-sm shadow-amber-500/30 dark:from-amber-300 dark:via-yellow-400 dark:to-amber-500 dark:text-amber-950",
+  pro_5x:
+    "bg-gradient-to-r from-amber-400 via-yellow-500 to-orange-400 text-amber-950 shadow-sm shadow-amber-500/35 dark:from-amber-400 dark:via-yellow-400 dark:to-orange-400 dark:text-amber-950",
+  "pro-5x":
+    "bg-gradient-to-r from-amber-400 via-yellow-500 to-orange-400 text-amber-950 shadow-sm shadow-amber-500/35 dark:from-amber-400 dark:via-yellow-400 dark:to-orange-400 dark:text-amber-950",
+  pro_20x:
+    "bg-gradient-to-r from-yellow-300 via-amber-500 to-orange-600 text-amber-950 shadow-sm shadow-orange-500/40 dark:from-yellow-300 dark:via-amber-400 dark:to-orange-500 dark:text-amber-950",
+  "pro-20x":
+    "bg-gradient-to-r from-yellow-300 via-amber-500 to-orange-600 text-amber-950 shadow-sm shadow-orange-500/40 dark:from-yellow-300 dark:via-amber-400 dark:to-orange-500 dark:text-amber-950",
+  chatgptpro:
+    "bg-gradient-to-r from-amber-300 via-yellow-400 to-amber-500 text-amber-950 shadow-sm shadow-amber-500/30 dark:from-amber-300 dark:via-yellow-400 dark:to-amber-500 dark:text-amber-950",
   free: "bg-slate-100 text-slate-600 ring-1 ring-inset ring-slate-200/80 dark:bg-white/10 dark:text-white/65 dark:ring-white/10",
-  plus: "bg-gradient-to-r from-sky-500 to-blue-600 text-white shadow-sm shadow-sky-500/25 dark:from-sky-400 dark:to-blue-500",
-  pro: "bg-gradient-to-r from-amber-400 via-orange-500 to-rose-500 text-white shadow-sm shadow-orange-500/30 dark:from-amber-300 dark:via-orange-400 dark:to-rose-400",
   team: "bg-gradient-to-r from-violet-500 to-indigo-600 text-white shadow-sm shadow-violet-500/25 dark:from-violet-400 dark:to-indigo-500",
+  // Claude Code family: warm clay / copper
+  max: "bg-gradient-to-r from-orange-400 via-amber-500 to-orange-600 text-white shadow-sm shadow-orange-500/30 dark:from-orange-400 dark:via-amber-500 dark:to-orange-500",
+  max_5x:
+    "bg-gradient-to-r from-orange-500 via-amber-500 to-rose-500 text-white shadow-sm shadow-orange-500/35 dark:from-orange-400 dark:via-amber-400 dark:to-rose-400",
+  "max-5x":
+    "bg-gradient-to-r from-orange-500 via-amber-500 to-rose-500 text-white shadow-sm shadow-orange-500/35 dark:from-orange-400 dark:via-amber-400 dark:to-rose-400",
+  max_20x:
+    "bg-gradient-to-r from-amber-500 via-orange-600 to-rose-600 text-white shadow-sm shadow-rose-500/35 dark:from-amber-400 dark:via-orange-500 dark:to-rose-500",
+  "max-20x":
+    "bg-gradient-to-r from-amber-500 via-orange-600 to-rose-600 text-white shadow-sm shadow-rose-500/35 dark:from-amber-400 dark:via-orange-500 dark:to-rose-500",
   premium: "bg-gradient-to-r from-fuchsia-500 to-purple-600 text-white shadow-sm shadow-fuchsia-500/25 dark:from-fuchsia-400 dark:to-purple-500",
   business: "bg-gradient-to-r from-slate-700 to-slate-900 text-white shadow-sm shadow-slate-900/20 dark:from-slate-500 dark:to-slate-700",
   enterprise: "bg-gradient-to-r from-zinc-800 via-slate-900 to-black text-amber-100 shadow-sm shadow-black/20 dark:from-zinc-600 dark:via-slate-700 dark:to-zinc-900",
+  // Grok: dark emerald
   supergrok:
     "bg-gradient-to-r from-neutral-900 to-emerald-700 text-emerald-50 shadow-sm shadow-emerald-900/30 dark:from-neutral-800 dark:to-emerald-600",
   "supergrok-heavy":
@@ -1297,16 +1320,78 @@ export const PLAN_BADGE_CLASSES: Record<string, string> = {
   supergrokheavy:
     "bg-gradient-to-r from-black via-emerald-900 to-teal-700 text-emerald-50 shadow-sm shadow-emerald-950/40 dark:from-black dark:via-emerald-800 dark:to-teal-600",
   unknown:
-    "bg-gradient-to-r from-orange-400 to-amber-500 text-white shadow-sm shadow-orange-500/25 dark:from-orange-400 dark:to-amber-400",
+    "bg-gradient-to-r from-slate-400 to-slate-500 text-white shadow-sm shadow-slate-500/20 dark:from-slate-500 dark:to-slate-600",
+};
+
+/** Codex-only: weekly budget (USD) thresholds for Pro multiplier badges. */
+export const CODEX_PRO_20X_WEEKLY_BUDGET_USD = 1000;
+export const CODEX_PRO_5X_WEEKLY_BUDGET_USD = 200;
+
+export type AuthFileCycleBudgetStats = {
+  cycleCostTotal?: number | null;
+  weeklyQuotaUsedPercent?: number | null;
+};
+
+/** cost / (used%/100) → estimated full-window budget; null when underdetermined. */
+export const estimateQuotaBudgetUsd = (
+  cost: number | null | undefined,
+  usedPercent: number | null | undefined,
+): number | null => {
+  if (typeof cost !== "number" || !Number.isFinite(cost) || cost <= 0) return null;
+  if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) return null;
+  const normalizedUsed = Math.min(100, Math.max(0, usedPercent));
+  if (normalizedUsed <= 0) return null;
+  return cost / (normalizedUsed / 100);
+};
+
+/**
+ * Codex Pro only: map estimated weekly USD budget → pro_20x / pro_5x / pro.
+ * Non-pro base plans pass through unchanged; missing budget falls back to plain pro.
+ */
+export const resolveCodexProMultiplierTier = (
+  basePlan: string | null | undefined,
+  estimatedWeeklyBudgetUsd: number | null | undefined,
+): string | null => {
+  const base = normalizeTagValue(basePlan);
+  if (!base) return null;
+  if (base === "pro_20x" || base === "pro-20x") return "pro_20x";
+  if (base === "pro_5x" || base === "pro-5x") return "pro_5x";
+  if (base !== "pro" && base !== "chatgptpro") return base;
+  if (
+    typeof estimatedWeeklyBudgetUsd !== "number" ||
+    !Number.isFinite(estimatedWeeklyBudgetUsd) ||
+    estimatedWeeklyBudgetUsd <= 0
+  ) {
+    return "pro";
+  }
+  if (estimatedWeeklyBudgetUsd >= CODEX_PRO_20X_WEEKLY_BUDGET_USD) return "pro_20x";
+  if (estimatedWeeklyBudgetUsd >= CODEX_PRO_5X_WEEKLY_BUDGET_USD) return "pro_5x";
+  return "pro";
+};
+
+export const resolveAuthFileDisplayPlanType = (
+  file: AuthFileItem,
+  quotaState?: QuotaState | null,
+  cycleStats?: AuthFileCycleBudgetStats | null,
+): string | null => {
+  const base = resolveAuthFilePlanType(file, quotaState);
+  if (!base) return null;
+  if (normalizeProviderKey(resolveFileType(file)) !== "codex") return base;
+  const budget = estimateQuotaBudgetUsd(
+    cycleStats?.cycleCostTotal,
+    cycleStats?.weeklyQuotaUsedPercent,
+  );
+  return resolveCodexProMultiplierTier(base, budget);
 };
 
 export const resolvePlanBadgeClass = (planType: string | null | undefined): string => {
   const normalized = normalizeTagValue(planType);
   if (!normalized) return PLAN_BADGE_CLASSES.unknown;
+  if (normalized === "chatgptpro") return PLAN_BADGE_CLASSES.pro;
   return PLAN_BADGE_CLASSES[normalized] ?? PLAN_BADGE_CLASSES.unknown;
 };
 
-/** Short membership chip copy (PRO / PLUS), distinct from soft info tags. */
+/** Short membership chip copy (PRO / PLUS / PRO 20X), distinct from soft info tags. */
 export const formatPlanBadgeLabel = (planType: string | null | undefined): string => {
   const normalized = normalizeTagValue(planType);
   if (!normalized) return "";
@@ -1320,7 +1405,12 @@ export const formatPlanBadgeLabel = (planType: string | null | undefined): strin
   if (normalized === "supergrok") return "SUPERGROK";
   if (normalized === "free") return "FREE";
   if (normalized === "plus") return "PLUS";
-  if (normalized === "pro") return "PRO";
+  if (normalized === "pro_20x" || normalized === "pro-20x") return "PRO 20X";
+  if (normalized === "pro_5x" || normalized === "pro-5x") return "PRO 5X";
+  if (normalized === "pro" || normalized === "chatgptpro") return "PRO";
+  if (normalized === "max_20x" || normalized === "max-20x") return "MAX 20X";
+  if (normalized === "max_5x" || normalized === "max-5x") return "MAX 5X";
+  if (normalized === "max") return "MAX";
   if (normalized === "team") return "TEAM";
   if (normalized === "premium") return "PREMIUM";
   if (normalized === "business") return "BUSINESS";

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -493,7 +493,7 @@ export function AuthFilesPage() {
     refreshUsageDataForFiles,
   });
 
-  const { callsByAuthIndex, refreshCycleUsageForFiles } =
+  const { callsByAuthIndex, cycleBudgetByAuthIndex, refreshCycleUsageForFiles } =
     useAuthFilesCycleUsageState();
 
   const refreshQuotaAndCycleUsage = useCallback(
@@ -819,6 +819,7 @@ export function AuthFilesPage() {
     connectivityState,
     checkAuthFileConnectivity,
     quotaByFileName,
+    cycleBudgetByAuthIndex,
     refreshQuota,
     requestResetCredit,
     resettingCreditFileName,
@@ -890,6 +891,7 @@ export function AuthFilesPage() {
         selectedFileNameSet={selectedFileNameSet}
         quotaByFileName={quotaByFileName}
         cycleCallsByAuthIndex={callsByAuthIndex}
+        cycleBudgetByAuthIndex={cycleBudgetByAuthIndex}
         resolveQuotaProvider={resolveQuotaProvider}
         resolveQuotaCardSlots={resolveQuotaCardSlots}
         refreshQuota={refreshQuotaAndCycleUsage}

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -16,10 +16,13 @@ import {
   resolveAuthFileDisplayName,
   resolveAuthFileRestrictionBadges,
   resolveAuthFileDisplayTags,
+  estimateQuotaBudgetUsd,
   formatPlanBadgeLabel,
+  resolveAuthFileDisplayPlanType,
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveAuthFileSubscriptionStatus,
+  resolveCodexProMultiplierTier,
   resolveFileType,
   resolveAuthFileStats,
   resolvePlanBadgeClass,
@@ -485,15 +488,50 @@ describe("Auth Files helper coverage", () => {
 
   test("membership plan badges use distinct solid styles and short labels", () => {
     expect(formatPlanBadgeLabel("pro")).toBe("PRO");
+    expect(formatPlanBadgeLabel("pro_5x")).toBe("PRO 5X");
+    expect(formatPlanBadgeLabel("pro_20x")).toBe("PRO 20X");
     expect(formatPlanBadgeLabel("plus")).toBe("PLUS");
     expect(formatPlanBadgeLabel("team")).toBe("TEAM");
     expect(formatPlanBadgeLabel("supergrok-heavy")).toBe("SUPERGROK HEAVY");
-    expect(resolvePlanBadgeClass("pro")).toContain("from-amber-400");
-    expect(resolvePlanBadgeClass("plus")).toContain("from-sky-500");
+    expect(resolvePlanBadgeClass("pro")).toContain("from-amber-300");
+    expect(resolvePlanBadgeClass("plus")).toContain("from-slate-100");
     expect(resolvePlanBadgeClass("team")).toContain("from-violet-500");
+    expect(resolvePlanBadgeClass("pro_20x")).toContain("from-yellow-300");
     // Soft info tags use sky-50; membership chips must not.
     expect(resolvePlanBadgeClass("pro")).not.toContain("bg-sky-50");
-    expect(resolvePlanBadgeClass("pro")).not.toContain("bg-amber-50");
+    expect(resolvePlanBadgeClass("plus")).not.toContain("bg-sky-50");
+  });
+
+  test("codex pro multiplier tiers use estimated weekly budget thresholds", () => {
+    expect(estimateQuotaBudgetUsd(100, 10)).toBe(1000);
+    expect(estimateQuotaBudgetUsd(50, 10)).toBe(500);
+    expect(estimateQuotaBudgetUsd(0, 10)).toBeNull();
+    expect(resolveCodexProMultiplierTier("pro", 1500)).toBe("pro_20x");
+    expect(resolveCodexProMultiplierTier("pro", 500)).toBe("pro_5x");
+    expect(resolveCodexProMultiplierTier("pro", 100)).toBe("pro");
+    expect(resolveCodexProMultiplierTier("pro", null)).toBe("pro");
+    expect(resolveCodexProMultiplierTier("plus", 2000)).toBe("plus");
+    expect(
+      resolveAuthFileDisplayPlanType(
+        { name: "codex.json", type: "codex", plan_type: "pro" } as AuthFileItem,
+        null,
+        { cycleCostTotal: 120, weeklyQuotaUsedPercent: 10 },
+      ),
+    ).toBe("pro_20x");
+    expect(
+      resolveAuthFileDisplayPlanType(
+        { name: "codex.json", type: "codex", plan_type: "pro" } as AuthFileItem,
+        null,
+        { cycleCostTotal: 30, weeklyQuotaUsedPercent: 10 },
+      ),
+    ).toBe("pro_5x");
+    expect(
+      resolveAuthFileDisplayPlanType(
+        { name: "xai.json", type: "xai", plan_type: "supergrok" } as AuthFileItem,
+        null,
+        { cycleCostTotal: 9999, weeklyQuotaUsedPercent: 10 },
+      ),
+    ).toBe("supergrok");
   });
 
   test("always shows quota-derived plan badges even when display tags omit them", () => {

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -58,12 +58,14 @@ import {
   normalizeProviderKey,
   normalizeTagValue,
   resolveAuthFileDisplayName,
+  resolveAuthFileDisplayPlanType,
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveFileType,
   resolvePlanBadgeClass,
   shouldShowAuthFileDisplayTag,
   shouldShowAuthFilePlanBadge,
+  type AuthFileCycleBudgetStats,
 } from "@code-proxy/domain";
 import {
   parseIdTokenPayload,
@@ -637,6 +639,7 @@ interface AuthFilesFilesTabProps {
   selectedFileNameSet: Set<string>;
   quotaByFileName: Record<string, QuotaState>;
   cycleCallsByAuthIndex: Record<string, number>;
+  cycleBudgetByAuthIndex: Record<string, AuthFileCycleBudgetStats>;
   resolveQuotaProvider: (file: AuthFileItem) => QuotaProvider | null;
   resolveQuotaCardSlots: (
     provider: QuotaProvider,
@@ -725,6 +728,7 @@ export function AuthFilesFilesTab({
   selectedFileNameSet,
   quotaByFileName,
   cycleCallsByAuthIndex,
+  cycleBudgetByAuthIndex,
   resolveQuotaProvider,
   resolveQuotaCardSlots,
   refreshQuota,
@@ -1512,7 +1516,17 @@ export function AuthFilesFilesTab({
                     status: "idle",
                     items: [],
                   };
-                  const planType = resolveAuthFilePlanType(file, state);
+                  const authIndexForPlan = normalizeAuthIndexValue(
+                    file.auth_index ?? file.authIndex,
+                  );
+                  const basePlanType = resolveAuthFilePlanType(file, state);
+                  const planType = resolveAuthFileDisplayPlanType(
+                    file,
+                    state,
+                    authIndexForPlan
+                      ? cycleBudgetByAuthIndex[authIndexForPlan]
+                      : null,
+                  );
                   const displayTags = resolveAuthFileSupplementalTags(
                     file,
                     state,
@@ -1523,7 +1537,7 @@ export function AuthFilesFilesTab({
                   );
                   const showPlanBadge = shouldShowAuthFilePlanBadge(
                     file,
-                    planType,
+                    basePlanType,
                   );
                   const subscriptionBadge = renderSubscriptionBadge(file);
                   const restrictionBadges = renderRestrictionBadges(file);

--- a/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
+++ b/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
@@ -1,9 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usageApi, type AuthFileItem } from "@code-proxy/api-client";
-import { normalizeAuthIndexValue, normalizeProviderKey, resolveFileType } from "@code-proxy/domain";
+import {
+  normalizeAuthIndexValue,
+  normalizeProviderKey,
+  resolveFileType,
+  type AuthFileCycleBudgetStats,
+} from "@code-proxy/domain";
 
 type RefreshCycleUsageOptions = {
   force?: boolean;
+};
+
+export type AuthFileCycleUsageSnapshot = {
+  calls: number | null;
+  cycleCostTotal: number | null;
+  weeklyQuotaUsedPercent: number | null;
 };
 
 const supportsCycleUsage = (file: AuthFileItem): boolean => {
@@ -43,11 +54,24 @@ const resolveDisplayCycleCount = (trend: {
   return null;
 };
 
+const toFiniteOrNull = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+const readCycleBudgetStats = (trend: {
+  cycle_cost_total?: number;
+  weekly_quota_used_percent?: number | null;
+}): Pick<AuthFileCycleUsageSnapshot, "cycleCostTotal" | "weeklyQuotaUsedPercent"> => ({
+  cycleCostTotal: toFiniteOrNull(trend.cycle_cost_total),
+  weeklyQuotaUsedPercent: toFiniteOrNull(trend.weekly_quota_used_percent),
+});
+
 export function useAuthFilesCycleUsageState() {
   const mountedRef = useRef(true);
-  const inFlightRef = useRef<Map<string, Promise<number | null>>>(new Map());
-  const callsByAuthIndexRef = useRef<Record<string, number>>({});
-  const [callsByAuthIndex, setCallsByAuthIndex] = useState<Record<string, number>>({});
+  const inFlightRef = useRef<Map<string, Promise<AuthFileCycleUsageSnapshot | null>>>(new Map());
+  const snapshotByAuthIndexRef = useRef<Record<string, AuthFileCycleUsageSnapshot>>({});
+  const [snapshotByAuthIndex, setSnapshotByAuthIndex] = useState<
+    Record<string, AuthFileCycleUsageSnapshot>
+  >({});
 
   useEffect(() => {
     return () => {
@@ -56,37 +80,54 @@ export function useAuthFilesCycleUsageState() {
   }, []);
 
   useEffect(() => {
-    callsByAuthIndexRef.current = callsByAuthIndex;
-  }, [callsByAuthIndex]);
+    snapshotByAuthIndexRef.current = snapshotByAuthIndex;
+  }, [snapshotByAuthIndex]);
 
-  const fetchCycleUsage = useCallback(async (authIndex: string): Promise<number | null> => {
-    const existing = inFlightRef.current.get(authIndex);
-    if (existing) return existing;
+  const fetchCycleUsage = useCallback(
+    async (authIndex: string): Promise<AuthFileCycleUsageSnapshot | null> => {
+      const existing = inFlightRef.current.get(authIndex);
+      if (existing) return existing;
 
-    let request: Promise<number | null>;
-    request = usageApi
-      .getAuthFileTrend(authIndex, { days: 7, hours: 5 })
-      .then((trend) => {
-        const nextCount = resolveDisplayCycleCount(trend);
-        if (nextCount === null) return null;
+      let request: Promise<AuthFileCycleUsageSnapshot | null>;
+      request = usageApi
+        .getAuthFileTrend(authIndex, { days: 7, hours: 5 })
+        .then((trend) => {
+          const nextCount = resolveDisplayCycleCount(trend);
+          const budget = readCycleBudgetStats(trend);
+          const snapshot: AuthFileCycleUsageSnapshot = {
+            calls: nextCount,
+            cycleCostTotal: budget.cycleCostTotal,
+            weeklyQuotaUsedPercent: budget.weeklyQuotaUsedPercent,
+          };
 
-        if (mountedRef.current) {
-          setCallsByAuthIndex((prev) =>
-            prev[authIndex] === nextCount ? prev : { ...prev, [authIndex]: nextCount },
-          );
-        }
-        return nextCount;
-      })
-      .catch(() => null)
-      .finally(() => {
-        if (inFlightRef.current.get(authIndex) === request) {
-          inFlightRef.current.delete(authIndex);
-        }
-      });
+          if (mountedRef.current) {
+            setSnapshotByAuthIndex((prev) => {
+              const current = prev[authIndex];
+              if (
+                current &&
+                current.calls === snapshot.calls &&
+                current.cycleCostTotal === snapshot.cycleCostTotal &&
+                current.weeklyQuotaUsedPercent === snapshot.weeklyQuotaUsedPercent
+              ) {
+                return prev;
+              }
+              return { ...prev, [authIndex]: snapshot };
+            });
+          }
+          return snapshot;
+        })
+        .catch(() => null)
+        .finally(() => {
+          if (inFlightRef.current.get(authIndex) === request) {
+            inFlightRef.current.delete(authIndex);
+          }
+        });
 
-    inFlightRef.current.set(authIndex, request);
-    return request;
-  }, []);
+      inFlightRef.current.set(authIndex, request);
+      return request;
+    },
+    [],
+  );
 
   const refreshCycleUsageForFiles = useCallback(
     async (files: AuthFileItem[], options?: RefreshCycleUsageOptions): Promise<void> => {
@@ -99,7 +140,7 @@ export function useAuthFilesCycleUsageState() {
       );
       const targets = options?.force
         ? authIndexes
-        : authIndexes.filter((authIndex) => callsByAuthIndexRef.current[authIndex] === undefined);
+        : authIndexes.filter((authIndex) => snapshotByAuthIndexRef.current[authIndex] === undefined);
       if (targets.length === 0) return;
 
       await Promise.allSettled(targets.map((authIndex) => fetchCycleUsage(authIndex)));
@@ -107,8 +148,25 @@ export function useAuthFilesCycleUsageState() {
     [fetchCycleUsage],
   );
 
+  const callsByAuthIndex = Object.fromEntries(
+    Object.entries(snapshotByAuthIndex)
+      .filter(([, snapshot]) => typeof snapshot.calls === "number")
+      .map(([authIndex, snapshot]) => [authIndex, snapshot.calls as number]),
+  );
+
+  const cycleBudgetByAuthIndex: Record<string, AuthFileCycleBudgetStats> = Object.fromEntries(
+    Object.entries(snapshotByAuthIndex).map(([authIndex, snapshot]) => [
+      authIndex,
+      {
+        cycleCostTotal: snapshot.cycleCostTotal,
+        weeklyQuotaUsedPercent: snapshot.weeklyQuotaUsedPercent,
+      } satisfies AuthFileCycleBudgetStats,
+    ]),
+  );
+
   return {
     callsByAuthIndex,
+    cycleBudgetByAuthIndex,
     refreshCycleUsageForFiles,
   };
 }

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -33,8 +33,10 @@ import {
   formatPlanBadgeLabel,
   resolveClaudeOAuthHealthBadges,
   isRuntimeOnlyAuthFile,
+  normalizeAuthIndexValue,
   parseAdditionalQuotaWindowLabel,
   resolveAuthFileDisplayName,
+  resolveAuthFileDisplayPlanType,
   resolveAuthFilePlanType,
   resolveAuthFileRestrictionBadges,
   resolveAuthFileWeeklyQuotaResetAtMs,
@@ -46,6 +48,7 @@ import {
   resolvePlanBadgeClass,
   shouldShowAuthFileDisplayTag,
   shouldShowAuthFilePlanBadge,
+  type AuthFileCycleBudgetStats,
 } from "@code-proxy/domain";
 import { resolveQuotaProvider, type QuotaProvider } from "@features/quota-preview/quota-fetch";
 import {
@@ -154,6 +157,7 @@ interface UseAuthFilesFilesPresentationOptions {
   connectivityState: Map<string, { loading: boolean; latencyMs: number | null; error: boolean }>;
   checkAuthFileConnectivity: (name: string) => Promise<void>;
   quotaByFileName: Record<string, QuotaState>;
+  cycleBudgetByAuthIndex: Record<string, AuthFileCycleBudgetStats>;
   refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   requestResetCredit: (file: AuthFileItem) => void;
   resettingCreditFileName: string | null;
@@ -180,6 +184,7 @@ export function useAuthFilesFilesPresentation({
   connectivityState,
   checkAuthFileConnectivity,
   quotaByFileName,
+  cycleBudgetByAuthIndex,
   refreshQuota,
   requestResetCredit,
   resettingCreditFileName,
@@ -722,10 +727,16 @@ export function useAuthFilesFilesPresentation({
         render: (file) => {
           const typeKey = resolveFileType(file);
           const badgeClass = TYPE_BADGE_CLASSES[typeKey] ?? TYPE_BADGE_CLASSES.unknown;
-          const planType = resolveAuthFilePlanType(file, quotaByFileName[file.name]);
+          const authIndex = normalizeAuthIndexValue(file.auth_index ?? file.authIndex);
+          const basePlanType = resolveAuthFilePlanType(file, quotaByFileName[file.name]);
+          const planType = resolveAuthFileDisplayPlanType(
+            file,
+            quotaByFileName[file.name],
+            authIndex ? cycleBudgetByAuthIndex[authIndex] : null,
+          );
           const runtimeOnly = isRuntimeOnlyAuthFile(file);
           const showTypeBadge = shouldShowAuthFileDisplayTag(file, typeKey);
-          const showPlanBadge = shouldShowAuthFilePlanBadge(file, planType);
+          const showPlanBadge = shouldShowAuthFilePlanBadge(file, basePlanType);
 
           return (
             <div className="flex flex-col gap-1">
@@ -1078,6 +1089,7 @@ export function useAuthFilesFilesPresentation({
     allPageSelected,
     checkAuthFileConnectivity,
     connectivityState,
+    cycleBudgetByAuthIndex,
     downloadAuthFile,
     formatQuotaItemDetailText,
     formatPlanTypeLabel,


### PR DESCRIPTION
## Summary
- Membership badges use distinct color families: Plus silver, Pro gold scale, SuperGrok emerald, Claude Max warm copper
- Codex Pro only: infer `PRO 5X` / `PRO 20X` from estimated weekly budget (`cycle_cost / used%`)
  - `>= $1000` → PRO 20X
  - `>= $200` → PRO 5X
  - otherwise / missing data → PRO
- Non-Codex plans are unchanged except color styling

## Test plan
- [x] `./scripts/ci-pr.sh`
- [x] unit tests for budget thresholds + badge labels/classes
- [x] auth-files cards tests
- [ ] visual check on `/manage/access/ai-accounts` after deploy