### PR TITLE
feat(apikey-lookup): model plaza style cards and vendor tabs

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3143,7 +3143,7 @@
     "load_failed": "Failed to load channel group configuration"
   },
   "apikey_lookup": {
-    "available_models": "Available Models",
+    "available_models": "Model Plaza",
     "usage_stats": "Usage Stats",
     "request_logs": "Request Logs",
     "quick_import": "Quick Import",
@@ -3198,9 +3198,9 @@
     "quick_import_empty_title": "No quick import presets available",
     "quick_import_empty_desc": "This API key has no matching Codex / Claude import cards. The key may not cover any presets, or the admin has not configured import cards yet.",
     "empty_title": "Sign in to view usage",
-    "empty_desc": "Sign in with your account to view usage stats, request logs, and available models.",
+    "empty_desc": "Sign in with your account to view usage stats, request logs, and the model plaza.",
     "login_title": "Sign in",
-    "login_desc": "Use your account credentials to view usage stats, request logs, and available models.",
+    "login_desc": "Use your account credentials to view usage stats, request logs, and the model plaza.",
     "username": "Username",
     "password": "Password",
     "username_placeholder": "Enter username",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3440,7 +3440,7 @@
     "load_failed": "加载渠道分组配置失败"
   },
   "apikey_lookup": {
-    "available_models": "可用模型",
+    "available_models": "模型广场",
     "usage_stats": "使用统计",
     "request_logs": "请求日志",
     "quick_import": "快捷导入",
@@ -3495,9 +3495,9 @@
     "quick_import_empty_title": "暂无可用的快捷导入预设",
     "quick_import_empty_desc": "当前 API Key 没有匹配的 Codex / Claude 导入卡片。可能是密钥权限未覆盖任何预设，或管理员尚未配置导入卡片。",
     "empty_title": "登录后查看用量",
-    "empty_desc": "使用账号密码登录后，可查看用量统计、请求日志和可用模型。",
+    "empty_desc": "使用账号密码登录后，可查看用量统计、请求日志和模型广场。",
     "login_title": "账号登录",
-    "login_desc": "使用账号密码登录，查看用量、请求日志和可用模型。",
+    "login_desc": "使用账号密码登录，查看用量、请求日志和模型广场。",
     "username": "账号",
     "password": "密码",
     "username_placeholder": "请输入账号",

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1312,7 +1312,7 @@ export function ApiKeyLookupPage() {
             </h2>
             <p className="text-sm text-slate-500 dark:text-white/55">
               {t("apikey_lookup.login_desc", {
-                defaultValue: "使用账号密码登录，查看用量、请求日志和可用模型。",
+                defaultValue: "使用账号密码登录，查看用量、请求日志和模型广场。",
               })}
             </p>
           </div>

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -365,12 +365,12 @@ describe("ApiKeyLookupPage", () => {
     );
 
     await screen.findByTestId("usage-tab");
-    await userEvent.click(screen.getByRole("tab", { name: /models/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /model plaza/i }));
 
     expect(await screen.findByText("gpt-5.3-codex")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("tab", { name: /usage/i }));
-    await userEvent.click(screen.getByRole("tab", { name: /models/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /model plaza/i }));
 
     expect(screen.getByText("gpt-5.3-codex")).toBeInTheDocument();
     expect(mocks.fetchAvailableModels).toHaveBeenCalledTimes(2);

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -95,7 +95,7 @@ export function LookupResultsToolbar({
                 </TabsTrigger>
               ) : null}
               <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
-              <TabsTrigger value="models">{t("apikey_lookup.available_models")}</TabsTrigger>
+              <TabsTrigger value="models">{t("model_plaza.title")}</TabsTrigger>
               <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
             </TabsList>
           </Tabs>

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -1,16 +1,81 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Layers, RefreshCw, Search } from "lucide-react";
-import { Card } from "@code-proxy/ui";
-import { ScrollArea } from "@code-proxy/ui";
-import { TextInput } from "@code-proxy/ui";
+import { Check, Copy, Layers, RefreshCw, Search, Store } from "lucide-react";
+import { VendorIcon } from "@code-proxy/assets";
+import {
+  Card,
+  EmptyState,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TextInput,
+  useToast,
+} from "@code-proxy/ui";
 import {
   buildModelVendorStats,
-  CopyableModelTag,
   getModelVendorKey,
-  ModelVendorStatBadge,
   type ModelVendorKey,
 } from "@features/model-tags";
+
+type VendorFilter = "all" | ModelVendorKey;
+
+function ModelIdCard({ id, onCopied }: { id: string; onCopied: () => void }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const vendorGlyph = id.trim().charAt(0).toUpperCase() || "M";
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(id);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+    onCopied();
+  };
+
+  return (
+    <div data-testid="apikey-lookup-model-card" className="h-full min-h-[120px]">
+      <Card
+        padding="compact"
+        bodyClassName="mt-0 flex h-full min-h-[96px] flex-col"
+        className="group h-full transition hover:border-indigo-200/70 hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.06)] dark:hover:border-indigo-500/25 dark:hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.28)]"
+      >
+        <div className="flex items-start gap-3">
+          <div className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200/80 bg-slate-50 dark:border-neutral-700/70 dark:bg-neutral-900/70">
+            <span className="pointer-events-none absolute text-sm font-bold text-slate-300 dark:text-white/25">
+              {vendorGlyph}
+            </span>
+            <span className="relative z-10 flex items-center justify-center [&:empty]:hidden">
+              <VendorIcon modelId={id} size={22} />
+            </span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <h3
+                  className="truncate font-mono text-sm font-semibold text-slate-900 dark:text-white"
+                  title={id}
+                >
+                  {id}
+                </h3>
+                <p className="mt-0.5 truncate text-2xs text-slate-400 dark:text-white/35">
+                  {t("model_plaza.no_owner")}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="inline-flex shrink-0 items-center justify-center rounded-md p-1.5 text-slate-400 opacity-100 transition hover:bg-slate-100 hover:text-slate-700 sm:opacity-0 sm:group-hover:opacity-100 dark:hover:bg-neutral-800 dark:hover:text-white"
+                title={t("model_plaza.copy_id")}
+                aria-label={t("model_plaza.copy_id")}
+              >
+                {copied ? <Check size={14} className="text-emerald-500" /> : <Copy size={14} />}
+              </button>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
 
 export function ModelsTabContent({
   models,
@@ -26,124 +91,119 @@ export function ModelsTabContent({
   onSearchChange: (value: string) => void;
 }) {
   const { t } = useTranslation();
-  const [selectedModelVendor, setSelectedModelVendor] = useState<"all" | ModelVendorKey>("all");
+  const { notify } = useToast();
+  const [selectedVendor, setSelectedVendor] = useState<VendorFilter>("all");
+
+  const vendorStats = useMemo(
+    () => buildModelVendorStats(models, t("common.other")),
+    [models, t],
+  );
 
   const filteredModels = useMemo(() => {
     const needle = searchFilter.trim().toLowerCase();
     return models.filter((id) => {
-      if (selectedModelVendor !== "all" && getModelVendorKey(id) !== selectedModelVendor) {
+      if (selectedVendor !== "all" && getModelVendorKey(id) !== selectedVendor) {
         return false;
       }
       return !needle || id.toLowerCase().includes(needle);
     });
-  }, [models, searchFilter, selectedModelVendor]);
+  }, [models, searchFilter, selectedVendor]);
 
-  const vendorStats = useMemo(() => {
-    return buildModelVendorStats(models, t("common.other"));
-  }, [models, t]);
-  const isModelFilterActive = Boolean(searchFilter.trim()) || selectedModelVendor !== "all";
+  const handleCopied = useCallback(() => {
+    notify({ type: "success", message: t("model_plaza.copied"), duration: 1200 });
+  }, [notify, t]);
+
+  const isFilterActive = Boolean(searchFilter.trim()) || selectedVendor !== "all";
 
   return (
-    <Card padding="none" className="overflow-hidden">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-5 py-3.5 dark:border-neutral-800">
+    <div className="flex min-w-0 flex-col" data-testid="apikey-lookup-models-scroll-area">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
         <div className="flex items-center gap-2.5">
-          <Layers size={15} className="text-slate-500 dark:text-white/40" />
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-            {t("apikey_lookup.available_models")}
-          </h3>
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+            <Store size={16} className="text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
+              {t("model_plaza.title")}
+            </h3>
+            <p className="hidden text-xs text-slate-500 dark:text-white/45 sm:block">
+              {t("model_plaza.subtitle")}
+            </p>
+          </div>
           <span className="rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-bold tabular-nums text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-300">
             {filteredModels.length}
           </span>
-          {isModelFilterActive && filteredModels.length !== models.length ? (
+          {isFilterActive && filteredModels.length !== models.length ? (
             <span className="text-2xs text-slate-400 dark:text-white/30">/ {models.length}</span>
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <TextInput
-            value={searchFilter}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder={t("models_page.search")}
-            className="!w-48"
-            startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
-          />
-        </div>
+        <TextInput
+          value={searchFilter}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={t("model_plaza.search")}
+          className="!w-40 sm:!w-56"
+          startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
+        />
       </div>
 
-      {vendorStats.length > 0 ? (
-        <div
-          className="flex flex-wrap items-center gap-2 border-b border-slate-100 px-5 py-2.5 dark:border-neutral-800/60"
-          aria-label={t("apikey_lookup.available_models")}
-        >
-          <button
-            type="button"
-            aria-label={`${t("common.all", { defaultValue: "All" })} ${models.length}`}
-            aria-pressed={selectedModelVendor === "all"}
-            onClick={() => setSelectedModelVendor("all")}
-            className={[
-              "inline-flex items-center gap-1.5 rounded-md border border-slate-200/70 bg-white px-2 py-0.5 text-2xs font-semibold text-slate-600 transition hover:shadow-sm dark:border-neutral-700/60 dark:bg-neutral-900 dark:text-white/70",
-              selectedModelVendor === "all"
-                ? "ring-2 ring-indigo-500/35 ring-offset-1 ring-offset-white dark:ring-indigo-300/40 dark:ring-offset-neutral-950"
-                : "",
-            ]
-              .filter(Boolean)
-              .join(" ")}
+      {vendorStats.length > 0 && !loading ? (
+        <div className="sticky top-0 z-20 py-2.5">
+          <Tabs
+            value={selectedVendor}
+            onValueChange={(next) => setSelectedVendor(next as VendorFilter)}
+            size="sm"
           >
-            <Layers size={12} aria-hidden="true" />
-            {t("common.all", { defaultValue: "All" })}
-            <span className="tabular-nums">{models.length}</span>
-          </button>
-          {vendorStats.map((stat) => (
-            <ModelVendorStatBadge
-              key={stat.key}
-              vendorKey={stat.key}
-              label={stat.label}
-              count={stat.count}
-              active={selectedModelVendor === stat.key}
-              onClick={() => setSelectedModelVendor(stat.key)}
-            />
-          ))}
+            <TabsList aria-label={t("model_plaza.vendor_tabs")} className="max-w-full">
+              <TabsTrigger value="all">
+                <Layers size={12} aria-hidden="true" />
+                {t("common.all", { defaultValue: "All" })}
+                <span className="tabular-nums text-slate-400 dark:text-white/40">{models.length}</span>
+              </TabsTrigger>
+              {vendorStats.map((stat) => (
+                <TabsTrigger key={stat.key} value={stat.key}>
+                  <VendorIcon modelId={stat.key} size={12} />
+                  {stat.label}
+                  <span className="tabular-nums text-slate-400 dark:text-white/40">{stat.count}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
         </div>
       ) : null}
 
-      {error ? (
-        <div className="border-b border-rose-100 bg-rose-50 px-5 py-2.5 text-sm text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">
-          {error}
-        </div>
-      ) : null}
+      <div className="mt-4 flex min-w-0 flex-col gap-4">
+        {error ? (
+          <div className="rounded-xl border border-rose-100 bg-rose-50 px-4 py-2.5 text-sm text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-200">
+            {error}
+          </div>
+        ) : null}
 
-      <ScrollArea
-        className="[&_[data-scroll-area-scrollbar='y']]:right-1"
-        viewportClassName="max-h-[480px]"
-        contentClassName="px-5 py-4 pr-8"
-        scrollbarVisibility="track-hover"
-        scrollbarTrackInset={4}
-        data-testid="apikey-lookup-models-scroll-area"
-      >
         {loading && models.length === 0 ? (
-          <div className="flex items-center justify-center py-12 text-sm text-slate-500 dark:text-white/50">
+          <div className="flex items-center justify-center py-16 text-sm text-slate-500 dark:text-white/50">
             <RefreshCw size={14} className="mr-2 animate-spin" />
-            {t("models_page.loading")}
+            {t("model_plaza.loading")}
           </div>
         ) : filteredModels.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
+          <div
+            className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+            data-testid="apikey-lookup-model-grid"
+          >
             {filteredModels.map((id) => (
-              <CopyableModelTag
-                key={id}
-                id={id}
-                title={t("apikey_lookup.copy_model")}
-                copiedLabel={t("common.copied")}
-              />
+              <ModelIdCard key={id} id={id} onCopied={handleCopied} />
             ))}
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center py-12 text-slate-400 dark:text-white/30">
-            <Layers size={28} className="mb-2 opacity-40" />
-            <p className="text-sm">
-              {models.length === 0 ? t("common.no_model_data") : t("models_page.no_results")}
-            </p>
-          </div>
+          <EmptyState
+            icon={<Store size={28} className="opacity-50" />}
+            title={models.length === 0 ? t("model_plaza.no_models") : t("model_plaza.no_match")}
+            description={
+              models.length === 0
+                ? t("model_plaza.no_models_desc")
+                : t("model_plaza.no_match_desc")
+            }
+          />
         )}
-      </ScrollArea>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
@@ -11,10 +11,10 @@ describe("ModelsTabContent", () => {
     vi.restoreAllMocks();
   });
 
-  test("filters available models by vendor and uses the shared scroll area", async () => {
+  test("filters available models by vendor tabs and shows plaza-style cards", async () => {
     await i18n.changeLanguage("en");
 
-    const { container } = render(
+    render(
       <ThemeProvider>
         <ToastProvider>
           <ModelsTabContent
@@ -28,22 +28,20 @@ describe("ModelsTabContent", () => {
       </ThemeProvider>,
     );
 
+    expect(screen.getByText("Model Plaza")).toBeInTheDocument();
+    expect(screen.getByTestId("apikey-lookup-model-grid")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.4")).toBeInTheDocument();
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search models/i)).toBeInTheDocument();
 
-    const viewport = container.querySelector(
-      '[data-testid="apikey-lookup-models-scroll-area"] [data-scroll-area-viewport]',
-    );
-    expect(viewport).toHaveAttribute("data-scrollbar-visibility", "track-hover");
-
-    await userEvent.click(screen.getByRole("button", { name: /^qwen 1$/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /qwen/i }));
 
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.queryByText("gpt-5.4")).not.toBeInTheDocument();
     expect(screen.queryByText("deepseek-chat")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /^All 3$/i }));
+    await userEvent.click(screen.getByRole("tab", { name: /all/i }));
 
     expect(screen.getByText("gpt-5.4")).toBeInTheDocument();
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Rename apikey-lookup「可用模型」tab to「模型广场」
- Match `/models/plaza` UI: card grid, search box, vendor Tabs
- Reuse `model_plaza.*` i18n for titles/empty/search

## Test plan
- [x] `bun run test:ci -- pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx` (12 passed)
- [ ] Manual: open `/manage/apikey-lookup` → 模型广场 tab → search + vendor tabs