### PR TITLE
fix(portal): polish secret modals, require key name, show key column

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2627,7 +2627,7 @@
     "system_call": "System Call",
     "col_id": "ID",
     "col_time": "Time",
-    "col_key_name": "Account Name",
+    "col_key_name": "Key Name",
     "col_model": "Model",
     "real_model_id": "Real model ID",
     "vision_fallback_model_id": "Vision fallback model ID",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2924,7 +2924,7 @@
     "system_call": "系统调用",
     "col_id": "ID",
     "col_time": "时间",
-    "col_key_name": "账户名称",
+    "col_key_name": "Key 名称",
     "col_model": "模型",
     "real_model_id": "真实模型 ID",
     "vision_fallback_model_id": "视觉补位模型 ID",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -91,6 +91,7 @@ export { useLocalStorage } from "./hooks/useLocalStorage";
 export { useResizeLayoutAnimation } from "./hooks/useResizeLayoutAnimation";
 
 export { copyTextToClipboard } from "./utils/clipboard";
+export { SecretRevealModal } from "./overlays/SecretRevealModal";
 export {
   type ControlSize,
   controlHeightBySize,

--- a/packages/ui/src/overlays/SecretRevealModal.tsx
+++ b/packages/ui/src/overlays/SecretRevealModal.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useState } from "react";
+import { Check, Copy, KeyRound, Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "../primitives/Button";
+import { Modal } from "../overlays/Modal";
+import { copyTextToClipboard } from "../utils/clipboard";
+
+export function SecretRevealModal({
+  open,
+  title,
+  description,
+  secret,
+  warning,
+  closeText = "",
+  onClose,
+}: {
+  open: boolean;
+  title: string;
+  description?: string;
+  secret: string;
+  warning?: string;
+  closeText?: string;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const [copying, setCopying] = useState(false);
+  const resolvedClose = closeText || t("common.close", { defaultValue: "关闭" });
+
+  const handleCopy = useCallback(async () => {
+    if (!secret || copying) return;
+    setCopying(true);
+    try {
+      const ok = await copyTextToClipboard(secret);
+      if (ok) {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      }
+    } finally {
+      setCopying(false);
+    }
+  }, [copying, secret]);
+
+  return (
+    <Modal
+      open={open}
+      title={title}
+      description={description}
+      onClose={onClose}
+      maxWidth="max-w-md"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            {resolvedClose}
+          </Button>
+          <Button variant="primary" onClick={() => void handleCopy()} disabled={!secret || copying}>
+            {copying ? (
+              <Loader2 size={16} className="animate-spin" aria-hidden="true" />
+            ) : copied ? (
+              <Check size={16} aria-hidden="true" />
+            ) : (
+              <Copy size={16} aria-hidden="true" />
+            )}
+            {copied
+              ? t("common.copied", { defaultValue: "已复制" })
+              : t("common.copy", { defaultValue: "复制" })}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-amber-50 text-amber-600 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
+            <KeyRound size={18} />
+          </div>
+          <p className="min-w-0 pt-1.5 text-sm leading-relaxed text-slate-600 dark:text-white/65">
+            {warning ||
+              t("common.secret_once_warning", {
+                defaultValue: "请立即复制，关闭后将无法再次查看。",
+              })}
+          </p>
+        </div>
+        <div className="relative rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-white/10 dark:bg-neutral-900">
+          <code className="block select-all break-all pr-10 font-mono text-sm text-slate-900 dark:text-white">
+            {secret}
+          </code>
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="absolute top-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 transition hover:bg-white hover:text-slate-900 dark:hover:bg-white/10 dark:hover:text-white"
+            aria-label={t("common.copy", { defaultValue: "复制" })}
+          >
+            {copied ? <Check size={15} /> : <Copy size={15} />}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -8,6 +8,7 @@ import { LanguageSelector } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
 import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
+import { SecretRevealModal } from "@code-proxy/ui";
 import { Select, type SelectOption } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
@@ -311,10 +312,7 @@ export function ApiKeyLookupPage() {
   }, []);
 
   const logColumns = useMemo(
-    () =>
-      buildRequestLogsColumns((key) => t(key), handleContentClick).filter(
-        (column) => column.key !== "apiKeyName",
-      ),
+    () => buildRequestLogsColumns((key) => t(key), handleContentClick),
     [t, handleContentClick],
   );
   // ── Tab state ──
@@ -769,6 +767,9 @@ export function ApiKeyLookupPage() {
   const [pwdForm, setPwdForm] = useState({ current: "", next: "" });
   const [pwdError, setPwdError] = useState<string | null>(null);
   const [secretOnce, setSecretOnce] = useState<string | null>(null);
+  const [createKeyOpen, setCreateKeyOpen] = useState(false);
+  const [createKeyName, setCreateKeyName] = useState("");
+  const [createKeyError, setCreateKeyError] = useState<string | null>(null);
   const [portalKeysBusy, setPortalKeysBusy] = useState(false);
   const [portalKeysLoading, setPortalKeysLoading] = useState(false);
   const [usagePreviewKey, setUsagePreviewKey] = useState<EndUserAPIKey | null>(null);
@@ -1158,14 +1159,9 @@ export function ApiKeyLookupPage() {
                   busy={portalKeysBusy}
                   onRefresh={() => void refreshPortalKeys()}
                   onCreate={() => {
-                    setPortalKeysBusy(true);
-                    void portalApi
-                      .createKey()
-                      .then(async (res) => {
-                        if (res.plaintext_key) setSecretOnce(res.plaintext_key);
-                        await refreshPortalKeys();
-                      })
-                      .finally(() => setPortalKeysBusy(false));
+                    setCreateKeyName("");
+                    setCreateKeyError(null);
+                    setCreateKeyOpen(true);
                   }}
                   onViewUsage={(key) => openUsagePreview(key)}
                   onSetDefault={(key) => {
@@ -1394,67 +1390,169 @@ export function ApiKeyLookupPage() {
       <Modal
         open={changePasswordOpen}
         title={t("apikey_lookup.change_password", { defaultValue: "修改密码" })}
+        maxWidth="max-w-md"
         onClose={() => {
           // Force password change: only allow close after success clears the flag.
           if (portalUser?.must_change_password) return;
           setChangePasswordOpen(false);
         }}
+        footer={
+          <>
+            {!portalUser?.must_change_password ? (
+              <Button
+                variant="secondary"
+                onClick={() => setChangePasswordOpen(false)}
+                disabled={portalKeysBusy}
+              >
+                {t("common.cancel", { defaultValue: "取消" })}
+              </Button>
+            ) : null}
+            <Button
+              variant="primary"
+              disabled={!pwdForm.current || pwdForm.next.length < 8 || portalKeysBusy}
+              onClick={() => {
+                setPwdError(null);
+                setPortalKeysBusy(true);
+                void portalApi
+                  .changePassword(pwdForm.current, pwdForm.next)
+                  .then(async () => {
+                    setPortalUser((u) => (u ? { ...u, must_change_password: false } : u));
+                    try {
+                      const items = (await portalApi.listKeys()).items ?? [];
+                      setPortalKeys(items);
+                      const usable = items.filter((k) => !k.disabled);
+                      const def = usable.find((k) => k.is_default) ?? usable[0];
+                      if (def) await activateOwnedKey(def.id);
+                      else if (items.length) setActiveTab("keys");
+                      setPwdForm({ current: "", next: "" });
+                      setPwdError(null);
+                      setChangePasswordOpen(false);
+                    } catch (err) {
+                      setPortalKeys([]);
+                      setPwdError(err instanceof Error ? err.message : "failed");
+                    }
+                  })
+                  .catch((err) => setPwdError(err instanceof Error ? err.message : "failed"))
+                  .finally(() => setPortalKeysBusy(false));
+              }}
+            >
+              {t("common.save", { defaultValue: "保存" })}
+            </Button>
+          </>
+        }
       >
         <form
-          className="space-y-3"
+          className="space-y-4"
           onSubmit={(e) => {
             e.preventDefault();
-            setPwdError(null);
-            void portalApi
-              .changePassword(pwdForm.current, pwdForm.next)
-              .then(async () => {
-                setPortalUser((u) => (u ? { ...u, must_change_password: false } : u));
-                try {
-                  const items = (await portalApi.listKeys()).items ?? [];
-                  setPortalKeys(items);
-                  const usable = items.filter((k) => !k.disabled);
-                  const def = usable.find((k) => k.is_default) ?? usable[0];
-                  if (def) await activateOwnedKey(def.id);
-                  else if (items.length) setActiveTab("keys");
-                  setPwdForm({ current: "", next: "" });
-                  setPwdError(null);
-                  setChangePasswordOpen(false);
-                } catch (err) {
-                  setPortalKeys([]);
-                  setPwdError(err instanceof Error ? err.message : "failed");
-                }
-              })
-              .catch((err) => setPwdError(err instanceof Error ? err.message : "failed"));
           }}
         >
           <label className="block space-y-1.5">
-            <span className="text-sm font-medium">
+            <span className="text-sm font-medium text-slate-700 dark:text-white/75">
               {t("apikey_lookup.current_password", { defaultValue: "当前密码" })}
             </span>
             <TextInput
               type="password"
               value={pwdForm.current}
               onChange={(e) => setPwdForm((f) => ({ ...f, current: e.target.value }))}
+              autoComplete="current-password"
             />
           </label>
           <label className="block space-y-1.5">
-            <span className="text-sm font-medium">
+            <span className="text-sm font-medium text-slate-700 dark:text-white/75">
               {t("apikey_lookup.new_password", { defaultValue: "新密码" })}
             </span>
             <TextInput
               type="password"
               value={pwdForm.next}
               onChange={(e) => setPwdForm((f) => ({ ...f, next: e.target.value }))}
+              autoComplete="new-password"
+              placeholder={t("apikey_lookup.new_password_hint", {
+                defaultValue: "至少 8 位",
+              })}
             />
           </label>
           {pwdError ? <p className="text-sm text-rose-600 dark:text-rose-300">{pwdError}</p> : null}
-          <Button
-            type="submit"
-            variant="primary"
-            disabled={!pwdForm.current || pwdForm.next.length < 8}
-          >
-            {t("common.save", { defaultValue: "保存" })}
-          </Button>
+        </form>
+      </Modal>
+
+      <Modal
+        open={createKeyOpen}
+        title={t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
+        description={t("apikey_lookup.create_key_desc", {
+          defaultValue: "为新 Key 填写名称，便于在请求日志中区分来源。",
+        })}
+        maxWidth="max-w-md"
+        onClose={() => {
+          if (portalKeysBusy) return;
+          setCreateKeyOpen(false);
+          setCreateKeyError(null);
+        }}
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              disabled={portalKeysBusy}
+              onClick={() => {
+                setCreateKeyOpen(false);
+                setCreateKeyError(null);
+              }}
+            >
+              {t("common.cancel", { defaultValue: "取消" })}
+            </Button>
+            <Button
+              type="submit"
+              form="portal-create-key-form"
+              variant="primary"
+              disabled={portalKeysBusy || !createKeyName.trim()}
+            >
+              {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
+            </Button>
+          </>
+        }
+      >
+        <form
+          id="portal-create-key-form"
+          className="space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const name = createKeyName.trim();
+            if (!name) {
+              setCreateKeyError(
+                t("apikey_lookup.key_name_required", { defaultValue: "请输入 Key 名称" }),
+              );
+              return;
+            }
+            setCreateKeyError(null);
+            setPortalKeysBusy(true);
+            void portalApi
+              .createKey(name)
+              .then(async (res) => {
+                if (res.plaintext_key) setSecretOnce(res.plaintext_key);
+                setCreateKeyOpen(false);
+                setCreateKeyName("");
+                await refreshPortalKeys();
+              })
+              .catch((err) => setCreateKeyError(err instanceof Error ? err.message : "failed"))
+              .finally(() => setPortalKeysBusy(false));
+          }}
+        >
+          <label className="block space-y-1.5">
+            <span className="text-sm font-medium text-slate-700 dark:text-white/75">
+              {t("apikey_lookup.key_name", { defaultValue: "Key 名称" })}
+            </span>
+            <TextInput
+              value={createKeyName}
+              onChange={(e) => setCreateKeyName(e.target.value)}
+              autoFocus
+              placeholder={t("apikey_lookup.key_name_placeholder", {
+                defaultValue: "例如：Claude Desktop / 生产环境",
+              })}
+            />
+          </label>
+          {createKeyError ? (
+            <p className="text-sm text-rose-600 dark:text-rose-300">{createKeyError}</p>
+          ) : null}
         </form>
       </Modal>
 
@@ -1548,16 +1646,15 @@ export function ApiKeyLookupPage() {
         </div>
       </Modal>
 
-      <Modal
+      <SecretRevealModal
         open={Boolean(secretOnce)}
         title={t("apikey_lookup.copy_secret", { defaultValue: "请立即复制" })}
+        secret={secretOnce ?? ""}
+        warning={t("apikey_lookup.secret_once_warning", {
+          defaultValue: "离开后无法再查看明文 Key，请立即复制保存。",
+        })}
         onClose={() => setSecretOnce(null)}
-      >
-        <p className="mb-2 text-sm text-amber-600">离开后无法再查看明文 Key。</p>
-        <code className="block select-all break-all rounded bg-slate-100 p-3 text-sm dark:bg-neutral-900">
-          {secretOnce}
-        </code>
-      </Modal>
+      />
     </div>
   );
 }

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -262,7 +262,8 @@ describe("ApiKeyLookupPage", () => {
     });
     expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Codex 主渠道")).toBeInTheDocument();
-    expect(screen.queryByText(/key name/i)).not.toBeInTheDocument();
+    // Multi-key accounts need a Key name column to tell request sources apart.
+    expect(screen.getByRole("columnheader", { name: /key name|账户名称|account name/i })).toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: /^duration$/i })).not.toBeInTheDocument();
   });
 

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -15,6 +15,7 @@ import {
   ConfirmModal,
   DataTable,
   Modal,
+  SecretRevealModal,
   Select,
   TextInput,
   type DataTableColumn,
@@ -652,13 +653,15 @@ export function EndUsersPage() {
         </form>
       </Modal>
 
-      <Modal
+      <SecretRevealModal
         open={Boolean(generatedReset)}
         onClose={() => setGeneratedReset("")}
-        title="新密码（请立即复制）"
-      >
-        <code className="select-all break-all">{generatedReset}</code>
-      </Modal>
+        title={t("end_users.new_password_title", { defaultValue: "新密码（请立即复制）" })}
+        secret={generatedReset}
+        warning={t("end_users.new_password_warning", {
+          defaultValue: "请立即复制新密码，关闭后将无法再次查看。",
+        })}
+      />
 
       <ConfirmModal
         open={Boolean(resetUser)}


### PR DESCRIPTION
## Summary
- 统一「新密码 / 明文 Key」为 `SecretRevealModal`（`max-w-md` + 复制按钮 + footer）
- 修改密码弹窗尺寸/按钮区与确认弹窗一致
- 用户页新建 Key 必须填写名称
- 请求日志恢复 Key 名称列，便于多 Key 区分来源

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / e2e critical）
- [x] `ApiKeyLookupPage` 单测 10/10

## Notes
- 与 CliRelay `fix/public-usage-aggregate-enduser-keys` 配合：后端按账号聚合用量后，前端 Key 列才有意义