### PR TITLE
feat: add Claude Fable default model to CC Switch configs

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -60,7 +60,13 @@ const controlClassName =
   "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
 const fieldClassName = "flex flex-col gap-1.5";
 
-const CLAUDE_ROLE_ORDER: CcSwitchClaudeModelRole[] = ["main", "haiku", "sonnet", "opus"];
+const CLAUDE_ROLE_ORDER: CcSwitchClaudeModelRole[] = [
+  "main",
+  "haiku",
+  "sonnet",
+  "opus",
+  "fable",
+];
 const MODEL_MAPPING_LOADING_ROWS = ["short", "medium", "long"];
 const CONFIG_MODAL_CLIENTS = CC_SWITCH_CLIENTS.filter((client) => client.type !== "gemini");
 const DEFAULT_CODEX_CONTEXT_WINDOW = 128_000;
@@ -70,6 +76,8 @@ const rolePriority: Record<CcSwitchClaudeModelRole, string[]> = {
   haiku: ["haiku", "sonnet", "claude"],
   sonnet: ["sonnet", "claude"],
   opus: ["opus", "sonnet", "claude"],
+  // fable → opus fallback mirrors cc-switch / Claude Code official downgrade
+  fable: ["fable", "opus", "sonnet", "claude"],
 };
 
 type ConfigDraft = CcSwitchImportConfigListItem;
@@ -213,10 +221,14 @@ function reconcileClaudeMappings(
       pickClaudeRoleModel(role, models) ||
       (role === "main" ? fallbackModel.trim() : "");
     const existingRequestModel = existing?.requestModel.trim() ?? "";
+    // Claude Code sends claude-fable-5; cc-switch deeplink still ignores fableModel, so default request id for rewrite.
+    const defaultRequestModel = role === "fable" ? "claude-fable-5" : targetModel;
     return {
       role,
       requestModel:
-        existingRequestModel && existingRequestModel !== role ? existingRequestModel : targetModel,
+        existingRequestModel && existingRequestModel !== role
+          ? existingRequestModel
+          : defaultRequestModel,
       targetModel,
     };
   });

--- a/packages/api-client/src/endpoints/ccswitch-import-configs.ts
+++ b/packages/api-client/src/endpoints/ccswitch-import-configs.ts
@@ -40,7 +40,11 @@ const normalizeModelMappings = (value: unknown): CcSwitchModelMapping[] => {
       if (!record) return null;
       const role = normalizeString(record.role)?.toLowerCase();
       const normalizedRole =
-        role === "main" || role === "haiku" || role === "sonnet" || role === "opus"
+        role === "main" ||
+        role === "haiku" ||
+        role === "sonnet" ||
+        role === "opus" ||
+        role === "fable"
           ? role
           : undefined;
       const targetModel = normalizeString(

--- a/packages/domain/src/ccswitch/ccswitchImport.ts
+++ b/packages/domain/src/ccswitch/ccswitchImport.ts
@@ -6,7 +6,7 @@ import {
 } from "./ccswitchImportSettings";
 
 export type CcSwitchClientType = "claude" | "codex" | "gemini";
-export type CcSwitchClaudeModelRole = "main" | "haiku" | "sonnet" | "opus";
+export type CcSwitchClaudeModelRole = "main" | "haiku" | "sonnet" | "opus" | "fable";
 
 export interface CcSwitchModelMappingInput {
   requestModel: string;
@@ -215,7 +215,8 @@ const normalizeModelMappings = (
         mapping.role === "main" ||
         mapping.role === "haiku" ||
         mapping.role === "sonnet" ||
-        mapping.role === "opus"
+        mapping.role === "opus" ||
+        mapping.role === "fable"
           ? mapping.role
           : undefined;
       const requestModel = String(mapping.requestModel ?? "").trim();
@@ -804,9 +805,12 @@ export function buildCcSwitchImportUrl(input: {
     const haikuModel = getRoleRequestModel(modelMappings, "haiku");
     const sonnetModel = getRoleRequestModel(modelMappings, "sonnet");
     const opusModel = getRoleRequestModel(modelMappings, "opus");
+    const fableModel = getRoleRequestModel(modelMappings, "fable");
     if (haikuModel) params.set("haikuModel", haikuModel);
     if (sonnetModel) params.set("sonnetModel", sonnetModel);
     if (opusModel) params.set("opusModel", opusModel);
+    // ponytail: cc-switch deeplink still only reads haiku/sonnet/opus; keep fable in model_mappings for route rewrite
+    if (fableModel) params.set("fableModel", fableModel);
   }
   if (input.clientType === "codex") {
     params.set("apiFormat", CC_SWITCH_CODEX_API_FORMAT);

--- a/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
+++ b/packages/domain/src/ccswitch/ccswitchImportConfigList.ts
@@ -68,7 +68,8 @@ const normalizeClaudeRole = (value: unknown): CcSwitchClaudeModelRole | undefine
   return normalized === "main" ||
     normalized === "haiku" ||
     normalized === "sonnet" ||
-    normalized === "opus"
+    normalized === "opus" ||
+    normalized === "fable"
     ? normalized
     : undefined;
 };

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2792,6 +2792,7 @@
     "config_claude_role_haiku": "Haiku default model",
     "config_claude_role_sonnet": "Sonnet default model",
     "config_claude_role_opus": "Opus default model",
+    "config_claude_role_fable": "Fable default model",
     "model_use_custom": "Use \"{{value}}\""
   },
   "api_keys_page": {

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -171,6 +171,7 @@
     "config_claude_role_haiku": "Haiku default model",
     "config_claude_role_sonnet": "Sonnet default model",
     "config_claude_role_opus": "Opus default model",
+    "config_claude_role_fable": "Fable default model",
     "model_use_custom": "Use \"{{value}}\""
   },
   "title": {

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3089,6 +3089,7 @@
     "config_claude_role_haiku": "Haiku 默认模型",
     "config_claude_role_sonnet": "Sonnet 默认模型",
     "config_claude_role_opus": "Opus 默认模型",
+    "config_claude_role_fable": "Fable 默认模型",
     "model_use_custom": "使用“{{value}}”"
   },
   "api_keys_page": {

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -871,6 +871,9 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(
       await within(dialog).findAllByDisplayValue("kimi-k2.5"),
     ).toHaveLength(4);
+    expect(
+      await within(dialog).findByDisplayValue("claude-fable-5"),
+    ).toBeInTheDocument();
     await user.click(
       within(dialog).getByRole("combobox", { name: /^main model$/i }),
     );
@@ -1265,6 +1268,7 @@ describe("CcSwitchImportSettingsPage", () => {
       within(dialog).getByText(/sonnet default model/i),
     ).toBeInTheDocument();
     expect(within(dialog).getByText(/opus default model/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/fable default model/i)).toBeInTheDocument();
     expect(
       within(dialog).getByText(/cc switch request model/i),
     ).toBeInTheDocument();
@@ -1315,6 +1319,11 @@ describe("CcSwitchImportSettingsPage", () => {
             {
               role: "opus",
               requestModel: "claude-opus-4-1",
+              targetModel: "claude-opus-4-1",
+            },
+            {
+              role: "fable",
+              requestModel: "claude-fable-5",
               targetModel: "claude-opus-4-1",
             },
           ]),
@@ -1506,6 +1515,11 @@ describe("CcSwitchImportSettingsPage", () => {
             targetModel: "target-sonnet",
           },
           { role: "opus", requestModel: "b-opus", targetModel: "target-opus" },
+          {
+            role: "fable",
+            requestModel: "c-fable",
+            targetModel: "target-opus",
+          },
         ],
       },
     ]);
@@ -1531,6 +1545,7 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(orderedRequestModels).toEqual([
       "a-haiku",
       "b-opus",
+      "c-fable",
       "m-sonnet",
       "z-main",
     ]);
@@ -1550,6 +1565,11 @@ describe("CcSwitchImportSettingsPage", () => {
             {
               role: "opus",
               requestModel: "b-opus",
+              targetModel: "target-opus",
+            },
+            {
+              role: "fable",
+              requestModel: "c-fable",
               targetModel: "target-opus",
             },
             {

--- a/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
+++ b/pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts
@@ -80,6 +80,7 @@ describe("ccswitchImport", () => {
         { role: "haiku", requestModel: "claude-haiku-router", targetModel: "claude-haiku-4-5" },
         { role: "sonnet", requestModel: "claude-sonnet-router", targetModel: "claude-sonnet-4-5" },
         { role: "opus", requestModel: "claude-opus-router", targetModel: "claude-opus-4-1" },
+        { role: "fable", requestModel: "claude-fable-router", targetModel: "claude-fable-5" },
       ],
     });
 
@@ -88,6 +89,7 @@ describe("ccswitchImport", () => {
     expect(parsed.searchParams.get("haikuModel")).toBe("claude-haiku-router");
     expect(parsed.searchParams.get("sonnetModel")).toBe("claude-sonnet-router");
     expect(parsed.searchParams.get("opusModel")).toBe("claude-opus-router");
+    expect(parsed.searchParams.get("fableModel")).toBe("claude-fable-router");
   });
 
   test("keeps legacy Claude role placeholders compatible when building deeplinks", () => {


### PR DESCRIPTION
## Summary
- Add Claude Fable as the fifth CC Switch role (main/haiku/sonnet/opus/fable), matching cc-switch's fourth model tier.
- Default fable request model to `claude-fable-5` so route rewrite hits Claude Code's real request id; target falls back fable → opus.
- Emit `fableModel` on import deeplink (cc-switch may ignore until it supports it; relay rewrite still works via model_mappings).

## Test plan
- [x] `bun run test:ci -- pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx pages/ccswitch-import-settings/__tests__/ccswitchImport.test.ts packages/api-client/src/endpoints/__tests__/ccswitch-import-configs.test.ts`
- [x] `bun run lint` / `design:check` / `build` / `bundle:diff`
- [ ] Pair with CliRelay PR that accepts `fable` role in `normalizeCcSwitchModelRole`