### PR TITLE
fix(portal): localize apikey-lookup login errors

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Eye, EyeOff, Key, KeyRound, LogOut, UserRound } from "lucide-react";
-import { portalApi, type EndUser, type EndUserAPIKey } from "@code-proxy/api-client";
+import {
+  extractApiErrorCode,
+  isApiClientError,
+  portalApi,
+  type EndUser,
+  type EndUserAPIKey,
+} from "@code-proxy/api-client";
+import { resolveLoginErrorMessage } from "../login/loginErrors";
 import { useTheme } from "@code-proxy/ui";
 import { ThemeToggleButton } from "@code-proxy/ui";
 import { LanguageSelector } from "@code-proxy/ui";
@@ -849,11 +856,19 @@ export function ApiKeyLookupPage() {
         }
       }
     } catch (err) {
-      setLoginError(err instanceof Error ? err.message : "login failed");
+      setLoginError(
+        resolveLoginErrorMessage({
+          t,
+          code: isApiClientError(err) ? extractApiErrorCode(err.payload) : "",
+          status: isApiClientError(err) ? err.status : 0,
+          isTimeout: isApiClientError(err) ? err.isTimeout : false,
+          fallbackMessage: err instanceof Error ? err.message : "",
+        }),
+      );
     } finally {
       setLoginBusy(false);
     }
-  }, [activateOwnedKey, loginUsername, loginPassword]);
+  }, [activateOwnedKey, loginPassword, loginUsername, t]);
 
   const handleLogout = useCallback(() => {
     void portalApi.logout();
@@ -1429,10 +1444,28 @@ export function ApiKeyLookupPage() {
                       setChangePasswordOpen(false);
                     } catch (err) {
                       setPortalKeys([]);
-                      setPwdError(err instanceof Error ? err.message : "failed");
+                      setPwdError(
+                        resolveLoginErrorMessage({
+                          t,
+                          code: isApiClientError(err) ? extractApiErrorCode(err.payload) : "",
+                          status: isApiClientError(err) ? err.status : 0,
+                          isTimeout: isApiClientError(err) ? err.isTimeout : false,
+                          fallbackMessage: err instanceof Error ? err.message : "",
+                        }),
+                      );
                     }
                   })
-                  .catch((err) => setPwdError(err instanceof Error ? err.message : "failed"))
+                  .catch((err) =>
+                    setPwdError(
+                      resolveLoginErrorMessage({
+                        t,
+                        code: isApiClientError(err) ? extractApiErrorCode(err.payload) : "",
+                        status: isApiClientError(err) ? err.status : 0,
+                        isTimeout: isApiClientError(err) ? err.isTimeout : false,
+                        fallbackMessage: err instanceof Error ? err.message : "",
+                      }),
+                    ),
+                  )
                   .finally(() => setPortalKeysBusy(false));
               }}
             >

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -179,6 +179,37 @@ describe("ApiKeyLookupPage", () => {
     });
   });
 
+  test("localizes invalid credentials on portal login failure", async () => {
+    const { portalApi, ApiClientError } = await import("@code-proxy/api-client");
+    vi.mocked(portalApi.login).mockRejectedValue(
+      new ApiClientError({
+        message: "invalid credentials",
+        status: 401,
+        data: { error: { code: "invalid_credentials", message: "invalid credentials" } },
+      }),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    await userEvent.type(screen.getByPlaceholderText(/enter username|请输入账号/i), "alice");
+    await userEvent.type(screen.getByPlaceholderText(/enter password|请输入密码/i), "bad-pass");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: /^(login|sign in|登录)$/i }),
+    );
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(/incorrect username or password|用户名或密码错误/i)).toBeInTheDocument();
+    });
+    expect(within(dialog).queryByText(/invalid credentials/i)).not.toBeInTheDocument();
+  });
+
   test("restores the last looked up API key after page refresh and shows its name", async () => {
     window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
 

--- a/pages/login/__tests__/loginErrors.test.ts
+++ b/pages/login/__tests__/loginErrors.test.ts
@@ -39,7 +39,12 @@ describe("resolveLoginErrorMessage", () => {
     expect(resolveLoginErrorMessage({ t, code: "login_rate_limited", status: 429 })).toBe(
       "尝试过多",
     );
+    expect(resolveLoginErrorMessage({ t, code: "login_cooldown", status: 429 })).toBe("尝试过多");
     expect(resolveLoginErrorMessage({ t, status: 429 })).toBe("尝试过多");
+  });
+
+  test("maps portal internal_error code", () => {
+    expect(resolveLoginErrorMessage({ t, code: "internal_error", status: 500 })).toBe("服务器错误");
   });
 
   test("falls back to status-based messages", () => {

--- a/pages/login/loginErrors.ts
+++ b/pages/login/loginErrors.ts
@@ -33,8 +33,10 @@ export function resolveLoginErrorMessage({
     case "tenant_suspended":
       return t("login.tenant_suspended");
     case "login_rate_limited":
+    case "login_cooldown":
       return t("login.error_rate_limited");
     case "identity_unavailable":
+    case "internal_error":
       return t("login.error_server");
     case "validation_failed":
       return t("login.error_required");


### PR DESCRIPTION
## Summary
- Portal apikey-lookup login/change-password now maps API error codes via `resolveLoginErrorMessage` (e.g. 中文「用户名或密码错误」instead of raw `invalid credentials`).
- Extend code map for portal `login_cooldown` / `internal_error`.
- Add regression test for localized invalid credentials on the login modal.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e critical)
- [x] `bun run --filter @code-proxy/admin-panel test -- pages/login/__tests__/loginErrors.test.ts pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx`
- [ ] Manual: open `/manage/apikey-lookup`, switch UI to 中文, wrong password → expect「用户名或密码错误」