### PR TITLE
fix(auth-files): 收紧 AI 账号卡片最大宽到 24rem

### DIFF
--- a/e2e/account-security-identity-fingerprint.spec.ts
+++ b/e2e/account-security-identity-fingerprint.spec.ts
@@ -895,9 +895,9 @@ test("AI Accounts cards auto-fill with max width on wide desktop", async ({
   expect(columnCount).toBeGreaterThanOrEqual(3);
   expect(desktopCardLayout.justifyItems).toBe("stretch");
   expect(desktopCardLayout.cards).toHaveLength(3);
-  // 34rem @ 16px root = 544px; track max and card max-width both cap growth
+  // 24rem @ 16px root = 384px; track max and card max-width both cap growth
   expect(
-    desktopCardLayout.cards.every((card) => card.maxWidth === "544px"),
+    desktopCardLayout.cards.every((card) => card.maxWidth === "384px"),
   ).toBe(true);
   expect(desktopCardLayout.cards[1].x).toBeGreaterThan(
     desktopCardLayout.cards[0].x,
@@ -907,17 +907,17 @@ test("AI Accounts cards auto-fill with max width on wide desktop", async ({
   );
   expect(
     Math.min(...desktopCardLayout.cards.map((card) => card.width)),
-  ).toBeGreaterThan(320);
+  ).toBeGreaterThan(280);
   expect(
     Math.max(...desktopCardLayout.cards.map((card) => card.width)),
-  ).toBeLessThanOrEqual(544);
+  ).toBeLessThanOrEqual(384);
   // auto-fill may place 4+ tracks on 1920; cards themselves stay capped
   expect(
     desktopCardLayout.gridTemplateColumns
       .split(" ")
       .every((track) => {
         const px = Number.parseFloat(track);
-        return Number.isFinite(px) && px <= 544 + 1;
+        return Number.isFinite(px) && px <= 384 + 1;
       }),
   ).toBe(true);
 });

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1499,7 +1499,7 @@ export function AuthFilesFilesTab({
                 data-testid="auth-files-cards"
                 className="items-stretch md:h-full"
                 viewportClassName="max-md:h-auto max-md:touch-pan-y max-md:overflow-visible max-md:overscroll-auto"
-                contentClassName="grid grid-cols-1 items-stretch justify-items-center gap-5 px-4 py-4 sm:px-5 sm:py-5 md:grid-cols-[repeat(auto-fill,minmax(20rem,34rem))] md:justify-items-stretch md:pr-8"
+                contentClassName="grid grid-cols-1 items-stretch justify-items-center gap-5 px-4 py-4 sm:px-5 sm:py-5 md:grid-cols-[repeat(auto-fill,minmax(18rem,24rem))] md:justify-items-stretch md:pr-8"
                 scrollbarTrackInset={0}
               >
                 {pageItems.map((file) => {
@@ -1642,7 +1642,7 @@ export function AuthFilesFilesTab({
                       padding="default"
                       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[
-                        "group/card flex h-full w-full max-w-[34rem] flex-col rounded-3xl border-slate-200/80 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+                        "group/card flex h-full w-full max-w-[24rem] flex-col rounded-3xl border-slate-200/80 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
                         fileSelected
                           ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
                           : "",


### PR DESCRIPTION
## Summary
- 卡片/列宽上限从 34rem 收到 24rem（约 384px）
- min 同步到 18rem，宽屏更密、单卡更窄
- e2e 断言同步

## Test plan
- [x] `./scripts/ci-pr.sh`
- [ ] 宽屏卡片视图确认更窄、可多列