### PR TITLE
feat(auth-files): add batch disable action

### DIFF
--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -319,12 +319,14 @@ export function AuthFilesPage() {
     uploading,
     uploadProgress,
     deletingAll,
+    batchStatusUpdating,
     statusUpdating,
     tagSavingByName,
     downloadAuthFile,
     handleDownloadSelection,
     handleUpload,
     handleDeleteSelection,
+    handleDisableSelection,
     setFileEnabled,
     saveAuthFileTags,
   } = useAuthFilesFileActions({
@@ -861,6 +863,8 @@ export function AuthFilesPage() {
         setConfirm={setConfirm}
         selectedFileNames={selectedFileNames}
         deletingAll={deletingAll}
+        batchStatusUpdating={batchStatusUpdating}
+        handleDisableSelection={handleDisableSelection}
         pageItems={pageItems}
         fileColumns={fileColumns}
         filesViewMode={filesViewMode}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1410,6 +1410,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("qwen.json")).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText("Select qwen.json"));
+    expect(screen.getByRole("button", { name: "Disable" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Delete selected (1)" }));
     fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
 

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -633,6 +633,8 @@ interface AuthFilesFilesTabProps {
   ) => void;
   selectedFileNames: string[];
   deletingAll: boolean;
+  batchStatusUpdating: boolean;
+  handleDisableSelection: (names: string[]) => Promise<void>;
   pageItems: AuthFileItem[];
   fileColumns: DataTableColumn<AuthFileItem>[];
   filesViewMode: FilesViewMode;
@@ -722,6 +724,8 @@ export function AuthFilesFilesTab({
   setConfirm,
   selectedFileNames,
   deletingAll,
+  batchStatusUpdating,
+  handleDisableSelection,
   pageItems,
   fileColumns,
   filesViewMode,
@@ -1035,7 +1039,7 @@ export function AuthFilesFilesTab({
 
   const selectionToolbar =
     selectedCount > 0 ? (
-      <div className="inline-flex h-9 max-w-full min-w-0 items-center gap-1.5 rounded-full bg-slate-50/90 px-1.5 text-xs transition-colors duration-200 ease-out dark:bg-white/[0.04]">
+      <div className="inline-flex h-9 max-w-full min-w-0 items-center gap-1.5 overflow-x-auto rounded-full bg-slate-50/90 px-1.5 text-xs transition-colors duration-200 ease-out dark:bg-white/[0.04]">
         {selectionActionsMenu}
         <span className="min-w-0 truncate px-1 font-medium text-slate-600 dark:text-white/65">
           {t("auth_files.batch_selected", { count: selectedCount })}
@@ -1049,6 +1053,16 @@ export function AuthFilesFilesTab({
           {t("auth_files.batch_clear")}
         </Button>
         <Button
+          variant="secondary"
+          size="xs"
+          className="px-2"
+          onClick={() => void handleDisableSelection([...selectedFileNames])}
+          disabled={deletingAll || batchStatusUpdating || selectedCount === 0}
+        >
+          <CircleOff size={13} className="shrink-0" />
+          <span>{t("auth_files.batch_disable")}</span>
+        </Button>
+        <Button
           variant="danger"
           size="xs"
           className="px-2"
@@ -1058,7 +1072,7 @@ export function AuthFilesFilesTab({
               names: [...selectedFileNames],
             })
           }
-          disabled={deletingAll}
+          disabled={deletingAll || batchStatusUpdating}
         >
           {t("auth_files.batch_delete_action", { count: selectedCount })}
         </Button>
@@ -1067,7 +1081,7 @@ export function AuthFilesFilesTab({
           size="xs"
           className="px-2"
           onClick={() => void handleDownloadSelection([...selectedFileNames])}
-          disabled={deletingAll || selectedCount === 0}
+          disabled={deletingAll || batchStatusUpdating || selectedCount === 0}
         >
           <Download size={13} className="shrink-0" />
           <span>{t("auth_files.batch_download_action", { count: selectedCount })}</span>
@@ -1313,7 +1327,7 @@ export function AuthFilesFilesTab({
                     {renderFilesViewModeTabs}
                   </div>
                   {modelOwnerToolbarButton}
-                  {selectionToolbar}
+                  {selectedCount === 0 ? selectionActionsMenu : null}
                 </div>
 
                 <div className="flex shrink-0 flex-wrap items-center gap-2">
@@ -1416,6 +1430,9 @@ export function AuthFilesFilesTab({
               </div>
             </div>
           </div>
+          {selectedCount > 0 ? (
+            <div className="min-w-0 overflow-x-auto">{selectionToolbar}</div>
+          ) : null}
         </div>
       </div>
 

--- a/pages/auth-files/hooks/__tests__/useAuthFilesFileActions.batch.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesFileActions.batch.test.tsx
@@ -1,0 +1,135 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import { createRef, type Dispatch, type SetStateAction } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthFileItem } from "@code-proxy/api-client";
+
+const mocks = vi.hoisted(() => ({
+  deleteFile: vi.fn(async (_name: string): Promise<void> => undefined),
+  setStatus: vi.fn(
+    async (_name: string, disabled: boolean): Promise<{ status: string; disabled: boolean }> => ({
+      status: "ok",
+      disabled,
+    }),
+  ),
+  notify: vi.fn(),
+  invalidateConfiguredModelAvailability: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@code-proxy/ui", () => ({
+  useToast: () => ({ notify: mocks.notify }),
+}));
+
+vi.mock("@code-proxy/api-client", () => ({
+  authFilesApi: {
+    downloadFile: vi.fn(),
+    downloadBlob: vi.fn(),
+    upload: vi.fn(),
+    deleteFile: mocks.deleteFile,
+    setStatus: mocks.setStatus,
+    patchFields: vi.fn(),
+  },
+}));
+
+vi.mock("@features/model-availability", () => ({
+  invalidateConfiguredModelAvailability: mocks.invalidateConfiguredModelAvailability,
+}));
+
+import { useAuthFilesFileActions } from "../useAuthFilesFileActions";
+
+interface SetupOptions {
+  loadAll: () => Promise<AuthFileItem[]>;
+}
+
+const setup = ({ loadAll }: SetupOptions) => {
+  const setFiles = vi.fn<Dispatch<SetStateAction<AuthFileItem[]>>>();
+  const setSelectedFileNames = vi.fn<Dispatch<SetStateAction<string[]>>>();
+  const setDetailFile = vi.fn<Dispatch<SetStateAction<AuthFileItem | null>>>();
+  const setDetailOpen = vi.fn<Dispatch<SetStateAction<boolean>>>();
+  const hook = renderHook(() =>
+    useAuthFilesFileActions({
+      loadAll,
+      fileInputRef: createRef<HTMLInputElement>(),
+      detailFile: null,
+      setDetailFile,
+      setDetailOpen,
+      setFiles,
+      setSelectedFileNames,
+    }),
+  );
+  return { ...hook, setFiles, setSelectedFileNames, setDetailFile };
+};
+
+describe("useAuthFilesFileActions batch mutations", () => {
+  beforeEach(() => {
+    mocks.deleteFile.mockReset();
+    mocks.setStatus.mockReset();
+    mocks.notify.mockReset();
+    mocks.invalidateConfiguredModelAvailability.mockReset();
+    mocks.deleteFile.mockResolvedValue(undefined);
+    mocks.setStatus.mockImplementation(async (_name: string, disabled: boolean) => ({
+      status: "ok",
+      disabled,
+    }));
+  });
+
+  it("disables every selected auth file and reports one batch result", async () => {
+    const loadAll = vi.fn(async (): Promise<AuthFileItem[]> => [
+      { name: "a.json", disabled: true },
+      { name: "b.json", disabled: true },
+    ]);
+    const { result, setFiles } = setup({ loadAll });
+
+    await act(async () => {
+      await result.current.handleDisableSelection(["a.json", "b.json"]);
+    });
+
+    expect(mocks.setStatus.mock.calls).toEqual([
+      ["a.json", true],
+      ["b.json", true],
+    ]);
+    expect(loadAll).toHaveBeenCalledTimes(1);
+    const updateFiles = setFiles.mock.calls.at(-1)?.[0];
+    expect(typeof updateFiles).toBe("function");
+    expect(
+      (updateFiles as (files: AuthFileItem[]) => AuthFileItem[])([
+        { name: "a.json", disabled: false },
+        { name: "b.json", disabled: false },
+      ]),
+    ).toEqual([
+      { name: "a.json", disabled: true },
+      { name: "b.json", disabled: true },
+    ]);
+    expect(mocks.notify).toHaveBeenCalledWith({
+      type: "success",
+      message: "auth_files.batch_status_success",
+    });
+  });
+
+  it("treats an errored delete as successful when authoritative refresh shows it absent", async () => {
+    mocks.deleteFile.mockRejectedValueOnce(new Error("response lost"));
+    const loadAll = vi.fn(async (): Promise<AuthFileItem[]> => []);
+    const { result, setSelectedFileNames } = setup({ loadAll });
+
+    await act(async () => {
+      await result.current.handleDeleteSelection(["tenant-account.json"]);
+    });
+
+    expect(loadAll).toHaveBeenCalledTimes(1);
+    const updateSelection = setSelectedFileNames.mock.calls.at(-1)?.[0];
+    expect(typeof updateSelection).toBe("function");
+    expect((updateSelection as (names: string[]) => string[])(["tenant-account.json"])).toEqual(
+      [],
+    );
+    expect(mocks.notify).toHaveBeenCalledWith({
+      type: "success",
+      message: "auth_files.batch_deleted_selected",
+    });
+  });
+});

--- a/pages/auth-files/hooks/useAuthFilesFileActions.ts
+++ b/pages/auth-files/hooks/useAuthFilesFileActions.ts
@@ -65,6 +65,7 @@ export function useAuthFilesFileActions({
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<AuthFilesUploadProgress>(IDLE_UPLOAD_PROGRESS);
   const [deletingAll, setDeletingAll] = useState(false);
+  const [batchStatusUpdating, setBatchStatusUpdating] = useState(false);
   const [statusUpdating, setStatusUpdating] = useState<Record<string, boolean>>({});
   const [tagSavingByName, setTagSavingByName] = useState<Record<string, boolean>>({});
 
@@ -311,41 +312,46 @@ export function useAuthFilesFileActions({
 
       setDeletingAll(true);
       try {
-        let success = 0;
-        let failed = 0;
-        const deletedNames: string[] = [];
+        const deletedNames = new Set<string>();
+        const requestFailures = new Set<string>();
 
         for (const name of targets) {
           try {
             await authFilesApi.deleteFile(name);
-            success += 1;
-            deletedNames.push(name);
+            deletedNames.add(name);
           } catch {
-            failed += 1;
+            requestFailures.add(name);
           }
         }
 
-        if (deletedNames.length > 0) {
+        // Re-read authoritative state: deletion can succeed before a trailing cleanup/response fails.
+        const refreshedFiles = await loadAll();
+        const remainingNames = new Set(refreshedFiles.map((file) => file.name));
+        requestFailures.forEach((name) => {
+          if (!remainingNames.has(name)) deletedNames.add(name);
+        });
+
+        if (deletedNames.size > 0) {
           invalidateConfiguredModelAvailability();
-          setFiles((prev) => prev.filter((file) => !deletedNames.includes(file.name)));
-          setSelectedFileNames((prev) => prev.filter((name) => !deletedNames.includes(name)));
-          setDetailFile((prev) => (prev && deletedNames.includes(prev.name) ? null : prev));
+          const deleted = Array.from(deletedNames);
+          setSelectedFileNames((prev) => prev.filter((name) => !deletedNames.has(name)));
+          setDetailFile((prev) => (prev && deletedNames.has(prev.name) ? null : prev));
           setDetailOpen((prev) =>
-            prev && detailFile && deletedNames.includes(detailFile.name) ? false : prev,
+            prev && detailFile && deletedNames.has(detailFile.name) ? false : prev,
           );
+          // loadAll normally replaced the list; this also covers aborted/stale refreshes.
+          setFiles((prev) => prev.filter((file) => !deleted.includes(file.name)));
         }
 
-        if (failed === 0) {
-          notify({
-            type: "success",
-            message: t("auth_files.batch_deleted_selected", { count: success }),
-          });
-        } else {
-          notify({
-            type: "error",
-            message: t("auth_files.batch_delete_partial", { success, failed }),
-          });
-        }
+        const success = deletedNames.size;
+        const failed = targets.length - success;
+        notify({
+          type: failed === 0 ? "success" : "error",
+          message:
+            failed === 0
+              ? t("auth_files.batch_deleted_selected", { count: success })
+              : t("auth_files.batch_delete_partial", { success, failed }),
+        });
       } catch (err: unknown) {
         notify({
           type: "error",
@@ -355,7 +361,70 @@ export function useAuthFilesFileActions({
         setDeletingAll(false);
       }
     },
-    [detailFile, notify, setDetailFile, setDetailOpen, setFiles, setSelectedFileNames, t],
+    [detailFile, loadAll, notify, setDetailFile, setDetailOpen, setFiles, setSelectedFileNames, t],
+  );
+
+  const handleDisableSelection = useCallback(
+    async (names: string[]) => {
+      const targets = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
+      if (targets.length === 0) return;
+
+      setBatchStatusUpdating(true);
+      setStatusUpdating((prev) => ({
+        ...prev,
+        ...Object.fromEntries(targets.map((name) => [name, true])),
+      }));
+      try {
+        const disabledNames = new Set<string>();
+        const requestFailures = new Set<string>();
+
+        for (const name of targets) {
+          try {
+            const result = await authFilesApi.setStatus(name, true);
+            if (result.disabled) disabledNames.add(name);
+            else requestFailures.add(name);
+          } catch {
+            requestFailures.add(name);
+          }
+        }
+
+        const refreshedFiles = await loadAll();
+        const filesByName = new Map(refreshedFiles.map((file) => [file.name, file]));
+        requestFailures.forEach((name) => {
+          if (filesByName.get(name)?.disabled === true) disabledNames.add(name);
+        });
+
+        if (disabledNames.size > 0) {
+          invalidateConfiguredModelAvailability();
+          setFiles((prev) =>
+            prev.map((file) =>
+              disabledNames.has(file.name) ? { ...file, disabled: true } : file,
+            ),
+          );
+          setDetailFile((prev) =>
+            prev && disabledNames.has(prev.name) ? { ...prev, disabled: true } : prev,
+          );
+        }
+
+        const success = disabledNames.size;
+        const failed = targets.length - success;
+        notify({
+          type: failed === 0 ? "success" : "error",
+          message:
+            failed === 0
+              ? t("auth_files.batch_status_success", { count: success })
+              : t("auth_files.batch_status_partial", { success, failed }),
+        });
+      } finally {
+        setBatchStatusUpdating(false);
+        setStatusUpdating((prev) => {
+          const next = { ...prev };
+          targets.forEach((name) => delete next[name]);
+          return next;
+        });
+      }
+    },
+    [loadAll, notify, setDetailFile, setFiles, t],
   );
 
   const setFileEnabled = useCallback(
@@ -450,12 +519,14 @@ export function useAuthFilesFileActions({
     uploading,
     uploadProgress,
     deletingAll,
+    batchStatusUpdating,
     statusUpdating,
     tagSavingByName,
     downloadAuthFile,
     handleDownloadSelection,
     handleUpload,
     handleDeleteSelection,
+    handleDisableSelection,
     setFileEnabled,
     saveAuthFileTags,
   };


### PR DESCRIPTION
## Summary
- add a batch disable action to the AI account selection toolbar
- serialize status updates to avoid persistence races and reload authoritative server state after batch operations
- reconcile delete/disable results with the refreshed list so a lost response or cleanup warning does not leave stale cards
- keep batch actions available on mobile without requiring the filter panel to be expanded
- add hook and page regression coverage

## Validation
- `./scripts/ci-pr.sh`
- `bun run test:ci -- pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx pages/auth-files/hooks/__tests__/useAuthFilesFileActions.batch.test.tsx` (84 passed)
- real Vite management page with mocked management APIs: desktop and 375x812; batch disable updated both switches and showed the 2-file success message; no page-level horizontal overflow or console errors

## Scope
- Repository: `codeProxy`
- Target: `dev`