### PR TITLE
fix(auth-files): seed 本周期 from cache so reload is 93→98 not --→89

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -90,6 +90,13 @@ export type AuthFilesUiState = {
   page?: number;
 };
 
+/** Last known 本周期 snapshot per auth_index for first paint after full reload. */
+export type AuthFileCycleCacheSnapshot = {
+  calls: number;
+  cycleCostTotal?: number | null;
+  weeklyQuotaUsedPercent?: number | null;
+};
+
 export type AuthFilesDataCache = {
   /** Effective tenant id that owns this cache bucket. Required to prevent cross-tenant reuse. */
   tenantId: string;
@@ -97,6 +104,8 @@ export type AuthFilesDataCache = {
   files: AuthFileItem[];
   usageData?: EntityStatsResponse | null;
   quotaByFileName?: Record<string, QuotaState>;
+  /** Seed card cycle badges so full reload is 93→98, not --→98. */
+  cycleByAuthIndex?: Record<string, AuthFileCycleCacheSnapshot>;
 };
 
 type AuthFilesDataCacheBucket = Omit<AuthFilesDataCache, "tenantId">;
@@ -572,6 +581,38 @@ const sanitizeQuotaByFileNameForCache = (
   return Object.keys(output).length > 0 ? output : undefined;
 };
 
+const sanitizeCycleByAuthIndexForCache = (
+  cycleByAuthIndex: unknown,
+): Record<string, AuthFileCycleCacheSnapshot> | undefined => {
+  if (!cycleByAuthIndex || typeof cycleByAuthIndex !== "object" || Array.isArray(cycleByAuthIndex)) {
+    return undefined;
+  }
+  const output: Record<string, AuthFileCycleCacheSnapshot> = {};
+  for (const [authIndex, raw] of Object.entries(
+    cycleByAuthIndex as Record<string, unknown>,
+  )) {
+    const key = typeof authIndex === "string" ? authIndex.trim() : "";
+    if (!key || !raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const snapshot = raw as Record<string, unknown>;
+    const calls =
+      typeof snapshot.calls === "number" && Number.isFinite(snapshot.calls)
+        ? Math.max(0, Math.round(snapshot.calls))
+        : null;
+    if (calls === null) continue;
+    const cycleCostTotal =
+      typeof snapshot.cycleCostTotal === "number" && Number.isFinite(snapshot.cycleCostTotal)
+        ? snapshot.cycleCostTotal
+        : null;
+    const weeklyQuotaUsedPercent =
+      typeof snapshot.weeklyQuotaUsedPercent === "number" &&
+      Number.isFinite(snapshot.weeklyQuotaUsedPercent)
+        ? snapshot.weeklyQuotaUsedPercent
+        : null;
+    output[key] = { calls, cycleCostTotal, weeklyQuotaUsedPercent };
+  }
+  return Object.keys(output).length > 0 ? output : undefined;
+};
+
 const parseAuthFilesDataCacheBucket = (
   value: unknown,
 ): AuthFilesDataCacheBucket | null => {
@@ -591,6 +632,7 @@ const parseAuthFilesDataCacheBucket = (
         ? (parsed.usageData as EntityStatsResponse)
         : undefined,
     quotaByFileName: sanitizeQuotaByFileNameForCache(parsed.quotaByFileName),
+    cycleByAuthIndex: sanitizeCycleByAuthIndexForCache(parsed.cycleByAuthIndex),
   };
 };
 
@@ -628,6 +670,7 @@ export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
       files: cache.files,
       usageData: cache.usageData,
       quotaByFileName: cache.quotaByFileName,
+      cycleByAuthIndex: cache.cycleByAuthIndex,
     },
     merge: (previous, next) => {
       const fileNames = new Set(next.files.map((file) => file.name).filter(Boolean));
@@ -638,6 +681,9 @@ export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
         quotaByFileName: sanitizeQuotaByFileNameForCache(
           next.quotaByFileName ?? previous?.quotaByFileName,
           fileNames,
+        ),
+        cycleByAuthIndex: sanitizeCycleByAuthIndexForCache(
+          next.cycleByAuthIndex ?? previous?.cycleByAuthIndex,
         ),
       };
     },

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2177,6 +2177,75 @@ describe("AuthFilesPage files table", () => {
     expect(mocks.getStatus).toHaveBeenCalled();
   });
 
+  test("full reload seeds 本周期 from cache so first paint is not Cycle --", async () => {
+    window.localStorage.setItem(
+      "authFilesPage.filesViewMode.v1",
+      JSON.stringify("cards"),
+    );
+    setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
+    const file = {
+      name: "codex-cycle.json",
+      label: "Cycle Cached",
+      account_type: "oauth",
+      type: "codex",
+      auth_index: "cycle-93",
+      size: 1024,
+      modified: Date.now(),
+      disabled: false,
+    };
+    writeAuthFilesDataCache({
+      tenantId: DEFAULT_CACHE_TENANT_ID,
+      savedAtMs: Date.now(),
+      files: [file],
+      cycleByAuthIndex: {
+        "cycle-93": { calls: 93, cycleCostTotal: null, weeklyQuotaUsedPercent: null },
+      },
+    });
+    mocks.list.mockImplementation(async () => ({ files: [file] }));
+    // Delay status so first paint must come from cache, not network.
+    mocks.getStatus.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                items: [
+                  {
+                    auth_index: "cycle-93",
+                    quotas: [],
+                    usage: {
+                      cycle_request_total: 98,
+                      cycle_known: true,
+                      request_total: 200,
+                    },
+                  },
+                ],
+              }),
+            80,
+          );
+        }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const title = await screen.findByText("Cycle Cached");
+    const card = title.closest("section");
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).getByText("Cycle 93")).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("Cycle --")).not.toBeInTheDocument();
+    expect(await within(card as HTMLElement).findByText("Cycle 98")).toBeInTheDocument();
+  });
+
   test("cards view shows unknown cycle without lifetime/scope noise when weekly cycle is unknown", async () => {
     window.localStorage.setItem(
       "authFilesPage.filesViewMode.v1",

--- a/pages/auth-files/hooks/useAuthFilesStatusState.ts
+++ b/pages/auth-files/hooks/useAuthFilesStatusState.ts
@@ -172,7 +172,27 @@ export function useAuthFilesStatusState({
   );
   const [cycleByAuthIndex, setCycleByAuthIndex] = useState<
     Record<string, AuthFileCycleUsageSnapshot>
-  >({});
+  >(() => {
+    const cached = initialDataCache?.cycleByAuthIndex;
+    if (!cached) return {};
+    const seeded: Record<string, AuthFileCycleUsageSnapshot> = {};
+    for (const [authIndex, snapshot] of Object.entries(cached)) {
+      if (typeof snapshot?.calls !== "number" || !Number.isFinite(snapshot.calls)) continue;
+      seeded[authIndex] = {
+        calls: snapshot.calls,
+        cycleCostTotal:
+          typeof snapshot.cycleCostTotal === "number" && Number.isFinite(snapshot.cycleCostTotal)
+            ? snapshot.cycleCostTotal
+            : null,
+        weeklyQuotaUsedPercent:
+          typeof snapshot.weeklyQuotaUsedPercent === "number" &&
+          Number.isFinite(snapshot.weeklyQuotaUsedPercent)
+            ? snapshot.weeklyQuotaUsedPercent
+            : null,
+      };
+    }
+    return seeded;
+  });
   const [statusApiSupported, setStatusApiSupported] = useState(true);
   const [statusLoading, setStatusLoading] = useState(false);
   const [refreshingPage, setRefreshingPage] = useState(false);
@@ -242,8 +262,25 @@ export function useAuthFilesStatusState({
     statusLoadSeqRef.current += 1;
     loadedVisibleScopeRef.current = null;
     appliedFreshnessRef.current.clear();
-    setQuotaByFileName({});
-    setCycleByAuthIndex({});
+    const tenantCache = readAuthFilesDataCache(cacheTenantId);
+    setQuotaByFileName(tenantCache?.quotaByFileName ?? {});
+    const seeded: Record<string, AuthFileCycleUsageSnapshot> = {};
+    for (const [authIndex, snapshot] of Object.entries(tenantCache?.cycleByAuthIndex ?? {})) {
+      if (typeof snapshot?.calls !== "number" || !Number.isFinite(snapshot.calls)) continue;
+      seeded[authIndex] = {
+        calls: snapshot.calls,
+        cycleCostTotal:
+          typeof snapshot.cycleCostTotal === "number" && Number.isFinite(snapshot.cycleCostTotal)
+            ? snapshot.cycleCostTotal
+            : null,
+        weeklyQuotaUsedPercent:
+          typeof snapshot.weeklyQuotaUsedPercent === "number" &&
+          Number.isFinite(snapshot.weeklyQuotaUsedPercent)
+            ? snapshot.weeklyQuotaUsedPercent
+            : null,
+      };
+    }
+    setCycleByAuthIndex(seeded);
     setRefreshingPage(false);
     setStatusLoading(false);
     setStatusApiSupported(true);
@@ -285,15 +322,27 @@ export function useAuthFilesStatusState({
       const tenantId = getActiveCacheTenantId();
       const current = readAuthFilesDataCache(tenantId);
       if (!current || !Array.isArray(current.files)) return;
+      const cycleCache: Record<string, { calls: number; cycleCostTotal: number | null; weeklyQuotaUsedPercent: number | null }> = {};
+      for (const [authIndex, snapshot] of Object.entries(cycleByAuthIndex)) {
+        if (typeof snapshot.calls !== "number" || !Number.isFinite(snapshot.calls)) continue;
+        cycleCache[authIndex] = {
+          calls: snapshot.calls,
+          cycleCostTotal: snapshot.cycleCostTotal,
+          weeklyQuotaUsedPercent: snapshot.weeklyQuotaUsedPercent,
+        };
+      }
       writeAuthFilesDataCache({
         ...current,
         tenantId,
         savedAtMs: Date.now(),
         quotaByFileName,
+        // Keep last known cycle when state is still empty (first paint / tenant seed).
+        cycleByAuthIndex:
+          Object.keys(cycleCache).length > 0 ? cycleCache : current.cycleByAuthIndex,
       });
     }, 250);
     return () => window.clearTimeout(timer);
-  }, [quotaByFileName]);
+  }, [quotaByFileName, cycleByAuthIndex]);
 
   const patchAuthFileByName = useCallback(
     (name: string, patch: Partial<AuthFileItem>) => {


### PR DESCRIPTION
## Summary
- Root cause: `cycleByAuthIndex` was memory-only; full page reload always first-painted `本周期 --`, then jumped to the network value.
- Persist/restore `cycleByAuthIndex` in auth-files data cache (same path as quotas) so reload is last-known → fresh (e.g. 93→98).

## Test plan
- [x] focused auth-files tests + `./scripts/ci-pr.sh`