### PR TITLE
fix(auth-files): restore manual subscription override over JWT claims

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -1173,16 +1173,26 @@ export const normalizeAuthFileSubscriptionPeriod = (value: unknown): AuthFileSub
   return "monthly";
 };
 
-// Prefer provider-asserted shared subscription; tenant metadata is legacy fallback only.
+// Tenant manual override first (auth-file metadata); shared provider claims are fallback.
+// JWT chatgpt_subscription_* can lag after renewals, so manual must win when set.
+const hasTenantSubscriptionOverride = (file: AuthFileItem): boolean =>
+  parseDateLikeMs(file.subscription_started_at_ms ?? file.subscriptionStartedAtMs) !== null ||
+  parseDateLikeMs(
+    file.subscription_started_at ??
+      file.subscriptionStartedAt ??
+      file.subscription_start_at ??
+      file.subscriptionStartAt,
+  ) !== null;
+
 const resolveSubscriptionStartMs = (file: AuthFileItem): number | null =>
-  parseDateLikeMs(file.shared_subscription_started_at) ??
   parseDateLikeMs(file.subscription_started_at_ms ?? file.subscriptionStartedAtMs) ??
   parseDateLikeMs(
     file.subscription_started_at ??
       file.subscriptionStartedAt ??
       file.subscription_start_at ??
       file.subscriptionStartAt,
-  );
+  ) ??
+  parseDateLikeMs(file.shared_subscription_started_at);
 
 const addCalendarMonths = (startMs: number, months: number): number | null => {
   const date = new Date(startMs);
@@ -1202,22 +1212,45 @@ export const resolveAuthFileSubscriptionStatus = (
   file: AuthFileItem,
   nowMs = Date.now(),
 ): AuthFileSubscriptionStatus | null => {
-  const sharedExpiresAtMs = parseDateLikeMs(file.shared_subscription_expires_at);
   const startedAtMs = resolveSubscriptionStartMs(file);
-  // Auto path: provider shared expires alone is enough for the remaining badge.
-  if (startedAtMs === null && sharedExpiresAtMs === null) return null;
+  if (startedAtMs === null) {
+    // Shared expires alone still enough when no start is known.
+    const sharedOnly = parseDateLikeMs(file.shared_subscription_expires_at);
+    if (sharedOnly === null) return null;
+    const period = normalizeAuthFileSubscriptionPeriod(
+      file.subscription_period ?? file.subscriptionPeriod,
+    );
+    const diffMs = sharedOnly - nowMs;
+    const remainingDays =
+      diffMs === 0
+        ? 0
+        : diffMs > 0
+          ? Math.ceil(diffMs / DAY_MS)
+          : -Math.ceil(Math.abs(diffMs) / DAY_MS);
+    const expired = remainingDays <= 0;
+    const tone = expired ? "expired" : remainingDays <= 5 ? "urgent" : "active";
+    return {
+      startedAtMs: sharedOnly,
+      startedAtText: new Date(sharedOnly).toLocaleString(),
+      expiresAtMs: sharedOnly,
+      expiresAtText: new Date(sharedOnly).toLocaleString(),
+      remainingDays,
+      expired,
+      period,
+      tone,
+    };
+  }
 
   const period = normalizeAuthFileSubscriptionPeriod(
     file.subscription_period ?? file.subscriptionPeriod,
   );
+  const sharedExpiresAtMs = parseDateLikeMs(file.shared_subscription_expires_at);
   const expiresAtMs =
-    sharedExpiresAtMs !== null
+    !hasTenantSubscriptionOverride(file) && sharedExpiresAtMs !== null
       ? sharedExpiresAtMs
-      : startedAtMs === null
-        ? null
-        : addCalendarMonths(startedAtMs, period === "yearly" ? 12 : 1);
+      : addCalendarMonths(startedAtMs, period === "yearly" ? 12 : 1);
   if (expiresAtMs === null) return null;
-  const effectiveStartedAtMs = startedAtMs ?? expiresAtMs;
+  const effectiveStartedAtMs = startedAtMs;
 
   const diffMs = expiresAtMs - nowMs;
   const remainingDays =
@@ -1950,6 +1983,8 @@ export type PrefixProxyEditorState = {
   prefix: string;
   proxyUrl: string;
   proxyId: string;
+  subscriptionStartedAt: string;
+  subscriptionPeriod: AuthFileSubscriptionPeriod;
 };
 
 export type AuthFilesGroupOverview = {

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -53,6 +53,8 @@ const basePrefixProxyEditor: DetailModalProps["prefixProxyEditor"] = {
   prefix: "team-a",
   proxyUrl: "http://127.0.0.1:7890",
   proxyId: "primary",
+  subscriptionStartedAt: "2026-04-01T08:30",
+  subscriptionPeriod: "monthly",
 };
 
 const baseCodexOAuthAdmissionEditor: DetailModalProps["codexOAuthAdmissionEditor"] = {
@@ -916,7 +918,7 @@ describe("AuthFileDetailModal", () => {
     expect(within(grid).getByPlaceholderText("e.g. http://127.0.0.1:7890")).toHaveValue(
       "http://127.0.0.1:7890",
     );
-    expect(within(grid).queryByLabelText(/Subscription start/)).not.toBeInTheDocument();
+    expect(within(grid).getByLabelText(/Subscription start/)).toBeInTheDocument();
     expect(screen.queryByTestId("auth-file-fields-preview")).not.toBeInTheDocument();
     expect(screen.queryByText(/"prefix"/)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -157,6 +157,21 @@ vi.mock("@code-proxy/ui", async (importOriginal) => ({
   EChart: ({ className }: { className?: string }) => <div className={className}>chart</div>,
 }));
 
+const padDatePart = (value: number): string => String(value).padStart(2, "0");
+
+const toDateTimeLocalInput = (date: Date): string =>
+  [
+    date.getFullYear(),
+    "-",
+    padDatePart(date.getMonth() + 1),
+    "-",
+    padDatePart(date.getDate()),
+    "T",
+    padDatePart(date.getHours()),
+    ":",
+    padDatePart(date.getMinutes()),
+  ].join("");
+
 
 const decodeBase64UrlJson = (part: string): Record<string, unknown> =>
   JSON.parse(Buffer.from(part, "base64url").toString("utf8")) as Record<string, unknown>;
@@ -3266,7 +3281,7 @@ describe("AuthFilesPage files table", () => {
     expect(screen.getByText("<1d left")).toBeInTheDocument();
   });
 
-  test("does not show manual subscription editor in auth fields", async () => {
+  test("saves subscription start and period from the auth fields editor", async () => {
     mocks.list.mockImplementation(async () => ({
       files: [
         {
@@ -3277,9 +3292,6 @@ describe("AuthFilesPage files table", () => {
           size: 1024,
           modified: Date.now(),
           disabled: false,
-          shared_subscription_started_at: "2026-07-01T00:00:00Z",
-          shared_subscription_expires_at: "2026-08-01T00:00:00Z",
-          shared_subscription_source: "signed_claims",
         },
       ],
     }));
@@ -3289,6 +3301,7 @@ describe("AuthFilesPage files table", () => {
           type: "codex",
           subscription_started_at: "2027-01-02T03:04:00Z",
           subscription_period: "monthly",
+          subscription_expires_at: "2099-01-01T00:00:00Z",
         },
         null,
         2,
@@ -3311,10 +3324,19 @@ describe("AuthFilesPage files table", () => {
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     fireEvent.click(await screen.findByRole("tab", { name: "Fields" }));
 
-    expect(screen.queryByLabelText("Subscription start date")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Subscription cycle")).not.toBeInTheDocument();
-    expect(screen.queryByText("Subscription start date")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    const input = await screen.findByLabelText("Subscription start date");
+    fireEvent.change(input, { target: { value: "2027-01-03T04:05" } });
+    fireEvent.click(screen.getByRole("combobox", { name: "Subscription cycle" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Yearly" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mocks.upload).toHaveBeenCalledTimes(1));
+    const uploadCalls = mocks.upload.mock.calls as unknown as [[File]];
+    const uploaded = uploadCalls[0][0];
+    const uploadedJson = JSON.parse(await uploaded.text()) as Record<string, unknown>;
+    expect(uploadedJson.subscription_started_at).toBe(new Date("2027-01-03T04:05").toISOString());
+    expect(uploadedJson.subscription_period).toBe("yearly");
+    expect(uploadedJson.subscription_expires_at).toBeUndefined();
   });
 
   test("shows card subscription badge from shared provider subscription", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -1062,23 +1062,24 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
     );
   });
 
-  test("prefers shared provider subscription over tenant metadata", () => {
+  test("prefers tenant manual subscription override over shared provider claims", () => {
+    // Manual override exists so stale JWT claims (e.g. expired until 7/11 after renew) lose.
     const status = resolveAuthFileSubscriptionStatus(
       {
         name: "codex.json",
-        subscription_started_at: "2026-01-01T00:00:00.000Z",
+        subscription_started_at: "2026-07-11T00:00:00.000Z",
         subscription_period: "monthly",
-        shared_subscription_started_at: "2026-07-01T00:00:00.000Z",
-        shared_subscription_expires_at: "2026-08-01T00:00:00.000Z",
+        shared_subscription_started_at: "2026-06-11T00:00:00.000Z",
+        shared_subscription_expires_at: "2026-07-11T00:00:00.000Z",
         shared_subscription_source: "signed_claims",
       } as AuthFileItem,
-      Date.parse("2026-07-06T00:00:00.000Z"),
+      Date.parse("2026-07-21T00:00:00.000Z"),
     );
     expect(status).toEqual(
       expect.objectContaining({
-        startedAtMs: Date.parse("2026-07-01T00:00:00.000Z"),
-        expiresAtMs: Date.parse("2026-08-01T00:00:00.000Z"),
-        remainingDays: 26,
+        startedAtMs: Date.parse("2026-07-11T00:00:00.000Z"),
+        expiresAtMs: Date.parse("2026-08-11T00:00:00.000Z"),
+        remainingDays: 21,
         expired: false,
         tone: "active",
       }),

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -13,6 +13,7 @@ import { Download, RefreshCw, ShieldCheck } from "lucide-react";
 import type { AuthFileTrendResponse } from "@code-proxy/api-client/endpoints/usage";
 import type {
   AuthFileItem,
+  AuthFileSubscriptionPeriod,
   IdentityFingerprintAccountDetail,
   IdentityFingerprintFieldSource,
 } from "@code-proxy/api-client";
@@ -20,6 +21,7 @@ import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { Button } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
+import { DateTimePicker } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
@@ -275,7 +277,7 @@ export function AuthFileDetailModal({
   xaiEndpointDirty,
   saveXAIEndpoint,
 }: AuthFileDetailModalProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const isIdentityDesktopLayout = useIdentityDesktopLayout();
   const [viewedIdentityProfileKey, setViewedIdentityProfileKey] = useState("");
   const proxyCheckState = useProxyPoolChecks(proxyPoolEntries, open && detailTab === "fields");
@@ -1794,6 +1796,60 @@ export function AuthFileDetailModal({
                               />
                               <p className="text-xs text-slate-500 dark:text-white/55">
                                 {t("auth_files.leave_empty_prefix")}
+                              </p>
+                            </div>
+
+                            <div className="grid gap-2">
+                              <p className="text-xs font-semibold text-slate-700 dark:text-white/75">
+                                {t("auth_files.subscription_started_at_label")}
+                              </p>
+                              <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
+                                <DateTimePicker
+                                  value={prefixProxyEditor.subscriptionStartedAt}
+                                  onChange={(value) => {
+                                    setPrefixProxyEditor((prev) => ({
+                                      ...prev,
+                                      subscriptionStartedAt: value,
+                                    }));
+                                  }}
+                                  aria-label={t("auth_files.subscription_started_at_label")}
+                                  locale={i18n.language}
+                                  labels={{
+                                    picker: t("auth_files.subscription_date_picker"),
+                                    open: t("auth_files.subscription_date_picker_open"),
+                                    previousMonth: t(
+                                      "auth_files.subscription_date_picker_previous_month",
+                                    ),
+                                    nextMonth: t("auth_files.subscription_date_picker_next_month"),
+                                    today: t("auth_files.subscription_date_picker_today"),
+                                    clear: t("auth_files.subscription_date_picker_clear"),
+                                    hour: t("auth_files.subscription_date_picker_hour"),
+                                    minute: t("auth_files.subscription_date_picker_minute"),
+                                  }}
+                                />
+                                <Select
+                                  value={prefixProxyEditor.subscriptionPeriod}
+                                  onChange={(value) =>
+                                    setPrefixProxyEditor((prev) => ({
+                                      ...prev,
+                                      subscriptionPeriod: value as AuthFileSubscriptionPeriod,
+                                    }))
+                                  }
+                                  options={[
+                                    {
+                                      value: "monthly",
+                                      label: t("auth_files.subscription_period_monthly"),
+                                    },
+                                    {
+                                      value: "yearly",
+                                      label: t("auth_files.subscription_period_yearly"),
+                                    },
+                                  ]}
+                                  aria-label={t("auth_files.subscription_period_label")}
+                                />
+                              </div>
+                              <p className="text-xs text-slate-500 dark:text-white/55">
+                                {t("auth_files.subscription_started_at_hint")}
                               </p>
                             </div>
                           </>

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -13,11 +13,14 @@ import type { AuthFileTrendResponse } from "@code-proxy/api-client/endpoints/usa
 import type { AuthFileItem, IdentityFingerprintAccountDetail } from "@code-proxy/api-client";
 import { useToast } from "@code-proxy/ui";
 import {
+  dateLikeToDateTimeLocalInput,
+  dateTimeLocalInputToIso,
   formatFileSize,
   MAX_AUTH_FILE_SIZE,
   canRenameAuthFileChannel,
   normalizeAuthIndexValue,
   normalizeProviderKey,
+  normalizeAuthFileSubscriptionPeriod,
   readAuthFileChannelName,
   resolveFileType,
   type AuthFileModelItem,
@@ -42,6 +45,8 @@ const createPrefixProxyEditorState = (): PrefixProxyEditorState => ({
   prefix: "",
   proxyUrl: "",
   proxyId: "",
+  subscriptionStartedAt: "",
+  subscriptionPeriod: "monthly",
 });
 
 const createChannelEditorState = (): ChannelEditorState => ({
@@ -159,6 +164,65 @@ const buildXAIEndpointEditorState = (file: AuthFileItem): XAIEndpointEditorState
   };
 };
 
+const readSubscriptionStartValue = (json: Record<string, unknown>): unknown =>
+  json.subscription_started_at ??
+  json.subscriptionStartedAt ??
+  json.subscription_start_at ??
+  json.subscriptionStartAt;
+
+const removeSubscriptionFields = (json: Record<string, unknown>) => {
+  delete json.subscription_started_at;
+  delete json.subscriptionStartedAt;
+  delete json.subscription_start_at;
+  delete json.subscriptionStartAt;
+  delete json.subscription_started_at_ms;
+  delete json.subscriptionStartedAtMs;
+  delete json.subscription_period;
+  delete json.subscriptionPeriod;
+  delete json.subscription_expires_at;
+  delete json.subscriptionExpiresAt;
+  delete json.subscription_expires_at_ms;
+  delete json.subscriptionExpiresAtMs;
+  delete json.subscription_remaining_minutes;
+  delete json.subscriptionRemainingMinutes;
+  delete json.subscription_expired;
+  delete json.subscriptionExpired;
+};
+
+const mergeSavedSubscriptionFields = (
+  file: AuthFileItem,
+  json: Record<string, unknown>,
+): AuthFileItem => {
+  const next = { ...file };
+  const startedAt = readSubscriptionStartValue(json);
+
+  delete next.subscription_started_at;
+  delete next.subscriptionStartedAt;
+  delete next.subscription_start_at;
+  delete next.subscriptionStartAt;
+  delete next.subscription_started_at_ms;
+  delete next.subscriptionStartedAtMs;
+  delete next.subscription_period;
+  delete next.subscriptionPeriod;
+  delete next.subscription_expires_at;
+  delete next.subscriptionExpiresAt;
+  delete next.subscription_expires_at_ms;
+  delete next.subscriptionExpiresAtMs;
+  delete next.subscription_remaining_minutes;
+  delete next.subscriptionRemainingMinutes;
+  delete next.subscription_expired;
+  delete next.subscriptionExpired;
+
+  if (typeof startedAt === "string" && startedAt.trim()) {
+    next.subscription_started_at = startedAt;
+    next.subscription_period = normalizeAuthFileSubscriptionPeriod(
+      json.subscription_period ?? json.subscriptionPeriod,
+    );
+  }
+
+  return next;
+};
+
 const mergeSavedCodexOAuthAdmissionFields = (
   file: AuthFileItem,
   editor: CodexOAuthAdmissionEditorState,
@@ -264,6 +328,17 @@ export function useAuthFilesDetailEditors(
     );
   const [xaiEndpointEditor, setXAIEndpointEditor] = useState<XAIEndpointEditorState>(() =>
     createXAIEndpointEditorState(),
+  );
+
+  const applySavedAuthFilePatch = useCallback(
+    (fileName: string, json: Record<string, unknown>) => {
+      const applyPatch = (file: AuthFileItem): AuthFileItem =>
+        file.name === fileName ? mergeSavedSubscriptionFields(file, json) : file;
+
+      setFiles?.((prev) => prev.map(applyPatch));
+      setDetailFile((prev) => (prev && prev.name === fileName ? applyPatch(prev) : prev));
+    },
+    [setFiles],
   );
 
   const loadModelsForDetail = useCallback(
@@ -685,6 +760,8 @@ export function useAuthFilesDetailEditors(
         prefix: "",
         proxyUrl: "",
         proxyId: "",
+        subscriptionStartedAt: "",
+        subscriptionPeriod: "monthly",
       });
 
       try {
@@ -716,6 +793,12 @@ export function useAuthFilesDetailEditors(
         const prefix = typeof json.prefix === "string" ? json.prefix : "";
         const proxyUrl = typeof json.proxy_url === "string" ? json.proxy_url : "";
         const proxyId = typeof json.proxy_id === "string" ? json.proxy_id : "";
+        const subscriptionStartedAt = dateLikeToDateTimeLocalInput(
+          readSubscriptionStartValue(json),
+        );
+        const subscriptionPeriod = normalizeAuthFileSubscriptionPeriod(
+          json.subscription_period ?? json.subscriptionPeriod,
+        );
 
         setPrefixProxyEditor((prev) => ({
           ...prev,
@@ -724,6 +807,8 @@ export function useAuthFilesDetailEditors(
           prefix,
           proxyUrl,
           proxyId,
+          subscriptionStartedAt,
+          subscriptionPeriod,
           error: null,
         }));
       } catch (err: unknown) {
@@ -1021,16 +1106,26 @@ export function useAuthFilesDetailEditors(
       typeof prefixProxyEditor.json.proxy_url === "string" ? prefixProxyEditor.json.proxy_url : "";
     const originalProxyId =
       typeof prefixProxyEditor.json.proxy_id === "string" ? prefixProxyEditor.json.proxy_id : "";
+    const originalSubscriptionStartedAt = dateLikeToDateTimeLocalInput(
+      readSubscriptionStartValue(prefixProxyEditor.json),
+    );
+    const originalSubscriptionPeriod = normalizeAuthFileSubscriptionPeriod(
+      prefixProxyEditor.json.subscription_period ?? prefixProxyEditor.json.subscriptionPeriod,
+    );
     return (
       originalPrefix !== prefixProxyEditor.prefix ||
       originalProxyUrl !== prefixProxyEditor.proxyUrl ||
-      originalProxyId !== prefixProxyEditor.proxyId
+      originalProxyId !== prefixProxyEditor.proxyId ||
+      originalSubscriptionStartedAt !== prefixProxyEditor.subscriptionStartedAt ||
+      originalSubscriptionPeriod !== prefixProxyEditor.subscriptionPeriod
     );
   }, [
     prefixProxyEditor.json,
     prefixProxyEditor.prefix,
     prefixProxyEditor.proxyId,
     prefixProxyEditor.proxyUrl,
+    prefixProxyEditor.subscriptionPeriod,
+    prefixProxyEditor.subscriptionStartedAt,
   ]);
 
   const prefixProxyUpdatedText = useMemo(() => {
@@ -1049,18 +1144,39 @@ export function useAuthFilesDetailEditors(
     if (proxyId) next.proxy_id = proxyId;
     else delete next.proxy_id;
 
-    // Subscription is provider-asserted (shared status); never write tenant overrides here.
+    removeSubscriptionFields(next);
+    const subscriptionStartedAt = prefixProxyEditor.subscriptionStartedAt.trim();
+    if (subscriptionStartedAt) {
+      const isoValue = dateTimeLocalInputToIso(subscriptionStartedAt);
+      if (isoValue) {
+        next.subscription_started_at = isoValue;
+        next.subscription_period = prefixProxyEditor.subscriptionPeriod;
+      }
+    }
+
     return JSON.stringify(next, null, 2);
   }, [
     prefixProxyEditor.json,
     prefixProxyEditor.prefix,
     prefixProxyEditor.proxyId,
     prefixProxyEditor.proxyUrl,
+    prefixProxyEditor.subscriptionPeriod,
+    prefixProxyEditor.subscriptionStartedAt,
   ]);
 
   const savePrefixProxy = useCallback(async () => {
     if (!prefixProxyEditor.json) return;
     if (!prefixProxyDirty) return;
+    if (
+      prefixProxyEditor.subscriptionStartedAt.trim() &&
+      dateTimeLocalInputToIso(prefixProxyEditor.subscriptionStartedAt) === null
+    ) {
+      notify({
+        type: "error",
+        message: t("auth_files.subscription_started_at_invalid"),
+      });
+      return;
+    }
 
     const payload = prefixProxyUpdatedText;
     const fileSize = new Blob([payload]).size;
@@ -1080,6 +1196,7 @@ export function useAuthFilesDetailEditors(
       const file = new File([payload], name, { type: "application/json" });
       await authFilesApi.upload(file);
       const parsedPayload = JSON.parse(payload) as Record<string, unknown>;
+      applySavedAuthFilePatch(name, parsedPayload);
       notify({ type: "success", message: t("auth_files.saved") });
       setPrefixProxyEditor((prev) => ({
         ...prev,
@@ -1094,7 +1211,7 @@ export function useAuthFilesDetailEditors(
       setDetailText((prev) => (name && detailFile?.name === name ? payload : prev));
       setDetailOpen(false);
       setDetailTab("fields");
-      void loadAll();
+      void loadAll().finally(() => applySavedAuthFilePatch(name, parsedPayload));
     } catch (err: unknown) {
       notify({
         type: "error",
@@ -1103,12 +1220,14 @@ export function useAuthFilesDetailEditors(
       setPrefixProxyEditor((prev) => ({ ...prev, saving: false }));
     }
   }, [
+    applySavedAuthFilePatch,
     detailFile?.name,
     loadAll,
     notify,
     prefixProxyDirty,
     prefixProxyEditor.fileName,
     prefixProxyEditor.json,
+    prefixProxyEditor.subscriptionStartedAt,
     prefixProxyUpdatedText,
     t,
   ]);


### PR DESCRIPTION
## Summary
- Restore auth-file fields editor for subscription start date + period.
- Prefer tenant manual `subscription_started_at` / period over shared Codex JWT claims (claims lag after renewals).
- Keep shared signed claims as fallback when no manual override is set.

## Why
After PR #783, subscription badges were auto-only from JWT. Real ChatGPT renewals can update billing while `chatgpt_subscription_active_*` claims stay stale (e.g. yuan364299311 still 6/11–7/11 after renew to 8/11). Manual override must win so operators can correct remaining days.

## Test plan
- [x] `./scripts/ci-pr.sh` (lint, design:check, full vitest, build, bundle:diff, critical e2e)
- [x] helpers: tenant manual override preferred over shared claims
- [x] detail modal shows subscription controls
- [x] fields editor saves `subscription_started_at` + `subscription_period`