### PR TITLE
feat: end-user management and portal login for apikey-lookup

### DIFF
--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -225,6 +225,17 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
     sort_order: 30,
   }),
   menu({
+    code: "access.end-users",
+    parent_code: "group.access",
+    type: "menu",
+    path: "/access/end-users",
+    component: "end-users",
+    label_key: "shell.nav_end_users",
+    icon: "user-round",
+    permission_code: "end_users.read",
+    sort_order: 35,
+  }),
+  menu({
     code: "system.api-key-permissions",
     parent_code: "group.access",
     type: "menu",
@@ -480,18 +491,32 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const [isRestoring, setIsRestoring] = useState(true);
   const [apiBase, setApiBase] = useState("");
   const [accessToken, setAccessToken] = useState("");
+  const [refreshToken, setRefreshToken] = useState("");
   const [rememberPassword, setRememberPassword] = useState(false);
   const [serverVersion, setServerVersion] = useState<string | null>(null);
   const [serverBuildDate, setServerBuildDate] = useState<string | null>(null);
   const [principal, setPrincipal] = useState<ManagementPrincipal | null>(null);
   const [authFailureCode, setAuthFailureCode] = useState("");
 
-  const configureClient = useCallback((base: string, token: string, effectiveTenant = "") => {
-    apiClient.setConfig({ apiBase: base, managementKey: token });
-    const tenantId = normalizeTenantOverride(effectiveTenant);
-    // Always replace headers so a previous tenant override cannot leak into home-tenant mode.
-    apiClient.setDefaultHeaders(tenantId ? { "X-Effective-Tenant-ID": tenantId } : {});
-  }, []);
+  const configureClient = useCallback(
+    (
+      base: string,
+      token: string,
+      effectiveTenant = "",
+      /** undefined keeps current refresh; string/null replaces it */
+      nextRefresh?: string | null,
+    ) => {
+      apiClient.setConfig({
+        apiBase: base,
+        managementKey: token,
+        ...(nextRefresh !== undefined ? { refreshToken: nextRefresh ?? "" } : {}),
+      });
+      const tenantId = normalizeTenantOverride(effectiveTenant);
+      // Always replace headers so a previous tenant override cannot leak into home-tenant mode.
+      apiClient.setDefaultHeaders(tenantId ? { "X-Effective-Tenant-ID": tenantId } : {});
+    },
+    [],
+  );
 
   // Prefer live principal.effective_tenant for cache keys; fall back to last explicit pin.
   useEffect(() => {
@@ -516,8 +541,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
     setApiBase(resolvedBase);
     setAccessToken(resolvedToken);
+    setRefreshToken(snapshot?.refreshToken ?? "");
     setRememberPassword(resolvedRemember);
-    configureClient(resolvedBase, resolvedToken, requestedTenant);
+    configureClient(resolvedBase, resolvedToken, requestedTenant, snapshot?.refreshToken ?? "");
     // Pin cache tenant before any page paints from localStorage/sessionStorage.
     syncActiveDataCacheTenant(requestedTenant || DEFAULT_CACHE_TENANT_ID);
 
@@ -556,13 +582,14 @@ export function AuthProvider({ children }: PropsWithChildren) {
         if (!requestedTenant || !isRecoverableTenantOverrideError(overrideError)) {
           throw overrideError;
         }
-        configureClient(resolvedBase, resolvedToken, "");
+        // Keep refresh token while clearing tenant override.
+        configureClient(resolvedBase, resolvedToken, "", snapshot?.refreshToken);
         syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
         restoredPrincipal = (await identityApi.me()).principal;
       }
       // If the server ignored or could not apply the override, drop the stale value.
       if (requestedTenant && restoredPrincipal.effective_tenant.id !== requestedTenant) {
-        configureClient(resolvedBase, resolvedToken, "");
+        configureClient(resolvedBase, resolvedToken, "", snapshot?.refreshToken);
         if (restoredPrincipal.effective_tenant.id !== restoredPrincipal.home_tenant.id) {
           restoredPrincipal = (await identityApi.me()).principal;
         }
@@ -573,7 +600,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
           ? ""
           : restoredPrincipal.effective_tenant.id;
       if (confirmedOverride !== requestedTenant) {
-        configureClient(resolvedBase, resolvedToken, confirmedOverride);
+        configureClient(resolvedBase, resolvedToken, confirmedOverride, snapshot?.refreshToken);
       }
       persistEffectiveTenantOverride(confirmedOverride);
       setPrincipal(restoredPrincipal);
@@ -616,11 +643,18 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setServerVersion(detail?.version ?? null);
       setServerBuildDate(detail?.buildDate ?? null);
     };
+    const handleTokenRefreshed = (event: Event) => {
+      const detail = (event as CustomEvent<{ accessToken?: string; refreshToken?: string }>).detail;
+      if (detail?.accessToken) setAccessToken(detail.accessToken);
+      if (detail?.refreshToken) setRefreshToken(detail.refreshToken);
+    };
     window.addEventListener("unauthorized", handleUnauthorized);
     window.addEventListener("server-version-update", handleVersion as EventListener);
+    window.addEventListener("auth-token-refreshed", handleTokenRefreshed as EventListener);
     return () => {
       window.removeEventListener("unauthorized", handleUnauthorized);
       window.removeEventListener("server-version-update", handleVersion as EventListener);
+      window.removeEventListener("auth-token-refreshed", handleTokenRefreshed as EventListener);
     };
   }, []);
 
@@ -639,9 +673,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
         password: input.password,
         remember_me: input.rememberPassword,
       });
-      configureClient(normalizedBase, response.access_token, "");
+      configureClient(normalizedBase, response.access_token, "", response.refresh_token ?? "");
       setApiBase(normalizedBase);
       setAccessToken(response.access_token);
+      setRefreshToken(response.refresh_token ?? "");
       setRememberPassword(input.rememberPassword);
       setPrincipal(response.principal);
       syncActiveDataCacheTenant(response.principal.effective_tenant.id);
@@ -650,6 +685,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       writePersistedAuthSnapshot({
         apiBase: normalizedBase,
         managementKey: response.access_token,
+        ...(response.refresh_token ? { refreshToken: response.refresh_token } : {}),
         rememberPassword: input.rememberPassword,
         // Explicit empty override so a leftover legacy key cannot re-apply.
         effectiveTenantId: undefined,
@@ -663,9 +699,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
     void identityApi.logout().catch(() => undefined);
     setIsAuthenticated(false);
     setAccessToken("");
+    setRefreshToken("");
     setPrincipal(null);
     setAuthFailureCode("");
-    configureClient(apiBase, "", "");
+    configureClient(apiBase, "", "", "");
     syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
     clearPersistedAuthSnapshot();
   }, [apiBase, configureClient]);
@@ -684,9 +721,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
           ? ""
           : principal.effective_tenant.id;
       // Home tenant is represented as no override header.
-      const nextOverride =
-        nextTenant && nextTenant !== principal.home_tenant.id ? nextTenant : "";
-      configureClient(apiBase, accessToken, nextOverride);
+      const nextOverride = nextTenant && nextTenant !== principal.home_tenant.id ? nextTenant : "";
+      configureClient(apiBase, accessToken, nextOverride, refreshToken);
       persistEffectiveTenantOverride(nextOverride);
       // Switch cache bucket immediately so remounted pages never paint prior tenant data.
       syncActiveDataCacheTenant(nextTenant || principal.home_tenant.id);
@@ -697,18 +733,18 @@ export function AuthProvider({ children }: PropsWithChildren) {
           effective.id === response.principal.home_tenant.id ? "" : effective.id;
         // Align storage with what the server actually accepted.
         if (confirmedOverride !== nextOverride) {
-          configureClient(apiBase, accessToken, confirmedOverride);
+          configureClient(apiBase, accessToken, confirmedOverride, refreshToken);
           persistEffectiveTenantOverride(confirmedOverride);
         }
         setPrincipal(response.principal);
         syncActiveDataCacheTenant(effective.id);
       } catch {
-        configureClient(apiBase, accessToken, previousTenant);
+        configureClient(apiBase, accessToken, previousTenant, refreshToken);
         persistEffectiveTenantOverride(previousTenant);
         syncActiveDataCacheTenant(previousTenant || principal.home_tenant.id);
       }
     },
-    [accessToken, apiBase, configureClient, principal],
+    [accessToken, apiBase, configureClient, principal, refreshToken],
   );
 
   const permissions = useMemo(

--- a/packages/api-client/src/client/auth-storage.ts
+++ b/packages/api-client/src/client/auth-storage.ts
@@ -61,6 +61,9 @@ export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
       return {
         apiBase: normalizeApiBase(parsed.apiBase),
         managementKey: parsed.managementKey,
+        ...(typeof parsed.refreshToken === "string" && parsed.refreshToken
+          ? { refreshToken: parsed.refreshToken }
+          : {}),
         rememberPassword: Boolean(parsed.rememberPassword),
         ...(effectiveTenantId ? { effectiveTenantId } : {}),
       };
@@ -80,6 +83,7 @@ export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
   const payload: PersistedAuthSnapshot = {
     apiBase: snapshot.apiBase,
     managementKey: snapshot.managementKey,
+    ...(snapshot.refreshToken ? { refreshToken: snapshot.refreshToken } : {}),
     rememberPassword: snapshot.rememberPassword,
     expiresAt: Date.now() + AUTH_PERSIST_TTL_MS,
     ...(effectiveTenantId ? { effectiveTenantId } : {}),

--- a/packages/api-client/src/client/client.ts
+++ b/packages/api-client/src/client/client.ts
@@ -79,14 +79,26 @@ export class ApiClient {
 
   private managementKey = "";
 
+  private refreshToken = "";
+
   private authSuspended = false;
+
+  private refreshInFlight: Promise<boolean> | null = null;
 
   private defaultHeaders = new Headers();
 
-  setConfig(config: ApiClientConfig): void {
+  setConfig(config: ApiClientConfig & { refreshToken?: string | null }): void {
     this.apiBase = computeManagementApiBase(config.apiBase);
     this.managementKey = config.managementKey.trim();
+    // undefined = keep existing refresh; null/string = replace (logout passes null/"").
+    if (config.refreshToken !== undefined) {
+      this.refreshToken = (config.refreshToken ?? "").trim();
+    }
     this.authSuspended = false;
+  }
+
+  setRefreshToken(token: string): void {
+    this.refreshToken = token.trim();
   }
 
   setDefaultHeaders(headers: HeadersInit): void {
@@ -284,16 +296,71 @@ export class ApiClient {
     }
   }
 
+  private async tryRefreshAccessToken(): Promise<boolean> {
+    if (!this.refreshToken) return false;
+    if (this.refreshInFlight) return this.refreshInFlight;
+    this.refreshInFlight = (async () => {
+      try {
+        const base = this.apiBase.replace(/\/v0\/management\/?$/, "");
+        const response = await fetch(`${base}/v0/auth/refresh`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: this.refreshToken }),
+        });
+        if (!response.ok) return false;
+        const payload = (await response.json()) as {
+          access_token?: string;
+          refresh_token?: string;
+        };
+        if (!payload.access_token) return false;
+        this.managementKey = payload.access_token;
+        if (payload.refresh_token) this.refreshToken = payload.refresh_token;
+        this.authSuspended = false;
+        // best-effort persist for admin session
+        try {
+          const { readPersistedAuthSnapshot, writePersistedAuthSnapshot } =
+            await import("./auth-storage");
+          const current = readPersistedAuthSnapshot();
+          if (current) {
+            writePersistedAuthSnapshot({
+              ...current,
+              managementKey: this.managementKey,
+              refreshToken: this.refreshToken || current.refreshToken,
+            });
+          }
+        } catch {
+          /* ignore */
+        }
+        dispatchWindowEvent(
+          new CustomEvent("auth-token-refreshed", {
+            detail: {
+              accessToken: this.managementKey,
+              refreshToken: this.refreshToken,
+            },
+          }),
+        );
+        return true;
+      } catch {
+        return false;
+      } finally {
+        this.refreshInFlight = null;
+      }
+    })();
+    return this.refreshInFlight;
+  }
+
   private async request<T>(
     path: string,
     {
       init,
       options,
       responseType = "json",
+      retried = false,
     }: {
       init?: RequestInit;
       options?: RequestOptions;
       responseType?: ResponseType;
+      retried?: boolean;
     } = {},
   ): Promise<T> {
     this.assertAuthActive();
@@ -312,6 +379,12 @@ export class ApiClient {
       this.applyVersionHeaders(response);
 
       if (!response.ok) {
+        if (response.status === 401 && !retried && this.refreshToken) {
+          const refreshed = await this.tryRefreshAccessToken();
+          if (refreshed) {
+            return this.request<T>(path, { init, options, responseType, retried: true });
+          }
+        }
         const error = await this.buildApiError(response);
         if (error.isAuthError) {
           this.suspendAuth(extractApiErrorCode(error.payload));

--- a/packages/api-client/src/client/portal-client.ts
+++ b/packages/api-client/src/client/portal-client.ts
@@ -1,0 +1,214 @@
+import { detectApiBaseFromLocation, normalizeApiBase, REQUEST_TIMEOUT_MS } from "./constants";
+
+export { detectApiBaseFromLocation };
+import { ApiClientError, extractApiErrorMessage } from "./errors";
+
+export const PORTAL_AUTH_STORAGE_KEY = "code-proxy-portal-auth";
+
+export interface PortalAuthSnapshot {
+  apiBase: string;
+  accessToken: string;
+  refreshToken: string;
+  remember: boolean;
+  expiresAt: number;
+  user?: {
+    id: string;
+    username: string;
+    display_name: string;
+  };
+}
+
+const storages = (): Storage[] => {
+  const items: Storage[] = [];
+  try {
+    if (typeof window !== "undefined") items.push(window.sessionStorage, window.localStorage);
+  } catch {
+    /* unavailable */
+  }
+  return items;
+};
+
+export const readPortalAuth = (): PortalAuthSnapshot | null => {
+  for (const storage of storages()) {
+    try {
+      const raw = storage.getItem(PORTAL_AUTH_STORAGE_KEY);
+      if (!raw) continue;
+      const parsed = JSON.parse(raw) as PortalAuthSnapshot;
+      if (!parsed.accessToken || !parsed.apiBase) {
+        storage.removeItem(PORTAL_AUTH_STORAGE_KEY);
+        continue;
+      }
+      return {
+        ...parsed,
+        apiBase: normalizeApiBase(parsed.apiBase),
+      };
+    } catch {
+      storage.removeItem(PORTAL_AUTH_STORAGE_KEY);
+    }
+  }
+  return null;
+};
+
+export const writePortalAuth = (snapshot: PortalAuthSnapshot): void => {
+  const [session, local] = storages();
+  const target = snapshot.remember ? local : session;
+  if (!target) return;
+  clearPortalAuth();
+  target.setItem(
+    PORTAL_AUTH_STORAGE_KEY,
+    JSON.stringify({
+      ...snapshot,
+      apiBase: normalizeApiBase(snapshot.apiBase),
+    }),
+  );
+};
+
+export const clearPortalAuth = (): void => {
+  for (const storage of storages()) storage.removeItem(PORTAL_AUTH_STORAGE_KEY);
+};
+
+const parseJsonOrText = async (response: Response): Promise<unknown> => {
+  const text = await response.text();
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return trimmed;
+  }
+};
+
+export class PortalApiClient {
+  private accessToken = "";
+  private refreshToken = "";
+  private apiBase = detectApiBaseFromLocation();
+  private refreshing: Promise<boolean> | null = null;
+
+  loadFromStorage(): PortalAuthSnapshot | null {
+    const snap = readPortalAuth();
+    if (snap) {
+      this.apiBase = snap.apiBase;
+      this.accessToken = snap.accessToken;
+      this.refreshToken = snap.refreshToken;
+    }
+    return snap;
+  }
+
+  setSession(snap: PortalAuthSnapshot): void {
+    this.apiBase = normalizeApiBase(snap.apiBase);
+    this.accessToken = snap.accessToken;
+    this.refreshToken = snap.refreshToken;
+    writePortalAuth(snap);
+  }
+
+  clearSession(): void {
+    this.accessToken = "";
+    this.refreshToken = "";
+    clearPortalAuth();
+  }
+
+  getAccessToken(): string {
+    return this.accessToken;
+  }
+
+  private url(path: string): string {
+    const base = this.apiBase || detectApiBaseFromLocation();
+    const p = path.startsWith("/") ? path : `/${path}`;
+    return `${base}${p}`;
+  }
+
+  private async tryRefresh(): Promise<boolean> {
+    if (!this.refreshToken) return false;
+    if (this.refreshing) return this.refreshing;
+    this.refreshing = (async () => {
+      try {
+        const response = await fetch(this.url("/v0/portal/auth/refresh"), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refresh_token: this.refreshToken }),
+        });
+        const payload = (await parseJsonOrText(response)) as {
+          access_token?: string;
+          refresh_token?: string;
+          expires_at?: string;
+        };
+        if (!response.ok || !payload?.access_token) {
+          this.clearSession();
+          return false;
+        }
+        this.accessToken = payload.access_token;
+        if (payload.refresh_token) this.refreshToken = payload.refresh_token;
+        const existing = readPortalAuth();
+        writePortalAuth({
+          apiBase: this.apiBase,
+          accessToken: this.accessToken,
+          refreshToken: this.refreshToken,
+          remember: existing?.remember ?? true,
+          expiresAt: payload.expires_at
+            ? Date.parse(payload.expires_at)
+            : Date.now() + 12 * 3600 * 1000,
+          user: existing?.user,
+        });
+        return true;
+      } catch {
+        this.clearSession();
+        return false;
+      } finally {
+        this.refreshing = null;
+      }
+    })();
+    return this.refreshing;
+  }
+
+  async request<T>(method: string, path: string, body?: unknown, retried = false): Promise<T> {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    if (this.accessToken) headers.set("Authorization", `Bearer ${this.accessToken}`);
+    const controller = new AbortController();
+    const timer = globalThis.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(this.url(path), {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (response.status === 401 && !retried && this.refreshToken) {
+        const ok = await this.tryRefresh();
+        if (ok) return this.request<T>(method, path, body, true);
+      }
+      if (response.status === 204) return undefined as T;
+      const payload = await parseJsonOrText(response);
+      if (!response.ok) {
+        throw new ApiClientError({
+          message: extractApiErrorMessage(payload, `Request failed (${response.status})`),
+          status: response.status,
+          statusText: response.statusText,
+          url: this.url(path),
+          method,
+          data: payload ?? null,
+        });
+      }
+      return payload as T;
+    } finally {
+      globalThis.clearTimeout(timer);
+    }
+  }
+
+  get<T>(path: string) {
+    return this.request<T>("GET", path);
+  }
+  post<T>(path: string, body?: unknown) {
+    return this.request<T>("POST", path, body);
+  }
+  put<T>(path: string, body?: unknown) {
+    return this.request<T>("PUT", path, body);
+  }
+  patch<T>(path: string, body?: unknown) {
+    return this.request<T>("PATCH", path, body);
+  }
+  delete<T>(path: string) {
+    return this.request<T>("DELETE", path);
+  }
+}
+
+export const portalClient = new PortalApiClient();

--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -1,6 +1,7 @@
 export interface AuthSnapshot {
   apiBase: string;
   managementKey: string;
+  refreshToken?: string;
   rememberPassword: boolean;
   /** Platform-admin override; empty/omitted means home tenant (no X-Effective-Tenant-ID). */
   effectiveTenantId?: string;
@@ -481,11 +482,7 @@ export interface AiAccountStatusRefreshAcceptedDto {
 
 export type AiAccountStatusRefreshJobState = "running" | "completed";
 
-export type AiAccountStatusRefreshAccountState =
-  | "queued"
-  | "running"
-  | "success"
-  | "error";
+export type AiAccountStatusRefreshAccountState = "queued" | "running" | "success" | "error";
 
 export interface AiAccountStatusRefreshAccountResultDto {
   auth_index: string;

--- a/packages/api-client/src/endpoints/end-users.ts
+++ b/packages/api-client/src/endpoints/end-users.ts
@@ -1,0 +1,122 @@
+import { apiClient } from "../client/client";
+import {
+  detectApiBaseFromLocation,
+  portalClient,
+  type PortalAuthSnapshot,
+} from "../client/portal-client";
+
+export interface EndUser {
+  id: string;
+  tenant_id: string;
+  username: string;
+  display_name: string;
+  status: string;
+  must_change_password: boolean;
+  last_login_at?: string | null;
+  failed_login_count?: number;
+  lock_stage?: number;
+  locked_until?: string | null;
+  created_at: string;
+  updated_at: string;
+  version: number;
+}
+
+export interface EndUserAPIKey {
+  id: string;
+  tenant_id: string;
+  end_user_id: string;
+  key_masked?: string;
+  name: string;
+  disabled: boolean;
+  is_default: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateEndUserResult {
+  user: EndUser;
+  generated_password?: string;
+  default_api_key?: EndUserAPIKey & { key?: string };
+}
+
+export interface PortalLoginResult {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_at: string;
+  refresh_expires_at: string;
+  user: EndUser;
+  must_change_password: boolean;
+}
+
+export const endUsersApi = {
+  list: () => apiClient.get<{ items: EndUser[] }>("/end-users"),
+  create: (body: { username?: string; display_name: string; password?: string }) =>
+    apiClient.post<CreateEndUserResult>("/end-users", body),
+  update: (id: string, body: { display_name?: string; status?: string }) =>
+    apiClient.patch<EndUser>(`/end-users/${id}`, body),
+  remove: (id: string) => apiClient.delete(`/end-users/${id}`),
+  resetPassword: (id: string, password?: string) =>
+    apiClient.post<{ generated_password?: string }>(`/end-users/${id}/reset-password`, {
+      password: password || "",
+    }),
+  listKeys: (id: string) => apiClient.get<{ items: EndUserAPIKey[] }>(`/end-users/${id}/api-keys`),
+  createKey: (id: string, name?: string) =>
+    apiClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>(
+      `/end-users/${id}/api-keys`,
+      { name: name || "" },
+    ),
+};
+
+export const portalApi = {
+  client: portalClient,
+  loadSession: () => portalClient.loadFromStorage(),
+  clearSession: () => portalClient.clearSession(),
+  async login(username: string, password: string, remember = true): Promise<PortalLoginResult> {
+    portalClient.loadFromStorage();
+    const result = await portalClient.post<PortalLoginResult>("/v0/portal/auth/login", {
+      username,
+      password,
+    });
+    const snap: PortalAuthSnapshot = {
+      apiBase: detectApiBaseFromLocation(),
+      accessToken: result.access_token,
+      refreshToken: result.refresh_token,
+      remember,
+      expiresAt: Date.parse(result.expires_at) || Date.now() + 12 * 3600 * 1000,
+      user: {
+        id: result.user.id,
+        username: result.user.username,
+        display_name: result.user.display_name,
+      },
+    };
+    portalClient.setSession(snap);
+    return result;
+  },
+  logout: async () => {
+    try {
+      await portalClient.post("/v0/portal/auth/logout", {});
+    } catch {
+      /* ignore */
+    }
+    portalClient.clearSession();
+  },
+  me: () => portalClient.get<{ user: EndUser }>("/v0/portal/auth/me"),
+  changePassword: (current_password: string, new_password: string) =>
+    portalClient.put<void>("/v0/portal/auth/password", { current_password, new_password }),
+  listKeys: () => portalClient.get<{ items: EndUserAPIKey[] }>("/v0/portal/api-keys"),
+  keySecret: (id: string) =>
+    portalClient.get<{ id: string; key: string }>(`/v0/portal/api-keys/${id}/secret`),
+  createKey: (name?: string) =>
+    portalClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>("/v0/portal/api-keys", {
+      name: name || "",
+    }),
+  updateKey: (id: string, body: { name?: string; is_default?: boolean }) =>
+    portalClient.patch<EndUserAPIKey>(`/v0/portal/api-keys/${id}`, body),
+  rotateKey: (id: string) =>
+    portalClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>(
+      `/v0/portal/api-keys/${id}/rotate`,
+      {},
+    ),
+  deleteKey: (id: string) => portalClient.delete(`/v0/portal/api-keys/${id}`),
+};

--- a/packages/api-client/src/endpoints/identity.ts
+++ b/packages/api-client/src/endpoints/identity.ts
@@ -19,6 +19,8 @@ export interface TenantIdentity {
   effective_status: "active" | "suspended" | "disabled" | "expired";
   expires_at: string | null;
   description: string;
+  access_token_ttl_seconds?: number;
+  refresh_token_ttl_seconds?: number;
   version: number;
   created_at: string;
   updated_at: string;
@@ -109,8 +111,10 @@ export interface ManagementPrincipal {
 
 export interface LoginResponse {
   access_token: string;
+  refresh_token?: string;
   token_type: "Bearer";
   expires_at: string;
+  refresh_expires_at?: string;
   principal: ManagementPrincipal;
 }
 
@@ -185,6 +189,8 @@ export interface AuditLogsResponse {
 export const identityApi = {
   login: (body: { username: string; password: string; remember_me: boolean }) =>
     apiClient.post<LoginResponse>("/../auth/login", body),
+  refresh: (refresh_token: string) =>
+    apiClient.post<LoginResponse>("/../auth/refresh", { refresh_token }),
   me: () => apiClient.get<{ principal: ManagementPrincipal }>("/../auth/me"),
   logout: () => apiClient.post<void>("/../auth/logout"),
   changePassword: (body: { current_password: string; new_password: string }) =>
@@ -212,6 +218,8 @@ export const identityApi = {
       description?: string;
       status?: string;
       expires_at?: string;
+      access_token_ttl_seconds?: number;
+      refresh_token_ttl_seconds?: number;
       version: number;
     },
   ) => {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -30,7 +30,18 @@ export {
   updatePersistedEffectiveTenantId,
   writePersistedAuthSnapshot,
 } from "./client/auth-storage";
+export {
+  portalClient,
+  PortalApiClient,
+  PORTAL_AUTH_STORAGE_KEY,
+  clearPortalAuth,
+  readPortalAuth,
+  writePortalAuth,
+} from "./client/portal-client";
+export type { PortalAuthSnapshot } from "./client/portal-client";
 export type * from "./dto/types";
+export { endUsersApi, portalApi } from "./endpoints/end-users";
+export type * from "./endpoints/end-users";
 
 export { configApi } from "./endpoints/config";
 export type * from "./endpoints/config";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2026,6 +2026,7 @@
     "nav_ai_accounts": "AI Accounts",
     "nav_oauth": "OAuth Login",
     "nav_api_keys": "API Keys",
+    "nav_end_users": "End Users",
     "nav_api_key_permissions": "Key Permission Profiles",
     "nav_ccswitch_import_settings": "CC Switch Config",
     "nav_image_generation": "Image Models",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2043,6 +2043,7 @@
     "nav_ai_accounts": "AI 账号",
     "nav_oauth": "OAuth 登录",
     "nav_api_keys": "API Keys",
+    "nav_end_users": "终端用户",
     "nav_api_key_permissions": "Key 权限模板",
     "nav_ccswitch_import_settings": "CC Switch 配置",
     "nav_image_generation": "生图模型",

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Key, LogOut, Search } from "lucide-react";
+import { Key, LogOut, Search, KeyRound } from "lucide-react";
+import { portalApi, type EndUser, type EndUserAPIKey } from "@code-proxy/api-client";
 import { useTheme } from "@code-proxy/ui";
 import { ThemeToggleButton } from "@code-proxy/ui";
 import { LanguageSelector } from "@code-proxy/ui";
@@ -21,20 +22,13 @@ import {
   fetchPublicUsageSummary,
 } from "./api";
 import { LookupEmptyState } from "./components/LookupEmptyState";
-import {
-  LookupResultsToolbar,
-  type ApiKeyLookupTab,
-} from "./components/LookupResultsToolbar";
+import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
 import { ModelsTabContent } from "./components/ModelsTabContent";
 import { PublicLogsSection } from "./components/PublicLogsSection";
 import { QuickImportTabContent } from "./components/QuickImportTabContent";
 import { UsageTabSection } from "./components/UsageTabSection";
 import { useApiKeyLookupCharts } from "./hooks/useApiKeyLookupCharts";
-import type {
-  ChartDataResponse,
-  PublicLogItem,
-  PublicUsageLimits,
-} from "./types";
+import type { ChartDataResponse, PublicLogItem, PublicUsageLimits } from "./types";
 import {
   buildRequestLogsColumns,
   formatOptionalRequestLogLatencyMs,
@@ -62,15 +56,14 @@ const LOOKUP_CHART_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.chartCache.v1";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v2";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.modelsCache.v1";
 const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
+const CHANGE_PASSWORD_SELECT_VALUE = "__api-key-lookup-change-password__";
+const MANAGE_KEYS_SELECT_VALUE = "__api-key-lookup-manage-keys__";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 const readStoredLookupKey = (): string => {
   try {
-    return (
-      window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ??
-      ""
-    );
+    return window.sessionStorage.getItem(LOOKUP_LAST_API_KEY_STORAGE_KEY)?.trim() ?? "";
   } catch {
     return "";
   }
@@ -112,10 +105,7 @@ const readStoredChartCache = (cacheKey: string): ChartDataResponse | null => {
   });
 };
 
-const writeStoredChartCache = (
-  cacheKey: string,
-  data: ChartDataResponse,
-): void => {
+const writeStoredChartCache = (cacheKey: string, data: ChartDataResponse): void => {
   updateTenantBucketMapEntry({
     key: LOOKUP_CHART_CACHE_STORAGE_KEY,
     kind: "session",
@@ -145,8 +135,7 @@ const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === "string");
 
 const sameStringArray = (left: string[], right: string[]): boolean =>
-  left.length === right.length &&
-  left.every((value, index) => value === right[index]);
+  left.length === right.length && left.every((value, index) => value === right[index]);
 
 const readStoredModelsCache = (cacheKey: string): string[] | null => {
   return readTenantBucketMapEntry({
@@ -224,11 +213,7 @@ const localizeLookupError = (
 const readLegacyLookupKeyFromUrl = (): string => {
   try {
     const url = new URL(window.location.href);
-    return (
-      url.searchParams.get("api_key") ||
-      url.searchParams.get("key") ||
-      ""
-    ).trim();
+    return (url.searchParams.get("api_key") || url.searchParams.get("key") || "").trim();
   } catch {
     return "";
   }
@@ -308,10 +293,7 @@ export function ApiKeyLookupPage() {
     };
   }, []);
 
-  const initialLookupKey = useMemo(
-    () => readLegacyLookupKeyFromUrl() || readStoredLookupKey(),
-    [],
-  );
+  const initialLookupKey = useMemo(() => readLegacyLookupKeyFromUrl() || readStoredLookupKey(), []);
   const [apiKeyInput, setApiKeyInput] = useState(initialLookupKey);
   const [queriedKey, setQueriedKey] = useState(initialLookupKey);
   const [apiKeyName, setApiKeyName] = useState("");
@@ -319,21 +301,14 @@ export function ApiKeyLookupPage() {
 
   // ── Content modal state ──
   const [contentModalOpen, setContentModalOpen] = useState(false);
-  const [contentModalLogId, setContentModalLogId] = useState<number | null>(
-    null,
-  );
-  const [contentModalTab, setContentModalTab] = useState<"input" | "output">(
-    "input",
-  );
+  const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
+  const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
 
-  const handleContentClick = useCallback(
-    (logId: number, tab: "input" | "output") => {
-      setContentModalLogId(logId);
-      setContentModalTab(tab);
-      setContentModalOpen(true);
-    },
-    [],
-  );
+  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
+    setContentModalLogId(logId);
+    setContentModalTab(tab);
+    setContentModalOpen(true);
+  }, []);
 
   const logColumns = useMemo(
     () =>
@@ -374,10 +349,8 @@ export function ApiKeyLookupPage() {
 
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
-  const [selectedModels, setSelectedModels] =
-    useState<MultiSelectFilterState<string>>(null);
-  const [selectedChannels, setSelectedChannels] =
-    useState<MultiSelectFilterState<string>>(null);
+  const [selectedModels, setSelectedModels] = useState<MultiSelectFilterState<string>>(null);
+  const [selectedChannels, setSelectedChannels] = useState<MultiSelectFilterState<string>>(null);
   const [selectedStatuses, setSelectedStatuses] =
     useState<MultiSelectFilterState<StatusFilterValue>>(null);
 
@@ -412,9 +385,7 @@ export function ApiKeyLookupPage() {
 
   const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     const statuses =
-      filterOptions.statuses.length > 0
-        ? filterOptions.statuses
-        : ["success", "failed"];
+      filterOptions.statuses.length > 0 ? filterOptions.statuses : ["success", "failed"];
     return statuses.map((status) => ({
       value: status,
       label:
@@ -541,11 +512,7 @@ export function ApiKeyLookupPage() {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (myFetchId !== fetchIdRef.current) return;
 
-        const message = localizeLookupError(
-          t,
-          err,
-          "apikey_lookup.query_failed",
-        );
+        const message = localizeLookupError(t, err, "apikey_lookup.query_failed");
         setError(message);
         setRawItems([]);
         setTotalCount(0);
@@ -557,14 +524,7 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [
-      channelFilterParam,
-      modelFilterParam,
-      pageSize,
-      statusFilterParam,
-      t,
-      timeRange,
-    ],
+    [channelFilterParam, modelFilterParam, pageSize, statusFilterParam, t, timeRange],
   );
 
   // ================================================================
@@ -583,12 +543,10 @@ export function ApiKeyLookupPage() {
         apiKey: trimmedKey,
         signal: controller.signal,
       });
-      if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted)
-        return;
+      if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted) return;
       setQuotaLimits(summary.limits ?? null);
     } catch {
-      if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted)
-        return;
+      if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted) return;
       setQuotaLimits(null);
     } finally {
       if (summaryAbortControllerRef.current === controller) {
@@ -630,8 +588,7 @@ export function ApiKeyLookupPage() {
           days,
           signal: controller.signal,
         });
-        if (myFetchId !== chartFetchIdRef.current || controller.signal.aborted)
-          return;
+        if (myFetchId !== chartFetchIdRef.current || controller.signal.aborted) return;
 
         chartCacheRef.current[cacheKey] = data;
         writeStoredChartCache(cacheKey, data);
@@ -642,8 +599,7 @@ export function ApiKeyLookupPage() {
         writeStoredLookupKey(trimmedKey);
         setLoginModalOpen(false);
       } catch (err) {
-        if (controller.signal.aborted || myFetchId !== chartFetchIdRef.current)
-          return;
+        if (controller.signal.aborted || myFetchId !== chartFetchIdRef.current) return;
         if (!cached) {
           setError(localizeLookupError(t, err, "apikey_lookup.query_failed"));
         }
@@ -651,10 +607,7 @@ export function ApiKeyLookupPage() {
         if (chartAbortControllerRef.current === controller) {
           chartAbortControllerRef.current = null;
         }
-        if (
-          myFetchId === chartFetchIdRef.current &&
-          !controller.signal.aborted
-        ) {
+        if (myFetchId === chartFetchIdRef.current && !controller.signal.aborted) {
           setChartLoading(false);
         }
       }
@@ -666,10 +619,7 @@ export function ApiKeyLookupPage() {
   //  Derived rows for VirtualTable
   // ================================================================
 
-  const rows = useMemo<RequestLogsRow[]>(
-    () => rawItems.map((item) => toLogRow(item)),
-    [rawItems],
-  );
+  const rows = useMemo<RequestLogsRow[]>(() => rawItems.map((item) => toLogRow(item)), [rawItems]);
 
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
@@ -711,13 +661,10 @@ export function ApiKeyLookupPage() {
 
       const cached = options?.force
         ? null
-        : modelsCacheRef.current[trimmedKey] ||
-          readStoredModelsCache(trimmedKey);
+        : modelsCacheRef.current[trimmedKey] || readStoredModelsCache(trimmedKey);
       if (cached) {
         modelsCacheRef.current[trimmedKey] = cached;
-        setAvailableModels((prev) =>
-          sameStringArray(prev, cached) ? prev : cached,
-        );
+        setAvailableModels((prev) => (sameStringArray(prev, cached) ? prev : cached));
       }
 
       setModelsLoading(true);
@@ -729,9 +676,7 @@ export function ApiKeyLookupPage() {
         setAvailableModels((prev) => (sameStringArray(prev, ids) ? prev : ids));
       } catch (err: unknown) {
         if (!cached) {
-          setModelsError(
-            localizeLookupError(t, err, "apikey_lookup.load_models_failed"),
-          );
+          setModelsError(localizeLookupError(t, err, "apikey_lookup.load_models_failed"));
         }
       } finally {
         setModelsLoading(false);
@@ -805,15 +750,7 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [
-      apiKeyInput,
-      queriedKey,
-      activeTab,
-      timeRange,
-      fetchLogs,
-      fetchChartDataFn,
-      fetchModelsFn,
-    ],
+    [apiKeyInput, queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn],
   );
 
   const handleApiKeyInputChange = useCallback((value: string) => {
@@ -857,7 +794,97 @@ export function ApiKeyLookupPage() {
     writeStoredLookupKey("");
   }, []);
 
+  const [portalUser, setPortalUser] = useState<EndUser | null>(null);
+  const [portalKeys, setPortalKeys] = useState<EndUserAPIKey[]>([]);
+  const [loginUsername, setLoginUsername] = useState("");
+  const [loginPassword, setLoginPassword] = useState("");
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [loginBusy, setLoginBusy] = useState(false);
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
+  const [manageKeysOpen, setManageKeysOpen] = useState(false);
+  const [pwdForm, setPwdForm] = useState({ current: "", next: "" });
+  const [pwdError, setPwdError] = useState<string | null>(null);
+  const [secretOnce, setSecretOnce] = useState<string | null>(null);
+
+  const activateOwnedKey = useCallback(
+    async (keyId: string) => {
+      const secret = await portalApi.keySecret(keyId);
+      const plain = secret.key?.trim();
+      if (!plain) return;
+      setApiKeyInput(plain);
+      writeStoredLookupKey(plain);
+      setLoginModalOpen(false);
+      chartCacheRef.current = {};
+      void fetchChartDataFn(plain, timeRange);
+    },
+    [fetchChartDataFn, timeRange],
+  );
+
+  useEffect(() => {
+    const snap = portalApi.loadSession();
+    if (!snap?.accessToken) return;
+    void portalApi
+      .me()
+      .then(async (res) => {
+        setPortalUser(res.user);
+        if (res.user.must_change_password) {
+          setChangePasswordOpen(true);
+          setPortalKeys([]);
+          return;
+        }
+        try {
+          const keys = await portalApi.listKeys();
+          const items = keys.items ?? [];
+          setPortalKeys(items);
+          if (!queriedKey) {
+            const usable = items.filter((k) => !k.disabled);
+            const def = usable.find((k) => k.is_default) ?? usable[0];
+            if (def) await activateOwnedKey(def.id);
+            else if (items.length) setManageKeysOpen(true);
+          }
+        } catch {
+          setPortalKeys([]);
+        }
+      })
+      .catch(() => {
+        portalApi.clearSession();
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handlePortalLogin = useCallback(async () => {
+    setLoginBusy(true);
+    setLoginError(null);
+    try {
+      const result = await portalApi.login(loginUsername.trim(), loginPassword, true);
+      setPortalUser(result.user);
+      setLoginModalOpen(false);
+      setLoginPassword("");
+      if (result.must_change_password || result.user.must_change_password) {
+        setChangePasswordOpen(true);
+        setPortalKeys([]);
+      } else {
+        const keys = await portalApi.listKeys();
+        const items = keys.items ?? [];
+        setPortalKeys(items);
+        const usable = items.filter((k) => !k.disabled);
+        const def = usable.find((k) => k.is_default) ?? usable[0];
+        if (def) {
+          await activateOwnedKey(def.id);
+        } else {
+          setManageKeysOpen(true);
+        }
+      }
+    } catch (err) {
+      setLoginError(err instanceof Error ? err.message : "login failed");
+    } finally {
+      setLoginBusy(false);
+    }
+  }, [activateOwnedKey, loginUsername, loginPassword]);
+
   const handleLogout = useCallback(() => {
+    void portalApi.logout();
+    setPortalUser(null);
+    setPortalKeys([]);
     handleApiKeyInputChange("");
     setLoginModalOpen(true);
   }, [handleApiKeyInputChange]);
@@ -874,14 +901,7 @@ export function ApiKeyLookupPage() {
         fetchLogs(queriedKey, 1);
       }
     }
-  }, [
-    queriedKey,
-    activeTab,
-    timeRange,
-    fetchLogs,
-    fetchChartDataFn,
-    fetchModelsFn,
-  ]);
+  }, [queriedKey, activeTab, timeRange, fetchLogs, fetchChartDataFn, fetchModelsFn]);
 
   // Strip legacy sensitive query params from the URL on mount.
   useEffect(() => {
@@ -935,9 +955,34 @@ export function ApiKeyLookupPage() {
   }, [lastUpdatedAt]);
 
   const displayName =
-    apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
+    portalUser?.display_name ||
+    portalUser?.username ||
+    apiKeyName ||
+    (queriedKey ? t("apikey_lookup.unnamed_key") : "");
   const keyMenuOptions = useMemo<SelectOption[]>(
     () => [
+      ...(portalUser
+        ? [
+            {
+              value: CHANGE_PASSWORD_SELECT_VALUE,
+              label: (
+                <span className="flex items-center gap-2">
+                  <KeyRound size={15} />
+                  {t("apikey_lookup.change_password", { defaultValue: "修改密码" })}
+                </span>
+              ),
+            },
+            {
+              value: MANAGE_KEYS_SELECT_VALUE,
+              label: (
+                <span className="flex items-center gap-2">
+                  <Key size={15} />
+                  {t("apikey_lookup.manage_keys", { defaultValue: "管理 API Key" })}
+                </span>
+              ),
+            },
+          ]
+        : []),
       {
         value: LOGOUT_SELECT_VALUE,
         label: (
@@ -948,17 +993,19 @@ export function ApiKeyLookupPage() {
         ),
       },
     ],
-    [t],
+    [portalUser, t],
   );
   const handleKeyMenuChange = useCallback(
     (value: string) => {
       if (value === LOGOUT_SELECT_VALUE) handleLogout();
+      if (value === CHANGE_PASSWORD_SELECT_VALUE) setChangePasswordOpen(true);
+      if (value === MANAGE_KEYS_SELECT_VALUE) setManageKeysOpen(true);
     },
     [handleLogout],
   );
   const closeLoginModal = useCallback(() => {
-    if (queriedKey) setLoginModalOpen(false);
-  }, [queriedKey]);
+    if (queriedKey || portalUser) setLoginModalOpen(false);
+  }, [queriedKey, portalUser]);
 
   // ================================================================
   //  Render
@@ -989,9 +1036,9 @@ export function ApiKeyLookupPage() {
             </span>
           </div>
           <div className="flex items-center gap-2">
-            {queriedKey ? (
+            {queriedKey || portalUser ? (
               <Select
-                value={queriedKey}
+                value={queriedKey || portalUser?.id || ""}
                 onChange={handleKeyMenuChange}
                 options={keyMenuOptions}
                 placeholder={
@@ -1004,7 +1051,11 @@ export function ApiKeyLookupPage() {
                 className="max-w-[34vw] !border-0 !bg-transparent !px-1 !shadow-none hover:!bg-transparent dark:!bg-transparent dark:!shadow-none dark:hover:!bg-transparent sm:max-w-56"
                 size="sm"
               />
-            ) : null}
+            ) : (
+              <Button size="sm" variant="ghost" onClick={() => setLoginModalOpen(true)}>
+                {t("common.login", { defaultValue: "登录" })}
+              </Button>
+            )}
             <LanguageSelector className="inline-flex items-center rounded-xl p-2 text-slate-600 transition hover:bg-slate-100 dark:text-white/70 dark:hover:bg-white/10" />
             <ThemeToggleButton className="rounded-xl p-2 text-slate-600 transition hover:bg-slate-100 dark:text-white/70 dark:hover:bg-white/10" />
           </div>
@@ -1045,9 +1096,7 @@ export function ApiKeyLookupPage() {
                 setModelMetric={setModelMetric}
                 heatmapSeries={heatmapSeries}
                 modelDistributionData={modelDistributionData}
-                modelDistributionOption={
-                  modelDistributionOption as Record<string, unknown>
-                }
+                modelDistributionOption={modelDistributionOption as Record<string, unknown>}
                 modelDistributionLegend={modelDistributionLegend}
                 dailySeries={dailySeries}
                 dailyTrendOption={dailyTrendOption as Record<string, unknown>}
@@ -1100,10 +1149,7 @@ export function ApiKeyLookupPage() {
 
             {activeTab === "quickImport" ? (
               <Reveal>
-                <QuickImportTabContent
-                  apiKey={queriedKey}
-                  reloadToken={quickImportReloadToken}
-                />
+                <QuickImportTabContent apiKey={queriedKey} reloadToken={quickImportReloadToken} />
               </Reveal>
             ) : null}
           </>
@@ -1138,55 +1184,273 @@ export function ApiKeyLookupPage() {
 
       <Modal
         open={loginModalOpen}
-        title={t("apikey_lookup.login_title")}
-        description={t("apikey_lookup.login_desc")}
+        title={t("apikey_lookup.login_title", { defaultValue: "登录 / 查询" })}
+        description={t("apikey_lookup.login_desc", {
+          defaultValue: "使用账号密码管理自己的 Key，或粘贴 API Key 直接查询。",
+        })}
         maxWidth="max-w-lg"
         onClose={closeLoginModal}
-        footer={
-          <Button
-            variant="primary"
-            type="submit"
-            form="apikey-login-form"
-            disabled={!apiKeyInput.trim() || loading}
+      >
+        <div className="space-y-5">
+          <form
+            className="space-y-3 rounded-2xl border border-slate-200/80 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/50"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handlePortalLogin();
+            }}
           >
-            {loading ? (
-              <span
-                className="h-4 w-4 rounded-full border-2 border-white/30 border-t-white motion-reduce:animate-none motion-safe:animate-spin dark:border-neutral-950/30 dark:border-t-neutral-950"
-                aria-hidden="true"
+            <div className="text-sm font-semibold text-slate-800 dark:text-white">
+              {t("apikey_lookup.account_login", { defaultValue: "账号登录" })}
+            </div>
+            <label className="block space-y-1.5">
+              <span className="text-sm font-medium">
+                {t("apikey_lookup.username", { defaultValue: "账号" })}
+              </span>
+              <TextInput
+                value={loginUsername}
+                onChange={(e) => setLoginUsername(e.target.value)}
+                autoComplete="username"
               />
+            </label>
+            <label className="block space-y-1.5">
+              <span className="text-sm font-medium">
+                {t("apikey_lookup.password", { defaultValue: "密码" })}
+              </span>
+              <TextInput
+                type="password"
+                value={loginPassword}
+                onChange={(e) => setLoginPassword(e.target.value)}
+                autoComplete="current-password"
+              />
+            </label>
+            {loginError ? (
+              <p className="text-sm text-rose-600 dark:text-rose-300">{loginError}</p>
             ) : null}
-            {t("common.login")}
-          </Button>
-        }
+            <Button
+              type="submit"
+              variant="primary"
+              className="w-full"
+              disabled={loginBusy || !loginUsername.trim() || !loginPassword}
+            >
+              {loginBusy
+                ? t("common.loading", { defaultValue: "登录中…" })
+                : t("common.login", { defaultValue: "登录" })}
+            </Button>
+          </form>
+
+          <div className="relative text-center text-xs text-slate-400">
+            <span className="bg-white px-2 dark:bg-neutral-950">
+              {t("apikey_lookup.or_paste_key", { defaultValue: "或粘贴 API Key 查询" })}
+            </span>
+          </div>
+
+          <form id="apikey-login-form" onSubmit={handleSubmit} className="space-y-2">
+            <label
+              htmlFor="apikey-login-input"
+              className="block text-sm font-medium text-slate-700 dark:text-white/80"
+            >
+              {t("apikey_lookup.api_key_label")}
+            </label>
+            <TextInput
+              type="password"
+              id="apikey-login-input"
+              value={apiKeyInput}
+              onChange={(e) => handleApiKeyInputChange(e.target.value)}
+              placeholder={t("apikey_lookup.placeholder")}
+              autoComplete="off"
+              spellCheck={false}
+              startAdornment={<Search size={16} className="text-slate-400 dark:text-white/40" />}
+            />
+            {error ? <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p> : null}
+            <Button
+              variant="secondary"
+              type="submit"
+              className="w-full"
+              disabled={!apiKeyInput.trim() || loading}
+            >
+              {t("apikey_lookup.query_with_key", { defaultValue: "用 Key 查询" })}
+            </Button>
+          </form>
+        </div>
+      </Modal>
+
+      <Modal
+        open={changePasswordOpen}
+        title={t("apikey_lookup.change_password", { defaultValue: "修改密码" })}
+        onClose={() => {
+          // Force password change: only allow close after success clears the flag.
+          if (portalUser?.must_change_password) return;
+          setChangePasswordOpen(false);
+        }}
       >
         <form
-          id="apikey-login-form"
-          onSubmit={handleSubmit}
-          className="space-y-2"
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setPwdError(null);
+            void portalApi
+              .changePassword(pwdForm.current, pwdForm.next)
+              .then(async () => {
+                setPortalUser((u) => (u ? { ...u, must_change_password: false } : u));
+                try {
+                  const items = (await portalApi.listKeys()).items ?? [];
+                  setPortalKeys(items);
+                  const usable = items.filter((k) => !k.disabled);
+                  const def = usable.find((k) => k.is_default) ?? usable[0];
+                  if (def) await activateOwnedKey(def.id);
+                  else if (items.length) setManageKeysOpen(true);
+                  setPwdForm({ current: "", next: "" });
+                  setPwdError(null);
+                  setChangePasswordOpen(false);
+                } catch (err) {
+                  setPortalKeys([]);
+                  setPwdError(err instanceof Error ? err.message : "failed");
+                }
+              })
+              .catch((err) => setPwdError(err instanceof Error ? err.message : "failed"));
+          }}
         >
-          <label
-            htmlFor="apikey-login-input"
-            className="block text-sm font-medium text-slate-700 dark:text-white/80"
-          >
-            {t("apikey_lookup.api_key_label")}
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">
+              {t("apikey_lookup.current_password", { defaultValue: "当前密码" })}
+            </span>
+            <TextInput
+              type="password"
+              value={pwdForm.current}
+              onChange={(e) => setPwdForm((f) => ({ ...f, current: e.target.value }))}
+            />
           </label>
-          <TextInput
-            type="password"
-            id="apikey-login-input"
-            value={apiKeyInput}
-            onChange={(e) => handleApiKeyInputChange(e.target.value)}
-            placeholder={t("apikey_lookup.placeholder")}
-            autoComplete="off"
-            spellCheck={false}
-            autoFocus
-            startAdornment={
-              <Search size={16} className="text-slate-400 dark:text-white/40" />
-            }
-          />
-          {error ? (
-            <p className="text-sm text-rose-600 dark:text-rose-300">{error}</p>
-          ) : null}
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">
+              {t("apikey_lookup.new_password", { defaultValue: "新密码" })}
+            </span>
+            <TextInput
+              type="password"
+              value={pwdForm.next}
+              onChange={(e) => setPwdForm((f) => ({ ...f, next: e.target.value }))}
+            />
+          </label>
+          {pwdError ? <p className="text-sm text-rose-600 dark:text-rose-300">{pwdError}</p> : null}
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={!pwdForm.current || pwdForm.next.length < 8}
+          >
+            {t("common.save", { defaultValue: "保存" })}
+          </Button>
         </form>
+      </Modal>
+
+      <Modal
+        open={manageKeysOpen}
+        title={t("apikey_lookup.manage_keys", { defaultValue: "管理 API Key" })}
+        onClose={() => setManageKeysOpen(false)}
+        maxWidth="max-w-2xl"
+      >
+        <div className="space-y-3">
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              onClick={() => {
+                void portalApi.createKey().then(async (res) => {
+                  if (res.plaintext_key) setSecretOnce(res.plaintext_key);
+                  setPortalKeys((await portalApi.listKeys()).items ?? []);
+                });
+              }}
+            >
+              {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
+            </Button>
+          </div>
+          <div className="divide-y divide-slate-200 rounded-xl border dark:divide-neutral-800 dark:border-neutral-800">
+            {portalKeys.map((k) => (
+              <div key={k.id} className="flex items-center justify-between gap-3 p-3 text-sm">
+                <div className="min-w-0">
+                  <div className="font-medium">
+                    {k.name || k.id.slice(0, 8)}
+                    {k.is_default ? (
+                      <span className="ml-2 rounded bg-emerald-100 px-1.5 py-0.5 text-xs text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300">
+                        default
+                      </span>
+                    ) : null}
+                  </div>
+                  <code className="text-xs text-slate-500">{k.key_masked}</code>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      void activateOwnedKey(k.id).then(() => setManageKeysOpen(false));
+                    }}
+                  >
+                    查看用量
+                  </Button>
+                  {!k.is_default ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        void portalApi.updateKey(k.id, { is_default: true }).then(async () => {
+                          setPortalKeys((await portalApi.listKeys()).items ?? []);
+                          await activateOwnedKey(k.id);
+                        });
+                      }}
+                    >
+                      设默认
+                    </Button>
+                  ) : null}
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      void portalApi.rotateKey(k.id).then(async (res) => {
+                        if (res.plaintext_key) {
+                          setSecretOnce(res.plaintext_key);
+                          setApiKeyInput(res.plaintext_key);
+                          writeStoredLookupKey(res.plaintext_key);
+                          setQueriedKey(res.plaintext_key);
+                        }
+                        setPortalKeys((await portalApi.listKeys()).items ?? []);
+                      });
+                    }}
+                  >
+                    重置
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      void portalApi.deleteKey(k.id).then(async () => {
+                        const items = (await portalApi.listKeys()).items ?? [];
+                        setPortalKeys(items);
+                        const next = items.find((x) => x.is_default) ?? items[0];
+                        if (next) await activateOwnedKey(next.id);
+                        else handleApiKeyInputChange("");
+                      });
+                    }}
+                  >
+                    删除
+                  </Button>
+                </div>
+              </div>
+            ))}
+            {portalKeys.length === 0 ? (
+              <div className="p-4 text-sm text-slate-500">暂无 Key</div>
+            ) : null}
+          </div>
+          <p className="text-xs text-slate-500">至少保留一把 Key；重置后明文只展示一次。</p>
+        </div>
+      </Modal>
+
+      <Modal
+        open={Boolean(secretOnce)}
+        title={t("apikey_lookup.copy_secret", { defaultValue: "请立即复制" })}
+        onClose={() => setSecretOnce(null)}
+      >
+        <p className="mb-2 text-sm text-amber-600">离开后无法再查看明文 Key。</p>
+        <code className="block select-all break-all rounded bg-slate-100 p-3 text-sm dark:bg-neutral-900">
+          {secretOnce}
+        </code>
       </Modal>
     </div>
   );

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -7,27 +7,25 @@ import { ToastProvider } from "@code-proxy/ui";
 import type { PublicLogItem, PublicLogsResponse } from "../types";
 
 const mocks = vi.hoisted(() => ({
-  fetchPublicLogs: vi.fn(async (): Promise<PublicLogsResponse> => ({
-    items: [],
-    total: 0,
-    page: 1,
-    size: 50,
-    api_key_name: "Primary key",
-    stats: {
+  fetchPublicLogs: vi.fn(
+    async (): Promise<PublicLogsResponse> => ({
+      items: [],
       total: 0,
-      success_rate: 0,
-      total_tokens: 0,
-      total_sessions: 0,
-      total_cost: 0,
-    },
-    filters: { models: [], channels: [], statuses: ["success", "failed"] },
-  })),
+      page: 1,
+      size: 50,
+      api_key_name: "Primary key",
+      stats: {
+        total: 0,
+        success_rate: 0,
+        total_tokens: 0,
+        total_sessions: 0,
+        total_cost: 0,
+      },
+      filters: { models: [], channels: [], statuses: ["success", "failed"] },
+    }),
+  ),
   fetchPublicChartData: vi.fn(
-    async (_params?: {
-      apiKey: string;
-      days?: number;
-      signal?: AbortSignal;
-    }) => ({
+    async (_params?: { apiKey: string; days?: number; signal?: AbortSignal }) => ({
       daily_series: [],
       heatmap_series: [],
       model_distribution: [],
@@ -52,10 +50,7 @@ const mocks = vi.hoisted(() => ({
 
 type ChartResponse = Awaited<ReturnType<typeof mocks.fetchPublicChartData>>;
 
-const chartResponse = (
-  total: number,
-  apiKeyName = "Primary key",
-): ChartResponse => ({
+const chartResponse = (total: number, apiKeyName = "Primary key"): ChartResponse => ({
   daily_series: [],
   heatmap_series: [],
   model_distribution: [],
@@ -94,9 +89,30 @@ vi.mock("@features/log-content-viewer", () => ({
   LogContentModal: () => null,
 }));
 
+vi.mock("@code-proxy/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@code-proxy/api-client")>();
+  return {
+    ...actual,
+    portalApi: {
+      loadSession: () => null,
+      clearSession: () => undefined,
+      login: vi.fn(),
+      logout: vi.fn(async () => undefined),
+      me: vi.fn(),
+      listKeys: vi.fn(async () => ({ items: [] })),
+      createKey: vi.fn(),
+      updateKey: vi.fn(),
+      rotateKey: vi.fn(),
+      deleteKey: vi.fn(),
+      changePassword: vi.fn(),
+    },
+  };
+});
+
 describe("ApiKeyLookupPage", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
+    window.localStorage.clear();
     window.history.replaceState({}, "", "/manage/apikey-lookup");
     vi.clearAllMocks();
   });
@@ -110,15 +126,15 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    expect(
-      screen.getByRole("dialog", { name: /enter api key/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
 
     await userEvent.type(
       screen.getByPlaceholderText(/enter api key to lookup usage/i),
       "sk-new-key",
     );
-    await userEvent.click(screen.getByRole("button", { name: /login/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /query with key|用 key 查询|用 Key 查询/i }),
+    );
 
     await waitFor(() => {
       expect(mocks.fetchPublicChartData).toHaveBeenCalledWith(
@@ -129,10 +145,7 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("restores the last looked up API key after page refresh and shows its name", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     render(
       <ThemeProvider>
@@ -148,19 +161,12 @@ describe("ApiKeyLookupPage", () => {
       );
     });
     expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
-    expect(
-      await screen.findByRole("combobox", { name: /primary key/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("dialog", { name: /enter api key/i }),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByRole("combobox", { name: /primary key/i })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   test("loads public logs only after switching to the request logs tab", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
     const logItem: PublicLogItem = {
       id: 1,
       timestamp: new Date("2026-07-05T03:01:18Z").toISOString(),
@@ -222,16 +228,11 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Codex 主渠道")).toBeInTheDocument();
     expect(screen.queryByText(/key name/i)).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("columnheader", { name: /^duration$/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: /^duration$/i })).not.toBeInTheDocument();
   });
 
   test("uses the shared linked request-log filters on the public logs tab", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
     mocks.fetchPublicLogs
       .mockResolvedValueOnce({
         items: [],
@@ -280,28 +281,22 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(
-      await screen.findByRole("tab", { name: /request logs/i }),
-    );
+    await userEvent.click(await screen.findByRole("tab", { name: /request logs/i }));
 
-    expect(
-      await screen.findByRole("combobox", { name: /filter by model/i }),
-    ).toHaveTextContent(/all models/i);
+    expect(await screen.findByRole("combobox", { name: /filter by model/i })).toHaveTextContent(
+      /all models/i,
+    );
     const channelFilter = screen.getByRole("combobox", {
       name: /filter by channel/i,
     });
     expect(channelFilter).toHaveTextContent(/all channels/i);
-    expect(
-      screen.getByRole("combobox", { name: /filter by status/i }),
-    ).toHaveTextContent(/all status/i);
+    expect(screen.getByRole("combobox", { name: /filter by status/i })).toHaveTextContent(
+      /all status/i,
+    );
 
     await userEvent.click(channelFilter);
-    await userEvent.click(
-      await screen.findByRole("option", { name: "OpenCode" }),
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: /apply filters/i }),
-    );
+    await userEvent.click(await screen.findByRole("option", { name: "OpenCode" }));
+    await userEvent.click(screen.getByRole("button", { name: /apply filters/i }));
 
     await waitFor(() => {
       expect(mocks.fetchPublicLogs).toHaveBeenLastCalledWith(
@@ -315,10 +310,7 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("keeps cached models visible while refreshing the available models tab", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
     let resolveModelsRefresh: (value: string[]) => void = () => {};
     mocks.fetchAvailableModels
       .mockResolvedValueOnce(["gpt-5.3-codex", "claude-sonnet-4-5"])
@@ -352,10 +344,7 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("does not duplicate the current key in the header menu", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     render(
       <ThemeProvider>
@@ -365,13 +354,9 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(
-      await screen.findByRole("combobox", { name: /primary key/i }),
-    );
+    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
 
-    expect(
-      screen.queryByRole("option", { name: /primary key/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /primary key/i })).not.toBeInTheDocument();
     expect(screen.getByRole("option", { name: /logout/i })).toHaveAttribute(
       "aria-selected",
       "false",
@@ -379,10 +364,7 @@ describe("ApiKeyLookupPage", () => {
   });
 
   test("logs out from the header menu and asks for the API key again", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     render(
       <ThemeProvider>
@@ -392,24 +374,15 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(
-      await screen.findByRole("combobox", { name: /primary key/i }),
-    );
+    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
     await userEvent.click(screen.getByRole("option", { name: /logout/i }));
 
-    expect(
-      window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1"),
-    ).toBeNull();
-    expect(
-      screen.getByRole("dialog", { name: /enter api key/i }),
-    ).toBeInTheDocument();
+    expect(window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1")).toBeNull();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
   test("shows cached usage data while refreshing chart data", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
     // Legacy v1 unscoped chart cache migrates into the default tenant bucket.
     window.sessionStorage.setItem(
       "apiKeyLookup.chartCache.v1",
@@ -465,21 +438,14 @@ describe("ApiKeyLookupPage", () => {
       },
     });
 
-    await waitFor(() =>
-      expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"),
-    );
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("24"));
     // After refresh, data is written under the tenant-scoped v2 key.
-    expect(
-      window.sessionStorage.getItem("apiKeyLookup.chartCache.v2"),
-    ).toContain('"total":24');
+    expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v2")).toContain('"total":24');
     expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v1")).toBeNull();
   });
 
   test("ignores stale chart responses after rapid time range changes", async () => {
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
     const pending: Array<{
       days: number;
       signal?: AbortSignal;
@@ -514,29 +480,22 @@ describe("ApiKeyLookupPage", () => {
     if (!latest) throw new Error("missing latest chart request");
 
     latest.resolve(chartResponse(7, "Range 7"));
-    await waitFor(() =>
-      expect(screen.getByTestId("usage-tab")).toHaveTextContent("7"),
-    );
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("7"));
 
     for (const request of pending) {
       if (request !== latest) {
-        request.resolve(
-          chartResponse(request.days * 100, `Range ${request.days}`),
-        );
+        request.resolve(chartResponse(request.days * 100, `Range ${request.days}`));
       }
     }
 
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(screen.getByTestId("usage-tab")).toHaveTextContent("7");
-    expect(
-      pending.some((request) => request.days === 30 && request.signal?.aborted),
-    ).toBe(true);
+    expect(pending.some((request) => request.days === 30 && request.signal?.aborted)).toBe(true);
   });
 
   test("pins results toolbar with sticky top offset and collapses header on scroll", async () => {
     let toolbarTop = 120;
-    const originalGetBoundingClientRect =
-      Element.prototype.getBoundingClientRect;
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
     Element.prototype.getBoundingClientRect = function getBoundingClientRect() {
       const el = this as HTMLElement;
       if (el.dataset?.testid === "apikey-lookup-toolbar-sticky") {
@@ -555,10 +514,7 @@ describe("ApiKeyLookupPage", () => {
       return originalGetBoundingClientRect.call(this);
     };
 
-    window.sessionStorage.setItem(
-      "apiKeyLookup.lastApiKey.v1",
-      "sk-restored-key",
-    );
+    window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 
     try {
       render(

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -1,0 +1,332 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { KeyRound, Trash2, Unlock } from "lucide-react";
+import { endUsersApi, type CreateEndUserResult, type EndUser } from "@code-proxy/api-client";
+import {
+  Button,
+  ConfirmModal,
+  DataTable,
+  Modal,
+  TextInput,
+  type DataTableColumn,
+  useToast,
+} from "@code-proxy/ui";
+import { PermissionGate } from "@app/guards/PermissionGate";
+import { useAuth } from "@app/providers/AuthProvider";
+
+const emptyForm = { username: "", displayName: "", password: "" };
+
+export function EndUsersPage() {
+  const { notify } = useToast();
+  const { t } = useTranslation();
+  const { can } = useAuth();
+  const [users, setUsers] = useState<EndUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [createdSecrets, setCreatedSecrets] = useState<CreateEndUserResult | null>(null);
+  const [resetUser, setResetUser] = useState<EndUser | null>(null);
+  const [generatedReset, setGeneratedReset] = useState("");
+  const [deleteUser, setDeleteUser] = useState<EndUser | null>(null);
+  const [busy, setBusy] = useState(false);
+  const canWrite = can("end_users.write");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await endUsersApi.list();
+      setUsers(res.items ?? []);
+    } catch (e) {
+      notify({ type: "error", message: e instanceof Error ? e.message : "load failed" });
+    } finally {
+      setLoading(false);
+    }
+  }, [notify]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const unlock = useCallback(
+    async (row: EndUser) => {
+      setBusy(true);
+      try {
+        await endUsersApi.update(row.id, { status: "active" });
+        notify({ type: "success", message: t("end_users.unlocked", { defaultValue: "已解冻" }) });
+        await load();
+      } catch (e) {
+        notify({ type: "error", message: e instanceof Error ? e.message : "failed" });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [load, notify, t],
+  );
+
+  const columns = useMemo<DataTableColumn<EndUser>[]>(
+    () => [
+      {
+        key: "username",
+        label: t("end_users.username", { defaultValue: "用户名" }),
+        width: "w-40",
+        render: (row) => (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-slate-900 dark:text-white">
+              {row.display_name}
+            </div>
+            <div className="truncate text-xs text-slate-400">{row.username}</div>
+          </div>
+        ),
+      },
+      {
+        key: "status",
+        label: t("end_users.status", { defaultValue: "状态" }),
+        width: "w-28",
+        render: (row) => row.status,
+      },
+      {
+        key: "last_login",
+        label: t("end_users.last_login", { defaultValue: "最近登录" }),
+        width: "w-44",
+        render: (row) => row.last_login_at?.slice(0, 19).replace("T", " ") || "—",
+      },
+      {
+        key: "actions",
+        label: t("common.actions", { defaultValue: "操作" }),
+        width: "w-36",
+        render: (row) => (
+          <div className="flex items-center gap-1">
+            {canWrite && row.status === "locked" ? (
+              <Button size="sm" variant="ghost" title="解冻" onClick={() => void unlock(row)}>
+                <Unlock className="h-4 w-4" />
+              </Button>
+            ) : null}
+            {canWrite ? (
+              <Button size="sm" variant="ghost" title="重置密码" onClick={() => setResetUser(row)}>
+                <KeyRound className="h-4 w-4" />
+              </Button>
+            ) : null}
+            {canWrite ? (
+              <Button size="sm" variant="ghost" title="删除" onClick={() => setDeleteUser(row)}>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            ) : null}
+          </div>
+        ),
+      },
+    ],
+    [canWrite, t, unlock],
+  );
+
+  const onCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    try {
+      const result = await endUsersApi.create({
+        username: form.username.trim() || undefined,
+        display_name: form.displayName.trim(),
+        password: form.password || undefined,
+      });
+      setCreateOpen(false);
+      setForm(emptyForm);
+      if (result.generated_password || result.default_api_key?.key) {
+        setCreatedSecrets(result);
+      } else {
+        notify({ type: "success", message: t("end_users.created", { defaultValue: "已创建" }) });
+      }
+      await load();
+    } catch (err) {
+      notify({ type: "error", message: err instanceof Error ? err.message : "failed" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onReset = async () => {
+    if (!resetUser) return;
+    setBusy(true);
+    try {
+      const res = await endUsersApi.resetPassword(resetUser.id);
+      setGeneratedReset(res.generated_password || "");
+      notify({
+        type: "success",
+        message: t("end_users.password_reset", { defaultValue: "密码已重置，请立即复制" }),
+      });
+      setResetUser(null);
+      await load();
+    } catch (err) {
+      notify({ type: "error", message: err instanceof Error ? err.message : "failed" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDelete = async () => {
+    if (!deleteUser) return;
+    setBusy(true);
+    try {
+      await endUsersApi.remove(deleteUser.id);
+      setDeleteUser(null);
+      await load();
+    } catch (err) {
+      notify({ type: "error", message: err instanceof Error ? err.message : "failed" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <PermissionGate permission="end_users.read">
+      <section className="flex flex-1 flex-col">
+        <div className="flex flex-1 flex-col rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70">
+          <div className="flex flex-wrap items-start justify-between gap-3 px-5 pt-5 pb-3">
+            <div>
+              <h2 className="text-base font-semibold text-slate-950 dark:text-white">
+                {t("end_users.title", { defaultValue: "终端用户" })}
+              </h2>
+              <p className="text-sm text-slate-500">
+                {t("end_users.subtitle", {
+                  defaultValue: "门户账号（与后台管理员隔离），每人可持有多把 API Key。",
+                })}
+              </p>
+            </div>
+            {canWrite ? (
+              <Button variant="primary" onClick={() => setCreateOpen(true)}>
+                {t("end_users.create", { defaultValue: "创建用户" })}
+              </Button>
+            ) : null}
+          </div>
+          <div className="relative h-[calc(100dvh-250px)] min-h-[360px] overflow-hidden px-5 pb-5">
+            <DataTable
+              tableId="end-users"
+              rows={users}
+              columns={columns}
+              rowKey={(r) => r.id}
+              loading={loading}
+              virtualize={false}
+              rowHeight={60}
+              height="h-full"
+              minHeight="min-h-full"
+              emptyText={t("end_users.empty", { defaultValue: "暂无终端用户" })}
+              showAllLoadedMessage={false}
+            />
+          </div>
+        </div>
+      </section>
+
+      <Modal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        title={t("end_users.create", { defaultValue: "创建用户" })}
+        maxWidth="max-w-xl"
+        footer={
+          <>
+            <Button onClick={() => setCreateOpen(false)}>{t("common.cancel")}</Button>
+            <Button
+              type="submit"
+              form="create-end-user-form"
+              variant="primary"
+              disabled={busy || !form.displayName.trim()}
+            >
+              {t("end_users.create", { defaultValue: "创建" })}
+            </Button>
+          </>
+        }
+      >
+        <form id="create-end-user-form" className="space-y-3" onSubmit={onCreate}>
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">
+              {t("end_users.display_name", { defaultValue: "昵称" })}
+            </span>
+            <TextInput
+              value={form.displayName}
+              onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
+              required
+            />
+          </label>
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">
+              {t("end_users.username", { defaultValue: "用户名（可选）" })}
+            </span>
+            <TextInput
+              value={form.username}
+              onChange={(e) => setForm((f) => ({ ...f, username: e.target.value }))}
+              placeholder="空则按昵称生成"
+            />
+          </label>
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium">
+              {t("end_users.password", { defaultValue: "密码（可选）" })}
+            </span>
+            <TextInput
+              type="password"
+              value={form.password}
+              onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
+              placeholder="空则随机生成，请立即复制"
+            />
+          </label>
+          <p className="text-xs text-amber-600">
+            {t("end_users.password_hint", {
+              defaultValue: "不填密码将随机生成；生成后只展示一次，哈希后无法再查看。",
+            })}
+          </p>
+        </form>
+      </Modal>
+
+      <Modal
+        open={Boolean(createdSecrets)}
+        onClose={() => setCreatedSecrets(null)}
+        title={t("end_users.copy_secrets", { defaultValue: "请立即复制凭证" })}
+      >
+        {createdSecrets ? (
+          <div className="space-y-3 text-sm">
+            <p className="font-medium text-amber-600">离开此窗口后无法再查看明文密码 / API Key。</p>
+            <div>
+              用户名：<code>{createdSecrets.user.username}</code>
+            </div>
+            {createdSecrets.generated_password ? (
+              <div>
+                密码：
+                <code className="select-all break-all">{createdSecrets.generated_password}</code>
+              </div>
+            ) : null}
+            {createdSecrets.default_api_key?.key ? (
+              <div>
+                默认 API Key：
+                <code className="select-all break-all">{createdSecrets.default_api_key.key}</code>
+              </div>
+            ) : null}
+            <Button onClick={() => setCreatedSecrets(null)}>已复制，关闭</Button>
+          </div>
+        ) : null}
+      </Modal>
+
+      <Modal
+        open={Boolean(generatedReset)}
+        onClose={() => setGeneratedReset("")}
+        title="新密码（请立即复制）"
+      >
+        <code className="select-all break-all">{generatedReset}</code>
+      </Modal>
+
+      <ConfirmModal
+        open={Boolean(resetUser)}
+        onClose={() => setResetUser(null)}
+        title="重置密码"
+        description={`将为 ${resetUser?.username ?? ""} 生成新随机密码，旧会话失效。`}
+        confirmText="重置"
+        busy={busy}
+        onConfirm={() => void onReset()}
+      />
+      <ConfirmModal
+        open={Boolean(deleteUser)}
+        onClose={() => setDeleteUser(null)}
+        title="删除终端用户"
+        description={`删除 ${deleteUser?.username ?? ""}？其 API Key 将被禁用并解除归属，且无法再用于调用。`}
+        confirmText="删除"
+        busy={busy}
+        onConfirm={() => void onDelete()}
+      />
+    </PermissionGate>
+  );
+}

--- a/pages/end-users/route.tsx
+++ b/pages/end-users/route.tsx
@@ -1,0 +1,21 @@
+import { lazy, Suspense } from "react";
+import type { PageRoute } from "../registry";
+
+const EndUsersPage = lazy(() =>
+  import("./EndUsersPage").then((m) => ({ default: m.EndUsersPage })),
+);
+
+export const endUsersRoute: PageRoute = {
+  path: "/access/end-users",
+  element: (
+    <Suspense fallback={null}>
+      <EndUsersPage />
+    </Suspense>
+  ),
+  auth: true,
+  layout: "app",
+  nav: { labelKey: "shell.nav_end_users" },
+  requiredPermission: "end_users.read",
+  component: "end-users",
+  preload: () => import("./EndUsersPage"),
+};

--- a/pages/registry.ts
+++ b/pages/registry.ts
@@ -7,6 +7,7 @@ import { providersRoute } from "./providers/route";
 import { accountSecurityRoute } from "./account-security/route";
 import { authFilesRoute } from "./auth-files/route";
 import { apiKeysRoute } from "./api-keys/route";
+import { endUsersRoute } from "./end-users/route";
 import { apiKeyPermissionsRoute } from "./api-key-permissions/route";
 import { modelsRoute } from "./models/route";
 import { modelPlazaRoute } from "./model-plaza/route";
@@ -55,6 +56,7 @@ export const pageRoutes: PageRoute[] = [
   accountSecurityRoute,
   authFilesRoute,
   apiKeysRoute,
+  endUsersRoute,
   apiKeyPermissionsRoute,
   modelsRoute,
   modelPlazaRoute,

--- a/pages/tenants/TenantsPage.tsx
+++ b/pages/tenants/TenantsPage.tsx
@@ -41,7 +41,13 @@ export function TenantsPage() {
   const [createErrors, setCreateErrors] = useState<CreateFormErrors>({});
   const [detailsTenant, setDetailsTenant] = useState<TenantIdentity | null>(null);
   const [editTenant, setEditTenant] = useState<TenantIdentity | null>(null);
-  const [editForm, setEditForm] = useState({ name: "", description: "", status: "active" });
+  const [editForm, setEditForm] = useState({
+    name: "",
+    description: "",
+    status: "active",
+    access_token_ttl_seconds: 43200,
+    refresh_token_ttl_seconds: 2592000,
+  });
   const [renewTenant, setRenewTenant] = useState<TenantIdentity | null>(null);
   const [renewAt, setRenewAt] = useState("");
   const [renewError, setRenewError] = useState("");
@@ -191,6 +197,8 @@ export function TenantsPage() {
                       name: item.name,
                       description: item.description ?? "",
                       status: item.status,
+                      access_token_ttl_seconds: item.access_token_ttl_seconds ?? 43200,
+                      refresh_token_ttl_seconds: item.refresh_token_ttl_seconds ?? 2592000,
                     });
                   }}
                   title={t("identity_admin.edit")}
@@ -229,15 +237,18 @@ export function TenantsPage() {
     [i18n.language, statusLabel, t, tenantName],
   );
 
-  const updateCreateField = useCallback(<K extends CreateFormKey>(key: K, value: (typeof emptyCreateForm)[K]) => {
-    setCreateForm((prev) => ({ ...prev, [key]: value }));
-    setCreateErrors((prev) => {
-      if (!prev[key]) return prev;
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-  }, []);
+  const updateCreateField = useCallback(
+    <K extends CreateFormKey>(key: K, value: (typeof emptyCreateForm)[K]) => {
+      setCreateForm((prev) => ({ ...prev, [key]: value }));
+      setCreateErrors((prev) => {
+        if (!prev[key]) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    },
+    [],
+  );
 
   const validateCreateForm = useCallback((): CreateFormErrors => {
     const errors: CreateFormErrors = {};
@@ -306,6 +317,8 @@ export function TenantsPage() {
           name: editForm.name,
           description: editForm.description,
           status: editForm.status,
+          access_token_ttl_seconds: editForm.access_token_ttl_seconds,
+          refresh_token_ttl_seconds: editForm.refresh_token_ttl_seconds,
           version: editTenant.version,
         }),
       t("identity_admin.tenant_details_updated"),
@@ -406,11 +419,7 @@ export function TenantsPage() {
       >
         <Form id="create-tenant-form" onSubmit={createTenant} noValidate>
           <div className="grid gap-4 md:grid-cols-2">
-            <FormField
-              label={t("identity_admin.name")}
-              required
-              error={createErrors.name}
-            >
+            <FormField label={t("identity_admin.name")} required error={createErrors.name}>
               <TextInput
                 aria-label={t("identity_admin.name")}
                 value={createForm.name}
@@ -552,6 +561,40 @@ export function TenantsPage() {
               onChange={(event) => setEditForm({ ...editForm, description: event.target.value })}
             />
           </FormField>
+          <FormField
+            label={t("identity_admin.access_token_ttl", { defaultValue: "Access Token TTL (秒)" })}
+            orientation="horizontal"
+          >
+            <TextInput
+              type="number"
+              min={60}
+              value={String(editForm.access_token_ttl_seconds)}
+              onChange={(event) =>
+                setEditForm({
+                  ...editForm,
+                  access_token_ttl_seconds: Number(event.target.value) || 43200,
+                })
+              }
+            />
+          </FormField>
+          <FormField
+            label={t("identity_admin.refresh_token_ttl", {
+              defaultValue: "Refresh Token TTL (秒)",
+            })}
+            orientation="horizontal"
+          >
+            <TextInput
+              type="number"
+              min={300}
+              value={String(editForm.refresh_token_ttl_seconds)}
+              onChange={(event) =>
+                setEditForm({
+                  ...editForm,
+                  refresh_token_ttl_seconds: Number(event.target.value) || 2592000,
+                })
+              }
+            />
+          </FormField>
         </Form>
       </Modal>
 
@@ -570,11 +613,7 @@ export function TenantsPage() {
         }
       >
         <Form id="renew-tenant-form" onSubmit={renew} noValidate>
-          <FormField
-            label={t("identity_admin.expires_at")}
-            required
-            error={renewError}
-          >
+          <FormField label={t("identity_admin.expires_at")} required error={renewError}>
             <DateTimePicker
               value={renewAt}
               onChange={(value) => {


### PR DESCRIPTION
## Summary
- End-users admin page under 接入与凭证 with create/reset/unlock/delete
- apikey-lookup: account login modal + paste-key fallback, self-service multi-key management
- Portal client with refresh token; force password change; auto-activate default usable key
- Admin auth persists/rotates refresh tokens; tenant edit form adds access/refresh TTL

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci 785, build, bundle:diff, Playwright @critical 9)
- [x] ApiKeyLookupPage + identity unit tests
- [ ] Manual: `/manage/apikey-lookup` login, manage keys, change password

## Local CI
```bash
./scripts/ci-pr.sh
```

Depends on CliRelay PR for backend APIs.