### PR TITLE
fix(apikey-lookup): sticky manage-keys header with tabs

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1142,6 +1142,20 @@ export function ApiKeyLookupPage() {
               chartLoading={chartLoading}
               modelsLoading={modelsLoading}
               showKeysTab={Boolean(portalUser)}
+              keysHeader={
+                portalUser
+                  ? {
+                      loading: portalKeysLoading,
+                      busy: portalKeysBusy,
+                      onRefresh: () => void refreshPortalKeys(),
+                      onCreate: () => {
+                        setCreateKeyName("");
+                        setCreateKeyError(null);
+                        setCreateKeyOpen(true);
+                      },
+                    }
+                  : undefined
+              }
             />
 
             {activeTab === "usage" && queriedKey ? (
@@ -1170,14 +1184,7 @@ export function ApiKeyLookupPage() {
                 <ManageKeysTabContent
                   t={t}
                   keys={portalKeys}
-                  loading={portalKeysLoading}
                   busy={portalKeysBusy}
-                  onRefresh={() => void refreshPortalKeys()}
-                  onCreate={() => {
-                    setCreateKeyName("");
-                    setCreateKeyError(null);
-                    setCreateKeyOpen(true);
-                  }}
                   onViewUsage={(key) => openUsagePreview(key)}
                   onSetDefault={(key) => {
                     setPortalKeysBusy(true);

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { RefreshCw } from "lucide-react";
-import { HoverTooltip, Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
+import { Plus, RefreshCw } from "lucide-react";
+import { Button, HoverTooltip, Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { TimeRangeSelector } from "@features/monitor-widgets";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 
@@ -22,6 +22,7 @@ export function LookupResultsToolbar({
   chartLoading,
   modelsLoading,
   showKeysTab = false,
+  keysHeader,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   activeTab: ApiKeyLookupTab;
@@ -34,9 +35,17 @@ export function LookupResultsToolbar({
   modelsLoading: boolean;
   /** Portal login: show “管理 API Key” as the 2nd tab. */
   showKeysTab?: boolean;
+  /** keys tab：标题 + 刷新/新建 与 tabs 同吸顶，避免滚动后消失。 */
+  keysHeader?: {
+    loading?: boolean;
+    busy?: boolean;
+    onRefresh: () => void;
+    onCreate: () => void;
+  };
 }) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const [stuck, setStuck] = useState(false);
+  const showKeysHeader = activeTab === "keys" && keysHeader;
 
   // 不要再用短 relative 包裹 sticky：sticky 只能在「包含块」高度内钉住，
   // 外层高度≈自身时，一滚就会整段被带走，表现为「没吸顶、飘走」。
@@ -74,7 +83,7 @@ export function LookupResultsToolbar({
       data-testid="apikey-lookup-toolbar-sticky"
       data-stuck={stuck ? "true" : "false"}
       className={[
-        "sticky top-3 z-20 -mx-1 rounded-2xl px-1.5 py-1.5 backdrop-blur-md",
+        "sticky top-3 z-20 -mx-1 space-y-3 rounded-2xl px-1.5 py-1.5 backdrop-blur-md",
         "motion-safe:transition-[border-color,box-shadow,background-color] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
         stuck
           ? "border border-slate-200/80 bg-white/90 shadow-sm shadow-slate-900/5 dark:border-white/10 dark:bg-neutral-950/85 dark:shadow-black/25"
@@ -103,23 +112,58 @@ export function LookupResultsToolbar({
             <TimeRangeSelector value={timeRange} onChange={setTimeRange} />
           ) : null}
         </div>
-        <div className="flex items-center gap-2">
-          <HoverTooltip content={t("common.refresh")}>
-            <button
-              type="button"
-              onClick={handleRefresh}
-              disabled={loading || chartLoading || modelsLoading}
-              aria-label={t("common.refresh")}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
-            >
-              <RefreshCw
-                size={16}
-                className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
-              />
-            </button>
-          </HoverTooltip>
-        </div>
+        {!showKeysHeader ? (
+          <div className="flex items-center gap-2">
+            <HoverTooltip content={t("common.refresh")}>
+              <button
+                type="button"
+                onClick={handleRefresh}
+                disabled={loading || chartLoading || modelsLoading}
+                aria-label={t("common.refresh")}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
+              >
+                <RefreshCw
+                  size={16}
+                  className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
+                />
+              </button>
+            </HoverTooltip>
+          </div>
+        ) : null}
       </div>
+
+      {showKeysHeader ? (
+        <div
+          data-testid="apikey-lookup-keys-header-sticky"
+          className="flex flex-wrap items-start justify-between gap-3 px-0.5 pb-0.5"
+        >
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("apikey_lookup.manage_keys", { defaultValue: "管理 API Key" })}
+            </h3>
+            <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
+              {t("apikey_lookup.manage_keys_desc", {
+                defaultValue: "管理本账号下全部 API Key。查看用量以弹窗打开，不会离开当前页。",
+              })}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={keysHeader.onRefresh}
+              disabled={keysHeader.loading || keysHeader.busy}
+            >
+              <RefreshCw size={14} className={keysHeader.loading ? "animate-spin" : ""} />
+              {t("common.refresh")}
+            </Button>
+            <Button size="sm" variant="primary" onClick={keysHeader.onCreate} disabled={keysHeader.busy}>
+              <Plus size={14} />
+              {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
+            </Button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -1,14 +1,11 @@
-import { KeyRound, Plus, RefreshCw, Star, Trash2 } from "lucide-react";
+import { KeyRound, Star, Trash2 } from "lucide-react";
 import { Button } from "@code-proxy/ui";
 import type { EndUserAPIKey } from "@code-proxy/api-client";
 
 export function ManageKeysTabContent({
   t,
   keys,
-  loading,
   busy,
-  onRefresh,
-  onCreate,
   onViewUsage,
   onSetDefault,
   onRotate,
@@ -16,114 +13,83 @@ export function ManageKeysTabContent({
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   keys: EndUserAPIKey[];
-  loading?: boolean;
   busy?: boolean;
-  onRefresh: () => void;
-  onCreate: () => void;
   onViewUsage: (key: EndUserAPIKey) => void;
   onSetDefault: (key: EndUserAPIKey) => void;
   onRotate: (key: EndUserAPIKey) => void;
   onDelete: (key: EndUserAPIKey) => void;
 }) {
-  return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-            {t("apikey_lookup.manage_keys", { defaultValue: "管理 API Key" })}
-          </h3>
-          <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-            {t("apikey_lookup.manage_keys_desc", {
-              defaultValue: "管理本账号下全部 API Key。查看用量以弹窗打开，不会离开当前页。",
-            })}
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button size="sm" variant="secondary" onClick={onRefresh} disabled={loading || busy}>
-            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
-            {t("common.refresh")}
-          </Button>
-          <Button size="sm" variant="primary" onClick={onCreate} disabled={busy}>
-            <Plus size={14} />
-            {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
-          </Button>
-        </div>
+  if (keys.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-200 px-6 py-16 text-center dark:border-neutral-800">
+        <KeyRound size={28} className="mb-3 text-slate-400" />
+        <p className="text-sm text-slate-500 dark:text-white/55">
+          {t("apikey_lookup.no_keys", { defaultValue: "暂无 Key" })}
+        </p>
       </div>
+    );
+  }
 
-      {keys.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-200 px-6 py-16 text-center dark:border-neutral-800">
-          <KeyRound size={28} className="mb-3 text-slate-400" />
-          <p className="text-sm text-slate-500 dark:text-white/55">
-            {t("apikey_lookup.no_keys", { defaultValue: "暂无 Key" })}
-          </p>
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-2xl border border-slate-200/80 dark:border-white/10">
-          <div className="divide-y divide-slate-100 dark:divide-white/10">
-            {keys.map((k) => (
-              <div
-                key={k.id}
-                className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="truncate font-medium text-slate-900 dark:text-white">
-                      {k.name || k.id.slice(0, 8)}
-                    </span>
-                    {k.is_default ? (
-                      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300">
-                        <Star size={12} />
-                        {t("apikey_lookup.default_key", { defaultValue: "默认" })}
-                      </span>
-                    ) : null}
-                    {k.disabled ? (
-                      <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-white/10 dark:text-white/50">
-                        {t("common.disabled", { defaultValue: "已停用" })}
-                      </span>
-                    ) : null}
-                  </div>
-                  <code className="mt-1 block truncate text-xs text-slate-500 dark:text-white/45">
-                    {k.key_masked}
-                  </code>
-                </div>
-                <div className="flex shrink-0 flex-wrap gap-1.5">
-                  <Button size="sm" variant="secondary" disabled={busy} onClick={() => onViewUsage(k)}>
-                    {t("apikey_lookup.view_usage", { defaultValue: "查看用量" })}
-                  </Button>
-                  {!k.is_default ? (
-                    <Button size="sm" variant="ghost" disabled={busy} onClick={() => onSetDefault(k)}>
-                      {t("apikey_lookup.set_default", { defaultValue: "设默认" })}
-                    </Button>
-                  ) : null}
-                  <Button size="sm" variant="ghost" disabled={busy} onClick={() => onRotate(k)}>
-                    {t("apikey_lookup.rotate_key", { defaultValue: "重置" })}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={busy || keys.length <= 1}
-                    onClick={() => onDelete(k)}
-                    className="text-rose-600 hover:text-rose-700 dark:text-rose-300"
-                    title={
-                      keys.length <= 1
-                        ? t("apikey_lookup.keep_one_key", { defaultValue: "至少保留一把 Key" })
-                        : undefined
-                    }
-                  >
-                    <Trash2 size={14} />
-                    {t("common.delete", { defaultValue: "删除" })}
-                  </Button>
-                </div>
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-200/80 dark:border-white/10">
+      <div className="divide-y divide-slate-100 dark:divide-white/10">
+        {keys.map((k) => (
+          <div
+            key={k.id}
+            className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate font-medium text-slate-900 dark:text-white">
+                  {k.name || k.id.slice(0, 8)}
+                </span>
+                {k.is_default ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300">
+                    <Star size={12} />
+                    {t("apikey_lookup.default_key", { defaultValue: "默认" })}
+                  </span>
+                ) : null}
+                {k.disabled ? (
+                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-white/10 dark:text-white/50">
+                    {t("common.disabled", { defaultValue: "已停用" })}
+                  </span>
+                ) : null}
               </div>
-            ))}
+              <code className="mt-1 block truncate text-xs text-slate-500 dark:text-white/45">
+                {k.key_masked}
+              </code>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-1.5">
+              <Button size="sm" variant="secondary" disabled={busy} onClick={() => onViewUsage(k)}>
+                {t("apikey_lookup.view_usage", { defaultValue: "查看用量" })}
+              </Button>
+              {!k.is_default ? (
+                <Button size="sm" variant="ghost" disabled={busy} onClick={() => onSetDefault(k)}>
+                  {t("apikey_lookup.set_default", { defaultValue: "设默认" })}
+                </Button>
+              ) : null}
+              <Button size="sm" variant="ghost" disabled={busy} onClick={() => onRotate(k)}>
+                {t("apikey_lookup.rotate_key", { defaultValue: "重置" })}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={busy || keys.length <= 1}
+                onClick={() => onDelete(k)}
+                className="text-rose-600 hover:text-rose-700 dark:text-rose-300"
+                title={
+                  keys.length <= 1
+                    ? t("apikey_lookup.keep_one_key", { defaultValue: "至少保留一把 Key" })
+                    : undefined
+                }
+              >
+                <Trash2 size={14} />
+                {t("common.delete", { defaultValue: "删除" })}
+              </Button>
+            </div>
           </div>
-        </div>
-      )}
-      <p className="text-xs text-slate-500 dark:text-white/45">
-        {t("apikey_lookup.manage_keys_hint", {
-          defaultValue: "至少保留一把 Key；重置后明文只展示一次。",
-        })}
-      </p>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 管理 API Key 页的标题/描述/刷新/新建并入 sticky toolbar，滚动时不再消失
- 删除底部「至少保留一把 Key；重置后明文只展示一次。」提示文案

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / critical e2e）
- [ ] 登录 portal → 管理 API Key → 向下滚动确认标题与按钮吸顶
- [ ] 其它 tab 仍仅 tabs 吸顶，行为不变