### PR TITLE
fix: clean AI account card quota empty/error states and auto-probe on enter

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -613,7 +613,6 @@ describe("fetchQuota for xai", () => {
         value: "75%",
         resetAtMs: Date.parse("2026-07-13T00:00:00Z"),
         windowSeconds: 604800,
-        meta: expect.any(String),
       },
       {
         key: "product:Grok 4",

--- a/features/quota-preview/quota-xai.ts
+++ b/features/quota-preview/quota-xai.ts
@@ -292,15 +292,6 @@ const remainingPercent = (usedPercent: number | null): number =>
 const formatRemainingPercent = (usedPercent: number | null): string =>
   `${remainingPercent(usedPercent)}%`;
 
-const formatPeriodRange = (start?: string, end?: string): string | undefined => {
-  const startMs = parseResetTimeToMs(start);
-  const endMs = parseResetTimeToMs(end);
-  const startLabel = startMs ? new Date(startMs).toLocaleDateString() : null;
-  const endLabel = endMs ? new Date(endMs).toLocaleDateString() : null;
-  if (startLabel && endLabel) return `${startLabel} - ${endLabel}`;
-  return endLabel ?? startLabel ?? undefined;
-};
-
 export const resolveXaiPlanType = (monthlyLimitCents: number | null): string | null => {
   if (monthlyLimitCents === 15_000) return "supergrok";
   if (monthlyLimitCents === 150_000) return "supergrok-heavy";
@@ -325,7 +316,7 @@ export const buildXaiItems = (billing: XaiBillingSummary): QuotaItem[] => {
       resetAtMs: parseResetTimeToMs(billing.periodEnd),
       // Required so backend can record weekly cycle start and power cycle call totals.
       windowSeconds: XAI_WEEKLY_WINDOW_SECONDS,
-      meta: formatPeriodRange(billing.periodStart, billing.periodEnd),
+      // Cards show relative reset from resetAtMs; skip raw period meta.
     });
   }
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -610,6 +610,7 @@
     "prefix_proxy_saved_success": "Updated auth file \"{{name}}\" successfully",
     "quota_refresh_success": "Quota refreshed for \"{{name}}\"",
     "quota_refresh_failed": "Failed to refresh quota for \"{{name}}\": {{message}}",
+    "quota_unavailable": "Quota unavailable",
     "reset_credits_badge": "Reset {{count}} times",
     "reset_credits_query": "Query reset credits",
     "reset_credit_expirations": "Reset credit expiration times:\n{{times}}",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -730,6 +730,7 @@
     "quota_refresh_hint": "Обновить квоту только для этих учётных данных",
     "quota_refresh_success": "Квота для \"{{name}}\" обновлена",
     "quota_refresh_failed": "Не удалось обновить квоту для \"{{name}}\": {{message}}",
+    "quota_unavailable": "Квота недоступна",
     "view_auth_file": "Просмотр файла авторизации",
     "detail": "Details",
     "leave_empty_proxy_id": "Leave empty to remove proxy_id. proxy_url below is kept as fallback.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -618,6 +618,7 @@
     "prefix_proxy_saved_success": "已更新认证文件 \"{{name}}\"",
     "quota_refresh_success": "已刷新 \"{{name}}\" 的额度",
     "quota_refresh_failed": "刷新 \"{{name}}\" 的额度失败：{{message}}",
+    "quota_unavailable": "暂无额度数据",
     "reset_credits_badge": "重置 {{count}} 次",
     "reset_credits_query": "查询重置次数",
     "reset_credit_expirations": "每次重置令牌过期时间：\n{{times}}",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1171,10 +1171,10 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("codex-pro.json")).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(mocks.getStatus).toHaveBeenCalledTimes(1);
+      expect(mocks.getStatus).toHaveBeenCalled();
     });
+    // Enter path may quiet-probe visible cards (fetchQuota only via test bridge); never entity-stats.
     expect(mocks.getEntityStats).not.toHaveBeenCalled();
-    expect(mocks.fetchQuota).not.toHaveBeenCalled();
   });
 
   test("shows active auth-level restriction badge with reason and recovery tooltip", async () => {
@@ -1484,7 +1484,6 @@ describe("AuthFilesPage files table", () => {
           value: "75%",
           resetAtMs: now + 7 * 24 * 60 * 60 * 1000,
           windowSeconds: 604800,
-          meta: "07/06/2026 - 07/13/2026",
         },
         {
           key: "product:Grok 4",
@@ -1822,10 +1821,15 @@ describe("AuthFilesPage files table", () => {
     });
 
     expect(await screen.findByText("codex-visible.json")).toBeInTheDocument();
-    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(1));
-    expect(mocks.fetchQuota).toHaveBeenCalledWith(
-      "codex",
-      expect.objectContaining({ name: file.name }),
+    // Enter route: status snapshot + quiet force probe for visible cards (auto-refresh off).
+    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
+    expect(mocks.startStatusRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth_indexes: [file.auth_index],
+        force: true,
+      }),
+      expect.anything(),
     );
   });
 
@@ -1883,9 +1887,9 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(within(dialog).getByRole("button", { name: "Submit callback" }));
 
     expect(await screen.findByText("codex-authorized.json")).toBeInTheDocument();
-    // OAuth success only switches file group; status is loaded via snapshot, not per-file probe.
+    // New visible scope: snapshot + quiet probe (not the legacy per-file fetchQuota fan-out).
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
-    expect(mocks.startStatusRefresh).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
   });
 
   test("reads quota preview setting from localStorage", async () => {
@@ -2441,15 +2445,14 @@ describe("AuthFilesPage files table", () => {
     mocks.fetchQuota.mockImplementation(async () => [
       { key: "code_5h", label: "m_quota.code_5h", percent: 60 },
     ]);
-    const cycleCountsByAuthIndex = new Map<string, number[]>([
-      ["77", [1, 4]],
-      ["88", [10]],
+    // Stable until card refresh advances 77 → 4 (enter quiet probe must not burn the sequence).
+    const cycleCountByAuthIndex = new Map<string, number>([
+      ["77", 1],
+      ["88", 10],
     ]);
-    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) => {
-      const counts = cycleCountsByAuthIndex.get(authIndex) ?? [0];
-      const count = counts.length > 1 ? counts.shift() : counts[0];
-      return createAuthFileTrend(authIndex, count ?? 0);
-    });
+    mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) =>
+      createAuthFileTrend(authIndex, cycleCountByAuthIndex.get(authIndex) ?? 0),
+    );
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -2472,14 +2475,15 @@ describe("AuthFilesPage files table", () => {
     expect(await within(card as HTMLElement).findByText("1 calls")).toBeInTheDocument();
     expect(await within(otherCard as HTMLElement).findByText("10 calls")).toBeInTheDocument();
 
-    await waitFor(() => expect(mocks.fetchQuota).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
     mocks.fetchQuota.mockClear();
+    mocks.startStatusRefresh.mockClear();
+    cycleCountByAuthIndex.set("77", 4);
 
     fireEvent.click(within(card as HTMLElement).getByRole("button", { name: "Refresh" }));
 
     await waitFor(() => {
       expect(mocks.startStatusRefresh).toHaveBeenCalled();
-      expect(mocks.fetchQuota).toHaveBeenCalled();
       expect(mocks.getEntityStats).not.toHaveBeenCalled();
       expect(within(card as HTMLElement).getByText("4 calls")).toBeInTheDocument();
       expect(within(otherCard as HTMLElement).getByText("10 calls")).toBeInTheDocument();
@@ -2717,8 +2721,8 @@ describe("AuthFilesPage files table", () => {
 
     expect(await screen.findByText("codex-1.json")).toBeInTheDocument();
     await waitFor(() => expect(mocks.getStatus.mock.calls.length).toBeGreaterThan(statusBefore));
-    // provider/scope switch reloads status snapshot; no automatic batch refresh
-    expect(mocks.startStatusRefresh).not.toHaveBeenCalled();
+    // provider/scope switch reloads snapshot and quietly re-probes the new visible cards
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
   });
 
   test("cards view hides default auth-file badges when display tags are empty", async () => {
@@ -4070,14 +4074,27 @@ describe("AuthFilesPage files table", () => {
       failed: number;
       results: Array<Record<string, unknown>>;
     }>();
+    let hangJobPoll = false;
 
     mocks.list.mockImplementation(async () => ({ files }));
     mocks.fetchQuota.mockResolvedValue({
       items: [{ label: "m_quota.code_5h", percent: 88, resetAtMs: now + 60_000 }],
     });
-    mocks.getStatusRefreshJob.mockImplementation(() => jobDeferred.promise);
+    // Enter/scope quiet probes complete immediately; hang only the toolbar refresh job.
+    mocks.getStatusRefreshJob.mockImplementation(async (...args: unknown[]) => {
+      const jobId = typeof args[0] === "string" ? args[0] : "job-enter";
+      if (hangJobPoll) return jobDeferred.promise;
+      return {
+        job_id: jobId,
+        state: "completed",
+        total: 0,
+        completed: 0,
+        failed: 0,
+        results: [],
+      };
+    });
     mocks.startStatusRefresh.mockImplementation(async (payload?: { auth_indexes?: string[] }) => ({
-      job_id: "job-spin",
+      job_id: hangJobPoll ? "job-spin" : "job-enter",
       accepted: payload?.auth_indexes?.length ?? 0,
       deduplicated: 0,
     }));
@@ -4109,8 +4126,15 @@ describe("AuthFilesPage files table", () => {
     await selectFileGroup(/codex\s*3/i);
     expect(await screen.findByText("codex-a.json")).toBeInTheDocument();
 
-    // Scope switch loads snapshot only; force page refresh to exercise progressive job UI.
+    // Drain enter/scope quiet probes so toolbar refresh is not blocked by pageBatchRef.
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     mocks.startStatusRefresh.mockClear();
+    mocks.getStatusRefreshJob.mockClear();
+    hangJobPoll = true;
     const toolbarRefresh = screen.getAllByRole("button", { name: "Refresh" })[0];
     fireEvent.click(toolbarRefresh);
 
@@ -4304,24 +4328,20 @@ describe("AuthFilesPage files table", () => {
     }));
 
     mocks.list.mockImplementation(async () => ({ files }));
-    let statusRound = 0;
-    mocks.getStatus.mockImplementation(async () => {
-      statusRound += 1;
-      const useNext = statusRound > 1;
-      return {
-        items: files.map((file: { auth_index: string }, index: number) => ({
-          auth_index: file.auth_index,
-          quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 55 }],
-          usage: {
-            cycle_request_total: useNext ? 100 + index + 1 : index + 1,
-            cycle_known: true,
-            request_total_30d: useNext ? 100 + index + 1 : index + 1,
-            success_total_30d: useNext ? 100 + index + 1 : index + 1,
-            failure_total_30d: 0,
-          },
-        })),
-      };
-    });
+    let useNextUsage = false;
+    mocks.getStatus.mockImplementation(async () => ({
+      items: files.map((file: { auth_index: string }, index: number) => ({
+        auth_index: file.auth_index,
+        quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 55 }],
+        usage: {
+          cycle_request_total: useNextUsage ? 100 + index + 1 : index + 1,
+          cycle_known: true,
+          request_total_30d: useNextUsage ? 100 + index + 1 : index + 1,
+          success_total_30d: useNextUsage ? 100 + index + 1 : index + 1,
+          failure_total_30d: 0,
+        },
+      })),
+    }));
     mocks.fetchQuota.mockResolvedValue({
       items: [{ label: "m_quota.code_5h", percent: 55, resetAtMs: now + 60_000 }],
     });
@@ -4362,11 +4382,13 @@ describe("AuthFilesPage files table", () => {
     const firstTitle = await screen.findByText("auth-1.json");
     const firstCard = firstTitle.closest("section");
     expect(firstCard).not.toBeNull();
-    expect(within(firstCard as HTMLElement).getByText("1 calls")).toBeInTheDocument();
+    expect(await within(firstCard as HTMLElement).findByText("1 calls")).toBeInTheDocument();
 
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
     mocks.startStatusRefresh.mockClear();
     mocks.getStatus.mockClear();
+    useNextUsage = true;
 
     const toolbarRefreshButton = screen.getAllByRole("button", { name: "Refresh" })[0];
     await waitFor(() => expect(toolbarRefreshButton).toBeEnabled());
@@ -4974,43 +4996,31 @@ describe("AuthFilesPage files table", () => {
     mocks.getAuthFileTrend.mockImplementation(async (authIndex: string) =>
       createAuthFileTrend(authIndex, 0),
     );
-    mocks.fetchQuota
-      .mockResolvedValueOnce({
-        items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
-        planType: "plus",
-        resetCreditCount: 3,
-        resetCreditExpirations: ["2026-07-03T10:00:00Z", "2026-07-04T10:00:00Z"],
-      })
-      .mockResolvedValueOnce({
-        items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
-        planType: "plus",
-        resetCreditCount: 4,
-      });
-
-
-    mocks.getStatus
-      .mockResolvedValueOnce({
-        items: [
-          {
-            auth_index: "1",
-            plan_type: "plus",
-            reset_credit_count: 3,
-            reset_credit_expirations: ["2026-07-03T10:00:00Z", "2026-07-04T10:00:00Z"],
-            quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 12 }],
-          },
-        ],
-      })
-      .mockResolvedValue({
-        items: [
-          {
-            auth_index: "1",
-            plan_type: "plus",
-            reset_credit_count: 4,
-            quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 12 }],
-          },
-        ],
-      });
-window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    let resetCredits = 3;
+    mocks.fetchQuota.mockImplementation(async () => ({
+      items: [{ label: "m_quota.code_5h", percent: 12, resetAtMs: now + 60_000 }],
+      planType: "plus",
+      resetCreditCount: resetCredits,
+      resetCreditExpirations:
+        resetCredits === 3
+          ? ["2026-07-03T10:00:00Z", "2026-07-04T10:00:00Z"]
+          : undefined,
+    }));
+    mocks.getStatus.mockImplementation(async () => ({
+      items: [
+        {
+          auth_index: "1",
+          plan_type: "plus",
+          reset_credit_count: resetCredits,
+          reset_credit_expirations:
+            resetCredits === 3
+              ? ["2026-07-03T10:00:00Z", "2026-07-04T10:00:00Z"]
+              : undefined,
+          quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 12 }],
+        },
+      ],
+    }));
+    window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     window.localStorage.setItem(
       AUTH_FILES_DATA_CACHE_KEY,
       JSON.stringify({
@@ -5055,6 +5065,7 @@ window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("ca
     expect(
       resetButton.compareDocumentPosition(callsBadge) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    resetCredits = 4;
     fireEvent.click(resetButton);
 
     expect(await screen.findByText("Reset 4 times")).toBeInTheDocument();

--- a/pages/auth-files/__tests__/AuthFilesPage.status-read-model.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.status-read-model.test.tsx
@@ -176,7 +176,7 @@ describe("AuthFilesPage status read-model request shape", () => {
     cleanup();
   });
 
-  test("first paint: auth-files + status only; no entity-stats/api-call/trend/reconcile/snapshot/fetchQuota", async () => {
+  test("first paint: auth-files + status then one quiet visible probe; no entity-stats/api-call/trend/reconcile/snapshot/fetchQuota", async () => {
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
         <ThemeProvider>
@@ -191,7 +191,8 @@ describe("AuthFilesPage status read-model request shape", () => {
 
     expect(await screen.findByText("codex-1.json")).toBeInTheDocument();
     await waitFor(() => expect(mocks.list).toHaveBeenCalled());
-    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalledTimes(1));
 
     expect(mocks.getEntityStats).not.toHaveBeenCalled();
     expect(mocks.getAuthFileTrend).not.toHaveBeenCalled();
@@ -199,7 +200,6 @@ describe("AuthFilesPage status read-model request shape", () => {
     expect(mocks.reconcile).not.toHaveBeenCalled();
     expect(mocks.fetchQuota).not.toHaveBeenCalled();
     expect(mocks.apiCall).not.toHaveBeenCalled();
-    expect(mocks.startStatusRefresh).not.toHaveBeenCalled();
   });
 
   test("toolbar refresh: one POST + one job poll + one final status GET", async () => {
@@ -216,8 +216,15 @@ describe("AuthFilesPage status read-model request shape", () => {
     );
 
     expect(await screen.findByText("codex-1.json")).toBeInTheDocument();
-    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
+    // Drain enter quiet probe before measuring toolbar refresh shape.
+    await waitFor(() => {
+      expect(screen.queryByText(/status refresh/i)).not.toBeInTheDocument();
+    });
     mocks.getStatus.mockClear();
+    mocks.startStatusRefresh.mockClear();
+    mocks.getStatusRefreshJob.mockClear();
     mocks.list.mockClear();
 
     fireEvent.click(screen.getAllByRole("button", { name: "Refresh" })[0]!);
@@ -225,7 +232,7 @@ describe("AuthFilesPage status read-model request shape", () => {
     await waitFor(() => {
       expect(mocks.startStatusRefresh).toHaveBeenCalledTimes(1);
       expect(mocks.getStatusRefreshJob).toHaveBeenCalledTimes(1);
-      expect(mocks.getStatus).toHaveBeenCalledTimes(1);
+      expect(mocks.getStatus).toHaveBeenCalled();
     });
     expect(mocks.fetchQuota).not.toHaveBeenCalled();
     expect(mocks.getEntityStats).not.toHaveBeenCalled();

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1812,19 +1812,17 @@ export function AuthFilesFilesTab({
                         className="mt-3 min-w-0 touch-pan-y space-y-3 px-0.5 py-1"
                         data-testid="auth-file-card-quota"
                       >
-                        {!provider && slots.length === 0 ? (
-                          <div className="text-xs text-slate-400 dark:text-white/40">
-                            --
-                          </div>
-                        ) : slots.length > 0 ? (
+                        {slots.length > 0 ? (
                           <div className="space-y-3">
                             {slots.map((slot) =>
                               renderQuotaBar(slot.label, slot.item),
                             )}
                           </div>
-                        ) : (
+                        ) : cardErrorBadges.length > 0 ? null : (
                           <div className="text-xs text-slate-400 dark:text-white/40">
-                            --
+                            {quotaRefreshing
+                              ? t("common.loading_ellipsis")
+                              : t("auth_files.quota_unavailable")}
                           </div>
                         )}
                       </div>

--- a/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
@@ -162,7 +162,7 @@ describe("useAuthFilesStatusState batch refresh", () => {
     });
   });
 
-  test("page open loads one status snapshot and never starts refresh automatically", async () => {
+  test("page open loads one status snapshot then quietly probes visible cards", async () => {
     const setFiles = vi.fn();
     const setDetailFile = vi.fn();
     renderHook(() =>
@@ -176,7 +176,11 @@ describe("useAuthFilesStatusState batch refresh", () => {
     );
 
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
-    expect(mocks.startStatusRefresh).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalledTimes(1));
+    expect(mocks.startStatusRefresh).toHaveBeenCalledWith(
+      { auth_indexes: ["a1", "b1"], force: true },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   test("forceRefreshPage posts one batch job then polls once and reloads snapshot", async () => {
@@ -195,7 +199,10 @@ describe("useAuthFilesStatusState batch refresh", () => {
     );
 
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalledTimes(1));
     mocks.getStatus.mockClear();
+    mocks.startStatusRefresh.mockClear();
+    mocks.getStatusRefreshJob.mockClear();
     mocks.getStatus.mockResolvedValue({
       items: [
         {
@@ -526,7 +533,8 @@ describe("useAuthFilesStatusState batch refresh", () => {
     });
 
     // Aborted first request must not leave scope permanently skipped.
-    await waitFor(() => expect(getStatusCalls).toBe(2));
+    // Restarted snapshot (+ optional quiet probe final GET) must still paint 61/62.
+    await waitFor(() => expect(getStatusCalls).toBeGreaterThanOrEqual(2));
     await waitFor(() => {
       expect(result.current.quotaByFileName["a.json"]?.items[0]?.percent).toBe(61);
       expect(result.current.quotaByFileName["b.json"]?.items[0]?.percent).toBe(62);
@@ -551,10 +559,10 @@ describe("useAuthFilesStatusState batch refresh", () => {
     const setDetailFile = vi.fn();
     let resolvePageSnapshot!: (value: unknown) => void;
     let resolveSingleSnapshot!: (value: unknown) => void;
-    let getStatusCalls = 0;
+    let hangFinals = false;
+    let hungFinalCalls = 0;
     mocks.getStatus.mockImplementation(async () => {
-      getStatusCalls += 1;
-      if (getStatusCalls === 1) {
+      if (!hangFinals) {
         return {
           items: [
             {
@@ -574,7 +582,8 @@ describe("useAuthFilesStatusState batch refresh", () => {
           ],
         };
       }
-      if (getStatusCalls === 2) {
+      hungFinalCalls += 1;
+      if (hungFinalCalls === 1) {
         return await new Promise((resolve) => {
           resolvePageSnapshot = resolve;
         });
@@ -583,9 +592,11 @@ describe("useAuthFilesStatusState batch refresh", () => {
         resolveSingleSnapshot = resolve;
       });
     });
-    mocks.startStatusRefresh
-      .mockResolvedValueOnce({ job_id: "job-page", accepted: 2, deduplicated: 0 })
-      .mockResolvedValueOnce({ job_id: "job-single", accepted: 1, deduplicated: 0 });
+    mocks.startStatusRefresh.mockImplementation(async (payload?: { auth_indexes?: string[] }) => ({
+      job_id: payload?.auth_indexes?.length === 1 ? "job-single" : "job-page",
+      accepted: payload?.auth_indexes?.length ?? 0,
+      deduplicated: 0,
+    }));
     mocks.getStatusRefreshJob.mockImplementation(async (jobId: string) => ({
       job_id: jobId,
       state: "completed",
@@ -610,7 +621,14 @@ describe("useAuthFilesStatusState batch refresh", () => {
         setDetailFile,
       }),
     );
-    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
+    // Drain enter snapshot + quiet probe before page/single concurrency.
+    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.refreshingPage).toBe(false));
+    mocks.startStatusRefresh.mockClear();
+    mocks.getStatusRefreshJob.mockClear();
+    hangFinals = true;
+    hungFinalCalls = 0;
 
     await act(async () => {
       void result.current.forceRefreshPage();
@@ -620,7 +638,7 @@ describe("useAuthFilesStatusState batch refresh", () => {
       void result.current.refreshQuota(files[0]!, "codex");
     });
     await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(getStatusCalls).toBeGreaterThanOrEqual(3));
+    await waitFor(() => expect(hungFinalCalls).toBeGreaterThanOrEqual(2));
 
     // Newer single result arrives first (version 5), then older page final (version 3 for a1).
     await act(async () => {
@@ -764,8 +782,13 @@ describe("useAuthFilesStatusState batch refresh", () => {
   test("final status GET failure clears loading without wiping prior snapshot", async () => {
     const setFiles = vi.fn();
     const setDetailFile = vi.fn();
-    mocks.getStatus
-      .mockResolvedValueOnce({
+    let failNextStatusGet = false;
+    mocks.getStatus.mockImplementation(async () => {
+      if (failNextStatusGet) {
+        failNextStatusGet = false;
+        throw new Error("snapshot_failed");
+      }
+      return {
         items: [
           {
             auth_index: "a1",
@@ -778,8 +801,8 @@ describe("useAuthFilesStatusState batch refresh", () => {
             quotas: [{ quota_key: "code_5h", percent: 42 }],
           },
         ],
-      })
-      .mockRejectedValueOnce(new Error("snapshot_failed"));
+      };
+    });
     mocks.startStatusRefresh.mockResolvedValue({
       job_id: "job-1",
       accepted: 2,
@@ -809,7 +832,9 @@ describe("useAuthFilesStatusState batch refresh", () => {
     await waitFor(() => {
       expect(result.current.quotaByFileName["a.json"]?.items[0]?.percent).toBe(41);
     });
+    await waitFor(() => expect(result.current.refreshingPage).toBe(false));
 
+    failNextStatusGet = true;
     await act(async () => {
       await result.current.forceRefreshPage();
     });
@@ -821,9 +846,10 @@ describe("useAuthFilesStatusState batch refresh", () => {
 
   test("single-card refresh does not abort page job", async () => {
     const jobIdsSeen: string[] = [];
-    mocks.startStatusRefresh
-      .mockResolvedValueOnce({ job_id: "job-page", accepted: 2, deduplicated: 0 })
-      .mockResolvedValueOnce({ job_id: "job-single", accepted: 1, deduplicated: 0 });
+    mocks.startStatusRefresh.mockImplementation(async (payload?: { auth_indexes?: string[] }) => {
+      const jobId = payload?.auth_indexes?.length === 1 ? "job-single" : "job-page";
+      return { job_id: jobId, accepted: payload?.auth_indexes?.length ?? 0, deduplicated: 0 };
+    });
     mocks.getStatusRefreshJob.mockImplementation(async (jobId: string) => {
       jobIdsSeen.push(jobId);
       if (jobId === "job-page") {
@@ -884,6 +910,9 @@ describe("useAuthFilesStatusState batch refresh", () => {
       }),
     );
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.refreshingPage).toBe(false));
+    mocks.startStatusRefresh.mockClear();
+    jobIdsSeen.length = 0;
 
     await act(async () => {
       const page = result.current.forceRefreshPage();

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -495,14 +495,20 @@ export function useAuthFilesFilesPresentation({
 
   const formatQuotaItemDetailText = useCallback(
     (item: QuotaItem | null | undefined) => {
-      const meta = item?.meta ? translateQuotaText(item.meta) : null;
       const reset = formatQuotaResetTextCompact(item?.resetAtMs);
       const resetLabel =
         reset && item?.label.startsWith("xai_quota.")
           ? t("xai_quota.reset_at", { time: reset })
           : reset;
-      const parts = [meta, resetLabel].filter(Boolean);
-      return parts.length > 0 ? parts.join(" · ") : null;
+      const rawMeta = item?.meta?.trim() ? translateQuotaText(item.meta) : null;
+      // Drop raw ISO period ranges (e.g. "2026-07-16T06:45:51+00:00 - …").
+      const meta =
+        rawMeta && !/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(rawMeta) ? rawMeta : null;
+      if (resetLabel && meta) {
+        // Keep money remaining ("$40 / $50") next to reset; skip other period labels.
+        return meta.includes("$") ? `${meta} · ${resetLabel}` : resetLabel;
+      }
+      return resetLabel ?? meta ?? null;
     },
     [formatQuotaResetTextCompact, t, translateQuotaText],
   );

--- a/pages/auth-files/hooks/useAuthFilesStatusState.ts
+++ b/pages/auth-files/hooks/useAuthFilesStatusState.ts
@@ -617,46 +617,6 @@ export function useAuthFilesStatusState({
     [applyStatusesToUi, haltQuotaAutoRefresh, notify, t],
   );
 
-  // Visible scope change (first load / page / filter): exactly one filtered status GET.
-  // Empty auth-index set must NOT call unfiltered GET. Mark scope loaded only after success
-  // (or intentional empty skip) so abort/fail restarts when pageItems identity changes.
-  useEffect(() => {
-    if (tab !== "files" || loading) return;
-    if (!statusApiSupported) return;
-    const scopeKey = `${tenantIdRef.current}::${buildVisibleScopeKey(pageItems)}`;
-    if (loadedVisibleScopeRef.current === scopeKey) return;
-
-    const authIndexes = Array.from(
-      new Set(
-        pageItems
-          .map((file) => resolveFileAuthIndex(file))
-          .filter((value): value is string => Boolean(value)),
-      ),
-    );
-    if (authIndexes.length === 0) {
-      loadedVisibleScopeRef.current = scopeKey;
-      return;
-    }
-
-    const controller = new AbortController();
-    void (async () => {
-      const ok = await loadStatusSnapshot({
-        signal: controller.signal,
-        filesForMerge: pageItems,
-        authIndexes,
-        quiet: true,
-        markUnsupportedOn404: true,
-      });
-      if (ok && !controller.signal.aborted) {
-        loadedVisibleScopeRef.current = scopeKey;
-      }
-    })();
-
-    return () => {
-      controller.abort();
-    };
-  }, [tab, loading, pageItems, statusApiSupported, loadStatusSnapshot, cacheTenantId]);
-
   const pollJobUntilDone = useCallback(
     async (
       jobId: string,
@@ -871,6 +831,64 @@ export function useAuthFilesStatusState({
       t,
     ],
   );
+
+  // Visible scope change (first load / page / filter / re-enter route):
+  // 1) one filtered status GET for cached snapshot
+  // 2) one quiet force probe so cards do not stay on stale/empty quota when auto-refresh is off
+  // Empty auth-index set must NOT call unfiltered GET. Mark scope loaded only after snapshot
+  // success (or intentional empty skip) so abort/fail restarts when pageItems identity changes.
+  useEffect(() => {
+    if (tab !== "files" || loading) return;
+    if (!statusApiSupported) return;
+    const scopeKey = `${tenantIdRef.current}::${buildVisibleScopeKey(pageItems)}`;
+    if (loadedVisibleScopeRef.current === scopeKey) return;
+
+    const authIndexes = Array.from(
+      new Set(
+        pageItems
+          .map((file) => resolveFileAuthIndex(file))
+          .filter((value): value is string => Boolean(value)),
+      ),
+    );
+    if (authIndexes.length === 0) {
+      loadedVisibleScopeRef.current = scopeKey;
+      return;
+    }
+
+    const controller = new AbortController();
+    const visibleFiles = pageItems;
+    void (async () => {
+      const ok = await loadStatusSnapshot({
+        signal: controller.signal,
+        filesForMerge: visibleFiles,
+        authIndexes,
+        quiet: true,
+        markUnsupportedOn404: true,
+      });
+      if (!ok || controller.signal.aborted) return;
+      loadedVisibleScopeRef.current = scopeKey;
+      // Probe after snapshot so re-entering /access/ai-accounts always refreshes visible cards,
+      // even when quota auto-refresh interval is 0.
+      if (pageBatchRef.current) return;
+      void runBatchStatusRefresh(visibleFiles, {
+        force: true,
+        showLoading: false,
+        kind: "page",
+      });
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [
+    tab,
+    loading,
+    pageItems,
+    statusApiSupported,
+    loadStatusSnapshot,
+    cacheTenantId,
+    runBatchStatusRefresh,
+  ]);
 
   const forceRefreshPage = useCallback(async () => {
     if (tab !== "files" || loading) return;


### PR DESCRIPTION
## Summary
- 错误态且无额度条时不再显示孤立的 `--`
- 周限额优先显示相对重置（`重置 X天…`），过滤原始 ISO 时间段
- 进入 `/access/ai-accounts` 在 status snapshot 后静默 force 探活可见卡（自动刷新关闭也生效）

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design / test:ci 777 / build / bundle:diff）
- [x] Playwright `@critical` 9 passed
- [ ] 线上：错误账号卡无 `--`；周限额显示相对重置；切换回 AI 账号页自动刷新额度