### PR TITLE
feat(ui): user accounts own multi-key management

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -93,7 +93,11 @@ function menuChainEnabled(
 
 function AuthorizedPage({ route }: { route: PageRoute }) {
   const { can, state } = useAuth();
-  if (route.requiredPermission && !can(route.requiredPermission)) return <ForbiddenPage />;
+  const allowed =
+    !route.requiredPermission ||
+    can(route.requiredPermission) ||
+    (route.requiredAnyPermissions?.some((p) => can(p)) ?? false);
+  if (!allowed) return <ForbiddenPage />;
   if (!menuChainEnabled(state.principal?.menus, route.path)) return <ForbiddenPage />;
   return readyRoute(route.element);
 }

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -656,12 +656,22 @@ function ShellSidebar({
     if (principal?.menus?.length) return buildSidebarFromMenus(principal.menus);
     return { primaryItems: [FALLBACK_DASHBOARD_ITEM], groups: [...FALLBACK_NAV_GROUPS] };
   }, [principal?.menus]);
+  const canSeeMenuItem = useCallback(
+    (item: { permission?: string; menuCode?: string }) => {
+      if (!item.permission) return true;
+      if (can(item.permission)) return true;
+      // After API Keys → 用户账号 entry move: legacy key admins still see the user menu.
+      if (item.menuCode === "access.end-users" && can("api_keys.read")) return true;
+      return false;
+    },
+    [can],
+  );
   const visiblePrimaryItems = useMemo(
     () =>
       builtNav.primaryItems.filter(
-        (item) => (!item.permission || can(item.permission)) && menuIsVisible(item.menuCode),
+        (item) => canSeeMenuItem(item) && menuIsVisible(item.menuCode),
       ),
-    [builtNav.primaryItems, can, menuIsVisible],
+    [builtNav.primaryItems, canSeeMenuItem, menuIsVisible],
   );
   const visibleNavGroups = useMemo(
     () =>
@@ -669,11 +679,11 @@ function ShellSidebar({
         .map((group) => ({
           ...group,
           items: group.items.filter(
-            (item) => (!item.permission || can(item.permission)) && menuIsVisible(item.menuCode),
+            (item) => canSeeMenuItem(item) && menuIsVisible(item.menuCode),
           ),
         }))
         .filter((group) => menuIsVisible(group.menuCode) && group.items.length > 0),
-    [builtNav.groups, can, menuIsVisible],
+    [builtNav.groups, canSeeMenuItem, menuIsVisible],
   );
   // Interleave top-level leaves and groups by sort_order so a primary leaf
   // (e.g. 系统信息 at 70) can sit below every directory group.

--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -234,6 +234,7 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
     type: "menu",
     path: "/access/end-users",
     component: "end-users",
+    // Prefer end_users.read; legacy key admins also get the menu via api_keys.read in can() OR at route gate.
     label_key: "shell.nav_end_users",
     icon: "user-round",
     permission_code: "end_users.read",

--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -213,17 +213,21 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
     permission_code: "auth_files.read",
     sort_order: 20,
   }),
-  menu({
-    code: "access.api-keys",
-    parent_code: "group.access",
-    type: "menu",
-    path: "/access/api-keys",
-    component: "api-keys",
-    label_key: "shell.nav_api_keys",
-    icon: "sparkles",
-    permission_code: "api_keys.read",
-    sort_order: 30,
-  }),
+  // Hidden from sidebar: key management is under 用户账号 (?endUserId=). Route kept for deep links.
+  {
+    ...menu({
+      code: "access.api-keys",
+      parent_code: "group.access",
+      type: "menu",
+      path: "/access/api-keys",
+      component: "api-keys",
+      label_key: "shell.nav_api_keys",
+      icon: "sparkles",
+      permission_code: "api_keys.read",
+      sort_order: 30,
+    }),
+    hide_menu: true,
+  },
   menu({
     code: "access.end-users",
     parent_code: "group.access",
@@ -233,7 +237,7 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
     label_key: "shell.nav_end_users",
     icon: "user-round",
     permission_code: "end_users.read",
-    sort_order: 35,
+    sort_order: 25,
   }),
   menu({
     code: "system.api-key-permissions",

--- a/packages/api-client/src/endpoints/api-keys.ts
+++ b/packages/api-client/src/endpoints/api-keys.ts
@@ -25,6 +25,9 @@ export interface ApiKeyEntry {
   "permission-profile-id"?: string;
   "system-prompt"?: string;
   "created-at"?: string;
+  /** Portal end-user ownership (management list). */
+  end_user_id?: string;
+  is_default?: boolean;
 }
 
 export interface ApiKeyDailySpendingResetResult {

--- a/packages/api-client/src/endpoints/end-users.ts
+++ b/packages/api-client/src/endpoints/end-users.ts
@@ -69,6 +69,10 @@ export const endUsersApi = {
       `/end-users/${id}/api-keys`,
       { name: name || "" },
     ),
+  deleteKey: (userId: string, keyId: string) =>
+    apiClient.delete(`/end-users/${userId}/api-keys/${keyId}`),
+  setDefaultKey: (userId: string, keyId: string) =>
+    apiClient.post(`/end-users/${userId}/api-keys/${keyId}/default`, {}),
 };
 
 export const portalApi = {

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -26,6 +26,7 @@ import { copyTextToClipboard } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { Button } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
+import { Modal } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { DataTable } from "@code-proxy/ui";
 import { ApiKeyFormModal } from "./components/ApiKeyFormModal";
@@ -69,6 +70,7 @@ export function ApiKeysPage() {
   );
   const copiedCcSwitchImportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [saving, setSaving] = useState(false);
+  const [createdSecretOnce, setCreatedSecretOnce] = useState<string | null>(null);
   const [resettingDailySpendingKey, setResettingDailySpendingKey] = useState<string | null>(null);
   const [resetHistoryEntry, setResetHistoryEntry] = useState<ApiKeyEntry | null>(null);
   const [resetHistoryLoading, setResetHistoryLoading] = useState(false);
@@ -274,11 +276,9 @@ export function ApiKeysPage() {
           value: { disabled: nextDisabled },
         });
       } else if (endUserIdFilter) {
-        const all = await apiKeyEntriesApi.list();
-        const next = all.map((e) =>
-          e.key === entry.key ? { ...e, disabled: nextDisabled } : e,
-        );
-        await apiKeyEntriesApi.replace(next);
+        // Fail closed: never tenant-wide replace when scoped without stable id.
+        notify({ type: "error", message: t("api_keys_page.operation_failed") });
+        return;
       } else {
         const newEntries = [...entries];
         newEntries[index] = { ...entry, disabled: nextDisabled };
@@ -302,10 +302,28 @@ export function ApiKeysPage() {
   /* ─── create ─── */
 
   const handleOpenCreate = () => {
-    const next = makeEmptyApiKeyForm(generateApiKey());
+    // User-scoped create: server generates the secret; do not show a client-side fake key.
+    const next = makeEmptyApiKeyForm(endUserIdFilter ? "" : generateApiKey());
     setForm(next);
     setShowCreate(true);
   };
+
+  const handleSetDefault = useCallback(
+    async (entry: ApiKeyEntry) => {
+      if (!endUserIdFilter || !entry.id || entry.is_default) return;
+      try {
+        await endUsersApi.setDefaultKey(endUserIdFilter, entry.id);
+        notify({ type: "success", message: t("end_users.default_key_set", { defaultValue: "已设为默认 Key" }) });
+        await loadEntries();
+      } catch (err: unknown) {
+        notify({
+          type: "error",
+          message: err instanceof Error ? err.message : t("api_keys_page.operation_failed"),
+        });
+      }
+    },
+    [endUserIdFilter, loadEntries, notify, t],
+  );
 
   const handleCreate = async () => {
     if (!form.name.trim()) {
@@ -344,14 +362,10 @@ export function ApiKeysPage() {
           });
         }
         if (plain) {
-          notify({
-            type: "success",
-            message: t("api_keys_page.created_success"),
-          });
+          setCreatedSecretOnce(plain);
           void copyTextToClipboard(plain).catch(() => undefined);
-        } else {
-          notify({ type: "success", message: t("api_keys_page.created_success") });
         }
+        notify({ type: "success", message: t("api_keys_page.created_success") });
       } else {
         if (!form.key.trim()) {
           notify({ type: "error", message: t("api_keys_page.key_empty") });
@@ -702,9 +716,11 @@ export function ApiKeysPage() {
         onDelete: handleOpenDelete,
         onResetDailySpending: (index) => void handleResetDailySpending(index),
         onViewResetHistory: (entry) => void handleViewResetHistory(entry),
+        onSetDefault: endUserIdFilter ? (entry) => void handleSetDefault(entry) : undefined,
         resettingDailySpendingKey,
       }),
     [
+      endUserIdFilter,
       handleToggleDisable,
       handleViewUsage,
       handleCopy,
@@ -713,6 +729,7 @@ export function ApiKeysPage() {
       handleOpenDelete,
       handleResetDailySpending,
       handleViewResetHistory,
+      handleSetDefault,
       handleSelectAll,
       handleSelectRow,
       t,
@@ -809,6 +826,7 @@ export function ApiKeysPage() {
         onClose={() => setShowCreate(false)}
         onSubmit={handleCreate}
         regenerateKey={() => setForm((prev) => ({ ...prev, key: generateApiKey() }))}
+        serverGeneratesKey={Boolean(endUserIdFilter)}
       />
 
       <ApiKeyFormModal
@@ -823,6 +841,21 @@ export function ApiKeysPage() {
         onSubmit={handleEdit}
         regenerateKey={() => setForm((prev) => ({ ...prev, key: generateApiKey() }))}
       />
+
+      <Modal
+        open={Boolean(createdSecretOnce)}
+        onClose={() => setCreatedSecretOnce(null)}
+        title={t("end_users.copy_secret", { defaultValue: "请立即复制 API Key" })}
+      >
+        <p className="mb-2 text-sm text-amber-600 dark:text-amber-300">
+          {t("end_users.copy_secret_hint", {
+            defaultValue: "离开后无法再查看明文 Key。已尝试复制到剪贴板。",
+          })}
+        </p>
+        <code className="block select-all break-all rounded bg-slate-100 p-3 text-sm dark:bg-neutral-900">
+          {createdSecretOnce}
+        </code>
+      </Modal>
 
       <DeleteApiKeyModal
         t={t}

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Plus, KeyRound, RefreshCw, Trash2 } from "lucide-react";
 import {
@@ -761,6 +761,14 @@ export function ApiKeysPage() {
         }
         actions={
           <div className="flex flex-wrap justify-end gap-2">
+            {endUserIdFilter ? (
+              <Link
+                to="/access/end-users"
+                className="inline-flex h-8 items-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-neutral-800"
+              >
+                {t("end_users.back_to_users", { defaultValue: "返回用户账号" })}
+              </Link>
+            ) : null}
             <Button variant="primary" size="sm" onClick={handleOpenCreate}>
               <Plus size={14} />
               {t("api_keys_page.create_key")}

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Plus, KeyRound, RefreshCw, Trash2 } from "lucide-react";
 import {
@@ -47,6 +48,8 @@ export function ApiKeysPage() {
   const { t, i18n } = useTranslation();
   const { notify } = useToast();
   const auth = useOptionalAuth();
+  const [searchParams] = useSearchParams();
+  const endUserIdFilter = searchParams.get("endUserId")?.trim() || "";
 
   const [entries, setEntries] = useState<ApiKeyEntry[]>([]);
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(() => new Set());
@@ -132,7 +135,7 @@ export function ApiKeysPage() {
         .map((k: string): ApiKeyEntry => ({ key: k, "created-at": new Date().toISOString() }));
 
       let finalEntries: ApiKeyEntry[];
-      if (newEntries.length > 0) {
+      if (newEntries.length > 0 && !endUserIdFilter) {
         const merged = [...entriesData, ...newEntries];
         try {
           await apiKeyEntriesApi.replace(merged);
@@ -140,12 +143,15 @@ export function ApiKeysPage() {
             type: "success",
             message: t("api_keys_page.auto_import", { count: newEntries.length }),
           });
+          finalEntries = merged;
         } catch {
-          // silent
+          finalEntries = entriesData;
         }
-        finalEntries = merged;
       } else {
         finalEntries = entriesData;
+      }
+      if (endUserIdFilter) {
+        finalEntries = finalEntries.filter((e) => e.end_user_id === endUserIdFilter);
       }
       setEntries(finalEntries);
       // Load models after entries are available (needs a valid API key)
@@ -158,7 +164,7 @@ export function ApiKeysPage() {
     } finally {
       setLoading(false);
     }
-  }, [notify, refreshPermissionOptions, t]);
+  }, [endUserIdFilter, notify, refreshPermissionOptions, t]);
 
   useEffect(() => {
     void loadEntries();
@@ -258,16 +264,29 @@ export function ApiKeysPage() {
 
   const handleToggleDisable = async (index: number) => {
     const entry = entries[index];
-    const updated = { ...entry, disabled: !entry.disabled };
-    const newEntries = [...entries];
-    newEntries[index] = updated;
-
+    const nextDisabled = !entry.disabled;
     try {
-      await apiKeyEntriesApi.replace(newEntries);
-      setEntries(newEntries);
+      // Prefer id-based patch so user-scoped lists never replace the whole tenant table.
+      if (entry.id) {
+        await apiKeyEntriesApi.update({
+          id: entry.id,
+          value: { disabled: nextDisabled },
+        });
+      } else if (endUserIdFilter) {
+        const all = await apiKeyEntriesApi.list();
+        const next = all.map((e) =>
+          e.key === entry.key ? { ...e, disabled: nextDisabled } : e,
+        );
+        await apiKeyEntriesApi.replace(next);
+      } else {
+        const newEntries = [...entries];
+        newEntries[index] = { ...entry, disabled: nextDisabled };
+        await apiKeyEntriesApi.replace(newEntries);
+      }
+      await loadEntries();
       notify({
         type: "success",
-        message: updated.disabled
+        message: nextDisabled
           ? t("api_keys_page.disabled_toast", { name: entry.name || t("api_keys_page.unnamed") })
           : t("api_keys_page.enabled_toast", { name: entry.name || t("api_keys_page.unnamed") }),
       });
@@ -302,12 +321,25 @@ export function ApiKeysPage() {
         key: form.key.trim(),
         name: form.name.trim(),
         "created-at": new Date().toISOString(),
+        ...(endUserIdFilter
+          ? {
+              end_user_id: endUserIdFilter,
+              is_default: entries.length === 0,
+            }
+          : {}),
       };
       const profiledEntry = applyApiKeyPermissionProfile(
         newEntry,
         selectedPermissionProfile(form.permissionProfileId),
       );
-      await apiKeyEntriesApi.replace([...entries, profiledEntry]);
+      // When scoped to a user, merge into full list so we don't drop other users' keys.
+      let base = entries;
+      if (endUserIdFilter) {
+        const all = await apiKeyEntriesApi.list();
+        base = all.filter((e) => e.end_user_id !== endUserIdFilter);
+        base = [...base, ...entries];
+      }
+      await apiKeyEntriesApi.replace([...base.filter((e) => e.key !== profiledEntry.key), profiledEntry]);
       notify({ type: "success", message: t("api_keys_page.created_success") });
       setShowCreate(false);
       await loadEntries();
@@ -650,8 +682,18 @@ export function ApiKeysPage() {
       <Card
         className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
         bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
-        title={t("api_keys_page.title")}
-        description={t("api_keys_page.description")}
+        title={
+          endUserIdFilter
+            ? t("end_users.manage_keys_title", { defaultValue: "用户 API 密钥" })
+            : t("api_keys_page.title")
+        }
+        description={
+          endUserIdFilter
+            ? t("end_users.manage_keys_desc", {
+                defaultValue: "管理该用户账号下的全部 API 密钥（限额、权限、启停等）。",
+              })
+            : t("api_keys_page.description")
+        }
         actions={
           <div className="flex flex-wrap justify-end gap-2">
             <Button variant="primary" size="sm" onClick={handleOpenCreate}>

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -5,9 +5,10 @@ import { Plus, KeyRound, RefreshCw, Trash2 } from "lucide-react";
 import {
   apiKeyEntriesApi,
   apiKeysApi,
-  type ApiKeyDailySpendingResetEvent,
   type ApiKeyEntry,
+  type ApiKeyDailySpendingResetEvent,
 } from "@code-proxy/api-client/endpoints/api-keys";
+import { endUsersApi } from "@code-proxy/api-client/endpoints/end-users";
 import {
   applyApiKeyPermissionProfile,
   apiKeyPermissionProfilesApi,
@@ -311,36 +312,63 @@ export function ApiKeysPage() {
       notify({ type: "error", message: t("api_keys_page.name_required") });
       return;
     }
-    if (!form.key.trim()) {
-      notify({ type: "error", message: t("api_keys_page.key_empty") });
-      return;
-    }
     setSaving(true);
     try {
-      const newEntry: ApiKeyEntry = {
-        key: form.key.trim(),
-        name: form.name.trim(),
-        "created-at": new Date().toISOString(),
-        ...(endUserIdFilter
-          ? {
-              end_user_id: endUserIdFilter,
-              is_default: entries.length === 0,
-            }
-          : {}),
-      };
-      const profiledEntry = applyApiKeyPermissionProfile(
-        newEntry,
-        selectedPermissionProfile(form.permissionProfileId),
-      );
-      // When scoped to a user, merge into full list so we don't drop other users' keys.
-      let base = entries;
       if (endUserIdFilter) {
-        const all = await apiKeyEntriesApi.list();
-        base = all.filter((e) => e.end_user_id !== endUserIdFilter);
-        base = [...base, ...entries];
+        // Owner-scoped create: server generates unique key; never tenant-wide replace.
+        const created = await endUsersApi.createKey(endUserIdFilter, form.name.trim());
+        const keyId = created.api_key?.id;
+        const plain = created.plaintext_key;
+        if (keyId && form.permissionProfileId && form.permissionProfileId !== CUSTOM_PERMISSION_PROFILE_ID) {
+          const profiled = applyApiKeyPermissionProfile(
+            { key: plain || "", id: keyId },
+            selectedPermissionProfile(form.permissionProfileId),
+          );
+          await apiKeyEntriesApi.update({
+            id: keyId,
+            value: {
+              name: form.name.trim(),
+              "permission-profile-id": profiled["permission-profile-id"],
+              "daily-limit": profiled["daily-limit"],
+              "total-quota": profiled["total-quota"],
+              "spending-limit": profiled["spending-limit"],
+              "daily-spending-limit": profiled["daily-spending-limit"],
+              "concurrency-limit": profiled["concurrency-limit"],
+              "rpm-limit": profiled["rpm-limit"],
+              "tpm-limit": profiled["tpm-limit"],
+              "allowed-models": profiled["allowed-models"],
+              "allowed-channels": profiled["allowed-channels"],
+              "allowed-channel-groups": profiled["allowed-channel-groups"],
+              "system-prompt": profiled["system-prompt"],
+            },
+          });
+        }
+        if (plain) {
+          notify({
+            type: "success",
+            message: t("api_keys_page.created_success"),
+          });
+          void copyTextToClipboard(plain).catch(() => undefined);
+        } else {
+          notify({ type: "success", message: t("api_keys_page.created_success") });
+        }
+      } else {
+        if (!form.key.trim()) {
+          notify({ type: "error", message: t("api_keys_page.key_empty") });
+          return;
+        }
+        const newEntry: ApiKeyEntry = {
+          key: form.key.trim(),
+          name: form.name.trim(),
+          "created-at": new Date().toISOString(),
+        };
+        const profiledEntry = applyApiKeyPermissionProfile(
+          newEntry,
+          selectedPermissionProfile(form.permissionProfileId),
+        );
+        await apiKeyEntriesApi.replace([...entries, profiledEntry]);
+        notify({ type: "success", message: t("api_keys_page.created_success") });
       }
-      await apiKeyEntriesApi.replace([...base.filter((e) => e.key !== profiledEntry.key), profiledEntry]);
-      notify({ type: "success", message: t("api_keys_page.created_success") });
       setShowCreate(false);
       await loadEntries();
     } catch (err: unknown) {
@@ -411,9 +439,14 @@ export function ApiKeysPage() {
               { key: newKey },
               selectedPermissionProfile(form.permissionProfileId),
             );
+      if (!entries[editIndex].id && endUserIdFilter) {
+        notify({ type: "error", message: t("api_keys_page.update_failed") });
+        return;
+      }
       await apiKeyEntriesApi.update({
         id: entries[editIndex].id,
-        index: editIndex,
+        // Never pass filtered list index to tenant-wide index resolver.
+        ...(entries[editIndex].id ? {} : { index: editIndex }),
         value: {
           ...(newKey !== originalKey ? { key: newKey } : {}),
           name: form.name.trim(),
@@ -485,22 +518,37 @@ export function ApiKeysPage() {
 
   const handleDelete = async () => {
     if (deleteIndex === null) return;
+    const target = entries[deleteIndex];
+    if (!target) return;
     setSaving(true);
     try {
-      const response = (await apiKeyEntriesApi.delete({
-        id: entries[deleteIndex]?.id,
-        index: deleteIndex,
-        deleteLogs: deleteLogsOnDelete,
-      })) as { logs_deleted?: number } | undefined;
-      const logsDeleted =
-        typeof response?.logs_deleted === "number" ? response.logs_deleted : undefined;
-      notify({
-        type: "success",
-        message:
-          deleteLogsOnDelete && typeof logsDeleted === "number"
-            ? t("api_keys_page.deleted_success_with_logs", { count: logsDeleted })
-            : t("api_keys_page.deleted_success"),
-      });
+      if (endUserIdFilter) {
+        if (!target.id) {
+          notify({
+            type: "error",
+            message: t("api_keys_page.delete_failed"),
+          });
+          return;
+        }
+        // Owner-scoped delete promotes default key when needed; never use filtered index.
+        await endUsersApi.deleteKey(endUserIdFilter, target.id);
+        notify({ type: "success", message: t("api_keys_page.deleted_success") });
+      } else {
+        const response = (await apiKeyEntriesApi.delete({
+          id: target.id,
+          key: target.id ? undefined : target.key,
+          deleteLogs: deleteLogsOnDelete,
+        })) as { logs_deleted?: number } | undefined;
+        const logsDeleted =
+          typeof response?.logs_deleted === "number" ? response.logs_deleted : undefined;
+        notify({
+          type: "success",
+          message:
+            deleteLogsOnDelete && typeof logsDeleted === "number"
+              ? t("api_keys_page.deleted_success_with_logs", { count: logsDeleted })
+              : t("api_keys_page.deleted_success"),
+        });
+      }
       setDeleteIndex(null);
       setDeleteLogsOnDelete(true);
       await loadEntries();
@@ -700,7 +748,7 @@ export function ApiKeysPage() {
               <Plus size={14} />
               {t("api_keys_page.create_key")}
             </Button>
-            {selectedEntries.length > 0 ? (
+            {selectedEntries.length > 0 && !endUserIdFilter ? (
               <Button
                 variant="danger"
                 size="sm"

--- a/pages/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/pages/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -21,8 +21,14 @@ const mocks = vi.hoisted(() => ({
     state.entries = entries;
     return {};
   }),
-  apiKeyEntriesUpdate: vi.fn(async ({ index, value }: any) => {
-    state.entries[index] = { ...state.entries[index], ...value };
+  apiKeyEntriesUpdate: vi.fn(async ({ id, index, value }: any) => {
+    const targetIndex =
+      typeof index === "number"
+        ? index
+        : state.entries.findIndex((entry) => (id ? entry.id === id : false));
+    if (targetIndex >= 0) {
+      state.entries[targetIndex] = { ...state.entries[targetIndex], ...value };
+    }
     return {};
   }),
   apiKeyEntriesDelete: vi.fn(async ({ id, index, key }: any) => {

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -39,6 +39,7 @@ type CreateApiKeyColumnsOptions = {
   onDelete: (index: number) => void;
   onResetDailySpending: (index: number) => void;
   onViewResetHistory: (entry: ApiKeyEntry) => void;
+  onSetDefault?: (entry: ApiKeyEntry) => void;
   resettingDailySpendingKey?: string | null;
 };
 
@@ -123,6 +124,7 @@ export const createApiKeyColumns = ({
   onDelete,
   onResetDailySpending,
   onViewResetHistory,
+  onSetDefault,
   resettingDailySpendingKey = null,
 }: CreateApiKeyColumnsOptions): DataTableColumn<ApiKeyEntry>[] => [
   {
@@ -158,13 +160,20 @@ export const createApiKeyColumns = ({
     headerClassName: stickyNameHeaderClass,
     cellClassName: stickyNameCellClass,
     render: (row) => (
-      <OverflowTooltip content={row.name || t("api_keys_page.unnamed")} className="block min-w-0">
-        <span className="block min-w-0 truncate">
-          {row.name || (
-            <span className="text-slate-400 dark:text-white/40">{t("common.unnamed")}</span>
-          )}
-        </span>
-      </OverflowTooltip>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <OverflowTooltip content={row.name || t("api_keys_page.unnamed")} className="block min-w-0">
+          <span className="block min-w-0 truncate">
+            {row.name || (
+              <span className="text-slate-400 dark:text-white/40">{t("common.unnamed")}</span>
+            )}
+          </span>
+        </OverflowTooltip>
+        {row.is_default ? (
+          <span className="shrink-0 rounded-full bg-emerald-50 px-1.5 py-0.5 text-2xs font-medium text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">
+            default
+          </span>
+        ) : null}
+      </div>
     ),
   },
   {
@@ -525,6 +534,18 @@ export const createApiKeyColumns = ({
               <RotateCcw size={15} className={isResetting ? "animate-spin" : ""} />
             </button>
           </HoverTooltip>
+          {onSetDefault && !row.is_default ? (
+            <HoverTooltip content={t("end_users.set_default_key", { defaultValue: "设为默认" })}>
+              <button
+                type="button"
+                onClick={() => onSetDefault(row)}
+                className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-emerald-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-emerald-400"
+                aria-label={t("end_users.set_default_key", { defaultValue: "设为默认" })}
+              >
+                <ShieldCheck size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
           <HoverTooltip content={editLabel}>
             <button
               type="button"

--- a/pages/api-keys/components/ApiKeyFormFields.tsx
+++ b/pages/api-keys/components/ApiKeyFormFields.tsx
@@ -11,6 +11,7 @@ export function ApiKeyFormFields({
   editMode,
   permissionProfileOptions,
   regenerateKey,
+  serverGeneratesKey = false,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   form: ApiKeyFormValues;
@@ -18,6 +19,8 @@ export function ApiKeyFormFields({
   editMode: boolean;
   permissionProfileOptions: SelectOption[];
   regenerateKey: () => void;
+  /** When true (user-scoped create), key is generated server-side after submit. */
+  serverGeneratesKey?: boolean;
 }) {
   return (
     <div className="space-y-4">
@@ -33,24 +36,32 @@ export function ApiKeyFormFields({
         />
       </div>
 
-      <div>
-        <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
-          {t("api_keys_page.form_key_label")}
-        </label>
-        <div className="flex gap-2">
-          <TextInput
-            type="text"
-            value={form.key}
-            onChange={(e) => setForm((prev) => ({ ...prev, key: e.target.value }))}
-            placeholder={t("api_keys_page.form_key_placeholder")}
-            className="flex-1 font-mono"
-          />
-          <Button variant="secondary" size="sm" onClick={regenerateKey}>
-            <RefreshCw size={14} />
-            {editMode ? t("api_keys_page.form_refresh_key") : t("api_keys_page.form_regenerate")}
-          </Button>
+      {serverGeneratesKey && !editMode ? (
+        <p className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-900/50 dark:text-white/60">
+          {t("end_users.key_server_generated", {
+            defaultValue: "创建后由服务端生成唯一 API Key，并仅展示一次（将尝试复制到剪贴板）。",
+          })}
+        </p>
+      ) : (
+        <div>
+          <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
+            {t("api_keys_page.form_key_label")}
+          </label>
+          <div className="flex gap-2">
+            <TextInput
+              type="text"
+              value={form.key}
+              onChange={(e) => setForm((prev) => ({ ...prev, key: e.target.value }))}
+              placeholder={t("api_keys_page.form_key_placeholder")}
+              className="flex-1 font-mono"
+            />
+            <Button variant="secondary" size="sm" onClick={regenerateKey}>
+              <RefreshCw size={14} />
+              {editMode ? t("api_keys_page.form_refresh_key") : t("api_keys_page.form_regenerate")}
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
 
       <div>
         <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">

--- a/pages/api-keys/components/ApiKeyFormModal.tsx
+++ b/pages/api-keys/components/ApiKeyFormModal.tsx
@@ -15,6 +15,7 @@ export function ApiKeyFormModal({
   onClose,
   onSubmit,
   regenerateKey,
+  serverGeneratesKey = false,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   open: boolean;
@@ -26,6 +27,7 @@ export function ApiKeyFormModal({
   onClose: () => void;
   onSubmit: () => Promise<void>;
   regenerateKey: () => void;
+  serverGeneratesKey?: boolean;
 }) {
   return (
     <Modal
@@ -57,6 +59,7 @@ export function ApiKeyFormModal({
         editMode={editMode}
         permissionProfileOptions={permissionProfileOptions}
         regenerateKey={regenerateKey}
+        serverGeneratesKey={serverGeneratesKey}
       />
     </Modal>
   );

--- a/pages/api-keys/route.tsx
+++ b/pages/api-keys/route.tsx
@@ -1,17 +1,28 @@
+import { Navigate, useSearchParams } from "react-router-dom";
 import { preloadablePage } from "../preloadablePage";
 
 const { Page: ApiKeysPage, preload: preloadApiKeysPage } = preloadablePage(() =>
   import("./ApiKeysPage").then((m) => ({ default: m.ApiKeysPage })),
 );
 
+function ApiKeysEntry() {
+  const [params] = useSearchParams();
+  // Product entry is 用户账号; bare /access/api-keys redirects there.
+  // Scoped deep-link ?endUserId= keeps the full key manager for one user.
+  if (!params.get("endUserId")?.trim()) {
+    return <Navigate to="/access/end-users" replace />;
+  }
+  return <ApiKeysPage />;
+}
+
 export const apiKeysRoute = {
   path: "/access/api-keys",
   component: "api-keys",
-  element: <ApiKeysPage />,
+  element: <ApiKeysEntry />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.apiKeys" },
-  redirects: [{ from: "/api-keys", to: "/access/api-keys" }],
+  redirects: [{ from: "/api-keys", to: "/access/end-users" }],
   requiredPermission: "api_keys.read",
   preload: preloadApiKeysPage,
 };

--- a/pages/config/visual/VisualConfigEditor.tsx
+++ b/pages/config/visual/VisualConfigEditor.tsx
@@ -114,7 +114,7 @@ export function VisualConfigEditor({
               <p className="text-sm text-indigo-800 dark:text-indigo-300">
                 {t("visual_config.api_migrated")}
                 <a
-                  href="/access/api-keys"
+                  href="/access/end-users"
                   className="ml-1 font-semibold underline underline-offset-2 hover:text-indigo-600 dark:hover:text-indigo-200"
                 >
                   {t("visual_config.go_to_api_keys")}

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -110,16 +110,18 @@ export function EndUsersPage() {
         width: "w-40",
         render: (row) => (
           <div className="flex items-center gap-1">
-            <Button
-              size="sm"
-              variant="ghost"
-              title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
-              onClick={() =>
-                navigate(`/access/api-keys?endUserId=${encodeURIComponent(row.id)}`)
-              }
-            >
-              <Key className="h-4 w-4" />
-            </Button>
+            {can("api_keys.read") ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
+                onClick={() =>
+                  navigate(`/access/api-keys?endUserId=${encodeURIComponent(row.id)}`)
+                }
+              >
+                <Key className="h-4 w-4" />
+              </Button>
+            ) : null}
             {canWrite ? (
               <Button
                 size="sm"
@@ -156,7 +158,7 @@ export function EndUsersPage() {
         ),
       },
     ],
-    [canWrite, navigate, t, unlock],
+    [can, canWrite, navigate, t, unlock],
   );
 
   const onCreate = async (e: FormEvent) => {

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { KeyRound, Pencil, Trash2, Unlock } from "lucide-react";
+import { Key, KeyRound, Pencil, Trash2, Unlock } from "lucide-react";
 import { endUsersApi, type CreateEndUserResult, type EndUser } from "@code-proxy/api-client";
 import {
   Button,
@@ -19,6 +20,7 @@ const emptyForm = { username: "", displayName: "", password: "" };
 export function EndUsersPage() {
   const { notify } = useToast();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { can } = useAuth();
   const [users, setUsers] = useState<EndUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -108,6 +110,16 @@ export function EndUsersPage() {
         width: "w-40",
         render: (row) => (
           <div className="flex items-center gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
+              onClick={() =>
+                navigate(`/access/api-keys?endUserId=${encodeURIComponent(row.id)}`)
+              }
+            >
+              <Key className="h-4 w-4" />
+            </Button>
             {canWrite ? (
               <Button
                 size="sm"
@@ -144,7 +156,7 @@ export function EndUsersPage() {
         ),
       },
     ],
-    [canWrite, t, unlock],
+    [canWrite, navigate, t, unlock],
   );
 
   const onCreate = async (e: FormEvent) => {
@@ -246,7 +258,8 @@ export function EndUsersPage() {
               </h2>
               <p className="mt-1 text-sm text-slate-500 dark:text-white/55">
                 {t("end_users.subtitle", {
-                  defaultValue: "门户账号（与后台管理员隔离），每人可持有多把 API Key。",
+                  defaultValue:
+                    "门户用户账号（与后台管理员隔离）。点击「密钥」管理该用户下全部 API Key（限额/权限/启停等）。",
                 })}
               </p>
             </div>

--- a/pages/end-users/route.tsx
+++ b/pages/end-users/route.tsx
@@ -16,6 +16,8 @@ export const endUsersRoute: PageRoute = {
   layout: "app",
   nav: { labelKey: "shell.nav_end_users" },
   requiredPermission: "end_users.read",
+  // Legacy key-admin roles: seed grants end_users.read from api_keys.read; keep OR for safety.
+  requiredAnyPermissions: ["api_keys.read"],
   component: "end-users",
   preload: () => import("./EndUsersPage"),
 };

--- a/pages/registry.ts
+++ b/pages/registry.ts
@@ -37,6 +37,8 @@ export interface PageRoute {
   hasWildcard?: boolean;
   preload?: () => Promise<unknown>;
   requiredPermission?: string;
+  /** Any-of alternative permissions (OR with requiredPermission). */
+  requiredAnyPermissions?: string[];
   /** Stable key for dynamic menu component binding */
   component?: string;
 }


### PR DESCRIPTION
## Summary
- Hide API Keys from sidebar (legacy service menus)
- User Accounts page: open full key manager via `?endUserId=`
- Scoped list/create for a user’s keys; safer disable patch
- Copy/limits/permissions/usage remain on the same ApiKeysPage

## Test plan
- [x] `bun run design:check`
- [x] `bun run lint` (warnings only, pre-existing)
- [x] `bun run test -- pages/api-keys/__tests__/ApiKeysPage.test.tsx`
- [ ] `./scripts/ci-pr.sh` on PR

Depends on CliRelay counterpart for `end_user_id`/`is_default` on entries.
Refs: docs/plan/063-user-account-api-key-merge-20260718.md