### PR TITLE
fix(auth-files): re-probe status API after sticky unsupported mark

### DIFF
--- a/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
@@ -321,8 +321,11 @@ describe("useAuthFilesStatusState batch refresh", () => {
     );
   });
 
-  test("status GET 404 marks unsupported and never starts refresh", async () => {
+  test("status GET 404 marks unsupported; force refresh re-probes instead of sticky lock", async () => {
     mocks.getStatus.mockRejectedValue(new ApiError({ message: "missing", status: 404 }));
+    mocks.startStatusRefresh.mockRejectedValue(
+      new ApiError({ message: "missing", status: 404 }),
+    );
     const setFiles = vi.fn();
     const setDetailFile = vi.fn();
     const { result } = renderHook(() =>
@@ -339,7 +342,83 @@ describe("useAuthFilesStatusState batch refresh", () => {
     await act(async () => {
       await result.current.forceRefreshPage();
     });
-    expect(mocks.startStatusRefresh).not.toHaveBeenCalled();
+    // Manual force must re-probe; sticky unsupported must not skip the POST forever.
+    expect(mocks.startStatusRefresh).toHaveBeenCalled();
+    expect(result.current.statusApiSupported).toBe(false);
+    expect(mocks.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "auth_files.status_batch_unsupported" }),
+    );
+  });
+
+  test("force refresh recovers after a transient unsupported mark", async () => {
+    mocks.getStatus.mockRejectedValueOnce(new ApiError({ message: "missing", status: 404 }));
+    mocks.getStatus.mockResolvedValue({
+      items: [
+        {
+          auth_index: "a1",
+          auth_subject_id: "sub-a",
+          quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 11 }],
+        },
+        {
+          auth_index: "b1",
+          auth_subject_id: "sub-b",
+          quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 22 }],
+        },
+      ],
+    });
+    mocks.startStatusRefresh.mockResolvedValue({
+      job_id: "job-recover",
+      accepted: 2,
+      deduplicated: 0,
+    });
+    mocks.getStatusRefreshJob.mockResolvedValue({
+      job_id: "job-recover",
+      state: "completed",
+      total: 2,
+      completed: 2,
+      failed: 0,
+      results: [
+        {
+          auth_index: "a1",
+          auth_subject_id: "sub-a",
+          state: "success",
+          result: {
+            auth_index: "a1",
+            auth_subject_id: "sub-a",
+            quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 11 }],
+          },
+        },
+        {
+          auth_index: "b1",
+          auth_subject_id: "sub-b",
+          state: "success",
+          result: {
+            auth_index: "b1",
+            auth_subject_id: "sub-b",
+            quotas: [{ quota_key: "code_5h", quota_label: "m_quota.code_5h", percent: 22 }],
+          },
+        },
+      ],
+    });
+    const setFiles = vi.fn();
+    const setDetailFile = vi.fn();
+    const { result } = renderHook(() =>
+      useAuthFilesStatusState({
+        tab: "files",
+        pageItems: files,
+        loading: false,
+        setFiles,
+        setDetailFile,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.statusApiSupported).toBe(false));
+    mocks.startStatusRefresh.mockClear();
+    await act(async () => {
+      await result.current.forceRefreshPage();
+    });
+    await waitFor(() => expect(result.current.statusApiSupported).toBe(true));
+    expect(mocks.startStatusRefresh).toHaveBeenCalled();
   });
 
   test("tenant switch aborts in-flight job so old result cannot paint 99%", async () => {

--- a/pages/auth-files/hooks/useAuthFilesStatusState.ts
+++ b/pages/auth-files/hooks/useAuthFilesStatusState.ts
@@ -67,7 +67,10 @@ export function isFatalQuotaRefreshError(error: unknown): boolean {
   );
 }
 
-/** Only initial status GET / start POST 404 marks API unsupported — not job poll 404. */
+/**
+ * Only status GET / start POST 404|405|501 mark API unsupported — not job poll 404.
+ * Transient network/proxy blips can also surface as those codes; force refresh re-probes.
+ */
 export function isStatusApiUnsupportedError(error: unknown): boolean {
   if (!isApiClientError(error)) return false;
   return error.status === 404 || error.status === 405 || error.status === 501;
@@ -704,15 +707,15 @@ export function useAuthFilesStatusState({
       options?: { force?: boolean; showLoading?: boolean; kind?: "page" | "single" },
     ): Promise<void> => {
       if (!targetFiles.length) return;
-      if (!statusApiSupported) {
-        notify({
-          type: "error",
-          message: t("auth_files.status_batch_unsupported"),
-        });
+
+      const kind = options?.kind ?? (targetFiles.length > 1 ? "page" : "single");
+      const force = options?.force ?? true;
+      // Auto paths skip while unsupported. Manual/force re-probes so a transient 404
+      // cannot lock the page until full reload.
+      if (!statusApiSupported && !force) {
         return;
       }
 
-      const kind = options?.kind ?? (targetFiles.length > 1 ? "page" : "single");
       const withAuth = targetFiles
         .map((file) => ({ file, authIndex: resolveFileAuthIndex(file) }))
         .filter((entry): entry is { file: AuthFileItem; authIndex: string } =>
@@ -757,11 +760,13 @@ export function useAuthFilesStatusState({
 
       try {
         const accepted = await aiAccountsStatusApi.startStatusRefresh(
-          { auth_indexes: authIndexes, force: options?.force ?? true },
+          { auth_indexes: authIndexes, force },
           { signal: controller.signal },
         );
         if (controller.signal.aborted || !mountedRef.current) return;
         if (tenantIdRef.current !== tenantId) return;
+        // Probe succeeded — clear sticky unsupported from an earlier false 404.
+        setStatusApiSupported(true);
         batch.jobId = accepted.job_id;
 
         const pollResult = await pollJobUntilDone(


### PR DESCRIPTION
## Summary
- Manual force refresh no longer short-circuits on a prior 404/405/501 `statusApiSupported=false` mark.
- Successful `POST /ai-accounts/status-refresh` clears the sticky unsupported flag so transient probe failures stop locking the page until full reload.
- Auto refresh (`force:false`) still silently skips while unsupported (no request/toast spam).

## Root cause
Frontend treated one failed status probe as permanent “server version unsupported”, then blocked all later manual refreshes with toast `服务器版本不支持批量账号状态刷新` without re-probing. Backend already exposes the routes.

## Test plan
- [x] `bun run lint`
- [x] `bun run design:check`
- [x] `bun run test:ci` (780 passed)
- [x] `bun run build`
- [x] `bun run bundle:diff`
- [x] Playwright `@critical` multi-tenant/login smoke (9 passed)
- [x] Codex gpt-5.6-sol xhigh review: approve