### PR TITLE
feat(end-users): add per-user usage/request logs action

### DIFF
--- a/pages/api-keys/hooks/useApiKeyUsageView.ts
+++ b/pages/api-keys/hooks/useApiKeyUsageView.ts
@@ -42,7 +42,7 @@ export function useApiKeyUsageView({
   const { t } = useTranslation();
   const { notify } = useToast();
 
-  const [usageViewKey, setUsageViewKey] = useState<string | null>(null);
+  const [usageViewKeys, setUsageViewKeys] = useState<string[]>([]);
   const [usageViewName, setUsageViewName] = useState("");
   const [usageLoading, setUsageLoading] = useState(false);
   const [usageRawItems, setUsageRawItems] = useState<UsageLogItem[]>([]);
@@ -73,6 +73,8 @@ export function useApiKeyUsageView({
   const [usageErrorModalLogId, setUsageErrorModalLogId] = useState<number | null>(null);
   const [usageErrorModalModel, setUsageErrorModalModel] = useState("");
   const usageFetchInFlightRef = useRef(false);
+  /** First key — keeps ApiKeysPage mask display working. */
+  const usageViewKey = usageViewKeys[0] ?? null;
 
   const handleUsageContentClick = useCallback((logId: number, tab: "input" | "output") => {
     setUsageContentModalLogId(logId);
@@ -120,7 +122,7 @@ export function useApiKeyUsageView({
 
   const fetchUsageLogs = useCallback(
     async (page: number, size: number) => {
-      if (!usageViewKey || usageFetchInFlightRef.current) return;
+      if (usageViewKeys.length === 0 || usageFetchInFlightRef.current) return;
       usageFetchInFlightRef.current = true;
       setUsageLoading(true);
 
@@ -130,7 +132,7 @@ export function useApiKeyUsageView({
           page,
           size,
           days: usageTimeRange,
-          api_key: usageViewKey,
+          api_keys: usageViewKeys,
           model: usageModelQuery || undefined,
           channel: channelQuery || undefined,
           status: usageStatusFilter || undefined,
@@ -163,7 +165,7 @@ export function useApiKeyUsageView({
       usageModelQuery,
       usageStatusFilter,
       usageTimeRange,
-      usageViewKey,
+      usageViewKeys,
     ],
   );
 
@@ -181,13 +183,24 @@ export function useApiKeyUsageView({
     setUsageStatusFilter("");
   }, []);
 
+  const openUsageView = useCallback(
+    (keys: string[], name: string) => {
+      const cleaned = Array.from(
+        new Set(keys.map((k) => k.trim()).filter(Boolean)),
+      );
+      if (cleaned.length === 0) return;
+      resetUsageViewState();
+      setUsageViewKeys(cleaned);
+      setUsageViewName(name);
+    },
+    [resetUsageViewState],
+  );
+
   const handleViewUsage = useCallback(
     async (entry: ApiKeyEntry) => {
-      resetUsageViewState();
-      setUsageViewKey(entry.key);
-      setUsageViewName(entry.name || t("api_keys_page.unnamed"));
+      openUsageView([entry.key], entry.name || t("api_keys_page.unnamed"));
     },
-    [resetUsageViewState, t],
+    [openUsageView, t],
   );
 
   const usageChannelOptions = useMemo(
@@ -232,7 +245,7 @@ export function useApiKeyUsageView({
   }, [usageFilterOptions]);
 
   useEffect(() => {
-    if (!usageViewKey) return;
+    if (usageViewKeys.length === 0) return;
     void fetchUsageLogs(1, usagePageSize);
   }, [
     fetchUsageLogs,
@@ -242,18 +255,20 @@ export function useApiKeyUsageView({
     usagePageSize,
     usageStatusFilter,
     usageTimeRange,
-    usageViewKey,
+    usageViewKeys,
   ]);
 
   const closeUsageModal = useCallback(() => {
-    setUsageViewKey(null);
+    setUsageViewKeys([]);
     setUsageViewName("");
     resetUsageViewState();
   }, [resetUsageViewState]);
 
   return {
     usageViewKey,
+    usageViewKeys,
     usageViewName,
+    openUsageView,
     usageLoading,
     usageTotalCount,
     usageCurrentPage,

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -1,7 +1,16 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { Infinity as InfinityIcon, Key, KeyRound, Pencil, Trash2, Unlock } from "lucide-react";
 import {
+  BarChart3,
+  Infinity as InfinityIcon,
+  Key,
+  KeyRound,
+  Pencil,
+  Trash2,
+  Unlock,
+} from "lucide-react";
+import {
+  apiKeyEntriesApi,
   apiKeyPermissionProfilesApi,
   endUsersApi,
   type ApiKeyPermissionProfile,
@@ -23,6 +32,10 @@ import {
 } from "@code-proxy/ui";
 import { PermissionGate } from "@app/guards/PermissionGate";
 import { useAuth } from "@app/providers/AuthProvider";
+import { useApiKeyPermissionOptions } from "@features/api-key-restrictions";
+import { ErrorDetailModal, LogContentModal } from "@features/log-content-viewer";
+import { ApiKeyUsageModal } from "../api-keys/components/ApiKeyUsageModal";
+import { useApiKeyUsageView } from "../api-keys/hooks/useApiKeyUsageView";
 
 const emptyForm = { username: "", displayName: "", password: "", permissionProfileId: "" };
 
@@ -83,6 +96,44 @@ export function EndUsersPage() {
   const [permissionProfiles, setPermissionProfiles] = useState<ApiKeyPermissionProfile[]>([]);
   const canWrite = can("end_users.write");
   const unlimitedLabel = t("api_keys_page.unlimited", { defaultValue: "无限制" });
+  const { channelGroupByName, refreshPermissionOptions } = useApiKeyPermissionOptions();
+  const {
+    usageViewKey,
+    usageViewName,
+    usageLoading,
+    usageTotalCount,
+    usageCurrentPage,
+    usagePageSize,
+    setUsagePageSize,
+    usageLastUpdatedText,
+    usageTimeRange,
+    setUsageTimeRange,
+    usageChannelQuery,
+    setUsageChannelQuery,
+    usageChannelGroupQuery,
+    setUsageChannelGroupQuery,
+    usageModelQuery,
+    setUsageModelQuery,
+    usageStatusFilter,
+    setUsageStatusFilter,
+    usageContentModalOpen,
+    setUsageContentModalOpen,
+    usageContentModalLogId,
+    usageContentModalTab,
+    usageErrorModalOpen,
+    setUsageErrorModalOpen,
+    usageErrorModalLogId,
+    usageErrorModalModel,
+    usageLogColumns,
+    usageRows,
+    usageTotalPages,
+    usageChannelOptions,
+    usageChannelGroupOptions,
+    usageModelOptions,
+    fetchUsageLogs,
+    openUsageView,
+    closeUsageModal,
+  } = useApiKeyUsageView({ channelGroupByName });
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -108,7 +159,8 @@ export function EndUsersPage() {
   useEffect(() => {
     void load();
     void loadProfiles();
-  }, [load, loadProfiles]);
+    void refreshPermissionOptions();
+  }, [load, loadProfiles, refreshPermissionOptions]);
 
   const profileNameById = useMemo(() => {
     const map = new Map<string, string>();
@@ -138,6 +190,34 @@ export function EndUsersPage() {
       }
     },
     [load, notify, t],
+  );
+
+  const handleViewUserUsage = useCallback(
+    async (row: EndUser) => {
+      const name = row.display_name || row.username || t("end_users.unnamed", { defaultValue: "未命名用户" });
+      try {
+        const entries = await apiKeyEntriesApi.list();
+        const keys = entries
+          .filter((e) => e.end_user_id === row.id && e.key?.trim())
+          .map((e) => e.key.trim());
+        if (keys.length === 0) {
+          notify({
+            type: "info",
+            message: t("end_users.no_keys_for_usage", {
+              defaultValue: "该用户暂无 API 密钥，无法查看用量",
+            }),
+          });
+          return;
+        }
+        openUsageView(keys, name);
+      } catch (e) {
+        notify({
+          type: "error",
+          message: e instanceof Error ? e.message : t("api_keys_page.load_usage_failed"),
+        });
+      }
+    },
+    [notify, openUsageView, t],
   );
 
   const columns = useMemo<DataTableColumn<EndUser>[]>(
@@ -262,15 +342,23 @@ export function EndUsersPage() {
       {
         key: "actions",
         label: t("common.actions", { defaultValue: "操作" }),
-        width: "w-44 min-w-[11rem]",
-        minWidthPx: 168,
-        maxWidthPx: 220,
+        width: "w-52 min-w-[13rem]",
+        minWidthPx: 200,
+        maxWidthPx: 260,
         resizable: false,
         lockOrder: "end",
         headerClassName: stickyActionsHeaderClass,
         cellClassName: stickyActionsCellClass,
         render: (row) => (
           <div className="flex items-center justify-center gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              title={t("end_users.view_usage", { defaultValue: "查看用量" })}
+              onClick={() => void handleViewUserUsage(row)}
+            >
+              <BarChart3 className="h-4 w-4" />
+            </Button>
             {can("api_keys.read") ? (
               <Button
                 size="sm"
@@ -318,7 +406,7 @@ export function EndUsersPage() {
         ),
       },
     ],
-    [can, canWrite, profileNameById, t, unlimitedLabel, unlock],
+    [can, canWrite, handleViewUserUsage, profileNameById, t, unlimitedLabel, unlock],
   );
 
   const onCreate = async (e: FormEvent) => {
@@ -717,6 +805,56 @@ export function EndUsersPage() {
           </Suspense>
         ) : null}
       </Modal>
+
+      <ApiKeyUsageModal
+        open={usageViewKey !== null}
+        onClose={closeUsageModal}
+        usageViewName={usageViewName}
+        maskedKey={
+          usageViewKey
+            ? t("end_users.usage_keys_summary", {
+                defaultValue: "账号下全部密钥",
+              })
+            : ""
+        }
+        usageTotalCount={usageTotalCount}
+        usageTimeRange={usageTimeRange}
+        setUsageTimeRange={setUsageTimeRange}
+        fetchUsageLogs={fetchUsageLogs}
+        usagePageSize={usagePageSize}
+        usageLoading={usageLoading}
+        usageLastUpdatedText={usageLastUpdatedText}
+        usageChannelGroupQuery={usageChannelGroupQuery}
+        setUsageChannelGroupQuery={setUsageChannelGroupQuery}
+        setUsageChannelQuery={setUsageChannelQuery}
+        usageChannelGroupOptions={usageChannelGroupOptions}
+        usageChannelQuery={usageChannelQuery}
+        setUsageChannelQueryDirect={setUsageChannelQuery}
+        usageChannelOptions={usageChannelOptions}
+        usageModelQuery={usageModelQuery}
+        setUsageModelQuery={setUsageModelQuery}
+        usageModelOptions={usageModelOptions}
+        usageStatusFilter={usageStatusFilter}
+        setUsageStatusFilter={setUsageStatusFilter}
+        usageLogColumns={usageLogColumns}
+        usageRows={usageRows}
+        usageCurrentPage={usageCurrentPage}
+        usageTotalPages={usageTotalPages}
+        setUsagePageSize={setUsagePageSize}
+      />
+
+      <LogContentModal
+        open={usageContentModalOpen}
+        logId={usageContentModalLogId}
+        initialTab={usageContentModalTab}
+        onClose={() => setUsageContentModalOpen(false)}
+      />
+      <ErrorDetailModal
+        open={usageErrorModalOpen}
+        logId={usageErrorModalLogId}
+        model={usageErrorModalModel}
+        onClose={() => setUsageErrorModalOpen(false)}
+      />
     </PermissionGate>
   );
 }


### PR DESCRIPTION
## Summary
- End-users 操作列新增「查看用量」按钮
- 拉取该用户全部 API key，用 `api_keys` 多 key 过滤打开与 request-logs 同结构的用量表格（复用 ApiKeyUsageModal）
- `useApiKeyUsageView` 支持多 key（`openUsageView`），单 key 路径兼容不变

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / critical e2e）
- [ ] 管理端 `/manage/access/end-users` 点用量图标，确认表格与筛选可用
- [ ] 无密钥用户提示「暂无 API 密钥」