### PR TITLE
ci: shard Vitest PR tests across runners

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -15,7 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-build:
+  quality_build_e2e:
+    name: quality-build-e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,5 +35,74 @@ jobs:
           restore-keys: |
             bun-${{ runner.os }}-
 
-      - name: PR checks
-        run: ./scripts/ci-pr.sh
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Design checks
+        run: bun run design:check
+
+      - name: Build
+        run: bun run build
+
+      - name: Bundle diff
+        run: bun run bundle:diff
+
+      - name: Install Chromium
+        run: bunx playwright install chromium
+
+      - name: Critical E2E
+        run: bunx playwright test e2e/multi-tenant-auth.spec.ts e2e/login-lifecycle.spec.ts --grep '@critical'
+
+  vitest:
+    name: vitest-${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - 1/2
+          - 2/2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.2
+
+      - name: Cache Bun downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Vitest shard ${{ matrix.shard }}
+        run: bun run test:ci -- --shard=${{ matrix.shard }}
+
+  test-build:
+    name: test-build
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - quality_build_e2e
+      - vitest
+    steps:
+      - name: Verify required jobs
+        env:
+          QUALITY_BUILD_E2E_RESULT: ${{ needs.quality_build_e2e.result }}
+          VITEST_RESULT: ${{ needs.vitest.result }}
+        run: |
+          if [[ "$QUALITY_BUILD_E2E_RESULT" != "success" || "$VITEST_RESULT" != "success" ]]; then
+            echo "quality-build-e2e=$QUALITY_BUILD_E2E_RESULT"
+            echo "vitest=$VITEST_RESULT"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- run the full Vitest suite as two deterministic shards on independent GitHub runners
- keep lint, design checks, build, bundle diff, and critical Playwright E2E in a parallel quality job
- preserve the branch-protection required check with a final `test-build` aggregator

## Validation
- `bun run test:ci -- --shard=1/2` (57 files, 452 tests passed)
- `bun run test:ci -- --shard=2/2` (56 files, 361 tests passed)
- `bun run lint` (0 errors; 6 existing warnings)
- `bun run design:check`
- `bun run build`
- `bun run bundle:diff`
- Ruby YAML parse and `git diff --check`

## Local limitation
- Critical Playwright was attempted locally, but `127.0.0.1:5173` was occupied by an unrelated PDF application and Playwright reused that server. The unchanged critical suite remains mandatory in `quality-build-e2e` and will be validated on the clean GitHub runner.