### PR TITLE
fix(admin): remove multi-account switch from management login

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -194,13 +194,9 @@ vi.mock("@app/providers/AuthProvider", () => ({
     can: () => true,
     state: {
       principal: authPrincipal,
-      savedAccounts: [],
     },
     actions: {
       switchTenant: vi.fn(),
-      beginAddAccount: vi.fn(),
-      switchAccount: vi.fn(),
-      removeSavedAccount: vi.fn(),
     },
   }),
 }));

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -21,9 +21,6 @@ import {
   PanelLeft,
   Settings,
   ShieldCheck,
-  UserPlus,
-  Users,
-  X,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -39,7 +36,6 @@ import {
 import { preloadPageRoute } from "@pages/registry";
 import { recoverFromChunkLoadError } from "@pages/chunkLoadRecovery";
 import {
-  buildAccountKey,
   identityApi,
   IDENTITY_TENANTS_UPDATED_EVENT,
   type MenuIdentity,
@@ -640,10 +636,6 @@ function ShellSidebar({
   const auth = useOptionalAuth();
   const can = auth?.can ?? (() => true);
   const principal = auth?.state.principal ?? null;
-  const savedAccounts = auth?.state.savedAccounts ?? [];
-  const switchAccount = auth?.actions.switchAccount;
-  const beginAddAccount = auth?.actions.beginAddAccount;
-  const removeSavedAccount = auth?.actions.removeSavedAccount;
   const menuByCode = useMemo(
     () => (principal?.menus ? new Map(principal.menus.map((menu) => [menu.code, menu])) : null),
     [principal?.menus],
@@ -871,36 +863,6 @@ function ShellSidebar({
     logout();
   }, [logout, navigate]);
 
-  const handleAddAccount = useCallback(() => {
-    beginAddAccount?.();
-    navigate("/login", { replace: true, viewTransition: true });
-  }, [beginAddAccount, navigate]);
-
-  const handleSwitchAccount = useCallback(
-    (accountId: string) => {
-      if (!switchAccount) return;
-      // On failure switchAccount rolls back; ProtectedRoute sends unauth to login.
-      void switchAccount(accountId).then((ok) => {
-        if (ok) navigate("/dashboard", { replace: true, viewTransition: true });
-      });
-    },
-    [navigate, switchAccount],
-  );
-
-  const currentAccountKey = useMemo(() => {
-    if (!principal?.user.id || !auth?.state.apiBase) return "";
-    return buildAccountKey(auth.state.apiBase, principal.user.id);
-  }, [auth?.state.apiBase, principal?.user.id]);
-
-  const otherAccounts = useMemo(
-    () =>
-      savedAccounts.filter((row) => {
-        if (row.accountKey && currentAccountKey) return row.accountKey !== currentAccountKey;
-        return row.accountId !== principal?.user.id;
-      }),
-    [currentAccountKey, principal?.user.id, savedAccounts],
-  );
-
   return (
     <>
       {pendingTo && <div className={progressDone ? "rp rp-done" : "rp"} />}
@@ -1079,60 +1041,6 @@ function ShellSidebar({
                       </DropdownMenu.Item>
                     ) : null}
                     <DropdownMenu.Separator />
-                    {otherAccounts.length > 0 ? (
-                      <>
-                        <div className="px-2 py-1.5 text-2xs font-medium uppercase tracking-wide text-slate-400">
-                          {t("shell.switch_account")}
-                        </div>
-                        {otherAccounts.map((account) => {
-                          const key = account.accountKey || account.accountId;
-                          return (
-                            <DropdownMenu.Item
-                              key={key}
-                              className="group/saved-account py-2.5"
-                              onSelect={(event) => {
-                                if (
-                                  event.target instanceof Element &&
-                                  event.target.closest("[data-remove-saved-account]")
-                                ) {
-                                  event.preventDefault();
-                                  removeSavedAccount?.(key);
-                                  return;
-                                }
-                                handleSwitchAccount(key);
-                              }}
-                            >
-                              <Users size={16} />
-                              <span className="min-w-0 flex-1 truncate leading-tight">
-                                <span className="block truncate">
-                                  {account.displayName || account.username}
-                                </span>
-                                <span className="block truncate text-2xs font-normal text-slate-400">
-                                  {account.username}
-                                  {account.apiBase
-                                    ? ` · ${account.apiBase.replace(/^https?:\/\//, "")}`
-                                    : ""}
-                                </span>
-                              </span>
-                              <span
-                                role="button"
-                                tabIndex={-1}
-                                data-remove-saved-account="true"
-                                aria-label={t("shell.forget_saved_account")}
-                                className="ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 opacity-0 transition hover:bg-slate-100 hover:text-rose-600 group-hover/saved-account:opacity-100 group-focus-within/saved-account:opacity-100 dark:hover:bg-white/10"
-                              >
-                                <X size={12} />
-                              </span>
-                            </DropdownMenu.Item>
-                          );
-                        })}
-                        <DropdownMenu.Separator />
-                      </>
-                    ) : null}
-                    <DropdownMenu.Item onSelect={handleAddAccount} className="py-2.5">
-                      <UserPlus size={16} />
-                      {t("shell.add_account")}
-                    </DropdownMenu.Item>
                     <DropdownMenu.Item
                       onSelect={handleLogout}
                       className="py-2.5 text-rose-600 focus:text-rose-700 dark:text-rose-300"

--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -10,28 +10,20 @@ import {
 } from "react";
 import {
   apiClient,
-  AUTH_ACCOUNTS_CHANGED_EVENT,
-  AUTH_ACCOUNTS_STORAGE_KEY,
-  buildAccountKey,
   clearPersistedAuthSnapshot,
   computeManagementApiBase,
   detectApiBaseFromLocation,
-  getSavedAuthAccount,
   identityApi,
   IDENTITY_MENUS_UPDATED_EVENT,
   extractApiErrorCode,
   isApiClientError,
   configApi,
-  listSavedAuthAccounts,
   normalizeApiBase,
   readPersistedAuthSnapshot,
-  removeSavedAuthAccount,
   updatePersistedEffectiveTenantId,
-  upsertSavedAuthAccount,
   writePersistedAuthSnapshot,
   type ManagementPrincipal,
   type MenuIdentity,
-  type SavedAuthAccount,
 } from "@code-proxy/api-client";
 import {
   DEFAULT_CACHE_TENANT_ID,
@@ -54,7 +46,6 @@ interface AuthContextState {
     principal: ManagementPrincipal | null;
     authFailureCode: string;
     permissions: ReadonlySet<string>;
-    savedAccounts: SavedAuthAccount[];
   };
   actions: {
     login: (input: {
@@ -66,11 +57,6 @@ interface AuthContextState {
     logout: () => void;
     restore: () => Promise<void>;
     switchTenant: (tenantId: string) => Promise<void>;
-    /** Soft-switch: keep current session in vault, go to login to add another. */
-    beginAddAccount: () => void;
-    /** @returns true when the target session is active after switch. Accepts accountKey or legacy id. */
-    switchAccount: (accountKeyOrId: string) => Promise<boolean>;
-    removeSavedAccount: (accountKeyOrId: string) => void;
   };
   meta: { managementEndpoint: string };
   can: (permission: string) => boolean;
@@ -522,16 +508,6 @@ const legacyServicePrincipal = (): ManagementPrincipal => ({
   platform_admin: true,
 });
 
-const accountMetaFromPrincipal = (apiBase: string, principal: ManagementPrincipal) => {
-  const accountId = principal.user.id;
-  return {
-    accountId,
-    accountKey: buildAccountKey(apiBase, accountId),
-    username: principal.user.username,
-    displayName: principal.user.display_name || principal.user.username,
-  };
-};
-
 const parseExpiryMs = (value?: string | null): number | undefined => {
   if (!value) return undefined;
   const ms = Date.parse(value);
@@ -548,21 +524,23 @@ const persistSession = (input: {
   expiresAtMs?: number;
   refreshExpiresAtMs?: number;
 }) => {
-  const meta = input.principal ? accountMetaFromPrincipal(input.apiBase, input.principal) : {};
-  const expiry = {
-    ...(input.expiresAtMs ? { expiresAtMs: input.expiresAtMs } : {}),
-    ...(input.refreshExpiresAtMs ? { refreshExpiresAtMs: input.refreshExpiresAtMs } : {}),
-  };
+  const principal = input.principal;
   writePersistedAuthSnapshot({
     apiBase: input.apiBase,
     managementKey: input.managementKey,
     ...(input.refreshToken ? { refreshToken: input.refreshToken } : {}),
     rememberPassword: input.rememberPassword,
     effectiveTenantId: input.effectiveTenantId,
-    ...meta,
-    ...expiry,
+    ...(principal
+      ? {
+          accountId: principal.user.id,
+          username: principal.user.username,
+          displayName: principal.user.display_name || principal.user.username,
+        }
+      : {}),
+    ...(input.expiresAtMs ? { expiresAtMs: input.expiresAtMs } : {}),
+    ...(input.refreshExpiresAtMs ? { refreshExpiresAtMs: input.refreshExpiresAtMs } : {}),
   });
-  // writePersistedAuthSnapshot already upserts vault when accountKey is present.
 };
 
 export function AuthProvider({ children }: PropsWithChildren) {
@@ -576,15 +554,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const [serverBuildDate, setServerBuildDate] = useState<string | null>(null);
   const [principal, setPrincipal] = useState<ManagementPrincipal | null>(null);
   const [authFailureCode, setAuthFailureCode] = useState("");
-  const [savedAccounts, setSavedAccounts] = useState<SavedAuthAccount[]>(() =>
-    listSavedAuthAccounts(),
-  );
-  // Monotonic op id so a slower bootstrap cannot overwrite a newer login/switch.
+  // Monotonic op id so a slower bootstrap cannot overwrite a newer login.
   const bootstrapOpRef = useRef(0);
-
-  const refreshSavedAccounts = useCallback(() => {
-    setSavedAccounts(listSavedAuthAccounts());
-  }, []);
 
   const configureClient = useCallback(
     (
@@ -729,7 +700,6 @@ export function AuthProvider({ children }: PropsWithChildren) {
         expiresAtMs: snapshot?.expiresAtMs,
         refreshExpiresAtMs: snapshot?.refreshExpiresAtMs,
       });
-      refreshSavedAccounts();
       return true;
     } catch (error) {
       if (!isCurrent()) return false;
@@ -740,16 +710,13 @@ export function AuthProvider({ children }: PropsWithChildren) {
       // Transient restore failures keep the snapshot (including tenant override)
       // so a refresh can retry the same context instead of wiping it.
       if (!isTransientRestoreError(error)) {
-        const staleKey = snapshot?.accountKey || snapshot?.accountId;
         clearPersistedAuthSnapshot();
-        if (staleKey) removeSavedAuthAccount(staleKey);
-        refreshSavedAccounts();
       }
       return false;
     } finally {
       if (isCurrent()) setIsRestoring(false);
     }
-  }, [configureClient, refreshSavedAccounts]);
+  }, [configureClient]);
 
   useEffect(() => void bootstrap(), [bootstrap]);
 
@@ -775,11 +742,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
       setIsAuthenticated(false);
       setPrincipal(null);
       syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase });
-      const snap = readPersistedAuthSnapshot();
-      const staleKey = snap?.accountKey || snap?.accountId;
       clearPersistedAuthSnapshot();
-      if (staleKey) removeSavedAuthAccount(staleKey);
-      setSavedAccounts(listSavedAuthAccounts());
     };
     const handleVersion = (event: Event) => {
       const detail = (event as CustomEvent<{ version?: string; buildDate?: string }>).detail;
@@ -803,23 +766,13 @@ export function AuthProvider({ children }: PropsWithChildren) {
       if (detail?.accessToken) setAccessToken(detail.accessToken);
       if (detail?.refreshToken) setRefreshToken(detail.refreshToken);
     };
-    const handleAccountsChanged = () => setSavedAccounts(listSavedAuthAccounts());
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key === AUTH_ACCOUNTS_STORAGE_KEY || event.key === null) {
-        setSavedAccounts(listSavedAuthAccounts());
-      }
-    };
     window.addEventListener("unauthorized", handleUnauthorized);
     window.addEventListener("server-version-update", handleVersion as EventListener);
     window.addEventListener("auth-token-refreshed", handleTokenRefreshed as EventListener);
-    window.addEventListener(AUTH_ACCOUNTS_CHANGED_EVENT, handleAccountsChanged);
-    window.addEventListener("storage", handleStorage);
     return () => {
       window.removeEventListener("unauthorized", handleUnauthorized);
       window.removeEventListener("server-version-update", handleVersion as EventListener);
       window.removeEventListener("auth-token-refreshed", handleTokenRefreshed as EventListener);
-      window.removeEventListener(AUTH_ACCOUNTS_CHANGED_EVENT, handleAccountsChanged);
-      window.removeEventListener("storage", handleStorage);
     };
   }, [accessToken, apiBase, bootstrap, configureClient, principal, refreshToken]);
 
@@ -861,16 +814,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
         expiresAtMs: parseExpiryMs(response.expires_at),
         refreshExpiresAtMs: parseExpiryMs(response.refresh_expires_at),
       });
-      refreshSavedAccounts();
       return response.principal;
     },
-    [configureClient, refreshSavedAccounts],
+    [configureClient],
   );
 
   const logout = useCallback(() => {
-    const accountKey = principal
-      ? buildAccountKey(apiBase, principal.user.id)
-      : readPersistedAuthSnapshot()?.accountKey;
     void identityApi.logout().catch(() => undefined);
     setIsAuthenticated(false);
     setAccessToken("");
@@ -880,126 +829,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
     configureClient(apiBase, "", "", "");
     syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase });
     clearPersistedAuthSnapshot();
-    if (accountKey) removeSavedAuthAccount(accountKey);
-    refreshSavedAccounts();
-  }, [apiBase, configureClient, principal, refreshSavedAccounts]);
-
-  const beginAddAccount = useCallback(() => {
-    // Soft logout: keep vault entry so user can switch back after adding another account.
-    if (principal && accessToken) {
-      const override =
-        principal.effective_tenant.id === principal.home_tenant.id
-          ? undefined
-          : principal.effective_tenant.id;
-      const meta = accountMetaFromPrincipal(apiBase, principal);
-      upsertSavedAuthAccount({
-        apiBase,
-        managementKey: accessToken,
-        ...(refreshToken ? { refreshToken } : {}),
-        rememberPassword,
-        effectiveTenantId: override,
-        ...meta,
-        lastUsedAt: Date.now(),
-      });
-      refreshSavedAccounts();
-    }
-    setIsAuthenticated(false);
-    setAccessToken("");
-    setRefreshToken("");
-    setPrincipal(null);
-    setAuthFailureCode("");
-    configureClient(apiBase, "", "", "");
-    syncActiveDataCacheTenant(DEFAULT_CACHE_TENANT_ID, { apiBase });
-    clearPersistedAuthSnapshot();
-  }, [
-    accessToken,
-    apiBase,
-    configureClient,
-    principal,
-    refreshSavedAccounts,
-    refreshToken,
-    rememberPassword,
-  ]);
-
-  const switchAccount = useCallback(
-    async (accountKeyOrId: string): Promise<boolean> => {
-      const target = getSavedAuthAccount(accountKeyOrId);
-      if (!target) return false;
-      const currentKey = principal ? buildAccountKey(apiBase, principal.user.id) : "";
-      if (currentKey && target.accountKey === currentKey) return true;
-
-      const previousSnapshot =
-        principal && accessToken
-          ? {
-              apiBase,
-              managementKey: accessToken,
-              ...(refreshToken ? { refreshToken } : {}),
-              rememberPassword,
-              effectiveTenantId:
-                principal.effective_tenant.id === principal.home_tenant.id
-                  ? undefined
-                  : principal.effective_tenant.id,
-              ...accountMetaFromPrincipal(apiBase, principal),
-            }
-          : null;
-
-      // Park current session before swapping active snapshot.
-      if (previousSnapshot) {
-        upsertSavedAuthAccount({
-          ...previousSnapshot,
-          lastUsedAt: Date.now(),
-        });
-      }
-
-      writePersistedAuthSnapshot({
-        apiBase: target.apiBase,
-        managementKey: target.managementKey,
-        ...(target.refreshToken ? { refreshToken: target.refreshToken } : {}),
-        rememberPassword: target.rememberPassword,
-        effectiveTenantId: target.effectiveTenantId,
-        accountId: target.accountId,
-        accountKey: target.accountKey,
-        username: target.username,
-        displayName: target.displayName,
-        ...(target.expiresAtMs ? { expiresAtMs: target.expiresAtMs } : {}),
-        ...(target.refreshExpiresAtMs ? { refreshExpiresAtMs: target.refreshExpiresAtMs } : {}),
-      });
-      refreshSavedAccounts();
-      setIsRestoring(true);
-      const ok = await bootstrap();
-      if (ok) return true;
-
-      // Target failed: roll back to the parked previous session when possible.
-      if (previousSnapshot) {
-        writePersistedAuthSnapshot(previousSnapshot);
-        refreshSavedAccounts();
-        setIsRestoring(true);
-        return bootstrap();
-      }
-      return false;
-    },
-    [
-      accessToken,
-      apiBase,
-      bootstrap,
-      principal,
-      refreshSavedAccounts,
-      refreshToken,
-      rememberPassword,
-    ],
-  );
-
-  const removeSavedAccount = useCallback(
-    (accountKeyOrId: string) => {
-      const currentKey = principal ? buildAccountKey(apiBase, principal.user.id) : "";
-      if (currentKey && (accountKeyOrId === currentKey || accountKeyOrId === principal?.user.id)) {
-        return;
-      }
-      removeSavedAuthAccount(accountKeyOrId);
-      refreshSavedAccounts();
-    },
-    [apiBase, principal, refreshSavedAccounts],
-  );
+  }, [apiBase, configureClient]);
 
   const restore = useCallback(async () => {
     setIsRestoring(true);
@@ -1073,16 +903,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
         principal,
         authFailureCode,
         permissions,
-        savedAccounts,
       },
       actions: {
         login,
         logout,
         restore,
         switchTenant,
-        beginAddAccount,
-        switchAccount,
-        removeSavedAccount,
       },
       meta: { managementEndpoint: computeManagementApiBase(apiBase) },
       can,
@@ -1091,7 +917,6 @@ export function AuthProvider({ children }: PropsWithChildren) {
       accessToken,
       apiBase,
       authFailureCode,
-      beginAddAccount,
       can,
       isAuthenticated,
       isRestoring,
@@ -1100,12 +925,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
       permissions,
       principal,
       rememberPassword,
-      removeSavedAccount,
       restore,
-      savedAccounts,
       serverBuildDate,
       serverVersion,
-      switchAccount,
       switchTenant,
     ],
   );

--- a/e2e/login-lifecycle.spec.ts
+++ b/e2e/login-lifecycle.spec.ts
@@ -96,15 +96,13 @@ test("Login: successful sign in persists auth snapshot and restores dashboard af
 
   await expect(page).toHaveURL(/#\/dashboard$/);
 
-  // Active session is always sessionStorage (per-tab); vault may also land in localStorage.
-  const sessionSnapshot = await page.evaluate(() => sessionStorage.getItem("code-proxy-admin-auth"));
-  expect(sessionSnapshot).toBeTruthy();
-  expect(sessionSnapshot).toContain("cps_test");
-  expect(sessionSnapshot).toContain("expiresAt");
-
-  const vault = await page.evaluate(() => localStorage.getItem("code-proxy-admin-auth-accounts"));
-  expect(vault).toBeTruthy();
-  expect(vault).toContain("cps_test");
+  // remember=true → durable localStorage snapshot (single admin session, no multi-account vault).
+  const snapshot = await page.evaluate(() => localStorage.getItem("code-proxy-admin-auth"));
+  expect(snapshot).toBeTruthy();
+  expect(snapshot).toContain("cps_test");
+  expect(snapshot).toContain("expiresAt");
+  expect(await page.evaluate(() => sessionStorage.getItem("code-proxy-admin-auth"))).toBeNull();
+  expect(await page.evaluate(() => localStorage.getItem("code-proxy-admin-auth-accounts"))).toBeNull();
 
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(page).toHaveURL(/#\/dashboard$/);

--- a/packages/api-client/src/client/__tests__/auth-storage.test.ts
+++ b/packages/api-client/src/client/__tests__/auth-storage.test.ts
@@ -1,13 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   clearPersistedAuthSnapshot,
-  getSavedAuthAccount,
   LEGACY_EFFECTIVE_TENANT_KEY,
-  listSavedAuthAccounts,
   readPersistedAuthSnapshot,
-  removeSavedAuthAccount,
   updatePersistedEffectiveTenantId,
-  upsertSavedAuthAccount,
   writePersistedAuthSnapshot,
 } from "../auth-storage";
 import { AUTH_STORAGE_KEY } from "../constants";
@@ -41,10 +37,21 @@ describe("auth-storage effective tenant persistence", () => {
       effectiveTenantId: "tenant-acme",
     });
 
-    // Active snapshot is per-tab (sessionStorage) to isolate multi-account tabs.
-    const raw = sessionStorage.getItem(AUTH_STORAGE_KEY);
+    const raw = localStorage.getItem(AUTH_STORAGE_KEY);
     expect(raw).toContain("tenant-acme");
+    expect(sessionStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
+  });
+
+  test("remember=false stays in sessionStorage only", () => {
+    writePersistedAuthSnapshot({
+      apiBase: "http://127.0.0.1:8317",
+      managementKey: "cps_test",
+      rememberPassword: false,
+    });
+
+    expect(sessionStorage.getItem(AUTH_STORAGE_KEY)).toBeTruthy();
+    expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
   });
 
   test("falls back to the legacy effective-tenant key once", () => {
@@ -102,146 +109,5 @@ describe("auth-storage effective tenant persistence", () => {
     expect(localStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
     expect(sessionStorage.getItem(AUTH_STORAGE_KEY)).toBeNull();
     expect(localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY)).toBeNull();
-  });
-});
-
-describe("auth-storage multi-account vault", () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-    localStorage.clear();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-13T12:00:00.000Z"));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    sessionStorage.clear();
-    localStorage.clear();
-  });
-
-  test("write with accountId upserts vault entry", () => {
-    writePersistedAuthSnapshot({
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_a",
-      rememberPassword: true,
-      accountId: "user-a",
-      username: "alice",
-      displayName: "Alice",
-    });
-
-    expect(listSavedAuthAccounts()).toEqual([
-      expect.objectContaining({
-        accountId: "user-a",
-        accountKey: "http://127.0.0.1:8317\0user-a",
-        username: "alice",
-        displayName: "Alice",
-        managementKey: "cps_a",
-      }),
-    ]);
-  });
-
-  test("upsert replaces same account and keeps others", () => {
-    const now = Date.now();
-    upsertSavedAuthAccount({
-      accountId: "user-a",
-      accountKey: "http://127.0.0.1:8317\0user-a",
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_a",
-      rememberPassword: true,
-      username: "alice",
-      displayName: "Alice",
-      lastUsedAt: now - 2,
-    });
-    upsertSavedAuthAccount({
-      accountId: "user-b",
-      accountKey: "http://127.0.0.1:8317\0user-b",
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_b",
-      rememberPassword: true,
-      username: "bob",
-      displayName: "Bob",
-      lastUsedAt: now - 1,
-    });
-    upsertSavedAuthAccount({
-      accountId: "user-a",
-      accountKey: "http://127.0.0.1:8317\0user-a",
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_a2",
-      rememberPassword: true,
-      username: "alice",
-      displayName: "Alice",
-      lastUsedAt: now,
-    });
-
-    const accounts = listSavedAuthAccounts();
-    expect(accounts.map((row) => row.accountId)).toEqual(["user-a", "user-b"]);
-    expect(getSavedAuthAccount("http://127.0.0.1:8317\0user-a")?.managementKey).toBe("cps_a2");
-  });
-
-  test("same user id on different apiBase does not collide", () => {
-    const now = Date.now();
-    upsertSavedAuthAccount({
-      accountId: "user-a",
-      accountKey: "https://a.example\0user-a",
-      apiBase: "https://a.example",
-      managementKey: "cps_a",
-      rememberPassword: true,
-      username: "alice",
-      displayName: "Alice",
-      lastUsedAt: now - 1,
-    });
-    upsertSavedAuthAccount({
-      accountId: "user-a",
-      accountKey: "https://b.example\0user-a",
-      apiBase: "https://b.example",
-      managementKey: "cps_b",
-      rememberPassword: true,
-      username: "alice",
-      displayName: "Alice",
-      lastUsedAt: now,
-    });
-    expect(listSavedAuthAccounts()).toHaveLength(2);
-  });
-
-  test("remember=false stays in session vault only", () => {
-    upsertSavedAuthAccount({
-      accountId: "user-s",
-      accountKey: "http://127.0.0.1:8317\0user-s",
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_s",
-      rememberPassword: false,
-      username: "session",
-      displayName: "Session",
-      lastUsedAt: Date.now(),
-    });
-    expect(listSavedAuthAccounts()).toHaveLength(1);
-    expect(localStorage.getItem("code-proxy-admin-auth-accounts")).toBeNull();
-    expect(sessionStorage.getItem("code-proxy-admin-auth-accounts-session")).toBeTruthy();
-  });
-
-  test("removeSavedAuthAccount drops one vault entry", () => {
-    const now = Date.now();
-    upsertSavedAuthAccount({
-      accountId: "user-a",
-      accountKey: "http://127.0.0.1:8317\0user-a",
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_a",
-      rememberPassword: true,
-      username: "alice",
-      displayName: "Alice",
-      lastUsedAt: now - 1,
-    });
-    upsertSavedAuthAccount({
-      accountId: "user-b",
-      accountKey: "http://127.0.0.1:8317\0user-b",
-      apiBase: "http://127.0.0.1:8317",
-      managementKey: "cps_b",
-      rememberPassword: true,
-      username: "bob",
-      displayName: "Bob",
-      lastUsedAt: now,
-    });
-    removeSavedAuthAccount("http://127.0.0.1:8317\0user-a");
-    expect(listSavedAuthAccounts().map((row) => row.accountId)).toEqual(["user-b"]);
   });
 });

--- a/packages/api-client/src/client/auth-storage.ts
+++ b/packages/api-client/src/client/auth-storage.ts
@@ -1,12 +1,5 @@
-import type { AuthSnapshot, SavedAuthAccount } from "../dto/types";
-import {
-  AUTH_ACCOUNTS_CHANGED_EVENT,
-  AUTH_ACCOUNTS_SESSION_STORAGE_KEY,
-  AUTH_ACCOUNTS_STORAGE_KEY,
-  AUTH_PERSIST_TTL_MS,
-  AUTH_STORAGE_KEY,
-  normalizeApiBase,
-} from "./constants";
+import type { AuthSnapshot } from "../dto/types";
+import { AUTH_PERSIST_TTL_MS, AUTH_STORAGE_KEY, normalizeApiBase } from "./constants";
 
 /** Legacy key used before effective tenant was stored inside the auth snapshot. */
 export const LEGACY_EFFECTIVE_TENANT_KEY = "code-proxy-effective-tenant";
@@ -26,24 +19,6 @@ const storages = (): Storage[] => {
   return items;
 };
 
-const localOnly = (): Storage | null => {
-  try {
-    if (typeof window !== "undefined") return window.localStorage;
-  } catch {
-    /* unavailable */
-  }
-  return null;
-};
-
-const sessionOnly = (): Storage | null => {
-  try {
-    if (typeof window !== "undefined") return window.sessionStorage;
-  } catch {
-    /* unavailable */
-  }
-  return null;
-};
-
 const normalizeEffectiveTenantId = (value: unknown): string | undefined => {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -61,71 +36,11 @@ const normalizeOptionalMs = (value: unknown): number | undefined => {
   return value;
 };
 
-/** Stable composite key so the same user.id on different apiBase does not collide. */
-export const buildAccountKey = (apiBase: string, accountId: string): string => {
-  const base = normalizeApiBase(apiBase.trim());
-  const id = accountId.trim();
-  if (!base || !id) return "";
-  return `${base}\0${id}`;
-};
-
-export const parseAccountKey = (
-  accountKey: string,
-): { apiBase: string; accountId: string } | null => {
-  const raw = accountKey.trim();
-  const sep = raw.indexOf("\0");
-  if (sep <= 0 || sep === raw.length - 1) return null;
-  return {
-    apiBase: normalizeApiBase(raw.slice(0, sep)),
-    accountId: raw.slice(sep + 1).trim(),
-  };
-};
-
-const readLegacyEffectiveTenantId = (): string | undefined => {
-  try {
-    return normalizeEffectiveTenantId(window.localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY));
-  } catch {
-    return undefined;
-  }
-};
-
-const clearLegacyEffectiveTenantId = (): void => {
-  try {
-    window.localStorage.removeItem(LEGACY_EFFECTIVE_TENANT_KEY);
-  } catch {
-    /* Storage is optional. */
-  }
-};
-
-const emitAccountsChanged = (): void => {
-  try {
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent(AUTH_ACCOUNTS_CHANGED_EVENT));
-    }
-  } catch {
-    /* ignore */
-  }
-};
-
-const resolveAccountKey = (snapshot: {
-  apiBase?: string;
-  accountId?: string;
-  accountKey?: string;
-}): string | undefined => {
-  const explicit = normalizeOptionalString(snapshot.accountKey);
-  if (explicit) return explicit;
-  const apiBase = normalizeOptionalString(snapshot.apiBase);
-  const accountId = normalizeOptionalString(snapshot.accountId);
-  if (!apiBase || !accountId) return undefined;
-  return buildAccountKey(apiBase, accountId) || undefined;
-};
-
 const isTokenExpired = (snapshot: {
   expiresAtMs?: number;
   refreshExpiresAtMs?: number;
 }): boolean => {
   const now = Date.now();
-  // Prefer refresh expiry when present; fall back to access expiry.
   if (snapshot.refreshExpiresAtMs && snapshot.refreshExpiresAtMs <= now) return true;
   if (!snapshot.refreshExpiresAtMs && snapshot.expiresAtMs && snapshot.expiresAtMs <= now) {
     return true;
@@ -144,23 +59,17 @@ const toAuthSnapshot = (parsed: Partial<PersistedAuthSnapshot>): AuthSnapshot | 
   }
   const effectiveTenantId =
     normalizeEffectiveTenantId(parsed.effectiveTenantId) ?? readLegacyEffectiveTenantId();
-  const accountId = normalizeOptionalString(parsed.accountId);
-  const apiBase = normalizeApiBase(parsed.apiBase);
-  const accountKey = resolveAccountKey({
-    apiBase,
-    accountId,
-    accountKey: parsed.accountKey,
-  });
   const snapshot: AuthSnapshot = {
-    apiBase,
+    apiBase: normalizeApiBase(parsed.apiBase),
     managementKey: parsed.managementKey,
     ...(typeof parsed.refreshToken === "string" && parsed.refreshToken
       ? { refreshToken: parsed.refreshToken }
       : {}),
     rememberPassword: Boolean(parsed.rememberPassword),
     ...(effectiveTenantId ? { effectiveTenantId } : {}),
-    ...(accountId ? { accountId } : {}),
-    ...(accountKey ? { accountKey } : {}),
+    ...(normalizeOptionalString(parsed.accountId)
+      ? { accountId: normalizeOptionalString(parsed.accountId) }
+      : {}),
     ...(normalizeOptionalString(parsed.username)
       ? { username: normalizeOptionalString(parsed.username) }
       : {}),
@@ -178,8 +87,23 @@ const toAuthSnapshot = (parsed: Partial<PersistedAuthSnapshot>): AuthSnapshot | 
   return snapshot;
 };
 
+const readLegacyEffectiveTenantId = (): string | undefined => {
+  try {
+    return normalizeEffectiveTenantId(window.localStorage.getItem(LEGACY_EFFECTIVE_TENANT_KEY));
+  } catch {
+    return undefined;
+  }
+};
+
+const clearLegacyEffectiveTenantId = (): void => {
+  try {
+    window.localStorage.removeItem(LEGACY_EFFECTIVE_TENANT_KEY);
+  } catch {
+    /* Storage is optional. */
+  }
+};
+
 export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
-  // Prefer session (per-tab active) so multi-tab does not share one active account.
   for (const storage of storages()) {
     try {
       const raw = storage.getItem(AUTH_STORAGE_KEY);
@@ -200,14 +124,11 @@ export const readPersistedAuthSnapshot = (): AuthSnapshot | null => {
 
 export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
   const [session, local] = storages();
-  // Active snapshot is always per-tab (sessionStorage) to avoid multi-tab hijack.
-  // rememberPassword only controls whether the vault entry is durable (local).
-  const target = session ?? (snapshot.rememberPassword ? local : null);
+  // rememberPassword → localStorage (survives browser restart); otherwise session only.
+  const target = snapshot.rememberPassword ? (local ?? session) : (session ?? local);
   if (!target) return;
   clearPersistedAuthSnapshot();
   const effectiveTenantId = normalizeEffectiveTenantId(snapshot.effectiveTenantId);
-  const accountId = normalizeOptionalString(snapshot.accountId);
-  const accountKey = resolveAccountKey(snapshot);
   const payload: PersistedAuthSnapshot = {
     apiBase: snapshot.apiBase,
     managementKey: snapshot.managementKey,
@@ -215,8 +136,9 @@ export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
     rememberPassword: snapshot.rememberPassword,
     expiresAt: Date.now() + AUTH_PERSIST_TTL_MS,
     ...(effectiveTenantId ? { effectiveTenantId } : {}),
-    ...(accountId ? { accountId } : {}),
-    ...(accountKey ? { accountKey } : {}),
+    ...(normalizeOptionalString(snapshot.accountId)
+      ? { accountId: normalizeOptionalString(snapshot.accountId) }
+      : {}),
     ...(normalizeOptionalString(snapshot.username)
       ? { username: normalizeOptionalString(snapshot.username) }
       : {}),
@@ -236,16 +158,6 @@ export const writePersistedAuthSnapshot = (snapshot: AuthSnapshot): void => {
     /* quota / private mode — session may still work in-memory */
   }
   clearLegacyEffectiveTenantId();
-  if (accountId && accountKey) {
-    upsertSavedAuthAccount({
-      ...payload,
-      accountId,
-      accountKey,
-      username: payload.username ?? accountId,
-      displayName: payload.displayName ?? payload.username ?? accountId,
-      lastUsedAt: Date.now(),
-    });
-  }
 };
 
 export const clearPersistedAuthSnapshot = (): void => {
@@ -267,194 +179,4 @@ export const updatePersistedEffectiveTenantId = (tenantId: string): void => {
     ...current,
     effectiveTenantId: normalizeEffectiveTenantId(tenantId),
   });
-};
-
-const isSavedAccount = (value: unknown): value is SavedAuthAccount => {
-  if (!value || typeof value !== "object") return false;
-  const row = value as Partial<SavedAuthAccount>;
-  return Boolean(
-    (normalizeOptionalString(row.accountKey) ||
-      (normalizeOptionalString(row.accountId) && normalizeOptionalString(row.apiBase))) &&
-      normalizeOptionalString(row.apiBase) &&
-      normalizeOptionalString(row.managementKey) &&
-      normalizeOptionalString(row.username),
-  );
-};
-
-const readVaultFrom = (storage: Storage | null, key: string): SavedAuthAccount[] => {
-  if (!storage) return [];
-  try {
-    const raw = storage.getItem(key);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    const now = Date.now();
-    const kept: SavedAuthAccount[] = [];
-    let dirty = false;
-    for (const row of parsed) {
-      if (!isSavedAccount(row)) {
-        dirty = true;
-        continue;
-      }
-      const apiBase = normalizeApiBase(row.apiBase);
-      const accountId = (row.accountId || parseAccountKey(row.accountKey ?? "")?.accountId || "").trim();
-      const accountKey =
-        resolveAccountKey({ apiBase, accountId, accountKey: row.accountKey }) ?? "";
-      if (!accountId || !accountKey) {
-        dirty = true;
-        continue;
-      }
-      const entry: SavedAuthAccount = {
-        accountId,
-        accountKey,
-        apiBase,
-        managementKey: row.managementKey,
-        ...(row.refreshToken ? { refreshToken: row.refreshToken } : {}),
-        rememberPassword: Boolean(row.rememberPassword),
-        ...(normalizeEffectiveTenantId(row.effectiveTenantId)
-          ? { effectiveTenantId: normalizeEffectiveTenantId(row.effectiveTenantId) }
-          : {}),
-        username: row.username.trim(),
-        displayName: (row.displayName || row.username).trim(),
-        lastUsedAt: typeof row.lastUsedAt === "number" ? row.lastUsedAt : 0,
-        ...(normalizeOptionalMs(row.expiresAtMs)
-          ? { expiresAtMs: normalizeOptionalMs(row.expiresAtMs) }
-          : {}),
-        ...(normalizeOptionalMs(row.refreshExpiresAtMs)
-          ? { refreshExpiresAtMs: normalizeOptionalMs(row.refreshExpiresAtMs) }
-          : {}),
-      };
-      if (isTokenExpired(entry)) {
-        dirty = true;
-        continue;
-      }
-      // Drop entries whose retention would have expired if lastUsedAt is ancient.
-      if (entry.lastUsedAt > 0 && entry.lastUsedAt + AUTH_PERSIST_TTL_MS < now) {
-        dirty = true;
-        continue;
-      }
-      kept.push(entry);
-    }
-    if (dirty) {
-      if (kept.length === 0) storage.removeItem(key);
-      else storage.setItem(key, JSON.stringify(kept));
-    }
-    return kept;
-  } catch {
-    return [];
-  }
-};
-
-const writeVaultTo = (storage: Storage | null, key: string, accounts: SavedAuthAccount[]): void => {
-  if (!storage) return;
-  try {
-    if (accounts.length === 0) {
-      storage.removeItem(key);
-      return;
-    }
-    storage.setItem(key, JSON.stringify(accounts));
-  } catch {
-    /* ignore */
-  }
-};
-
-export const listSavedAuthAccounts = (): SavedAuthAccount[] => {
-  const local = readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY);
-  const session = readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY);
-  const byKey = new Map<string, SavedAuthAccount>();
-  for (const row of [...local, ...session]) {
-    const prev = byKey.get(row.accountKey);
-    if (!prev || row.lastUsedAt >= prev.lastUsedAt) byKey.set(row.accountKey, row);
-  }
-  return [...byKey.values()].sort((a, b) => b.lastUsedAt - a.lastUsedAt);
-};
-
-export const upsertSavedAuthAccount = (account: SavedAuthAccount): void => {
-  const accountId = normalizeOptionalString(account.accountId);
-  const managementKey = normalizeOptionalString(account.managementKey);
-  const apiBase = normalizeOptionalString(account.apiBase);
-  const username = normalizeOptionalString(account.username);
-  if (!accountId || !managementKey || !apiBase || !username) return;
-  const accountKey =
-    resolveAccountKey({ apiBase, accountId, accountKey: account.accountKey }) ??
-    buildAccountKey(apiBase, accountId);
-  if (!accountKey) return;
-  if (isTokenExpired(account)) {
-    removeSavedAuthAccount(accountKey);
-    return;
-  }
-  const next: SavedAuthAccount = {
-    accountId,
-    accountKey,
-    apiBase: normalizeApiBase(apiBase),
-    managementKey,
-    ...(account.refreshToken ? { refreshToken: account.refreshToken } : {}),
-    rememberPassword: Boolean(account.rememberPassword),
-    ...(normalizeEffectiveTenantId(account.effectiveTenantId)
-      ? { effectiveTenantId: normalizeEffectiveTenantId(account.effectiveTenantId) }
-      : {}),
-    username,
-    displayName: normalizeOptionalString(account.displayName) ?? username,
-    lastUsedAt: typeof account.lastUsedAt === "number" ? account.lastUsedAt : Date.now(),
-    ...(normalizeOptionalMs(account.expiresAtMs)
-      ? { expiresAtMs: normalizeOptionalMs(account.expiresAtMs) }
-      : {}),
-    ...(normalizeOptionalMs(account.refreshExpiresAtMs)
-      ? { refreshExpiresAtMs: normalizeOptionalMs(account.refreshExpiresAtMs) }
-      : {}),
-  };
-  // Remembered → local vault; non-remembered → session vault only (tab-scoped).
-  if (next.rememberPassword) {
-    const local = readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY).filter(
-      (row) => row.accountKey !== accountKey,
-    );
-    writeVaultTo(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY, [next, ...local]);
-    // Drop any session-only copy so we do not keep two sources of truth.
-    const session = readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY).filter(
-      (row) => row.accountKey !== accountKey,
-    );
-    writeVaultTo(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY, session);
-  } else {
-    const session = readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY).filter(
-      (row) => row.accountKey !== accountKey,
-    );
-    writeVaultTo(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY, [next, ...session]);
-    const local = readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY).filter(
-      (row) => row.accountKey !== accountKey,
-    );
-    writeVaultTo(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY, local);
-  }
-  emitAccountsChanged();
-};
-
-/** Accepts accountKey or legacy accountId (matches first entry). */
-export const removeSavedAuthAccount = (accountKeyOrId: string): void => {
-  const key = normalizeOptionalString(accountKeyOrId);
-  if (!key) return;
-  const match = (row: SavedAuthAccount) => row.accountKey === key || row.accountId === key;
-  writeVaultTo(
-    localOnly(),
-    AUTH_ACCOUNTS_STORAGE_KEY,
-    readVaultFrom(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY).filter((row) => !match(row)),
-  );
-  writeVaultTo(
-    sessionOnly(),
-    AUTH_ACCOUNTS_SESSION_STORAGE_KEY,
-    readVaultFrom(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY).filter((row) => !match(row)),
-  );
-  emitAccountsChanged();
-};
-
-export const clearSavedAuthAccounts = (): void => {
-  writeVaultTo(localOnly(), AUTH_ACCOUNTS_STORAGE_KEY, []);
-  writeVaultTo(sessionOnly(), AUTH_ACCOUNTS_SESSION_STORAGE_KEY, []);
-  emitAccountsChanged();
-};
-
-export const getSavedAuthAccount = (accountKeyOrId: string): SavedAuthAccount | null => {
-  const key = normalizeOptionalString(accountKeyOrId);
-  if (!key) return null;
-  return (
-    listSavedAuthAccounts().find((row) => row.accountKey === key || row.accountId === key) ?? null
-  );
 };

--- a/packages/api-client/src/client/constants.ts
+++ b/packages/api-client/src/client/constants.ts
@@ -2,13 +2,7 @@ export const MANAGEMENT_API_PREFIX = "/v0/management";
 export const DEFAULT_API_PORT = 8317;
 export const REQUEST_TIMEOUT_MS = 30000;
 export const AUTH_STORAGE_KEY = "code-proxy-admin-auth";
-/** Remembered multi-account vault (localStorage). */
-export const AUTH_ACCOUNTS_STORAGE_KEY = "code-proxy-admin-auth-accounts";
-/** Non-remembered multi-account vault for the current tab (sessionStorage). */
-export const AUTH_ACCOUNTS_SESSION_STORAGE_KEY = "code-proxy-admin-auth-accounts-session";
 export const AUTH_PERSIST_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-/** Fired on window after vault mutations so other tabs/UI can refresh lists. */
-export const AUTH_ACCOUNTS_CHANGED_EVENT = "auth-accounts-changed";
 export const VERSION_HEADER_KEYS = ["x-cpa-version", "x-server-version"];
 export const BUILD_DATE_HEADER_KEYS = ["x-cpa-build-date", "x-server-build-date"];
 

--- a/packages/api-client/src/dto/types.ts
+++ b/packages/api-client/src/dto/types.ts
@@ -5,25 +5,14 @@ export interface AuthSnapshot {
   rememberPassword: boolean;
   /** Platform-admin override; empty/omitted means home tenant (no X-Effective-Tenant-ID). */
   effectiveTenantId?: string;
-  /** User id within one apiBase (not globally unique). */
+  /** User id for the active admin session. */
   accountId?: string;
-  /** Composite key: normalizeApiBase(apiBase) + "\\0" + accountId. */
-  accountKey?: string;
   username?: string;
   displayName?: string;
   /** Access-token wall clock expiry (ms). */
   expiresAtMs?: number;
   /** Refresh-token wall clock expiry (ms). */
   refreshExpiresAtMs?: number;
-}
-
-/** Saved admin session for local multi-account switch. */
-export interface SavedAuthAccount extends AuthSnapshot {
-  accountId: string;
-  accountKey: string;
-  username: string;
-  displayName: string;
-  lastUsedAt: number;
 }
 
 export type AuthFileType =

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,9 +1,6 @@
 export { ApiClient, apiClient } from "./client/client";
 export type { RequestOptions } from "./client/client";
 export {
-  AUTH_ACCOUNTS_CHANGED_EVENT,
-  AUTH_ACCOUNTS_SESSION_STORAGE_KEY,
-  AUTH_ACCOUNTS_STORAGE_KEY,
   AUTH_PERSIST_TTL_MS,
   AUTH_STORAGE_KEY,
   BUILD_DATE_HEADER_KEYS,
@@ -27,17 +24,10 @@ export { ensureArrayPayload, isApiEnvelope, unwrapApiEnvelope } from "./client/r
 export type { ApiEnvelope, ApiListPayload, ApiSuccessEnvelope } from "./client/response";
 export { publicApiClient, PublicApiClient } from "./client/public-client";
 export {
-  buildAccountKey,
   clearPersistedAuthSnapshot,
-  clearSavedAuthAccounts,
-  getSavedAuthAccount,
   LEGACY_EFFECTIVE_TENANT_KEY,
-  listSavedAuthAccounts,
-  parseAccountKey,
   readPersistedAuthSnapshot,
-  removeSavedAuthAccount,
   updatePersistedEffectiveTenantId,
-  upsertSavedAuthAccount,
   writePersistedAuthSnapshot,
 } from "./client/auth-storage";
 export {

--- a/pages/login/LoginPage.tsx
+++ b/pages/login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
-import { Eye, EyeOff, KeyRound, Lock, UserRound, Users, X } from "lucide-react";
+import { Eye, EyeOff, KeyRound, Lock, UserRound } from "lucide-react";
 import {
   detectApiBaseFromLocation,
   extractApiErrorCode,
@@ -28,9 +28,8 @@ export function LoginPage() {
       rememberPassword: persistedRemember,
       principal,
       authFailureCode,
-      savedAccounts,
     },
-    actions: { login, switchAccount, removeSavedAccount },
+    actions: { login },
   } = useAuth();
   const { notify } = useToast();
   const [apiBase, setApiBase] = useState(persistedBase || detectApiBaseFromLocation());
@@ -100,27 +99,6 @@ export function LoginPage() {
     [apiBase, login, navigate, notify, password, redirect, rememberPassword, t, username],
   );
 
-  const handleResumeAccount = useCallback(
-    async (accountId: string) => {
-      setLoading(true);
-      try {
-        const ok = await switchAccount(accountId);
-        if (!ok) {
-          notify({
-            type: "error",
-            message: t("login.switch_account_failed", "Could not restore that account. Sign in again."),
-          });
-          return;
-        }
-        notify({ type: "success", message: t("login.login_success") });
-        navigate(redirect, { replace: true, viewTransition: true });
-      } finally {
-        setLoading(false);
-      }
-    },
-    [navigate, notify, redirect, switchAccount, t],
-  );
-
   if (isRestoring) return null;
   if (isAuthenticated) {
     return (
@@ -182,56 +160,6 @@ export function LoginPage() {
                 {accessFailureMessage ? (
                   <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-200">
                     {accessFailureMessage}
-                  </div>
-                ) : null}
-                {savedAccounts.length > 0 ? (
-                  <div className="space-y-2">
-                    <div className="text-xs font-medium text-slate-600 dark:text-white/60">
-                      {t("shell.switch_account")}
-                    </div>
-                    <div className="space-y-1.5">
-                      {savedAccounts.map((account) => {
-                        const key = account.accountKey || account.accountId;
-                        return (
-                          <div
-                            key={key}
-                            className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50/80 px-3 py-2 dark:border-white/10 dark:bg-white/5"
-                          >
-                            <button
-                              type="button"
-                              disabled={loading}
-                              onClick={() => void handleResumeAccount(key)}
-                              className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm font-medium text-slate-800 transition hover:text-slate-950 disabled:opacity-60 dark:text-white/90"
-                            >
-                              <Users size={15} className="shrink-0 text-slate-400" />
-                              <span className="min-w-0 flex-1 truncate leading-tight">
-                                <span className="block truncate">
-                                  {account.displayName || account.username}
-                                </span>
-                                <span className="block truncate text-2xs font-normal text-slate-400">
-                                  {account.username}
-                                  {account.apiBase
-                                    ? ` · ${account.apiBase.replace(/^https?:\/\//, "")}`
-                                    : ""}
-                                </span>
-                              </span>
-                            </button>
-                            <button
-                              type="button"
-                              disabled={loading}
-                              aria-label={t("shell.forget_saved_account")}
-                              onClick={() => removeSavedAccount(key)}
-                              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-slate-400 hover:bg-white hover:text-rose-600 dark:hover:bg-white/10"
-                            >
-                              <X size={13} />
-                            </button>
-                          </div>
-                        );
-                      })}
-                    </div>
-                    <div className="pt-1 text-center text-2xs text-slate-400">
-                      {t("login.or_sign_in", "or sign in with password")}
-                    </div>
                   </div>
                 ) : null}
                 <label className="block space-y-2">

--- a/pages/login/__tests__/LoginPage.test.tsx
+++ b/pages/login/__tests__/LoginPage.test.tsx
@@ -9,8 +9,6 @@ const toastMocks = vi.hoisted(() => ({
 
 const authMocks = vi.hoisted(() => ({
   login: vi.fn(),
-  switchAccount: vi.fn(),
-  removeSavedAccount: vi.fn(),
   state: {
     isAuthenticated: false,
     isRestoring: false,
@@ -18,11 +16,6 @@ const authMocks = vi.hoisted(() => ({
     rememberPassword: false,
     principal: null,
     authFailureCode: "",
-    savedAccounts: [] as Array<{
-      accountId: string;
-      username: string;
-      displayName: string;
-    }>,
   },
 }));
 
@@ -37,8 +30,6 @@ vi.mock("@app/providers/AuthProvider", () => ({
     state: authMocks.state,
     actions: {
       login: authMocks.login,
-      switchAccount: authMocks.switchAccount,
-      removeSavedAccount: authMocks.removeSavedAccount,
     },
   }),
 }));


### PR DESCRIPTION
## Summary
- Remove admin multi-account vault/switch UI from login page and sidebar account menu
- Keep single admin session only; `remember` still persists one snapshot to localStorage
- Leave end-user portal multi-account switch untouched

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full test:ci, build, bundle:diff, critical e2e)
- [x] Login page no longer shows saved-account switcher
- [x] Sidebar account menu only has password/config/logout
- [x] remember=true restores session after reload