### PR TITLE
fix(apikey-lookup): channel filter badges and no landing flash

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -8,6 +8,10 @@ import {
   type EndUser,
   type EndUserAPIKey,
 } from "@code-proxy/api-client";
+import {
+  normalizeChannelOptions,
+  type UsageChannelFilterOption,
+} from "@code-proxy/api-client/endpoints/usage";
 import { resolveLoginErrorMessage } from "../login/loginErrors";
 import { useTheme } from "@code-proxy/ui";
 import { ThemeToggleButton } from "@code-proxy/ui";
@@ -42,8 +46,10 @@ import { useApiKeyLookupCharts } from "./hooks/useApiKeyLookupCharts";
 import type { ChartDataResponse, PublicLogItem, PublicUsageLimits } from "./types";
 import {
   buildRequestLogsColumns,
+  ChannelIdentityLabel,
   formatOptionalRequestLogLatencyMs,
   formatRequestLogLatencyMs,
+  normalizeChannelAuthType,
   normalizeFilterSelection,
   toFilterParam,
   toStatusFilterValues,
@@ -243,6 +249,7 @@ const readLegacyLookupKeyFromUrl = (): string => {
 };
 
 function toLogRow(item: PublicLogItem): RequestLogsRow {
+  const channelAuthType = normalizeChannelAuthType(item.auth_type);
   return {
     id: String(item.id),
     timestamp: item.timestamp,
@@ -254,9 +261,8 @@ function toLogRow(item: PublicLogItem): RequestLogsRow {
     endUserDisplayName: item.end_user_display_name || item.api_key_name || "",
     isSystemCall: false,
     channelName: item.channel_name || "",
-    // Public lookup logs do not currently expose provider/auth metadata.
-    channelProvider: undefined,
-    channelAuthType: undefined,
+    channelProvider: String(item.provider ?? "").trim() || undefined,
+    channelAuthType: channelAuthType || undefined,
     maskedApiKey: item.api_key_masked || maskRequestLogApiKey(item.api_key || ""),
     model: item.model,
     upstreamModel: item.upstream_model || "",
@@ -417,8 +423,9 @@ export function ApiKeyLookupPage() {
   const [filterOptions, setFilterOptions] = useState<{
     models: string[];
     channels: string[];
+    channel_options: UsageChannelFilterOption[];
     statuses: string[];
-  }>({ models: [], channels: [], statuses: ["success", "failed"] });
+  }>({ models: [], channels: [], channel_options: [], statuses: ["success", "failed"] });
 
   const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return filterOptions.models.map((model) => ({
@@ -429,12 +436,35 @@ export function ApiKeyLookupPage() {
   }, [filterOptions.models]);
 
   const channelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
-    return filterOptions.channels.map((channel) => ({
-      value: channel,
-      label: channel,
-      searchText: channel,
-    }));
-  }, [filterOptions.channels]);
+    const source: UsageChannelFilterOption[] =
+      filterOptions.channel_options.length > 0
+        ? filterOptions.channel_options
+        : filterOptions.channels.map((ch) => ({
+            value: ch,
+            label: ch,
+          }));
+    const apiLabel = t("request_logs.auth_type_api");
+    const oauthLabel = t("request_logs.auth_type_oauth");
+    return source.map((option) => {
+      const provider = String(option.provider ?? "").trim();
+      const authType = String(option.auth_type ?? "").trim();
+      return {
+        value: option.value,
+        label: (
+          <ChannelIdentityLabel
+            name={option.label}
+            provider={option.provider}
+            authType={option.auth_type}
+            apiLabel={apiLabel}
+            oauthLabel={oauthLabel}
+            className="w-full"
+            nameClassName="text-sm font-normal text-inherit"
+          />
+        ),
+        searchText: [option.label, provider, authType, option.value].filter(Boolean).join(" "),
+      };
+    });
+  }, [filterOptions.channel_options, filterOptions.channels, t]);
 
   const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     const statuses =
@@ -553,6 +583,10 @@ export function ApiKeyLookupPage() {
         setFilterOptions({
           models: resp.filters?.models ?? [],
           channels: resp.filters?.channels ?? [],
+          channel_options: normalizeChannelOptions(
+            resp.filters?.channel_options,
+            resp.filters?.channels,
+          ),
           statuses: resp.filters?.statuses ?? ["success", "failed"],
         });
         setLastUpdatedAt(Date.now());
@@ -786,6 +820,7 @@ export function ApiKeyLookupPage() {
     setFilterOptions({
       models: [],
       channels: [],
+      channel_options: [],
       statuses: ["success", "failed"],
     });
     setSelectedModels(null);
@@ -807,12 +842,22 @@ export function ApiKeyLookupPage() {
     setLoginModalOpen(false);
   }, []);
 
+  // Avoid landing flash while a stored portal session is still hydrating.
+  const [portalSessionPending, setPortalSessionPending] = useState(
+    () => Boolean(portalApi.loadSession()?.accessToken),
+  );
+
   useEffect(() => {
     const snap = portalApi.loadSession();
-    if (!snap?.accessToken) return;
+    if (!snap?.accessToken) {
+      setPortalSessionPending(false);
+      return;
+    }
+    let cancelled = false;
     void portalApi
       .me()
       .then(async (res) => {
+        if (cancelled) return;
         setPortalUser(res.user);
         if (res.user.must_change_password) {
           setChangePasswordOpen(true);
@@ -821,17 +866,25 @@ export function ApiKeyLookupPage() {
         }
         try {
           const keys = await portalApi.listKeys();
+          if (cancelled) return;
           const items = keys.items ?? [];
           setPortalKeys(items);
           const firstUsable = items.find((key) => !key.disabled);
           if (firstUsable) await activateOwnedKey(firstUsable.id);
         } catch {
-          setPortalKeys([]);
+          if (!cancelled) setPortalKeys([]);
         }
       })
       .catch(() => {
+        if (cancelled) return;
         portalApi.clearSession();
+      })
+      .finally(() => {
+        if (!cancelled) setPortalSessionPending(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handlePortalLogin = useCallback(async () => {
@@ -1012,7 +1065,7 @@ export function ApiKeyLookupPage() {
   //  Render
   // ================================================================
 
-  const showLanding = !queriedKey && !portalUser && !error;
+  const showLanding = !queriedKey && !portalUser && !portalSessionPending && !error;
 
   return (
     <PageBackground variant={showLanding ? "login" : "app"}>

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -347,6 +347,9 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
+    // Stored portal session must not flash the public landing before /me resolves.
+    expect(screen.queryByTestId("apikey-lookup-landing")).not.toBeInTheDocument();
+
     await waitFor(() => {
       expect(mocks.fetchPublicChartData).toHaveBeenCalledWith(
         expect.objectContaining({ apiKey: "", portalAccount: true }),
@@ -362,6 +365,81 @@ describe("ApiKeyLookupPage", () => {
       screen.queryByRole("button", { name: /set as default|设默认/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/^default$|^默认$/i)).not.toBeInTheDocument();
+  });
+
+  test("renders channel filter options with provider icon and auth badge", async () => {
+    window.history.replaceState({}, "", "/manage/apikey-lookup?api_key=sk-restored-key");
+    mocks.fetchPublicLogs.mockResolvedValueOnce({
+      items: [
+        {
+          id: 1,
+          timestamp: new Date("2026-07-05T03:01:18Z").toISOString(),
+          channel_name: "owner@example.com",
+          provider: "codex",
+          auth_type: "oauth",
+          model: "gpt-5.5",
+          failed: false,
+          streaming: true,
+          latency_ms: 1000,
+          first_token_ms: 100,
+          input_tokens: 1,
+          cached_tokens: 0,
+          output_tokens: 1,
+          total_tokens: 2,
+          cost: 0,
+          has_content: false,
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 50,
+      api_key_name: "Primary key",
+      stats: {
+        total: 1,
+        success_rate: 100,
+        total_tokens: 2,
+        total_sessions: 1,
+        total_cost: 0,
+      },
+      filters: {
+        models: ["gpt-5.5"],
+        channels: ["owner@example.com"],
+        channel_options: [
+          {
+            value: "authsub_codex_owner",
+            label: "owner@example.com",
+            provider: "codex",
+            auth_type: "oauth",
+          },
+        ],
+        statuses: ["success", "failed"],
+      },
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await userEvent.click(await screen.findByRole("tab", { name: /request logs/i }));
+    await waitFor(() => {
+      expect(mocks.fetchPublicLogs).toHaveBeenCalled();
+    });
+
+    // Table channel cell also uses ChannelIdentityLabel (icon + OAuth badge).
+    expect(await screen.findByText("owner@example.com")).toBeInTheDocument();
+    expect(screen.getByText("OAuth")).toBeInTheDocument();
+
+    const channelFilter = screen.getByRole("combobox", { name: /filter by channel/i });
+    await userEvent.click(channelFilter);
+    // Filter option value comes from channel_options, not the display label alone.
+    expect(
+      await screen.findByRole("option", { name: /owner@example.com/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("OAuth").length).toBeGreaterThan(0);
   });
 
   test("loads public logs only after switching to the request logs tab", async () => {
@@ -401,6 +479,14 @@ describe("ApiKeyLookupPage", () => {
       filters: {
         models: ["gpt-5.5"],
         channels: ["Codex 主渠道"],
+        channel_options: [
+          {
+            value: "authsub_codex_main",
+            label: "Codex 主渠道",
+            provider: "codex",
+            auth_type: "oauth",
+          },
+        ],
         statuses: ["success", "failed"],
       },
     });

--- a/pages/api-key-lookup/types.ts
+++ b/pages/api-key-lookup/types.ts
@@ -1,3 +1,11 @@
+export interface PublicChannelFilterOption {
+  value: string;
+  label: string;
+  provider?: string;
+  auth_type?: "oauth" | "api" | string;
+  auth_index?: string;
+}
+
 export interface PublicLogItem {
   id: number;
   timestamp: string;
@@ -8,6 +16,8 @@ export interface PublicLogItem {
   api_key_own_name?: string;
   end_user_display_name?: string;
   channel_name?: string;
+  provider?: string;
+  auth_type?: "oauth" | "api" | string;
   model: string;
   upstream_model?: string;
   vision_fallback_model?: string;
@@ -39,6 +49,7 @@ export interface PublicLogsResponse {
   filters: {
     models: string[];
     channels: string[];
+    channel_options?: PublicChannelFilterOption[];
     statuses: string[];
   };
 }


### PR DESCRIPTION
## Summary
- Public API key lookup channel multi-select now reuses `ChannelIdentityLabel` (provider icon + OAuth/API badge), matching `/runtime/request-logs`.
- Consume backend `filters.channel_options` (with legacy `channels` fallback) and pass `provider`/`auth_type` through to log rows.
- While a stored portal session is hydrating, skip the marketing landing so a normal refresh no longer flashes that page.

## Test plan
- [x] `bun run test:ci -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx` (15 passed)
- [x] `bun run lint` / `design:check` / full `test:ci` (796) / `build` / `bundle:diff`
- [x] Playwright `@critical` smoke on free port (9 passed; local 5173 was occupied by another app)

## Notes
- Frontend-only; backend already returns `channel_options` + item `provider`/`auth_type` for public usage logs.