### PR TITLE
fix(auth-files): put columns icon inside card density select

### DIFF
--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -798,10 +798,20 @@ export function AuthFilesFilesTab({
   const denseCards = cardColumns >= 4;
   const cardColumnOptions = useMemo(
     () =>
-      AUTH_FILES_CARD_COLUMN_OPTIONS.map((count) => ({
-        value: String(count),
-        label: t("auth_files.card_columns_option", { count }),
-      })),
+      AUTH_FILES_CARD_COLUMN_OPTIONS.map((count) => {
+        const label = t("auth_files.card_columns_option", { count });
+        return {
+          value: String(count),
+          label,
+          // Icon lives inside the select trigger; no separate leading glyph.
+          triggerLabel: (
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <Columns3 size={14} className="shrink-0 opacity-70" aria-hidden />
+              <span className="truncate">{label}</span>
+            </span>
+          ),
+        };
+      }),
     [t],
   );
   const [draftModelOwnerEnabled, setDraftModelOwnerEnabled] = useState(
@@ -1368,29 +1378,22 @@ export function AuthFilesFilesTab({
                     {renderFilesViewModeTabs}
                   </div>
                   {filesViewMode === "cards" ? (
-                    <HoverTooltip content={t("auth_files.card_columns")}>
-                      <div
-                        className="hidden min-w-[7.5rem] items-center gap-1.5 xl:flex"
-                        data-testid="auth-files-card-columns"
-                      >
-                        <Columns3
-                          size={15}
-                          className="shrink-0 text-slate-500 dark:text-white/50"
-                          aria-hidden
-                        />
-                        <Select
-                          value={String(cardColumns)}
-                          onChange={(value) =>
-                            setCardColumnsRaw(normalizeAuthFilesCardColumns(value))
-                          }
-                          options={cardColumnOptions}
-                          aria-label={t("auth_files.card_columns")}
-                          variant="chip"
-                          size="sm"
-                          className="min-w-[5.5rem]"
-                        />
-                      </div>
-                    </HoverTooltip>
+                    <div
+                      className="hidden xl:block"
+                      data-testid="auth-files-card-columns"
+                    >
+                      <Select
+                        value={String(cardColumns)}
+                        onChange={(value) =>
+                          setCardColumnsRaw(normalizeAuthFilesCardColumns(value))
+                        }
+                        options={cardColumnOptions}
+                        aria-label={t("auth_files.card_columns")}
+                        variant="chip"
+                        size="sm"
+                        className="min-w-[6.25rem]"
+                      />
+                    </div>
                   ) : null}
                   {modelOwnerToolbarButton}
                   {selectedCount === 0 ? selectionActionsMenu : null}


### PR DESCRIPTION
## Summary
- 去掉列数控件外侧多余的 Columns3 icon 与 HoverTooltip
- 列 icon 放进 Select chip 触发器内部（`triggerLabel`），与「N 列」文案一体

## Test plan
- [ ] 卡片模式 xl 下仅见一个带列 icon 的 chip 下拉
- [ ] 切换 2–6 列仍生效并持久化
- [ ] 列表模式不显示该控件