### PR TITLE
fix: slow dashboard-summary poll to 20s

### DIFF
--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -506,9 +506,11 @@ export function DashboardPage() {
     void refresh(range);
   }, [refresh, range]);
 
+  // Backend caches dashboard-summary for ~15s; poll slightly above that so
+  // multi-tab remounts do not re-stampede request_logs aggregation.
   useInterval(() => {
     void refresh(range, true);
-  }, 5000);
+  }, 20_000);
 
   const kpi = summary?.kpi;
   const trends = summary?.trends;

--- a/pages/dashboard/__tests__/DashboardCards.test.ts
+++ b/pages/dashboard/__tests__/DashboardCards.test.ts
@@ -27,7 +27,7 @@ describe("dashboard card composition", () => {
     expect(source).toContain("throughput_all_tenants_hint");
     expect(source).toContain("meta.generated_at");
     expect(source).toContain('<EChart option={option} className="h-10" overflowVisible />');
-    expect(source).toContain("}, 5000);");
+    expect(source).toContain("}, 20_000);");
     expect(source).not.toContain('replaceMerge="series"');
     expect(source).not.toContain('from "@features/monitor-widgets"');
     expect(source).not.toContain("<KpiCard");


### PR DESCRIPTION
## Summary
- Slow dashboard silent refresh from 5s to 20s to match the backend ~15s `dashboard-summary` cache TTL.
- Reduces multi-tab poll storms that previously forced a nginx load-incident 503 on `/v0/management/dashboard-summary`.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e)
- [ ] After merge + deploy with CliRelay #705: dashboard loads without "temporarily disabled for load incident"