### PR TITLE
fix(auth-files): drop noisy badges and keep cycle on partial refresh

### DIFF
--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -776,7 +776,8 @@ describe("AuthFileDetailModal", () => {
       useIdentityFingerprintCLIPreferred: useCliPreferred,
     });
 
-    expect(screen.getByTestId("auth-file-identity-summary")).toHaveTextContent("Shared account");
+    expect(screen.getByTestId("auth-file-identity-summary")).toBeInTheDocument();
+    expect(screen.queryByText("Shared account")).not.toBeInTheDocument();
     expect(screen.getByTestId("identity-profile-codex_cli_rs")).toHaveTextContent("In use");
     expect(screen.getByTestId("auth-file-identity-fields")).toHaveTextContent(
       "codex_cli_rs/0.144.1",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1984,7 +1984,7 @@ describe("AuthFilesPage files table", () => {
     expect(within(card as HTMLElement).queryByText("pro")).not.toBeInTheDocument();
   });
 
-  test("table view shows shared scope and separate cycle and lifetime calls", async () => {
+  test("table view shows cycle calls without shared-scope or lifetime noise", async () => {
     useTableFilesView();
     mocks.list.mockImplementation(async () => ({
       files: [
@@ -2034,12 +2034,11 @@ describe("AuthFilesPage files table", () => {
     const title = await screen.findByText("Shared Codex");
     const row = title.closest("tr");
     expect(row).not.toBeNull();
-    expect(screen.getByRole("columnheader", { name: "Account scope" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Cycle calls" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Lifetime calls" })).toBeInTheDocument();
-    expect(await within(row as HTMLElement).findByText("Shared account")).toBeInTheDocument();
-    expect(within(row as HTMLElement).getByText("7")).toBeInTheDocument();
-    expect(within(row as HTMLElement).getByText("99")).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Account scope" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Lifetime calls" })).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("Shared account")).not.toBeInTheDocument();
+    expect(await within(row as HTMLElement).findByText("7")).toBeInTheDocument();
     expect(within(row as HTMLElement).getByText("90")).toBeInTheDocument();
     expect(within(row as HTMLElement).getByText("9")).toBeInTheDocument();
   });
@@ -2167,15 +2166,18 @@ describe("AuthFilesPage files table", () => {
       await within(card as HTMLElement).findByText("Cycle 7"),
     ).toBeInTheDocument();
     expect(
-      within(card as HTMLElement).getByText("Lifetime 99"),
-    ).toBeInTheDocument();
+      within(card as HTMLElement).queryByText("Lifetime 99"),
+    ).not.toBeInTheDocument();
     expect(
-      within(card as HTMLElement).getByText("Tenant only"),
-    ).toBeInTheDocument();
+      within(card as HTMLElement).queryByText("Tenant only"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(card as HTMLElement).queryByText("Success 99 / Failed 0"),
+    ).not.toBeInTheDocument();
     expect(mocks.getStatus).toHaveBeenCalled();
   });
 
-  test("cards view shows unknown cycle and lifetime total when xAI weekly cycle is unknown", async () => {
+  test("cards view shows unknown cycle without lifetime/scope noise when weekly cycle is unknown", async () => {
     window.localStorage.setItem(
       "authFilesPage.filesViewMode.v1",
       JSON.stringify("cards"),
@@ -2272,19 +2274,14 @@ describe("AuthFilesPage files table", () => {
       await within(card as HTMLElement).findByText("Cycle --"),
     ).toBeInTheDocument();
     expect(
-      within(card as HTMLElement).getByText("Lifetime 116"),
-    ).toBeInTheDocument();
+      within(card as HTMLElement).queryByText("Lifetime 116"),
+    ).not.toBeInTheDocument();
     expect(
       within(card as HTMLElement).getByText("SUPERGROK"),
     ).toBeInTheDocument();
     expect(
-      within(card as HTMLElement).getByText("Shared account"),
-    ).toBeInTheDocument();
-    const user = userEvent.setup();
-    await user.hover(within(card as HTMLElement).getByText("Lifetime 116"));
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Shared history is projected from",
-    );
+      within(card as HTMLElement).queryByText("Shared account"),
+    ).not.toBeInTheDocument();
     expect(mocks.getStatus).toHaveBeenCalled();
   });
 
@@ -2901,7 +2898,7 @@ describe("AuthFilesPage files table", () => {
       within(card as HTMLElement).queryByText("Plan Pro"),
     ).not.toBeInTheDocument();
     expect(
-      within(card as HTMLElement).getByText("Lifetime 0"),
+      within(card as HTMLElement).getByText("Cycle --"),
     ).toBeInTheDocument();
   });
 
@@ -3077,7 +3074,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByText("z-last.json")).not.toBeInTheDocument();
     expect(screen.queryByText("codex-prod.json")).not.toBeInTheDocument();
     expect(screen.getAllByText("PLUS").length).toBeGreaterThan(0);
-    expect(await screen.findByText("Lifetime 9")).toBeInTheDocument();
+    expect(await screen.findByText("Cycle 9")).toBeInTheDocument();
 
     const cards = screen.getByTestId("auth-files-cards");
     expect(cards.textContent?.indexOf("Alpha Channel")).toBeLessThan(
@@ -4531,7 +4528,7 @@ describe("AuthFilesPage files table", () => {
     const firstCard = firstTitle.closest("section");
     expect(firstCard).not.toBeNull();
     expect(
-      await within(firstCard as HTMLElement).findByText("Lifetime 1"),
+      await within(firstCard as HTMLElement).findByText("Cycle 1"),
     ).toBeInTheDocument();
 
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalled());
@@ -4549,7 +4546,7 @@ describe("AuthFilesPage files table", () => {
       expect(mocks.getStatusRefreshJob).toHaveBeenCalled();
       expect(mocks.getStatus).toHaveBeenCalled();
       expect(
-        within(firstCard as HTMLElement).getByText("Lifetime 101"),
+        within(firstCard as HTMLElement).getByText("Cycle 101"),
       ).toBeInTheDocument();
     });
 
@@ -4560,7 +4557,7 @@ describe("AuthFilesPage files table", () => {
     expect(tenthCard).not.toBeNull();
     // Final snapshot may refresh all accounts; page 2 still shows a finite call badge.
     expect(
-      within(tenthCard as HTMLElement).getByText(/Lifetime \d+/),
+      within(tenthCard as HTMLElement).getByText(/Cycle \d+/),
     ).toBeInTheDocument();
   });
 
@@ -5213,7 +5210,7 @@ describe("AuthFilesPage files table", () => {
     const resetTooltip = await screen.findByRole("tooltip");
     expect(resetTooltip).toHaveTextContent("Reset credit expiration times:");
     expect(resetTooltip).toHaveTextContent("2026");
-    const callsBadge = within(cards).getByText("Lifetime 0");
+    const callsBadge = within(cards).getByText(/Cycle/);
     expect(
       resetButton.compareDocumentPosition(callsBadge) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -881,24 +881,6 @@ export function AuthFileDetailModal({
             className="min-w-0 rounded-lg bg-slate-50/80 px-4 py-4 lg:min-h-0 lg:overflow-y-auto dark:bg-white/[0.04]"
             data-testid="auth-file-identity-summary"
           >
-            {identityFingerprintDetail?.subject_scope ? (
-              <HoverTooltip content={t("auth_files.shared_usage_scope_help")}>
-                <span
-                  className={[
-                    "mb-3 inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold",
-                    identityFingerprintDetail.subject_scope === "shared"
-                      ? "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200"
-                      : "bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/65",
-                  ].join(" ")}
-                >
-                  {t(
-                    identityFingerprintDetail.subject_scope === "shared"
-                      ? "auth_files.shared_subject"
-                      : "auth_files.tenant_subject",
-                  )}
-                </span>
-              </HoverTooltip>
-            ) : null}
             {hasCodexProfiles ? (
               <div className="space-y-4" data-testid="auth-file-identity-profiles">
                 <div className="rounded-lg bg-white px-3 py-3 ring-1 ring-slate-200 dark:bg-neutral-950/40 dark:ring-white/10">

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1779,31 +1779,6 @@ export function AuthFilesFilesTab({
                                 })
                               : t("auth_files.cycle_calls_unknown")}
                           </span>
-                          <HoverTooltip
-                            content={
-                              file.usage_history_complete === false
-                                ? t("auth_files.shared_history_incomplete", {
-                                    since: file.usage_projected_since
-                                      ? new Date(
-                                          file.usage_projected_since,
-                                        ).toLocaleString()
-                                      : "--",
-                                  })
-                                : t("auth_files.shared_usage_scope_help")
-                            }
-                          >
-                            <span className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
-                              {t("auth_files.lifetime_calls_count", {
-                                count: usageTotalCalls,
-                              })}
-                            </span>
-                          </HoverTooltip>
-                          <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-50 px-2 py-0.5 text-2xs font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200">
-                            {t("auth_files.success_failure_count", {
-                              success: stats.success,
-                              failure: stats.failure,
-                            })}
-                          </span>
                           <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-2xs font-semibold text-slate-700 dark:bg-white/10 dark:text-white/70">
                             <span>{t("common.success_rate")}</span>
                             <span
@@ -1814,24 +1789,6 @@ export function AuthFilesFilesTab({
                                 : `${successRate.toFixed(1)}%`}
                             </span>
                           </span>
-                          {file.subject_scope ? (
-                            <HoverTooltip
-                              content={t("auth_files.shared_usage_scope_help")}
-                            >
-                              <span
-                                className={[
-                                  "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-2xs font-semibold",
-                                  file.subject_scope === "shared"
-                                    ? "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200"
-                                    : "bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/65",
-                                ].join(" ")}
-                              >
-                                {file.subject_scope === "shared"
-                                  ? t("auth_files.shared_subject")
-                                  : t("auth_files.tenant_subject")}
-                              </span>
-                            </HoverTooltip>
-                          ) : null}
                           {subscriptionBadge}
                           {runtimeOnly ? (
                             <span className="inline-flex shrink-0 items-center rounded-full bg-slate-900 px-2 py-0.5 text-2xs font-semibold text-white dark:bg-white dark:text-neutral-950">

--- a/pages/auth-files/hooks/__tests__/mapAccountStatusToUi.test.ts
+++ b/pages/auth-files/hooks/__tests__/mapAccountStatusToUi.test.ts
@@ -67,6 +67,23 @@ describe("mapAccountStatusToUi", () => {
     expect(state.error).toBe("upstream_timeout");
   });
 
+  test("unknown cycle does not emit a cycle snapshot that would wipe local 本周期", () => {
+    const patch = applyAccountStatuses([
+      {
+        auth_index: "77",
+        auth_subject_id: "sub-77",
+        quotas: [],
+        usage: {
+          cycle_known: false,
+          cycle_request_total: 0,
+          request_total: 89,
+        },
+      },
+    ]);
+    expect(patch.cycleByKey["77"]).toBeUndefined();
+    expect(patch.cycleByKey["sub-77"]).toBeUndefined();
+  });
+
   test("isAccountStatusFresher prefers version then time", () => {
     expect(
       isAccountStatusFresher({ version: 2, timeMs: 1 }, { version: 1, timeMs: 99 }),

--- a/pages/auth-files/hooks/mapAccountStatusToUi.ts
+++ b/pages/auth-files/hooks/mapAccountStatusToUi.ts
@@ -151,14 +151,12 @@ export const mapAccountStatusToCycleUsage = (
   const usage = account.usage;
   if (!usage) return null;
   const cycleTotal = usage.cycle_request_total;
-  const calls =
-    usage.cycle_known === true &&
-    typeof cycleTotal === "number" &&
-    Number.isFinite(cycleTotal)
-      ? Math.max(0, Math.round(cycleTotal))
-      : null;
+  // Only emit a cycle snapshot when the weekly cycle is known. Returning
+  // calls:null here would overwrite a good local value after partial refresh.
+  if (usage.cycle_known !== true) return null;
+  if (typeof cycleTotal !== "number" || !Number.isFinite(cycleTotal)) return null;
   return {
-    calls,
+    calls: Math.max(0, Math.round(cycleTotal)),
     cycleCostTotal:
       typeof usage.cycle_cost_total === "number" && Number.isFinite(usage.cycle_cost_total)
         ? usage.cycle_cost_total

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -835,31 +835,6 @@ export function useAuthFilesFilesPresentation({
         },
       },
       {
-        key: "subject_scope",
-        label: t("auth_files.col_subject_scope"),
-        width: "w-32",
-        render: (file) => {
-          if (!file.subject_scope) {
-            return <span className="text-xs text-slate-400 dark:text-white/40">--</span>;
-          }
-          const shared = file.subject_scope === "shared";
-          return (
-            <HoverTooltip content={t("auth_files.shared_usage_scope_help")}>
-              <span
-                className={[
-                  "inline-flex items-center rounded-full px-2 py-0.5 text-2xs font-semibold",
-                  shared
-                    ? "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200"
-                    : "bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-white/65",
-                ].join(" ")}
-              >
-                {t(shared ? "auth_files.shared_subject" : "auth_files.tenant_subject")}
-              </span>
-            </HoverTooltip>
-          );
-        },
-      },
-      {
         key: "cycle_calls",
         label: t("auth_files.col_cycle_calls"),
         width: "w-24",
@@ -872,34 +847,6 @@ export function useAuthFilesFilesPresentation({
             <span className="text-xs font-semibold tabular-nums text-slate-700 dark:text-white/70">
               {typeof calls === "number" ? calls : "--"}
             </span>
-          );
-        },
-      },
-      {
-        key: "lifetime_calls",
-        label: t("auth_files.col_lifetime_calls"),
-        width: "w-24",
-        headerClassName: "text-right",
-        cellClassName: "text-right",
-        render: (file) => {
-          const stats = resolveAuthFileStats(file, usageIndex);
-          const calls = stats.success + stats.failure;
-          return (
-            <HoverTooltip
-              content={
-                file.usage_history_complete === false
-                  ? t("auth_files.shared_history_incomplete", {
-                      since: file.usage_projected_since
-                        ? new Date(file.usage_projected_since).toLocaleString()
-                        : "--",
-                    })
-                  : t("auth_files.shared_usage_scope_help")
-              }
-            >
-              <span className="text-xs font-semibold tabular-nums text-slate-700 dark:text-white/70">
-                {calls}
-              </span>
-            </HoverTooltip>
           );
         },
       },

--- a/pages/auth-files/hooks/useAuthFilesStatusState.ts
+++ b/pages/auth-files/hooks/useAuthFilesStatusState.ts
@@ -412,7 +412,8 @@ export function useAuthFilesStatusState({
               : group.authIndexes.find((key) => patch.cycleByKey[key]);
           if (!sourceKey) continue;
           const cycle = patch.cycleByKey[sourceKey];
-          if (!cycle) continue;
+          // Skip unknown cycle: never wipe a known 本周期 with null after partial refresh.
+          if (!cycle || typeof cycle.calls !== "number") continue;
           if (!changed) {
             next = { ...prev };
             changed = true;


### PR DESCRIPTION
## Summary
- Remove noisy AI account UI badges/columns: lifetime calls, success/failure counts, shared-subject / tenant-only scope chips (cards, table, detail).
- Partial status refresh no longer overwrites a known 本周期 when `cycle_known` is false (skip null cycle snapshots).

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, test:ci 807, build, bundle:diff, e2e 9)