### PR TITLE
fix(portal): account menu UX for multi-account

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3298,7 +3298,8 @@
     "confirm_delete": "Delete",
     "deleting": "Deleting…",
     "add_account": "Add account",
-    "switch_account": "Switch account"
+    "switch_account": "Switch account",
+    "current_account": "Current account"
   },
   "auth_files_page": {
     "files_tab": "Files",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2754,6 +2754,7 @@
     "confirm_delete": "Delete",
     "deleting": "Deleting…",
     "add_account": "Add account",
-    "switch_account": "Switch account"
+    "switch_account": "Switch account",
+    "current_account": "Current account"
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3595,7 +3595,8 @@
     "confirm_delete": "删除",
     "deleting": "删除中…",
     "add_account": "添加账号",
-    "switch_account": "切换账号"
+    "switch_account": "切换账号",
+    "current_account": "当前账号"
   },
   "config_page": {
     "save_warning_title": "确认高影响配置变更",

--- a/packages/ui/src/primitives/DropdownMenu.tsx
+++ b/packages/ui/src/primitives/DropdownMenu.tsx
@@ -30,6 +30,8 @@ const Trigger = DropdownMenuPrimitive.Trigger;
 const Portal = DropdownMenuPrimitive.Portal;
 const Group = DropdownMenuPrimitive.Group;
 const ItemIndicator = DropdownMenuPrimitive.ItemIndicator;
+const Sub = DropdownMenuPrimitive.Sub;
+const RadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const CONTENT_CLASS_BY_SIZE: Record<ControlSize, string> = {
   sm: "min-w-28 p-1",
@@ -94,6 +96,62 @@ const Separator = forwardRef<
   );
 });
 
+const SubTrigger = forwardRef<
+  ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger>
+>(function DropdownMenuSubTrigger({ className, ...props }, ref) {
+  const size = useContext(DropdownMenuSizeContext);
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      ref={ref}
+      className={cn(
+        "flex w-full cursor-default select-none items-center font-medium text-slate-700 outline-none transition-colors duration-150 focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[state=open]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10 dark:data-[state=open]:bg-white/10",
+        ITEM_CLASS_BY_SIZE[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+const SubContent = forwardRef<
+  ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(function DropdownMenuSubContent({ className, sideOffset = 6, ...props }, ref) {
+  const size = useContext(DropdownMenuSizeContext);
+  return (
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[9999] overflow-hidden outline-none",
+        floatingPanelSurface,
+        CONTENT_CLASS_BY_SIZE[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+const RadioItem = forwardRef<
+  ComponentRef<typeof DropdownMenuPrimitive.RadioItem>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(function DropdownMenuRadioItem({ className, ...props }, ref) {
+  const size = useContext(DropdownMenuSizeContext);
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      ref={ref}
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center font-medium text-slate-700 outline-none transition-colors duration-150 focus:bg-slate-100 data-[highlighted]:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-45 dark:text-white/75 dark:focus:bg-white/10 dark:data-[highlighted]:bg-white/10",
+        ITEM_CLASS_BY_SIZE[size],
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
 export const DropdownMenu = {
   Root,
   Trigger,
@@ -103,4 +161,9 @@ export const DropdownMenu = {
   Item,
   ItemIndicator,
   Separator,
+  Sub,
+  SubTrigger,
+  SubContent,
+  RadioGroup,
+  RadioItem,
 };

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1,6 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Eye, EyeOff, Key, KeyRound, LogOut, UserPlus, Users, UserRound } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  Eye,
+  EyeOff,
+  Key,
+  KeyRound,
+  LogOut,
+  UserPlus,
+  Users,
+  UserRound,
+} from "lucide-react";
 import {
   extractApiErrorCode,
   isApiClientError,
@@ -22,7 +33,7 @@ import { Button } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { PageBackground } from "@code-proxy/ui";
 import { SecretRevealModal } from "@code-proxy/ui";
-import { Select, type SelectOption } from "@code-proxy/ui";
+import { DropdownMenu } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
@@ -73,10 +84,7 @@ const LOOKUP_CHART_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.chartCache.v1";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY = "apiKeyLookup.modelsCache.v3";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY_V2 = "apiKeyLookup.modelsCache.v2";
 const LOOKUP_MODELS_CACHE_STORAGE_KEY_V1 = "apiKeyLookup.modelsCache.v1";
-const LOGOUT_SELECT_VALUE = "__api-key-lookup-logout__";
-const CHANGE_PASSWORD_SELECT_VALUE = "__api-key-lookup-change-password__";
-const ADD_ACCOUNT_SELECT_VALUE = "__api-key-lookup-add-account__";
-const SWITCH_ACCOUNT_PREFIX = "__api-key-lookup-switch__:";
+
 type UsageLookupSubject =
   | { mode: "portal"; apiKey: ""; cacheKey: string }
   | { mode: "legacy"; apiKey: string; cacheKey: string };
@@ -960,17 +968,16 @@ export function ApiKeyLookupPage() {
   }, [handleApiKeyInputChange]);
 
   const handleAddAccount = useCallback(() => {
-    portalApi.beginAddAccount();
-    setPortalUser(null);
-    setPortalKeys([]);
-    setOperationalKeyId("");
-    handleApiKeyInputChange("");
+    // Keep current session/UI visible; only open login for the next account.
+    // Re-persist active session so it stays in the multi-account vault.
+    const snap = portalApi.loadSession();
+    if (snap?.user?.id) portalApi.client.setSession(snap);
     setLoginUsername("");
     setLoginPassword("");
     setLoginError(null);
     setLoginModalOpen(true);
     setSavedPortalAccounts(portalApi.listSavedAccounts());
-  }, [handleApiKeyInputChange]);
+  }, []);
 
   const handleSwitchAccount = useCallback(
     async (accountKey: string) => {
@@ -1095,79 +1102,9 @@ export function ApiKeyLookupPage() {
       }),
     [portalUser, savedPortalAccounts],
   );
-  const keyMenuOptions = useMemo<SelectOption[]>(
-    () => [
-      ...(portalUser
-        ? [
-            {
-              value: CHANGE_PASSWORD_SELECT_VALUE,
-              label: (
-                <span className="flex items-center gap-2">
-                  <KeyRound size={15} />
-                  {t("apikey_lookup.change_password", { defaultValue: "修改密码" })}
-                </span>
-              ),
-            },
-          ]
-        : []),
-      ...otherPortalAccounts.map((account) => ({
-        value: `${SWITCH_ACCOUNT_PREFIX}${account.accountKey}`,
-        label: (
-          <span className="flex min-w-0 items-center gap-2">
-            <Users size={15} className="shrink-0" />
-            <span className="min-w-0 truncate">
-              {account.user.display_name || account.user.username}
-            </span>
-          </span>
-        ),
-      })),
-      ...(portalUser
-        ? [
-            {
-              value: ADD_ACCOUNT_SELECT_VALUE,
-              label: (
-                <span className="flex items-center gap-2">
-                  <UserPlus size={15} />
-                  {t("apikey_lookup.add_account", { defaultValue: "添加账号" })}
-                </span>
-              ),
-            },
-          ]
-        : []),
-      {
-        value: LOGOUT_SELECT_VALUE,
-        label: (
-          <span className="flex items-center gap-2">
-            <LogOut size={15} />
-            {t("common.logout")}
-          </span>
-        ),
-      },
-    ],
-    [otherPortalAccounts, portalUser, t],
-  );
-  const handleKeyMenuChange = useCallback(
-    (value: string) => {
-      if (value === LOGOUT_SELECT_VALUE) {
-        handleLogout();
-        return;
-      }
-      if (value === CHANGE_PASSWORD_SELECT_VALUE) {
-        setChangePasswordOpen(true);
-        return;
-      }
-      if (value === ADD_ACCOUNT_SELECT_VALUE) {
-        handleAddAccount();
-        return;
-      }
-      if (value.startsWith(SWITCH_ACCOUNT_PREFIX)) {
-        void handleSwitchAccount(value.slice(SWITCH_ACCOUNT_PREFIX.length));
-      }
-    },
-    [handleAddAccount, handleLogout, handleSwitchAccount],
-  );
 
   // Landing CTA opens login; always allow dismiss (backdrop / Esc / X).
+  // Keep results UI when the add-account login modal is open over an active session.
   const closeLoginModal = useCallback(() => {
     setLoginModalOpen(false);
   }, []);
@@ -1223,12 +1160,14 @@ export function ApiKeyLookupPage() {
             </div>
             <div className="flex items-center gap-2">
               {queriedKey || portalUser ? (
-                <Select
-                  value={queriedKey || portalUser?.id || ""}
-                  onChange={handleKeyMenuChange}
-                  options={keyMenuOptions}
-                  placeholder={
-                    <span className="flex min-w-0 items-center gap-1.5">
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger asChild>
+                    <button
+                      type="button"
+                      aria-label={displayName}
+                      data-testid="apikey-lookup-account-menu"
+                      className="inline-flex max-w-[34vw] items-center gap-1.5 rounded-xl px-1 py-1 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:text-white/80 dark:hover:bg-white/10 sm:max-w-56"
+                    >
                       <Key size={14} className="shrink-0" />
                       <span className="min-w-0 truncate">{displayName}</span>
                       {extraKeyCount > 0 ? (
@@ -1236,12 +1175,84 @@ export function ApiKeyLookupPage() {
                           +{extraKeyCount}
                         </span>
                       ) : null}
-                    </span>
-                  }
-                  aria-label={displayName}
-                  className="max-w-[34vw] !border-0 !bg-transparent !px-1 !shadow-none hover:!bg-transparent dark:!bg-transparent dark:!shadow-none dark:hover:!bg-transparent sm:max-w-56"
-                  size="sm"
-                />
+                      <ChevronRight
+                        size={14}
+                        className="shrink-0 rotate-90 text-slate-400 dark:text-white/40"
+                      />
+                    </button>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content
+                      align="end"
+                      sideOffset={8}
+                      className="min-w-48"
+                      data-testid="apikey-lookup-account-menu-content"
+                    >
+                      {portalUser ? (
+                        <DropdownMenu.Item
+                          disabled
+                          className="data-[disabled]:opacity-100"
+                          data-testid="apikey-lookup-current-account"
+                        >
+                          <Check size={15} className="shrink-0 text-emerald-600 dark:text-emerald-400" />
+                          <span className="min-w-0 flex-1 truncate">
+                            {portalUser.display_name || portalUser.username}
+                          </span>
+                        </DropdownMenu.Item>
+                      ) : null}
+                      {portalUser ? (
+                        <DropdownMenu.Item onSelect={() => setChangePasswordOpen(true)}>
+                          <KeyRound size={15} />
+                          {t("apikey_lookup.change_password", { defaultValue: "修改密码" })}
+                        </DropdownMenu.Item>
+                      ) : null}
+                      {otherPortalAccounts.length > 0 ? (
+                        <DropdownMenu.Sub>
+                          <DropdownMenu.SubTrigger>
+                            <Users size={15} />
+                            <span className="min-w-0 flex-1">
+                              {t("apikey_lookup.switch_account", { defaultValue: "切换账号" })}
+                            </span>
+                            <ChevronRight size={14} className="ml-auto shrink-0 text-slate-400" />
+                          </DropdownMenu.SubTrigger>
+                          <DropdownMenu.Portal>
+                            <DropdownMenu.SubContent
+                              sideOffset={6}
+                              className="min-w-44"
+                              data-testid="apikey-lookup-switch-account-menu"
+                            >
+                              {otherPortalAccounts.map((account) => (
+                                <DropdownMenu.Item
+                                  key={account.accountKey}
+                                  onSelect={() => void handleSwitchAccount(account.accountKey)}
+                                >
+                                  <Users size={15} className="shrink-0" />
+                                  <span className="min-w-0 truncate">
+                                    {account.user.display_name || account.user.username}
+                                  </span>
+                                </DropdownMenu.Item>
+                              ))}
+                            </DropdownMenu.SubContent>
+                          </DropdownMenu.Portal>
+                        </DropdownMenu.Sub>
+                      ) : null}
+                      {portalUser ? (
+                        <DropdownMenu.Item onSelect={handleAddAccount}>
+                          <UserPlus size={15} />
+                          {t("apikey_lookup.add_account", { defaultValue: "添加账号" })}
+                        </DropdownMenu.Item>
+                      ) : null}
+                      <DropdownMenu.Separator />
+                      <DropdownMenu.Item
+                        onSelect={handleLogout}
+                        className="text-rose-600 focus:text-rose-700 dark:text-rose-300"
+                      >
+                        <LogOut size={15} />
+                        {t("common.logout")}
+                      </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
               ) : (
                 <Button
                   size="sm"

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -125,6 +125,7 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       removeSavedAccount: vi.fn(),
       beginAddAccount: vi.fn(),
       switchAccount: vi.fn(() => null),
+      client: { setSession: vi.fn() },
       login: vi.fn(),
       logout: vi.fn(async () => undefined),
       me: vi.fn(),
@@ -298,7 +299,7 @@ describe("ApiKeyLookupPage", () => {
       );
     });
     expect(mocks.fetchPublicLogs).not.toHaveBeenCalled();
-    expect(await screen.findByRole("combobox", { name: /primary key/i })).toBeInTheDocument();
+    expect(await screen.findByTestId("apikey-lookup-account-menu")).toBeInTheDocument();
     expect(window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1")).toBeNull();
     expect(window.location.search).toBe("");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
@@ -669,13 +670,10 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
-
-    expect(screen.queryByRole("option", { name: /primary key/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("option", { name: /logout/i })).toHaveAttribute(
-      "aria-selected",
-      "false",
-    );
+    await userEvent.click(await screen.findByTestId("apikey-lookup-account-menu"));
+    const menu = await screen.findByTestId("apikey-lookup-account-menu-content");
+    expect(within(menu).queryByText(/primary key/i)).not.toBeInTheDocument();
+    expect(within(menu).getByText(/logout|退出登录|登出/i)).toBeInTheDocument();
   });
 
   test("confirms before deleting a managed API key", async () => {
@@ -790,8 +788,12 @@ describe("ApiKeyLookupPage", () => {
       </ThemeProvider>,
     );
 
-    await userEvent.click(await screen.findByRole("combobox", { name: /primary key/i }));
-    await userEvent.click(screen.getByRole("option", { name: /logout/i }));
+    await userEvent.click(await screen.findByTestId("apikey-lookup-account-menu"));
+    await userEvent.click(
+      within(await screen.findByTestId("apikey-lookup-account-menu-content")).getByText(
+        /logout|退出登录|登出/i,
+      ),
+    );
 
     expect(window.sessionStorage.getItem("apiKeyLookup.lastApiKey.v1")).toBeNull();
     expect(screen.getByTestId("apikey-lookup-landing")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- **添加账号** no longer clears the current portal session / drops to landing; only opens the login modal
- Header menu rebuilt:
  1. Current account at top with checkmark
  2. 修改密码
  3. **切换账号** as a submenu (other saved accounts)
  4. 添加账号
  5. 登出
- DropdownMenu gains Sub / Radio primitives for the nested switch list

## Test plan
- [x] ApiKeyLookupPage unit tests (15)
- [ ] Manual: login A → 添加账号 (stay on page) → login B → menu shows B checked at top → 切换账号 → A