### PR TITLE
fix: keep warm chart cache when switching portal accounts

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -983,23 +983,85 @@ export function ApiKeyLookupPage() {
     async (accountKey: string) => {
       const target = portalApi.switchAccount(accountKey);
       if (!target) return;
+
+      // Abort in-flight lookups for the previous account, but keep multi-account
+      // chart cache so warm accounts can paint immediately (SWR).
+      abortControllerRef.current?.abort();
+      fetchIdRef.current += 1;
+      paginationInFlightRef.current = false;
+      chartAbortControllerRef.current?.abort();
+      chartFetchIdRef.current += 1;
+      summaryAbortControllerRef.current?.abort();
+      summaryFetchIdRef.current += 1;
+
       setPortalSessionPending(true);
       setOperationalKeyId("");
-      handleApiKeyInputChange("");
+      setApiKeyInput("");
+      setQueriedKey("");
+      setApiKeyName("");
       setPortalKeys([]);
+      setError(null);
+      setModelsError(null);
+      setModelsSearchFilter("");
+      modelsCacheRef.current = {};
+      setAvailableModels([]);
+      setRawItems([]);
+      setTotalCount(0);
+      setCurrentPage(1);
+      setLastUpdatedAt(null);
+      setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
+      setFilterOptions({
+        models: [],
+        channels: [],
+        channel_options: [],
+        statuses: ["success", "failed"],
+      });
+      setSelectedModels(null);
+      setSelectedChannels(null);
+      setSelectedStatuses(null);
+      setQuotaLimits(null);
+
+      // Prefill usage from this account's cache; cold accounts still skeleton.
+      const nextChartKey = `account:${target.user.id}|${timeRange}`;
+      const cached =
+        chartCacheRef.current[nextChartKey] || readStoredChartCache(nextChartKey);
+      if (cached) {
+        chartCacheRef.current[nextChartKey] = cached;
+        setChartData(cached);
+        const cachedName = cached.api_key_name?.trim() ?? "";
+        if (cachedName) setApiKeyName(cachedName);
+      } else {
+        setChartData(null);
+      }
+      setChartLoading(false);
+
+      // Align usageSubject immediately so the effect can revalidate under the new id.
+      setPortalUser({
+        id: target.user.id,
+        tenant_id: "",
+        username: target.user.username,
+        display_name: target.user.display_name,
+        status: "active",
+        must_change_password: false,
+        created_at: "",
+        updated_at: "",
+        version: 0,
+      });
+
       try {
         await hydratePortalSession();
       } catch {
         portalApi.removeSavedAccount(accountKey);
         portalApi.clearSession();
         setPortalUser(null);
+        setChartData(null);
         setLoginModalOpen(true);
       } finally {
         setPortalSessionPending(false);
         setSavedPortalAccounts(portalApi.listSavedAccounts());
       }
     },
-    [handleApiKeyInputChange, hydratePortalSession],
+    [hydratePortalSession, timeRange],
   );
 
   const refreshPortalKeys = useCallback(async () => {

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -863,6 +863,133 @@ describe("ApiKeyLookupPage", () => {
     expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v1")).toBeNull();
   });
 
+  test("keeps warm account chart cache when switching portal accounts", async () => {
+    const { portalApi } = await import("@code-proxy/api-client");
+    const accountA = {
+      accountKey: "http://relay.test\0u-a",
+      apiBase: "http://relay.test",
+      accessToken: "cpt_a",
+      refreshToken: "cpr_a",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      lastUsedAt: Date.now(),
+      user: { id: "u-a", username: "alice", display_name: "Alice" },
+    };
+    const accountB = {
+      accountKey: "http://relay.test\0u-b",
+      apiBase: "http://relay.test",
+      accessToken: "cpt_b",
+      refreshToken: "cpr_b",
+      remember: true,
+      expiresAt: Date.now() + 60_000,
+      lastUsedAt: Date.now() - 1_000,
+      user: { id: "u-b", username: "bob", display_name: "Bob" },
+    };
+
+    vi.mocked(portalApi.loadSession).mockReturnValue({
+      apiBase: accountA.apiBase,
+      accessToken: accountA.accessToken,
+      refreshToken: accountA.refreshToken,
+      remember: true,
+      expiresAt: accountA.expiresAt,
+      user: accountA.user,
+    });
+    vi.mocked(portalApi.listSavedAccounts).mockReturnValue([accountA, accountB] as never);
+    vi.mocked(portalApi.switchAccount).mockImplementation((key: string) => {
+      const target =
+        key === accountB.accountKey ? accountB : key === accountA.accountKey ? accountA : null;
+      if (!target) return null;
+      vi.mocked(portalApi.loadSession).mockReturnValue({
+        apiBase: target.apiBase,
+        accessToken: target.accessToken,
+        refreshToken: target.refreshToken,
+        remember: true,
+        expiresAt: target.expiresAt,
+        user: target.user,
+      });
+      return target as never;
+    });
+    vi.mocked(portalApi.me).mockImplementation(async () => {
+      const snap = portalApi.loadSession();
+      const id = snap?.user?.id === "u-b" ? "u-b" : "u-a";
+      return {
+        user: {
+          id,
+          tenant_id: "t1",
+          username: id === "u-b" ? "bob" : "alice",
+          display_name: id === "u-b" ? "Bob" : "Alice",
+          status: "active",
+          must_change_password: false,
+          created_at: "",
+          updated_at: "",
+          version: 1,
+        },
+      } as never;
+    });
+    vi.mocked(portalApi.listKeys).mockResolvedValue({
+      items: [
+        {
+          id: "k1",
+          tenant_id: "t1",
+          end_user_id: "u-a",
+          name: "default",
+          key_masked: "sk-****",
+          disabled: false,
+          is_default: true,
+        },
+      ],
+    } as never);
+    vi.mocked(portalApi.keySecret).mockResolvedValue({ id: "k1", key: "sk-op" });
+
+    window.sessionStorage.setItem(
+      "apiKeyLookup.chartCache.v2",
+      JSON.stringify({
+        byTenant: {
+          default: {
+            "account:u-a|7": chartResponse(11, "Alice"),
+            "account:u-b|7": chartResponse(77, "Bob"),
+          },
+        },
+      }),
+    );
+
+    let resolveBChart: (value: ChartResponse) => void = () => {};
+    mocks.fetchPublicChartData.mockImplementation(async (params?: { portalAccount?: boolean }) => {
+      if (!params?.portalAccount) return chartResponse(0);
+      const snap = portalApi.loadSession();
+      if (snap?.user?.id === "u-b") {
+        return new Promise<ChartResponse>((resolve) => {
+          resolveBChart = resolve;
+        });
+      }
+      return chartResponse(11, "Alice");
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("11"));
+
+    await userEvent.click(await screen.findByTestId("apikey-lookup-account-menu"));
+    await userEvent.click(await screen.findByTestId("apikey-lookup-switch-account-trigger"));
+    await userEvent.click(await screen.findByTestId("apikey-lookup-switch-u-b"));
+
+    // Warm B: paint cached stats immediately (no skeleton / no-stats flash).
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("77"));
+    expect(screen.getByTestId("usage-tab")).not.toHaveTextContent("no-stats");
+    // Multi-account chart cache must survive the switch wipe path.
+    expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v2")).toContain("account:u-b|7");
+    expect(window.sessionStorage.getItem("apiKeyLookup.chartCache.v2")).toContain('"total":77');
+
+    resolveBChart(chartResponse(88, "Bob fresh"));
+    await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("88"));
+  });
+
   test("ignores stale chart responses after rapid time range changes", async () => {
     window.history.replaceState({}, "", "/manage/apikey-lookup?api_key=sk-restored-key");
     const pending: Array<{


### PR DESCRIPTION
## Summary
- Portal account switch no longer routes through `handleApiKeyInputChange("")`, which wiped multi-account chart cache and forced a full usage skeleton flash.
- Prefill usage charts from account-scoped cache (SWR); only cold accounts show skeleton.
- Add regression test for warm-account switch paint.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci, build, bundle:diff, e2e subset via script)
- [x] `bun run test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx` (16 passed)
- [ ] Manual: switch between two portal accounts on usage tab — warm account should keep numbers, no full-page skeleton flash