### PR TITLE
fix(ccswitch): Codex 默认模型选择 + 表头滚动回弹

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -683,6 +683,13 @@ export function CcSwitchImportConfigModal({
       ]),
     [availableModels, draft.modelMappings],
   );
+  const codexDefaultModelOptions = useMemo(() => {
+    const requestModels = draft.modelMappings
+      .filter((mapping) => !mapping.role)
+      .map((mapping) => mapping.requestModel.trim() || mapping.targetModel.trim())
+      .filter(Boolean);
+    return modelOptions([...requestModels, draft.defaultModel]);
+  }, [draft.defaultModel, draft.modelMappings]);
   const preparedDraft = prepareDraftForSave(draft);
   const hasRenderableMappings = draft.modelMappings.length > 0;
   const modelMappingsLoading = Boolean(selectedGroup && modelsLoading && !hasRenderableMappings);
@@ -771,18 +778,38 @@ export function CcSwitchImportConfigModal({
   const updateGenericRequestModel = (index: number, requestModel: string) => {
     setModelMappingSort(null);
     setDraft((current) => {
+      const currentDefault = current.defaultModel.trim().toLowerCase();
+      // Prefer the mapping that currently owns the default request name.
+      const defaultRowIndex = current.modelMappings.findIndex(
+        (mapping) =>
+          !mapping.role &&
+          currentDefault &&
+          mapping.requestModel.trim().toLowerCase() === currentDefault,
+      );
       const modelMappings = current.modelMappings.map((mapping, mappingIndex) =>
         !mapping.role && mappingIndex === index ? { ...mapping, requestModel } : mapping,
       );
+      if (defaultRowIndex === index) {
+        // Keep default glued to that row while typing (including empty mid-edit).
+        return {
+          ...current,
+          modelMappings,
+          defaultModel: requestModel.trim() || current.defaultModel.trim(),
+        };
+      }
       return {
         ...current,
         modelMappings,
-        defaultModel:
-          modelMappings
-            .find((mapping) => !mapping.role && mapping.requestModel.trim())
-            ?.requestModel.trim() ?? "",
+        defaultModel: resolveGenericDefaultModel(modelMappings, current.defaultModel),
       };
     });
+  };
+
+  const setCodexDefaultModel = (defaultModel: string) => {
+    setDraft((current) => ({
+      ...current,
+      defaultModel: defaultModel.trim(),
+    }));
   };
 
   const updateGenericContextWindow = (index: number, contextWindow: string) => {
@@ -1103,6 +1130,26 @@ export function CcSwitchImportConfigModal({
                 options={authFieldOptions}
                 aria-label={t("ccswitch.settings_auth_field", { client: clientLabel })}
                 className={controlClassName}
+              />
+            </label>
+          ) : null}
+
+          {draft.clientType === "codex" ? (
+            <label className={fieldClassName}>
+              <span className={labelClassName}>
+                {t("ccswitch.settings_default_model", { client: clientLabel })}
+              </span>
+              <SearchableSelect
+                value={draft.defaultModel}
+                onChange={setCodexDefaultModel}
+                options={codexDefaultModelOptions}
+                allowCreate
+                createLabel={(value) => t("ccswitch.model_use_custom", { value })}
+                placeholder={t("ccswitch.settings_default_model_placeholder")}
+                searchPlaceholder={t("ccswitch.config_model_search_placeholder")}
+                aria-label={t("ccswitch.settings_default_model", { client: clientLabel })}
+                className={`${controlClassName} w-full`}
+                disabled={!selectedGroup}
               />
             </label>
           ) : null}

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2086,9 +2086,11 @@ export function DataTable<T>({
         className={
           naturalFlow
             ? "relative z-10 min-h-0 overflow-visible rounded-xl"
-            : `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none ${
+            : // Always contain vertical overscroll so sticky headers never rubber-band;
+              // boundary wheel handoff is handled in JS (handleWheel), not overscroll-behavior.
+              `relative col-start-1 row-start-1 h-full min-h-0 table-scrollbar overscroll-x-none overscroll-y-none ${
                 isEmpty ? "overflow-x-hidden overflow-y-auto" : "overflow-auto"
-              } ${allowWheelPropagationAtBoundary ? "overscroll-y-auto" : "overscroll-y-none"}`
+              }`
         }
       >
         <div

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -332,8 +332,9 @@ describe("DataTable scroll chrome and row dividers", () => {
 
     expect(viewport.scrollTop).toBe(240);
     expect(parent.scrollTop).toBe(120);
-    expect(viewport).toHaveClass("overscroll-y-auto");
-    expect(viewport).not.toHaveClass("overscroll-y-none");
+    // Wheel handoff is JS-driven; keep overscroll contained so sticky headers never bounce.
+    expect(viewport).toHaveClass("overscroll-y-none");
+    expect(viewport).not.toHaveClass("overscroll-y-auto");
     const headerChrome = document.querySelector("[data-vt-header-chrome]");
     expect(headerChrome).not.toBeNull();
     expect(headerChrome).toHaveClass("absolute", "left-0", "top-0");

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -182,9 +182,10 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(
       within(dialog).queryByLabelText(/codex endpoint path/i),
     ).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole("combobox", { name: /default model/i }),
-    ).not.toBeInTheDocument();
+    const defaultModelSelect = within(dialog).getByRole("combobox", {
+      name: /codex default model/i,
+    });
+    expect(defaultModelSelect).toBeDisabled();
     expect(
       within(dialog).queryByText(/for codex cli/i),
     ).not.toBeInTheDocument();
@@ -219,11 +220,16 @@ describe("CcSwitchImportSettingsPage", () => {
       await within(dialog).findByDisplayValue("kimi-k2"),
     ).toBeInTheDocument();
     expect(listAvailableModels).not.toHaveBeenCalled();
+    expect(defaultModelSelect).not.toBeDisabled();
+    expect(defaultModelSelect).toHaveTextContent("deepseek-v4-flash");
     const requestModelInput = within(dialog).getByLabelText(
       /cc switch request model for mapping 1/i,
     );
     await user.clear(requestModelInput);
     await user.type(requestModelInput, "gpt-5.5");
+    await waitFor(() =>
+      expect(defaultModelSelect).toHaveTextContent("gpt-5.5"),
+    );
     const contextWindowInput = within(dialog).getByLabelText(
       /context window for mapping 1/i,
     );
@@ -236,6 +242,9 @@ describe("CcSwitchImportSettingsPage", () => {
       "Relay Codex",
     );
     await user.type(within(dialog).getByLabelText(/remark/i), "Pro preset");
+
+    // Explicit default is already following the renamed first mapping row.
+    expect(defaultModelSelect).toHaveTextContent("gpt-5.5");
 
     await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
 
@@ -951,6 +960,16 @@ describe("CcSwitchImportSettingsPage", () => {
     expect(
       within(dialog).getByRole("combobox", { name: /actual channel model 2/i }),
     ).toHaveTextContent("gpt-5.5");
+    const defaultModelSelect = within(dialog).getByRole("combobox", {
+      name: /codex default model/i,
+    });
+    expect(defaultModelSelect).toHaveTextContent("gpt-5.5");
+
+    await user.click(defaultModelSelect);
+    await user.click(
+      await screen.findByRole("option", { name: "gpt-5.4-mini" }),
+    );
+    expect(defaultModelSelect).toHaveTextContent("gpt-5.4-mini");
 
     await user.click(within(dialog).getByRole("button", { name: /^save$/i }));
 
@@ -958,7 +977,7 @@ describe("CcSwitchImportSettingsPage", () => {
       expect(replaceConfigs).toHaveBeenCalledWith([
         expect.objectContaining({
           id: "cfg-kimi",
-          defaultModel: "gpt-5.5",
+          defaultModel: "gpt-5.4-mini",
           allowedChannelGroups: ["kimicode"],
           modelMappings: [
             {
@@ -1391,8 +1410,9 @@ describe("CcSwitchImportSettingsPage", () => {
       "h-[320px]",
       "min-h-[320px]",
     );
-    expect(tableViewport).toHaveClass("overscroll-y-auto");
-    expect(tableViewport).not.toHaveClass("overscroll-y-none");
+    // Contain rubber-band overscroll so sticky headers never bounce with body.
+    expect(tableViewport).toHaveClass("overscroll-y-none");
+    expect(tableViewport).not.toHaveClass("overscroll-y-auto");
     const headerCells = Array.from(
       tableViewport?.querySelectorAll("thead th") ?? [],
     );


### PR DESCRIPTION
## Summary
- Codex 配置弹窗补上默认模型选择器（从映射请求模型中选，可自定义）
- DataTable 始终 `overscroll-y-none`，避免 sticky 表头随 body 橡胶带回弹；边界滚轮仍由 JS 上抛

## Test plan
- [x] `bun run test -- packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx`
- [x] `./scripts/ci-pr.sh`
- [ ] 手动：编辑 Codex 配置，切换默认模型后保存
- [ ] 手动：模型映射表上下滚动，表头不再回弹