### PR TITLE
fix: map opencode-go provider id to OpenCode vendor icon

### DIFF
--- a/packages/assets/src/vendor-icons/VendorIcon.tsx
+++ b/packages/assets/src/vendor-icons/VendorIcon.tsx
@@ -48,6 +48,8 @@ const VENDOR_ICONS: Record<string, { light: string; dark: string }> = {
   o3: { light: iconOpenaiLight, dark: iconOpenaiDark },
   o4: { light: iconOpenaiLight, dark: iconOpenaiDark },
   opencode: { light: iconOpencodeLight, dark: iconOpencodeDark },
+  "opencode-go": { light: iconOpencodeLight, dark: iconOpencodeDark },
+  "opencode_go": { light: iconOpencodeLight, dark: iconOpencodeDark },
   openai: { light: iconOpenaiLight, dark: iconOpenaiDark },
   qwen: { light: iconQwen, dark: iconQwen },
   vertex: { light: iconVertex, dark: iconVertex },


### PR DESCRIPTION
## Summary
- `VendorIcon` 增加 `opencode-go` / `opencode_go` 映射，request-logs 渠道筛选项能显示 OpenCode 图标

## Test plan
- [x] `bun run lint`
- [x] `bun run design:check`
- [x] `bun run build`
- [x] `bun run bundle:diff`
- [ ] 部署后土豆租户 `opencode go` 渠道有 OpenCode icon + API 徽章