### PR TITLE
fix: lookup KPI layout and whole-dollar spending limits

### DIFF
--- a/features/monitor-widgets/MonitorPagePieces.tsx
+++ b/features/monitor-widgets/MonitorPagePieces.tsx
@@ -14,11 +14,14 @@ export const KpiCard = ({
   value,
   hint,
   icon: Icon,
+  valueClassName = "text-2xl",
 }: {
   title: string;
   value: ReactNode;
   hint: string;
   icon: ComponentType<{ size?: number; className?: string }>;
+  /** Optional size override when the value node does not carry its own text size. */
+  valueClassName?: string;
 }) => {
   const reduceMotion = useReducedMotion();
   const cardRef = useResizeLayoutAnimation<HTMLElement>(!reduceMotion);
@@ -26,16 +29,18 @@ export const KpiCard = ({
   return (
     <article
       ref={cardRef}
-      className="rounded-2xl border border-black/[0.06] bg-white p-5 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70 dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.22)]"
+      className="flex h-full min-w-0 flex-col rounded-2xl border border-black/[0.06] bg-white p-5 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70 dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.22)]"
     >
-      <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
-        <Icon size={14} className="text-slate-900 dark:text-white" />
-        <span>{title}</span>
+      <p className="flex min-w-0 items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
+        <Icon size={14} className="shrink-0 text-slate-900 dark:text-white" />
+        <span className="min-w-0 truncate">{title}</span>
       </p>
-      <p className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">
+      <p
+        className={`mt-3 min-w-0 overflow-hidden font-semibold tracking-tight text-slate-900 dark:text-white ${valueClassName}`}
+      >
         {value}
       </p>
-      <p className="mt-2 text-xs text-slate-600 dark:text-white/65">{hint}</p>
+      <p className="mt-auto pt-2 text-xs text-slate-600 dark:text-white/65">{hint}</p>
     </article>
   );
 };

--- a/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
+++ b/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
@@ -2,14 +2,11 @@ import type { ComponentType, ReactNode } from "react";
 import { Coins, Gauge, Hash, Wallet } from "lucide-react";
 import { KpiCard } from "@features/monitor-widgets";
 import type { PublicUsageLimits } from "../types";
-
-function formatUsd(value: number): string {
-  return `$${value.toFixed(4)}`;
-}
-
-function formatCount(value: number): string {
-  return Math.round(value).toLocaleString();
-}
+import {
+  formatQuotaCount,
+  formatQuotaUsd,
+  kpiValueSizeClass,
+} from "./kpiValueSize";
 
 export type QuotaKpiItem = {
   key: string;
@@ -33,7 +30,7 @@ export function buildQuotaKpiItems(
       title: t("apikey_lookup.quota_daily_requests"),
       used: limits["daily-used"] ?? 0,
       limit: limits["daily-limit"],
-      format: formatCount,
+      format: formatQuotaCount,
       icon: Hash,
     });
   }
@@ -43,7 +40,7 @@ export function buildQuotaKpiItems(
       title: t("apikey_lookup.quota_total_requests"),
       used: limits["total-used"] ?? 0,
       limit: limits["total-quota"],
-      format: formatCount,
+      format: formatQuotaCount,
       icon: Gauge,
     });
   }
@@ -56,7 +53,7 @@ export function buildQuotaKpiItems(
       title: t("apikey_lookup.quota_daily_spending"),
       used: limits["daily-spending-used"] ?? 0,
       limit: limits["daily-spending-limit"],
-      format: formatUsd,
+      format: formatQuotaUsd,
       icon: Wallet,
     });
   }
@@ -69,14 +66,14 @@ export function buildQuotaKpiItems(
       title: t("apikey_lookup.quota_total_spending"),
       used: limits["spending-used"] ?? 0,
       limit: limits["spending-limit"],
-      format: formatUsd,
+      format: formatQuotaUsd,
       icon: Coins,
     });
   }
   return items;
 }
 
-/** Renders configured quota limits as the same KPI cards used for usage stats. */
+/** Renders configured quota limits as fixed-width KPI cards. */
 export function QuotaLimitKpiCards({
   t,
   limits,
@@ -91,24 +88,35 @@ export function QuotaLimitKpiCards({
 
   return (
     <>
-      {items.map((item) => (
-        <div key={item.key} data-testid={`api-key-lookup-quota-${item.key}`}>
-          <KpiCard
-            title={item.title}
-            icon={item.icon}
-            hint={t("apikey_lookup.quota_used_of_limit")}
-            value={renderValue(
-              <span className="tabular-nums">
-                {item.format(item.used)}
-                <span className="mx-1 text-base font-normal text-slate-400 dark:text-white/40">
-                  /
-                </span>
-                {item.format(item.limit)}
-              </span>,
-            )}
-          />
-        </div>
-      ))}
+      {items.map((item) => {
+        const usedText = item.format(item.used);
+        const limitText = item.format(item.limit);
+        const display = `${usedText} / ${limitText}`;
+        const sizeClass = kpiValueSizeClass(display);
+        return (
+          <div
+            key={item.key}
+            className="min-w-0"
+            data-testid={`api-key-lookup-quota-${item.key}`}
+          >
+            <KpiCard
+              title={item.title}
+              icon={item.icon}
+              hint={t("apikey_lookup.quota_used_of_limit")}
+              valueClassName={sizeClass}
+              value={renderValue(
+                <span className="block whitespace-nowrap tabular-nums leading-tight">
+                  {usedText}
+                  <span className="mx-1 font-normal text-slate-400 dark:text-white/40">
+                    /
+                  </span>
+                  {limitText}
+                </span>,
+              )}
+            />
+          </div>
+        );
+      })}
     </>
   );
 }

--- a/pages/api-key-lookup/components/UsageTabSection.tsx
+++ b/pages/api-key-lookup/components/UsageTabSection.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@features/monitor-widgets/chart-options/types";
 import type { PublicUsageLimits } from "../types";
 import { QuotaLimitKpiCards } from "./QuotaLimitsBanner";
+import { formatQuotaUsd, kpiValueSizeClass } from "./kpiValueSize";
 
 const DAILY_LEGEND_KEYS = {
   input: "daily_input",
@@ -277,67 +278,102 @@ export function UsageTabSection({
   return (
     <Reveal>
       <div className="space-y-5">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
           <QuotaLimitKpiCards
             t={t}
             limits={quotaLimits}
             renderValue={renderKpiValue}
           />
-          <KpiCard
-            title={t("apikey_lookup.total_requests")}
-            icon={Activity}
-            hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={renderKpiValue(
-              <AnimatedNumber
-                value={chartStats?.total ?? 0}
-                format={formatInteger}
-              />,
-            )}
-          />
-          <KpiCard
-            title={t("common.success_rate")}
-            icon={ShieldCheck}
-            hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={renderKpiValue(
-              <AnimatedNumber
-                value={chartStats?.success_rate ?? 0}
-                format={(value) => `${value.toFixed(1)}%`}
-              />,
-            )}
-          />
-          <KpiCard
-            title={t("apikey_lookup.total_tokens")}
-            icon={Sigma}
-            hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={renderKpiValue(
-              <AnimatedNumber
-                value={chartStats?.total_tokens ?? 0}
-                format={formatInteger}
-              />,
-            )}
-          />
-          <KpiCard
-            title={t("apikey_lookup.total_sessions")}
-            icon={MessagesSquare}
-            hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={renderKpiValue(
-              <AnimatedNumber
-                value={chartStats?.total_sessions ?? 0}
-                format={formatInteger}
-              />,
-            )}
-          />
-          <KpiCard
-            title={t("apikey_lookup.total_cost")}
-            icon={Coins}
-            hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-            value={renderKpiValue(
-              <AnimatedNumber
-                value={chartStats?.total_cost ?? 0}
-                format={(value) => `$${value.toFixed(4)}`}
-              />,
-            )}
-          />
+          <div className="min-w-0">
+            <KpiCard
+              title={t("apikey_lookup.total_requests")}
+              icon={Activity}
+              hint={t("apikey_lookup.last_n_days", { days: timeRange })}
+              valueClassName={kpiValueSizeClass(
+                formatInteger(chartStats?.total ?? 0),
+              )}
+              value={renderKpiValue(
+                <span className="block whitespace-nowrap tabular-nums">
+                  <AnimatedNumber
+                    value={chartStats?.total ?? 0}
+                    format={formatInteger}
+                  />
+                </span>,
+              )}
+            />
+          </div>
+          <div className="min-w-0">
+            <KpiCard
+              title={t("common.success_rate")}
+              icon={ShieldCheck}
+              hint={t("apikey_lookup.last_n_days", { days: timeRange })}
+              valueClassName={kpiValueSizeClass(
+                `${(chartStats?.success_rate ?? 0).toFixed(1)}%`,
+              )}
+              value={renderKpiValue(
+                <span className="block whitespace-nowrap tabular-nums">
+                  <AnimatedNumber
+                    value={chartStats?.success_rate ?? 0}
+                    format={(value) => `${value.toFixed(1)}%`}
+                  />
+                </span>,
+              )}
+            />
+          </div>
+          <div className="min-w-0">
+            <KpiCard
+              title={t("apikey_lookup.total_tokens")}
+              icon={Sigma}
+              hint={t("apikey_lookup.last_n_days", { days: timeRange })}
+              valueClassName={kpiValueSizeClass(
+                formatInteger(chartStats?.total_tokens ?? 0),
+              )}
+              value={renderKpiValue(
+                <span className="block whitespace-nowrap tabular-nums">
+                  <AnimatedNumber
+                    value={chartStats?.total_tokens ?? 0}
+                    format={formatInteger}
+                  />
+                </span>,
+              )}
+            />
+          </div>
+          <div className="min-w-0">
+            <KpiCard
+              title={t("apikey_lookup.total_sessions")}
+              icon={MessagesSquare}
+              hint={t("apikey_lookup.last_n_days", { days: timeRange })}
+              valueClassName={kpiValueSizeClass(
+                formatInteger(chartStats?.total_sessions ?? 0),
+              )}
+              value={renderKpiValue(
+                <span className="block whitespace-nowrap tabular-nums">
+                  <AnimatedNumber
+                    value={chartStats?.total_sessions ?? 0}
+                    format={formatInteger}
+                  />
+                </span>,
+              )}
+            />
+          </div>
+          <div className="min-w-0">
+            <KpiCard
+              title={t("apikey_lookup.total_cost")}
+              icon={Coins}
+              hint={t("apikey_lookup.last_n_days", { days: timeRange })}
+              valueClassName={kpiValueSizeClass(
+                formatQuotaUsd(chartStats?.total_cost ?? 0),
+              )}
+              value={renderKpiValue(
+                <span className="block whitespace-nowrap tabular-nums">
+                  <AnimatedNumber
+                    value={chartStats?.total_cost ?? 0}
+                    format={formatQuotaUsd}
+                  />
+                </span>,
+              )}
+            />
+          </div>
         </div>
 
         <Card

--- a/pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx
@@ -45,7 +45,7 @@ describe("QuotaLimitKpiCards", () => {
     expect(screen.getByText("Daily spending")).toBeInTheDocument();
     expect(screen.getByText("Total spending")).toBeInTheDocument();
     expect(screen.getByText(/12/)).toBeInTheDocument();
-    expect(screen.getByText(/\$1\.2500/)).toBeInTheDocument();
+    expect(screen.getByText(/\$1\.25/)).toBeInTheDocument();
   });
 
   test("hides unset limits", () => {

--- a/pages/api-key-lookup/components/__tests__/kpiValueSize.test.ts
+++ b/pages/api-key-lookup/components/__tests__/kpiValueSize.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { formatQuotaUsd, kpiValueSizeClass } from "../kpiValueSize";
+
+describe("kpiValueSizeClass", () => {
+  test("keeps large type for short values", () => {
+    expect(kpiValueSizeClass("21")).toBe("text-2xl");
+    expect(kpiValueSizeClass("99.5%")).toBe("text-2xl");
+    expect(kpiValueSizeClass("$25.91")).toBe("text-2xl");
+  });
+
+  test("shrinks long used/limit pairs", () => {
+    // lengths after stripping spaces: 14 / 18 / 25
+    expect(kpiValueSizeClass("$25.91 / $300.00")).toBe("text-lg");
+    expect(kpiValueSizeClass("$1,268.50 / $10,000.00")).toBe("text-base");
+    expect(kpiValueSizeClass("1,792,389,816 / 9,999,999,999")).toBe("text-sm");
+  });
+
+  test("formats USD with two decimals", () => {
+    expect(formatQuotaUsd(25.9065)).toBe("$25.91");
+    expect(formatQuotaUsd(300)).toBe("$300.00");
+  });
+});

--- a/pages/api-key-lookup/components/kpiValueSize.ts
+++ b/pages/api-key-lookup/components/kpiValueSize.ts
@@ -1,0 +1,17 @@
+/** Pick a KPI value font size so fixed-width cards never overflow. */
+export function kpiValueSizeClass(displayText: string): string {
+  const length = displayText.replace(/\s+/g, "").length;
+  if (length <= 9) return "text-2xl";
+  if (length <= 13) return "text-xl";
+  if (length <= 17) return "text-lg";
+  if (length <= 22) return "text-base";
+  return "text-sm";
+}
+
+export function formatQuotaUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatQuotaCount(value: number): string {
+  return Math.round(value).toLocaleString();
+}

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -61,7 +61,8 @@ const limitFromText = (value: string) => {
 };
 
 const spendingLimitFromText = (value: string) => {
-  const parsed = Number.parseFloat(value.trim());
+  // Spending limits are whole USD dollars only.
+  const parsed = Number.parseInt(value.trim(), 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 };
 
@@ -69,7 +70,7 @@ const formatSpendingLimit = (value: number, unlimited: string) =>
   value > 0
     ? new Intl.NumberFormat("en-US", {
         currency: "USD",
-        maximumFractionDigits: 4,
+        maximumFractionDigits: 2,
         minimumFractionDigits: 2,
         style: "currency",
       }).format(value)
@@ -494,7 +495,7 @@ export function ApiKeyPermissionsPage() {
               [
                 ["dailyLimit", "form_daily_limit", "1"],
                 ["totalQuota", "form_total_quota", "1"],
-                ["dailySpendingLimit", "form_daily_spending_limit", "0.01"],
+                ["dailySpendingLimit", "form_daily_spending_limit", "1"],
                 ["concurrencyLimit", "form_concurrency_limit", "1"],
                 ["rpmLimit", "form_rpm_limit", "1"],
                 ["tpmLimit", "form_tpm_limit", "1"],
@@ -508,10 +509,17 @@ export function ApiKeyPermissionsPage() {
                   type="number"
                   min={0}
                   step={step}
+                  inputMode="numeric"
                   value={draft[key]}
                   aria-label={t(`api_key_permissions_page.${labelKey}`)}
                   placeholder={t("api_key_permissions_page.form_unlimited_hint")}
-                  onChange={(event) => setDraft((prev) => ({ ...prev, [key]: event.target.value }))}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    // Keep empty for unlimited; otherwise only whole numbers.
+                    if (raw === "" || /^\d+$/.test(raw)) {
+                      setDraft((prev) => ({ ...prev, [key]: raw }));
+                    }
+                  }}
                 />
               </div>
             ))}

--- a/pages/api-keys/apiKeyPageUtils.tsx
+++ b/pages/api-keys/apiKeyPageUtils.tsx
@@ -104,32 +104,24 @@ export const formatApiKeyLimit = (limit: number | undefined) => {
   return limit.toLocaleString();
 };
 
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  currency: "USD",
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2,
+  style: "currency",
+});
+
 export const formatApiKeySpendingLimit = (limit: number | undefined) => {
   if (!limit || limit <= 0 || !Number.isFinite(limit)) return null;
-  return new Intl.NumberFormat("en-US", {
-    currency: "USD",
-    maximumFractionDigits: 4,
-    minimumFractionDigits: 2,
-    style: "currency",
-  }).format(limit);
+  return usdFormatter.format(limit);
 };
 
 /** Format a USD amount for display, including $0.00. */
 export const formatApiKeySpendingAmount = (amount: number | undefined | null) => {
   if (amount == null || !Number.isFinite(amount)) {
-    return new Intl.NumberFormat("en-US", {
-      currency: "USD",
-      maximumFractionDigits: 4,
-      minimumFractionDigits: 2,
-      style: "currency",
-    }).format(0);
+    return usdFormatter.format(0);
   }
-  return new Intl.NumberFormat("en-US", {
-    currency: "USD",
-    maximumFractionDigits: 4,
-    minimumFractionDigits: 2,
-    style: "currency",
-  }).format(Math.max(amount, 0));
+  return usdFormatter.format(Math.max(amount, 0));
 };
 
 export const normalizeChannelKey = (value: string) => value.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Fixed equal-width KPI grid (`xl:grid-cols-6`)
- Adaptive font size by display text length (no overflow)
- USD display uses 2 decimals
- Permission profile spending limit input: integers only

## Test plan
- [x] `./scripts/ci-pr.sh`