### PR TITLE
feat: key filter on apikey-lookup request logs

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -807,9 +807,12 @@ export function ApiKeyLookupPage() {
     setLastUpdatedAt(null);
     setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
     setFilterOptions({
+      api_key_ids: [],
+      api_key_id_names: {},
       models: [],
       statuses: ["success", "failed"],
     });
+    setSelectedApiKeyIds(null);
     setSelectedModels(null);
     setSelectedStatuses(null);
 
@@ -983,9 +986,12 @@ export function ApiKeyLookupPage() {
       setLastUpdatedAt(null);
       setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
       setFilterOptions({
+        api_key_ids: [],
+        api_key_id_names: {},
         models: [],
         statuses: ["success", "failed"],
       });
+      setSelectedApiKeyIds(null);
       setSelectedModels(null);
       setSelectedStatuses(null);
       setQuotaLimits(null);

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -418,6 +418,8 @@ export function ApiKeyLookupPage() {
 
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
+  const [selectedApiKeyIds, setSelectedApiKeyIds] =
+    useState<MultiSelectFilterState<string>>(null);
   const [selectedModels, setSelectedModels] = useState<MultiSelectFilterState<string>>(null);
   const [selectedStatuses, setSelectedStatuses] =
     useState<MultiSelectFilterState<StatusFilterValue>>(null);
@@ -430,9 +432,22 @@ export function ApiKeyLookupPage() {
     total_cost: number;
   }>({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
   const [filterOptions, setFilterOptions] = useState<{
+    api_key_ids: string[];
+    api_key_id_names: Record<string, string>;
     models: string[];
     statuses: string[];
-  }>({ models: [], statuses: ["success", "failed"] });
+  }>({ api_key_ids: [], api_key_id_names: {}, models: [], statuses: ["success", "failed"] });
+
+  const keyOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    return (filterOptions.api_key_ids ?? []).map((id) => {
+      const name = filterOptions.api_key_id_names?.[id] || id;
+      return {
+        value: id,
+        label: name,
+        searchText: name,
+      };
+    });
+  }, [filterOptions.api_key_ids, filterOptions.api_key_id_names]);
 
   const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return filterOptions.models.map((model) => ({
@@ -457,6 +472,10 @@ export function ApiKeyLookupPage() {
     }));
   }, [filterOptions.statuses, t]);
 
+  const apiKeyIdFilterValues = useMemo(
+    () => keyOptions.map((option) => option.value),
+    [keyOptions],
+  );
   const modelFilterValues = useMemo(
     () => modelOptions.map((option) => option.value),
     [modelOptions],
@@ -466,6 +485,10 @@ export function ApiKeyLookupPage() {
     [statusOptions],
   );
 
+  const apiKeyIdFilterParam = useMemo(
+    () => toFilterParam(selectedApiKeyIds, apiKeyIdFilterValues),
+    [apiKeyIdFilterValues, selectedApiKeyIds],
+  );
   const modelFilterParam = useMemo(
     () => toFilterParam(selectedModels, modelFilterValues),
     [modelFilterValues, selectedModels],
@@ -475,6 +498,12 @@ export function ApiKeyLookupPage() {
     [selectedStatuses, statusFilterValues],
   );
 
+  const handleApiKeyIdsChange = useCallback(
+    (value: string[]) => {
+      setSelectedApiKeyIds(normalizeFilterSelection(value, apiKeyIdFilterValues));
+    },
+    [apiKeyIdFilterValues],
+  );
   const handleModelsChange = useCallback(
     (value: string[]) => {
       setSelectedModels(normalizeFilterSelection(value, modelFilterValues));
@@ -487,6 +516,7 @@ export function ApiKeyLookupPage() {
     },
     [statusFilterValues],
   );
+  const clearApiKeyIdFilter = useCallback(() => setSelectedApiKeyIds(null), []);
   const clearModelFilter = useCallback(() => setSelectedModels(null), []);
   const clearStatusFilter = useCallback(() => setSelectedStatuses(null), []);
 
@@ -520,8 +550,10 @@ export function ApiKeyLookupPage() {
           page,
           size: size ?? pageSize,
           days: timeRange,
+          apiKeyIds: apiKeyIdFilterParam.values,
           models: modelFilterParam.values,
           statuses: statusFilterParam.values,
+          apiKeyIdsEmpty: apiKeyIdFilterParam.matchesNone,
           modelsEmpty: modelFilterParam.matchesNone,
           statusesEmpty: statusFilterParam.matchesNone,
           signal: controller.signal,
@@ -541,6 +573,8 @@ export function ApiKeyLookupPage() {
           },
         );
         setFilterOptions({
+          api_key_ids: resp.filters?.api_key_ids ?? [],
+          api_key_id_names: resp.filters?.api_key_id_names ?? {},
           models: resp.filters?.models ?? [],
           statuses: resp.filters?.statuses ?? ["success", "failed"],
         });
@@ -563,7 +597,7 @@ export function ApiKeyLookupPage() {
         }
       }
     },
-    [modelFilterParam, pageSize, statusFilterParam, t, timeRange],
+    [apiKeyIdFilterParam, modelFilterParam, pageSize, statusFilterParam, t, timeRange],
   );
 
   // ================================================================
@@ -681,7 +715,7 @@ export function ApiKeyLookupPage() {
     if (usageSubject && activeTab === "logs") {
       fetchLogs(usageSubject, 1);
     }
-  }, [timeRange, selectedModels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [timeRange, selectedApiKeyIds, selectedModels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Models fetching ──
   const fetchModelsFn = useCallback(
@@ -1392,12 +1426,16 @@ export function ApiKeyLookupPage() {
               {activeTab === "logs" && usageReady ? (
                 <PublicLogsSection
                   t={t}
+                  keyOptions={keyOptions}
                   modelOptions={modelOptions}
                   statusOptions={statusOptions}
+                  selectedApiKeyIds={selectedApiKeyIds}
                   selectedModels={selectedModels}
                   selectedStatuses={selectedStatuses}
+                  onApiKeyIdsChange={handleApiKeyIdsChange}
                   onModelsChange={handleModelsChange}
                   onStatusesChange={handleStatusesChange}
+                  onApiKeyIdsClear={clearApiKeyIdFilter}
                   onModelsClear={clearModelFilter}
                   onStatusesClear={clearStatusFilter}
                   stats={stats}

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -535,6 +535,8 @@ describe("ApiKeyLookupPage", () => {
           total_cost: 0,
         },
         filters: {
+          api_key_ids: ["key-laptop", "key-auto"],
+          api_key_id_names: { "key-laptop": "Laptop", "key-auto": "Automation" },
           models: ["gpt-5.5"],
           channels: ["Codex 主渠道", "OpenCode"],
           statuses: ["success", "failed"],
@@ -554,6 +556,8 @@ describe("ApiKeyLookupPage", () => {
           total_cost: 0,
         },
         filters: {
+          api_key_ids: ["key-laptop", "key-auto"],
+          api_key_id_names: { "key-laptop": "Laptop", "key-auto": "Automation" },
           models: ["gpt-5.5"],
           channels: ["Codex 主渠道"],
           statuses: ["success"],
@@ -570,6 +574,9 @@ describe("ApiKeyLookupPage", () => {
 
     await userEvent.click(await screen.findByRole("tab", { name: /request logs/i }));
 
+    expect(await screen.findByRole("combobox", { name: /filter by key/i })).toHaveTextContent(
+      /all keys/i,
+    );
     expect(await screen.findByRole("combobox", { name: /filter by model/i })).toHaveTextContent(
       /all models/i,
     );
@@ -578,16 +585,17 @@ describe("ApiKeyLookupPage", () => {
       /all status/i,
     );
 
-    await userEvent.click(screen.getByRole("combobox", { name: /filter by status/i }));
-    await userEvent.click(await screen.findByRole("option", { name: /failed|失败/i }));
+    await userEvent.click(screen.getByRole("combobox", { name: /filter by key/i }));
+    // emptyValueMeansAllSelected: clicking one option deselects it from "all".
+    await userEvent.click(await screen.findByRole("option", { name: /Laptop/i }));
     await userEvent.click(screen.getByRole("button", { name: /apply filters/i }));
 
     await waitFor(() => {
       expect(mocks.fetchPublicLogs).toHaveBeenLastCalledWith(
         expect.objectContaining({
           apiKey: "sk-restored-key",
-          statuses: ["success"],
-          statusesEmpty: false,
+          apiKeyIds: ["key-auto"],
+          apiKeyIdsEmpty: false,
         }),
       );
     });

--- a/pages/api-key-lookup/api.ts
+++ b/pages/api-key-lookup/api.ts
@@ -93,9 +93,11 @@ export async function fetchPublicLogs(params: {
   page?: number;
   size?: number;
   days?: number;
+  apiKeyIds?: string[];
   models?: string[];
   channels?: string[];
   statuses?: string[];
+  apiKeyIdsEmpty?: boolean;
   modelsEmpty?: boolean;
   channelsEmpty?: boolean;
   statusesEmpty?: boolean;
@@ -110,9 +112,11 @@ export async function fetchPublicLogs(params: {
       page: params.page,
       size: params.size,
       days: params.days,
+      api_key_ids: params.apiKeyIds,
       models: params.models,
       channels: params.channels,
       statuses: params.statuses,
+      api_key_ids_empty: params.apiKeyIdsEmpty,
       models_empty: params.modelsEmpty,
       channels_empty: params.channelsEmpty,
       statuses_empty: params.statusesEmpty,

--- a/pages/api-key-lookup/components/PublicLogsSection.tsx
+++ b/pages/api-key-lookup/components/PublicLogsSection.tsx
@@ -2,6 +2,7 @@ import { Filter } from "lucide-react";
 import { Card } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
+import { SearchableCheckboxMultiSelect } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import {
   RequestLogFacetFilters,
@@ -13,12 +14,16 @@ import {
 
 export function PublicLogsSection({
   t,
+  keyOptions,
   statusOptions,
   modelOptions,
+  selectedApiKeyIds,
   selectedModels,
   selectedStatuses,
+  onApiKeyIdsChange,
   onModelsChange,
   onStatusesChange,
+  onApiKeyIdsClear,
   onModelsClear,
   onStatusesClear,
   stats,
@@ -34,12 +39,16 @@ export function PublicLogsSection({
   onPageSizeChange,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
+  keyOptions: SearchableCheckboxMultiSelectOption[];
   modelOptions: SearchableCheckboxMultiSelectOption[];
   statusOptions: SearchableCheckboxMultiSelectOption[];
+  selectedApiKeyIds: MultiSelectFilterState<string>;
   selectedModels: MultiSelectFilterState<string>;
   selectedStatuses: MultiSelectFilterState<StatusFilterValue>;
+  onApiKeyIdsChange: (value: string[]) => void;
   onModelsChange: (value: string[]) => void;
   onStatusesChange: (value: StatusFilterValue[]) => void;
+  onApiKeyIdsClear: () => void;
   onModelsClear: () => void;
   onStatusesClear: () => void;
   stats: {
@@ -65,6 +74,37 @@ export function PublicLogsSection({
         <div className="border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60">
           <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-2">
             <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:gap-2">
+              {keyOptions.length > 0 ? (
+                <div className="w-full min-[480px]:w-auto sm:w-[180px]">
+                  <SearchableCheckboxMultiSelect
+                    value={selectedApiKeyIds ?? []}
+                    onChange={onApiKeyIdsChange}
+                    options={keyOptions}
+                    placeholder={t("request_logs.all_keys_placeholder")}
+                    searchPlaceholder={t("request_logs.search_keys")}
+                    selectFilteredLabel={t("request_logs.select_filtered")}
+                    deselectFilteredLabel={t("request_logs.deselect_filtered")}
+                    selectedCountLabel={(count: number) =>
+                      t("request_logs.selected_count", { count })
+                    }
+                    noResultsLabel={t("request_logs.no_filter_results")}
+                    aria-label={t("request_logs.filter_key")}
+                    clearLabel={t("request_logs.clear_key_filter")}
+                    onClear={onApiKeyIdsClear}
+                    showClearButton
+                    size="sm"
+                    emptyValueMeansAllSelected
+                    emptyValueRepresentsAllSelected={selectedApiKeyIds === null}
+                    showFilteredToggleWithoutQuery={false}
+                    applyMode="manual"
+                    applyLabel={t("request_logs.apply_filters")}
+                    cancelLabel={t("common.cancel")}
+                    selectAllLabel={t("request_logs.select_all")}
+                    deselectAllLabel={t("request_logs.deselect_all")}
+                    emptySelectionLabel={t("request_logs.none_selected")}
+                  />
+                </div>
+              ) : null}
               <RequestLogFacetFilters
                 modelOptions={modelOptions}
                 channelOptions={[]}

--- a/pages/api-key-lookup/types.ts
+++ b/pages/api-key-lookup/types.ts
@@ -47,6 +47,8 @@ export interface PublicLogsResponse {
     total_cost: number;
   };
   filters: {
+    api_key_ids?: string[];
+    api_key_id_names?: Record<string, string>;
     models: string[];
     channels: string[];
     channel_options?: PublicChannelFilterOption[];


### PR DESCRIPTION
## Summary
- Add Key multi-select filter on public apikey-lookup request logs (next to model/status)
- Call public `/usage/logs` with `api_key_ids` / `api_key_ids_empty`
- Depends on CliRelay public key-id filter support

## Test plan
- [x] vitest: ApiKeyLookupPage key filter + channel-hidden cases
- [ ] Manual: multi-key portal account → request logs → filter by key name