### PR TITLE
fix(ui): manage-keys modal table layout and account-scoped actions

### DIFF
--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -788,11 +788,12 @@ export function ApiKeysPage({
           rowHeight={44}
           height={
             embed
-              ? "h-full"
+              ? "min-h-0 flex-1"
               : "h-[calc(100dvh-260px)] md:h-auto md:flex-1"
           }
           minHeight={embed ? "min-h-0" : "min-h-[320px] md:min-h-0"}
-          minWidth="min-w-[2314px]"
+          // Full key table needs all quota/permission columns; account-scoped embed only keeps credentials.
+          minWidth={endUserIdFilter ? "min-w-[876px]" : "min-w-[2314px]"}
           caption={t("api_keys_page.table_caption")}
           emptyText={t("api_keys_page.no_api_keys")}
           showAllLoadedMessage={false}
@@ -808,7 +809,9 @@ export function ApiKeysPage({
           <div className="flex shrink-0 items-center justify-end border-b border-slate-100 px-4 py-3 dark:border-white/10">
             {toolbar}
           </div>
-          <div className="min-h-0 flex-1 overflow-hidden px-4 py-3">{tableBody}</div>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-3">
+            {tableBody}
+          </div>
         </div>
       ) : (
         <Card

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -462,7 +462,8 @@ export const createApiKeyColumns = ({
   {
     key: "actions",
     label: t("api_keys_page.col_actions"),
-    width: "w-[256px] min-w-[256px]",
+    // accountScoped drops usage + daily-reset; keep room for set-default.
+    width: accountScoped ? "w-[220px] min-w-[220px]" : "w-[256px] min-w-[256px]",
     lockOrder: "end",
     headerClassName: stickyActionsHeaderClass,
     cellClassName: stickyActionsCellClass,
@@ -497,16 +498,18 @@ export const createApiKeyColumns = ({
               <Power size={15} />
             </button>
           </HoverTooltip>
-          <HoverTooltip content={viewUsageLabel}>
-            <button
-              type="button"
-              onClick={() => onViewUsage(row)}
-              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-blue-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-blue-400"
-              aria-label={viewUsageLabel}
-            >
-              <BarChart3 size={15} />
-            </button>
-          </HoverTooltip>
+          {!accountScoped ? (
+            <HoverTooltip content={viewUsageLabel}>
+              <button
+                type="button"
+                onClick={() => onViewUsage(row)}
+                className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-blue-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-blue-400"
+                aria-label={viewUsageLabel}
+              >
+                <BarChart3 size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
           <HoverTooltip content={copyKeyLabel}>
             <button
               type="button"
@@ -527,17 +530,19 @@ export const createApiKeyColumns = ({
               <Upload size={15} />
             </button>
           </HoverTooltip>
-          <HoverTooltip content={resetLabel}>
-            <button
-              type="button"
-              onClick={() => onResetDailySpending(idx)}
-              disabled={!hasDailyLimit || isResetting}
-              className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-orange-400"
-              aria-label={resetLabel}
-            >
-              <RotateCcw size={15} className={isResetting ? "animate-spin" : ""} />
-            </button>
-          </HoverTooltip>
+          {!accountScoped ? (
+            <HoverTooltip content={resetLabel}>
+              <button
+                type="button"
+                onClick={() => onResetDailySpending(idx)}
+                disabled={!hasDailyLimit || isResetting}
+                className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-orange-400"
+                aria-label={resetLabel}
+              >
+                <RotateCcw size={15} className={isResetting ? "animate-spin" : ""} />
+              </button>
+            </HoverTooltip>
+          ) : null}
           {onSetDefault && !row.is_default ? (
             <HoverTooltip content={t("end_users.set_default_key", { defaultValue: "设为默认" })}>
               <button

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -257,6 +257,27 @@ describe("ApiKeyColumns", () => {
     expect(screen.getByRole("button", { name: "Click to enable" })).toBeInTheDocument();
   });
 
+  test("account-scoped columns drop quota fields and usage/reset actions", () => {
+    const row: ApiKeyEntry = {
+      key: "sk-owned",
+      name: "Owned",
+      "daily-spending-limit": 10,
+      "created-at": "2026-04-28T00:00:00Z",
+    };
+    const columns = createColumns({ accountScoped: true });
+    const keys = columns.map((column) => column.key);
+    const actionsColumn = columns.find((column) => column.key === "actions");
+
+    expect(keys).toEqual(["select", "name", "key", "createdAt", "actions"]);
+    expect(actionsColumn?.width).toBe("w-[220px] min-w-[220px]");
+
+    render(<div>{actionsColumn?.render(row, 0)}</div>);
+
+    expect(screen.queryByRole("button", { name: "View usage" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reset today spending" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy key" })).toBeInTheDocument();
+  });
+
   test("places daily spending column immediately after name", () => {
     const columns = createColumns();
     const keys = columns.map((column) => column.key);


### PR DESCRIPTION
## Summary
- 管理密钥弹窗内表格高度撑满，横向滚动条贴弹窗底部
- 账号作用域密钥表用窄 `minWidth`，避免假横向滚动导致固定列异常
- 账号作用域隐藏用量查询与日消费重置按钮

## Test plan
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / critical e2e）
- [x] `ApiKeyColumns` unit tests including account-scoped actions
- [ ] 打开用户账号 → 管理密钥弹窗：滚动条在底部、固定列正常、无用量按钮