### PR TITLE
fix(end-users): disable reset-today when daily spending is unlimited

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3186,6 +3186,7 @@
     "today_spending": "Today usage",
     "unlimited": "Unlimited",
     "reset_today_spending": "Reset account today's spending",
+    "reset_today_spending_disabled": "Set a daily spending limit in the permission config before resetting",
     "reset_today_spending_success": "Account today's spending reset",
     "account_permission_profile": "Account Permission Profile",
     "account_permission_profile_placeholder": "Select an account permission profile",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3483,6 +3483,7 @@
     "today_spending": "今日用量",
     "unlimited": "未限制",
     "reset_today_spending": "重置账号今日消费",
+    "reset_today_spending_disabled": "请先在权限配置中设置每日消费额度后再重置",
     "reset_today_spending_success": "已重置该账号今日消费",
     "account_permission_profile": "账户权限模板",
     "account_permission_profile_placeholder": "选择账户权限模板",

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -229,6 +229,8 @@ export function EndUsersPage() {
 
   const resetTodaySpending = useCallback(
     async (row: EndUser) => {
+      // ponytail: same gate as API Key list — unlimited daily spending has nothing to reset
+      if (!((row["daily-spending-limit"] ?? 0) > 0)) return;
       setBusy(true);
       try {
         await endUsersApi.resetDailySpending(row.id);
@@ -441,92 +443,100 @@ export function EndUsersPage() {
         lockOrder: "end",
         headerClassName: stickyActionsHeaderClass,
         cellClassName: stickyActionsCellClass,
-        render: (row) => (
-          <div className="flex items-center justify-center gap-1">
-            <Button
-              size="sm"
-              variant="ghost"
-              title={t("end_users.view_usage", { defaultValue: "查看用量" })}
-              onClick={() => void handleViewUserUsage(row)}
-            >
-              <BarChart3 className="h-4 w-4" />
-            </Button>
-            {can("api_keys.read") ? (
+        render: (row) => {
+          const hasDailyLimit = (row["daily-spending-limit"] ?? 0) > 0;
+          const resetLabel = hasDailyLimit
+            ? t("end_users.reset_today_spending", {
+                defaultValue: "重置账号今日消费",
+              })
+            : t("end_users.reset_today_spending_disabled", {
+                defaultValue: "请先在权限配置中设置每日消费额度后再重置",
+              });
+          return (
+            <div className="flex items-center justify-center gap-1">
               <Button
                 size="sm"
                 variant="ghost"
-                title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
-                onClick={() => setKeysUser(row)}
+                title={t("end_users.view_usage", { defaultValue: "查看用量" })}
+                onClick={() => void handleViewUserUsage(row)}
               >
-                <Key className="h-4 w-4" />
+                <BarChart3 className="h-4 w-4" />
               </Button>
-            ) : null}
-            {canWrite ? (
-              <Button
-                size="sm"
-                variant="ghost"
-                title={t("end_users.edit", { defaultValue: "编辑" })}
-                onClick={() => {
-                  setEditUser(row);
-                  setEditForm({
-                    username: row.username,
-                    displayName: row.display_name,
-                    password: "",
-                    permissionProfileId: row["permission-profile-id"] ?? "",
-                  });
-                }}
-              >
-                <Pencil className="h-4 w-4" />
-              </Button>
-            ) : null}
-            {canWrite ? (
-              row.status === "active" ? (
+              {can("api_keys.read") ? (
                 <Button
                   size="sm"
                   variant="ghost"
-                  disabled={busy}
-                  title={t("end_users.freeze", { defaultValue: "冻结账号" })}
-                  onClick={() => void setFrozen(row, true)}
+                  title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
+                  onClick={() => setKeysUser(row)}
                 >
-                  <Snowflake className="h-4 w-4" />
+                  <Key className="h-4 w-4" />
                 </Button>
-              ) : (
+              ) : null}
+              {canWrite ? (
                 <Button
                   size="sm"
                   variant="ghost"
-                  disabled={busy}
-                  title={t("end_users.activate", { defaultValue: "激活账号" })}
-                  onClick={() => void setFrozen(row, false)}
+                  title={t("end_users.edit", { defaultValue: "编辑" })}
+                  onClick={() => {
+                    setEditUser(row);
+                    setEditForm({
+                      username: row.username,
+                      displayName: row.display_name,
+                      password: "",
+                      permissionProfileId: row["permission-profile-id"] ?? "",
+                    });
+                  }}
                 >
-                  <Unlock className="h-4 w-4" />
+                  <Pencil className="h-4 w-4" />
                 </Button>
-              )
-            ) : null}
-            {canWrite ? (
-              <Button
-                size="sm"
-                variant="ghost"
-                disabled={busy}
-                title={t("end_users.reset_today_spending", {
-                  defaultValue: "重置账号今日消费",
-                })}
-                onClick={() => void resetTodaySpending(row)}
-              >
-                <RotateCcw className="h-4 w-4" />
-              </Button>
-            ) : null}
-            {canWrite ? (
-              <Button size="sm" variant="ghost" title="重置密码" onClick={() => setResetUser(row)}>
-                <KeyRound className="h-4 w-4" />
-              </Button>
-            ) : null}
-            {canWrite ? (
-              <Button size="sm" variant="ghost" title="删除" onClick={() => setDeleteUser(row)}>
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            ) : null}
-          </div>
-        ),
+              ) : null}
+              {canWrite ? (
+                row.status === "active" ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy}
+                    title={t("end_users.freeze", { defaultValue: "冻结账号" })}
+                    onClick={() => void setFrozen(row, true)}
+                  >
+                    <Snowflake className="h-4 w-4" />
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy}
+                    title={t("end_users.activate", { defaultValue: "激活账号" })}
+                    onClick={() => void setFrozen(row, false)}
+                  >
+                    <Unlock className="h-4 w-4" />
+                  </Button>
+                )
+              ) : null}
+              {canWrite ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={busy || !hasDailyLimit}
+                  title={resetLabel}
+                  onClick={() => void resetTodaySpending(row)}
+                >
+                  <RotateCcw className="h-4 w-4" />
+                </Button>
+              ) : null}
+              {canWrite ? (
+                <Button size="sm" variant="ghost" title="重置密码" onClick={() => setResetUser(row)}>
+                  <KeyRound className="h-4 w-4" />
+                </Button>
+              ) : null}
+              {canWrite ? (
+                <Button size="sm" variant="ghost" title="删除" onClick={() => setDeleteUser(row)}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </div>
+          );
+        },
       },
     ],
     [

--- a/pages/end-users/__tests__/EndUsersPage.test.tsx
+++ b/pages/end-users/__tests__/EndUsersPage.test.tsx
@@ -99,11 +99,17 @@ describe("EndUsersPage account semantics", () => {
       screen.getByRole("columnheader", { name: "Account Permission Profile" }),
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByRole("button", {
+        name: "Set a daily spending limit in the permission config before resetting",
+      }),
+    ).toBeDisabled();
+
     await userEvent.click(
-      screen.getAllByRole("button", { name: "Reset account today's spending" })[0],
+      screen.getByRole("button", { name: "Reset account today's spending" }),
     );
     await waitFor(() => {
-      expect(mocks.resetDailySpending).toHaveBeenCalledWith("user-active");
+      expect(mocks.resetDailySpending).toHaveBeenCalledWith("user-frozen");
     });
 
     await userEvent.click(screen.getByRole("button", { name: "Freeze account" }));


### PR DESCRIPTION
## Summary
- 用户账号列表在 `daily-spending-limit` 未设置/无限制时禁用「重置账号今日消费」
- 与 API Key 列表同一语义；handler 二次拦截；tooltip 提示先配置每日消费额度

## Test plan
- [x] `bun run test -- pages/end-users/__tests__/EndUsersPage.test.tsx`
- [x] `./scripts/ci-pr.sh`（lint / design:check / test:ci / build / bundle:diff / e2e critical）