### PR TITLE
feat(portal): multi-account switch on apikey-lookup

### DIFF
--- a/packages/api-client/src/client/__tests__/portal-accounts.test.ts
+++ b/packages/api-client/src/client/__tests__/portal-accounts.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  PORTAL_ACCOUNTS_STORAGE_KEY,
+  PORTAL_AUTH_STORAGE_KEY,
+  clearPortalAuth,
+  getSavedPortalAccount,
+  listSavedPortalAccounts,
+  portalClient,
+  removeSavedPortalAccount,
+  writePortalAuth,
+} from "../portal-client";
+
+describe("portal multi-account vault", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  test("writePortalAuth upserts vault by accountKey", () => {
+    writePortalAuth({
+      apiBase: "http://127.0.0.1:8317",
+      accessToken: "tok-a",
+      refreshToken: "ref-a",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      user: { id: "u1", username: "alice", display_name: "Alice" },
+    });
+    expect(listSavedPortalAccounts()).toEqual([
+      expect.objectContaining({
+        accessToken: "tok-a",
+        user: expect.objectContaining({ id: "u1", username: "alice" }),
+      }),
+    ]);
+    expect(localStorage.getItem(PORTAL_AUTH_STORAGE_KEY)).toContain("tok-a");
+  });
+
+  test("switch parks current and activates target", () => {
+    writePortalAuth({
+      apiBase: "http://127.0.0.1:8317",
+      accessToken: "tok-a",
+      refreshToken: "ref-a",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      user: { id: "u1", username: "alice", display_name: "Alice" },
+    });
+    portalClient.loadFromStorage();
+    writePortalAuth({
+      apiBase: "http://127.0.0.1:8317",
+      accessToken: "tok-b",
+      refreshToken: "ref-b",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      user: { id: "u2", username: "bob", display_name: "Bob" },
+    });
+    portalClient.loadFromStorage();
+    expect(listSavedPortalAccounts()).toHaveLength(2);
+
+    const switched = portalClient.switchToSavedAccount("u1");
+    expect(switched?.user.id).toBe("u1");
+    expect(portalClient.getAccessToken()).toBe("tok-a");
+    expect(listSavedPortalAccounts().map((r) => r.user.id).sort()).toEqual(["u1", "u2"]);
+  });
+
+  test("removeSavedPortalAccount drops one entry", () => {
+    writePortalAuth({
+      apiBase: "http://127.0.0.1:8317",
+      accessToken: "tok-a",
+      refreshToken: "ref-a",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      user: { id: "u1", username: "alice", display_name: "Alice" },
+    });
+    writePortalAuth({
+      apiBase: "http://127.0.0.1:8317",
+      accessToken: "tok-b",
+      refreshToken: "ref-b",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      user: { id: "u2", username: "bob", display_name: "Bob" },
+    });
+    removeSavedPortalAccount("u1");
+    expect(listSavedPortalAccounts().map((r) => r.user.id)).toEqual(["u2"]);
+    expect(getSavedPortalAccount("u1")).toBeNull();
+    expect(localStorage.getItem(PORTAL_ACCOUNTS_STORAGE_KEY)).toContain("u2");
+  });
+
+  test("parkSession clears active auth but keeps vault", () => {
+    writePortalAuth({
+      apiBase: "http://127.0.0.1:8317",
+      accessToken: "tok-a",
+      refreshToken: "ref-a",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      user: { id: "u1", username: "alice", display_name: "Alice" },
+    });
+    portalClient.loadFromStorage();
+    portalClient.parkSession();
+    expect(portalClient.getAccessToken()).toBe("");
+    expect(listSavedPortalAccounts()).toHaveLength(1);
+    clearPortalAuth();
+  });
+});

--- a/packages/api-client/src/client/portal-client.ts
+++ b/packages/api-client/src/client/portal-client.ts
@@ -4,6 +4,8 @@ export { detectApiBaseFromLocation };
 import { ApiClientError, extractApiErrorMessage } from "./errors";
 
 export const PORTAL_AUTH_STORAGE_KEY = "code-proxy-portal-auth";
+/** Multi-account vault for portal (end-user) sessions. */
+export const PORTAL_ACCOUNTS_STORAGE_KEY = "code-proxy-portal-auth-accounts";
 
 export interface PortalAuthSnapshot {
   apiBase: string;
@@ -12,6 +14,16 @@ export interface PortalAuthSnapshot {
   remember: boolean;
   expiresAt: number;
   user?: {
+    id: string;
+    username: string;
+    display_name: string;
+  };
+}
+
+export interface SavedPortalAccount extends PortalAuthSnapshot {
+  accountKey: string;
+  lastUsedAt: number;
+  user: {
     id: string;
     username: string;
     display_name: string;
@@ -49,18 +61,135 @@ export const readPortalAuth = (): PortalAuthSnapshot | null => {
   return null;
 };
 
+export const buildPortalAccountKey = (apiBase: string, userId: string): string => {
+  const base = normalizeApiBase(apiBase.trim());
+  const id = userId.trim();
+  if (!base || !id) return "";
+  return `${base}\0${id}`;
+};
+
+const localOnly = (): Storage | null => {
+  try {
+    if (typeof window !== "undefined") return window.localStorage;
+  } catch {
+    /* unavailable */
+  }
+  return null;
+};
+
+const isSavedPortalAccount = (value: unknown): value is SavedPortalAccount => {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<SavedPortalAccount>;
+  return Boolean(
+    row.accessToken &&
+      row.apiBase &&
+      row.user &&
+      typeof row.user.id === "string" &&
+      row.user.id.trim(),
+  );
+};
+
+export const listSavedPortalAccounts = (): SavedPortalAccount[] => {
+  const storage = localOnly();
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(PORTAL_ACCOUNTS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(isSavedPortalAccount)
+      .map((row) => {
+        const apiBase = normalizeApiBase(row.apiBase);
+        const accountKey =
+          (typeof row.accountKey === "string" && row.accountKey.trim()) ||
+          buildPortalAccountKey(apiBase, row.user.id);
+        return {
+          ...row,
+          apiBase,
+          accountKey,
+          lastUsedAt: typeof row.lastUsedAt === "number" ? row.lastUsedAt : 0,
+          user: {
+            id: row.user.id.trim(),
+            username: row.user.username?.trim() || row.user.id,
+            display_name: row.user.display_name?.trim() || row.user.username || row.user.id,
+          },
+        };
+      })
+      .filter((row) => Boolean(row.accountKey && row.accessToken))
+      .sort((a, b) => b.lastUsedAt - a.lastUsedAt);
+  } catch {
+    return [];
+  }
+};
+
+const writeSavedPortalAccounts = (accounts: SavedPortalAccount[]): void => {
+  const storage = localOnly();
+  if (!storage) return;
+  try {
+    if (accounts.length === 0) storage.removeItem(PORTAL_ACCOUNTS_STORAGE_KEY);
+    else storage.setItem(PORTAL_ACCOUNTS_STORAGE_KEY, JSON.stringify(accounts));
+  } catch {
+    /* ignore quota */
+  }
+};
+
+export const upsertSavedPortalAccount = (snapshot: PortalAuthSnapshot): void => {
+  const user = snapshot.user;
+  if (!user?.id?.trim() || !snapshot.accessToken) return;
+  const apiBase = normalizeApiBase(snapshot.apiBase);
+  const accountKey = buildPortalAccountKey(apiBase, user.id);
+  if (!accountKey) return;
+  const next: SavedPortalAccount = {
+    apiBase,
+    accessToken: snapshot.accessToken,
+    refreshToken: snapshot.refreshToken || "",
+    remember: Boolean(snapshot.remember),
+    expiresAt: snapshot.expiresAt || Date.now() + 12 * 3600 * 1000,
+    user: {
+      id: user.id.trim(),
+      username: user.username?.trim() || user.id,
+      display_name: user.display_name?.trim() || user.username || user.id,
+    },
+    accountKey,
+    lastUsedAt: Date.now(),
+  };
+  const others = listSavedPortalAccounts().filter((row) => row.accountKey !== accountKey);
+  writeSavedPortalAccounts([next, ...others]);
+};
+
+export const removeSavedPortalAccount = (accountKeyOrId: string): void => {
+  const key = accountKeyOrId.trim();
+  if (!key) return;
+  writeSavedPortalAccounts(
+    listSavedPortalAccounts().filter(
+      (row) => row.accountKey !== key && row.user.id !== key,
+    ),
+  );
+};
+
+export const getSavedPortalAccount = (accountKeyOrId: string): SavedPortalAccount | null => {
+  const key = accountKeyOrId.trim();
+  if (!key) return null;
+  return (
+    listSavedPortalAccounts().find(
+      (row) => row.accountKey === key || row.user.id === key,
+    ) ?? null
+  );
+};
+
 export const writePortalAuth = (snapshot: PortalAuthSnapshot): void => {
   const [session, local] = storages();
   const target = snapshot.remember ? local : session;
   if (!target) return;
   clearPortalAuth();
-  target.setItem(
-    PORTAL_AUTH_STORAGE_KEY,
-    JSON.stringify({
-      ...snapshot,
-      apiBase: normalizeApiBase(snapshot.apiBase),
-    }),
-  );
+  const normalized: PortalAuthSnapshot = {
+    ...snapshot,
+    apiBase: normalizeApiBase(snapshot.apiBase),
+  };
+  target.setItem(PORTAL_AUTH_STORAGE_KEY, JSON.stringify(normalized));
+  // Keep multi-account vault in sync for switch-account.
+  if (normalized.user?.id) upsertSavedPortalAccount(normalized);
 };
 
 export const clearPortalAuth = (): void => {
@@ -109,6 +238,36 @@ export class PortalApiClient {
     this.accessToken = "";
     this.refreshToken = "";
     clearPortalAuth();
+  }
+
+  /** Soft clear: keep vault entry so the user can switch back after adding another account. */
+  parkSession(): void {
+    const current = readPortalAuth();
+    if (current?.user?.id && current.accessToken) {
+      upsertSavedPortalAccount({
+        ...current,
+        accessToken: this.accessToken || current.accessToken,
+        refreshToken: this.refreshToken || current.refreshToken,
+      });
+    }
+    this.clearSession();
+  }
+
+  switchToSavedAccount(accountKeyOrId: string): SavedPortalAccount | null {
+    const target = getSavedPortalAccount(accountKeyOrId);
+    if (!target) return null;
+    const current = readPortalAuth();
+    if (current?.user?.id && current.accessToken) {
+      const currentKey = buildPortalAccountKey(current.apiBase, current.user.id);
+      if (currentKey && currentKey === target.accountKey) return target;
+      upsertSavedPortalAccount({
+        ...current,
+        accessToken: this.accessToken || current.accessToken,
+        refreshToken: this.refreshToken || current.refreshToken,
+      });
+    }
+    this.setSession(target);
+    return target;
   }
 
   getAccessToken(): string {

--- a/packages/api-client/src/endpoints/end-users.ts
+++ b/packages/api-client/src/endpoints/end-users.ts
@@ -1,7 +1,10 @@
 import { apiClient } from "../client/client";
 import {
+  buildPortalAccountKey,
   detectApiBaseFromLocation,
+  listSavedPortalAccounts,
   portalClient,
+  removeSavedPortalAccount,
   type PortalAuthSnapshot,
 } from "../client/portal-client";
 
@@ -116,6 +119,12 @@ export const portalApi = {
   client: portalClient,
   loadSession: () => portalClient.loadFromStorage(),
   clearSession: () => portalClient.clearSession(),
+  listSavedAccounts: () => listSavedPortalAccounts(),
+  removeSavedAccount: (accountKeyOrId: string) => removeSavedPortalAccount(accountKeyOrId),
+  beginAddAccount: () => {
+    portalClient.parkSession();
+  },
+  switchAccount: (accountKeyOrId: string) => portalClient.switchToSavedAccount(accountKeyOrId),
   async login(username: string, password: string, remember = true): Promise<PortalLoginResult> {
     portalClient.loadFromStorage();
     const result = await portalClient.post<PortalLoginResult>("/v0/portal/auth/login", {
@@ -138,10 +147,14 @@ export const portalApi = {
     return result;
   },
   logout: async () => {
+    const current = portalClient.loadFromStorage();
     try {
       await portalClient.post("/v0/portal/auth/logout", {});
     } catch {
       /* ignore */
+    }
+    if (current?.user?.id) {
+      removeSavedPortalAccount(buildPortalAccountKey(current.apiBase, current.user.id));
     }
     portalClient.clearSession();
   },

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -44,11 +44,17 @@ export {
   portalClient,
   PortalApiClient,
   PORTAL_AUTH_STORAGE_KEY,
+  PORTAL_ACCOUNTS_STORAGE_KEY,
+  buildPortalAccountKey,
   clearPortalAuth,
+  getSavedPortalAccount,
+  listSavedPortalAccounts,
   readPortalAuth,
+  removeSavedPortalAccount,
+  upsertSavedPortalAccount,
   writePortalAuth,
 } from "./client/portal-client";
-export type { PortalAuthSnapshot } from "./client/portal-client";
+export type { PortalAuthSnapshot, SavedPortalAccount } from "./client/portal-client";
 export type * from "./dto/types";
 export { endUsersApi, portalApi } from "./endpoints/end-users";
 export type * from "./endpoints/end-users";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3296,7 +3296,9 @@
     "confirm_delete_title": "Delete API key?",
     "confirm_delete_desc": "This cannot be undone. Requests using this key will stop working.",
     "confirm_delete": "Delete",
-    "deleting": "Deleting…"
+    "deleting": "Deleting…",
+    "add_account": "Add account",
+    "switch_account": "Switch account"
   },
   "auth_files_page": {
     "files_tab": "Files",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2752,6 +2752,8 @@
     "confirm_delete_title": "Delete API key?",
     "confirm_delete_desc": "This cannot be undone. Requests using this key will stop working.",
     "confirm_delete": "Delete",
-    "deleting": "Deleting…"
+    "deleting": "Deleting…",
+    "add_account": "Add account",
+    "switch_account": "Switch account"
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3593,7 +3593,9 @@
     "confirm_delete_title": "删除 API Key？",
     "confirm_delete_desc": "删除后不可恢复，使用该 Key 的请求将失败。",
     "confirm_delete": "删除",
-    "deleting": "删除中…"
+    "deleting": "删除中…",
+    "add_account": "添加账号",
+    "switch_account": "切换账号"
   },
   "config_page": {
     "save_warning_title": "确认高影响配置变更",

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Eye, EyeOff, Key, KeyRound, LogOut, UserRound } from "lucide-react";
+import { Eye, EyeOff, Key, KeyRound, LogOut, UserPlus, Users, UserRound } from "lucide-react";
 import {
   extractApiErrorCode,
   isApiClientError,
   portalApi,
   type EndUser,
   type EndUserAPIKey,
+  type SavedPortalAccount,
 } from "@code-proxy/api-client";
 import {
   normalizeChannelOptions,
@@ -74,6 +75,8 @@ const LOOKUP_MODELS_CACHE_STORAGE_KEY_V2 = "apiKeyLookup.modelsCache.v2";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.modelsCache.v1";
 const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
 const CHANGE_PASSWORD_SELECT_VALUE = "__api-key-lookup-change-password__";
+const ADD_ACCOUNT_SELECT_VALUE = "__api-key-lookup-add-account__";
+const SWITCH_ACCOUNT_PREFIX = "__api-key-lookup-switch__:";
 type UsageLookupSubject =
   | { mode: "portal"; apiKey: ""; cacheKey: string }
   | { mode: "legacy"; apiKey: string; cacheKey: string };
@@ -332,6 +335,9 @@ export function ApiKeyLookupPage() {
   const [apiKeyName, setApiKeyName] = useState("");
   const [portalUser, setPortalUser] = useState<EndUser | null>(null);
   const [portalKeys, setPortalKeys] = useState<EndUserAPIKey[]>([]);
+  const [savedPortalAccounts, setSavedPortalAccounts] = useState<SavedPortalAccount[]>(() =>
+    portalApi.listSavedAccounts(),
+  );
   const [loginUsername, setLoginUsername] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
   const [loginError, setLoginError] = useState<string | null>(null);
@@ -859,6 +865,7 @@ export function ApiKeyLookupPage() {
       .then(async (res) => {
         if (cancelled) return;
         setPortalUser(res.user);
+        setSavedPortalAccounts(portalApi.listSavedAccounts());
         if (res.user.must_change_password) {
           setChangePasswordOpen(true);
           setPortalKeys([]);
@@ -878,6 +885,7 @@ export function ApiKeyLookupPage() {
       .catch(() => {
         if (cancelled) return;
         portalApi.clearSession();
+        setSavedPortalAccounts(portalApi.listSavedAccounts());
       })
       .finally(() => {
         if (!cancelled) setPortalSessionPending(false);
@@ -887,12 +895,33 @@ export function ApiKeyLookupPage() {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const hydratePortalSession = useCallback(async () => {
+    const res = await portalApi.me();
+    setPortalUser(res.user);
+    setSavedPortalAccounts(portalApi.listSavedAccounts());
+    if (res.user.must_change_password) {
+      setChangePasswordOpen(true);
+      setPortalKeys([]);
+      return;
+    }
+    try {
+      const keys = await portalApi.listKeys();
+      const items = keys.items ?? [];
+      setPortalKeys(items);
+      const firstUsable = items.find((key) => !key.disabled);
+      if (firstUsable) await activateOwnedKey(firstUsable.id);
+    } catch {
+      setPortalKeys([]);
+    }
+  }, [activateOwnedKey]);
+
   const handlePortalLogin = useCallback(async () => {
     setLoginBusy(true);
     setLoginError(null);
     try {
       const result = await portalApi.login(loginUsername.trim(), loginPassword, true);
       setPortalUser(result.user);
+      setSavedPortalAccounts(portalApi.listSavedAccounts());
       setLoginModalOpen(false);
       setLoginPassword("");
       if (result.must_change_password || result.user.must_change_password) {
@@ -927,7 +956,44 @@ export function ApiKeyLookupPage() {
     setOperationalKeyId("");
     handleApiKeyInputChange("");
     setLoginModalOpen(false);
+    setSavedPortalAccounts(portalApi.listSavedAccounts());
   }, [handleApiKeyInputChange]);
+
+  const handleAddAccount = useCallback(() => {
+    portalApi.beginAddAccount();
+    setPortalUser(null);
+    setPortalKeys([]);
+    setOperationalKeyId("");
+    handleApiKeyInputChange("");
+    setLoginUsername("");
+    setLoginPassword("");
+    setLoginError(null);
+    setLoginModalOpen(true);
+    setSavedPortalAccounts(portalApi.listSavedAccounts());
+  }, [handleApiKeyInputChange]);
+
+  const handleSwitchAccount = useCallback(
+    async (accountKey: string) => {
+      const target = portalApi.switchAccount(accountKey);
+      if (!target) return;
+      setPortalSessionPending(true);
+      setOperationalKeyId("");
+      handleApiKeyInputChange("");
+      setPortalKeys([]);
+      try {
+        await hydratePortalSession();
+      } catch {
+        portalApi.removeSavedAccount(accountKey);
+        portalApi.clearSession();
+        setPortalUser(null);
+        setLoginModalOpen(true);
+      } finally {
+        setPortalSessionPending(false);
+        setSavedPortalAccounts(portalApi.listSavedAccounts());
+      }
+    },
+    [handleApiKeyInputChange, hydratePortalSession],
+  );
 
   const refreshPortalKeys = useCallback(async () => {
     setPortalKeysLoading(true);
@@ -1021,6 +1087,14 @@ export function ApiKeyLookupPage() {
     apiKeyName ||
     (queriedKey ? t("apikey_lookup.unnamed_key") : "");
   const extraKeyCount = Math.max(0, portalKeys.length - 1);
+  const otherPortalAccounts = useMemo(
+    () =>
+      savedPortalAccounts.filter((account) => {
+        if (!portalUser) return true;
+        return account.user.id !== portalUser.id;
+      }),
+    [portalUser, savedPortalAccounts],
+  );
   const keyMenuOptions = useMemo<SelectOption[]>(
     () => [
       ...(portalUser
@@ -1036,6 +1110,30 @@ export function ApiKeyLookupPage() {
             },
           ]
         : []),
+      ...otherPortalAccounts.map((account) => ({
+        value: `${SWITCH_ACCOUNT_PREFIX}${account.accountKey}`,
+        label: (
+          <span className="flex min-w-0 items-center gap-2">
+            <Users size={15} className="shrink-0" />
+            <span className="min-w-0 truncate">
+              {account.user.display_name || account.user.username}
+            </span>
+          </span>
+        ),
+      })),
+      ...(portalUser
+        ? [
+            {
+              value: ADD_ACCOUNT_SELECT_VALUE,
+              label: (
+                <span className="flex items-center gap-2">
+                  <UserPlus size={15} />
+                  {t("apikey_lookup.add_account", { defaultValue: "添加账号" })}
+                </span>
+              ),
+            },
+          ]
+        : []),
       {
         value: LOGOUT_SELECT_VALUE,
         label: (
@@ -1046,14 +1144,27 @@ export function ApiKeyLookupPage() {
         ),
       },
     ],
-    [portalUser, t],
+    [otherPortalAccounts, portalUser, t],
   );
   const handleKeyMenuChange = useCallback(
     (value: string) => {
-      if (value === LOGOUT_SELECT_VALUE) handleLogout();
-      if (value === CHANGE_PASSWORD_SELECT_VALUE) setChangePasswordOpen(true);
+      if (value === LOGOUT_SELECT_VALUE) {
+        handleLogout();
+        return;
+      }
+      if (value === CHANGE_PASSWORD_SELECT_VALUE) {
+        setChangePasswordOpen(true);
+        return;
+      }
+      if (value === ADD_ACCOUNT_SELECT_VALUE) {
+        handleAddAccount();
+        return;
+      }
+      if (value.startsWith(SWITCH_ACCOUNT_PREFIX)) {
+        void handleSwitchAccount(value.slice(SWITCH_ACCOUNT_PREFIX.length));
+      }
     },
-    [handleLogout],
+    [handleAddAccount, handleLogout, handleSwitchAccount],
   );
 
   // Landing CTA opens login; always allow dismiss (backdrop / Esc / X).

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -121,6 +121,10 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
     portalApi: {
       loadSession: vi.fn(() => null),
       clearSession: () => undefined,
+      listSavedAccounts: vi.fn(() => []),
+      removeSavedAccount: vi.fn(),
+      beginAddAccount: vi.fn(),
+      switchAccount: vi.fn(() => null),
       login: vi.fn(),
       logout: vi.fn(async () => undefined),
       me: vi.fn(),


### PR DESCRIPTION
## Summary
- **Correct surface:** end-user portal at `/manage/apikey-lookup` (not admin shell)
- Header menu: **添加账号**, **切换账号** (other saved sessions), 修改密码, 登出
- Portal multi-account vault in `localStorage` (`code-proxy-portal-auth-accounts`)
- Soft park current session when adding another account; logout removes current from vault

## Note
PR #771 added admin-shell multi-account by mistake for this request; this PR delivers the intended portal UX shown in the product screenshot.

## Test plan
- [x] `portal-accounts` unit tests
- [x] `ApiKeyLookupPage` tests (mock portalApi extended)
- [ ] Manual on apikey-lookup: login A → 添加账号 → login B → menu shows A → switch back