### PR TITLE
fix(apikey-lookup): icon actions and unique key names

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -812,13 +812,6 @@ export function ApiKeyLookupPage() {
   const [createKeyError, setCreateKeyError] = useState<string | null>(null);
   const [portalKeysBusy, setPortalKeysBusy] = useState(false);
   const [portalKeysLoading, setPortalKeysLoading] = useState(false);
-  const [usagePreviewKey, setUsagePreviewKey] = useState<EndUserAPIKey | null>(null);
-  const [usagePreviewPlain, setUsagePreviewPlain] = useState("");
-  const [usagePreviewLoading, setUsagePreviewLoading] = useState(false);
-  const [usagePreviewError, setUsagePreviewError] = useState<string | null>(null);
-  const [usagePreviewChart, setUsagePreviewChart] = useState<ChartDataResponse | null>(null);
-  const [usagePreviewQuota, setUsagePreviewQuota] = useState<PublicUsageLimits | null>(null);
-  const [usagePreviewTimeRange, setUsagePreviewTimeRange] = useState<TimeRange>(7);
 
   const activateOwnedKey = useCallback(
     async (keyId: string) => {
@@ -1041,54 +1034,6 @@ export function ApiKeyLookupPage() {
     [handleLogout],
   );
 
-  const loadUsagePreview = useCallback(
-    async (keyId: string, days: TimeRange) => {
-      setUsagePreviewLoading(true);
-      setUsagePreviewError(null);
-      try {
-        const secret = await portalApi.keySecret(keyId);
-        const plain = secret.key?.trim();
-        if (!plain) throw new Error("empty key secret");
-        setUsagePreviewPlain(plain);
-        const [chart, summary] = await Promise.all([
-          fetchPublicChartData({ apiKey: plain, days }),
-          fetchPublicUsageSummary({ apiKey: plain }).catch(() => null),
-        ]);
-        setUsagePreviewChart(chart);
-        setUsagePreviewQuota(summary?.limits ?? null);
-      } catch (err) {
-        setUsagePreviewError(
-          localizeLookupError(t, err, "apikey_lookup.query_failed"),
-        );
-        setUsagePreviewChart(null);
-        setUsagePreviewQuota(null);
-      } finally {
-        setUsagePreviewLoading(false);
-      }
-    },
-    [t],
-  );
-
-  const openUsagePreview = useCallback(
-    (key: EndUserAPIKey) => {
-      setUsagePreviewKey(key);
-      setUsagePreviewTimeRange(timeRange);
-      void loadUsagePreview(key.id, timeRange);
-    },
-    [loadUsagePreview, timeRange],
-  );
-
-  useEffect(() => {
-    if (!usagePreviewKey) return;
-    void loadUsagePreview(usagePreviewKey.id, usagePreviewTimeRange);
-  }, [usagePreviewKey?.id, usagePreviewTimeRange]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const usagePreviewCharts = useApiKeyLookupCharts({
-    chartData: usagePreviewChart,
-    compact,
-    isDark,
-    t,
-  });
   const closeLoginModal = useCallback(() => {
     if (queriedKey || portalUser) setLoginModalOpen(false);
   }, [queriedKey, portalUser]);
@@ -1232,7 +1177,6 @@ export function ApiKeyLookupPage() {
                   t={t}
                   keys={portalKeys}
                   busy={portalKeysBusy}
-                  onViewUsage={(key) => openUsagePreview(key)}
                   onSetDefault={(key) => {
                     setPortalKeysBusy(true);
                     void portalApi
@@ -1612,6 +1556,17 @@ export function ApiKeyLookupPage() {
               );
               return;
             }
+            const nameTaken = portalKeys.some(
+              (key) => (key.name || "").trim().toLowerCase() === name.toLowerCase(),
+            );
+            if (nameTaken) {
+              setCreateKeyError(
+                t("apikey_lookup.key_name_duplicate", {
+                  defaultValue: "Key 名称已存在，请换一个。",
+                }),
+              );
+              return;
+            }
             setCreateKeyError(null);
             setPortalKeysBusy(true);
             void portalApi
@@ -1622,7 +1577,18 @@ export function ApiKeyLookupPage() {
                 setCreateKeyName("");
                 await refreshPortalKeys();
               })
-              .catch((err) => setCreateKeyError(err instanceof Error ? err.message : "failed"))
+              .catch((err) => {
+                const code = isApiClientError(err) ? extractApiErrorCode(err.payload) : "";
+                if (code === "duplicate_key_name") {
+                  setCreateKeyError(
+                    t("apikey_lookup.key_name_duplicate", {
+                      defaultValue: "Key 名称已存在，请换一个。",
+                    }),
+                  );
+                  return;
+                }
+                setCreateKeyError(err instanceof Error ? err.message : "failed");
+              })
               .finally(() => setPortalKeysBusy(false));
           }}
         >
@@ -1632,7 +1598,10 @@ export function ApiKeyLookupPage() {
             </span>
             <TextInput
               value={createKeyName}
-              onChange={(e) => setCreateKeyName(e.target.value)}
+              onChange={(e) => {
+                setCreateKeyName(e.target.value);
+                if (createKeyError) setCreateKeyError(null);
+              }}
               autoFocus
               placeholder={t("apikey_lookup.key_name_placeholder", {
                 defaultValue: "例如：Claude Desktop / 生产环境",
@@ -1643,96 +1612,6 @@ export function ApiKeyLookupPage() {
             <p className="text-sm text-rose-600 dark:text-rose-300">{createKeyError}</p>
           ) : null}
         </form>
-      </Modal>
-
-      <Modal
-        open={Boolean(usagePreviewKey)}
-        onClose={() => {
-          setUsagePreviewKey(null);
-          setUsagePreviewPlain("");
-          setUsagePreviewChart(null);
-          setUsagePreviewQuota(null);
-          setUsagePreviewError(null);
-        }}
-        title={t("apikey_lookup.usage_preview_title", {
-          defaultValue: "Key 用量 · {{name}}",
-          name:
-            usagePreviewKey?.name ||
-            usagePreviewKey?.key_masked ||
-            usagePreviewKey?.id?.slice(0, 8) ||
-            "",
-        })}
-        description={usagePreviewKey?.key_masked}
-        maxWidth="max-w-[96vw]"
-        panelClassName="h-[min(90dvh,920px)]"
-        bodyHeightClassName="h-[calc(min(90dvh,920px)-7.5rem)]"
-        bodyOverflowClassName="overflow-y-auto"
-      >
-        <div className="space-y-4">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex flex-wrap gap-1.5">
-              {([1, 7, 14, 30] as TimeRange[]).map((days) => (
-                <button
-                  key={days}
-                  type="button"
-                  onClick={() => setUsagePreviewTimeRange(days)}
-                  className={[
-                    "rounded-full px-3 py-1 text-xs font-medium transition",
-                    usagePreviewTimeRange === days
-                      ? "bg-slate-900 text-white dark:bg-white dark:text-neutral-950"
-                      : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-white/10 dark:text-white/70",
-                  ].join(" ")}
-                >
-                  {days === 1
-                    ? t("apikey_lookup.today", { defaultValue: "今天" })
-                    : t("apikey_lookup.days", { defaultValue: "{{n}} 天", n: days })}
-                </button>
-              ))}
-            </div>
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={usagePreviewLoading || !usagePreviewKey}
-              onClick={() => {
-                if (usagePreviewKey) void loadUsagePreview(usagePreviewKey.id, usagePreviewTimeRange);
-              }}
-            >
-              {t("common.refresh")}
-            </Button>
-          </div>
-          {usagePreviewError ? (
-            <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-300">
-              {usagePreviewError}
-            </div>
-          ) : null}
-          <UsageTabSection
-            t={t}
-            timeRange={usagePreviewTimeRange}
-            chartStats={usagePreviewCharts.chartStats}
-            chartLoading={usagePreviewLoading}
-            quotaLimits={usagePreviewQuota}
-            modelMetric={usagePreviewCharts.modelMetric}
-            setModelMetric={usagePreviewCharts.setModelMetric}
-            heatmapSeries={usagePreviewCharts.heatmapSeries}
-            modelDistributionData={usagePreviewCharts.modelDistributionData}
-            modelDistributionOption={
-              usagePreviewCharts.modelDistributionOption as Record<string, unknown>
-            }
-            modelDistributionLegend={usagePreviewCharts.modelDistributionLegend}
-            dailySeries={usagePreviewCharts.dailySeries}
-            dailyTrendOption={usagePreviewCharts.dailyTrendOption as Record<string, unknown>}
-            dailyLegendAvailability={usagePreviewCharts.dailyLegendAvailability}
-            dailyLegendSelected={usagePreviewCharts.dailyLegendSelected}
-            toggleDailyLegend={usagePreviewCharts.toggleDailyLegend}
-          />
-          {usagePreviewPlain ? (
-            <p className="text-xs text-slate-400">
-              {t("apikey_lookup.usage_preview_hint", {
-                defaultValue: "此为弹窗预览，不影响主页面当前选中的 Key。",
-              })}
-            </p>
-          ) : null}
-        </div>
       </Modal>
 
       <SecretRevealModal

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -143,7 +143,7 @@ export function LookupResultsToolbar({
             </h3>
             <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
               {t("apikey_lookup.manage_keys_desc", {
-                defaultValue: "管理本账号下全部 API Key。查看用量以弹窗打开，不会离开当前页。",
+                defaultValue: "管理本账号下全部 API Key。",
               })}
             </p>
           </div>

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -1,12 +1,14 @@
-import { KeyRound, Star, Trash2 } from "lucide-react";
-import { Button } from "@code-proxy/ui";
+import { KeyRound, RotateCcw, Star, Trash2 } from "lucide-react";
+import { HoverTooltip } from "@code-proxy/ui";
 import type { EndUserAPIKey } from "@code-proxy/api-client";
+
+const iconBtnClass =
+  "rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/50 dark:hover:bg-neutral-800";
 
 export function ManageKeysTabContent({
   t,
   keys,
   busy,
-  onViewUsage,
   onSetDefault,
   onRotate,
   onDelete,
@@ -14,7 +16,6 @@ export function ManageKeysTabContent({
   t: (key: string, options?: Record<string, unknown>) => string;
   keys: EndUserAPIKey[];
   busy?: boolean;
-  onViewUsage: (key: EndUserAPIKey) => void;
   onSetDefault: (key: EndUserAPIKey) => void;
   onRotate: (key: EndUserAPIKey) => void;
   onDelete: (key: EndUserAPIKey) => void;
@@ -33,62 +34,79 @@ export function ManageKeysTabContent({
   return (
     <div className="overflow-hidden rounded-2xl border border-slate-200/80 dark:border-white/10">
       <div className="divide-y divide-slate-100 dark:divide-white/10">
-        {keys.map((k) => (
-          <div
-            key={k.id}
-            className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
-          >
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="truncate font-medium text-slate-900 dark:text-white">
-                  {k.name || k.id.slice(0, 8)}
-                </span>
-                {k.is_default ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300">
-                    <Star size={12} />
-                    {t("apikey_lookup.default_key", { defaultValue: "默认" })}
+        {keys.map((k) => {
+          const setDefaultLabel = t("apikey_lookup.set_default", { defaultValue: "设默认" });
+          const rotateLabel = t("apikey_lookup.rotate_key", { defaultValue: "重置" });
+          const deleteLabel = t("common.delete", { defaultValue: "删除" });
+          const keepOneLabel = t("apikey_lookup.keep_one_key", { defaultValue: "至少保留一把 Key" });
+          const canDelete = keys.length > 1;
+
+          return (
+            <div
+              key={k.id}
+              className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="truncate font-medium text-slate-900 dark:text-white">
+                    {k.name || k.id.slice(0, 8)}
                   </span>
-                ) : null}
-                {k.disabled ? (
-                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-white/10 dark:text-white/50">
-                    {t("common.disabled", { defaultValue: "已停用" })}
-                  </span>
-                ) : null}
+                  {k.is_default ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300">
+                      <Star size={12} />
+                      {t("apikey_lookup.default_key", { defaultValue: "默认" })}
+                    </span>
+                  ) : null}
+                  {k.disabled ? (
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-white/10 dark:text-white/50">
+                      {t("common.disabled", { defaultValue: "已停用" })}
+                    </span>
+                  ) : null}
+                </div>
+                <code className="mt-1 block truncate text-xs text-slate-500 dark:text-white/45">
+                  {k.key_masked}
+                </code>
               </div>
-              <code className="mt-1 block truncate text-xs text-slate-500 dark:text-white/45">
-                {k.key_masked}
-              </code>
+              <div className="flex shrink-0 items-center gap-1.5">
+                {!k.is_default ? (
+                  <HoverTooltip content={setDefaultLabel}>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => onSetDefault(k)}
+                      className={`${iconBtnClass} hover:text-emerald-600 dark:hover:text-emerald-400`}
+                      aria-label={setDefaultLabel}
+                    >
+                      <Star size={15} />
+                    </button>
+                  </HoverTooltip>
+                ) : null}
+                <HoverTooltip content={rotateLabel}>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => onRotate(k)}
+                    className={`${iconBtnClass} hover:text-orange-600 dark:hover:text-orange-400`}
+                    aria-label={rotateLabel}
+                  >
+                    <RotateCcw size={15} />
+                  </button>
+                </HoverTooltip>
+                <HoverTooltip content={canDelete ? deleteLabel : keepOneLabel}>
+                  <button
+                    type="button"
+                    disabled={busy || !canDelete}
+                    onClick={() => onDelete(k)}
+                    className={`${iconBtnClass} hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400`}
+                    aria-label={canDelete ? deleteLabel : keepOneLabel}
+                  >
+                    <Trash2 size={15} />
+                  </button>
+                </HoverTooltip>
+              </div>
             </div>
-            <div className="flex shrink-0 flex-wrap gap-1.5">
-              <Button size="sm" variant="secondary" disabled={busy} onClick={() => onViewUsage(k)}>
-                {t("apikey_lookup.view_usage", { defaultValue: "查看用量" })}
-              </Button>
-              {!k.is_default ? (
-                <Button size="sm" variant="ghost" disabled={busy} onClick={() => onSetDefault(k)}>
-                  {t("apikey_lookup.set_default", { defaultValue: "设默认" })}
-                </Button>
-              ) : null}
-              <Button size="sm" variant="ghost" disabled={busy} onClick={() => onRotate(k)}>
-                {t("apikey_lookup.rotate_key", { defaultValue: "重置" })}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                disabled={busy || keys.length <= 1}
-                onClick={() => onDelete(k)}
-                className="text-rose-600 hover:text-rose-700 dark:text-rose-300"
-                title={
-                  keys.length <= 1
-                    ? t("apikey_lookup.keep_one_key", { defaultValue: "至少保留一把 Key" })
-                    : undefined
-                }
-              >
-                <Trash2 size={14} />
-                {t("common.delete", { defaultValue: "删除" })}
-              </Button>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- 管理 API Key 行操作改为 HoverTooltip icon 按钮（设默认 / 重置 / 删除）
- 移除「查看用量」按钮与相关弹窗预览链路
- 新建 Key 前端拦截重名；后端 `duplicate_key_name` 时本地化提示

## Test plan
- [x] `./scripts/ci-pr.sh`
- [ ] 管理 API Key：icon + tooltip
- [ ] 新建重复名称：前端拦截