### PR TITLE
fix(auth-files): show card-style empty state when quota is missing

### DIFF
--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1376,6 +1376,9 @@ describe("AuthFilesPage files table", () => {
           Node.DOCUMENT_POSITION_FOLLOWING,
       ),
     ).toBe(true);
+    expect(
+      within(quota).getByTestId("auth-file-card-quota-empty"),
+    ).toHaveTextContent("Quota unavailable");
     const badge = within(errorBadges).getByText("429 Error");
     const tooltipTrigger = badge.closest("[aria-describedby]") ?? badge;
     fireEvent.mouseEnter(tooltipTrigger);

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1809,7 +1809,10 @@ export function AuthFilesFilesTab({
                       ) : null}
 
                       <div
-                        className="mt-3 min-w-0 touch-pan-y space-y-3 px-0.5 py-1"
+                        className={[
+                          "mt-3 min-h-0 min-w-0 flex-1 touch-pan-y px-0.5 py-1",
+                          slots.length === 0 ? "flex flex-col" : "space-y-3",
+                        ].join(" ")}
                         data-testid="auth-file-card-quota"
                       >
                         {slots.length > 0 ? (
@@ -1818,11 +1821,22 @@ export function AuthFilesFilesTab({
                               renderQuotaBar(slot.label, slot.item),
                             )}
                           </div>
-                        ) : cardErrorBadges.length > 0 ? null : (
-                          <div className="text-xs text-slate-400 dark:text-white/40">
-                            {quotaRefreshing
-                              ? t("common.loading_ellipsis")
-                              : t("auth_files.quota_unavailable")}
+                        ) : (
+                          <div
+                            className="flex flex-1 flex-col items-center justify-center gap-2 py-6 text-center"
+                            data-testid="auth-file-card-quota-empty"
+                          >
+                            <div
+                              className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100/90 text-slate-400 dark:bg-white/[0.06] dark:text-white/40"
+                              aria-hidden="true"
+                            >
+                              <Gauge size={16} strokeWidth={1.5} />
+                            </div>
+                            <p className="text-xs font-medium text-slate-500 dark:text-white/50">
+                              {quotaRefreshing
+                                ? t("common.loading_ellipsis")
+                                : t("auth_files.quota_unavailable")}
+                            </p>
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- AI 账号卡片在只有错误 badge、无配额 slots 时，配额区不再留白
- 使用与卡片风格一致的简洁 empty（Gauge 图标 + 暂无额度数据），并 `flex-1` 居中填满高度

> 注：#727 因默认 base 误合到 `main`；本 PR 将同一修复合入 `dev` 以触发 dev 发布。

## Test plan
- [x] `./scripts/ci-pr.sh`（在 #727 同源提交上已跑通）
- [x] 单测覆盖 empty state