### PR TITLE
feat(ui): end-users table layout + keys manage modal

### DIFF
--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -46,12 +46,19 @@ import { LogContentModal } from "@features/log-content-viewer";
 import { ErrorDetailModal } from "@features/log-content-viewer";
 import type { ApiKeyFormValues } from "./types";
 
-export function ApiKeysPage() {
+export function ApiKeysPage({
+  endUserId,
+  embed = false,
+}: {
+  endUserId?: string;
+  /** When true, hide outer card chrome for modal embedding. */
+  embed?: boolean;
+} = {}) {
   const { t, i18n } = useTranslation();
   const { notify } = useToast();
   const auth = useOptionalAuth();
   const [searchParams] = useSearchParams();
-  const endUserIdFilter = searchParams.get("endUserId")?.trim() || "";
+  const endUserIdFilter = (endUserId ?? searchParams.get("endUserId") ?? "").trim();
 
   const [entries, setEntries] = useState<ApiKeyEntry[]>([]);
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(() => new Set());
@@ -742,86 +749,105 @@ export function ApiKeysPage() {
 
   /* ─── main render ─── */
 
-  return (
-    <div className="space-y-6">
-      <Card
-        className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
-        bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
-        title={
-          endUserIdFilter
-            ? t("end_users.manage_keys_title", { defaultValue: "用户 API 密钥" })
-            : t("api_keys_page.title")
+  const toolbar = (
+    <div className="flex flex-wrap justify-end gap-2">
+      {endUserIdFilter && !embed ? (
+        <Link
+          to="/access/end-users"
+          className="inline-flex h-8 items-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-neutral-800"
+        >
+          {t("end_users.back_to_users", { defaultValue: "返回用户账号" })}
+        </Link>
+      ) : null}
+      <Button variant="primary" size="sm" onClick={handleOpenCreate}>
+        <Plus size={14} />
+        {t("api_keys_page.create_key")}
+      </Button>
+      {selectedEntries.length > 0 && !endUserIdFilter ? (
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={() => setBatchDeleteOpen(true)}
+          disabled={saving}
+        >
+          <Trash2 size={14} />
+          {t("api_keys_page.batch_delete")}
+        </Button>
+      ) : null}
+      <Button variant="secondary" size="sm" onClick={() => void loadEntries()} disabled={loading}>
+        <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+        {t("api_keys_page.refresh")}
+      </Button>
+    </div>
+  );
+
+  const tableBody =
+    entries.length === 0 ? (
+      <EmptyState
+        title={t("api_keys_page.no_keys")}
+        description={t("api_keys_page.no_keys_desc")}
+        icon={<KeyRound size={32} className="text-slate-400" />}
+      />
+    ) : (
+      <div
+        className={
+          embed
+            ? "flex min-h-0 flex-1 flex-col"
+            : "space-y-3 md:flex md:min-h-0 md:flex-1 md:flex-col"
         }
-        description={
-          endUserIdFilter
-            ? t("end_users.manage_keys_desc", {
-                defaultValue: "管理该用户账号下的全部 API 密钥（限额、权限、启停等）。",
-              })
-            : t("api_keys_page.description")
-        }
-        actions={
-          <div className="flex flex-wrap justify-end gap-2">
-            {endUserIdFilter ? (
-              <Link
-                to="/access/end-users"
-                className="inline-flex h-8 items-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-neutral-800"
-              >
-                {t("end_users.back_to_users", { defaultValue: "返回用户账号" })}
-              </Link>
-            ) : null}
-            <Button variant="primary" size="sm" onClick={handleOpenCreate}>
-              <Plus size={14} />
-              {t("api_keys_page.create_key")}
-            </Button>
-            {selectedEntries.length > 0 && !endUserIdFilter ? (
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={() => setBatchDeleteOpen(true)}
-                disabled={saving}
-              >
-                <Trash2 size={14} />
-                {t("api_keys_page.batch_delete")}
-              </Button>
-            ) : null}
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => void loadEntries()}
-              disabled={loading}
-            >
-              <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
-              {t("api_keys_page.refresh")}
-            </Button>
-          </div>
-        }
-        loading={loading}
       >
-        {entries.length === 0 ? (
-          <EmptyState
-            title={t("api_keys_page.no_keys")}
-            description={t("api_keys_page.no_keys_desc")}
-            icon={<KeyRound size={32} className="text-slate-400" />}
-          />
-        ) : (
-          <div className="space-y-3 md:flex md:min-h-0 md:flex-1 md:flex-col">
-            <DataTable<ApiKeyEntry>
-              tableId="api-keys"
-              rows={entries}
-              columns={apiKeyColumns}
-              rowKey={(row) => row.key}
-              rowHeight={44}
-              height="h-[calc(100dvh-260px)] md:h-auto md:flex-1"
-              minHeight="min-h-[320px] md:min-h-0"
-              minWidth="min-w-[2314px]"
-              caption={t("api_keys_page.table_caption")}
-              emptyText={t("api_keys_page.no_api_keys")}
-              showAllLoadedMessage={false}
-              rowClassName={(row) => (row.disabled ? "opacity-50" : "")}
-            />
+        <DataTable<ApiKeyEntry>
+          tableId={endUserIdFilter ? "api-keys-end-user" : "api-keys"}
+          rows={entries}
+          columns={apiKeyColumns}
+          rowKey={(row) => row.key}
+          rowHeight={44}
+          height={
+            embed
+              ? "h-full"
+              : "h-[calc(100dvh-260px)] md:h-auto md:flex-1"
+          }
+          minHeight={embed ? "min-h-0" : "min-h-[320px] md:min-h-0"}
+          minWidth="min-w-[2314px]"
+          caption={t("api_keys_page.table_caption")}
+          emptyText={t("api_keys_page.no_api_keys")}
+          showAllLoadedMessage={false}
+          rowClassName={(row) => (row.disabled ? "opacity-50" : "")}
+        />
+      </div>
+    );
+
+  return (
+    <div className={embed ? "flex h-full min-h-0 flex-col" : "space-y-6"}>
+      {embed ? (
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="flex shrink-0 items-center justify-end border-b border-slate-100 px-4 py-3 dark:border-white/10">
+            {toolbar}
           </div>
-        )}
-      </Card>
+          <div className="min-h-0 flex-1 overflow-hidden px-4 py-3">{tableBody}</div>
+        </div>
+      ) : (
+        <Card
+          className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
+          bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
+          title={
+            endUserIdFilter
+              ? t("end_users.manage_keys_title", { defaultValue: "用户 API 密钥" })
+              : t("api_keys_page.title")
+          }
+          description={
+            endUserIdFilter
+              ? t("end_users.manage_keys_desc", {
+                  defaultValue: "管理该用户账号下的全部 API 密钥（限额、权限、启停等）。",
+                })
+              : t("api_keys_page.description")
+          }
+          actions={toolbar}
+          loading={loading}
+        >
+          {tableBody}
+        </Card>
+      )}
 
       <ApiKeyFormModal
         t={t}

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Key, KeyRound, Pencil, Trash2, Unlock } from "lucide-react";
 import { endUsersApi, type CreateEndUserResult, type EndUser } from "@code-proxy/api-client";
@@ -17,10 +16,17 @@ import { useAuth } from "@app/providers/AuthProvider";
 
 const emptyForm = { username: "", displayName: "", password: "" };
 
+const stickyActionsHeaderClass =
+  "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
+const stickyActionsCellClass = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
+
+const ApiKeysPage = lazy(() =>
+  import("../api-keys/ApiKeysPage").then((m) => ({ default: m.ApiKeysPage })),
+);
+
 export function EndUsersPage() {
   const { notify } = useToast();
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const { can } = useAuth();
   const [users, setUsers] = useState<EndUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -32,6 +38,7 @@ export function EndUsersPage() {
   const [resetUser, setResetUser] = useState<EndUser | null>(null);
   const [generatedReset, setGeneratedReset] = useState("");
   const [deleteUser, setDeleteUser] = useState<EndUser | null>(null);
+  const [keysUser, setKeysUser] = useState<EndUser | null>(null);
   const [busy, setBusy] = useState(false);
   const canWrite = can("end_users.write");
 
@@ -72,7 +79,11 @@ export function EndUsersPage() {
       {
         key: "username",
         label: t("end_users.username", { defaultValue: "用户名" }),
-        width: "w-48",
+        width: "w-56 min-w-[14rem]",
+        minWidthPx: 160,
+        maxWidthPx: 480,
+        headerClassName: "text-left",
+        cellClassName: "text-left",
         render: (row) => {
           const extraKeys = Math.max(0, (row.api_key_count ?? 0) - 1);
           return (
@@ -95,29 +106,41 @@ export function EndUsersPage() {
       {
         key: "status",
         label: t("end_users.status", { defaultValue: "状态" }),
-        width: "w-28",
+        width: "w-28 min-w-[7rem]",
+        minWidthPx: 96,
+        maxWidthPx: 220,
+        headerClassName: "text-center",
+        cellClassName: "text-center",
         render: (row) => row.status,
       },
       {
         key: "last_login",
         label: t("end_users.last_login", { defaultValue: "最近登录" }),
-        width: "w-44",
+        width: "w-48 min-w-[12rem]",
+        minWidthPx: 140,
+        maxWidthPx: 320,
+        headerClassName: "text-center",
+        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
         render: (row) => row.last_login_at?.slice(0, 19).replace("T", " ") || "—",
       },
       {
         key: "actions",
         label: t("common.actions", { defaultValue: "操作" }),
-        width: "w-40",
+        width: "w-44 min-w-[11rem]",
+        minWidthPx: 168,
+        maxWidthPx: 220,
+        resizable: false,
+        lockOrder: "end",
+        headerClassName: stickyActionsHeaderClass,
+        cellClassName: stickyActionsCellClass,
         render: (row) => (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center justify-center gap-1">
             {can("api_keys.read") ? (
               <Button
                 size="sm"
                 variant="ghost"
                 title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
-                onClick={() =>
-                  navigate(`/access/api-keys?endUserId=${encodeURIComponent(row.id)}`)
-                }
+                onClick={() => setKeysUser(row)}
               >
                 <Key className="h-4 w-4" />
               </Button>
@@ -158,7 +181,7 @@ export function EndUsersPage() {
         ),
       },
     ],
-    [can, canWrite, navigate, t, unlock],
+    [can, canWrite, t, unlock],
   );
 
   const onCreate = async (e: FormEvent) => {
@@ -282,8 +305,10 @@ export function EndUsersPage() {
               rowHeight={60}
               height="h-full"
               minHeight="min-h-full"
+              minWidth="min-w-[720px]"
               emptyText={t("end_users.empty", { defaultValue: "暂无用户账号" })}
               showAllLoadedMessage={false}
+              columnResizable
             />
           </div>
         </div>
@@ -467,6 +492,42 @@ export function EndUsersPage() {
         busy={busy}
         onConfirm={() => void onDelete()}
       />
+
+      <Modal
+        open={Boolean(keysUser)}
+        onClose={() => {
+          setKeysUser(null);
+          void load();
+        }}
+        title={
+          keysUser
+            ? t("end_users.manage_keys_title_for", {
+                defaultValue: "管理密钥 · {{name}}",
+                name: keysUser.display_name || keysUser.username,
+              })
+            : t("end_users.manage_keys_title", { defaultValue: "用户 API 密钥" })
+        }
+        description={t("end_users.manage_keys_desc", {
+          defaultValue: "管理该用户账号下的全部 API 密钥（限额、权限、启停等）。",
+        })}
+        maxWidth="max-w-[96vw]"
+        panelClassName="h-[min(90dvh,920px)]"
+        bodyHeightClassName="h-[calc(min(90dvh,920px)-7.5rem)]"
+        bodyOverflowClassName="overflow-hidden"
+        bodyClassName="!p-0"
+      >
+        {keysUser ? (
+          <Suspense
+            fallback={
+              <div className="flex h-full items-center justify-center text-sm text-slate-500">
+                Loading…
+              </div>
+            }
+          >
+            <ApiKeysPage endUserId={keysUser.id} embed />
+          </Suspense>
+        ) : null}
+      </Modal>
     </PermissionGate>
   );
 }


### PR DESCRIPTION
## Summary
- 操作列右侧 sticky 固定；用户名左对齐；状态/最近登录居中；列宽可拖拽调整
- 「管理密钥」改为管理后台大弹窗（内嵌 `ApiKeysPage`），不再跳转独立页
- 关闭弹窗后刷新用户列表（key count 等）

## Test plan
- [x] `./scripts/ci-pr.sh`
- [ ] 线上：用户账号表列对齐/拖宽；点钥匙图标出弹窗可管理密钥