### PR TITLE
feat(apikey-lookup): model plaza cards with pricing metadata

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -21,6 +21,7 @@ import {
   fetchPublicLogContent,
   fetchPublicLogs,
   fetchPublicUsageSummary,
+  type PublicModelItem,
 } from "./api";
 import { LookupEmptyState } from "./components/LookupEmptyState";
 import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
@@ -55,7 +56,8 @@ const LOOKUP_LAST_API_KEY_STORAGE_KEY = "apiKeyLookup.lastApiKey.v1";
 /** Tenant-scoped chart cache (v2). Legacy v1 migrates into the default tenant only. */
 const LOOKUP_CHART_CACHE_STORAGE_KEY = "apiKeyLookup.chartCache.v2";
 const LOOKUP_CHART_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.chartCache.v1";
-const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v2";
+const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v3";
+const LOOKUP_MODELS_CACHE_STORAGE_KEY_V2 = "apiKeyLookup.modelsCache.v2";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.modelsCache.v1";
 const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
 const CHANGE_PASSWORD_SELECT_VALUE = "__api-key-lookup-change-password__";
@@ -132,24 +134,55 @@ const clearStoredChartCache = (): void => {
   }
 };
 
-const isStringArray = (value: unknown): value is string[] =>
-  Array.isArray(value) && value.every((item) => typeof item === "string");
+const isPublicModelItem = (value: unknown): value is PublicModelItem => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const item = value as PublicModelItem;
+  return (
+    typeof item.id === "string" &&
+    typeof item.description === "string" &&
+    typeof item.ownedBy === "string" &&
+    Boolean(item.pricing) &&
+    typeof item.pricing === "object" &&
+    Array.isArray(item.inputModalities) &&
+    Array.isArray(item.outputModalities) &&
+    typeof item.supportsVision === "boolean"
+  );
+};
 
-const sameStringArray = (left: string[], right: string[]): boolean =>
-  left.length === right.length && left.every((value, index) => value === right[index]);
+const isPublicModelArray = (value: unknown): value is PublicModelItem[] =>
+  Array.isArray(value) && value.every(isPublicModelItem);
 
-const readStoredModelsCache = (cacheKey: string): string[] | null => {
+const samePublicModelArray = (left: PublicModelItem[], right: PublicModelItem[]): boolean => {
+  if (left.length !== right.length) return false;
+  return left.every((item, index) => {
+    const other = right[index];
+    return (
+      item.id === other.id &&
+      item.description === other.description &&
+      item.ownedBy === other.ownedBy &&
+      item.supportsVision === other.supportsVision &&
+      item.pricing.mode === other.pricing.mode &&
+      item.pricing.inputPricePerMillion === other.pricing.inputPricePerMillion &&
+      item.pricing.outputPricePerMillion === other.pricing.outputPricePerMillion &&
+      item.pricing.cachedPricePerMillion === other.pricing.cachedPricePerMillion &&
+      item.pricing.cacheReadPricePerMillion === other.pricing.cacheReadPricePerMillion &&
+      item.pricing.cacheWritePricePerMillion === other.pricing.cacheWritePricePerMillion &&
+      item.pricing.pricePerCall === other.pricing.pricePerCall
+    );
+  });
+};
+
+const readStoredModelsCache = (cacheKey: string): PublicModelItem[] | null => {
   return readTenantBucketMapEntry({
     key: LOOKUP_MODELS_CACHE_STORAGE_KEY,
     kind: "session",
     tenantId: getActiveCacheTenantId(),
     entryKey: cacheKey,
-    legacyKey: LOOKUP_MODELS_CACHE_STORAGE_KEY_V1,
-    isEntry: isStringArray,
+    isEntry: isPublicModelArray,
   });
 };
 
-const writeStoredModelsCache = (cacheKey: string, models: string[]): void => {
+const writeStoredModelsCache = (cacheKey: string, models: PublicModelItem[]): void => {
   updateTenantBucketMapEntry({
     key: LOOKUP_MODELS_CACHE_STORAGE_KEY,
     kind: "session",
@@ -157,8 +190,7 @@ const writeStoredModelsCache = (cacheKey: string, models: string[]): void => {
     entryKey: cacheKey,
     entryValue: models,
     maxEntries: 8,
-    legacyKey: LOOKUP_MODELS_CACHE_STORAGE_KEY_V1,
-    legacyKeysToRemove: [LOOKUP_MODELS_CACHE_STORAGE_KEY_V1],
+    legacyKeysToRemove: [LOOKUP_MODELS_CACHE_STORAGE_KEY_V2, LOOKUP_MODELS_CACHE_STORAGE_KEY_V1],
   });
 };
 
@@ -339,11 +371,11 @@ export function ApiKeyLookupPage() {
   const summaryFetchIdRef = useRef(0);
 
   // ── Models state ──
-  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [availableModels, setAvailableModels] = useState<PublicModelItem[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
   const [modelsSearchFilter, setModelsSearchFilter] = useState("");
-  const modelsCacheRef = useRef<Record<string, string[]>>({});
+  const modelsCacheRef = useRef<Record<string, PublicModelItem[]>>({});
 
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
@@ -662,16 +694,16 @@ export function ApiKeyLookupPage() {
         : modelsCacheRef.current[trimmedKey] || readStoredModelsCache(trimmedKey);
       if (cached) {
         modelsCacheRef.current[trimmedKey] = cached;
-        setAvailableModels((prev) => (sameStringArray(prev, cached) ? prev : cached));
+        setAvailableModels((prev) => (samePublicModelArray(prev, cached) ? prev : cached));
       }
 
       setModelsLoading(true);
       setModelsError(null);
       try {
-        const ids = await fetchAvailableModels(trimmedKey);
-        modelsCacheRef.current[trimmedKey] = ids;
-        writeStoredModelsCache(trimmedKey, ids);
-        setAvailableModels((prev) => (sameStringArray(prev, ids) ? prev : ids));
+        const models = await fetchAvailableModels(trimmedKey);
+        modelsCacheRef.current[trimmedKey] = models;
+        writeStoredModelsCache(trimmedKey, models);
+        setAvailableModels((prev) => (samePublicModelArray(prev, models) ? prev : models));
       } catch (err: unknown) {
         if (!cached) {
           setModelsError(localizeLookupError(t, err, "apikey_lookup.load_models_failed"));

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -39,7 +39,25 @@ const mocks = vi.hoisted(() => ({
       },
     }),
   ),
-  fetchAvailableModels: vi.fn(async (): Promise<string[]> => []),
+  fetchAvailableModels: vi.fn(async (): Promise<
+    Array<{
+      id: string;
+      description: string;
+      ownedBy: string;
+      pricing: {
+        mode: "token" | "call";
+        inputPricePerMillion: number;
+        outputPricePerMillion: number;
+        cachedPricePerMillion: number;
+        cacheReadPricePerMillion: number;
+        cacheWritePricePerMillion: number;
+        pricePerCall: number;
+      };
+      inputModalities: string[];
+      outputModalities: string[];
+      supportsVision: boolean;
+    }>
+  > => []),
   fetchPublicUsageSummary: vi.fn(async () => ({
     found: true,
     range: "today",
@@ -347,9 +365,26 @@ describe("ApiKeyLookupPage", () => {
 
   test("keeps cached models visible while refreshing the available models tab", async () => {
     window.sessionStorage.setItem("apiKeyLookup.lastApiKey.v1", "sk-restored-key");
-    let resolveModelsRefresh: (value: string[]) => void = () => {};
+    const asModel = (id: string) => ({
+      id,
+      description: "",
+      ownedBy: "",
+      pricing: {
+        mode: "token" as const,
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        cachedPricePerMillion: 0,
+        cacheReadPricePerMillion: 0,
+        cacheWritePricePerMillion: 0,
+        pricePerCall: 0,
+      },
+      inputModalities: ["text"],
+      outputModalities: ["text"],
+      supportsVision: false,
+    });
+    let resolveModelsRefresh: (value: ReturnType<typeof asModel>[]) => void = () => {};
     mocks.fetchAvailableModels
-      .mockResolvedValueOnce(["gpt-5.3-codex", "claude-sonnet-4-5"])
+      .mockResolvedValueOnce([asModel("gpt-5.3-codex"), asModel("claude-sonnet-4-5")])
       .mockReturnValueOnce(
         new Promise((resolve) => {
           resolveModelsRefresh = resolve;
@@ -375,7 +410,11 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.getByText("gpt-5.3-codex")).toBeInTheDocument();
     expect(mocks.fetchAvailableModels).toHaveBeenCalledTimes(2);
 
-    resolveModelsRefresh(["gpt-5.3-codex", "claude-sonnet-4-5", "deepseek-v4"]);
+    resolveModelsRefresh([
+      asModel("gpt-5.3-codex"),
+      asModel("claude-sonnet-4-5"),
+      asModel("deepseek-v4"),
+    ]);
     expect(await screen.findByText("deepseek-v4")).toBeInTheDocument();
   });
 

--- a/pages/api-key-lookup/__tests__/api.test.ts
+++ b/pages/api-key-lookup/__tests__/api.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { normalizePublicModelItem } from "../api";
+
+describe("normalizePublicModelItem", () => {
+  test("maps description and pricing fields from /v1/models payload", () => {
+    const model = normalizePublicModelItem({
+      id: "gpt-5.4",
+      owned_by: "openai",
+      description: "OpenAI flagship",
+      input_modalities: ["text", "image"],
+      output_modalities: ["text"],
+      supports_vision: true,
+      pricing: {
+        mode: "token",
+        input_price_per_million: 2.5,
+        output_price_per_million: 10,
+        cached_price_per_million: 0.25,
+        cache_read_price_per_million: 0.25,
+        cache_write_price_per_million: 1.25,
+      },
+    });
+
+    expect(model).toEqual({
+      id: "gpt-5.4",
+      description: "OpenAI flagship",
+      ownedBy: "openai",
+      pricing: {
+        mode: "token",
+        inputPricePerMillion: 2.5,
+        outputPricePerMillion: 10,
+        cachedPricePerMillion: 0.25,
+        cacheReadPricePerMillion: 0.25,
+        cacheWritePricePerMillion: 1.25,
+        pricePerCall: 0,
+      },
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportsVision: true,
+    });
+  });
+
+  test("falls back to empty pricing when payload only has id", () => {
+    const model = normalizePublicModelItem({ id: "gpt-5.4" });
+    expect(model?.id).toBe("gpt-5.4");
+    expect(model?.description).toBe("");
+    expect(model?.pricing.inputPricePerMillion).toBe(0);
+  });
+});

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -41,8 +41,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const extractModelItems = (payload: V1ModelsResponse): unknown[] => {
   if (Array.isArray(payload)) return payload;
-  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
-  if (isRecord(payload) && Array.isArray(payload.models)) return payload.models;
+  if (!isRecord(payload)) return [];
+  if (Array.isArray(payload.data)) return payload.data as unknown[];
+  if (Array.isArray(payload.models)) return payload.models as unknown[];
   return [];
 };
 

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -30,20 +30,14 @@ export type PublicModelItem = {
   supportsVision: boolean;
 };
 
-type V1ModelsResponse =
-  | { data?: unknown[] }
-  | { models?: unknown[] }
-  | unknown[]
-  | Record<string, unknown>;
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
-const extractModelItems = (payload: V1ModelsResponse): unknown[] => {
+const extractModelItems = (payload: unknown): unknown[] => {
   if (Array.isArray(payload)) return payload;
   if (!isRecord(payload)) return [];
-  if (Array.isArray(payload.data)) return payload.data as unknown[];
-  if (Array.isArray(payload.models)) return payload.models as unknown[];
+  if (Array.isArray(payload.data)) return payload.data;
+  if (Array.isArray(payload.models)) return payload.models;
   return [];
 };
 
@@ -76,7 +70,7 @@ export const normalizePublicModelItem = (item: unknown): PublicModelItem | null 
   };
 };
 
-const extractModels = (payload: V1ModelsResponse): PublicModelItem[] => {
+const extractModels = (payload: unknown): PublicModelItem[] => {
   const byId = new Map<string, PublicModelItem>();
   for (const item of extractModelItems(payload)) {
     const model = normalizePublicModelItem(item);
@@ -173,6 +167,5 @@ export async function fetchAvailableModels(apiKey: string): Promise<PublicModelI
     const text = await resp.text().catch(() => "");
     throw new Error(text || `Request failed (${resp.status})`);
   }
-  const payload = (await resp.json()) as V1ModelsResponse;
-  return extractModels(payload);
+  return extractModels(await resp.json());
 }

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -2,6 +2,12 @@ import {
   detectApiBaseFromLocation,
   publicApiClient,
 } from "@code-proxy/api-client";
+import {
+  emptyModelPricing,
+  normalizeModelModalities,
+  normalizeModelPricing,
+  type ModelPricing,
+} from "@features/model-availability";
 import type {
   ChartDataResponse,
   PublicLogsResponse,
@@ -14,32 +20,69 @@ type PublicLogContentResponse =
   | { id: number; model: string; part: LogContentBodyPart; content: string }
   | { input_content: string; output_content: string; model: string };
 
+export type PublicModelItem = {
+  id: string;
+  description: string;
+  ownedBy: string;
+  pricing: ModelPricing;
+  inputModalities: string[];
+  outputModalities: string[];
+  supportsVision: boolean;
+};
+
 type V1ModelsResponse =
-  | { data?: Array<{ id?: string }> }
-  | { models?: Array<{ id?: string }> }
-  | Array<{ id?: string }>
+  | { data?: unknown[] }
+  | { models?: unknown[] }
+  | unknown[]
   | Record<string, unknown>;
 
-const extractModelIds = (payload: V1ModelsResponse): string[] => {
-  const data = Array.isArray(payload)
-    ? payload
-    : Array.isArray((payload as { data?: unknown }).data)
-      ? ((payload as { data: unknown[] }).data as Array<{ id?: string }>)
-      : Array.isArray((payload as { models?: unknown }).models)
-        ? ((payload as { models: unknown[] }).models as Array<{ id?: string }>)
-        : [];
-  return Array.from(
-    new Set(
-      data
-        .map((item) =>
-          item && typeof item === "object"
-            ? String((item as { id?: unknown }).id)
-            : "",
-        )
-        .map((value) => value.trim())
-        .filter(Boolean),
-    ),
-  ).sort((a, b) => a.localeCompare(b));
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const extractModelItems = (payload: V1ModelsResponse): unknown[] => {
+  if (Array.isArray(payload)) return payload;
+  if (isRecord(payload) && Array.isArray(payload.data)) return payload.data;
+  if (isRecord(payload) && Array.isArray(payload.models)) return payload.models;
+  return [];
+};
+
+export const normalizePublicModelItem = (item: unknown): PublicModelItem | null => {
+  if (!isRecord(item)) return null;
+  const id = String(item.id ?? item.model_id ?? item.name ?? "").trim();
+  if (!id) return null;
+  const inputModalities = normalizeModelModalities(
+    item.input_modalities ?? item.inputModalities,
+  );
+  const outputModalities = normalizeModelModalities(
+    item.output_modalities ?? item.outputModalities,
+  );
+  const explicitVision = item.supports_vision ?? item.supportsVision;
+  const supportsVision =
+    typeof explicitVision === "boolean"
+      ? explicitVision
+      : inputModalities.some((m) => m.toLowerCase() === "image");
+
+  return {
+    id,
+    description: String(item.description ?? "").trim(),
+    ownedBy: String(item.owned_by ?? item.ownedBy ?? "").trim(),
+    pricing: isRecord(item.pricing)
+      ? normalizeModelPricing(item)
+      : emptyModelPricing(),
+    inputModalities,
+    outputModalities,
+    supportsVision,
+  };
+};
+
+const extractModels = (payload: V1ModelsResponse): PublicModelItem[] => {
+  const byId = new Map<string, PublicModelItem>();
+  for (const item of extractModelItems(payload)) {
+    const model = normalizePublicModelItem(item);
+    if (!model) continue;
+    byId.set(model.id.toLowerCase(), model);
+  }
+  return Array.from(byId.values()).sort((a, b) => a.id.localeCompare(b.id));
 };
 
 export async function fetchPublicLogs(params: {
@@ -120,7 +163,7 @@ export async function fetchPublicLogContent(params: {
   );
 }
 
-export async function fetchAvailableModels(apiKey: string): Promise<string[]> {
+export async function fetchAvailableModels(apiKey: string): Promise<PublicModelItem[]> {
   const base = detectApiBaseFromLocation();
   const resp = await fetch(`${base}/v1/models`, {
     headers: { Authorization: `Bearer ${apiKey.trim()}` },
@@ -130,5 +173,5 @@ export async function fetchAvailableModels(apiKey: string): Promise<string[]> {
     throw new Error(text || `Request failed (${resp.status})`);
   }
   const payload = (await resp.json()) as V1ModelsResponse;
-  return extractModelIds(payload);
+  return extractModels(payload);
 }

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -12,30 +12,119 @@ import {
   useToast,
 } from "@code-proxy/ui";
 import {
+  formatModelPriceAmount,
+  hasModelPricing,
+} from "@features/model-availability";
+import {
   buildModelVendorStats,
   getModelVendorKey,
   type ModelVendorKey,
 } from "@features/model-tags";
+import { ModelCapabilityBadges } from "../../models/components/ModelCapabilityBadges";
+import type { PublicModelItem } from "../api";
 
 type VendorFilter = "all" | ModelVendorKey;
 
-function ModelIdCard({ id, onCopied }: { id: string; onCopied: () => void }) {
+function PriceChip({
+  label,
+  value,
+  muted = false,
+}: {
+  label: string;
+  value: string;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className={[
+        "min-w-0 rounded-lg border px-2 py-1.5",
+        muted
+          ? "border-slate-100 bg-slate-50/70 dark:border-neutral-800 dark:bg-neutral-900/40"
+          : "border-slate-200/80 bg-white dark:border-neutral-700/70 dark:bg-neutral-950/50",
+      ].join(" ")}
+    >
+      <div className="text-2xs font-medium uppercase tracking-wide text-slate-400 dark:text-white/35">
+        {label}
+      </div>
+      <div
+        className={[
+          "mt-0.5 truncate font-mono text-xs font-semibold tabular-nums",
+          muted ? "text-slate-400 dark:text-white/35" : "text-slate-800 dark:text-white/90",
+        ].join(" ")}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function formatPriceCell(amount: number, notPriced: string): string {
+  if (!Number.isFinite(amount) || amount <= 0) return notPriced;
+  return `$${formatModelPriceAmount(amount)}`;
+}
+
+function ModelPlazaCard({
+  model,
+  onCopied,
+}: {
+  model: PublicModelItem;
+  onCopied: () => void;
+}) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
-  const vendorGlyph = id.trim().charAt(0).toUpperCase() || "M";
+  const priced = hasModelPricing(model.pricing);
+  const notPriced = t("model_plaza.not_priced");
+  const vendorGlyph = model.id.trim().charAt(0).toUpperCase() || "M";
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(id);
+    void navigator.clipboard.writeText(model.id);
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1500);
     onCopied();
   };
 
+  const priceGrid =
+    model.pricing.mode === "call" ? (
+      <div className="grid grid-cols-1 gap-1.5">
+        <PriceChip
+          label={t("model_plaza.price_per_call")}
+          value={formatPriceCell(model.pricing.pricePerCall, notPriced)}
+          muted={model.pricing.pricePerCall <= 0}
+        />
+      </div>
+    ) : (
+      <div className="grid grid-cols-3 gap-1.5">
+        <PriceChip
+          label={t("model_plaza.input_price")}
+          value={formatPriceCell(model.pricing.inputPricePerMillion, notPriced)}
+          muted={model.pricing.inputPricePerMillion <= 0}
+        />
+        <PriceChip
+          label={t("model_plaza.output_price")}
+          value={formatPriceCell(model.pricing.outputPricePerMillion, notPriced)}
+          muted={model.pricing.outputPricePerMillion <= 0}
+        />
+        <PriceChip
+          label={t("model_plaza.cache_price")}
+          value={formatPriceCell(
+            model.pricing.cacheReadPricePerMillion > 0
+              ? model.pricing.cacheReadPricePerMillion
+              : model.pricing.cachedPricePerMillion,
+            notPriced,
+          )}
+          muted={
+            model.pricing.cacheReadPricePerMillion <= 0 &&
+            model.pricing.cachedPricePerMillion <= 0
+          }
+        />
+      </div>
+    );
+
   return (
-    <div data-testid="apikey-lookup-model-card" className="h-full min-h-[120px]">
+    <div data-testid="apikey-lookup-model-card" className="h-full min-h-[220px]">
       <Card
         padding="compact"
-        bodyClassName="mt-0 flex h-full min-h-[96px] flex-col"
+        bodyClassName="mt-0 flex h-full min-h-[196px] flex-col"
         className="group h-full transition hover:border-indigo-200/70 hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.06)] dark:hover:border-indigo-500/25 dark:hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.28)]"
       >
         <div className="flex items-start gap-3">
@@ -44,7 +133,7 @@ function ModelIdCard({ id, onCopied }: { id: string; onCopied: () => void }) {
               {vendorGlyph}
             </span>
             <span className="relative z-10 flex items-center justify-center [&:empty]:hidden">
-              <VendorIcon modelId={id} size={22} />
+              <VendorIcon modelId={model.id} size={22} />
             </span>
           </div>
           <div className="min-w-0 flex-1">
@@ -52,12 +141,12 @@ function ModelIdCard({ id, onCopied }: { id: string; onCopied: () => void }) {
               <div className="min-w-0 flex-1">
                 <h3
                   className="truncate font-mono text-sm font-semibold text-slate-900 dark:text-white"
-                  title={id}
+                  title={model.id}
                 >
-                  {id}
+                  {model.id}
                 </h3>
                 <p className="mt-0.5 truncate text-2xs text-slate-400 dark:text-white/35">
-                  {t("model_plaza.no_owner")}
+                  {model.ownedBy || t("model_plaza.no_owner")}
                 </p>
               </div>
               <button
@@ -70,7 +159,43 @@ function ModelIdCard({ id, onCopied }: { id: string; onCopied: () => void }) {
                 {copied ? <Check size={14} className="text-emerald-500" /> : <Copy size={14} />}
               </button>
             </div>
+            <div className="mt-1.5">
+              <ModelCapabilityBadges
+                model={{
+                  id: model.id,
+                  inputModalities: model.inputModalities,
+                  outputModalities: model.outputModalities,
+                  supportsVision: model.supportsVision,
+                }}
+                size="sm"
+                showUnknown={false}
+              />
+            </div>
           </div>
+        </div>
+
+        <p className="mt-3 line-clamp-2 min-h-10 flex-1 text-xs leading-5 text-slate-500 dark:text-white/55">
+          {model.description?.trim()
+            ? model.description
+            : t("model_plaza.no_description")}
+        </p>
+
+        <div className="mt-auto pt-2">
+          <div className="mb-1.5 flex items-center justify-between gap-2">
+            <span className="text-2xs font-semibold uppercase tracking-wide text-slate-400 dark:text-white/35">
+              {t("model_plaza.pricing")}
+            </span>
+            {!priced ? (
+              <span className="text-2xs text-slate-400 dark:text-white/30">
+                {t("model_plaza.not_priced")}
+              </span>
+            ) : model.pricing.mode === "token" ? (
+              <span className="text-2xs text-slate-400 dark:text-white/30">
+                {t("model_plaza.per_million")}
+              </span>
+            ) : null}
+          </div>
+          {priceGrid}
         </div>
       </Card>
     </div>
@@ -84,7 +209,7 @@ export function ModelsTabContent({
   searchFilter,
   onSearchChange,
 }: {
-  models: string[];
+  models: PublicModelItem[];
   loading: boolean;
   error: string | null;
   searchFilter: string;
@@ -94,18 +219,25 @@ export function ModelsTabContent({
   const { notify } = useToast();
   const [selectedVendor, setSelectedVendor] = useState<VendorFilter>("all");
 
+  const modelIds = useMemo(() => models.map((model) => model.id), [models]);
+
   const vendorStats = useMemo(
-    () => buildModelVendorStats(models, t("common.other")),
-    [models, t],
+    () => buildModelVendorStats(modelIds, t("common.other")),
+    [modelIds, t],
   );
 
   const filteredModels = useMemo(() => {
     const needle = searchFilter.trim().toLowerCase();
-    return models.filter((id) => {
-      if (selectedVendor !== "all" && getModelVendorKey(id) !== selectedVendor) {
+    return models.filter((model) => {
+      if (selectedVendor !== "all" && getModelVendorKey(model.id) !== selectedVendor) {
         return false;
       }
-      return !needle || id.toLowerCase().includes(needle);
+      if (!needle) return true;
+      return (
+        model.id.toLowerCase().includes(needle) ||
+        model.description.toLowerCase().includes(needle) ||
+        model.ownedBy.toLowerCase().includes(needle)
+      );
     });
   }, [models, searchFilter, selectedVendor]);
 
@@ -147,7 +279,8 @@ export function ModelsTabContent({
       </div>
 
       {vendorStats.length > 0 && !loading ? (
-        <div className="sticky top-0 z-20 py-2.5">
+        // 不要 sticky：父页顶栏 toolbar 已 sticky，二级厂商 tabs 再 sticky 会压住「快捷导入」。
+        <div className="py-2.5">
           <Tabs
             value={selectedVendor}
             onValueChange={(next) => setSelectedVendor(next as VendorFilter)}
@@ -188,8 +321,8 @@ export function ModelsTabContent({
             className="grid auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
             data-testid="apikey-lookup-model-grid"
           >
-            {filteredModels.map((id) => (
-              <ModelIdCard key={id} id={id} onCopied={handleCopied} />
+            {filteredModels.map((model) => (
+              <ModelPlazaCard key={model.id} model={model} onCopied={handleCopied} />
             ))}
           </div>
         ) : (

--- a/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
@@ -2,23 +2,51 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import i18n from "@code-proxy/i18n";
+import { emptyModelPricing } from "@features/model-availability";
 import { ModelsTabContent } from "../ModelsTabContent";
 import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
+import type { PublicModelItem } from "../../api";
+
+const model = (
+  id: string,
+  extras?: Partial<PublicModelItem>,
+): PublicModelItem => ({
+  id,
+  description: extras?.description ?? "",
+  ownedBy: extras?.ownedBy ?? "",
+  pricing: extras?.pricing ?? emptyModelPricing(),
+  inputModalities: extras?.inputModalities ?? ["text"],
+  outputModalities: extras?.outputModalities ?? ["text"],
+  supportsVision: extras?.supportsVision ?? false,
+});
 
 describe("ModelsTabContent", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test("filters available models by vendor tabs and shows plaza-style cards", async () => {
+  test("filters available models by vendor tabs and shows plaza-style cards with pricing", async () => {
     await i18n.changeLanguage("en");
 
     render(
       <ThemeProvider>
         <ToastProvider>
           <ModelsTabContent
-            models={["gpt-5.4", "qwen3.5-plus", "deepseek-chat"]}
+            models={[
+              model("gpt-5.4", {
+                description: "OpenAI flagship",
+                ownedBy: "openai",
+                pricing: {
+                  ...emptyModelPricing(),
+                  inputPricePerMillion: 2.5,
+                  outputPricePerMillion: 10,
+                  cacheReadPricePerMillion: 0.25,
+                },
+              }),
+              model("qwen3.5-plus", { description: "Qwen plus", ownedBy: "qwen" }),
+              model("deepseek-chat", { description: "DeepSeek chat", ownedBy: "deepseek" }),
+            ]}
             loading={false}
             error={null}
             searchFilter=""
@@ -31,6 +59,10 @@ describe("ModelsTabContent", () => {
     expect(screen.getByText("Model Plaza")).toBeInTheDocument();
     expect(screen.getByTestId("apikey-lookup-model-grid")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.4")).toBeInTheDocument();
+    expect(screen.getByText("OpenAI flagship")).toBeInTheDocument();
+    expect(screen.getByText("$2.5")).toBeInTheDocument();
+    expect(screen.getByText("$10")).toBeInTheDocument();
+    expect(screen.getByText("$0.25")).toBeInTheDocument();
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/search models/i)).toBeInTheDocument();
@@ -55,7 +87,11 @@ describe("ModelsTabContent", () => {
       <ThemeProvider>
         <ToastProvider>
           <ModelsTabContent
-            models={["claude-sonnet-4-5", "gpt-5.3-codex", "gemini-2.5-pro"]}
+            models={[
+              model("claude-sonnet-4-5"),
+              model("gpt-5.3-codex"),
+              model("gemini-2.5-pro"),
+            ]}
             loading={false}
             error={null}
             searchFilter=""


### PR DESCRIPTION
## Summary
- Parse description/owned_by/pricing/modalities from `/v1/models`
- Render plaza-style cards with input/output/cache prices
- Remove sticky vendor tabs so they no longer overlay the page tab bar (快捷导入)

## Depends on
CliRelay PR that enriches `/v1/models` with catalog metadata.

## Test plan
- [x] `bun run test:ci -- pages/api-key-lookup/...` (14 passed)
- [ ] Manual after backend deploy: cards show description + prices