### PR TITLE
fix: align portal logs models and permission sync

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -587,9 +587,11 @@ export function buildRequestLogsColumns(
   t: (key: string) => string,
   onContentClick?: (logId: number, tab: "input" | "output") => void,
   onErrorClick?: (logId: number, model: string) => void,
+  options: { identityColumn?: "user" | "key" } = {},
 ): RequestLogsTableColumn<RequestLogsRow>[] {
   const apiLabel = t("request_logs.auth_type_api");
   const oauthLabel = t("request_logs.auth_type_oauth");
+  const identityColumn = options.identityColumn ?? "user";
   return [
     {
       key: "id",
@@ -815,19 +817,36 @@ export function buildRequestLogsColumns(
     },
     {
       key: "apiKeyName",
-      label: t("request_logs.col_user_name"),
+      label:
+        identityColumn === "key" ? t("request_logs.col_key_name") : t("request_logs.col_user_name"),
       width: "w-40",
       headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
       render: (row) => {
+        const keyFallback = row.maskedApiKey || (row.apiKeyId ? row.apiKeyId.slice(0, 8) : "");
+        const keyName =
+          row.apiKeyOwnName ||
+          (!row.endUserDisplayName ? row.apiKeyName : "") ||
+          keyFallback ||
+          "--";
+        if (identityColumn === "key") {
+          const displayName = row.isSystemCall ? t("request_logs.system_call") : keyName;
+          return (
+            <HoverTooltip content={displayName} className="block min-w-0">
+              <span
+                className={`block min-w-0 truncate text-xs font-medium ${displayName !== "--" ? "text-indigo-600 dark:text-indigo-400" : "text-slate-400 dark:text-white/30"}`}
+              >
+                {displayName}
+              </span>
+            </HoverTooltip>
+          );
+        }
         const userName = row.isSystemCall
           ? t("request_logs.system_call")
           : row.endUserDisplayName || row.apiKeyName || "--";
-        const keyFallback = row.maskedApiKey || (row.apiKeyId ? row.apiKeyId.slice(0, 8) : "");
-        const keyName = row.apiKeyOwnName || keyFallback;
         const showKeyName = Boolean(keyName && keyName !== userName);
         return (
-          <OverflowTooltip
+          <HoverTooltip
             content={showKeyName ? `${userName} · ${keyName}` : userName}
             className="block min-w-0"
           >
@@ -843,7 +862,7 @@ export function buildRequestLogsColumns(
                 </span>
               ) : null}
             </span>
-          </OverflowTooltip>
+          </HoverTooltip>
         );
       },
     },

--- a/packages/api-client/src/endpoints/__tests__/api-key-permission-profiles.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/api-key-permission-profiles.test.ts
@@ -54,34 +54,42 @@ describe("apiKeyPermissionProfilesApi", () => {
   });
 
   test("replaces permission profiles through the management database endpoint", async () => {
-    mocks.put.mockResolvedValue({});
+    mocks.put.mockResolvedValue({ applied_count: 2 });
 
-    await apiKeyPermissionProfilesApi.replace([
-      {
-        id: "standard",
-        name: "Standard",
-        "daily-limit": 15000,
-        "total-quota": 0,
-        "daily-spending-limit": 100.5,
-        "concurrency-limit": 0,
-        "rpm-limit": 0,
-        "tpm-limit": 0,
-        "allowed-channel-groups": ["pro"],
-        "allowed-channels": [],
-        "allowed-models": [],
-        "system-prompt": "",
-      },
-    ]);
+    await expect(
+      apiKeyPermissionProfilesApi.replace(
+        [
+          {
+            id: "standard",
+            name: "Standard",
+            "daily-limit": 15000,
+            "total-quota": 0,
+            "daily-spending-limit": 100.5,
+            "concurrency-limit": 0,
+            "rpm-limit": 0,
+            "tpm-limit": 0,
+            "allowed-channel-groups": ["pro"],
+            "allowed-channels": [],
+            "allowed-models": [],
+            "system-prompt": "",
+          },
+        ],
+        { syncAccounts: true },
+      ),
+    ).resolves.toEqual({ appliedCount: 2 });
 
-    expect(mocks.put).toHaveBeenCalledWith("/api-key-permission-profiles", [
-      expect.objectContaining({
-        id: "standard",
-        name: "Standard",
-        "daily-limit": 15000,
-        "daily-spending-limit": 100.5,
-        "allowed-channel-groups": ["pro"],
-      }),
-    ]);
+    expect(mocks.put).toHaveBeenCalledWith("/api-key-permission-profiles", {
+      items: [
+        expect.objectContaining({
+          id: "standard",
+          name: "Standard",
+          "daily-limit": 15000,
+          "daily-spending-limit": 100.5,
+          "allowed-channel-groups": ["pro"],
+        }),
+      ],
+      "sync-accounts": true,
+    });
     expect(mocks.putRawText).not.toHaveBeenCalled();
   });
 

--- a/packages/api-client/src/endpoints/api-key-permission-profiles.ts
+++ b/packages/api-client/src/endpoints/api-key-permission-profiles.ts
@@ -18,6 +18,14 @@ export interface ApiKeyPermissionProfile {
   "system-prompt": string;
 }
 
+export interface ReplaceApiKeyPermissionProfilesOptions {
+  syncAccounts?: boolean;
+}
+
+export interface ReplaceApiKeyPermissionProfilesResult {
+  appliedCount: number;
+}
+
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -209,10 +217,16 @@ export const apiKeyPermissionProfilesApi = {
     );
   },
 
-  async replace(profiles: ApiKeyPermissionProfile[]): Promise<void> {
-    await apiClient.put(
+  async replace(
+    profiles: ApiKeyPermissionProfile[],
+    options: ReplaceApiKeyPermissionProfilesOptions = {},
+  ): Promise<ReplaceApiKeyPermissionProfilesResult> {
+    const items = profiles.map(serializeApiKeyPermissionProfile);
+    const data = await apiClient.put<{ applied_count?: unknown }>(
       "/api-key-permission-profiles",
-      profiles.map(serializeApiKeyPermissionProfile),
+      options.syncAccounts ? { items, "sync-accounts": true } : items,
     );
+    const appliedCount = Number(data?.applied_count ?? 0);
+    return { appliedCount: Number.isFinite(appliedCount) ? appliedCount : 0 };
   },
 };

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2629,6 +2629,7 @@
     "col_id": "ID",
     "col_time": "Time",
     "col_user_name": "User Name",
+    "col_key_name": "Key Name",
     "col_model": "Model",
     "real_model_id": "Real model ID",
     "vision_fallback_model_id": "Vision fallback model ID",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2926,6 +2926,7 @@
     "col_id": "ID",
     "col_time": "时间",
     "col_user_name": "用户名称",
+    "col_key_name": "Key 名称",
     "col_model": "模型",
     "real_model_id": "真实模型 ID",
     "vision_fallback_model_id": "视觉补位模型 ID",

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -364,7 +364,10 @@ export function ApiKeyLookupPage() {
   }, []);
 
   const logColumns = useMemo(
-    () => buildRequestLogsColumns((key) => t(key), handleContentClick),
+    () =>
+      buildRequestLogsColumns((key) => t(key), handleContentClick, undefined, {
+        identityColumn: "key",
+      }),
     [t, handleContentClick],
   );
   // ── Tab state ──

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -429,8 +429,8 @@ describe("ApiKeyLookupPage", () => {
     });
     expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Codex 主渠道")).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: /user name|用户名称/i })).toBeInTheDocument();
-    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /key name|Key 名称/i })).toBeInTheDocument();
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
     expect(screen.getByText("Laptop")).toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: /^duration$/i })).not.toBeInTheDocument();
   });

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -2,19 +2,8 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Copy, Layers, RefreshCw, Search, Store } from "lucide-react";
 import { VendorIcon } from "@code-proxy/assets";
-import {
-  Card,
-  EmptyState,
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  TextInput,
-  useToast,
-} from "@code-proxy/ui";
-import {
-  formatModelPriceAmount,
-  hasModelPricing,
-} from "@features/model-availability";
+import { Card, EmptyState, Tabs, TabsList, TabsTrigger, TextInput, useToast } from "@code-proxy/ui";
+import { formatModelPriceAmount, hasModelPricing } from "@features/model-availability";
 import {
   buildModelVendorStats,
   getModelVendorKey,
@@ -63,13 +52,7 @@ function formatPriceCell(amount: number, notPriced: string): string {
   return `$${formatModelPriceAmount(amount)}`;
 }
 
-function ModelPlazaCard({
-  model,
-  onCopied,
-}: {
-  model: PublicModelItem;
-  onCopied: () => void;
-}) {
+function ModelPlazaCard({ model, onCopied }: { model: PublicModelItem; onCopied: () => void }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const priced = hasModelPricing(model.pricing);
@@ -113,8 +96,7 @@ function ModelPlazaCard({
             notPriced,
           )}
           muted={
-            model.pricing.cacheReadPricePerMillion <= 0 &&
-            model.pricing.cachedPricePerMillion <= 0
+            model.pricing.cacheReadPricePerMillion <= 0 && model.pricing.cachedPricePerMillion <= 0
           }
         />
       </div>
@@ -179,9 +161,7 @@ function ModelPlazaCard({
             className="line-clamp-2 break-words text-xs leading-5 text-slate-500 dark:text-white/55"
             data-testid="model-description-clamp"
           >
-            {model.description?.trim()
-              ? model.description
-              : t("model_plaza.no_description")}
+            {model.description?.trim() ? model.description : t("model_plaza.no_description")}
           </p>
         </div>
 
@@ -274,18 +254,13 @@ export function ModelsTabContent({
             <span className="text-2xs text-slate-400 dark:text-white/30">/ {models.length}</span>
           ) : null}
         </div>
-        <TextInput
-          value={searchFilter}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder={t("model_plaza.search")}
-          className="!w-40 sm:!w-56"
-          startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
-        />
       </div>
 
       {vendorStats.length > 0 && !loading ? (
-        // 不要 sticky：父页顶栏 toolbar 已 sticky，二级厂商 tabs 再 sticky 会压住「快捷导入」。
-        <div className="py-2.5">
+        <div
+          data-testid="apikey-lookup-model-tabs-sticky"
+          className="sticky top-20 z-10 -mx-1 flex flex-col gap-2 bg-white/95 px-1 py-2.5 backdrop-blur-sm sm:flex-row sm:items-center sm:justify-between dark:bg-neutral-950/90"
+        >
           <Tabs
             value={selectedVendor}
             onValueChange={(next) => setSelectedVendor(next as VendorFilter)}
@@ -295,19 +270,38 @@ export function ModelsTabContent({
               <TabsTrigger value="all">
                 <Layers size={12} aria-hidden="true" />
                 {t("common.all", { defaultValue: "All" })}
-                <span className="tabular-nums text-slate-400 dark:text-white/40">{models.length}</span>
+                <span className="tabular-nums text-slate-400 dark:text-white/40">
+                  {models.length}
+                </span>
               </TabsTrigger>
               {vendorStats.map((stat) => (
                 <TabsTrigger key={stat.key} value={stat.key}>
                   <VendorIcon modelId={stat.key} size={12} />
                   {stat.label}
-                  <span className="tabular-nums text-slate-400 dark:text-white/40">{stat.count}</span>
+                  <span className="tabular-nums text-slate-400 dark:text-white/40">
+                    {stat.count}
+                  </span>
                 </TabsTrigger>
               ))}
             </TabsList>
           </Tabs>
+          <TextInput
+            value={searchFilter}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={t("model_plaza.search")}
+            className="!w-full sm:!w-56 sm:shrink-0"
+            startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
+          />
         </div>
-      ) : null}
+      ) : (
+        <TextInput
+          value={searchFilter}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={t("model_plaza.search")}
+          className="!w-full sm:!w-56"
+          startAdornment={<Search size={14} className="text-slate-400 dark:text-white/35" />}
+        />
+      )}
 
       <div className="mt-4 flex min-w-0 flex-col gap-4">
         {error ? (
@@ -335,9 +329,7 @@ export function ModelsTabContent({
             icon={<Store size={28} className="opacity-50" />}
             title={models.length === 0 ? t("model_plaza.no_models") : t("model_plaza.no_match")}
             description={
-              models.length === 0
-                ? t("model_plaza.no_models_desc")
-                : t("model_plaza.no_match_desc")
+              models.length === 0 ? t("model_plaza.no_models_desc") : t("model_plaza.no_match_desc")
             }
           />
         )}

--- a/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/ModelsTabContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import i18n from "@code-proxy/i18n";
@@ -8,10 +8,7 @@ import { ThemeProvider } from "@code-proxy/ui";
 import { ToastProvider } from "@code-proxy/ui";
 import type { PublicModelItem } from "../../api";
 
-const model = (
-  id: string,
-  extras?: Partial<PublicModelItem>,
-): PublicModelItem => ({
+const model = (id: string, extras?: Partial<PublicModelItem>): PublicModelItem => ({
   id,
   description: extras?.description ?? "",
   ownedBy: extras?.ownedBy ?? "",
@@ -66,6 +63,10 @@ describe("ModelsTabContent", () => {
     expect(screen.getByText("qwen3.5-plus")).toBeInTheDocument();
     expect(screen.getByText("deepseek-chat")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/search models/i)).toBeInTheDocument();
+    const sticky = screen.getByTestId("apikey-lookup-model-tabs-sticky");
+    expect(sticky).toHaveClass("sticky", "top-20", "z-10");
+    expect(within(sticky).getByRole("tablist", { name: /filter by vendor/i })).toBeInTheDocument();
+    expect(within(sticky).getByPlaceholderText(/search models/i)).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("tab", { name: /qwen/i }));
 
@@ -119,11 +120,7 @@ describe("ModelsTabContent", () => {
       <ThemeProvider>
         <ToastProvider>
           <ModelsTabContent
-            models={[
-              model("claude-sonnet-4-5"),
-              model("gpt-5.3-codex"),
-              model("gemini-2.5-pro"),
-            ]}
+            models={[model("claude-sonnet-4-5"), model("gpt-5.3-codex"), model("gemini-2.5-pro")]}
             loading={false}
             error={null}
             searchFilter=""

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -245,19 +245,14 @@ export function ApiKeyPermissionsPage() {
       const nextProfiles = isEdit
         ? profiles.map((item) => (item.id === profile.id ? profile : item))
         : [...profiles, profile];
-      await apiKeyPermissionProfilesApi.replace(nextProfiles);
+      await apiKeyPermissionProfilesApi.replace(nextProfiles, { syncAccounts: true });
 
       let nextAccounts = accounts;
       if (isEdit) {
-        const boundAccounts = accounts.filter(
-          (account) => account["permission-profile-id"] === profile.id,
-        );
         const update = profileToAccountUpdate(profile);
-        const updatedAccounts = await Promise.all(
-          boundAccounts.map((account) => endUsersApi.update(account.id, update)),
+        nextAccounts = accounts.map((account) =>
+          account["permission-profile-id"] === profile.id ? { ...account, ...update } : account,
         );
-        const updatedById = new Map(updatedAccounts.map((account) => [account.id, account]));
-        nextAccounts = accounts.map((account) => updatedById.get(account.id) ?? account);
       }
 
       setProfiles(nextProfiles);
@@ -279,18 +274,15 @@ export function ApiKeyPermissionsPage() {
     setSaving(true);
     try {
       const nextProfiles = profiles.filter((profile) => profile.id !== deleteTarget.id);
-      await apiKeyPermissionProfilesApi.replace(nextProfiles);
-      const boundAccounts = accounts.filter(
-        (account) => account["permission-profile-id"] === deleteTarget.id,
-      );
-      const updatedAccounts = await Promise.all(
-        boundAccounts.map((account) =>
-          endUsersApi.update(account.id, { "permission-profile-id": "" }),
+      await apiKeyPermissionProfilesApi.replace(nextProfiles, { syncAccounts: true });
+      setProfiles(nextProfiles);
+      setAccounts(
+        accounts.map((account) =>
+          account["permission-profile-id"] === deleteTarget.id
+            ? { ...account, "permission-profile-id": "" }
+            : account,
         ),
       );
-      const updatedById = new Map(updatedAccounts.map((account) => [account.id, account]));
-      setProfiles(nextProfiles);
-      setAccounts(accounts.map((account) => updatedById.get(account.id) ?? account));
       setDeleteTarget(null);
       notify({ type: "success", message: t("api_key_permissions_page.profile_deleted") });
     } catch (err: unknown) {

--- a/pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
+++ b/pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
@@ -28,9 +28,14 @@ const mocks = vi.hoisted(() => ({
     state.accounts = state.accounts.map((account) => (account.id === id ? updated : account));
     return updated;
   }),
-  apiClientPut: vi.fn(async (url: string, body: ApiKeyPermissionProfile[]) => {
-    if (url === "/api-key-permission-profiles") state.permissionProfiles = body;
-    return {};
+  apiClientPut: vi.fn(async (url: string, body: unknown) => {
+    if (url === "/api-key-permission-profiles") {
+      const items = Array.isArray(body)
+        ? body
+        : ((body as { items?: ApiKeyPermissionProfile[] } | null)?.items ?? []);
+      state.permissionProfiles = items;
+    }
+    return { applied_count: 2 };
   }),
   authFilesList: vi.fn(async () => ({ files: [] })),
   getGeminiKeys: vi.fn(async (): Promise<unknown[]> => []),
@@ -85,8 +90,16 @@ vi.mock("@code-proxy/api-client/endpoints/api-key-permission-profiles", async (i
             "api-key-permission-profiles"
           ] ?? [],
         ),
-      replace: async (profiles: ApiKeyPermissionProfile[]) =>
-        mocks.apiClientPut("/api-key-permission-profiles", profiles),
+      replace: async (
+        profiles: ApiKeyPermissionProfile[],
+        options?: { syncAccounts?: boolean },
+      ) => {
+        const response = await mocks.apiClientPut(
+          "/api-key-permission-profiles",
+          options?.syncAccounts ? { items: profiles, "sync-accounts": true } : profiles,
+        );
+        return { appliedCount: response.applied_count };
+      },
     },
   };
 });
@@ -206,20 +219,23 @@ describe("ApiKeyPermissionsPage", () => {
     await waitFor(() => {
       expect(mocks.apiClientPut).toHaveBeenCalledWith(
         "/api-key-permission-profiles",
-        expect.arrayContaining([
-          expect.objectContaining({
-            name: "专业配置",
-            "daily-limit": 15000,
-            "allowed-channel-groups": ["pro"],
-            "system-prompt": "专业系统提示词",
-          }),
-        ]),
+        expect.objectContaining({
+          "sync-accounts": true,
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              name: "专业配置",
+              "daily-limit": 15000,
+              "allowed-channel-groups": ["pro"],
+              "system-prompt": "专业系统提示词",
+            }),
+          ]),
+        }),
       );
     });
     expect(mocks.endUsersUpdate).not.toHaveBeenCalled();
   });
 
-  test("applies an edited profile to every bound user account", async () => {
+  test("applies an edited profile through one atomic server request", async () => {
     renderPage();
     expect(await screen.findByText("标准配置")).toBeInTheDocument();
 
@@ -231,23 +247,20 @@ describe("ApiKeyPermissionsPage", () => {
     await userEvent.click(within(dialog).getByRole("button", { name: "保存配置" }));
 
     await waitFor(() => {
-      expect(mocks.endUsersUpdate).toHaveBeenCalledTimes(2);
-      expect(mocks.endUsersUpdate).toHaveBeenCalledWith(
-        "user-a",
+      expect(mocks.apiClientPut).toHaveBeenCalledWith(
+        "/api-key-permission-profiles",
         expect.objectContaining({
-          "permission-profile-id": "standard",
-          "daily-limit": 16000,
-        }),
-      );
-      expect(mocks.endUsersUpdate).toHaveBeenCalledWith(
-        "user-c",
-        expect.objectContaining({
-          "permission-profile-id": "standard",
-          "daily-limit": 16000,
+          "sync-accounts": true,
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              id: "standard",
+              "daily-limit": 16000,
+            }),
+          ]),
         }),
       );
     });
-    expect(mocks.endUsersUpdate).not.toHaveBeenCalledWith("user-b", expect.anything());
+    expect(mocks.endUsersUpdate).not.toHaveBeenCalled();
   });
 
   test("loads provider channels from OpenCode Go, ClinePass and Ollama Cloud configs", async () => {

--- a/pages/api-keys/hooks/useApiKeyUsageView.ts
+++ b/pages/api-keys/hooks/useApiKeyUsageView.ts
@@ -89,7 +89,10 @@ export function useApiKeyUsageView({
   }, []);
 
   const usageLogColumns = useMemo(
-    () => buildRequestLogsColumns(t, handleUsageContentClick, handleUsageErrorClick),
+    () =>
+      buildRequestLogsColumns(t, handleUsageContentClick, handleUsageErrorClick, {
+        identityColumn: "key",
+      }),
     [t, handleUsageContentClick, handleUsageErrorClick],
   );
 
@@ -185,9 +188,7 @@ export function useApiKeyUsageView({
 
   const openUsageView = useCallback(
     (keys: string[], name: string) => {
-      const cleaned = Array.from(
-        new Set(keys.map((k) => k.trim()).filter(Boolean)),
-      );
+      const cleaned = Array.from(new Set(keys.map((k) => k.trim()).filter(Boolean)));
       if (cleaned.length === 0) return;
       resetUsageViewState();
       setUsageViewKeys(cleaned);

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -1,3 +1,5 @@
+import { createElement } from "react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import {
   buildRequestLogsColumns,
@@ -103,5 +105,40 @@ describe("requestLogsShared", () => {
     expect(keys.indexOf("cost")).toBeLessThan(keys.indexOf("model"));
     expect(columns.find((column) => column.key === "apiKeyName")?.width).toBe("w-40");
     expect(columns.find((column) => column.key === "model")?.width).toBe("w-44");
+  });
+
+  test("builds a key-primary identity column for account usage and portal logs", () => {
+    const row = toRequestLogsRow({
+      id: 9,
+      timestamp: "2026-07-19T12:00:00Z",
+      api_key: "sk-owned-123456",
+      api_key_id: "key-laptop-123456",
+      api_key_name: "Alice",
+      end_user_display_name: "Alice",
+      api_key_own_name: "Laptop",
+      model: "gpt-5.4",
+      source: "codex",
+      channel_name: "Codex",
+      auth_index: "auth-9",
+      failed: false,
+      latency_ms: 100,
+      first_token_ms: 20,
+      input_tokens: 1,
+      output_tokens: 1,
+      reasoning_tokens: 0,
+      cached_tokens: 0,
+      total_tokens: 2,
+      cost: 0,
+      has_content: false,
+    });
+    const column = buildRequestLogsColumns((key) => key, undefined, undefined, {
+      identityColumn: "key",
+    }).find((item) => item.key === "apiKeyName");
+
+    expect(column?.label).toBe("request_logs.col_key_name");
+    if (!column) throw new Error("missing apiKeyName column");
+    render(createElement("div", null, column.render(row, 0)));
+    expect(screen.getByText("Laptop")).toBeInTheDocument();
+    expect(screen.queryByText("Alice")).not.toBeInTheDocument();
   });
 });

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -255,6 +255,11 @@ describe("RequestLogsPage", () => {
     expect(within(table).getByText("183ms")).toBeInTheDocument();
     expect(within(table).queryByText("First Token Latency")).not.toBeInTheDocument();
 
+    await user.hover(within(table).getByText("Zhang Bolun"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Zhang Bolun · Laptop");
+    await user.unhover(within(table).getByText("Zhang Bolun"));
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+
     await user.hover(within(table).getByLabelText("Duration: 1.20s"));
     expect(await screen.findByRole("tooltip")).toHaveTextContent("First Token Latency: 183ms");
   });


### PR DESCRIPTION
## Summary

Finish the frontend portions of end-user residual risks #6 and portal UX issues P2–P5:

- save permission profiles with one atomic `sync-accounts` request instead of N account PATCHes
- show user + key identity in management request logs
- use Key Name as the primary identity in account usage and portal request logs
- make portal model-vendor tabs sticky and keep search on the same wide-screen row
- add API client, page, shared-column, and layout regression coverage

## Verification

- focused Vitest: 6 files / 46 tests
- `./scripts/ci-pr.sh` on rebased `origin/dev`:
  - lint/design checks passed
  - Vitest 111 files / 794 tests passed
  - production build and bundle diff passed
  - critical Playwright 9/9 passed

No deployment or production database changes were performed.
