### PR TITLE
fix: load request-log toggles from dedicated management endpoints

### DIFF
--- a/packages/api-client/src/endpoints/config.ts
+++ b/packages/api-client/src/endpoints/config.ts
@@ -42,6 +42,18 @@ export const configApi = {
     apiClient.put("/quota-exceeded/switch-preview-model", { value: enabled }),
   updateUsageStatistics: (enabled: boolean) =>
     apiClient.put("/usage-statistics-enabled", { value: enabled }),
+  getUsageStatisticsEnabled: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>("/usage-statistics-enabled");
+    return Boolean(data?.["usage-statistics-enabled"] ?? data?.usageStatisticsEnabled ?? false);
+  },
+  getDebug: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>("/debug");
+    return Boolean(data?.debug ?? false);
+  },
+  getRequestLog: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>("/request-log");
+    return Boolean(data?.["request-log"] ?? data?.requestLog ?? false);
+  },
   updateRequestLog: (enabled: boolean) => apiClient.put("/request-log", { value: enabled }),
   getRequestLogBodyStorage: async (): Promise<boolean> => {
     const data = await apiClient.get<RequestLogBodyStorageResponse>(
@@ -58,7 +70,25 @@ export const configApi = {
       },
       { timeoutMs: 10 * 60_000 },
     ),
+  getLoggingToFile: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>("/logging-to-file");
+    return Boolean(data?.["logging-to-file"] ?? data?.loggingToFile ?? false);
+  },
   updateLoggingToFile: (enabled: boolean) => apiClient.put("/logging-to-file", { value: enabled }),
+  getWsAuth: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>("/ws-auth");
+    return Boolean(data?.["ws-auth"] ?? data?.wsAuth ?? false);
+  },
+  getSwitchProject: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>("/quota-exceeded/switch-project");
+    return Boolean(data?.["switch-project"] ?? data?.switchProject ?? false);
+  },
+  getSwitchPreviewModel: async (): Promise<boolean> => {
+    const data = await apiClient.get<Record<string, unknown>>(
+      "/quota-exceeded/switch-preview-model",
+    );
+    return Boolean(data?.["switch-preview-model"] ?? data?.switchPreviewModel ?? false);
+  },
   getLogsMaxTotalSizeMb: async (): Promise<number> => {
     const data = await apiClient.get<Record<string, unknown>>("/logs-max-total-size-mb");
     const value = data?.["logs-max-total-size-mb"] ?? data?.logsMaxTotalSizeMb ?? 0;

--- a/pages/config/RuntimeConfigPanel.tsx
+++ b/pages/config/RuntimeConfigPanel.tsx
@@ -138,6 +138,10 @@ export function RuntimeConfigPanel() {
   const loadRuntimeConfig = useCallback(async () => {
     setLoading(true);
     try {
+      // Process-global toggles (request-log, logging-to-file, …) must come from
+      // dedicated GET endpoints. GET /config is tenant-scoped for business tenants
+      // and omits those fields; readBool would default missing keys to false while
+      // the host still wrote multi-MB request files.
       const [
         config,
         logsLimit,
@@ -147,6 +151,13 @@ export function RuntimeConfigPanel() {
         autoUpdateChannelValue,
         codexOAuthAdmission,
         requestLogBodyStorage,
+        debugEnabledValue,
+        usageStatisticsEnabledValue,
+        requestLogEnabledValue,
+        loggingToFileEnabledValue,
+        wsAuthEnabledValue,
+        switchProjectEnabledValue,
+        switchPreviewModelEnabledValue,
       ] = await Promise.all([
         configApi.getConfig(),
         configApi.getLogsMaxTotalSizeMb().catch(() => 0),
@@ -158,23 +169,26 @@ export function RuntimeConfigPanel() {
           return emptyCodexOAuthAdmission;
         }),
         configApi.getRequestLogBodyStorage().catch(() => false),
+        configApi.getDebug().catch(() => false),
+        configApi.getUsageStatisticsEnabled().catch(() => false),
+        configApi.getRequestLog().catch(() => false),
+        configApi.getLoggingToFile().catch(() => false),
+        configApi.getWsAuth().catch(() => false),
+        configApi.getSwitchProject().catch(() => false),
+        configApi.getSwitchPreviewModel().catch(() => false),
       ]);
 
       const record = isRecord(config) ? (config as Record<string, unknown>) : null;
       setRawConfig(record);
 
-      setDebugEnabled(readBool(record, "debug", "debug-enabled", "debugEnabled"));
-      setUsageStatisticsEnabled(
-        readBool(record, "usage-statistics-enabled", "usageStatisticsEnabled"),
-      );
-      setRequestLogEnabled(readBool(record, "request-log", "requestLog"));
+      setDebugEnabled(debugEnabledValue);
+      setUsageStatisticsEnabled(usageStatisticsEnabledValue);
+      setRequestLogEnabled(requestLogEnabledValue);
       setRequestLogBodyStorageEnabled(requestLogBodyStorage);
-      setLoggingToFileEnabled(readBool(record, "logging-to-file", "loggingToFile"));
-      setWsAuthEnabled(readBool(record, "ws-auth", "wsAuth"));
-      setSwitchProjectEnabled(readBool(record, "quota-exceeded.switch-project", "switchProject"));
-      setSwitchPreviewModelEnabled(
-        readBool(record, "quota-exceeded.switch-preview-model", "switchPreviewModel"),
-      );
+      setLoggingToFileEnabled(loggingToFileEnabledValue);
+      setWsAuthEnabled(wsAuthEnabledValue);
+      setSwitchProjectEnabled(switchProjectEnabledValue);
+      setSwitchPreviewModelEnabled(switchPreviewModelEnabledValue);
 
       setProxyUrl(readString(record, "proxy-url", "proxyUrl"));
       const retry = readNumber(record, "request-retry", "requestRetry");

--- a/pages/config/__tests__/RuntimeConfigPanel.test.tsx
+++ b/pages/config/__tests__/RuntimeConfigPanel.test.tsx
@@ -23,6 +23,13 @@ const mocks = vi.hoisted(() => ({
   getAutoUpdateChannel: vi.fn(),
   getCodexOAuthAdmission: vi.fn(),
   getRequestLogBodyStorage: vi.fn(),
+  getDebug: vi.fn(),
+  getUsageStatisticsEnabled: vi.fn(),
+  getRequestLog: vi.fn(),
+  getLoggingToFile: vi.fn(),
+  getWsAuth: vi.fn(),
+  getSwitchProject: vi.fn(),
+  getSwitchPreviewModel: vi.fn(),
   updateProxyUrl: vi.fn(),
   clearProxyUrl: vi.fn(),
   updateRequestRetry: vi.fn(),
@@ -52,6 +59,13 @@ vi.mock("@code-proxy/api-client/endpoints/config", () => ({
     getAutoUpdateChannel: mocks.getAutoUpdateChannel,
     getCodexOAuthAdmission: mocks.getCodexOAuthAdmission,
     getRequestLogBodyStorage: mocks.getRequestLogBodyStorage,
+    getDebug: mocks.getDebug,
+    getUsageStatisticsEnabled: mocks.getUsageStatisticsEnabled,
+    getRequestLog: mocks.getRequestLog,
+    getLoggingToFile: mocks.getLoggingToFile,
+    getWsAuth: mocks.getWsAuth,
+    getSwitchProject: mocks.getSwitchProject,
+    getSwitchPreviewModel: mocks.getSwitchPreviewModel,
     updateProxyUrl: mocks.updateProxyUrl,
     clearProxyUrl: mocks.clearProxyUrl,
     updateRequestRetry: mocks.updateRequestRetry,
@@ -86,11 +100,8 @@ describe("RuntimeConfigPanel", () => {
   beforeEach(async () => {
     await i18n.changeLanguage("en");
     mocks.getConfig.mockResolvedValue({
-      debug: false,
-      "usage-statistics-enabled": true,
-      "request-log": false,
-      "logging-to-file": false,
-      "ws-auth": true,
+      // Tenant-scoped /config may omit process-global toggles; dedicated GETs below
+      // are the source of truth for request-log and related switches.
       proxyUrl: "http://127.0.0.1:7890",
       requestRetry: 2,
     });
@@ -110,6 +121,13 @@ describe("RuntimeConfigPanel", () => {
       ],
     });
     mocks.getRequestLogBodyStorage.mockResolvedValue(true);
+    mocks.getDebug.mockResolvedValue(false);
+    mocks.getUsageStatisticsEnabled.mockResolvedValue(true);
+    mocks.getRequestLog.mockResolvedValue(true);
+    mocks.getLoggingToFile.mockResolvedValue(false);
+    mocks.getWsAuth.mockResolvedValue(true);
+    mocks.getSwitchProject.mockResolvedValue(false);
+    mocks.getSwitchPreviewModel.mockResolvedValue(false);
     mocks.updateProxyUrl.mockResolvedValue({});
     mocks.clearProxyUrl.mockResolvedValue({});
     mocks.updateRequestRetry.mockResolvedValue({});
@@ -119,6 +137,21 @@ describe("RuntimeConfigPanel", () => {
     mocks.updateAutoUpdateChannel.mockResolvedValue({});
     mocks.updateCodexOAuthAdmission.mockResolvedValue({});
     mocks.updateRequestLogBodyStorage.mockResolvedValue({ enabled: false });
+  });
+
+  test("loads request-log from dedicated endpoint when /config omits it", async () => {
+    mocks.getConfig.mockResolvedValue({
+      proxyUrl: "http://127.0.0.1:7890",
+      requestRetry: 2,
+    });
+    mocks.getRequestLog.mockResolvedValue(true);
+    renderPanel();
+
+    const toggle = await screen.findByRole("switch", { name: /request logs/i });
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+    expect(mocks.getRequestLog).toHaveBeenCalled();
   });
 
   test("confirms disabling body storage, clears existing bodies, and shows progress", async () => {


### PR DESCRIPTION
## Summary
- Runtime config panel previously read `request-log` / `logging-to-file` / related toggles only from `GET /config`.
- Tenant-scoped `/config` can omit those process-global fields; the UI then showed them as off while the host still wrote multi-MB request files.
- Load those toggles from dedicated management GETs (`/request-log`, `/logging-to-file`, `/debug`, …).

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- pages/config/__tests__/RuntimeConfigPanel.test.tsx`
- [x] `./scripts/ci-pr.sh` (full PR CI)