### PR TITLE
fix(model-plaza): prevent partial description clipping

### DIFF
--- a/e2e/api-key-lookup.spec.ts
+++ b/e2e/api-key-lookup.spec.ts
@@ -103,6 +103,52 @@ const mockLookupApisForQuickImport = async (page: Page) => {
   });
 };
 
+const mockLookupApisForModelCards = async (page: Page) => {
+  await page.route("**/v0/management/public/usage/logs", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [], total: 0 }),
+    });
+  });
+
+  await page.route("**/v0/management/public/usage/chart-data", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        daily_series: [],
+        heatmap_series: [],
+        model_distribution: [],
+        stats: { total: 0, success_rate: 0, total_tokens: 0, total_sessions: 0, total_cost: 0 },
+      }),
+    });
+  });
+
+  await page.route("**/v1/models", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [
+          {
+            id: "gpt-5",
+            owned_by: "openai",
+            description:
+              "GPT-5 is OpenAI’s most advanced model, offering major improvements in reasoning, code quality, and user experience. It is optimized for complex tasks that require step-by-step reasoning, instruction following, and reliable tool use.",
+            input_modalities: ["text", "image"],
+            pricing: {
+              input_price_per_million: 1.25,
+              output_price_per_million: 10,
+              cache_read_price_per_million: 0.125,
+            },
+          },
+        ],
+      }),
+    });
+  });
+};
+
 const localDateKey = (date: Date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -159,6 +205,33 @@ const decodeCodexConfigBlob = (url: string) => {
     modelCatalog?: { models: Array<Record<string, unknown>> };
   };
 };
+
+test("API Key Lookup: model description clamps to two complete lines", async ({ page }) => {
+  await page.setViewportSize({ width: 2048, height: 1100 });
+  await setQueriedLookupKey(page);
+  await mockLookupApisForModelCards(page);
+
+  await page.goto("/#/apikey-lookup");
+  await page.getByRole("tab", { name: /模型广场|Model Plaza/i }).click();
+
+  const description = page.getByTestId("model-description-clamp");
+  await expect(description).toBeVisible();
+
+  const metrics = await description.evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    const lineHeight = Number.parseFloat(style.lineHeight);
+    return {
+      height: element.getBoundingClientRect().height,
+      lineHeight,
+      scrollHeight: element.scrollHeight,
+      lineClamp: style.webkitLineClamp,
+    };
+  });
+
+  expect(metrics.lineClamp).toBe("2");
+  expect(metrics.height).toBeCloseTo(metrics.lineHeight * 2, 0);
+  expect(metrics.scrollHeight).toBeGreaterThan(metrics.height);
+});
 
 test("API Key Lookup: Heatmap tooltip stays inside the heatmap card when hovering the top row", async ({
   page,

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -174,11 +174,16 @@ function ModelPlazaCard({
           </div>
         </div>
 
-        <p className="mt-3 line-clamp-2 min-h-10 min-w-0 flex-1 overflow-hidden break-all text-xs leading-5 text-slate-500 dark:text-white/55">
-          {model.description?.trim()
-            ? model.description
-            : t("model_plaza.no_description")}
-        </p>
+        <div className="mt-3 min-h-10 min-w-0 flex-1" data-testid="model-description-space">
+          <p
+            className="line-clamp-2 break-words text-xs leading-5 text-slate-500 dark:text-white/55"
+            data-testid="model-description-clamp"
+          >
+            {model.description?.trim()
+              ? model.description
+              : t("model_plaza.no_description")}
+          </p>
+        </div>
 
         <div className="mt-auto pt-2">
           <div className="mb-1.5 flex items-center justify-between gap-2">

--- a/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
@@ -80,6 +80,38 @@ describe("ModelsTabContent", () => {
     expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
   });
 
+  test("keeps the two-line clamp separate from the flexible description spacer", async () => {
+    await i18n.changeLanguage("en");
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ModelsTabContent
+            models={[
+              model("gpt-5", {
+                description:
+                  "A long model description that must be clamped to exactly two complete lines without painting a partially clipped third line below the ellipsis.",
+                ownedBy: "openai",
+              }),
+            ]}
+            loading={false}
+            error={null}
+            searchFilter=""
+            onSearchChange={() => {}}
+          />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const clamp = screen.getByTestId("model-description-clamp");
+    const spacer = screen.getByTestId("model-description-space");
+
+    expect(clamp).toHaveClass("line-clamp-2");
+    expect(clamp).not.toHaveClass("flex-1", "min-h-10");
+    expect(spacer).toHaveClass("flex-1", "min-h-10");
+    expect(spacer).toContainElement(clamp);
+  });
+
   test("does not render the CC Switch import action inside available models", async () => {
     await i18n.changeLanguage("en");
 

--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -243,11 +243,16 @@ function ModelPlazaCard({
           </div>
         </div>
 
-        <p className="mt-3 line-clamp-2 min-h-10 flex-1 text-xs leading-5 text-slate-500 dark:text-white/55">
-          {model.description?.trim()
-            ? model.description
-            : t("model_plaza.no_description")}
-        </p>
+        <div className="mt-3 min-h-10 min-w-0 flex-1" data-testid="model-description-space">
+          <p
+            className="line-clamp-2 break-words text-xs leading-5 text-slate-500 dark:text-white/55"
+            data-testid="model-description-clamp"
+          >
+            {model.description?.trim()
+              ? model.description
+              : t("model_plaza.no_description")}
+          </p>
+        </div>
 
         <div className="mt-2 min-h-4">
           {sourceSummary ? (

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -174,6 +174,36 @@ describe("ModelPlazaPage", () => {
     expect(screen.queryByText("qwen3.5-plus")).not.toBeInTheDocument();
   });
 
+  test("keeps the model description clamp out of the flexible spacer", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: true,
+          data: [
+            {
+              id: "gpt-5",
+              description:
+                "A long model description that must end after two complete lines without exposing a clipped third line.",
+            },
+          ],
+        });
+      }
+      if (path === "/model-path-availability") return Promise.resolve({ data: [] });
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    const clamp = await screen.findByTestId("model-description-clamp");
+    const spacer = screen.getByTestId("model-description-space");
+
+    expect(clamp).toHaveClass("line-clamp-2");
+    expect(clamp).not.toHaveClass("flex-1", "min-h-10");
+    expect(spacer).toHaveClass("flex-1", "min-h-10");
+    expect(spacer).toContainElement(clamp);
+  });
+
   test("copies model id from the card action", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });


### PR DESCRIPTION
## 修改范围

- 修复 `/manage/apikey-lookup` 模型卡片描述在两行省略号下方仍露出半截第三行的问题
- 将 `line-clamp-2` 文本层与 `flex-1` 占位层分离，确保 clamp 盒严格保持两行高度
- 同步修复登录后模型广场的同源卡片实现
- 将 `break-all` 调整为 `break-words`，避免普通英文单词被无条件拆断
- 增加单元结构回归测试与 Chromium 几何回归测试

## 根因

描述 `<p>` 同时承担 `line-clamp-2` 和 `flex-1`。在卡片纵向 flex 布局中，浏览器把两行文本盒从 40px 拉伸到 50px，导致省略号后方继续绘制第三行并被卡片裁成半行。

## 验证

- `./scripts/ci-pr.sh`
  - `bun install --frozen-lockfile`
  - `bun run lint`（通过，保留 5 条既有 warning）
  - `bun run design:check`
  - `bun run test:ci`（111 files / 795 tests）
  - `bun run build`
  - `bun run bundle:diff`
  - critical Playwright（9 tests）
- `bunx playwright test e2e/api-key-lookup.spec.ts --grep "model description clamps" --project=chromium`
- 本地真实页面 + mock `/v1/models` 视觉验证：修复前描述盒 50px，修复后严格为 40px（2 × 20px），不再出现半截第三行

## 影响目录

- `pages/api-key-lookup/`
- `pages/model-plaza/`
- `e2e/api-key-lookup.spec.ts`

不涉及 `CliRelay`。