### PR TITLE
fix: lookup quota as KPI cards

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3152,6 +3152,7 @@
     "total_sessions": "Total Sessions",
     "total_cost": "Total Cost",
     "quota_limits_title": "Quota limits",
+    "quota_used_of_limit": "Used / limit",
     "quota_daily_requests": "Daily requests",
     "quota_total_requests": "Total request quota",
     "quota_daily_spending": "Daily spending",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3449,6 +3449,7 @@
     "total_sessions": "总会话",
     "total_cost": "总费用",
     "quota_limits_title": "额度限制",
+    "quota_used_of_limit": "已用 / 上限",
     "quota_daily_requests": "每日请求",
     "quota_total_requests": "总请求配额",
     "quota_daily_spending": "每日消费额度",

--- a/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
+++ b/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
@@ -1,3 +1,6 @@
+import type { ComponentType, ReactNode } from "react";
+import { Coins, Gauge, Hash, Wallet } from "lucide-react";
+import { KpiCard } from "@features/monitor-widgets";
 import type { PublicUsageLimits } from "../types";
 
 function formatUsd(value: number): string {
@@ -8,91 +11,104 @@ function formatCount(value: number): string {
   return Math.round(value).toLocaleString();
 }
 
-type QuotaRow = {
+export type QuotaKpiItem = {
   key: string;
-  label: string;
-  usedLabel: string;
-  limitLabel: string;
+  title: string;
+  used: number;
+  limit: number;
+  format: (value: number) => string;
+  icon: ComponentType<{ size?: number; className?: string }>;
 };
 
-export function QuotaLimitsBanner({
-  t,
-  limits,
-}: {
-  t: (key: string, options?: Record<string, unknown>) => string;
-  limits: PublicUsageLimits | null | undefined;
-}) {
-  if (!limits) return null;
+export function buildQuotaKpiItems(
+  t: (key: string, options?: Record<string, unknown>) => string,
+  limits: PublicUsageLimits | null | undefined,
+): QuotaKpiItem[] {
+  if (!limits) return [];
 
-  const rows: QuotaRow[] = [];
+  const items: QuotaKpiItem[] = [];
   if (typeof limits["daily-limit"] === "number" && limits["daily-limit"] > 0) {
-    rows.push({
+    items.push({
       key: "daily-limit",
-      label: t("apikey_lookup.quota_daily_requests"),
-      usedLabel: formatCount(limits["daily-used"] ?? 0),
-      limitLabel: formatCount(limits["daily-limit"]),
+      title: t("apikey_lookup.quota_daily_requests"),
+      used: limits["daily-used"] ?? 0,
+      limit: limits["daily-limit"],
+      format: formatCount,
+      icon: Hash,
     });
   }
   if (typeof limits["total-quota"] === "number" && limits["total-quota"] > 0) {
-    rows.push({
+    items.push({
       key: "total-quota",
-      label: t("apikey_lookup.quota_total_requests"),
-      usedLabel: formatCount(limits["total-used"] ?? 0),
-      limitLabel: formatCount(limits["total-quota"]),
+      title: t("apikey_lookup.quota_total_requests"),
+      used: limits["total-used"] ?? 0,
+      limit: limits["total-quota"],
+      format: formatCount,
+      icon: Gauge,
     });
   }
   if (
     typeof limits["daily-spending-limit"] === "number" &&
     limits["daily-spending-limit"] > 0
   ) {
-    rows.push({
+    items.push({
       key: "daily-spending",
-      label: t("apikey_lookup.quota_daily_spending"),
-      usedLabel: formatUsd(limits["daily-spending-used"] ?? 0),
-      limitLabel: formatUsd(limits["daily-spending-limit"]),
+      title: t("apikey_lookup.quota_daily_spending"),
+      used: limits["daily-spending-used"] ?? 0,
+      limit: limits["daily-spending-limit"],
+      format: formatUsd,
+      icon: Wallet,
     });
   }
   if (
     typeof limits["spending-limit"] === "number" &&
     limits["spending-limit"] > 0
   ) {
-    rows.push({
+    items.push({
       key: "spending",
-      label: t("apikey_lookup.quota_total_spending"),
-      usedLabel: formatUsd(limits["spending-used"] ?? 0),
-      limitLabel: formatUsd(limits["spending-limit"]),
+      title: t("apikey_lookup.quota_total_spending"),
+      used: limits["spending-used"] ?? 0,
+      limit: limits["spending-limit"],
+      format: formatUsd,
+      icon: Coins,
     });
   }
+  return items;
+}
 
-  if (rows.length === 0) return null;
+/** Renders configured quota limits as the same KPI cards used for usage stats. */
+export function QuotaLimitKpiCards({
+  t,
+  limits,
+  renderValue,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  limits: PublicUsageLimits | null | undefined;
+  renderValue: (value: ReactNode) => ReactNode;
+}) {
+  const items = buildQuotaKpiItems(t, limits);
+  if (items.length === 0) return null;
 
   return (
-    <div
-      className="rounded-2xl border border-amber-200/80 bg-amber-50/70 px-4 py-3 dark:border-amber-500/20 dark:bg-amber-500/10"
-      data-testid="api-key-lookup-quota-limits"
-    >
-      <div className="mb-2 text-sm font-semibold text-amber-900 dark:text-amber-100">
-        {t("apikey_lookup.quota_limits_title")}
-      </div>
-      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-        {rows.map((row) => (
-          <div
-            key={row.key}
-            className="rounded-xl border border-amber-100/80 bg-white/70 px-3 py-2 dark:border-amber-500/10 dark:bg-neutral-950/40"
-          >
-            <div className="text-xs text-amber-800/80 dark:text-amber-100/70">
-              {row.label}
-            </div>
-            <div className="mt-0.5 text-sm font-semibold tabular-nums text-amber-950 dark:text-amber-50">
-              {row.usedLabel}
-              <span className="mx-1 font-normal text-amber-700/60 dark:text-amber-100/40">
-                /
-              </span>
-              {row.limitLabel}
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
+    <>
+      {items.map((item) => (
+        <div key={item.key} data-testid={`api-key-lookup-quota-${item.key}`}>
+          <KpiCard
+            title={item.title}
+            icon={item.icon}
+            hint={t("apikey_lookup.quota_used_of_limit")}
+            value={renderValue(
+              <span className="tabular-nums">
+                {item.format(item.used)}
+                <span className="mx-1 text-base font-normal text-slate-400 dark:text-white/40">
+                  /
+                </span>
+                {item.format(item.limit)}
+              </span>,
+            )}
+          />
+        </div>
+      ))}
+    </>
   );
 }

--- a/pages/api-key-lookup/components/UsageTabSection.tsx
+++ b/pages/api-key-lookup/components/UsageTabSection.tsx
@@ -18,7 +18,7 @@ import type {
   DailySeriesPoint,
 } from "@features/monitor-widgets/chart-options/types";
 import type { PublicUsageLimits } from "../types";
-import { QuotaLimitsBanner } from "./QuotaLimitsBanner";
+import { QuotaLimitKpiCards } from "./QuotaLimitsBanner";
 
 const DAILY_LEGEND_KEYS = {
   input: "daily_input",
@@ -277,8 +277,12 @@ export function UsageTabSection({
   return (
     <Reveal>
       <div className="space-y-5">
-        <QuotaLimitsBanner t={t} limits={quotaLimits} />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          <QuotaLimitKpiCards
+            t={t}
+            limits={quotaLimits}
+            renderValue={renderKpiValue}
+          />
           <KpiCard
             title={t("apikey_lookup.total_requests")}
             icon={Activity}

--- a/pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
-import { QuotaLimitsBanner } from "../QuotaLimitsBanner";
+import { buildQuotaKpiItems, QuotaLimitKpiCards } from "../QuotaLimitsBanner";
 
 const t = (key: string) => {
   const labels: Record<string, string> = {
     "apikey_lookup.quota_limits_title": "Quota limits",
+    "apikey_lookup.quota_used_of_limit": "Used / limit",
     "apikey_lookup.quota_daily_requests": "Daily requests",
     "apikey_lookup.quota_total_requests": "Total request quota",
     "apikey_lookup.quota_daily_spending": "Daily spending",
@@ -13,30 +14,32 @@ const t = (key: string) => {
   return labels[key] ?? key;
 };
 
-describe("QuotaLimitsBanner", () => {
-  test("renders nothing without limits", () => {
-    const { container } = render(<QuotaLimitsBanner t={t} limits={null} />);
-    expect(container).toBeEmptyDOMElement();
+describe("QuotaLimitKpiCards", () => {
+  test("builds no items without limits", () => {
+    expect(buildQuotaKpiItems(t, null)).toEqual([]);
   });
 
-  test("renders only configured limit rows with used/limit", () => {
+  test("renders configured limits as KPI cards with used/limit", () => {
     render(
-      <QuotaLimitsBanner
-        t={t}
-        limits={{
-          "daily-limit": 100,
-          "daily-used": 12,
-          "total-quota": 1000,
-          "total-used": 40,
-          "daily-spending-limit": 5,
-          "daily-spending-used": 1.25,
-          "spending-limit": 50,
-          "spending-used": 9.5,
-        }}
-      />,
+      <div className="grid">
+        <QuotaLimitKpiCards
+          t={t}
+          limits={{
+            "daily-limit": 100,
+            "daily-used": 12,
+            "total-quota": 1000,
+            "total-used": 40,
+            "daily-spending-limit": 5,
+            "daily-spending-used": 1.25,
+            "spending-limit": 50,
+            "spending-used": 9.5,
+          }}
+          renderValue={(value) => value}
+        />
+      </div>,
     );
 
-    expect(screen.getByTestId("api-key-lookup-quota-limits")).toBeInTheDocument();
+    expect(screen.getByTestId("api-key-lookup-quota-daily-limit")).toBeInTheDocument();
     expect(screen.getByText("Daily requests")).toBeInTheDocument();
     expect(screen.getByText("Total request quota")).toBeInTheDocument();
     expect(screen.getByText("Daily spending")).toBeInTheDocument();
@@ -47,13 +50,16 @@ describe("QuotaLimitsBanner", () => {
 
   test("hides unset limits", () => {
     render(
-      <QuotaLimitsBanner
-        t={t}
-        limits={{
-          "daily-limit": 10,
-          "daily-used": 1,
-        }}
-      />,
+      <div className="grid">
+        <QuotaLimitKpiCards
+          t={t}
+          limits={{
+            "daily-limit": 10,
+            "daily-used": 1,
+          }}
+          renderValue={(value) => value}
+        />
+      </div>,
     );
     expect(screen.getByText("Daily requests")).toBeInTheDocument();
     expect(screen.queryByText("Total spending")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- apikey-lookup quotas render as normal KPI cards in the same grid
- removed the separate yellow banner region

## Test plan
- [x] `./scripts/ci-pr.sh`