### PR TITLE
fix: avoid focus ring after account switch

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -547,6 +547,7 @@ export function ApiKeyLookupPage() {
   const fetchIdRef = useRef(0);
   const paginationInFlightRef = useRef(false);
   const restoredLookupFetchedRef = useRef(false);
+  const suppressAccountMenuFocusRestoreRef = useRef(false);
 
   // ================================================================
   //  Logs fetching (with infinite scroll support)
@@ -1264,6 +1265,11 @@ export function ApiKeyLookupPage() {
                       sideOffset={8}
                       className="min-w-48"
                       data-testid="apikey-lookup-account-menu-content"
+                      onCloseAutoFocus={(event) => {
+                        if (!suppressAccountMenuFocusRestoreRef.current) return;
+                        suppressAccountMenuFocusRestoreRef.current = false;
+                        event.preventDefault();
+                      }}
                     >
                       {portalUser && switchablePortalAccounts.length > 1 ? (
                         <DropdownMenu.Sub>
@@ -1292,6 +1298,13 @@ export function ApiKeyLookupPage() {
                                         ? "apikey-lookup-current-account"
                                         : `apikey-lookup-switch-${account.user.id}`
                                     }
+                                    onClick={(event) => {
+                                      // A pointer-selected account changes the page context; do not let
+                                      // Radix restore focus to the now-updated trigger and leave its
+                                      // browser focus ring visible. Keyboard selection keeps the default
+                                      // focus restoration so the menu remains accessible.
+                                      suppressAccountMenuFocusRestoreRef.current = event.detail > 0;
+                                    }}
                                     onSelect={() => {
                                       if (!isCurrent) void handleSwitchAccount(account.accountKey);
                                     }}

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -975,9 +975,12 @@ describe("ApiKeyLookupPage", () => {
 
     await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("11"));
 
-    await userEvent.click(await screen.findByTestId("apikey-lookup-account-menu"));
+    const accountMenuTrigger = await screen.findByTestId("apikey-lookup-account-menu");
+    await userEvent.click(accountMenuTrigger);
     await userEvent.click(await screen.findByTestId("apikey-lookup-switch-account-trigger"));
     await userEvent.click(await screen.findByTestId("apikey-lookup-switch-u-b"));
+
+    await waitFor(() => expect(accountMenuTrigger).not.toHaveFocus());
 
     // Warm B: paint cached stats immediately (no skeleton / no-stats flash).
     await waitFor(() => expect(screen.getByTestId("usage-tab")).toHaveTextContent("77"));


### PR DESCRIPTION
## 修改范围
- 修复 API Key 用量查询页通过鼠标切换账号后，Radix DropdownMenu 自动把焦点恢复到账号按钮，导致浏览器 focus ring 持续显示的问题。
- 仅对鼠标/触控触发的账号切换取消焦点恢复；键盘选择仍保留默认焦点恢复行为。
- 增加回归断言，确保切换账号后账号菜单按钮不再持有焦点。

## 根因
账号切换菜单关闭时，Radix DropdownMenu 默认执行 close auto focus，将焦点恢复到已更新账号名称的 Trigger；浏览器因此绘制了截图中的蓝色焦点框。

## 验证
- `bun run --filter @code-proxy/admin-panel test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx`
- `bun run lint`
- `./scripts/ci-pr.sh`
  - lint / design:check 通过（仅仓库已有 5 条 warning）
  - Vitest: 112 files, 803 tests passed
  - build / bundle:diff 通过
  - critical Playwright: 9 passed
- 真实本地页面 + Chrome mock 双账号验证：切换 Alice → Bob 后，账号 Trigger 不再是 `document.activeElement`，菜单关闭后焦点落到 `body`，账号按钮无蓝色 focus ring。

## 影响范围
- 仅 `codeProxy` 前端 API Key Lookup 多账号菜单。
- 不涉及 `CliRelay`。
