### PR TITLE
feat: improve request log filter interactions

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -456,7 +456,44 @@ export type RequestLogKeyOption = {
   value: string;
   label: string;
   searchText?: string;
+  count: number;
 };
+
+export function RequestLogFilterCount({ count }: { count: number }) {
+  const { t, i18n } = useTranslation();
+  const safeCount = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+  const formattedCount = new Intl.NumberFormat(i18n.resolvedLanguage || undefined).format(
+    safeCount,
+  );
+  const accessibleLabel = t("request_logs.calls_count", { count: safeCount, formattedCount });
+
+  return (
+    <span
+      className="inline-flex min-w-[4.5rem] justify-end whitespace-nowrap text-xs font-semibold tabular-nums text-slate-500 dark:text-white/50"
+      aria-label={accessibleLabel}
+      title={accessibleLabel}
+    >
+      {formattedCount}
+    </span>
+  );
+}
+
+export function sortRequestLogKeyOptionsByCount(
+  options: RequestLogKeyOption[],
+  locale?: string,
+): RequestLogKeyOption[] {
+  const collator = new Intl.Collator(locale, { numeric: true, sensitivity: "base" });
+  const allOption = options.find((option) => option.value === "");
+  const sorted = options
+    .filter((option) => option.value !== "")
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        collator.compare(left.label, right.label) ||
+        left.value.localeCompare(right.value),
+    );
+  return allOption ? [allOption, ...sorted] : sorted;
+}
 
 export const maskRequestLogApiKey = (value: string): string => {
   const trimmed = value.trim();
@@ -533,26 +570,43 @@ export const buildRequestLogKeyOptions = (
     allKeys: string;
     systemCall: string;
   },
+  apiKeyCounts: Record<string, number> = {},
 ): RequestLogKeyOption[] => {
-  const options: RequestLogKeyOption[] = [{ value: "", label: labels.allKeys }];
-  let systemIncluded = false;
+  const countFor = (key: string) => {
+    const count = apiKeyCounts[key];
+    return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+  };
+  const options: RequestLogKeyOption[] = [
+    {
+      value: "",
+      label: labels.allKeys,
+      count: apiKeys.reduce((total, key) => total + countFor(key), 0),
+    },
+  ];
+  let systemOption: RequestLogKeyOption | null = null;
 
   for (const key of apiKeys) {
     const name = apiKeyNames[key];
+    const count = countFor(key);
     if (isSystemRequestLogKey(key, name)) {
-      if (systemIncluded) continue;
-      options.push({
+      if (systemOption) {
+        systemOption.count += count;
+        continue;
+      }
+      systemOption = {
         value: SYSTEM_REQUEST_LOG_FILTER_VALUE,
         label: labels.systemCall,
         searchText: labels.systemCall,
-      });
-      systemIncluded = true;
+        count,
+      };
+      options.push(systemOption);
       continue;
     }
     options.push({
       value: key,
       label: name || maskRequestLogApiKey(key),
       searchText: `${name || ""} ${key}`,
+      count,
     });
   }
 

--- a/packages/api-client/src/endpoints/__tests__/usage-logs.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/usage-logs.test.ts
@@ -23,6 +23,7 @@ describe("usage logs api", () => {
       filters: {
         api_keys: null,
         api_key_names: null,
+        api_key_counts: null,
         models: null,
         channels: null,
       },
@@ -37,6 +38,7 @@ describe("usage logs api", () => {
       filters: {
         api_keys: [],
         api_key_names: {},
+        api_key_counts: {},
         models: [],
         channels: [],
         channel_options: [],
@@ -52,14 +54,31 @@ describe("usage logs api", () => {
     expect(getMock).toHaveBeenCalledWith("/usage/logs?page=1&size=50");
   });
 
-  test("normalizes channel_options and falls back to legacy channels", async () => {
-    const { usageApi, normalizeChannelOptions } = await import(
-      "@code-proxy/api-client/endpoints/usage"
-    );
+  test("preserves valid request counts and rejects malformed count maps", async () => {
+    const { usageApi } = await import("@code-proxy/api-client/endpoints/usage");
+    getMock
+      .mockResolvedValueOnce({
+        filters: { api_key_counts: { "sk-primary": 42 } },
+        stats: {},
+      })
+      .mockResolvedValueOnce({
+        filters: { api_key_counts: { "sk-primary": "42" } },
+        stats: {},
+      });
 
-    expect(
-      normalizeChannelOptions(undefined, ["Codex", "Relay", "codex"]),
-    ).toEqual([
+    await expect(usageApi.getUsageLogs({})).resolves.toMatchObject({
+      filters: { api_key_counts: { "sk-primary": 42 } },
+    });
+    await expect(usageApi.getUsageLogs({})).resolves.toMatchObject({
+      filters: { api_key_counts: {} },
+    });
+  });
+
+  test("normalizes channel_options and falls back to legacy channels", async () => {
+    const { usageApi, normalizeChannelOptions } =
+      await import("@code-proxy/api-client/endpoints/usage");
+
+    expect(normalizeChannelOptions(undefined, ["Codex", "Relay", "codex"])).toEqual([
       { value: "Codex", label: "Codex" },
       { value: "Relay", label: "Relay" },
     ]);

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -119,6 +119,14 @@ const isStringRecord = (value: unknown): value is Record<string, string> =>
   !Array.isArray(value) &&
   Object.values(value).every((entry) => typeof entry === "string");
 
+const isNumberRecord = (value: unknown): value is Record<string, number> =>
+  value !== null &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  Object.values(value).every(
+    (entry) => typeof entry === "number" && Number.isFinite(entry) && entry >= 0,
+  );
+
 function asTrimmedString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -370,6 +378,7 @@ export const usageApi = {
       filters: {
         api_keys: Array.isArray(filters?.api_keys) ? filters.api_keys : [],
         api_key_names: isStringRecord(filters?.api_key_names) ? filters.api_key_names : {},
+        api_key_counts: isNumberRecord(filters?.api_key_counts) ? filters.api_key_counts : {},
         models: Array.isArray(filters?.models) ? filters.models : [],
         channels: Array.isArray(filters?.channels) ? filters.channels : [],
         channel_options: normalizeChannelOptions(filters?.channel_options, filters?.channels),
@@ -553,6 +562,7 @@ export interface UsageLogsResponse {
   filters: {
     api_keys: string[];
     api_key_names: Record<string, string>;
+    api_key_counts: Record<string, number>;
     models: string[];
     channels: string[];
     channel_options: UsageChannelFilterOption[];
@@ -570,6 +580,7 @@ export interface UsageLogsResponse {
 type UsageLogsFilterPayload = {
   api_keys?: unknown;
   api_key_names?: unknown;
+  api_key_counts?: unknown;
   models?: unknown;
   channels?: unknown;
   channel_options?: unknown;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2718,7 +2718,10 @@
     "cache_rate": "Cache Token Ratio",
     "auth_type_api": "API",
     "auth_type_oauth": "OAuth",
-    "no_data_desc": "Try another range or clear filters."
+    "no_data_desc": "Try another range or clear filters.",
+    "calls_count": "{{formattedCount}} calls",
+    "calls_sorted_hint": "Sorted by calls in the current log range",
+    "unrestricted": "Any"
   },
   "ccswitch": {
     "import_to_ccswitch": "Import to CC Switch",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3015,7 +3015,10 @@
     "clear_status_filter": "清空状态筛选",
     "auth_type_api": "API",
     "auth_type_oauth": "OAuth",
-    "no_data_desc": "调整时间范围或筛选条件后再试"
+    "no_data_desc": "调整时间范围或筛选条件后再试",
+    "calls_count": "{{formattedCount}} 次调用",
+    "calls_sorted_hint": "按当前日志范围内的调用次数排序",
+    "unrestricted": "不限"
   },
   "ccswitch": {
     "import_to_ccswitch": "导入到 CC Switch",

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -33,6 +33,8 @@ export interface SearchableCheckboxMultiSelectOption {
   value: string;
   label: ReactNode;
   searchText?: string;
+  /** Optional fixed trailing content, such as a request count. */
+  trailing?: ReactNode;
 }
 
 export interface SearchableCheckboxMultiSelectProps {
@@ -63,6 +65,10 @@ export interface SearchableCheckboxMultiSelectProps {
   deselectAllLabel?: string;
   emptySelectionLabel?: string;
   emptyValueRepresentsAllSelected?: boolean;
+  /** Render the implicit all state as an unrestricted filter with no checked rows. */
+  neutralAllSelection?: boolean;
+  allSelectionLabel?: string;
+  selectionHint?: string;
 }
 
 function optionText(option: SearchableCheckboxMultiSelectOption): string {
@@ -102,6 +108,9 @@ export function SearchableCheckboxMultiSelect({
   deselectAllLabel = "",
   emptySelectionLabel,
   emptyValueRepresentsAllSelected,
+  neutralAllSelection = false,
+  allSelectionLabel = "",
+  selectionHint = "",
 }: SearchableCheckboxMultiSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -119,9 +128,7 @@ export function SearchableCheckboxMultiSelect({
 
   const sanitizedExplicitValue = useMemo(() => {
     const allowed = new Set(options.map((option) => option.value));
-    return value.filter(
-      (item, index) => allowed.has(item) && value.indexOf(item) === index,
-    );
+    return value.filter((item, index) => allowed.has(item) && value.indexOf(item) === index);
   }, [options, value]);
 
   const [draftExplicitValue, setDraftExplicitValue] = useState<string[]>(sanitizedExplicitValue);
@@ -141,13 +148,16 @@ export function SearchableCheckboxMultiSelect({
     : committedEmptyMeansAllSelected;
 
   const implicitAllSelected =
-    emptyValueMeansAllSelected &&
-    activeEmptyMeansAllSelected &&
-    activeExplicitValue.length === 0;
+    emptyValueMeansAllSelected && activeEmptyMeansAllSelected && activeExplicitValue.length === 0;
 
   const effectiveValue = useMemo(
-    () => (implicitAllSelected ? options.map((option) => option.value) : activeExplicitValue),
-    [activeExplicitValue, implicitAllSelected, options],
+    () =>
+      implicitAllSelected
+        ? neutralAllSelection
+          ? []
+          : options.map((option) => option.value)
+        : activeExplicitValue,
+    [activeExplicitValue, implicitAllSelected, neutralAllSelection, options],
   );
 
   const allOptionsSelectedExplicitly =
@@ -198,7 +208,7 @@ export function SearchableCheckboxMultiSelect({
     const rect = trigger.getBoundingClientRect();
     const gap = 6;
     const maxHeight = 360;
-    const listChromeHeight = manualApply ? 132 : 84;
+    const listChromeHeight = (manualApply ? 132 : 84) + (selectionHint ? 14 : 0);
     const setPanelMaxHeight = (height: number) => {
       setListMaxHeight(Math.max(96, height - listChromeHeight));
       return height;
@@ -250,7 +260,7 @@ export function SearchableCheckboxMultiSelect({
         position: "fixed",
         bottom: window.innerHeight - rect.top + gap,
         left: rect.left,
-        width: Math.max(rect.width, 260),
+        width: Math.max(rect.width, options.some((option) => option.trailing) ? 300 : 260),
         maxHeight: panelMaxHeight,
         zIndex: 99999,
       });
@@ -263,11 +273,11 @@ export function SearchableCheckboxMultiSelect({
       position: "fixed",
       top: rect.bottom + gap,
       left: rect.left,
-      width: Math.max(rect.width, 260),
+      width: Math.max(rect.width, options.some((option) => option.trailing) ? 300 : 260),
       maxHeight: panelMaxHeight,
       zIndex: 99999,
     });
-  }, [manualApply, mobileBreakpoint]);
+  }, [manualApply, mobileBreakpoint, options, selectionHint]);
 
   useEffect(() => {
     if (!open) return;
@@ -311,9 +321,7 @@ export function SearchableCheckboxMultiSelect({
   const normalizeSelection = useCallback(
     (next: string[]) => {
       const allowed = new Set(options.map((option) => option.value));
-      return next.filter(
-        (item, index) => allowed.has(item) && next.indexOf(item) === index,
-      );
+      return next.filter((item, index) => allowed.has(item) && next.indexOf(item) === index);
     },
     [options],
   );
@@ -321,14 +329,26 @@ export function SearchableCheckboxMultiSelect({
   const updateSelection = useCallback(
     (next: string[], nextEmptyMeansAllSelected = false) => {
       const unique = normalizeSelection(next);
+      const representsAll =
+        emptyValueMeansAllSelected &&
+        (nextEmptyMeansAllSelected ||
+          (neutralAllSelection &&
+            (unique.length === 0 || (options.length > 0 && unique.length === options.length))));
       if (manualApply) {
-        setDraftExplicitValue(unique);
-        setDraftEmptyMeansAllSelected(unique.length === 0 && nextEmptyMeansAllSelected);
+        setDraftExplicitValue(representsAll ? [] : unique);
+        setDraftEmptyMeansAllSelected(representsAll);
         return;
       }
-      onChange(unique);
+      onChange(representsAll ? options.map((option) => option.value) : unique);
     },
-    [manualApply, normalizeSelection, onChange],
+    [
+      emptyValueMeansAllSelected,
+      manualApply,
+      neutralAllSelection,
+      normalizeSelection,
+      onChange,
+      options,
+    ],
   );
 
   const toggleOption = useCallback(
@@ -337,6 +357,8 @@ export function SearchableCheckboxMultiSelect({
         updateSelection(effectiveValue.filter((item) => item !== optionValue));
         return;
       }
+      // In neutral-all mode the unrestricted state has no checked rows, so the
+      // first click directly selects that item instead of excluding it from all.
       updateSelection([...effectiveValue, optionValue]);
     },
     [effectiveValue, selectedSet, updateSelection],
@@ -363,9 +385,21 @@ export function SearchableCheckboxMultiSelect({
 
   const applyDraftSelection = useCallback(() => {
     if (!manualApply) return;
-    onChange(normalizeSelection(draftExplicitValue));
+    onChange(
+      draftEmptyMeansAllSelected
+        ? options.map((option) => option.value)
+        : normalizeSelection(draftExplicitValue),
+    );
     closeDropdown(false);
-  }, [closeDropdown, draftExplicitValue, manualApply, normalizeSelection, onChange]);
+  }, [
+    closeDropdown,
+    draftEmptyMeansAllSelected,
+    draftExplicitValue,
+    manualApply,
+    normalizeSelection,
+    onChange,
+    options,
+  ]);
 
   const hasPendingChanges =
     manualApply &&
@@ -428,13 +462,13 @@ export function SearchableCheckboxMultiSelect({
           aria-label={ariaLabel}
           disabled={disabled}
           onClick={() => {
-              if (!open) {
-                if (manualApply) setDraftExplicitValue(sanitizedExplicitValue);
-                if (manualApply) setDraftEmptyMeansAllSelected(committedEmptyMeansAllSelected);
-                updatePosition();
-              }
-              setOpen((current) => !current);
-            }}
+            if (!open) {
+              if (manualApply) setDraftExplicitValue(sanitizedExplicitValue);
+              if (manualApply) setDraftEmptyMeansAllSelected(committedEmptyMeansAllSelected);
+              updatePosition();
+            }
+            setOpen((current) => !current);
+          }}
           className={cn(
             getSelectTriggerBase(size),
             "w-full justify-between text-left",
@@ -516,26 +550,45 @@ export function SearchableCheckboxMultiSelect({
                   spellCheck={false}
                 />
               </div>
-              {selectAllLabel || showFilteredToggle ? (
+              {selectAllLabel || neutralAllSelection || showFilteredToggle || selectionHint ? (
                 <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 dark:border-neutral-800">
-                  <span
-                    className={cn(
-                      "text-xs font-medium",
-                      showAllSelectionSummary
-                        ? "text-emerald-600 dark:text-emerald-300"
-                        : "text-slate-500 dark:text-white/50",
-                    )}
-                  >
-                    {showAllSelectionSummary ? placeholder : selectedCountLabel(effectiveValue.length)}
+                  <span className="min-w-0">
+                    <span
+                      className={cn(
+                        "block text-xs font-medium",
+                        showAllSelectionSummary
+                          ? "text-emerald-600 dark:text-emerald-300"
+                          : "text-slate-500 dark:text-white/50",
+                      )}
+                    >
+                      {showAllSelectionSummary
+                        ? placeholder
+                        : selectedCountLabel(effectiveValue.length)}
+                    </span>
+                    {selectionHint ? (
+                      <span className="mt-0.5 block truncate text-2xs text-slate-400 dark:text-white/35">
+                        {selectionHint}
+                      </span>
+                    ) : null}
                   </span>
-                  <div className="flex items-center gap-2">
-                    {selectAllLabel ? (
+                  <div className="flex shrink-0 items-center gap-2">
+                    {neutralAllSelection ? (
+                      <button
+                        type="button"
+                        onClick={() => updateSelection([], true)}
+                        disabled={options.length === 0 || showAllSelectionSummary}
+                        className="rounded-md px-2 py-1 text-xs font-medium text-indigo-600 transition hover:bg-indigo-50 disabled:cursor-default disabled:text-slate-300 dark:text-indigo-300 dark:hover:bg-indigo-500/10 dark:disabled:text-white/20"
+                      >
+                        {allSelectionLabel || placeholder}
+                      </button>
+                    ) : selectAllLabel ? (
                       <button
                         type="button"
                         onClick={showAllSelectionSummary ? deselectAllOptions : selectAllOptions}
                         disabled={
                           options.length === 0 ||
-                          (!deselectAllLabel && (allOptionsSelectedExplicitly || implicitAllSelected))
+                          (!deselectAllLabel &&
+                            (allOptionsSelectedExplicitly || implicitAllSelected))
                         }
                         className="rounded-md px-2 py-1 text-xs font-medium text-indigo-600 transition hover:bg-indigo-50 disabled:cursor-not-allowed disabled:text-slate-300 dark:text-indigo-300 dark:hover:bg-indigo-500/10 dark:disabled:text-white/20"
                       >
@@ -595,7 +648,20 @@ export function SearchableCheckboxMultiSelect({
                         >
                           {checked ? <Check size={12} /> : null}
                         </span>
-                        <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                        <span
+                          className="min-w-0 flex-1 truncate text-left"
+                          title={typeof option.label === "string" ? option.label : undefined}
+                        >
+                          {option.label}
+                        </span>
+                        {option.trailing ? (
+                          <>
+                            <span className="sr-only">, </span>
+                            <span className="inline-flex shrink-0 items-center">
+                              {option.trailing}
+                            </span>
+                          </>
+                        ) : null}
                       </button>
                     );
                   })

--- a/packages/ui/src/primitives/SearchableSelect.tsx
+++ b/packages/ui/src/primitives/SearchableSelect.tsx
@@ -67,6 +67,7 @@ export interface SearchableSelectProps {
   className?: string;
   disabled?: boolean;
   size?: ControlSize;
+  dropdownMinWidth?: number;
 }
 
 /* ------------------------------------------------------------------ */
@@ -92,13 +93,11 @@ function OptionContent({
         {label}
       </span>
       {trailing ? <span className="inline-flex shrink-0 items-center">{trailing}</span> : null}
-      {selected ? (
-        <Check
-          size={14}
-          className="ml-1 shrink-0 text-[#96969B] dark:text-[#9F9FA8]"
-          aria-hidden="true"
-        />
-      ) : null}
+      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center">
+        {selected ? (
+          <Check size={14} className="text-[#96969B] dark:text-[#9F9FA8]" aria-hidden="true" />
+        ) : null}
+      </span>
     </>
   );
 }
@@ -118,6 +117,7 @@ export function SearchableSelect({
   className,
   disabled = false,
   size = "default",
+  dropdownMinWidth = 0,
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -317,7 +317,7 @@ export function SearchableSelect({
               style={{
                 top: pos.top,
                 left: pos.left,
-                minWidth: pos.width,
+                minWidth: Math.max(pos.width, dropdownMinWidth),
                 maxWidth: "min(500px, 90vw)",
                 maxHeight: pos.maxHeight,
               }}

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -58,6 +58,8 @@ import {
   formatRequestLogLatencyMs,
   normalizeChannelAuthType,
   normalizeFilterSelection,
+  RequestLogFilterCount,
+  sortRequestLogKeyOptionsByCount,
   toFilterParam,
   toStatusFilterValues,
   maskRequestLogApiKey,
@@ -289,7 +291,7 @@ function toLogRow(item: PublicLogItem): RequestLogsRow {
 // ── Page Component ──────────────────────────────────────────────────────────
 
 export function ApiKeyLookupPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const {
     state: { mode },
   } = useTheme();
@@ -419,8 +421,7 @@ export function ApiKeyLookupPage() {
 
   // ── Filters ──
   const [timeRange, setTimeRange] = useState<TimeRange>(7);
-  const [selectedApiKeyIds, setSelectedApiKeyIds] =
-    useState<MultiSelectFilterState<string>>(null);
+  const [selectedApiKeyIds, setSelectedApiKeyIds] = useState<MultiSelectFilterState<string>>(null);
   const [selectedModels, setSelectedModels] = useState<MultiSelectFilterState<string>>(null);
   const [selectedStatuses, setSelectedStatuses] =
     useState<MultiSelectFilterState<StatusFilterValue>>(null);
@@ -435,20 +436,39 @@ export function ApiKeyLookupPage() {
   const [filterOptions, setFilterOptions] = useState<{
     api_key_ids: string[];
     api_key_id_names: Record<string, string>;
+    api_key_id_counts: Record<string, number>;
     models: string[];
     statuses: string[];
-  }>({ api_key_ids: [], api_key_id_names: {}, models: [], statuses: ["success", "failed"] });
+  }>({
+    api_key_ids: [],
+    api_key_id_names: {},
+    api_key_id_counts: {},
+    models: [],
+    statuses: ["success", "failed"],
+  });
 
   const keyOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
-    return (filterOptions.api_key_ids ?? []).map((id) => {
+    const options = (filterOptions.api_key_ids ?? []).map((id) => {
       const name = filterOptions.api_key_id_names?.[id] || id;
       return {
         value: id,
         label: name,
         searchText: name,
+        count: filterOptions.api_key_id_counts?.[id] ?? 0,
       };
     });
-  }, [filterOptions.api_key_ids, filterOptions.api_key_id_names]);
+    return sortRequestLogKeyOptionsByCount(options, i18n.resolvedLanguage).map((option) => ({
+      value: option.value,
+      label: option.label,
+      searchText: option.searchText,
+      trailing: <RequestLogFilterCount count={option.count} />,
+    }));
+  }, [
+    filterOptions.api_key_id_counts,
+    filterOptions.api_key_id_names,
+    filterOptions.api_key_ids,
+    i18n.resolvedLanguage,
+  ]);
 
   const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return filterOptions.models.map((model) => ({
@@ -576,6 +596,7 @@ export function ApiKeyLookupPage() {
         setFilterOptions({
           api_key_ids: resp.filters?.api_key_ids ?? [],
           api_key_id_names: resp.filters?.api_key_id_names ?? {},
+          api_key_id_counts: resp.filters?.api_key_id_counts ?? {},
           models: resp.filters?.models ?? [],
           statuses: resp.filters?.statuses ?? ["success", "failed"],
         });
@@ -810,6 +831,7 @@ export function ApiKeyLookupPage() {
     setFilterOptions({
       api_key_ids: [],
       api_key_id_names: {},
+      api_key_id_counts: {},
       models: [],
       statuses: ["success", "failed"],
     });
@@ -833,8 +855,8 @@ export function ApiKeyLookupPage() {
   }, []);
 
   // Avoid landing flash while a stored portal session is still hydrating.
-  const [portalSessionPending, setPortalSessionPending] = useState(
-    () => Boolean(portalApi.loadSession()?.accessToken),
+  const [portalSessionPending, setPortalSessionPending] = useState(() =>
+    Boolean(portalApi.loadSession()?.accessToken),
   );
 
   useEffect(() => {
@@ -989,6 +1011,7 @@ export function ApiKeyLookupPage() {
       setFilterOptions({
         api_key_ids: [],
         api_key_id_names: {},
+        api_key_id_counts: {},
         models: [],
         statuses: ["success", "failed"],
       });
@@ -999,8 +1022,7 @@ export function ApiKeyLookupPage() {
 
       // Prefill usage from this account's cache; cold accounts still skeleton.
       const nextChartKey = `account:${target.user.id}|${timeRange}`;
-      const cached =
-        chartCacheRef.current[nextChartKey] || readStoredChartCache(nextChartKey);
+      const cached = chartCacheRef.current[nextChartKey] || readStoredChartCache(nextChartKey);
       if (cached) {
         chartCacheRef.current[nextChartKey] = cached;
         setChartData(cached);
@@ -1323,7 +1345,9 @@ export function ApiKeyLookupPage() {
                                   <DropdownMenu.Item
                                     key={account.accountKey}
                                     disabled={isCurrent}
-                                    className={isCurrent ? "data-[disabled]:opacity-100" : undefined}
+                                    className={
+                                      isCurrent ? "data-[disabled]:opacity-100" : undefined
+                                    }
                                     data-testid={
                                       isCurrent
                                         ? "apikey-lookup-current-account"

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -537,6 +537,7 @@ describe("ApiKeyLookupPage", () => {
         filters: {
           api_key_ids: ["key-laptop", "key-auto"],
           api_key_id_names: { "key-laptop": "Laptop", "key-auto": "Automation" },
+          api_key_id_counts: { "key-laptop": 12, "key-auto": 37 },
           models: ["gpt-5.5"],
           channels: ["Codex 主渠道", "OpenCode"],
           statuses: ["success", "failed"],
@@ -558,6 +559,7 @@ describe("ApiKeyLookupPage", () => {
         filters: {
           api_key_ids: ["key-laptop", "key-auto"],
           api_key_id_names: { "key-laptop": "Laptop", "key-auto": "Automation" },
+          api_key_id_counts: { "key-laptop": 12, "key-auto": 37 },
           models: ["gpt-5.5"],
           channels: ["Codex 主渠道"],
           statuses: ["success"],
@@ -586,15 +588,23 @@ describe("ApiKeyLookupPage", () => {
     );
 
     await userEvent.click(screen.getByRole("combobox", { name: /filter by key/i }));
-    // emptyValueMeansAllSelected: clicking one option deselects it from "all".
-    await userEvent.click(await screen.findByRole("option", { name: /Laptop/i }));
+    const keyOptions = await screen.findAllByRole("option");
+    expect(keyOptions[0]).toHaveAccessibleName(/Automation,?\s*37 calls/i);
+    expect(keyOptions[1]).toHaveAccessibleName(/Laptop,?\s*12 calls/i);
+    expect(keyOptions[0]).toHaveAttribute("aria-selected", "false");
+    expect(keyOptions[1]).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("listbox", { name: /filter by key/i })).not.toHaveTextContent(
+      "sk-restored-key",
+    );
+
+    await userEvent.click(screen.getByRole("option", { name: /Laptop/i }));
     await userEvent.click(screen.getByRole("button", { name: /apply filters/i }));
 
     await waitFor(() => {
       expect(mocks.fetchPublicLogs).toHaveBeenLastCalledWith(
         expect.objectContaining({
           apiKey: "sk-restored-key",
-          apiKeyIds: ["key-auto"],
+          apiKeyIds: ["key-laptop"],
           apiKeyIdsEmpty: false,
         }),
       );

--- a/pages/api-key-lookup/components/PublicLogsSection.tsx
+++ b/pages/api-key-lookup/components/PublicLogsSection.tsx
@@ -99,9 +99,9 @@ export function PublicLogsSection({
                     applyMode="manual"
                     applyLabel={t("request_logs.apply_filters")}
                     cancelLabel={t("common.cancel")}
-                    selectAllLabel={t("request_logs.select_all")}
-                    deselectAllLabel={t("request_logs.deselect_all")}
-                    emptySelectionLabel={t("request_logs.none_selected")}
+                    neutralAllSelection
+                    allSelectionLabel={t("request_logs.unrestricted")}
+                    selectionHint={t("request_logs.calls_sorted_hint")}
                   />
                 </div>
               ) : null}
@@ -133,15 +133,10 @@ export function PublicLogsSection({
               </span>
               <span className="inline-flex items-center justify-end gap-1.5 whitespace-nowrap sm:justify-start">
                 {t("common.success_rate")}
-                <span className="font-mono tabular-nums">
-                  {stats.success_rate.toFixed(1)}%
-                </span>
+                <span className="font-mono tabular-nums">{stats.success_rate.toFixed(1)}%</span>
               </span>
               <span className="hidden sm:inline-flex items-center gap-1.5 whitespace-nowrap">
-                <span
-                  className="text-slate-300 dark:text-white/10"
-                  aria-hidden="true"
-                >
+                <span className="text-slate-300 dark:text-white/10" aria-hidden="true">
                   ·
                 </span>
                 {t("apikey_lookup.token")}
@@ -151,10 +146,7 @@ export function PublicLogsSection({
               </span>
               {lastUpdatedText ? (
                 <span className="hidden sm:inline-flex items-center gap-1.5 whitespace-nowrap">
-                  <span
-                    className="text-slate-300 dark:text-white/10"
-                    aria-hidden="true"
-                  >
+                  <span className="text-slate-300 dark:text-white/10" aria-hidden="true">
                     ·
                   </span>
                   <span className="text-slate-400 dark:text-white/40">

--- a/pages/api-key-lookup/types.ts
+++ b/pages/api-key-lookup/types.ts
@@ -49,6 +49,7 @@ export interface PublicLogsResponse {
   filters: {
     api_key_ids?: string[];
     api_key_id_names?: Record<string, string>;
+    api_key_id_counts?: Record<string, number>;
     models: string[];
     channels: string[];
     channel_options?: PublicChannelFilterOption[];

--- a/pages/api-keys/components/ApiKeyUsageModal.tsx
+++ b/pages/api-keys/components/ApiKeyUsageModal.tsx
@@ -120,8 +120,9 @@ export function ApiKeyUsageModal({
             placeholder={t("request_logs.all_keys_placeholder")}
             searchPlaceholder={t("request_logs.search_keys")}
             aria-label={t("request_logs.filter_key")}
-            className="w-full sm:w-auto"
+            className="w-full sm:w-[220px]"
             size="sm"
+            dropdownMinWidth={300}
           />
           <SearchableSelect
             value={usageChannelQuery}

--- a/pages/api-keys/hooks/__tests__/useApiKeyUsageView.test.tsx
+++ b/pages/api-keys/hooks/__tests__/useApiKeyUsageView.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { isValidElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { ThemeProvider, ToastProvider } from "@code-proxy/ui";
+import type { UsageLogsResponse } from "@code-proxy/api-client/endpoints/usage";
+import { useApiKeyUsageView } from "../useApiKeyUsageView";
+
+const mocks = vi.hoisted(() => ({
+  getUsageLogs: vi.fn<() => Promise<UsageLogsResponse>>(),
+}));
+
+vi.mock("@code-proxy/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@code-proxy/api-client")>();
+  return {
+    ...actual,
+    usageApi: {
+      ...actual.usageApi,
+      getUsageLogs: mocks.getUsageLogs,
+    },
+  };
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider>
+    <ToastProvider>{children}</ToastProvider>
+  </ThemeProvider>
+);
+
+function readTrailingCount(value: ReactNode): number | undefined {
+  return isValidElement<{ count: number }>(value) ? value.props.count : undefined;
+}
+
+describe("useApiKeyUsageView", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await i18n.changeLanguage("en");
+    mocks.getUsageLogs.mockResolvedValue({
+      items: [],
+      total: 42,
+      page: 1,
+      size: 50,
+      filters: {
+        api_keys: ["sk-low", "sk-high", "sk-out-of-scope"],
+        api_key_names: {
+          "sk-low": "Low volume",
+          "sk-high": "High volume",
+          "sk-out-of-scope": "Other account",
+        },
+        api_key_counts: {
+          "sk-low": 12,
+          "sk-high": 30,
+          "sk-out-of-scope": 999,
+        },
+        models: [],
+        channels: [],
+        channel_options: [],
+        statuses: ["success", "failed"],
+      },
+      stats: {
+        total: 42,
+        success_rate: 100,
+        total_tokens: 0,
+        total_cost: 0,
+        cache_rate: 0,
+      },
+    });
+  });
+
+  test("keeps All Keys first and sorts scoped keys by their request counts", async () => {
+    const { result } = renderHook(() => useApiKeyUsageView(), { wrapper });
+
+    act(() => {
+      result.current.openUsageView(["sk-low", "sk-high"], "Alice", {
+        "sk-low": "Low volume",
+        "sk-high": "High volume",
+      });
+    });
+
+    await waitFor(() => expect(mocks.getUsageLogs).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(result.current.usageKeyOptions.map((option) => option.value)).toEqual([
+        "",
+        "sk-high",
+        "sk-low",
+      ]),
+    );
+
+    expect(mocks.getUsageLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ api_keys: ["sk-low", "sk-high"] }),
+    );
+    expect(result.current.usageKeyOptions.map((option) => option.label)).toEqual([
+      "All Keys",
+      "High volume",
+      "Low volume",
+    ]);
+    expect(
+      result.current.usageKeyOptions.map((option) => readTrailingCount(option.trailing)),
+    ).toEqual([42, 30, 12]);
+    expect(
+      result.current.usageKeyOptions.some((option) => option.value === "sk-out-of-scope"),
+    ).toBe(false);
+  });
+});

--- a/pages/api-keys/hooks/useApiKeyUsageView.tsx
+++ b/pages/api-keys/hooks/useApiKeyUsageView.tsx
@@ -11,8 +11,10 @@ import { ModelTag } from "@features/model-tags";
 import {
   buildRequestLogKeyOptions,
   buildRequestLogsColumns,
+  RequestLogFilterCount,
   ChannelIdentityLabel,
   DEFAULT_REQUEST_LOG_PAGE_SIZE,
+  sortRequestLogKeyOptionsByCount,
   toRequestLogsRow,
   type RequestLogsRow,
   type TimeRange,
@@ -21,7 +23,7 @@ import {
 type StatusFilter = "" | "success" | "failed";
 
 export function useApiKeyUsageView() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { notify } = useToast();
 
   const [usageViewKeys, setUsageViewKeys] = useState<string[]>([]);
@@ -35,12 +37,14 @@ export function useApiKeyUsageView() {
   const [usageFilterOptions, setUsageFilterOptions] = useState<{
     api_keys: string[];
     api_key_names: Record<string, string>;
+    api_key_counts: Record<string, number>;
     channels: string[];
     channel_options: UsageChannelFilterOption[];
     models: string[];
   }>({
     api_keys: [],
     api_key_names: {},
+    api_key_counts: {},
     channels: [],
     channel_options: [],
     models: [],
@@ -117,14 +121,15 @@ export function useApiKeyUsageView() {
         const responseKeys = Array.isArray(result.filters?.api_keys)
           ? result.filters.api_keys.filter((key) => scopeSet.has(key))
           : [];
-        const keys =
-          responseKeys.length > 0
-            ? responseKeys
-            : usageViewKeys;
+        const keys = responseKeys.length > 0 ? responseKeys : usageViewKeys;
         const names = { ...result.filters?.api_key_names };
+        const counts = Object.fromEntries(
+          Object.entries(result.filters?.api_key_counts ?? {}).filter(([key]) => scopeSet.has(key)),
+        );
         setUsageFilterOptions({
           api_keys: keys,
           api_key_names: names,
+          api_key_counts: counts,
           channels: Array.isArray(result.filters?.channels) ? result.filters.channels : [],
           channel_options: Array.isArray(result.filters?.channel_options)
             ? result.filters.channel_options
@@ -163,6 +168,7 @@ export function useApiKeyUsageView() {
     setUsageFilterOptions({
       api_keys: [],
       api_key_names: {},
+      api_key_counts: {},
       channels: [],
       channel_options: [],
       models: [],
@@ -185,6 +191,7 @@ export function useApiKeyUsageView() {
       setUsageFilterOptions({
         api_keys: cleaned,
         api_key_names: keyNames ?? {},
+        api_key_counts: {},
         channels: [],
         channel_options: [],
         models: [],
@@ -204,16 +211,30 @@ export function useApiKeyUsageView() {
   const usageKeyOptions = useMemo<SearchableSelectOption[]>(() => {
     const sourceKeys =
       usageFilterOptions.api_keys.length > 0 ? usageFilterOptions.api_keys : usageViewKeys;
-    const opts = buildRequestLogKeyOptions(sourceKeys, usageFilterOptions.api_key_names, {
-      allKeys: t("request_logs.all_keys"),
-      systemCall: t("request_logs.system_call"),
-    });
-    return opts.map((option) => ({
+    const opts = buildRequestLogKeyOptions(
+      sourceKeys,
+      usageFilterOptions.api_key_names,
+      {
+        allKeys: t("request_logs.all_keys"),
+        systemCall: t("request_logs.system_call"),
+      },
+      usageFilterOptions.api_key_counts,
+    );
+    return sortRequestLogKeyOptionsByCount(opts, i18n.resolvedLanguage).map((option) => ({
       value: option.value,
       label: option.label,
-      searchText: option.searchText ?? (typeof option.label === "string" ? option.label : option.value),
+      triggerLabel: option.label,
+      searchText: option.searchText ?? option.label,
+      trailing: <RequestLogFilterCount count={option.count} />,
     }));
-  }, [t, usageFilterOptions.api_key_names, usageFilterOptions.api_keys, usageViewKeys]);
+  }, [
+    i18n.resolvedLanguage,
+    t,
+    usageFilterOptions.api_key_counts,
+    usageFilterOptions.api_key_names,
+    usageFilterOptions.api_keys,
+    usageViewKeys,
+  ]);
 
   const usageChannelOptions = useMemo<SearchableSelectOption[]>(() => {
     const apiLabel = t("request_logs.auth_type_api");
@@ -226,7 +247,11 @@ export function useApiKeyUsageView() {
             label: ch,
           }));
     return [
-      { value: "", label: t("request_logs.all_channels"), searchText: t("request_logs.all_channels") },
+      {
+        value: "",
+        label: t("request_logs.all_channels"),
+        searchText: t("request_logs.all_channels"),
+      },
       ...source.map((option) => {
         const provider = String(option.provider ?? "").trim();
         const authType = String(option.auth_type ?? "").trim();

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -5,6 +5,7 @@ import {
   buildRequestLogsColumns,
   buildRequestLogKeyOptions,
   isSystemRequestLogKey,
+  sortRequestLogKeyOptionsByCount,
   SYSTEM_REQUEST_LOG_FILTER_VALUE,
   toRequestLogsRow,
 } from "@features/request-log-viewer";
@@ -88,6 +89,36 @@ describe("requestLogsShared", () => {
       SYSTEM_REQUEST_LOG_FILTER_VALUE,
     );
     expect(options.find((option) => option.label === "Live Key")?.value).toBe("sk-live-123456");
+  });
+
+  test("aggregates system counts and sorts key options by count with stable ties", () => {
+    const options = buildRequestLogKeyOptions(
+      [
+        "POST /image-generation/test",
+        "/v0/management/image-generation/test",
+        "sk-zulu",
+        "sk-alpha",
+      ],
+      { "sk-zulu": "Zulu", "sk-alpha": "Alpha" },
+      { allKeys: "全部密钥", systemCall: "系统调用" },
+      {
+        "POST /image-generation/test": 4,
+        "/v0/management/image-generation/test": 6,
+        "sk-zulu": 8,
+        "sk-alpha": 8,
+      },
+    );
+
+    expect(options.find((option) => option.value === "")?.count).toBe(26);
+    expect(options.find((option) => option.value === SYSTEM_REQUEST_LOG_FILTER_VALUE)?.count).toBe(
+      10,
+    );
+    expect(sortRequestLogKeyOptionsByCount(options, "en").map((option) => option.label)).toEqual([
+      "全部密钥",
+      "系统调用",
+      "Alpha",
+      "Zulu",
+    ]);
   });
 
   test("keeps high-signal request metrics before bulky identifier columns", () => {

--- a/pages/request-logs/RequestLogsFilters.tsx
+++ b/pages/request-logs/RequestLogsFilters.tsx
@@ -77,9 +77,9 @@ export function RequestLogsFilters({
             applyMode="manual"
             applyLabel={t("request_logs.apply_filters")}
             cancelLabel={t("common.cancel")}
-            selectAllLabel={t("request_logs.select_all")}
-            deselectAllLabel={t("request_logs.deselect_all")}
-            emptySelectionLabel={t("request_logs.none_selected")}
+            neutralAllSelection
+            allSelectionLabel={t("request_logs.unrestricted")}
+            selectionHint={t("request_logs.calls_sorted_hint")}
           />
         </div>
         <RequestLogFacetFilters

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -31,9 +31,11 @@ import {
   DEFAULT_REQUEST_LOG_PAGE_SIZE,
   hasActiveFilterSelection,
   normalizeFilterSelection,
+  RequestLogFilterCount,
   RequestLogUsageMetricValue,
   RequestLogsPaginationBar,
   RequestLogsTimeRangeSelector,
+  sortRequestLogKeyOptionsByCount,
   toFilterParam,
   toRequestLogsRow,
   toStatusFilterValues,
@@ -84,7 +86,7 @@ function RequestLogsRecordsCount({ count }: { count: number }) {
 // ---------------------------------------------------------------------------
 
 export function RequestLogsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { notify } = useToast();
 
   // Content modal state
@@ -142,6 +144,7 @@ export function RequestLogsPage() {
   const [filterOptions, setFilterOptions] = useState<{
     api_keys: string[];
     api_key_names: Record<string, string>;
+    api_key_counts: Record<string, number>;
     models: string[];
     channels: string[];
     channel_options: UsageChannelFilterOption[];
@@ -149,6 +152,7 @@ export function RequestLogsPage() {
   }>({
     api_keys: [],
     api_key_names: {},
+    api_key_counts: {},
     models: [],
     channels: [],
     channel_options: [],
@@ -191,9 +195,23 @@ export function RequestLogsPage() {
         allKeys: t("request_logs.all_users"),
         systemCall: t("request_logs.system_call"),
       },
+      filterOptions.api_key_counts,
     );
-    return opts.filter((option) => option.value !== "");
-  }, [filterOptions.api_keys, filterOptions.api_key_names, t]);
+    return sortRequestLogKeyOptionsByCount(opts, i18n.resolvedLanguage)
+      .filter((option) => option.value !== "")
+      .map((option) => ({
+        value: option.value,
+        label: option.label,
+        searchText: option.searchText,
+        trailing: <RequestLogFilterCount count={option.count} />,
+      }));
+  }, [
+    filterOptions.api_key_counts,
+    filterOptions.api_key_names,
+    filterOptions.api_keys,
+    i18n.resolvedLanguage,
+    t,
+  ]);
 
   const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
     return filterOptions.models.map((m) => ({
@@ -370,6 +388,7 @@ export function RequestLogsPage() {
         setFilterOptions({
           api_keys: resp.filters?.api_keys ?? [],
           api_key_names: resp.filters?.api_key_names ?? {},
+          api_key_counts: resp.filters?.api_key_counts ?? {},
           models: resp.filters?.models ?? [],
           channels: resp.filters?.channels ?? [],
           channel_options: resp.filters?.channel_options ?? [],

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -49,6 +49,10 @@ const responseWithFilterOptions = {
       "sk-primary": "Primary",
       "sk-secondary": "Secondary",
     },
+    api_key_counts: {
+      "sk-primary": 12,
+      "sk-secondary": 37,
+    },
     models: ["gpt-5.4", "gpt-4.1"],
     channels: ["Codex", "Relay"],
     channel_options: [
@@ -423,7 +427,7 @@ describe("RequestLogsPage", () => {
     await waitFor(() => expect(screen.queryByText("stale-model")).not.toBeInTheDocument());
   });
 
-  test("shows request-log multi-select filters as all-selected by default", async () => {
+  test("shows request-log user counts in descending order with an unrestricted default", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();
 
@@ -446,14 +450,13 @@ describe("RequestLogsPage", () => {
 
     await user.click(keyFilter);
 
-    expect(await screen.findByRole("option", { name: "Primary" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    expect(screen.getByRole("option", { name: "Secondary" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
+    const options = await screen.findAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveAccessibleName(/Secondary,?\s*37 calls/i);
+    expect(options[1]).toHaveAccessibleName(/Primary,?\s*12 calls/i);
+    expect(options[0]).toHaveAttribute("aria-selected", "false");
+    expect(options[1]).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByText("Sorted by calls in the current log range")).toBeInTheDocument();
   });
 
   test("uses backend status filter candidates", async () => {
@@ -483,11 +486,25 @@ describe("RequestLogsPage", () => {
     expect(screen.queryByRole("option", { name: "Failed" })).not.toBeInTheDocument();
   });
 
-  test("only applies request-log multi-select changes after confirmation and restores full selection", async () => {
+  test("applies neutral user selections only after confirmation and supports multi-select", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();
 
-    mocks.getUsageLogs.mockResolvedValue(responseWithFilterOptions);
+    mocks.getUsageLogs.mockResolvedValue({
+      ...responseWithFilterOptions,
+      filters: {
+        ...responseWithFilterOptions.filters,
+        api_keys: ["sk-primary", "sk-secondary", "sk-tertiary"],
+        api_key_names: {
+          ...responseWithFilterOptions.filters.api_key_names,
+          "sk-tertiary": "Tertiary",
+        },
+        api_key_counts: {
+          ...responseWithFilterOptions.filters.api_key_counts,
+          "sk-tertiary": 5,
+        },
+      },
+    });
 
     render(
       <ThemeProvider>
@@ -517,7 +534,7 @@ describe("RequestLogsPage", () => {
     );
 
     await user.click(keyFilter);
-    await user.click(await screen.findByRole("option", { name: "Primary" }));
+    await user.click(await screen.findByRole("option", { name: /Primary/i }));
 
     expect(mocks.getUsageLogs).toHaveBeenCalledTimes(1);
 
@@ -527,7 +544,7 @@ describe("RequestLogsPage", () => {
       expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          api_keys: ["sk-secondary"],
+          api_keys: ["sk-primary"],
           api_keys_empty: false,
         }),
         expectSignalOptions(),
@@ -535,7 +552,7 @@ describe("RequestLogsPage", () => {
     );
 
     await user.click(keyFilter);
-    await user.click(screen.getByRole("button", { name: "Select all" }));
+    await user.click(screen.getByRole("option", { name: /Secondary/i }));
 
     expect(mocks.getUsageLogs).toHaveBeenCalledTimes(2);
 
@@ -545,7 +562,7 @@ describe("RequestLogsPage", () => {
       expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
         3,
         expect.objectContaining({
-          api_keys: undefined,
+          api_keys: ["sk-primary", "sk-secondary"],
           api_keys_empty: false,
         }),
         expectSignalOptions(),
@@ -553,25 +570,15 @@ describe("RequestLogsPage", () => {
     );
 
     await user.click(keyFilter);
-    await user.click(screen.getByRole("option", { name: "Primary" }));
+    await user.click(screen.getByRole("button", { name: "Any" }));
+
+    expect(mocks.getUsageLogs).toHaveBeenCalledTimes(3);
+
     await user.click(screen.getByRole("button", { name: "Apply filters" }));
 
     await waitFor(() =>
       expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
         4,
-        expect.objectContaining({
-          api_keys: ["sk-secondary"],
-          api_keys_empty: false,
-        }),
-        expectSignalOptions(),
-      ),
-    );
-
-    await user.click(await screen.findByText("Reset filters"));
-
-    await waitFor(() =>
-      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
-        5,
         expect.objectContaining({
           api_keys: undefined,
           api_keys_empty: false,
@@ -581,7 +588,7 @@ describe("RequestLogsPage", () => {
     );
   });
 
-  test("supports deselecting all request-log filter options in one click", async () => {
+  test("returns to unrestricted when the last selected user is cleared", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();
 
@@ -598,20 +605,36 @@ describe("RequestLogsPage", () => {
     const [keyFilter] = await screen.findAllByRole("combobox");
 
     await user.click(keyFilter);
-    expect(await screen.findByRole("button", { name: "Deselect all" })).toBeInTheDocument();
+    await user.click(await screen.findByRole("option", { name: /Primary/i }));
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
 
-    await user.click(screen.getByRole("button", { name: "Deselect all" }));
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          api_keys: ["sk-primary"],
+          api_keys_empty: false,
+        }),
+        expectSignalOptions(),
+      ),
+    );
+
+    await user.click(keyFilter);
+    const selectedPrimary = await screen.findByRole("option", { name: /Primary/i });
+    expect(selectedPrimary).toHaveAttribute("aria-selected", "true");
+    await user.click(selectedPrimary);
     expect(screen.getByRole("combobox", { name: "Filter by user name" })).toHaveTextContent(
-      "0 selected",
+      "All Users",
     );
 
     await user.click(screen.getByRole("button", { name: "Apply filters" }));
 
     await waitFor(() =>
-      expect(mocks.getUsageLogs).toHaveBeenLastCalledWith(
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        3,
         expect.objectContaining({
           api_keys: undefined,
-          api_keys_empty: true,
+          api_keys_empty: false,
         }),
         expectSignalOptions(),
       ),


### PR DESCRIPTION
## 修改范围

- `/runtime/request-logs` 用户筛选改为中性“不限”模型，默认不再把所有用户伪装成已勾选，首次点击具体用户即可直接筛选。
- `/access/end-users` 用量弹窗保留即时单选，在 Key 名称右侧固定显示调用次数，“全部 Key”固定第一项，其余按次数降序。
- `/apikey-lookup` 请求日志 Key 筛选同步采用中性“不限”模型，并按稳定 Key ID 展示调用次数，不暴露原始 Key secret。
- 三处统一调用次数格式、降序排序、同次数名称稳定排序、窄屏下拉宽度和可访问名称。
- 对接后端新增的 `api_key_counts` / `api_key_id_counts`，后端依赖已由 kittors/CliRelay#766 合入 `dev`。

## 交互结果

- 默认“不限”时，具体项均未勾选。
- 第一次点击具体项直接只选该项，无需先“取消全选”。
- 可继续追加多选；取消最后一项或点击“不限”后恢复不限范围。
- 名称左对齐、次数右对齐，长名称截断但完整名称保留在 title。

## 验证

- `SKIP_E2E_CRITICAL=1 ./scripts/ci-pr.sh`
  - lint 通过，保留仓库现有 6 条 warning
  - design token 检查通过
  - Vitest：115 files / 819 tests 通过
  - production build 通过
  - bundle diff 通过
- Playwright critical smoke 使用临时 5176 配置执行，因为本机 5173 被其他项目占用：9 tests 通过。
- 真实应用代码路径 + mock API 视觉验证：
  - `/manage/#/runtime/request-logs`
  - `/manage/#/access/end-users` 用量弹窗
  - `/manage/#/apikey-lookup` 请求日志
  - 桌面 1440×900 与移动端 375×812 均已检查。
