### PR TITLE
fix: limit AI Accounts cycle-usage trend fan-out concurrency

### DIFF
--- a/pages/auth-files/hooks/__tests__/useAuthFilesCycleUsageState.concurrency.test.ts
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesCycleUsageState.concurrency.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { mapWithConcurrency } from "../mapWithConcurrency";
+
+describe("mapWithConcurrency", () => {
+  it("never runs more than the concurrency limit at once", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 8 }, (_, i) => i);
+
+    const results = await mapWithConcurrency(items, 2, async (item) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      inFlight -= 1;
+      return item * 2;
+    });
+
+    expect(peak).toBeLessThanOrEqual(2);
+    expect(results).toHaveLength(8);
+    expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    expect(
+      results.map((r) => (r.status === "fulfilled" ? r.value : null)),
+    ).toEqual([0, 2, 4, 6, 8, 10, 12, 14]);
+  });
+
+  it("records rejections without aborting siblings", async () => {
+    const worker = vi.fn(async (item: number) => {
+      if (item === 1) throw new Error("boom");
+      return item;
+    });
+    const results = await mapWithConcurrency([0, 1, 2], 2, worker);
+    expect(results[0]).toEqual({ status: "fulfilled", value: 0 });
+    expect(results[1].status).toBe("rejected");
+    expect(results[2]).toEqual({ status: "fulfilled", value: 2 });
+  });
+});

--- a/pages/auth-files/hooks/mapWithConcurrency.ts
+++ b/pages/auth-files/hooks/mapWithConcurrency.ts
@@ -1,0 +1,31 @@
+/**
+ * Run async work over items with a hard concurrency cap.
+ * Used by AI Accounts cycle-usage fan-out so card loads cannot open
+ * unbounded /usage/auth-file-trend storms against the backend.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  if (items.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const run = async () => {
+    while (nextIndex < items.length) {
+      const current = nextIndex;
+      nextIndex += 1;
+      try {
+        const value = await worker(items[current]);
+        results[current] = { status: "fulfilled", value };
+      } catch (reason) {
+        results[current] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: limit }, () => run()));
+  return results;
+}

--- a/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
+++ b/pages/auth-files/hooks/useAuthFilesCycleUsageState.ts
@@ -6,6 +6,7 @@ import {
   resolveFileType,
   type AuthFileCycleBudgetStats,
 } from "@code-proxy/domain";
+import { mapWithConcurrency } from "./mapWithConcurrency";
 
 type RefreshCycleUsageOptions = {
   force?: boolean;
@@ -64,6 +65,13 @@ const readCycleBudgetStats = (trend: {
   cycleCostTotal: toFiniteOrNull(trend.cycle_cost_total),
   weeklyQuotaUsedPercent: toFiniteOrNull(trend.weekly_quota_used_percent),
 });
+
+/**
+ * Limit concurrent /usage/auth-file-trend fan-out from the AI Accounts card view.
+ * Each trend call fans into multiple request_logs aggregates on the backend; unbounded
+ * Promise.all on a full page can peg CPU while leaving other features starved.
+ */
+const AUTH_FILE_TREND_FETCH_CONCURRENCY = 2;
 
 export function useAuthFilesCycleUsageState() {
   const mountedRef = useRef(true);
@@ -143,7 +151,11 @@ export function useAuthFilesCycleUsageState() {
         : authIndexes.filter((authIndex) => snapshotByAuthIndexRef.current[authIndex] === undefined);
       if (targets.length === 0) return;
 
-      await Promise.allSettled(targets.map((authIndex) => fetchCycleUsage(authIndex)));
+      // Force refresh (manual button) still uses the same concurrency cap so a
+      // single page action cannot open N simultaneous auth-file-trend storms.
+      await mapWithConcurrency(targets, AUTH_FILE_TREND_FETCH_CONCURRENCY, (authIndex) =>
+        fetchCycleUsage(authIndex),
+      );
     },
     [fetchCycleUsage],
   );


### PR DESCRIPTION
## Summary
- Cap concurrent `/usage/auth-file-trend` fetches from the AI Accounts card view to 2 (was unbounded `Promise.all`).
- Extract `mapWithConcurrency` helper with unit tests so a full page of cards cannot open an N-way request storm against `request_logs`.

## Context
Pairs with CliRelay backend SQL aggregate + short TTL cache. Frontend still loads all visible card cycle stats, just without pegging the server by fanning every account at once.

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- pages/auth-files/hooks/__tests__/useAuthFilesCycleUsageState.concurrency.test.ts` (2 tests)
- [ ] After merge: open AI Accounts cards view; cycle usage still fills in; Network tab shows at most 2 concurrent auth-file-trend at a time