### PR TITLE
fix(ui): end-users page no longer redirects to dashboard

### DIFF
--- a/apps/admin-panel/src/app/guards/PermissionGate.tsx
+++ b/apps/admin-panel/src/app/guards/PermissionGate.tsx
@@ -3,8 +3,10 @@ import { useAuth } from "@app/providers/AuthProvider";
 
 export function PermissionGate({
   permission,
+  anyOf = [],
   fallback = null,
   children,
-}: PropsWithChildren<{ permission: string; fallback?: ReactNode }>) {
-  return useAuth().can(permission) ? children : fallback;
+}: PropsWithChildren<{ permission: string; anyOf?: string[]; fallback?: ReactNode }>) {
+  const { can } = useAuth();
+  return can(permission) || anyOf.some((p) => can(p)) ? children : fallback;
 }

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -250,7 +250,7 @@ export function EndUsersPage() {
   };
 
   return (
-    <PermissionGate permission="end_users.read">
+    <PermissionGate permission="end_users.read" anyOf={["api_keys.read"]}>
       <section className="flex flex-1 flex-col">
         <div className="flex flex-1 flex-col rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70">
           <div className="flex flex-wrap items-start justify-between gap-3 px-5 pt-5 pb-3">

--- a/pages/end-users/route.tsx
+++ b/pages/end-users/route.tsx
@@ -13,7 +13,7 @@ export const endUsersRoute: PageRoute = {
     </Suspense>
   ),
   auth: true,
-  layout: "app",
+  layout: "dashboard",
   nav: { labelKey: "shell.nav_end_users" },
   requiredPermission: "end_users.read",
   // Legacy key-admin roles: seed grants end_users.read from api_keys.read; keep OR for safety.


### PR DESCRIPTION
## Summary
- Root cause: `pages/end-users/route.tsx` used `layout: "app"`, which AppRouter never mounts (`authDashboardRoutes` only includes `layout === "dashboard"`), so `/access/end-users` hit `path="*"` → `/dashboard`.
- Fix: set `layout: "dashboard"`.
- Also align page `PermissionGate` with route OR (`end_users.read` || `api_keys.read`).

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e critical)
- [ ] After deploy: open 用户账户 → stay on `/manage/#/access/end-users` (not dashboard)