### PR TITLE
fix(apikey-lookup): hide channel column and filter

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -338,6 +338,7 @@ export function RequestLogFacetFilters({
   onModelsClear,
   onChannelsClear,
   onStatusesClear,
+  hideChannel = false,
 }: {
   modelOptions: SearchableCheckboxMultiSelectOption[];
   channelOptions: SearchableCheckboxMultiSelectOption[];
@@ -351,6 +352,7 @@ export function RequestLogFacetFilters({
   onModelsClear: () => void;
   onChannelsClear: () => void;
   onStatusesClear: () => void;
+  hideChannel?: boolean;
 }) {
   const { t } = useTranslation();
   const statusChangeAdapter = useMemo(
@@ -390,33 +392,35 @@ export function RequestLogFacetFilters({
           emptySelectionLabel={t("request_logs.none_selected")}
         />
       </div>
-      <div className="w-full min-[480px]:w-auto sm:w-[180px]">
-        <SearchableCheckboxMultiSelect
-          value={selectedChannels ?? []}
-          onChange={onChannelsChange}
-          options={channelOptions}
-          placeholder={t("request_logs.all_channels_placeholder")}
-          searchPlaceholder={t("request_logs.search_channels")}
-          selectFilteredLabel={t("request_logs.select_filtered")}
-          deselectFilteredLabel={t("request_logs.deselect_filtered")}
-          selectedCountLabel={(count: number) => t("request_logs.selected_count", { count })}
-          noResultsLabel={t("request_logs.no_filter_results")}
-          aria-label={t("request_logs.filter_channel")}
-          clearLabel={t("request_logs.clear_channel_filter")}
-          onClear={onChannelsClear}
-          showClearButton
-          size="sm"
-          emptyValueMeansAllSelected
-          emptyValueRepresentsAllSelected={selectedChannels === null}
-          showFilteredToggleWithoutQuery={false}
-          applyMode="manual"
-          applyLabel={t("request_logs.apply_filters")}
-          cancelLabel={t("common.cancel")}
-          selectAllLabel={t("request_logs.select_all")}
-          deselectAllLabel={t("request_logs.deselect_all")}
-          emptySelectionLabel={t("request_logs.none_selected")}
-        />
-      </div>
+      {!hideChannel ? (
+        <div className="w-full min-[480px]:w-auto sm:w-[180px]">
+          <SearchableCheckboxMultiSelect
+            value={selectedChannels ?? []}
+            onChange={onChannelsChange}
+            options={channelOptions}
+            placeholder={t("request_logs.all_channels_placeholder")}
+            searchPlaceholder={t("request_logs.search_channels")}
+            selectFilteredLabel={t("request_logs.select_filtered")}
+            deselectFilteredLabel={t("request_logs.deselect_filtered")}
+            selectedCountLabel={(count: number) => t("request_logs.selected_count", { count })}
+            noResultsLabel={t("request_logs.no_filter_results")}
+            aria-label={t("request_logs.filter_channel")}
+            clearLabel={t("request_logs.clear_channel_filter")}
+            onClear={onChannelsClear}
+            showClearButton
+            size="sm"
+            emptyValueMeansAllSelected
+            emptyValueRepresentsAllSelected={selectedChannels === null}
+            showFilteredToggleWithoutQuery={false}
+            applyMode="manual"
+            applyLabel={t("request_logs.apply_filters")}
+            cancelLabel={t("common.cancel")}
+            selectAllLabel={t("request_logs.select_all")}
+            deselectAllLabel={t("request_logs.deselect_all")}
+            emptySelectionLabel={t("request_logs.none_selected")}
+          />
+        </div>
+      ) : null}
       <div className="w-full min-[480px]:w-auto sm:w-[150px]">
         <SearchableCheckboxMultiSelect
           value={selectedStatuses ?? []}
@@ -587,12 +591,13 @@ export function buildRequestLogsColumns(
   t: (key: string) => string,
   onContentClick?: (logId: number, tab: "input" | "output") => void,
   onErrorClick?: (logId: number, model: string) => void,
-  options: { identityColumn?: "user" | "key" } = {},
+  options: { identityColumn?: "user" | "key"; hideChannel?: boolean } = {},
 ): RequestLogsTableColumn<RequestLogsRow>[] {
   const apiLabel = t("request_logs.auth_type_api");
   const oauthLabel = t("request_logs.auth_type_oauth");
   const identityColumn = options.identityColumn ?? "user";
-  return [
+  const hideChannel = options.hideChannel === true;
+  const columns: RequestLogsTableColumn<RequestLogsRow>[] = [
     {
       key: "id",
       label: t("request_logs.col_id"),
@@ -621,7 +626,9 @@ export function buildRequestLogsColumns(
         </OverflowTooltip>
       ),
     },
-    {
+  ];
+  if (!hideChannel) {
+    columns.push({
       key: "channelName",
       label: t("request_logs.col_channel"),
       // Wider default so icon + name + auth badge can share the cell; DataTable
@@ -656,7 +663,9 @@ export function buildRequestLogsColumns(
           </OverflowTooltip>
         );
       },
-    },
+    });
+  }
+  columns.push(
     {
       key: "status",
       label: t("request_logs.col_status"),
@@ -905,7 +914,8 @@ export function buildRequestLogsColumns(
           <span className="text-xs text-slate-400 dark:text-white/30">--</span>
         ),
     },
-  ];
+  );
+  return columns;
 }
 
 export function RequestLogsPaginationBar({

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -20,10 +20,6 @@ import {
   type EndUserAPIKey,
   type SavedPortalAccount,
 } from "@code-proxy/api-client";
-import {
-  normalizeChannelOptions,
-  type UsageChannelFilterOption,
-} from "@code-proxy/api-client/endpoints/usage";
 import { resolveLoginErrorMessage } from "../login/loginErrors";
 import { useTheme } from "@code-proxy/ui";
 import { ThemeToggleButton } from "@code-proxy/ui";
@@ -58,7 +54,6 @@ import { useApiKeyLookupCharts } from "./hooks/useApiKeyLookupCharts";
 import type { ChartDataResponse, PublicLogItem, PublicUsageLimits } from "./types";
 import {
   buildRequestLogsColumns,
-  ChannelIdentityLabel,
   formatOptionalRequestLogLatencyMs,
   formatRequestLogLatencyMs,
   normalizeChannelAuthType,
@@ -387,6 +382,7 @@ export function ApiKeyLookupPage() {
     () =>
       buildRequestLogsColumns((key) => t(key), handleContentClick, undefined, {
         identityColumn: "key",
+        hideChannel: true,
       }),
     [t, handleContentClick],
   );
@@ -423,7 +419,6 @@ export function ApiKeyLookupPage() {
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
   const [selectedModels, setSelectedModels] = useState<MultiSelectFilterState<string>>(null);
-  const [selectedChannels, setSelectedChannels] = useState<MultiSelectFilterState<string>>(null);
   const [selectedStatuses, setSelectedStatuses] =
     useState<MultiSelectFilterState<StatusFilterValue>>(null);
 
@@ -436,10 +431,8 @@ export function ApiKeyLookupPage() {
   }>({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
   const [filterOptions, setFilterOptions] = useState<{
     models: string[];
-    channels: string[];
-    channel_options: UsageChannelFilterOption[];
     statuses: string[];
-  }>({ models: [], channels: [], channel_options: [], statuses: ["success", "failed"] });
+  }>({ models: [], statuses: ["success", "failed"] });
 
   const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return filterOptions.models.map((model) => ({
@@ -448,37 +441,6 @@ export function ApiKeyLookupPage() {
       searchText: model,
     }));
   }, [filterOptions.models]);
-
-  const channelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
-    const source: UsageChannelFilterOption[] =
-      filterOptions.channel_options.length > 0
-        ? filterOptions.channel_options
-        : filterOptions.channels.map((ch) => ({
-            value: ch,
-            label: ch,
-          }));
-    const apiLabel = t("request_logs.auth_type_api");
-    const oauthLabel = t("request_logs.auth_type_oauth");
-    return source.map((option) => {
-      const provider = String(option.provider ?? "").trim();
-      const authType = String(option.auth_type ?? "").trim();
-      return {
-        value: option.value,
-        label: (
-          <ChannelIdentityLabel
-            name={option.label}
-            provider={option.provider}
-            authType={option.auth_type}
-            apiLabel={apiLabel}
-            oauthLabel={oauthLabel}
-            className="w-full"
-            nameClassName="text-sm font-normal text-inherit"
-          />
-        ),
-        searchText: [option.label, provider, authType, option.value].filter(Boolean).join(" "),
-      };
-    });
-  }, [filterOptions.channel_options, filterOptions.channels, t]);
 
   const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     const statuses =
@@ -499,10 +461,6 @@ export function ApiKeyLookupPage() {
     () => modelOptions.map((option) => option.value),
     [modelOptions],
   );
-  const channelFilterValues = useMemo(
-    () => channelOptions.map((option) => option.value),
-    [channelOptions],
-  );
   const statusFilterValues = useMemo<StatusFilterValue[]>(
     () => toStatusFilterValues(statusOptions.map((option) => option.value)),
     [statusOptions],
@@ -511,10 +469,6 @@ export function ApiKeyLookupPage() {
   const modelFilterParam = useMemo(
     () => toFilterParam(selectedModels, modelFilterValues),
     [modelFilterValues, selectedModels],
-  );
-  const channelFilterParam = useMemo(
-    () => toFilterParam(selectedChannels, channelFilterValues),
-    [channelFilterValues, selectedChannels],
   );
   const statusFilterParam = useMemo(
     () => toFilterParam(selectedStatuses, statusFilterValues),
@@ -527,12 +481,6 @@ export function ApiKeyLookupPage() {
     },
     [modelFilterValues],
   );
-  const handleChannelsChange = useCallback(
-    (value: string[]) => {
-      setSelectedChannels(normalizeFilterSelection(value, channelFilterValues));
-    },
-    [channelFilterValues],
-  );
   const handleStatusesChange = useCallback(
     (value: StatusFilterValue[]) => {
       setSelectedStatuses(normalizeFilterSelection(value, statusFilterValues));
@@ -540,7 +488,6 @@ export function ApiKeyLookupPage() {
     [statusFilterValues],
   );
   const clearModelFilter = useCallback(() => setSelectedModels(null), []);
-  const clearChannelFilter = useCallback(() => setSelectedChannels(null), []);
   const clearStatusFilter = useCallback(() => setSelectedStatuses(null), []);
 
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -574,10 +521,8 @@ export function ApiKeyLookupPage() {
           size: size ?? pageSize,
           days: timeRange,
           models: modelFilterParam.values,
-          channels: channelFilterParam.values,
           statuses: statusFilterParam.values,
           modelsEmpty: modelFilterParam.matchesNone,
-          channelsEmpty: channelFilterParam.matchesNone,
           statusesEmpty: statusFilterParam.matchesNone,
           signal: controller.signal,
         });
@@ -597,11 +542,6 @@ export function ApiKeyLookupPage() {
         );
         setFilterOptions({
           models: resp.filters?.models ?? [],
-          channels: resp.filters?.channels ?? [],
-          channel_options: normalizeChannelOptions(
-            resp.filters?.channel_options,
-            resp.filters?.channels,
-          ),
           statuses: resp.filters?.statuses ?? ["success", "failed"],
         });
         setLastUpdatedAt(Date.now());
@@ -623,7 +563,7 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [channelFilterParam, modelFilterParam, pageSize, statusFilterParam, t, timeRange],
+    [modelFilterParam, pageSize, statusFilterParam, t, timeRange],
   );
 
   // ================================================================
@@ -741,7 +681,7 @@ export function ApiKeyLookupPage() {
     if (usageSubject && activeTab === "logs") {
       fetchLogs(usageSubject, 1);
     }
-  }, [timeRange, selectedModels, selectedChannels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [timeRange, selectedModels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Models fetching ──
   const fetchModelsFn = useCallback(
@@ -834,12 +774,9 @@ export function ApiKeyLookupPage() {
     setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
     setFilterOptions({
       models: [],
-      channels: [],
-      channel_options: [],
       statuses: ["success", "failed"],
     });
     setSelectedModels(null);
-    setSelectedChannels(null);
     setSelectedStatuses(null);
 
     setQueriedKey("");
@@ -1013,12 +950,9 @@ export function ApiKeyLookupPage() {
       setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
       setFilterOptions({
         models: [],
-        channels: [],
-        channel_options: [],
         statuses: ["success", "failed"],
       });
       setSelectedModels(null);
-      setSelectedChannels(null);
       setSelectedStatuses(null);
       setQuotaLimits(null);
 
@@ -1459,16 +1393,12 @@ export function ApiKeyLookupPage() {
                 <PublicLogsSection
                   t={t}
                   modelOptions={modelOptions}
-                  channelOptions={channelOptions}
                   statusOptions={statusOptions}
                   selectedModels={selectedModels}
-                  selectedChannels={selectedChannels}
                   selectedStatuses={selectedStatuses}
                   onModelsChange={handleModelsChange}
-                  onChannelsChange={handleChannelsChange}
                   onStatusesChange={handleStatusesChange}
                   onModelsClear={clearModelFilter}
-                  onChannelsClear={clearChannelFilter}
                   onStatusesClear={clearStatusFilter}
                   stats={stats}
                   lastUpdatedText={lastUpdatedText}

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -372,7 +372,7 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.queryByText(/^default$|^默认$/i)).not.toBeInTheDocument();
   });
 
-  test("renders channel filter options with provider icon and auth badge", async () => {
+  test("hides channel column and channel filter on public request logs", async () => {
     window.history.replaceState({}, "", "/manage/apikey-lookup?api_key=sk-restored-key");
     mocks.fetchPublicLogs.mockResolvedValueOnce({
       items: [
@@ -434,17 +434,9 @@ describe("ApiKeyLookupPage", () => {
       expect(mocks.fetchPublicLogs).toHaveBeenCalled();
     });
 
-    // Table channel cell also uses ChannelIdentityLabel (icon + OAuth badge).
-    expect(await screen.findByText("owner@example.com")).toBeInTheDocument();
-    expect(screen.getByText("OAuth")).toBeInTheDocument();
-
-    const channelFilter = screen.getByRole("combobox", { name: /filter by channel/i });
-    await userEvent.click(channelFilter);
-    // Filter option value comes from channel_options, not the display label alone.
-    expect(
-      await screen.findByRole("option", { name: /owner@example.com/i }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText("OAuth").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("columnheader", { name: /channel|渠道/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: /filter by channel/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
   });
 
   test("loads public logs only after switching to the request logs tab", async () => {
@@ -519,7 +511,7 @@ describe("ApiKeyLookupPage", () => {
       );
     });
     expect(screen.getAllByText(/response metrics/i).length).toBeGreaterThan(0);
-    expect(await screen.findByText("Codex 主渠道")).toBeInTheDocument();
+    expect(screen.queryByText("Codex 主渠道")).not.toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: /key name|Key 名称/i })).toBeInTheDocument();
     expect(screen.queryByText("Alice")).not.toBeInTheDocument();
     expect(screen.getByText("Laptop")).toBeInTheDocument();
@@ -581,24 +573,21 @@ describe("ApiKeyLookupPage", () => {
     expect(await screen.findByRole("combobox", { name: /filter by model/i })).toHaveTextContent(
       /all models/i,
     );
-    const channelFilter = screen.getByRole("combobox", {
-      name: /filter by channel/i,
-    });
-    expect(channelFilter).toHaveTextContent(/all channels/i);
+    expect(screen.queryByRole("combobox", { name: /filter by channel/i })).not.toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: /filter by status/i })).toHaveTextContent(
       /all status/i,
     );
 
-    await userEvent.click(channelFilter);
-    await userEvent.click(await screen.findByRole("option", { name: "OpenCode" }));
+    await userEvent.click(screen.getByRole("combobox", { name: /filter by status/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /failed|失败/i }));
     await userEvent.click(screen.getByRole("button", { name: /apply filters/i }));
 
     await waitFor(() => {
       expect(mocks.fetchPublicLogs).toHaveBeenLastCalledWith(
         expect.objectContaining({
           apiKey: "sk-restored-key",
-          channels: ["Codex 主渠道"],
-          channelsEmpty: false,
+          statuses: ["success"],
+          statusesEmpty: false,
         }),
       );
     });

--- a/pages/api-key-lookup/components/PublicLogsSection.tsx
+++ b/pages/api-key-lookup/components/PublicLogsSection.tsx
@@ -15,15 +15,11 @@ export function PublicLogsSection({
   t,
   statusOptions,
   modelOptions,
-  channelOptions,
   selectedModels,
-  selectedChannels,
   selectedStatuses,
   onModelsChange,
-  onChannelsChange,
   onStatusesChange,
   onModelsClear,
-  onChannelsClear,
   onStatusesClear,
   stats,
   lastUpdatedText,
@@ -39,16 +35,12 @@ export function PublicLogsSection({
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   modelOptions: SearchableCheckboxMultiSelectOption[];
-  channelOptions: SearchableCheckboxMultiSelectOption[];
   statusOptions: SearchableCheckboxMultiSelectOption[];
   selectedModels: MultiSelectFilterState<string>;
-  selectedChannels: MultiSelectFilterState<string>;
   selectedStatuses: MultiSelectFilterState<StatusFilterValue>;
   onModelsChange: (value: string[]) => void;
-  onChannelsChange: (value: string[]) => void;
   onStatusesChange: (value: StatusFilterValue[]) => void;
   onModelsClear: () => void;
-  onChannelsClear: () => void;
   onStatusesClear: () => void;
   stats: {
     total: number;
@@ -75,17 +67,18 @@ export function PublicLogsSection({
             <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:gap-2">
               <RequestLogFacetFilters
                 modelOptions={modelOptions}
-                channelOptions={channelOptions}
+                channelOptions={[]}
                 statusOptions={statusOptions}
                 selectedModels={selectedModels}
-                selectedChannels={selectedChannels}
+                selectedChannels={null}
                 selectedStatuses={selectedStatuses}
                 onModelsChange={onModelsChange}
-                onChannelsChange={onChannelsChange}
+                onChannelsChange={() => {}}
                 onStatusesChange={onStatusesChange}
                 onModelsClear={onModelsClear}
-                onChannelsClear={onChannelsClear}
+                onChannelsClear={() => {}}
                 onStatusesClear={onStatusesClear}
+                hideChannel
               />
             </div>
 

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -141,4 +141,11 @@ describe("requestLogsShared", () => {
     expect(screen.getByText("Laptop")).toBeInTheDocument();
     expect(screen.queryByText("Alice")).not.toBeInTheDocument();
   });
+
+  test("can omit the channel column for public api key lookup logs", () => {
+    const keys = buildRequestLogsColumns((key) => key, undefined, undefined, {
+      hideChannel: true,
+    }).map((column) => column.key);
+    expect(keys).not.toContain("channelName");
+  });
 });


### PR DESCRIPTION
## Summary
- Hide channel column and channel multi-select on `/manage/apikey-lookup` request logs.
- Keep admin request logs channel column/filter unchanged via optional `hideChannel`.
- Update unit tests accordingly.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full test:ci, build, bundle:diff, critical e2e)
- [x] `bun run test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx pages/monitor/__tests__/requestLogsShared.test.ts`