### PR TITLE
feat: multi-account switch in admin shell

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -194,9 +194,13 @@ vi.mock("@app/providers/AuthProvider", () => ({
     can: () => true,
     state: {
       principal: authPrincipal,
+      savedAccounts: [],
     },
     actions: {
       switchTenant: vi.fn(),
+      beginAddAccount: vi.fn(),
+      switchAccount: vi.fn(),
+      removeSavedAccount: vi.fn(),
     },
   }),
 }));

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -21,6 +21,9 @@ import {
   PanelLeft,
   Settings,
   ShieldCheck,
+  UserPlus,
+  Users,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -36,6 +39,7 @@ import {
 import { preloadPageRoute } from "@pages/registry";
 import { recoverFromChunkLoadError } from "@pages/chunkLoadRecovery";
 import {
+  buildAccountKey,
   identityApi,
   IDENTITY_TENANTS_UPDATED_EVENT,
   type MenuIdentity,
@@ -636,6 +640,10 @@ function ShellSidebar({
   const auth = useOptionalAuth();
   const can = auth?.can ?? (() => true);
   const principal = auth?.state.principal ?? null;
+  const savedAccounts = auth?.state.savedAccounts ?? [];
+  const switchAccount = auth?.actions.switchAccount;
+  const beginAddAccount = auth?.actions.beginAddAccount;
+  const removeSavedAccount = auth?.actions.removeSavedAccount;
   const menuByCode = useMemo(
     () => (principal?.menus ? new Map(principal.menus.map((menu) => [menu.code, menu])) : null),
     [principal?.menus],
@@ -863,6 +871,36 @@ function ShellSidebar({
     logout();
   }, [logout, navigate]);
 
+  const handleAddAccount = useCallback(() => {
+    beginAddAccount?.();
+    navigate("/login", { replace: true, viewTransition: true });
+  }, [beginAddAccount, navigate]);
+
+  const handleSwitchAccount = useCallback(
+    (accountId: string) => {
+      if (!switchAccount) return;
+      // On failure switchAccount rolls back; ProtectedRoute sends unauth to login.
+      void switchAccount(accountId).then((ok) => {
+        if (ok) navigate("/dashboard", { replace: true, viewTransition: true });
+      });
+    },
+    [navigate, switchAccount],
+  );
+
+  const currentAccountKey = useMemo(() => {
+    if (!principal?.user.id || !auth?.state.apiBase) return "";
+    return buildAccountKey(auth.state.apiBase, principal.user.id);
+  }, [auth?.state.apiBase, principal?.user.id]);
+
+  const otherAccounts = useMemo(
+    () =>
+      savedAccounts.filter((row) => {
+        if (row.accountKey && currentAccountKey) return row.accountKey !== currentAccountKey;
+        return row.accountId !== principal?.user.id;
+      }),
+    [currentAccountKey, principal?.user.id, savedAccounts],
+  );
+
   return (
     <>
       {pendingTo && <div className={progressDone ? "rp rp-done" : "rp"} />}
@@ -1041,6 +1079,60 @@ function ShellSidebar({
                       </DropdownMenu.Item>
                     ) : null}
                     <DropdownMenu.Separator />
+                    {otherAccounts.length > 0 ? (
+                      <>
+                        <div className="px-2 py-1.5 text-2xs font-medium uppercase tracking-wide text-slate-400">
+                          {t("shell.switch_account")}
+                        </div>
+                        {otherAccounts.map((account) => {
+                          const key = account.accountKey || account.accountId;
+                          return (
+                            <DropdownMenu.Item
+                              key={key}
+                              className="group/saved-account py-2.5"
+                              onSelect={(event) => {
+                                if (
+                                  event.target instanceof Element &&
+                                  event.target.closest("[data-remove-saved-account]")
+                                ) {
+                                  event.preventDefault();
+                                  removeSavedAccount?.(key);
+                                  return;
+                                }
+                                handleSwitchAccount(key);
+                              }}
+                            >
+                              <Users size={16} />
+                              <span className="min-w-0 flex-1 truncate leading-tight">
+                                <span className="block truncate">
+                                  {account.displayName || account.username}
+                                </span>
+                                <span className="block truncate text-2xs font-normal text-slate-400">
+                                  {account.username}
+                                  {account.apiBase
+                                    ? ` · ${account.apiBase.replace(/^https?:\/\//, "")}`
+                                    : ""}
+                                </span>
+                              </span>
+                              <span
+                                role="button"
+                                tabIndex={-1}
+                                data-remove-saved-account="true"
+                                aria-label={t("shell.forget_saved_account")}
+                                className="ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-slate-100 hover:text-rose-600 group-hover/saved-account:opacity-100 group-focus-within/saved-account:opacity-100 dark:hover:bg-white/10"
+                              >
+                                <X size={12} />
+                              </span>
+                            </DropdownMenu.Item>
+                          );
+                        })}
+                        <DropdownMenu.Separator />
+                      </>
+                    ) : null}
+                    <DropdownMenu.Item onSelect={handleAddAccount} className="py-2.5">
+                      <UserPlus size={16} />
+                      {t("shell.add_account")}
+                    </DropdownMenu.Item>
                     <DropdownMenu.Item
                       onSelect={handleLogout}
                       className="py-2.5 text-rose-600 focus:text-rose-700 dark:text-rose-300"

--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -5,28 +5,39 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
   apiClient,
+  AUTH_ACCOUNTS_CHANGED_EVENT,
+  AUTH_ACCOUNTS_STORAGE_KEY,
+  buildAccountKey,
   clearPersistedAuthSnapshot,
   computeManagementApiBase,
   detectApiBaseFromLocation,
+  getSavedAuthAccount,
   identityApi,
   IDENTITY_MENUS_UPDATED_EVENT,
   extractApiErrorCode,
   isApiClientError,
   configApi,
+  listSavedAuthAccounts,
   normalizeApiBase,
   readPersistedAuthSnapshot,
+  removeSavedAuthAccount,
   updatePersistedEffectiveTenantId,
+  upsertSavedAuthAccount,
   writePersistedAuthSnapshot,
   type ManagementPrincipal,
   type MenuIdentity,
+  type SavedAuthAccount,
 } from "@code-proxy/api-client";
 import {
   DEFAULT_CACHE_TENANT_ID,
+  setActiveCacheScopePrefix,
   setActiveCacheTenantId,
+  setCacheScopeResolver,
   setCacheTenantResolver,
 } from "@code-proxy/domain";
 import { invalidateConfiguredModelAvailability } from "@features/model-availability";
@@ -43,6 +54,7 @@ interface AuthContextState {
     principal: ManagementPrincipal | null;
     authFailureCode: string;
     permissions: ReadonlySet<string>;
+    savedAccounts: SavedAuthAccount[];
   };
   actions: {
     login: (input: {
@@ -54,6 +66,11 @@ interface AuthContextState {
     logout: () => void;
     restore: () => Promise<void>;
     switchTenant: (tenantId: string) => Promise<void>;
+    /** Soft-switch: keep current session in vault, go to login to add another. */
+    beginAddAccount: () => void;
+    /** @returns true when the target session is active after switch. Accepts accountKey or legacy id. */
+    switchAccount: (accountKeyOrId: string) => Promise<boolean>;
+    removeSavedAccount: (accountKeyOrId: string) => void;
   };
   meta: { managementEndpoint: string };
   can: (permission: string) => boolean;
@@ -79,12 +96,26 @@ const persistEffectiveTenantOverride = (tenantId: string): void => {
   updatePersistedEffectiveTenantId(normalizeTenantOverride(tenantId));
 };
 
+const cacheScopePrefix = (apiBase: string, accountId?: string | null): string => {
+  const base = normalizeApiBase(apiBase);
+  const id = typeof accountId === "string" ? accountId.trim() : "";
+  if (!base) return "";
+  return id ? `${base}::${id}` : base;
+};
+
 /**
  * Pin the browser data-cache tenant to the effective management tenant.
  * Data caches (providers, auth-files, pricing, proxy checks, lookup charts)
  * all read getActiveCacheTenantId() so they never reuse another tenant's payload.
+ * Scope prefix (apiBase+account) prevents collisions across hosts/accounts.
  */
-const syncActiveDataCacheTenant = (tenantId?: string | null): void => {
+const syncActiveDataCacheTenant = (
+  tenantId?: string | null,
+  scope?: { apiBase?: string; accountId?: string | null },
+): void => {
+  if (scope) {
+    setActiveCacheScopePrefix(cacheScopePrefix(scope.apiBase ?? "", scope.accountId));
+  }
   setActiveCacheTenantId(tenantId ?? DEFAULT_CACHE_TENANT_ID);
   // Hard-invalidate process-global availability so in-flight promises cannot leak.
   invalidateConfiguredModelAvailability();
@@ -491,6 +522,49 @@ const legacyServicePrincipal = (): ManagementPrincipal => ({
   platform_admin: true,
 });
 
+const accountMetaFromPrincipal = (apiBase: string, principal: ManagementPrincipal) => {
+  const accountId = principal.user.id;
+  return {
+    accountId,
+    accountKey: buildAccountKey(apiBase, accountId),
+    username: principal.user.username,
+    displayName: principal.user.display_name || principal.user.username,
+  };
+};
+
+const parseExpiryMs = (value?: string | null): number | undefined => {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+};
+
+const persistSession = (input: {
+  apiBase: string;
+  managementKey: string;
+  refreshToken?: string;
+  rememberPassword: boolean;
+  effectiveTenantId?: string;
+  principal?: ManagementPrincipal | null;
+  expiresAtMs?: number;
+  refreshExpiresAtMs?: number;
+}) => {
+  const meta = input.principal ? accountMetaFromPrincipal(input.apiBase, input.principal) : {};
+  const expiry = {
+    ...(input.expiresAtMs ? { expiresAtMs: input.expiresAtMs } : {}),
+    ...(input.refreshExpiresAtMs ? { refreshExpiresAtMs: input.refreshExpiresAtMs } : {}),
+  };
+  writePersistedAuthSnapshot({
+    apiBase: input.apiBase,
+    managementKey: input.managementKey,
+    ...(input.refreshToken ? { refreshToken: input.refreshToken } : {}),
+    rememberPassword: input.rememberPassword,
+    effectiveTenantId: input.effectiveTenantId,
+    ...meta,
+    ...expiry,
+  });
+  // writePersistedAuthSnapshot already upserts vault when accountKey is present.
+};
+
 export function AuthProvider({ children }: PropsWithChildren) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);
@@ -502,6 +576,15 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const [serverBuildDate, setServerBuildDate] = useState<string | null>(null);
   const [principal, setPrincipal] = useState<ManagementPrincipal | null>(null);
   const [authFailureCode, setAuthFailureCode] = useState("");
+  const [savedAccounts, setSavedAccounts] = useState<SavedAuthAccount[]>(() =>
+    listSavedAuthAccounts(),
+  );
+  // Monotonic op id so a slower bootstrap cannot overwrite a newer login/switch.
+  const bootstrapOpRef = useRef(0);
+
+  const refreshSavedAccounts = useCallback(() => {
+    setSavedAccounts(listSavedAuthAccounts());
+  }, []);
 
   const configureClient = useCallback(
     (
@@ -526,15 +609,22 @@ export function AuthProvider({ children }: PropsWithChildren) {
   // Prefer live principal.effective_tenant for cache keys; fall back to last explicit pin.
   useEffect(() => {
     setCacheTenantResolver(() => principal?.effective_tenant?.id ?? null);
+    setCacheScopeResolver(() =>
+      principal ? cacheScopePrefix(apiBase, principal.user.id) : cacheScopePrefix(apiBase),
+    );
     if (principal?.effective_tenant?.id) {
       setActiveCacheTenantId(principal.effective_tenant.id);
+      setActiveCacheScopePrefix(cacheScopePrefix(apiBase, principal.user.id));
     }
     return () => {
       setCacheTenantResolver(null);
+      setCacheScopeResolver(null);
     };
-  }, [principal?.effective_tenant?.id]);
+  }, [apiBase, principal, principal?.effective_tenant?.id, principal?.user.id]);
 
-  const bootstrap = useCallback(async () => {
+  const bootstrap = useCallback(async (): Promise<boolean> => {
+    const op = ++bootstrapOpRef.current;
+    const isCurrent = () => bootstrapOpRef.current === op;
     const fallbackBase = detectApiBaseFromLocation();
     const snapshot = readPersistedAuthSnapshot();
     const resolvedBase = snapshot?.apiBase ?? fallbackBase;
@@ -550,32 +640,44 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setRememberPassword(resolvedRemember);
     configureClient(resolvedBase, resolvedToken, requestedTenant, snapshot?.refreshToken ?? "");
     // Pin cache tenant before any page paints from localStorage/sessionStorage.
-    syncActiveDataCacheTenant(requestedTenant || DEFAULT_CACHE_TENANT_ID);
+    syncActiveDataCacheTenant(requestedTenant || DEFAULT_CACHE_TENANT_ID, {
+      apiBase: resolvedBase,
+      accountId: snapshot?.accountId,
+    });
 
     if (!resolvedToken) {
+      if (!isCurrent()) return false;
       setIsAuthenticated(false);
       setPrincipal(null);
-      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
+      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase: resolvedBase });
       setIsRestoring(false);
-      return;
+      return false;
     }
     if (isLocalPreviewMode()) {
+      if (!isCurrent()) return false;
       const preview = legacyServicePrincipal();
       setPrincipal(preview);
-      syncActiveDataCacheTenant(preview.effective_tenant.id);
+      syncActiveDataCacheTenant(preview.effective_tenant.id, {
+        apiBase: resolvedBase,
+        accountId: preview.user.id,
+      });
       setIsAuthenticated(true);
       setIsRestoring(false);
-      return;
+      return true;
     }
 
     try {
       if (!resolvedToken.startsWith("cps_")) {
         await configApi.getConfig();
+        if (!isCurrent()) return false;
         const legacy = legacyServicePrincipal();
         setPrincipal(legacy);
-        syncActiveDataCacheTenant(legacy.effective_tenant.id);
+        syncActiveDataCacheTenant(legacy.effective_tenant.id, {
+          apiBase: resolvedBase,
+          accountId: legacy.user.id,
+        });
         setIsAuthenticated(true);
-        return;
+        return true;
       }
       let restoredPrincipal: ManagementPrincipal;
       try {
@@ -592,11 +694,13 @@ export function AuthProvider({ children }: PropsWithChildren) {
         syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
         restoredPrincipal = (await identityApi.me()).principal;
       }
+      if (!isCurrent()) return false;
       // If the server ignored or could not apply the override, drop the stale value.
       if (requestedTenant && restoredPrincipal.effective_tenant.id !== requestedTenant) {
         configureClient(resolvedBase, resolvedToken, "", snapshot?.refreshToken);
         if (restoredPrincipal.effective_tenant.id !== restoredPrincipal.home_tenant.id) {
           restoredPrincipal = (await identityApi.me()).principal;
+          if (!isCurrent()) return false;
         }
       }
       // Sync storage to what the server accepted so refresh keeps the same tenant.
@@ -609,22 +713,43 @@ export function AuthProvider({ children }: PropsWithChildren) {
       }
       persistEffectiveTenantOverride(confirmedOverride);
       setPrincipal(restoredPrincipal);
-      syncActiveDataCacheTenant(restoredPrincipal.effective_tenant.id);
+      syncActiveDataCacheTenant(restoredPrincipal.effective_tenant.id, {
+        apiBase: resolvedBase,
+        accountId: restoredPrincipal.user.id,
+      });
       setIsAuthenticated(true);
+      setAuthFailureCode("");
+      persistSession({
+        apiBase: resolvedBase,
+        managementKey: resolvedToken,
+        refreshToken: snapshot?.refreshToken,
+        rememberPassword: resolvedRemember,
+        effectiveTenantId: confirmedOverride || undefined,
+        principal: restoredPrincipal,
+        expiresAtMs: snapshot?.expiresAtMs,
+        refreshExpiresAtMs: snapshot?.refreshExpiresAtMs,
+      });
+      refreshSavedAccounts();
+      return true;
     } catch (error) {
+      if (!isCurrent()) return false;
       setIsAuthenticated(false);
       setPrincipal(null);
-      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
+      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase: resolvedBase });
       setAuthFailureCode(isApiClientError(error) ? extractApiErrorCode(error.payload) : "");
       // Transient restore failures keep the snapshot (including tenant override)
       // so a refresh can retry the same context instead of wiping it.
       if (!isTransientRestoreError(error)) {
+        const staleKey = snapshot?.accountKey || snapshot?.accountId;
         clearPersistedAuthSnapshot();
+        if (staleKey) removeSavedAuthAccount(staleKey);
+        refreshSavedAccounts();
       }
+      return false;
     } finally {
-      setIsRestoring(false);
+      if (isCurrent()) setIsRestoring(false);
     }
-  }, [configureClient]);
+  }, [configureClient, refreshSavedAccounts]);
 
   useEffect(() => void bootstrap(), [bootstrap]);
 
@@ -637,11 +762,24 @@ export function AuthProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     const handleUnauthorized = (event: Event) => {
       if (isLocalPreviewMode()) return;
-      setAuthFailureCode((event as CustomEvent<{ code?: string }>).detail?.code?.trim() ?? "");
+      const detail = (event as CustomEvent<{ code?: string; authGeneration?: number }>).detail;
+      // Ignore 401/403 from a request that started before the latest setConfig.
+      if (
+        typeof detail?.authGeneration === "number" &&
+        detail.authGeneration !== apiClient.getAuthGeneration()
+      ) {
+        return;
+      }
+      const code = detail?.code?.trim() ?? "";
+      setAuthFailureCode(code);
       setIsAuthenticated(false);
       setPrincipal(null);
-      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
+      syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase });
+      const snap = readPersistedAuthSnapshot();
+      const staleKey = snap?.accountKey || snap?.accountId;
       clearPersistedAuthSnapshot();
+      if (staleKey) removeSavedAuthAccount(staleKey);
+      setSavedAccounts(listSavedAuthAccounts());
     };
     const handleVersion = (event: Event) => {
       const detail = (event as CustomEvent<{ version?: string; buildDate?: string }>).detail;
@@ -649,19 +787,41 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setServerBuildDate(detail?.buildDate ?? null);
     };
     const handleTokenRefreshed = (event: Event) => {
-      const detail = (event as CustomEvent<{ accessToken?: string; refreshToken?: string }>).detail;
+      const detail = (
+        event as CustomEvent<{
+          accessToken?: string;
+          refreshToken?: string;
+          authGeneration?: number;
+        }>
+      ).detail;
+      if (
+        typeof detail?.authGeneration === "number" &&
+        detail.authGeneration !== apiClient.getAuthGeneration()
+      ) {
+        return;
+      }
       if (detail?.accessToken) setAccessToken(detail.accessToken);
       if (detail?.refreshToken) setRefreshToken(detail.refreshToken);
+    };
+    const handleAccountsChanged = () => setSavedAccounts(listSavedAuthAccounts());
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === AUTH_ACCOUNTS_STORAGE_KEY || event.key === null) {
+        setSavedAccounts(listSavedAuthAccounts());
+      }
     };
     window.addEventListener("unauthorized", handleUnauthorized);
     window.addEventListener("server-version-update", handleVersion as EventListener);
     window.addEventListener("auth-token-refreshed", handleTokenRefreshed as EventListener);
+    window.addEventListener(AUTH_ACCOUNTS_CHANGED_EVENT, handleAccountsChanged);
+    window.addEventListener("storage", handleStorage);
     return () => {
       window.removeEventListener("unauthorized", handleUnauthorized);
       window.removeEventListener("server-version-update", handleVersion as EventListener);
       window.removeEventListener("auth-token-refreshed", handleTokenRefreshed as EventListener);
+      window.removeEventListener(AUTH_ACCOUNTS_CHANGED_EVENT, handleAccountsChanged);
+      window.removeEventListener("storage", handleStorage);
     };
-  }, []);
+  }, [accessToken, apiBase, bootstrap, configureClient, principal, refreshToken]);
 
   const login = useCallback(
     async (input: {
@@ -684,23 +844,33 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setRefreshToken(response.refresh_token ?? "");
       setRememberPassword(input.rememberPassword);
       setPrincipal(response.principal);
-      syncActiveDataCacheTenant(response.principal.effective_tenant.id);
+      syncActiveDataCacheTenant(response.principal.effective_tenant.id, {
+        apiBase: normalizedBase,
+        accountId: response.principal.user.id,
+      });
       setAuthFailureCode("");
       setIsAuthenticated(true);
-      writePersistedAuthSnapshot({
+      // Explicit empty override so a leftover legacy key cannot re-apply.
+      persistSession({
         apiBase: normalizedBase,
         managementKey: response.access_token,
-        ...(response.refresh_token ? { refreshToken: response.refresh_token } : {}),
+        refreshToken: response.refresh_token,
         rememberPassword: input.rememberPassword,
-        // Explicit empty override so a leftover legacy key cannot re-apply.
         effectiveTenantId: undefined,
+        principal: response.principal,
+        expiresAtMs: parseExpiryMs(response.expires_at),
+        refreshExpiresAtMs: parseExpiryMs(response.refresh_expires_at),
       });
+      refreshSavedAccounts();
       return response.principal;
     },
-    [configureClient],
+    [configureClient, refreshSavedAccounts],
   );
 
   const logout = useCallback(() => {
+    const accountKey = principal
+      ? buildAccountKey(apiBase, principal.user.id)
+      : readPersistedAuthSnapshot()?.accountKey;
     void identityApi.logout().catch(() => undefined);
     setIsAuthenticated(false);
     setAccessToken("");
@@ -708,9 +878,128 @@ export function AuthProvider({ children }: PropsWithChildren) {
     setPrincipal(null);
     setAuthFailureCode("");
     configureClient(apiBase, "", "", "");
-    syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID);
+    syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase });
     clearPersistedAuthSnapshot();
-  }, [apiBase, configureClient]);
+    if (accountKey) removeSavedAuthAccount(accountKey);
+    refreshSavedAccounts();
+  }, [apiBase, configureClient, principal, refreshSavedAccounts]);
+
+  const beginAddAccount = useCallback(() => {
+    // Soft logout: keep vault entry so user can switch back after adding another account.
+    if (principal && accessToken) {
+      const override =
+        principal.effective_tenant.id === principal.home_tenant.id
+          ? undefined
+          : principal.effective_tenant.id;
+      const meta = accountMetaFromPrincipal(apiBase, principal);
+      upsertSavedAuthAccount({
+        apiBase,
+        managementKey: accessToken,
+        ...(refreshToken ? { refreshToken } : {}),
+        rememberPassword,
+        effectiveTenantId: override,
+        ...meta,
+        lastUsedAt: Date.now(),
+      });
+      refreshSavedAccounts();
+    }
+    setIsAuthenticated(false);
+    setAccessToken("");
+    setRefreshToken("");
+    setPrincipal(null);
+    setAuthFailureCode("");
+    configureClient(apiBase, "", "", "");
+    syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase });
+    clearPersistedAuthSnapshot();
+  }, [
+    accessToken,
+    apiBase,
+    configureClient,
+    principal,
+    refreshSavedAccounts,
+    refreshToken,
+    rememberPassword,
+  ]);
+
+  const switchAccount = useCallback(
+    async (accountKeyOrId: string): Promise<boolean> => {
+      const target = getSavedAuthAccount(accountKeyOrId);
+      if (!target) return false;
+      const currentKey = principal ? buildAccountKey(apiBase, principal.user.id) : "";
+      if (currentKey && target.accountKey === currentKey) return true;
+
+      const previousSnapshot =
+        principal && accessToken
+          ? {
+              apiBase,
+              managementKey: accessToken,
+              ...(refreshToken ? { refreshToken } : {}),
+              rememberPassword,
+              effectiveTenantId:
+                principal.effective_tenant.id === principal.home_tenant.id
+                  ? undefined
+                  : principal.effective_tenant.id,
+              ...accountMetaFromPrincipal(apiBase, principal),
+            }
+          : null;
+
+      // Park current session before swapping active snapshot.
+      if (previousSnapshot) {
+        upsertSavedAuthAccount({
+          ...previousSnapshot,
+          lastUsedAt: Date.now(),
+        });
+      }
+
+      writePersistedAuthSnapshot({
+        apiBase: target.apiBase,
+        managementKey: target.managementKey,
+        ...(target.refreshToken ? { refreshToken: target.refreshToken } : {}),
+        rememberPassword: target.rememberPassword,
+        effectiveTenantId: target.effectiveTenantId,
+        accountId: target.accountId,
+        accountKey: target.accountKey,
+        username: target.username,
+        displayName: target.displayName,
+        ...(target.expiresAtMs ? { expiresAtMs: target.expiresAtMs } : {}),
+        ...(target.refreshExpiresAtMs ? { refreshExpiresAtMs: target.refreshExpiresAtMs } : {}),
+      });
+      refreshSavedAccounts();
+      setIsRestoring(true);
+      const ok = await bootstrap();
+      if (ok) return true;
+
+      // Target failed: roll back to the parked previous session when possible.
+      if (previousSnapshot) {
+        writePersistedAuthSnapshot(previousSnapshot);
+        refreshSavedAccounts();
+        setIsRestoring(true);
+        return bootstrap();
+      }
+      return false;
+    },
+    [
+      accessToken,
+      apiBase,
+      bootstrap,
+      principal,
+      refreshSavedAccounts,
+      refreshToken,
+      rememberPassword,
+    ],
+  );
+
+  const removeSavedAccount = useCallback(
+    (accountKeyOrId: string) => {
+      const currentKey = principal ? buildAccountKey(apiBase, principal.user.id) : "";
+      if (currentKey && (accountKeyOrId === currentKey || accountKeyOrId === principal?.user.id)) {
+        return;
+      }
+      removeSavedAuthAccount(accountKeyOrId);
+      refreshSavedAccounts();
+    },
+    [apiBase, principal, refreshSavedAccounts],
+  );
 
   const restore = useCallback(async () => {
     setIsRestoring(true);
@@ -730,7 +1019,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
       configureClient(apiBase, accessToken, nextOverride, refreshToken);
       persistEffectiveTenantOverride(nextOverride);
       // Switch cache bucket immediately so remounted pages never paint prior tenant data.
-      syncActiveDataCacheTenant(nextTenant || principal.home_tenant.id);
+      syncActiveDataCacheTenant(nextTenant || principal.home_tenant.id, {
+        apiBase,
+        accountId: principal.user.id,
+      });
       try {
         const response = await identityApi.me();
         const effective = response.principal.effective_tenant;
@@ -742,11 +1034,17 @@ export function AuthProvider({ children }: PropsWithChildren) {
           persistEffectiveTenantOverride(confirmedOverride);
         }
         setPrincipal(response.principal);
-        syncActiveDataCacheTenant(effective.id);
+        syncActiveDataCacheTenant(effective.id, {
+          apiBase,
+          accountId: response.principal.user.id,
+        });
       } catch {
         configureClient(apiBase, accessToken, previousTenant, refreshToken);
         persistEffectiveTenantOverride(previousTenant);
-        syncActiveDataCacheTenant(previousTenant || principal.home_tenant.id);
+        syncActiveDataCacheTenant(previousTenant || principal.home_tenant.id, {
+          apiBase,
+          accountId: principal.user.id,
+        });
       }
     },
     [accessToken, apiBase, configureClient, principal, refreshToken],
@@ -775,8 +1073,17 @@ export function AuthProvider({ children }: PropsWithChildren) {
         principal,
         authFailureCode,
         permissions,
+        savedAccounts,
       },
-      actions: { login, logout, restore, switchTenant },
+      actions: {
+        login,
+        logout,
+        restore,
+        switchTenant,
+        beginAddAccount,
+        switchAccount,
+        removeSavedAccount,
+      },
       meta: { managementEndpoint: computeManagementApiBase(apiBase) },
       can,
     }),
@@ -784,6 +1091,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       accessToken,
       apiBase,
       authFailureCode,
+      beginAddAccount,
       can,
       isAuthenticated,
       isRestoring,
@@ -792,9 +1100,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
       permissions,
       principal,
       rememberPassword,
+      removeSavedAccount,
       restore,
+      savedAccounts,
       serverBuildDate,
       serverVersion,
+      switchAccount,
       switchTenant,
     ],
   );

--- a/docs/internal-review/bundle-baseline.md
+++ b/docs/internal-review/bundle-baseline.md
@@ -1,6 +1,6 @@
 # codeProxy Bundle Baseline
 
-更新时间：2026-07-13 11:32:00 +0800
+更新时间：2026-07-20 11:41:00 +0800
 
 ## 当前构建命令
 
@@ -17,7 +17,7 @@ bun run build
 | `vendor-markdown`    |  761.13 kB | 263.84 kB | Markdown + syntax highlighter 组合                                          |
 | `vendor-animation`   |  126.21 kB |  41.93 kB | 动画依赖独立 vendor chunk                                                   |
 | `vendor-charts`      |    0.07 kB |   0.08 kB | Chart.js 入口当前几乎未进入业务路径                                         |
-| `index`              |  372.68 kB | 115.07 kB | 纳入部署后懒加载 chunk 失效自动恢复（单次硬刷新 + ErrorBoundary）；后续仍需往下压 |
+| `index`              |  396.29 kB | 121.04 kB | 多账号切换（AuthProvider vault + AppShell 账号菜单）进入 shell 入口；后续可再拆 account menu |
 | `ConfigPage`         |  119.60 kB |  33.35 kB | 页面 chunk 低于预算                                                         |
 | `AuthFilesPage`      |  216.81 kB |  58.90 kB | 身份多档案与出站策略交互加入后仍低于页面 gzip 预算                          |
 | `ProvidersPage`      |  121.98 kB |  30.85 kB | 已低于 `< 80 kB gzip` 页面预算                                              |

--- a/e2e/login-lifecycle.spec.ts
+++ b/e2e/login-lifecycle.spec.ts
@@ -84,7 +84,10 @@ test("Login: successful sign in persists auth snapshot and restores dashboard af
   );
 
   await page.goto("/#/login");
-  await page.evaluate(() => localStorage.removeItem("code-proxy-admin-auth"));
+  await page.evaluate(() => {
+    localStorage.removeItem("code-proxy-admin-auth");
+    sessionStorage.removeItem("code-proxy-admin-auth");
+  });
 
   await page.getByLabel(/username/i).fill("admin");
   await page.getByLabel(/^password$/i).fill("correct-password");
@@ -93,11 +96,16 @@ test("Login: successful sign in persists auth snapshot and restores dashboard af
 
   await expect(page).toHaveURL(/#\/dashboard$/);
 
-  const authSnapshot = await page.evaluate(() => localStorage.getItem("code-proxy-admin-auth"));
-  expect(authSnapshot).toBeTruthy();
-  expect(authSnapshot).toContain("cps_test");
-  expect(authSnapshot).toContain("expiresAt");
+  // Active session is always sessionStorage (per-tab); vault may also land in localStorage.
+  const sessionSnapshot = await page.evaluate(() => sessionStorage.getItem("code-proxy-admin-auth"));
+  expect(sessionSnapshot).toBeTruthy();
+  expect(sessionSnapshot).toContain("cps_test");
+  expect(sessionSnapshot).toContain("expiresAt");
 
-  await page.reload();
+  const vault = await page.evaluate(() => localStorage.getItem("code-proxy-admin-auth-accounts"));
+  expect(vault).toBeTruthy();
+  expect(vault).toContain("cps_test");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
   await expect(page).toHaveURL(/#\/dashboard$/);
 });

--- a/packages/api-client/src/client/__tests__/auth-storage.test.ts
+++ b/packages/api-client/src/client/__tests__/auth-storage.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   clearPersistedAuthSnapshot,
+  getSavedAuthAccount,
   LEGACY_EFFECTIVE_TENANT_KEY,
+  listSavedAuthAccounts,
   readPersistedAuthSnapshot,
+  removeSavedAuthAccount,
   updatePersistedEffectiveTenantId,
+  upsertSavedAuthAccount,
   writePersistedAuthSnapshot,
 } from "../auth-storage";
 import { AUTH_STORAGE_KEY } from "../constants";
@@ -37,13 +41,14 @@ describe("auth-storage effective tenant persistence", () => {
       effectiveTenantId: "tenant-acme",
     });
 
-    const raw = localStorage.getItem(AUTH_STORAGE_KEY);
+    // Active snapshot is per-tab (sessionStorage) to isolate multi-account tabs.
+    const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
     expect(raw).toContain("tenant-acme");
     expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
   });
 
   test("falls back to the legacy effective-tenant key once", () => {
-    localStorage.setItem(
+    sessionStorage.setItem(
       AUTH_STORAGE_KEY,
       JSON.stringify({
         apiBase: "http://127.0.0.1:8317",
@@ -97,5 +102,146 @@ describe("auth-storage effective tenant persistence", () => {
     expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
     expect(sessionStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
+  });
+});
+
+describe("auth-storage multi-account vault", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  test("write with accountId upserts vault entry", () => {
+    writePersistedAuthSnapshot({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_a",
+      rememberPassword: true,
+      accountId: "user-a",
+      username: "alice",
+      displayName: "Alice",
+    });
+
+    expect(listSavedAuthAccounts()).toEqual([
+      expect.objectContaining({
+        accountId: "user-a",
+        accountKey: "http://127.0.0.1:8317\0user-a",
+        username: "alice",
+        displayName: "Alice",
+        managementKey: "cps_a",
+      }),
+    ]);
+  });
+
+  test("upsert replaces same account and keeps others", () => {
+    const now = Date.now();
+    upsertSavedAuthAccount({
+      accountId: "user-a",
+      accountKey: "http://127.0.0.1:8317\0user-a",
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_a",
+      rememberPassword: true,
+      username: "alice",
+      displayName: "Alice",
+      lastUsedAt: now - 2,
+    });
+    upsertSavedAuthAccount({
+      accountId: "user-b",
+      accountKey: "http://127.0.0.1:8317\0user-b",
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_b",
+      rememberPassword: true,
+      username: "bob",
+      displayName: "Bob",
+      lastUsedAt: now - 1,
+    });
+    upsertSavedAuthAccount({
+      accountId: "user-a",
+      accountKey: "http://127.0.0.1:8317\0user-a",
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_a2",
+      rememberPassword: true,
+      username: "alice",
+      displayName: "Alice",
+      lastUsedAt: now,
+    });
+
+    const accounts = listSavedAuthAccounts();
+    expect(accounts.map((row) => row.accountId)).toEqual(["user-a", "user-b"]);
+    expect(getSavedAuthAccount("http://127.0.0.1:8317\0user-a")?.managementKey).toBe("cps_a2");
+  });
+
+  test("same user id on different apiBase does not collide", () => {
+    const now = Date.now();
+    upsertSavedAuthAccount({
+      accountId: "user-a",
+      accountKey: "https://a.example\0user-a",
+      apiBase: "https://a.example",
+      managementKey: "cps_a",
+      rememberPassword: true,
+      username: "alice",
+      displayName: "Alice",
+      lastUsedAt: now - 1,
+    });
+    upsertSavedAuthAccount({
+      accountId: "user-a",
+      accountKey: "https://b.example\0user-a",
+      apiBase: "https://b.example",
+      managementKey: "cps_b",
+      rememberPassword: true,
+      username: "alice",
+      displayName: "Alice",
+      lastUsedAt: now,
+    });
+    expect(listSavedAuthAccounts()).toHaveLength(2);
+  });
+
+  test("remember=false stays in session vault only", () => {
+    upsertSavedAuthAccount({
+      accountId: "user-s",
+      accountKey: "http://127.0.0.1:8317\0user-s",
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_s",
+      rememberPassword: false,
+      username: "session",
+      displayName: "Session",
+      lastUsedAt: Date.now(),
+    });
+    expect(listSavedAuthAccounts()).toHaveLength(1);
+    expect(localStorage.getItem("code-proxy-admin-auth-accounts")).toBeNull();
+    expect(sessionStorage.getItem("code-proxy-admin-auth-accounts-session")).toBeTruthy();
+  });
+
+  test("removeSavedAuthAccount drops one vault entry", () => {
+    const now = Date.now();
+    upsertSavedAuthAccount({
+      accountId: "user-a",
+      accountKey: "http://127.0.0.1:8317\0user-a",
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_a",
+      rememberPassword: true,
+      username: "alice",
+      displayName: "Alice",
+      lastUsedAt: now - 1,
+    });
+    upsertSavedAuthAccount({
+      accountId: "user-b",
+      accountKey: "http://127.0.0.1:8317\0user-b",
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_b",
+      rememberPassword: true,
+      username: "bob",
+      displayName: "Bob",
+      lastUsedAt: now,
+    });
+    removeSavedAuthAccount("http://127.0.0.1:8317\0user-a");
+    expect(listSavedAuthAccounts().map((row) => row.accountId)).toEqual(["user-b"]);
   });
 });

--- a/packages/api-client/src/client/__tests__/client.test.ts
+++ b/packages/api-client/src/client/__tests__/client.test.ts
@@ -232,28 +232,37 @@ describe("ApiClient authentication failure handling", () => {
     }
   });
 
-  test("suspends an expired tenant session and exposes the server error code", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          error: { code: "tenant_expired", message: "tenant expired" },
+  test("does not suspend the session for tenant override scope errors", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { code: "tenant_expired", message: "tenant expired" },
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
         }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      ),
-    );
+      );
+    globalThis.fetch = fetchMock;
     const client = new ApiClient();
     client.setConfig({ apiBase: "http://localhost:8317", managementKey: "cps_test" });
-    let code = "";
-    const onUnauthorized = (event: Event) => {
-      code = (event as CustomEvent<{ code?: string }>).detail?.code ?? "";
+    let unauthorizedEvents = 0;
+    const onUnauthorized = () => {
+      unauthorizedEvents += 1;
     };
     window.addEventListener("unauthorized", onUnauthorized);
     try {
       await expect(client.get("/dashboard-summary")).rejects.toThrow("tenant expired");
-      expect(code).toBe("tenant_expired");
-      await expect(client.get("/auth-files")).rejects.toThrow(
-        "Management session is no longer valid",
-      );
+      expect(unauthorizedEvents).toBe(0);
+      // Session stays active so AuthProvider can drop the override and retry.
+      await expect(client.get("/auth-files")).resolves.toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
       window.removeEventListener("unauthorized", onUnauthorized);
     }

--- a/packages/api-client/src/client/auth-storage.ts
+++ b/packages/api-client/src/client/auth-storage.ts
@@ -1,10 +1,18 @@
-import type { AuthSnapshot } from "../dto/types";
-import { AUTH_PERSIST_TTL_MS, AUTH_STORAGE_KEY, normalizeApiBase } from "./constants";
+import type { AuthSnapshot, SavedAuthAccount } from "../dto/types";
+import {
+  AUTH_ACCOUNTS_CHANGED_EVENT,
+  AUTH_ACCOUNTS_SESSION_STORAGE_KEY,
+  AUTH_ACCOUNTS_STORAGE_KEY,
+  AUTH_PERSIST_TTL_MS,
+  AUTH_STORAGE_KEY,
+  normalizeApiBase,
+} from "./constants";
 
 /** Legacy key used before effective tenant was stored inside the auth snapshot. */
 export const LEGACY_EFFECTIVE_TENANT_KEY = "code-proxy-effective-tenant";
 
 interface PersistedAuthSnapshot extends AuthSnapshot {
+  /** Client retention wall clock for the active snapshot blob. */
   expiresAt: number;
 }
 
@@ -18,10 +26,59 @@ const storages = (): Storage[] => {
   return items;
 };
 
+const localOnly = (): Storage | null => {
+  try {
+    if (typeof window !== "undefined") return window.localStorage;
+  } catch {
+    /* unavailable */
+  }
+  return null;
+};
+
+const sessionOnly = (): Storage | null => {
+  try {
+    if (typeof window !== "undefined") return window.sessionStorage;
+  } catch {
+    /* unavailable */
+  }
+  return null;
+};
+
 const normalizeEffectiveTenantId = (value: unknown): string | undefined => {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed || undefined;
+};
+
+const normalizeOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const normalizeOptionalMs = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+};
+
+/** Stable composite key so the same user.id on different apiBase does not collide. */
+export const buildAccountKey = (apiBase: string, accountId: string): string => {
+  const base = normalizeApiBase(apiBase.trim());
+  const id = accountId.trim();
+  if (!base || !id) return "";
+  return `${base}\0${id}`;
+};
+
+export const parseAccountKey = (
+  accountKey: string,
+): { apiBase: string; accountId: string } | null => {
+  const raw = accountKey.trim();
+  const sep = raw.indexOf("\0");
+  if (sep <= 0 || sep === raw.length - 1) return null;
+  return {
+    apiBase: normalizeApiBase(raw.slice(0, sep)),
+    accountId: raw.slice(sep + 1).trim(),
+  };
 };
 
 const readLegacyEffectiveTenantId = (): string | undefined => {
@@ -40,33 +97,100 @@ const clearLegacyEffectiveTenantId = (): void => {
   }
 };
 
+const emitAccountsChanged = (): void => {
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent(AUTH_ACCOUNTS_CHANGED_EVENT));
+    }
+  } catch {
+    /* ignore */
+  }
+};
+
+const resolveAccountKey = (snapshot: {
+  apiBase?: string;
+  accountId?: string;
+  accountKey?: string;
+}): string | undefined => {
+  const explicit = normalizeOptionalString(snapshot.accountKey);
+  if (explicit) return explicit;
+  const apiBase = normalizeOptionalString(snapshot.apiBase);
+  const accountId = normalizeOptionalString(snapshot.accountId);
+  if (!apiBase || !accountId) return undefined;
+  return buildAccountKey(apiBase, accountId) || undefined;
+};
+
+const isTokenExpired = (snapshot: {
+  expiresAtMs?: number;
+  refreshExpiresAtMs?: number;
+}): boolean => {
+  const now = Date.now();
+  // Prefer refresh expiry when present; fall back to access expiry.
+  if (snapshot.refreshExpiresAtMs && snapshot.refreshExpiresAtMs <= now) return true;
+  if (!snapshot.refreshExpiresAtMs && snapshot.expiresAtMs && snapshot.expiresAtMs <= now) {
+    return true;
+  }
+  return false;
+};
+
+const toAuthSnapshot = (parsed: Partial<PersistedAuthSnapshot>): AuthSnapshot | null => {
+  if (
+    typeof parsed.expiresAt !== "number" ||
+    parsed.expiresAt <= Date.now() ||
+    !parsed.apiBase ||
+    !parsed.managementKey
+  ) {
+    return null;
+  }
+  const effectiveTenantId =
+    normalizeEffectiveTenantId(parsed.effectiveTenantId) ?? readLegacyEffectiveTenantId();
+  const accountId = normalizeOptionalString(parsed.accountId);
+  const apiBase = normalizeApiBase(parsed.apiBase);
+  const accountKey = resolveAccountKey({
+    apiBase,
+    accountId,
+    accountKey: parsed.accountKey,
+  });
+  const snapshot: AuthSnapshot = {
+    apiBase,
+    managementKey: parsed.managementKey,
+    ...(typeof parsed.refreshToken === "string" && parsed.refreshToken
+      ? { refreshToken: parsed.refreshToken }
+      : {}),
+    rememberPassword: Boolean(parsed.rememberPassword),
+    ...(effectiveTenantId ? { effectiveTenantId } : {}),
+    ...(accountId ? { accountId } : {}),
+    ...(accountKey ? { accountKey } : {}),
+    ...(normalizeOptionalString(parsed.username)
+      ? { username: normalizeOptionalString(parsed.username) }
+      : {}),
+    ...(normalizeOptionalString(parsed.displayName)
+      ? { displayName: normalizeOptionalString(parsed.displayName) }
+      : {}),
+    ...(normalizeOptionalMs(parsed.expiresAtMs)
+      ? { expiresAtMs: normalizeOptionalMs(parsed.expiresAtMs) }
+      : {}),
+    ...(normalizeOptionalMs(parsed.refreshExpiresAtMs)
+      ? { refreshExpiresAtMs: normalizeOptionalMs(parsed.refreshExpiresAtMs) }
+      : {}),
+  };
+  if (isTokenExpired(snapshot)) return null;
+  return snapshot;
+};
+
 export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
+  // Prefer session (per-tab active) so multi-tab does not share one active account.
   for (const storage of storages()) {
     try {
       const raw = storage.getItem(AUTH_STORAGE_KEY);
       if (!raw) continue;
       const parsed = JSON.parse(raw) as Partial<PersistedAuthSnapshot>;
-      if (
-        typeof parsed.expiresAt !== "number" ||
-        parsed.expiresAt <= Date.now() ||
-        !parsed.apiBase ||
-        !parsed.managementKey
-      ) {
+      const snapshot = toAuthSnapshot(parsed);
+      if (!snapshot) {
         storage.removeItem(AUTH_STORAGE_KEY);
         continue;
       }
-      // Prefer the value stored with the session; fall back to the pre-migration key once.
-      const effectiveTenantId =
-        normalizeEffectiveTenantId(parsed.effectiveTenantId) ?? readLegacyEffectiveTenantId();
-      return {
-        apiBase: normalizeApiBase(parsed.apiBase),
-        managementKey: parsed.managementKey,
-        ...(typeof parsed.refreshToken === "string" && parsed.refreshToken
-          ? { refreshToken: parsed.refreshToken }
-          : {}),
-        rememberPassword: Boolean(parsed.rememberPassword),
-        ...(effectiveTenantId ? { effectiveTenantId } : {}),
-      };
+      return snapshot;
     } catch {
       storage.removeItem(AUTH_STORAGE_KEY);
     }
@@ -76,10 +200,14 @@ export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
 
 export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
   const [session, local] = storages();
-  const target = snapshot.rememberPassword ? local : session;
+  // Active snapshot is always per-tab (sessionStorage) to avoid multi-tab hijack.
+  // rememberPassword only controls whether the vault entry is durable (local).
+  const target = session ?? (snapshot.rememberPassword ? local : null);
   if (!target) return;
   clearPersistedAuthSnapshot();
   const effectiveTenantId = normalizeEffectiveTenantId(snapshot.effectiveTenantId);
+  const accountId = normalizeOptionalString(snapshot.accountId);
+  const accountKey = resolveAccountKey(snapshot);
   const payload: PersistedAuthSnapshot = {
     apiBase: snapshot.apiBase,
     managementKey: snapshot.managementKey,
@@ -87,10 +215,37 @@ export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
     rememberPassword: snapshot.rememberPassword,
     expiresAt: Date.now() + AUTH_PERSIST_TTL_MS,
     ...(effectiveTenantId ? { effectiveTenantId } : {}),
+    ...(accountId ? { accountId } : {}),
+    ...(accountKey ? { accountKey } : {}),
+    ...(normalizeOptionalString(snapshot.username)
+      ? { username: normalizeOptionalString(snapshot.username) }
+      : {}),
+    ...(normalizeOptionalString(snapshot.displayName)
+      ? { displayName: normalizeOptionalString(snapshot.displayName) }
+      : {}),
+    ...(normalizeOptionalMs(snapshot.expiresAtMs)
+      ? { expiresAtMs: normalizeOptionalMs(snapshot.expiresAtMs) }
+      : {}),
+    ...(normalizeOptionalMs(snapshot.refreshExpiresAtMs)
+      ? { refreshExpiresAtMs: normalizeOptionalMs(snapshot.refreshExpiresAtMs) }
+      : {}),
   };
-  target.setItem(AUTH_STORAGE_KEY, JSON.stringify(payload));
-  // Drop the legacy key after a successful write so we do not keep two sources of truth.
+  try {
+    target.setItem(AUTH_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* quota / private mode — session may still work in-memory */
+  }
   clearLegacyEffectiveTenantId();
+  if (accountId && accountKey) {
+    upsertSavedAuthAccount({
+      ...payload,
+      accountId,
+      accountKey,
+      username: payload.username ?? accountId,
+      displayName: payload.displayName ?? payload.username ?? accountId,
+      lastUsedAt: Date.now(),
+    });
+  }
 };
 
 export const clearPersistedAuthSnapshot = (): void => {
@@ -105,7 +260,6 @@ export const clearPersistedAuthSnapshot = (): void => {
 export const updatePersistedEffectiveTenantId = (tenantId: string): void => {
   const current = readPersistedAuthSnapshot();
   if (!current) {
-    // Still clear any leftover override when the session is gone.
     if (!normalizeEffectiveTenantId(tenantId)) clearLegacyEffectiveTenantId();
     return;
   }
@@ -113,4 +267,194 @@ export const updatePersistedEffectiveTenantId = (tenantId: string): void => {
     ...current,
     effectiveTenantId: normalizeEffectiveTenantId(tenantId),
   });
+};
+
+const isSavedAccount = (value: unknown): value is SavedAuthAccount => {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<SavedAuthAccount>;
+  return Boolean(
+    (normalizeOptionalString(row.accountKey) ||
+      (normalizeOptionalString(row.accountId) && normalizeOptionalString(row.apiBase))) &&
+      normalizeOptionalString(row.apiBase) &&
+      normalizeOptionalString(row.managementKey) &&
+      normalizeOptionalString(row.username),
+  );
+};
+
+const readVaultFrom = (storage: Storage | null, key: string): SavedAuthAccount[] => {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const now = Date.now();
+    const kept: SavedAuthAccount[] = [];
+    let dirty = false;
+    for (const row of parsed) {
+      if (!isSavedAccount(row)) {
+        dirty = true;
+        continue;
+      }
+      const apiBase = normalizeApiBase(row.apiBase);
+      const accountId = (row.accountId || parseAccountKey(row.accountKey ?? "")?.accountId || "").trim();
+      const accountKey =
+        resolveAccountKey({ apiBase, accountId, accountKey: row.accountKey }) ?? "";
+      if (!accountId || !accountKey) {
+        dirty = true;
+        continue;
+      }
+      const entry: SavedAuthAccount = {
+        accountId,
+        accountKey,
+        apiBase,
+        managementKey: row.managementKey,
+        ...(row.refreshToken ? { refreshToken: row.refreshToken } : {}),
+        rememberPassword: Boolean(row.rememberPassword),
+        ...(normalizeEffectiveTenantId(row.effectiveTenantId)
+          ? { effectiveTenantId: normalizeEffectiveTenantId(row.effectiveTenantId) }
+          : {}),
+        username: row.username.trim(),
+        displayName: (row.displayName || row.username).trim(),
+        lastUsedAt: typeof row.lastUsedAt === "number" ? row.lastUsedAt : 0,
+        ...(normalizeOptionalMs(row.expiresAtMs)
+          ? { expiresAtMs: normalizeOptionalMs(row.expiresAtMs) }
+          : {}),
+        ...(normalizeOptionalMs(row.refreshExpiresAtMs)
+          ? { refreshExpiresAtMs: normalizeOptionalMs(row.refreshExpiresAtMs) }
+          : {}),
+      };
+      if (isTokenExpired(entry)) {
+        dirty = true;
+        continue;
+      }
+      // Drop entries whose retention would have expired if lastUsedAt is ancient.
+      if (entry.lastUsedAt > 0 && entry.lastUsedAt + AUTH_PERSIST_TTL_MS < now) {
+        dirty = true;
+        continue;
+      }
+      kept.push(entry);
+    }
+    if (dirty) {
+      if (kept.length === 0) storage.removeItem(key);
+      else storage.setItem(key, JSON.stringify(kept));
+    }
+    return kept;
+  } catch {
+    return [];
+  }
+};
+
+const writeVaultTo = (storage: Storage | null, key: string, accounts: SavedAuthAccount[]): void => {
+  if (!storage) return;
+  try {
+    if (accounts.length === 0) {
+      storage.removeItem(key);
+      return;
+    }
+    storage.setItem(key, JSON.stringify(accounts));
+  } catch {
+    /* ignore */
+  }
+};
+
+export const listSavedAuthAccounts = (): SavedAuthAccount[] => {
+  const local = readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY);
+  const session = readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY);
+  const byKey = new Map<string, SavedAuthAccount>();
+  for (const row of [...local, ...session]) {
+    const prev = byKey.get(row.accountKey);
+    if (!prev || row.lastUsedAt >= prev.lastUsedAt) byKey.set(row.accountKey, row);
+  }
+  return [...byKey.values()].sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+};
+
+export const upsertSavedAuthAccount = (account: SavedAuthAccount): void => {
+  const accountId = normalizeOptionalString(account.accountId);
+  const managementKey = normalizeOptionalString(account.managementKey);
+  const apiBase = normalizeOptionalString(account.apiBase);
+  const username = normalizeOptionalString(account.username);
+  if (!accountId || !managementKey || !apiBase || !username) return;
+  const accountKey =
+    resolveAccountKey({ apiBase, accountId, accountKey: account.accountKey }) ??
+    buildAccountKey(apiBase, accountId);
+  if (!accountKey) return;
+  if (isTokenExpired(account)) {
+    removeSavedAuthAccount(accountKey);
+    return;
+  }
+  const next: SavedAuthAccount = {
+    accountId,
+    accountKey,
+    apiBase: normalizeApiBase(apiBase),
+    managementKey,
+    ...(account.refreshToken ? { refreshToken: account.refreshToken } : {}),
+    rememberPassword: Boolean(account.rememberPassword),
+    ...(normalizeEffectiveTenantId(account.effectiveTenantId)
+      ? { effectiveTenantId: normalizeEffectiveTenantId(account.effectiveTenantId) }
+      : {}),
+    username,
+    displayName: normalizeOptionalString(account.displayName) ?? username,
+    lastUsedAt: typeof account.lastUsedAt === "number" ? account.lastUsedAt : Date.now(),
+    ...(normalizeOptionalMs(account.expiresAtMs)
+      ? { expiresAtMs: normalizeOptionalMs(account.expiresAtMs) }
+      : {}),
+    ...(normalizeOptionalMs(account.refreshExpiresAtMs)
+      ? { refreshExpiresAtMs: normalizeOptionalMs(account.refreshExpiresAtMs) }
+      : {}),
+  };
+  // Remembered → local vault; non-remembered → session vault only (tab-scoped).
+  if (next.rememberPassword) {
+    const local = readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY).filter(
+      (row) => row.accountKey !== accountKey,
+    );
+    writeVaultTo(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY, [next, ...local]);
+    // Drop any session-only copy so we do not keep two sources of truth.
+    const session = readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY).filter(
+      (row) => row.accountKey !== accountKey,
+    );
+    writeVaultTo(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY, session);
+  } else {
+    const session = readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY).filter(
+      (row) => row.accountKey !== accountKey,
+    );
+    writeVaultTo(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY, [next, ...session]);
+    const local = readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY).filter(
+      (row) => row.accountKey !== accountKey,
+    );
+    writeVaultTo(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY, local);
+  }
+  emitAccountsChanged();
+};
+
+/** Accepts accountKey or legacy accountId (matches first entry). */
+export const removeSavedAuthAccount = (accountKeyOrId: string): void => {
+  const key = normalizeOptionalString(accountKeyOrId);
+  if (!key) return;
+  const match = (row: SavedAuthAccount) => row.accountKey === key || row.accountId === key;
+  writeVaultTo(
+    localOnly(),
+    AUTH_ACCOUNTS_STORAGE_KEY,
+    readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY).filter((row) => !match(row)),
+  );
+  writeVaultTo(
+    sessionOnly(),
+    AUTH_ACCOUNTS_SESSION_STORAGE_KEY,
+    readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY).filter((row) => !match(row)),
+  );
+  emitAccountsChanged();
+};
+
+export const clearSavedAuthAccounts = (): void => {
+  writeVaultTo(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY, []);
+  writeVaultTo(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY, []);
+  emitAccountsChanged();
+};
+
+export const getSavedAuthAccount = (accountKeyOrId: string): SavedAuthAccount | null => {
+  const key = normalizeOptionalString(accountKeyOrId);
+  if (!key) return null;
+  return (
+    listSavedAuthAccounts().find((row) => row.accountKey === key || row.accountId === key) ?? null
+  );
 };

--- a/packages/api-client/src/client/client.ts
+++ b/packages/api-client/src/client/client.ts
@@ -83,9 +83,18 @@ export class ApiClient {
 
   private authSuspended = false;
 
+  /** Bumped on every setConfig so stale refresh/401 from a prior account is ignored. */
+  private authGeneration = 0;
+
   private refreshInFlight: Promise<boolean> | null = null;
 
+  private refreshInFlightGeneration = 0;
+
   private defaultHeaders = new Headers();
+
+  getAuthGeneration(): number {
+    return this.authGeneration;
+  }
 
   setConfig(config: ApiClientConfig & { refreshToken?: string | null }): void {
     this.apiBase = computeManagementApiBase(config.apiBase);
@@ -95,6 +104,10 @@ export class ApiClient {
       this.refreshToken = (config.refreshToken ?? "").trim();
     }
     this.authSuspended = false;
+    // Invalidate in-flight refresh and any completion handlers from the previous session.
+    this.authGeneration += 1;
+    this.refreshInFlight = null;
+    this.refreshInFlightGeneration = 0;
   }
 
   setRefreshToken(token: string): void {
@@ -255,22 +268,22 @@ export class ApiClient {
     if (status === 401) return true;
     if (status !== 403) return false;
     const code = extractApiErrorCode(payload);
+    // tenant_expired / tenant_suspended / tenant_scope_forbidden are override-scope
+    // issues handled by AuthProvider (drop override / re-bootstrap), not full logout.
     return (
-      [
-        "account_disabled",
-        "account_locked",
-        "session_expired",
-        "session_revoked",
-        "tenant_expired",
-        "tenant_suspended",
-      ].includes(code) || /IP banned due to too many failed attempts/i.test(message)
+      ["account_disabled", "account_locked", "session_expired", "session_revoked"].includes(code) ||
+      /IP banned due to too many failed attempts/i.test(message)
     );
   }
 
   private suspendAuth(code = ""): void {
     if (this.authSuspended) return;
     this.authSuspended = true;
-    dispatchWindowEvent(new CustomEvent("unauthorized", { detail: { code } }));
+    dispatchWindowEvent(
+      new CustomEvent("unauthorized", {
+        detail: { code, authGeneration: this.authGeneration },
+      }),
+    );
   }
 
   private assertAuthActive(): void {
@@ -298,20 +311,29 @@ export class ApiClient {
 
   private async tryRefreshAccessToken(): Promise<boolean> {
     if (!this.refreshToken) return false;
-    if (this.refreshInFlight) return this.refreshInFlight;
+    const generation = this.authGeneration;
+    if (this.refreshInFlight && this.refreshInFlightGeneration === generation) {
+      return this.refreshInFlight;
+    }
+    const refreshToken = this.refreshToken;
+    const apiBase = this.apiBase;
+    this.refreshInFlightGeneration = generation;
     this.refreshInFlight = (async () => {
       try {
-        const base = this.apiBase.replace(/\/v0\/management\/?$/, "");
+        const base = apiBase.replace(/\/v0\/management\/?$/, "");
         const response = await fetch(`${base}/v0/auth/refresh`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refresh_token: this.refreshToken }),
+          body: JSON.stringify({ refresh_token: refreshToken }),
         });
+        // Account switched while refresh was in flight — drop the result.
+        if (this.authGeneration !== generation) return false;
         if (!response.ok) return false;
         const payload = (await response.json()) as {
           access_token?: string;
           refresh_token?: string;
         };
+        if (this.authGeneration !== generation) return false;
         if (!payload.access_token) return false;
         this.managementKey = payload.access_token;
         if (payload.refresh_token) this.refreshToken = payload.refresh_token;
@@ -321,7 +343,7 @@ export class ApiClient {
           const { readPersistedAuthSnapshot, writePersistedAuthSnapshot } =
             await import("./auth-storage");
           const current = readPersistedAuthSnapshot();
-          if (current) {
+          if (current && this.authGeneration === generation) {
             writePersistedAuthSnapshot({
               ...current,
               managementKey: this.managementKey,
@@ -331,11 +353,13 @@ export class ApiClient {
         } catch {
           /* ignore */
         }
+        if (this.authGeneration !== generation) return false;
         dispatchWindowEvent(
           new CustomEvent("auth-token-refreshed", {
             detail: {
               accessToken: this.managementKey,
               refreshToken: this.refreshToken,
+              authGeneration: generation,
             },
           }),
         );
@@ -343,7 +367,10 @@ export class ApiClient {
       } catch {
         return false;
       } finally {
-        this.refreshInFlight = null;
+        if (this.refreshInFlightGeneration === generation) {
+          this.refreshInFlight = null;
+          this.refreshInFlightGeneration = 0;
+        }
       }
     })();
     return this.refreshInFlight;
@@ -364,6 +391,7 @@ export class ApiClient {
     } = {},
   ): Promise<T> {
     this.assertAuthActive();
+    const generation = this.authGeneration;
     const { controller, cleanup, didTimeout } = this.createAbortController(options);
 
     try {
@@ -376,17 +404,26 @@ export class ApiClient {
         headers,
       });
 
+      // Drop responses that arrived after an account switch.
+      if (this.authGeneration !== generation) {
+        throw new ApiError({
+          message: "Request cancelled because the management session changed.",
+          status: 0,
+          url: path,
+        });
+      }
+
       this.applyVersionHeaders(response);
 
       if (!response.ok) {
         if (response.status === 401 && !retried && this.refreshToken) {
           const refreshed = await this.tryRefreshAccessToken();
-          if (refreshed) {
+          if (refreshed && this.authGeneration === generation) {
             return this.request<T>(path, { init, options, responseType, retried: true });
           }
         }
         const error = await this.buildApiError(response);
-        if (error.isAuthError) {
+        if (error.isAuthError && this.authGeneration === generation) {
           this.suspendAuth(extractApiErrorCode(error.payload));
         }
         throw error;

--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -2,7 +2,13 @@ export const MANAGEMENT_API_PREFIX = "/v0/management";
 export const DEFAULT_API_PORT = 8317;
 export const REQUEST_TIMEOUT_MS = 30000;
 export const AUTH_STORAGE_KEY = "code-proxy-admin-auth";
+/** Remembered multi-account vault (localStorage). */
+export const AUTH_ACCOUNTS_STORAGE_KEY = "code-proxy-admin-auth-accounts";
+/** Non-remembered multi-account vault for the current tab (sessionStorage). */
+export const AUTH_ACCOUNTS_SESSION_STORAGE_KEY = "code-proxy-admin-auth-accounts-session";
 export const AUTH_PERSIST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+/** Fired on window after vault mutations so other tabs/UI can refresh lists. */
+export const AUTH_ACCOUNTS_CHANGED_EVENT = "auth-accounts-changed";
 export const VERSION_HEADER_KEYS = ["x-cpa-version", "x-server-version"];
 export const BUILD_DATE_HEADER_KEYS = ["x-cpa-build-date", "x-server-build-date"];
 

--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -5,6 +5,25 @@ export interface AuthSnapshot {
   rememberPassword: boolean;
   /** Platform-admin override; empty/omitted means home tenant (no X-Effective-Tenant-ID). */
   effectiveTenantId?: string;
+  /** User id within one apiBase (not globally unique). */
+  accountId?: string;
+  /** Composite key: normalizeApiBase(apiBase) + "\\0" + accountId. */
+  accountKey?: string;
+  username?: string;
+  displayName?: string;
+  /** Access-token wall clock expiry (ms). */
+  expiresAtMs?: number;
+  /** Refresh-token wall clock expiry (ms). */
+  refreshExpiresAtMs?: number;
+}
+
+/** Saved admin session for local multi-account switch. */
+export interface SavedAuthAccount extends AuthSnapshot {
+  accountId: string;
+  accountKey: string;
+  username: string;
+  displayName: string;
+  lastUsedAt: number;
 }
 
 export type AuthFileType =

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,6 +1,9 @@
 export { ApiClient, apiClient } from "./client/client";
 export type { RequestOptions } from "./client/client";
 export {
+  AUTH_ACCOUNTS_CHANGED_EVENT,
+  AUTH_ACCOUNTS_SESSION_STORAGE_KEY,
+  AUTH_ACCOUNTS_STORAGE_KEY,
   AUTH_PERSIST_TTL_MS,
   AUTH_STORAGE_KEY,
   BUILD_DATE_HEADER_KEYS,
@@ -24,10 +27,17 @@ export { ensureArrayPayload, isApiEnvelope, unwrapApiEnvelope } from "./client/r
 export type { ApiEnvelope, ApiListPayload, ApiSuccessEnvelope } from "./client/response";
 export { publicApiClient, PublicApiClient } from "./client/public-client";
 export {
+  buildAccountKey,
   clearPersistedAuthSnapshot,
+  clearSavedAuthAccounts,
+  getSavedAuthAccount,
   LEGACY_EFFECTIVE_TENANT_KEY,
+  listSavedAuthAccounts,
+  parseAccountKey,
   readPersistedAuthSnapshot,
+  removeSavedAuthAccount,
   updatePersistedEffectiveTenantId,
+  upsertSavedAuthAccount,
   writePersistedAuthSnapshot,
 } from "./client/auth-storage";
 export {

--- a/packages/domain/src/tenant-cache/__tests__/tenantScopedStorage.test.ts
+++ b/packages/domain/src/tenant-cache/__tests__/tenantScopedStorage.test.ts
@@ -6,7 +6,9 @@ import {
   readTenantBucket,
   readTenantBucketMapEntry,
   readTenantTtlSlot,
+  setActiveCacheScopePrefix,
   setActiveCacheTenantId,
+  setCacheScopeResolver,
   setCacheTenantResolver,
   updateTenantBucketMapEntry,
   writeTenantBucket,
@@ -18,6 +20,8 @@ describe("tenant-scoped storage", () => {
     window.localStorage.clear();
     window.sessionStorage.clear();
     setCacheTenantResolver(null);
+    setCacheScopeResolver(null);
+    setActiveCacheScopePrefix("");
     setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
   });
 
@@ -36,6 +40,14 @@ describe("tenant-scoped storage", () => {
     expect(getActiveCacheTenantId()).toBe("tenant-b");
 
     setCacheTenantResolver(() => "  ");
+    expect(getActiveCacheTenantId()).toBe("tenant-a");
+  });
+
+  test("account scope prefixes tenant cache keys", () => {
+    setActiveCacheTenantId("tenant-a");
+    setActiveCacheScopePrefix("https://api.example::user-1");
+    expect(getActiveCacheTenantId()).toBe("https://api.example::user-1::tenant-a");
+    setActiveCacheScopePrefix("");
     expect(getActiveCacheTenantId()).toBe("tenant-a");
   });
 

--- a/packages/domain/src/tenant-cache/activeTenant.ts
+++ b/packages/domain/src/tenant-cache/activeTenant.ts
@@ -2,7 +2,10 @@
 export const DEFAULT_CACHE_TENANT_ID = "default";
 
 let activeCacheTenantId = DEFAULT_CACHE_TENANT_ID;
+/** Optional prefix: apiBase + account so caches do not collide across accounts/hosts. */
+let activeCacheScopePrefix = "";
 let cacheTenantResolver: (() => string | null | undefined) | null = null;
+let cacheScopeResolver: (() => string | null | undefined) | null = null;
 
 /**
  * Normalize a tenant id for cache buckets.
@@ -12,6 +15,11 @@ let cacheTenantResolver: (() => string | null | undefined) | null = null;
 export const normalizeCacheTenantId = (tenantId?: string | null): string => {
   const trimmed = typeof tenantId === "string" ? tenantId.trim() : "";
   return trimmed || DEFAULT_CACHE_TENANT_ID;
+};
+
+const normalizeScopePrefix = (value?: string | null): string => {
+  if (typeof value !== "string") return "";
+  return value.trim();
 };
 
 /**
@@ -24,25 +32,57 @@ export const setCacheTenantResolver = (
   cacheTenantResolver = resolver;
 };
 
+/** Optional live resolver for apiBase+account scope prefix. */
+export const setCacheScopeResolver = (
+  resolver: (() => string | null | undefined) | null,
+): void => {
+  cacheScopeResolver = resolver;
+};
+
 /** Explicitly pin the active cache tenant (switchTenant / login / logout). */
 export const setActiveCacheTenantId = (tenantId?: string | null): void => {
   activeCacheTenantId = normalizeCacheTenantId(tenantId);
 };
 
 /**
+ * Pin account/host scope used as a prefix on tenant cache keys.
+ * Empty clears the prefix (logged out).
+ */
+export const setActiveCacheScopePrefix = (scope?: string | null): void => {
+  activeCacheScopePrefix = normalizeScopePrefix(scope);
+};
+
+export const getActiveCacheScopePrefix = (): string => {
+  if (cacheScopeResolver) {
+    try {
+      const resolved = cacheScopeResolver();
+      if (resolved != null && String(resolved).trim()) {
+        return normalizeScopePrefix(resolved);
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+  return activeCacheScopePrefix;
+};
+
+/**
  * Current tenant used by tenant-scoped data caches.
  * Resolution order: resolver() → last setActiveCacheTenantId → default.
+ * When an account/host scope is set, it is prefixed so keys do not collide.
  */
 export const getActiveCacheTenantId = (): string => {
+  let tenant = activeCacheTenantId;
   if (cacheTenantResolver) {
     try {
       const resolved = cacheTenantResolver();
       if (resolved != null && String(resolved).trim()) {
-        return normalizeCacheTenantId(resolved);
+        tenant = normalizeCacheTenantId(resolved);
       }
     } catch {
       // Resolver is best-effort; fall through to the pinned value.
     }
   }
-  return activeCacheTenantId;
+  const scope = getActiveCacheScopePrefix();
+  return scope ? `${scope}::${tenant}` : tenant;
 };

--- a/packages/domain/src/tenant-cache/index.ts
+++ b/packages/domain/src/tenant-cache/index.ts
@@ -1,8 +1,11 @@
 export {
   DEFAULT_CACHE_TENANT_ID,
+  getActiveCacheScopePrefix,
   getActiveCacheTenantId,
   normalizeCacheTenantId,
+  setActiveCacheScopePrefix,
   setActiveCacheTenantId,
+  setCacheScopeResolver,
   setCacheTenantResolver,
 } from "./activeTenant";
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -152,7 +152,9 @@
     "password_label": "Password",
     "advanced_connection": "Advanced connection settings",
     "show_key": "Show password",
-    "hide_key": "Hide password"
+    "hide_key": "Hide password",
+    "switch_account_failed": "Could not restore that account. Sign in again.",
+    "or_sign_in": "or sign in with password"
   },
   "header": {
     "check_connection": "Check Connection",
@@ -2046,12 +2048,17 @@
     "expand_sidebar": "Expand Sidebar",
     "collapse_sidebar": "Collapse Sidebar",
     "logout_button": "Logout",
+    "switch_account": "Switch account",
+    "add_account": "Add account",
+    "current_account": "Current account",
+    "remove_saved_account": "Remove account",
     "skip_to_content": "Skip to main content",
     "upgrade_title": "Upgrade Plan",
     "upgrade_description": "Unlock higher throughput, deeper monitoring, and priority support.",
     "upgrade_action": "Upgrade now",
     "sidebar_account_role": "Super Admin",
-    "nav_menu_management": "Menu Management"
+    "nav_menu_management": "Menu Management",
+    "forget_saved_account": "Forget saved account"
   },
   "proxies": {
     "title": "Proxy Management",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -230,7 +230,9 @@
     "signing_in": "Вход...",
     "show_key": "Показать пароль",
     "hide_key": "Скрыть пароль",
-    "sign_in": "Вход"
+    "sign_in": "Вход",
+    "switch_account_failed": "Could not restore that account. Sign in again.",
+    "or_sign_in": "or sign in with password"
   },
   "header": {
     "check_connection": "Проверить подключение",
@@ -1690,8 +1692,13 @@
     "expand_sidebar": "Expand Sidebar",
     "collapse_sidebar": "Collapse Sidebar",
     "logout_button": "Logout",
+    "switch_account": "Switch account",
+    "add_account": "Add account",
+    "current_account": "Current account",
+    "remove_saved_account": "Remove account",
     "skip_to_content": "Skip to main content",
-    "nav_menu_management": "Управление меню"
+    "nav_menu_management": "Управление меню",
+    "forget_saved_account": "Forget saved account"
   },
   "api_key_permissions_page": {
     "title": "API Key Permissions",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -154,7 +154,9 @@
     "session_unavailable": "当前管理会话已失效，请重新登录。",
     "username_label": "用户名",
     "password_label": "密码",
-    "advanced_connection": "高级连接设置"
+    "advanced_connection": "高级连接设置",
+    "switch_account_failed": "无法恢复该账号，请重新登录。",
+    "or_sign_in": "或使用密码登录"
   },
   "header": {
     "check_connection": "检查连接",
@@ -2063,12 +2065,17 @@
     "expand_sidebar": "展开侧边栏",
     "collapse_sidebar": "收起侧边栏",
     "logout_button": "退出登录",
+    "switch_account": "切换账号",
+    "add_account": "添加账号",
+    "current_account": "当前账号",
+    "remove_saved_account": "移除账号",
     "skip_to_content": "跳到主要内容",
     "upgrade_title": "升级到专业版",
     "upgrade_description": "获得更高吞吐、更细粒度监控与优先技术支持。",
     "upgrade_action": "立即升级",
     "sidebar_account_role": "超级管理员",
-    "nav_menu_management": "菜单管理"
+    "nav_menu_management": "菜单管理",
+    "forget_saved_account": "忘记此账号"
   },
   "proxies": {
     "title": "代理管理",

--- a/pages/login/LoginPage.tsx
+++ b/pages/login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
-import { Eye, EyeOff, KeyRound, Lock, UserRound } from "lucide-react";
+import { Eye, EyeOff, KeyRound, Lock, UserRound, Users, X } from "lucide-react";
 import {
   detectApiBaseFromLocation,
   extractApiErrorCode,
@@ -28,8 +28,9 @@ export function LoginPage() {
       rememberPassword: persistedRemember,
       principal,
       authFailureCode,
+      savedAccounts,
     },
-    actions: { login },
+    actions: { login, switchAccount, removeSavedAccount },
   } = useAuth();
   const { notify } = useToast();
   const [apiBase, setApiBase] = useState(persistedBase || detectApiBaseFromLocation());
@@ -99,6 +100,27 @@ export function LoginPage() {
     [apiBase, login, navigate, notify, password, redirect, rememberPassword, t, username],
   );
 
+  const handleResumeAccount = useCallback(
+    async (accountId: string) => {
+      setLoading(true);
+      try {
+        const ok = await switchAccount(accountId);
+        if (!ok) {
+          notify({
+            type: "error",
+            message: t("login.switch_account_failed", "Could not restore that account. Sign in again."),
+          });
+          return;
+        }
+        notify({ type: "success", message: t("login.login_success") });
+        navigate(redirect, { replace: true, viewTransition: true });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate, notify, redirect, switchAccount, t],
+  );
+
   if (isRestoring) return null;
   if (isAuthenticated) {
     return (
@@ -160,6 +182,56 @@ export function LoginPage() {
                 {accessFailureMessage ? (
                   <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-200">
                     {accessFailureMessage}
+                  </div>
+                ) : null}
+                {savedAccounts.length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="text-xs font-medium text-slate-600 dark:text-white/60">
+                      {t("shell.switch_account")}
+                    </div>
+                    <div className="space-y-1.5">
+                      {savedAccounts.map((account) => {
+                        const key = account.accountKey || account.accountId;
+                        return (
+                          <div
+                            key={key}
+                            className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50/80 px-3 py-2 dark:border-white/10 dark:bg-white/5"
+                          >
+                            <button
+                              type="button"
+                              disabled={loading}
+                              onClick={() => void handleResumeAccount(key)}
+                              className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm font-medium text-slate-800 transition hover:text-slate-950 disabled:opacity-60 dark:text-white/90"
+                            >
+                              <Users size={15} className="shrink-0 text-slate-400" />
+                              <span className="min-w-0 flex-1 truncate leading-tight">
+                                <span className="block truncate">
+                                  {account.displayName || account.username}
+                                </span>
+                                <span className="block truncate text-2xs font-normal text-slate-400">
+                                  {account.username}
+                                  {account.apiBase
+                                    ? ` · ${account.apiBase.replace(/^https?:\/\//, "")}`
+                                    : ""}
+                                </span>
+                              </span>
+                            </button>
+                            <button
+                              type="button"
+                              disabled={loading}
+                              aria-label={t("shell.forget_saved_account")}
+                              onClick={() => removeSavedAccount(key)}
+                              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-slate-400 hover:bg-white hover:text-rose-600 dark:hover:bg-white/10"
+                            >
+                              <X size={13} />
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    <div className="pt-1 text-center text-2xs text-slate-400">
+                      {t("login.or_sign_in", "or sign in with password")}
+                    </div>
                   </div>
                 ) : null}
                 <label className="block space-y-2">

--- a/pages/login/__tests__/LoginPage.test.tsx
+++ b/pages/login/__tests__/LoginPage.test.tsx
@@ -9,6 +9,8 @@ const toastMocks = vi.hoisted(() => ({
 
 const authMocks = vi.hoisted(() => ({
   login: vi.fn(),
+  switchAccount: vi.fn(),
+  removeSavedAccount: vi.fn(),
   state: {
     isAuthenticated: false,
     isRestoring: false,
@@ -16,6 +18,11 @@ const authMocks = vi.hoisted(() => ({
     rememberPassword: false,
     principal: null,
     authFailureCode: "",
+    savedAccounts: [] as Array<{
+      accountId: string;
+      username: string;
+      displayName: string;
+    }>,
   },
 }));
 
@@ -28,7 +35,11 @@ vi.mock("react-i18next", () => ({
 vi.mock("@app/providers/AuthProvider", () => ({
   useAuth: () => ({
     state: authMocks.state,
-    actions: { login: authMocks.login },
+    actions: {
+      login: authMocks.login,
+      switchAccount: authMocks.switchAccount,
+      removeSavedAccount: authMocks.removeSavedAccount,
+    },
   }),
 }));
 


### PR DESCRIPTION
## Summary
- Sidebar account menu: switch account, add account, forget saved account, logout
- Local multi-account vault (`apiBase\0userId`), remember/session split, expiry cleanup
- Auth hardening: auth generation, switch rollback, per-tab active snapshot, cache scope by host+account+tenant
- Login page can resume parked accounts; tenant override 403 no longer force-logs out

## Test plan
- [x] `./scripts/ci-pr.sh` equivalents:
  - `bun install --frozen-lockfile`
  - `bun run lint` / design:check / test:ci / build / bundle:diff (baseline updated for index gzip)
  - Playwright `@critical`: `e2e/login-lifecycle.spec.ts` + `e2e/multi-tenant-auth.spec.ts` (9 passed)
- [ ] Manual: login A → add account → login B → switch back to A; forget one account; reload with remember on/off