### PR TITLE
fix(auth-files): auto subscription only and sticky card badges

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -1173,26 +1173,16 @@ export const normalizeAuthFileSubscriptionPeriod = (value: unknown): AuthFileSub
   return "monthly";
 };
 
+// Prefer provider-asserted shared subscription; tenant metadata is legacy fallback only.
 const resolveSubscriptionStartMs = (file: AuthFileItem): number | null =>
+  parseDateLikeMs(file.shared_subscription_started_at) ??
   parseDateLikeMs(file.subscription_started_at_ms ?? file.subscriptionStartedAtMs) ??
   parseDateLikeMs(
     file.subscription_started_at ??
       file.subscriptionStartedAt ??
       file.subscription_start_at ??
       file.subscriptionStartAt,
-  ) ??
-  parseDateLikeMs(file.shared_subscription_started_at);
-
-const hasTenantSubscriptionOverride = (file: AuthFileItem): boolean =>
-  parseDateLikeMs(
-    file.subscription_started_at_ms ?? file.subscriptionStartedAtMs,
-  ) !== null ||
-  parseDateLikeMs(
-    file.subscription_started_at ??
-      file.subscriptionStartedAt ??
-      file.subscription_start_at ??
-      file.subscriptionStartAt,
-  ) !== null;
+  );
 
 const addCalendarMonths = (startMs: number, months: number): number | null => {
   const date = new Date(startMs);
@@ -1212,20 +1202,22 @@ export const resolveAuthFileSubscriptionStatus = (
   file: AuthFileItem,
   nowMs = Date.now(),
 ): AuthFileSubscriptionStatus | null => {
+  const sharedExpiresAtMs = parseDateLikeMs(file.shared_subscription_expires_at);
   const startedAtMs = resolveSubscriptionStartMs(file);
-  if (startedAtMs === null) return null;
+  // Auto path: provider shared expires alone is enough for the remaining badge.
+  if (startedAtMs === null && sharedExpiresAtMs === null) return null;
 
   const period = normalizeAuthFileSubscriptionPeriod(
     file.subscription_period ?? file.subscriptionPeriod,
   );
-  const sharedExpiresAtMs = parseDateLikeMs(
-    file.shared_subscription_expires_at,
-  );
   const expiresAtMs =
-    !hasTenantSubscriptionOverride(file) && sharedExpiresAtMs !== null
+    sharedExpiresAtMs !== null
       ? sharedExpiresAtMs
-      : addCalendarMonths(startedAtMs, period === "yearly" ? 12 : 1);
+      : startedAtMs === null
+        ? null
+        : addCalendarMonths(startedAtMs, period === "yearly" ? 12 : 1);
   if (expiresAtMs === null) return null;
+  const effectiveStartedAtMs = startedAtMs ?? expiresAtMs;
 
   const diffMs = expiresAtMs - nowMs;
   const remainingDays =
@@ -1238,8 +1230,8 @@ export const resolveAuthFileSubscriptionStatus = (
   const tone = expired ? "expired" : remainingDays <= 5 ? "urgent" : "active";
 
   return {
-    startedAtMs,
-    startedAtText: new Date(startedAtMs).toLocaleString(),
+    startedAtMs: effectiveStartedAtMs,
+    startedAtText: new Date(effectiveStartedAtMs).toLocaleString(),
     expiresAtMs,
     expiresAtText: new Date(expiresAtMs).toLocaleString(),
     remainingDays,
@@ -1411,11 +1403,13 @@ export const estimateQuotaBudgetUsd = (
 
 /**
  * Codex Pro only: map estimated weekly USD budget → pro_20x / pro_5x / pro.
- * Non-pro base plans pass through unchanged; missing budget falls back to plain pro.
+ * Non-pro base plans pass through unchanged; missing budget falls back to plain pro,
+ * or keeps a previously resolved pro_Nx tier so partial refresh does not flash PRO.
  */
 export const resolveCodexProMultiplierTier = (
   basePlan: string | null | undefined,
   estimatedWeeklyBudgetUsd: number | null | undefined,
+  previousTier?: string | null,
 ): string | null => {
   const base = normalizeTagValue(basePlan);
   if (!base) return null;
@@ -1427,6 +1421,9 @@ export const resolveCodexProMultiplierTier = (
     !Number.isFinite(estimatedWeeklyBudgetUsd) ||
     estimatedWeeklyBudgetUsd <= 0
   ) {
+    const previous = normalizeTagValue(previousTier);
+    if (previous === "pro_20x" || previous === "pro-20x") return "pro_20x";
+    if (previous === "pro_5x" || previous === "pro-5x") return "pro_5x";
     return "pro";
   }
   if (estimatedWeeklyBudgetUsd >= CODEX_PRO_20X_WEEKLY_BUDGET_USD) return "pro_20x";
@@ -1438,6 +1435,7 @@ export const resolveAuthFileDisplayPlanType = (
   file: AuthFileItem,
   quotaState?: QuotaState | null,
   cycleStats?: AuthFileCycleBudgetStats | null,
+  previousDisplayPlan?: string | null,
 ): string | null => {
   const base = resolveAuthFilePlanType(file, quotaState);
   if (!base) return null;
@@ -1446,7 +1444,7 @@ export const resolveAuthFileDisplayPlanType = (
     cycleStats?.cycleCostTotal,
     cycleStats?.weeklyQuotaUsedPercent,
   );
-  return resolveCodexProMultiplierTier(base, budget);
+  return resolveCodexProMultiplierTier(base, budget, previousDisplayPlan);
 };
 
 export const resolvePlanBadgeClass = (planType: string | null | undefined): string => {
@@ -1952,8 +1950,6 @@ export type PrefixProxyEditorState = {
   prefix: string;
   proxyUrl: string;
   proxyId: string;
-  subscriptionStartedAt: string;
-  subscriptionPeriod: AuthFileSubscriptionPeriod;
 };
 
 export type AuthFilesGroupOverview = {

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -775,6 +775,7 @@ export function AuthFilesPage() {
     : null;
   const {
     formatPlanTypeLabel,
+    resolveStickyDisplayPlanType,
     renderRestrictionBadges,
     renderClaudeOAuthHealthBadges,
     renderSubscriptionBadge,
@@ -886,6 +887,7 @@ export function AuthFilesPage() {
         resolveAuthFileStats={resolveAuthFileStats}
         toggleFileSelection={toggleFileSelection}
         formatPlanTypeLabel={formatPlanTypeLabel}
+        resolveStickyDisplayPlanType={resolveStickyDisplayPlanType}
         renderRestrictionBadges={renderRestrictionBadges}
         renderClaudeOAuthHealthBadges={renderClaudeOAuthHealthBadges}
         renderSubscriptionBadge={renderSubscriptionBadge}

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -53,8 +53,6 @@ const basePrefixProxyEditor: DetailModalProps["prefixProxyEditor"] = {
   prefix: "team-a",
   proxyUrl: "http://127.0.0.1:7890",
   proxyId: "primary",
-  subscriptionStartedAt: "2026-04-01T08:30",
-  subscriptionPeriod: "monthly",
 };
 
 const baseCodexOAuthAdmissionEditor: DetailModalProps["codexOAuthAdmissionEditor"] = {
@@ -918,7 +916,7 @@ describe("AuthFileDetailModal", () => {
     expect(within(grid).getByPlaceholderText("e.g. http://127.0.0.1:7890")).toHaveValue(
       "http://127.0.0.1:7890",
     );
-    expect(within(grid).getByLabelText(/Subscription start/)).toBeInTheDocument();
+    expect(within(grid).queryByLabelText(/Subscription start/)).not.toBeInTheDocument();
     expect(screen.queryByTestId("auth-file-fields-preview")).not.toBeInTheDocument();
     expect(screen.queryByText(/"prefix"/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -157,20 +157,6 @@ vi.mock("@code-proxy/ui", async (importOriginal) => ({
   EChart: ({ className }: { className?: string }) => <div className={className}>chart</div>,
 }));
 
-const padDatePart = (value: number): string => String(value).padStart(2, "0");
-
-const toDateTimeLocalInput = (date: Date): string =>
-  [
-    date.getFullYear(),
-    "-",
-    padDatePart(date.getMonth() + 1),
-    "-",
-    padDatePart(date.getDate()),
-    "T",
-    padDatePart(date.getHours()),
-    ":",
-    padDatePart(date.getMinutes()),
-  ].join("");
 
 const decodeBase64UrlJson = (part: string): Record<string, unknown> =>
   JSON.parse(Buffer.from(part, "base64url").toString("utf8")) as Record<string, unknown>;
@@ -3280,7 +3266,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("<1d left")).toBeInTheDocument();
   });
 
-  test("saves subscription start and period from the auth fields editor", async () => {
+  test("does not show manual subscription editor in auth fields", async () => {
     mocks.list.mockImplementation(async () => ({
       files: [
         {
@@ -3291,6 +3277,9 @@ describe("AuthFilesPage files table", () => {
           size: 1024,
           modified: Date.now(),
           disabled: false,
+          shared_subscription_started_at: "2026-07-01T00:00:00Z",
+          shared_subscription_expires_at: "2026-08-01T00:00:00Z",
+          shared_subscription_source: "signed_claims",
         },
       ],
     }));
@@ -3300,7 +3289,6 @@ describe("AuthFilesPage files table", () => {
           type: "codex",
           subscription_started_at: "2027-01-02T03:04:00Z",
           subscription_period: "monthly",
-          subscription_expires_at: "2099-01-01T00:00:00Z",
         },
         null,
         2,
@@ -3323,82 +3311,13 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     fireEvent.click(await screen.findByRole("tab", { name: "Fields" }));
 
-    const input = await screen.findByLabelText("Subscription start date");
-    fireEvent.change(input, { target: { value: "2027-01-03T04:05" } });
-    fireEvent.click(screen.getByRole("combobox", { name: "Subscription cycle" }));
-    fireEvent.click(await screen.findByRole("option", { name: "Yearly" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(1));
-    const uploadCalls = mocks.upload.mock.calls as unknown as [[File]];
-    const uploaded = uploadCalls[0][0];
-    const uploadedJson = JSON.parse(await uploaded.text()) as Record<string, unknown>;
-    expect(uploadedJson.subscription_started_at).toBe(new Date("2027-01-03T04:05").toISOString());
-    expect(uploadedJson.subscription_period).toBe("yearly");
-    expect(uploadedJson.subscription_expires_at).toBeUndefined();
+    expect(screen.queryByLabelText("Subscription start date")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Subscription cycle")).not.toBeInTheDocument();
+    expect(screen.queryByText("Subscription start date")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });
 
-  test("uses the subscription date picker from the auth fields editor", async () => {
-    const initialStartedAt = "2027-01-02T03:04:00Z";
-    const expectedStartedAt = new Date(initialStartedAt);
-    expectedStartedAt.setFullYear(2027, 0, 15);
-    mocks.list.mockImplementation(async () => ({
-      files: [
-        {
-          name: "codex-subscription.json",
-          label: "Codex Subscriber",
-          account_type: "oauth",
-          type: "codex",
-          size: 1024,
-          modified: Date.now(),
-          disabled: false,
-        },
-      ],
-    }));
-    mocks.downloadText.mockImplementation(async () =>
-      JSON.stringify(
-        {
-          type: "codex",
-          subscription_started_at: initialStartedAt,
-          subscription_period: "monthly",
-        },
-        null,
-        2,
-      ),
-    );
-
-    render(
-      <MemoryRouter initialEntries={["/auth-files"]}>
-        <ThemeProvider>
-          <ToastProvider>
-            <Routes>
-              <Route path="/auth-files" element={<AuthFilesPage />} />
-            </Routes>
-          </ToastProvider>
-        </ThemeProvider>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText("Codex Subscriber")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Details" }));
-    fireEvent.click(await screen.findByRole("tab", { name: "Fields" }));
-
-    fireEvent.click(await screen.findByLabelText("Subscription start date"));
-    expect(screen.getByRole("dialog", { name: "Date picker" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "15" }));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(1));
-    const uploadCalls = mocks.upload.mock.calls as unknown as [[File]];
-    const uploaded = uploadCalls[0][0];
-    const uploadedJson = JSON.parse(await uploaded.text()) as Record<string, unknown>;
-    expect(uploadedJson.subscription_started_at).toBe(expectedStartedAt.toISOString());
-  });
-
-  test("closes the fields modal and refreshes the card subscription badge after saving", async () => {
-    const startedAt = new Date(Date.now() - 25 * 24 * 60 * 60 * 1000);
-    startedAt.setSeconds(0, 0);
-    const startedAtInput = toDateTimeLocalInput(startedAt);
+  test("shows card subscription badge from shared provider subscription", async () => {
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     mocks.list.mockImplementation(async () => ({
       files: [
@@ -3410,10 +3329,16 @@ describe("AuthFilesPage files table", () => {
           size: 1024,
           modified: Date.now(),
           disabled: false,
+          shared_subscription_started_at: new Date(
+            Date.now() - 5 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          shared_subscription_expires_at: new Date(
+            Date.now() + 26 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          shared_subscription_source: "signed_claims",
         },
       ],
     }));
-    mocks.downloadText.mockImplementation(async () => JSON.stringify({ type: "codex" }, null, 2));
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -3427,24 +3352,7 @@ describe("AuthFilesPage files table", () => {
       </MemoryRouter>,
     );
 
-    const cards = await screen.findByTestId("auth-files-cards");
-    expect(cards).not.toHaveTextContent(/d left/);
-    fireEvent.click(within(cards).getByRole("button", { name: "Details" }));
-    const dialog = await screen.findByRole("dialog", { name: "Codex Subscriber" });
-    fireEvent.click(within(dialog).getByRole("tab", { name: "Fields" }));
-
-    const input = await within(dialog).findByLabelText("Subscription start date");
-    fireEvent.change(input, { target: { value: startedAtInput } });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(1));
-    const uploadCalls = mocks.upload.mock.calls as unknown as [[File]];
-    const uploadedJson = JSON.parse(await uploadCalls[0][0].text()) as Record<string, unknown>;
-    expect(uploadedJson.subscription_started_at).toBe(new Date(startedAtInput).toISOString());
-    await waitFor(() =>
-      expect(screen.queryByRole("dialog", { name: "Codex Subscriber" })).not.toBeInTheDocument(),
-    );
-    await waitFor(() => expect(screen.getByTestId("auth-files-cards")).toHaveTextContent(/d left/));
+    expect(await screen.findByTestId("auth-files-cards")).toHaveTextContent(/d left/);
   });
 
   test("opens usage trend cards for codex files inferred from dotted email file names", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -510,6 +510,9 @@ describe("Auth Files helper coverage", () => {
     expect(resolveCodexProMultiplierTier("pro", 500)).toBe("pro_5x");
     expect(resolveCodexProMultiplierTier("pro", 100)).toBe("pro");
     expect(resolveCodexProMultiplierTier("pro", null)).toBe("pro");
+    // Partial refresh without budget keeps last-known pro_Nx tier instead of flashing PRO.
+    expect(resolveCodexProMultiplierTier("pro", null, "pro_20x")).toBe("pro_20x");
+    expect(resolveCodexProMultiplierTier("pro", null, "pro_5x")).toBe("pro_5x");
     expect(resolveCodexProMultiplierTier("plus", 2000)).toBe("plus");
     expect(
       resolveAuthFileDisplayPlanType(
@@ -525,6 +528,14 @@ describe("Auth Files helper coverage", () => {
         { cycleCostTotal: 30, weeklyQuotaUsedPercent: 10 },
       ),
     ).toBe("pro_5x");
+    expect(
+      resolveAuthFileDisplayPlanType(
+        { name: "codex.json", type: "codex", plan_type: "pro" } as AuthFileItem,
+        null,
+        null,
+        "pro_20x",
+      ),
+    ).toBe("pro_20x");
     expect(
       resolveAuthFileDisplayPlanType(
         { name: "xai.json", type: "xai", plan_type: "supergrok" } as AuthFileItem,
@@ -1047,6 +1058,48 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
         remainingDays: 5,
         expired: false,
         tone: "urgent",
+      }),
+    );
+  });
+
+  test("prefers shared provider subscription over tenant metadata", () => {
+    const status = resolveAuthFileSubscriptionStatus(
+      {
+        name: "codex.json",
+        subscription_started_at: "2026-01-01T00:00:00.000Z",
+        subscription_period: "monthly",
+        shared_subscription_started_at: "2026-07-01T00:00:00.000Z",
+        shared_subscription_expires_at: "2026-08-01T00:00:00.000Z",
+        shared_subscription_source: "signed_claims",
+      } as AuthFileItem,
+      Date.parse("2026-07-06T00:00:00.000Z"),
+    );
+    expect(status).toEqual(
+      expect.objectContaining({
+        startedAtMs: Date.parse("2026-07-01T00:00:00.000Z"),
+        expiresAtMs: Date.parse("2026-08-01T00:00:00.000Z"),
+        remainingDays: 26,
+        expired: false,
+        tone: "active",
+      }),
+    );
+  });
+
+  test("shows remaining days from shared expires alone", () => {
+    const status = resolveAuthFileSubscriptionStatus(
+      {
+        name: "codex.json",
+        shared_subscription_expires_at: "2026-08-01T00:00:00.000Z",
+        shared_subscription_source: "signed_claims",
+      } as AuthFileItem,
+      Date.parse("2026-07-06T00:00:00.000Z"),
+    );
+    expect(status).toEqual(
+      expect.objectContaining({
+        expiresAtMs: Date.parse("2026-08-01T00:00:00.000Z"),
+        remainingDays: 26,
+        expired: false,
+        tone: "active",
       }),
     );
   });

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -13,7 +13,6 @@ import { Download, RefreshCw, ShieldCheck } from "lucide-react";
 import type { AuthFileTrendResponse } from "@code-proxy/api-client/endpoints/usage";
 import type {
   AuthFileItem,
-  AuthFileSubscriptionPeriod,
   IdentityFingerprintAccountDetail,
   IdentityFingerprintFieldSource,
 } from "@code-proxy/api-client";
@@ -21,9 +20,7 @@ import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { Button } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
-import { DateTimePicker } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
-import { HoverTooltip } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Select } from "@code-proxy/ui";
@@ -191,7 +188,7 @@ interface AuthFileDetailModalProps {
   deleteIdentityFingerprintProfile: (profileKey: string) => Promise<void>;
   refreshDetailTrend: (file?: AuthFileItem | null, options?: { silent?: boolean }) => Promise<void>;
   loadModelsForDetail: (file: AuthFileItem, options?: { force?: boolean }) => Promise<void>;
-  loadModelOwnerGroups: () => Promise<void>;
+  loadModelOwnerGroups: (options?: { silent?: boolean }) => Promise<void>;
   modelsLoading: boolean;
   modelsError: string | null;
   modelsList: AuthFileModelItem[];
@@ -278,7 +275,7 @@ export function AuthFileDetailModal({
   xaiEndpointDirty,
   saveXAIEndpoint,
 }: AuthFileDetailModalProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const isIdentityDesktopLayout = useIdentityDesktopLayout();
   const [viewedIdentityProfileKey, setViewedIdentityProfileKey] = useState("");
   const proxyCheckState = useProxyPoolChecks(proxyPoolEntries, open && detailTab === "fields");
@@ -1333,7 +1330,7 @@ export function AuthFileDetailModal({
               variant="secondary"
               onClick={() => {
                 if (usesMappedModelOwner) {
-                  void loadModelOwnerGroups();
+                  void loadModelOwnerGroups({ silent: true });
                 } else {
                   void loadModelsForDetail(detailFile, { force: true });
                 }
@@ -1797,60 +1794,6 @@ export function AuthFileDetailModal({
                               />
                               <p className="text-xs text-slate-500 dark:text-white/55">
                                 {t("auth_files.leave_empty_prefix")}
-                              </p>
-                            </div>
-
-                            <div className="grid gap-2">
-                              <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
-                                {t("auth_files.subscription_started_at_label")}
-                              </p>
-                              <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
-                                <DateTimePicker
-                                  value={prefixProxyEditor.subscriptionStartedAt}
-                                  onChange={(value) => {
-                                    setPrefixProxyEditor((prev) => ({
-                                      ...prev,
-                                      subscriptionStartedAt: value,
-                                    }));
-                                  }}
-                                  aria-label={t("auth_files.subscription_started_at_label")}
-                                  locale={i18n.language}
-                                  labels={{
-                                    picker: t("auth_files.subscription_date_picker"),
-                                    open: t("auth_files.subscription_date_picker_open"),
-                                    previousMonth: t(
-                                      "auth_files.subscription_date_picker_previous_month",
-                                    ),
-                                    nextMonth: t("auth_files.subscription_date_picker_next_month"),
-                                    today: t("auth_files.subscription_date_picker_today"),
-                                    clear: t("auth_files.subscription_date_picker_clear"),
-                                    hour: t("auth_files.subscription_date_picker_hour"),
-                                    minute: t("auth_files.subscription_date_picker_minute"),
-                                  }}
-                                />
-                                <Select
-                                  value={prefixProxyEditor.subscriptionPeriod}
-                                  onChange={(value) =>
-                                    setPrefixProxyEditor((prev) => ({
-                                      ...prev,
-                                      subscriptionPeriod: value as AuthFileSubscriptionPeriod,
-                                    }))
-                                  }
-                                  options={[
-                                    {
-                                      value: "monthly",
-                                      label: t("auth_files.subscription_period_monthly"),
-                                    },
-                                    {
-                                      value: "yearly",
-                                      label: t("auth_files.subscription_period_yearly"),
-                                    },
-                                  ]}
-                                  aria-label={t("auth_files.subscription_period_label")}
-                                />
-                              </div>
-                              <p className="text-xs text-slate-500 dark:text-white/55">
-                                {t("auth_files.subscription_started_at_hint")}
                               </p>
                             </div>
                           </>

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -58,7 +58,6 @@ import {
   normalizeProviderKey,
   normalizeTagValue,
   resolveAuthFileDisplayName,
-  resolveAuthFileDisplayPlanType,
   resolveAuthFilePlanType,
   resolveAuthFileSupplementalTags,
   resolveFileType,
@@ -661,6 +660,11 @@ interface AuthFilesFilesTabProps {
   ) => { success: number; failure: number };
   toggleFileSelection: (name: string, checked: boolean) => void;
   formatPlanTypeLabel: (planType: string) => string;
+  resolveStickyDisplayPlanType: (
+    file: AuthFileItem,
+    quotaState?: QuotaState | null,
+    cycleStats?: AuthFileCycleBudgetStats | null,
+  ) => string | null;
   renderRestrictionBadges: (file: AuthFileItem) => ReactNode | null;
   renderClaudeOAuthHealthBadges: (file: AuthFileItem) => ReactNode | null;
   renderSubscriptionBadge: (file: AuthFileItem) => ReactNode | null;
@@ -746,6 +750,7 @@ export function AuthFilesFilesTab({
   resolveAuthFileStats,
   toggleFileSelection,
   formatPlanTypeLabel,
+  resolveStickyDisplayPlanType,
   renderRestrictionBadges,
   renderClaudeOAuthHealthBadges,
   renderSubscriptionBadge,
@@ -1535,7 +1540,7 @@ export function AuthFilesFilesTab({
                     file.auth_index ?? file.authIndex,
                   );
                   const basePlanType = resolveAuthFilePlanType(file, state);
-                  const planType = resolveAuthFileDisplayPlanType(
+                  const planType = resolveStickyDisplayPlanType(
                     file,
                     state,
                     authIndexForPlan

--- a/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
@@ -315,6 +315,57 @@ describe("useAuthFilesStatusState batch refresh", () => {
     });
   });
 
+  test("partial status without subscription fields keeps existing badge fields", async () => {
+    const seeded: AuthFileItem[] = [
+      {
+        name: "a.json",
+        auth_index: "a1",
+        type: "codex",
+        shared_subscription_started_at: "2026-07-01T00:00:00Z",
+        shared_subscription_expires_at: "2026-08-01T00:00:00Z",
+        shared_subscription_source: "signed_claims",
+      } as AuthFileItem,
+    ];
+    mocks.getStatus.mockResolvedValue({
+      items: [
+        {
+          auth_index: "a1",
+          quotas: [{ quota_key: "code_5h", percent: 12 }],
+          usage: {
+            cycle_request_total: 3,
+            cycle_known: true,
+            request_total: 10,
+            success_total: 9,
+            failure_total: 1,
+          },
+        },
+      ],
+    });
+    const setFiles = vi.fn();
+    const setDetailFile = vi.fn();
+    const { result } = renderHook(() =>
+      useAuthFilesStatusState({
+        tab: "files",
+        pageItems: seeded,
+        loading: false,
+        setFiles,
+        setDetailFile,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.quotaByFileName["a.json"]?.items[0]?.percent).toBe(12);
+    });
+
+    let patched = seeded;
+    for (const [update] of setFiles.mock.calls) {
+      if (typeof update === "function") patched = update(patched);
+    }
+    expect(patched[0]?.shared_subscription_started_at).toBe("2026-07-01T00:00:00Z");
+    expect(patched[0]?.shared_subscription_expires_at).toBe("2026-08-01T00:00:00Z");
+    expect(patched[0]?.shared_subscription_source).toBe("signed_claims");
+  });
+
   test("job poll 404 does not mark status API unsupported", async () => {
     mocks.getStatusRefreshJob.mockRejectedValue(
       new ApiError({ message: "gone", status: 404 }),

--- a/pages/auth-files/hooks/useAuthFilesDataState.ts
+++ b/pages/auth-files/hooks/useAuthFilesDataState.ts
@@ -71,11 +71,35 @@ export function useAuthFilesDataState() {
         const filesRes = await authFilesApi.list(signal ? { signal } : undefined);
         if (!isActive()) return filesRef.current;
         const list = Array.isArray(filesRes?.files) ? filesRes.files : [];
-        filesRef.current = list;
-        setFiles(list);
+        // List has no shared status projection. Merge in-memory shared fields so
+        // subscription badge / plan / scope do not flash on full list reload.
+        const prevByName = new Map(filesRef.current.map((file) => [file.name, file]));
+        const merged = list.map((fresh) => {
+          const prev = prevByName.get(fresh.name);
+          if (!prev) return fresh;
+          return {
+            ...fresh,
+            shared_subscription_started_at:
+              fresh.shared_subscription_started_at ?? prev.shared_subscription_started_at,
+            shared_subscription_expires_at:
+              fresh.shared_subscription_expires_at ?? prev.shared_subscription_expires_at,
+            shared_subscription_source:
+              fresh.shared_subscription_source ?? prev.shared_subscription_source,
+            account_status_scope: fresh.account_status_scope ?? prev.account_status_scope,
+            subject_scope: fresh.subject_scope ?? prev.subject_scope,
+            share_eligible: fresh.share_eligible ?? prev.share_eligible,
+            usage_history_complete: fresh.usage_history_complete ?? prev.usage_history_complete,
+            usage_projected_since: fresh.usage_projected_since ?? prev.usage_projected_since,
+            // Keep status-derived plan when list metadata omits it.
+            plan_type: fresh.plan_type ?? fresh.planType ?? prev.plan_type ?? prev.planType,
+            planType: fresh.planType ?? fresh.plan_type ?? prev.planType ?? prev.plan_type,
+          };
+        });
+        filesRef.current = merged;
+        setFiles(merged);
         warmPaintRef.current = true;
         // Calls / success-rate come from ai-accounts status usage — no entity-stats.
-        return list;
+        return merged;
       } catch (err: unknown) {
         if (!isActive() || isRequestCancelled(err, signal)) return filesRef.current;
         notify({
@@ -112,7 +136,28 @@ export function useAuthFilesDataState() {
         setFiles((prev) => {
           const next = prev.map((item) => {
             if (!targetNames.has(item.name)) return item;
-            return filesByName.get(item.name) ?? item;
+            const fresh = filesByName.get(item.name);
+            if (!fresh) return item;
+            // List API has no shared status projection; keep in-memory shared fields
+            // so subscription badge / scope do not flash away on partial file refresh.
+            return {
+              ...fresh,
+              shared_subscription_started_at:
+                fresh.shared_subscription_started_at ?? item.shared_subscription_started_at,
+              shared_subscription_expires_at:
+                fresh.shared_subscription_expires_at ?? item.shared_subscription_expires_at,
+              shared_subscription_source:
+                fresh.shared_subscription_source ?? item.shared_subscription_source,
+              account_status_scope: fresh.account_status_scope ?? item.account_status_scope,
+              subject_scope: fresh.subject_scope ?? item.subject_scope,
+              share_eligible: fresh.share_eligible ?? item.share_eligible,
+              usage_history_complete:
+                fresh.usage_history_complete ?? item.usage_history_complete,
+              usage_projected_since:
+                fresh.usage_projected_since ?? item.usage_projected_since,
+              plan_type: fresh.plan_type ?? fresh.planType ?? item.plan_type ?? item.planType,
+              planType: fresh.planType ?? fresh.plan_type ?? item.planType ?? item.plan_type,
+            };
           });
           updatedFiles = next;
           filesRef.current = next;

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -13,14 +13,11 @@ import type { AuthFileTrendResponse } from "@code-proxy/api-client/endpoints/usa
 import type { AuthFileItem, IdentityFingerprintAccountDetail } from "@code-proxy/api-client";
 import { useToast } from "@code-proxy/ui";
 import {
-  dateLikeToDateTimeLocalInput,
-  dateTimeLocalInputToIso,
   formatFileSize,
   MAX_AUTH_FILE_SIZE,
   canRenameAuthFileChannel,
   normalizeAuthIndexValue,
   normalizeProviderKey,
-  normalizeAuthFileSubscriptionPeriod,
   readAuthFileChannelName,
   resolveFileType,
   type AuthFileModelItem,
@@ -45,8 +42,6 @@ const createPrefixProxyEditorState = (): PrefixProxyEditorState => ({
   prefix: "",
   proxyUrl: "",
   proxyId: "",
-  subscriptionStartedAt: "",
-  subscriptionPeriod: "monthly",
 });
 
 const createChannelEditorState = (): ChannelEditorState => ({
@@ -164,65 +159,6 @@ const buildXAIEndpointEditorState = (file: AuthFileItem): XAIEndpointEditorState
   };
 };
 
-const readSubscriptionStartValue = (json: Record<string, unknown>): unknown =>
-  json.subscription_started_at ??
-  json.subscriptionStartedAt ??
-  json.subscription_start_at ??
-  json.subscriptionStartAt;
-
-const removeSubscriptionFields = (json: Record<string, unknown>) => {
-  delete json.subscription_started_at;
-  delete json.subscriptionStartedAt;
-  delete json.subscription_start_at;
-  delete json.subscriptionStartAt;
-  delete json.subscription_started_at_ms;
-  delete json.subscriptionStartedAtMs;
-  delete json.subscription_period;
-  delete json.subscriptionPeriod;
-  delete json.subscription_expires_at;
-  delete json.subscriptionExpiresAt;
-  delete json.subscription_expires_at_ms;
-  delete json.subscriptionExpiresAtMs;
-  delete json.subscription_remaining_minutes;
-  delete json.subscriptionRemainingMinutes;
-  delete json.subscription_expired;
-  delete json.subscriptionExpired;
-};
-
-const mergeSavedSubscriptionFields = (
-  file: AuthFileItem,
-  json: Record<string, unknown>,
-): AuthFileItem => {
-  const next = { ...file };
-  const startedAt = readSubscriptionStartValue(json);
-
-  delete next.subscription_started_at;
-  delete next.subscriptionStartedAt;
-  delete next.subscription_start_at;
-  delete next.subscriptionStartAt;
-  delete next.subscription_started_at_ms;
-  delete next.subscriptionStartedAtMs;
-  delete next.subscription_period;
-  delete next.subscriptionPeriod;
-  delete next.subscription_expires_at;
-  delete next.subscriptionExpiresAt;
-  delete next.subscription_expires_at_ms;
-  delete next.subscriptionExpiresAtMs;
-  delete next.subscription_remaining_minutes;
-  delete next.subscriptionRemainingMinutes;
-  delete next.subscription_expired;
-  delete next.subscriptionExpired;
-
-  if (typeof startedAt === "string" && startedAt.trim()) {
-    next.subscription_started_at = startedAt;
-    next.subscription_period = normalizeAuthFileSubscriptionPeriod(
-      json.subscription_period ?? json.subscriptionPeriod,
-    );
-  }
-
-  return next;
-};
-
 const mergeSavedCodexOAuthAdmissionFields = (
   file: AuthFileItem,
   editor: CodexOAuthAdmissionEditorState,
@@ -328,17 +264,6 @@ export function useAuthFilesDetailEditors(
     );
   const [xaiEndpointEditor, setXAIEndpointEditor] = useState<XAIEndpointEditorState>(() =>
     createXAIEndpointEditorState(),
-  );
-
-  const applySavedAuthFilePatch = useCallback(
-    (fileName: string, json: Record<string, unknown>) => {
-      const applyPatch = (file: AuthFileItem): AuthFileItem =>
-        file.name === fileName ? mergeSavedSubscriptionFields(file, json) : file;
-
-      setFiles?.((prev) => prev.map(applyPatch));
-      setDetailFile((prev) => (prev && prev.name === fileName ? applyPatch(prev) : prev));
-    },
-    [setFiles],
   );
 
   const loadModelsForDetail = useCallback(
@@ -760,8 +685,6 @@ export function useAuthFilesDetailEditors(
         prefix: "",
         proxyUrl: "",
         proxyId: "",
-        subscriptionStartedAt: "",
-        subscriptionPeriod: "monthly",
       });
 
       try {
@@ -793,12 +716,6 @@ export function useAuthFilesDetailEditors(
         const prefix = typeof json.prefix === "string" ? json.prefix : "";
         const proxyUrl = typeof json.proxy_url === "string" ? json.proxy_url : "";
         const proxyId = typeof json.proxy_id === "string" ? json.proxy_id : "";
-        const subscriptionStartedAt = dateLikeToDateTimeLocalInput(
-          readSubscriptionStartValue(json),
-        );
-        const subscriptionPeriod = normalizeAuthFileSubscriptionPeriod(
-          json.subscription_period ?? json.subscriptionPeriod,
-        );
 
         setPrefixProxyEditor((prev) => ({
           ...prev,
@@ -807,8 +724,6 @@ export function useAuthFilesDetailEditors(
           prefix,
           proxyUrl,
           proxyId,
-          subscriptionStartedAt,
-          subscriptionPeriod,
           error: null,
         }));
       } catch (err: unknown) {
@@ -1106,26 +1021,16 @@ export function useAuthFilesDetailEditors(
       typeof prefixProxyEditor.json.proxy_url === "string" ? prefixProxyEditor.json.proxy_url : "";
     const originalProxyId =
       typeof prefixProxyEditor.json.proxy_id === "string" ? prefixProxyEditor.json.proxy_id : "";
-    const originalSubscriptionStartedAt = dateLikeToDateTimeLocalInput(
-      readSubscriptionStartValue(prefixProxyEditor.json),
-    );
-    const originalSubscriptionPeriod = normalizeAuthFileSubscriptionPeriod(
-      prefixProxyEditor.json.subscription_period ?? prefixProxyEditor.json.subscriptionPeriod,
-    );
     return (
       originalPrefix !== prefixProxyEditor.prefix ||
       originalProxyUrl !== prefixProxyEditor.proxyUrl ||
-      originalProxyId !== prefixProxyEditor.proxyId ||
-      originalSubscriptionStartedAt !== prefixProxyEditor.subscriptionStartedAt ||
-      originalSubscriptionPeriod !== prefixProxyEditor.subscriptionPeriod
+      originalProxyId !== prefixProxyEditor.proxyId
     );
   }, [
     prefixProxyEditor.json,
     prefixProxyEditor.prefix,
     prefixProxyEditor.proxyId,
     prefixProxyEditor.proxyUrl,
-    prefixProxyEditor.subscriptionPeriod,
-    prefixProxyEditor.subscriptionStartedAt,
   ]);
 
   const prefixProxyUpdatedText = useMemo(() => {
@@ -1144,39 +1049,18 @@ export function useAuthFilesDetailEditors(
     if (proxyId) next.proxy_id = proxyId;
     else delete next.proxy_id;
 
-    removeSubscriptionFields(next);
-    const subscriptionStartedAt = prefixProxyEditor.subscriptionStartedAt.trim();
-    if (subscriptionStartedAt) {
-      const isoValue = dateTimeLocalInputToIso(subscriptionStartedAt);
-      if (isoValue) {
-        next.subscription_started_at = isoValue;
-        next.subscription_period = prefixProxyEditor.subscriptionPeriod;
-      }
-    }
-
+    // Subscription is provider-asserted (shared status); never write tenant overrides here.
     return JSON.stringify(next, null, 2);
   }, [
     prefixProxyEditor.json,
     prefixProxyEditor.prefix,
     prefixProxyEditor.proxyId,
     prefixProxyEditor.proxyUrl,
-    prefixProxyEditor.subscriptionPeriod,
-    prefixProxyEditor.subscriptionStartedAt,
   ]);
 
   const savePrefixProxy = useCallback(async () => {
     if (!prefixProxyEditor.json) return;
     if (!prefixProxyDirty) return;
-    if (
-      prefixProxyEditor.subscriptionStartedAt.trim() &&
-      dateTimeLocalInputToIso(prefixProxyEditor.subscriptionStartedAt) === null
-    ) {
-      notify({
-        type: "error",
-        message: t("auth_files.subscription_started_at_invalid"),
-      });
-      return;
-    }
 
     const payload = prefixProxyUpdatedText;
     const fileSize = new Blob([payload]).size;
@@ -1196,7 +1080,6 @@ export function useAuthFilesDetailEditors(
       const file = new File([payload], name, { type: "application/json" });
       await authFilesApi.upload(file);
       const parsedPayload = JSON.parse(payload) as Record<string, unknown>;
-      applySavedAuthFilePatch(name, parsedPayload);
       notify({ type: "success", message: t("auth_files.saved") });
       setPrefixProxyEditor((prev) => ({
         ...prev,
@@ -1211,7 +1094,7 @@ export function useAuthFilesDetailEditors(
       setDetailText((prev) => (name && detailFile?.name === name ? payload : prev));
       setDetailOpen(false);
       setDetailTab("fields");
-      void loadAll().finally(() => applySavedAuthFilePatch(name, parsedPayload));
+      void loadAll();
     } catch (err: unknown) {
       notify({
         type: "error",
@@ -1220,14 +1103,12 @@ export function useAuthFilesDetailEditors(
       setPrefixProxyEditor((prev) => ({ ...prev, saving: false }));
     }
   }, [
-    applySavedAuthFilePatch,
     detailFile?.name,
     loadAll,
     notify,
     prefixProxyDirty,
     prefixProxyEditor.fileName,
     prefixProxyEditor.json,
-    prefixProxyEditor.subscriptionStartedAt,
     prefixProxyUpdatedText,
     t,
   ]);

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, useMemo, useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertTriangle,
@@ -197,6 +197,17 @@ export function useAuthFilesFilesPresentation({
   setFileEnabled,
   usageIndex,
 }: UseAuthFilesFilesPresentationOptions) {
+  // Sticky last-good plan tier so PRO / PRO 5X / PRO 20X do not flash on partial refresh.
+  const stickyDisplayPlanRef = useRef<Map<string, string>>(new Map());
+  const resolveStickyDisplayPlanType = useCallback(
+    (file: AuthFileItem, quotaState?: QuotaState | null, cycleStats?: AuthFileCycleBudgetStats | null) => {
+      const previous = stickyDisplayPlanRef.current.get(file.name) ?? null;
+      const next = resolveAuthFileDisplayPlanType(file, quotaState, cycleStats, previous);
+      if (next) stickyDisplayPlanRef.current.set(file.name, next);
+      return next;
+    },
+    [],
+  );
   const { t } = useTranslation();
 
   const translateQuotaText = useCallback(
@@ -737,7 +748,7 @@ export function useAuthFilesFilesPresentation({
           const badgeClass = TYPE_BADGE_CLASSES[typeKey] ?? TYPE_BADGE_CLASSES.unknown;
           const authIndex = normalizeAuthIndexValue(file.auth_index ?? file.authIndex);
           const basePlanType = resolveAuthFilePlanType(file, quotaByFileName[file.name]);
-          const planType = resolveAuthFileDisplayPlanType(
+          const planType = resolveStickyDisplayPlanType(
             file,
             quotaByFileName[file.name],
             authIndex ? cycleBudgetByAuthIndex[authIndex] : null,
@@ -1125,6 +1136,7 @@ export function useAuthFilesFilesPresentation({
     quotaProgressCircle,
     refreshQuota,
     requestResetCredit,
+    resolveStickyDisplayPlanType,
     renderQuotaErrorBadge,
     renderRestrictionBadges,
     renderClaudeOAuthHealthBadges,
@@ -1146,6 +1158,7 @@ export function useAuthFilesFilesPresentation({
   return {
     translateQuotaText,
     formatPlanTypeLabel,
+    resolveStickyDisplayPlanType,
     renderRestrictionBadges,
     renderClaudeOAuthHealthBadges,
     renderSubscriptionBadge,

--- a/pages/auth-files/hooks/useAuthFilesModelOwnerGroups.ts
+++ b/pages/auth-files/hooks/useAuthFilesModelOwnerGroups.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { modelsApi } from "@code-proxy/api-client";
 import type {
@@ -76,9 +76,26 @@ export function useAuthFilesModelOwnerGroups() {
   const [modelOwnerByAuthGroup, setModelOwnerByAuthGroup] = useState<AuthFilesModelOwnerGroupMap>(
     {},
   );
+  const hasLoadedRef = useRef(false);
 
-  const loadModelOwnerGroups = useCallback(async () => {
-    setModelOwnerGroupsLoading(true);
+  const sameGroups = (
+    a: AuthFileModelOwnerGroup[],
+    b: AuthFileModelOwnerGroup[],
+  ): boolean => {
+    if (a.length !== b.length) return false;
+    return a.every((group, index) => {
+      const other = b[index];
+      if (!other) return false;
+      if (group.value !== other.value || group.label !== other.label) return false;
+      if (group.models.length !== other.models.length) return false;
+      return group.models.every((model, modelIndex) => model.id === other.models[modelIndex]?.id);
+    });
+  };
+
+  const loadModelOwnerGroups = useCallback(async (options?: { silent?: boolean }) => {
+    // Keep the green owner chip / existing lists stable while revalidating.
+    const silent = options?.silent === true || hasLoadedRef.current;
+    if (!silent) setModelOwnerGroupsLoading(true);
     try {
       const [models, presets, mappings] = await Promise.all([
         modelsApi.getModelConfigs("library"),
@@ -86,15 +103,16 @@ export function useAuthFilesModelOwnerGroups() {
         modelsApi.getAuthGroupModelOwnerMappingMap(),
       ]);
       const groups = buildModelOwnerGroups(models, presets);
-      setModelOwnerGroups(groups);
+      setModelOwnerGroups((current) => (sameGroups(current, groups) ? current : groups));
       setModelOwnerByAuthGroup((current) => (sameMap(current, mappings) ? current : mappings));
+      hasLoadedRef.current = true;
     } catch (err: unknown) {
       notify({
         type: "error",
         message: err instanceof Error ? err.message : t("auth_files.failed_get_model_owners"),
       });
     } finally {
-      setModelOwnerGroupsLoading(false);
+      if (!silent) setModelOwnerGroupsLoading(false);
     }
   }, [notify, t]);
 

--- a/pages/auth-files/hooks/useAuthFilesStatusState.ts
+++ b/pages/auth-files/hooks/useAuthFilesStatusState.ts
@@ -468,7 +468,21 @@ export function useAuthFilesStatusState({
             changed = true;
           }
           for (const authIndex of group.authIndexes) {
-            next[authIndex] = cycle;
+            const previous = next[authIndex];
+            // Keep budget fields when partial payload omits them — plan tier (PRO 5X/20X)
+            // and other cycle-derived badges depend on these not flashing empty.
+            next[authIndex] = {
+              calls: cycle.calls,
+              cycleCostTotal:
+                typeof cycle.cycleCostTotal === "number" && Number.isFinite(cycle.cycleCostTotal)
+                  ? cycle.cycleCostTotal
+                  : (previous?.cycleCostTotal ?? null),
+              weeklyQuotaUsedPercent:
+                typeof cycle.weeklyQuotaUsedPercent === "number" &&
+                Number.isFinite(cycle.weeklyQuotaUsedPercent)
+                  ? cycle.weeklyQuotaUsedPercent
+                  : (previous?.weeklyQuotaUsedPercent ?? null),
+            };
           }
         }
         return next;
@@ -488,6 +502,15 @@ export function useAuthFilesStatusState({
                 )
               : undefined);
           if (!sourcePoint) continue;
+          // Ignore empty usage shells so success-rate / total do not flash to 0.
+          if (
+            !(
+              (typeof sourcePoint.requests === "number" && sourcePoint.requests > 0) ||
+              (typeof sourcePoint.failed === "number" && sourcePoint.failed > 0)
+            )
+          ) {
+            continue;
+          }
           for (const authIndex of group.authIndexes) {
             if (seen.has(authIndex)) continue;
             seen.add(authIndex);
@@ -519,17 +542,43 @@ export function useAuthFilesStatusState({
         for (const name of group.names) {
           const file = filesForMerge.find((item) => item.name === name);
           const hasPrivatePlan = Boolean(file?.plan_type ?? file?.planType);
-          patchAuthFileByName(name, {
-            account_status_scope: group.account.status_scope,
-            subject_scope: group.account.subject_scope,
-            share_eligible: group.account.share_eligible,
-            usage_history_complete: group.account.usage?.history_complete,
-            usage_projected_since: group.account.usage?.projected_since,
-            shared_subscription_started_at: group.account.subscription_started_at,
-            shared_subscription_expires_at: group.account.subscription_expires_at,
-            shared_subscription_source: group.account.subscription_source,
-            ...(!hasPrivatePlan && planType ? { plan_type: planType, planType } : {}),
-          });
+          // Partial refresh: only write subscription / scope / plan when present.
+          // Empty/null must not wipe known card badges (remaining days, plan, scope).
+          const started = group.account.subscription_started_at;
+          const expires = group.account.subscription_expires_at;
+          const source = group.account.subscription_source;
+          const filePatch: Partial<AuthFileItem> = {};
+          if (group.account.status_scope) {
+            filePatch.account_status_scope = group.account.status_scope;
+          }
+          if (group.account.subject_scope) {
+            filePatch.subject_scope = group.account.subject_scope;
+          }
+          if (typeof group.account.share_eligible === "boolean") {
+            filePatch.share_eligible = group.account.share_eligible;
+          }
+          if (typeof group.account.usage?.history_complete === "boolean") {
+            filePatch.usage_history_complete = group.account.usage.history_complete;
+          }
+          if (group.account.usage?.projected_since) {
+            filePatch.usage_projected_since = group.account.usage.projected_since;
+          }
+          if (typeof started === "string" && started.trim()) {
+            filePatch.shared_subscription_started_at = started;
+          }
+          if (typeof expires === "string" && expires.trim()) {
+            filePatch.shared_subscription_expires_at = expires;
+          }
+          if (typeof source === "string" && source.trim()) {
+            filePatch.shared_subscription_source = source;
+          }
+          if (!hasPrivatePlan && planType) {
+            filePatch.plan_type = planType;
+            filePatch.planType = planType;
+          }
+          if (Object.keys(filePatch).length > 0) {
+            patchAuthFileByName(name, filePatch);
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- 移除 AI 账号「字段」里的手工订阅开始时间/周期编辑，订阅只走 provider 自动 claims（shared status）。
- 局部刷新时不再用空字段冲掉已有订阅/计划/用量/scope，避免「剩余 X 天」、PRO/PRO 5X/PRO 20X、成功率等徽章闪跳。
- list/loadAll 与 model owner（顶部绿点 Codex）刷新保留内存态，避免整页闪。

## Test plan
- [x] vitest: auth-files-helpers / status batch / detail modal / subscription-related files-table
- [x] lint + admin-panel build
- [ ] 管理端卡片：刷新单卡/自动刷新后订阅剩余与计划徽章不闪、不连带清其它卡