### PR TITLE
fix(ui): center auth card header controls and animate mobile sidebar

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -868,14 +868,15 @@ function ShellSidebar({
       {pendingTo && <div className={progressDone ? "rp rp-done" : "rp"} />}
       <aside
         data-collapsed={railCollapsed ? "true" : "false"}
+        data-mobile-open={isMobile ? (collapsed ? "false" : "true") : undefined}
         className={[
           "group/sidebar shrink-0 overflow-visible bg-white/94 dark:bg-neutral-950/88",
           isMobile ? "fixed inset-y-0 left-0 z-40 w-60" : "relative z-30 h-[100dvh]",
           "border-r border-slate-200 shadow-[12px_0_28px_rgba(15,23,42,0.04)] dark:border-neutral-800",
-          "motion-reduce:transition-none motion-safe:transition-[width,transform,background-color,border-color] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+          "motion-reduce:transition-none motion-safe:transition-[width,transform,background-color,border-color,box-shadow] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
           isMobile
             ? collapsed
-              ? "-translate-x-full"
+              ? "pointer-events-none -translate-x-full shadow-none"
               : "translate-x-0"
             : visualRailCollapsed
               ? "w-16"
@@ -1331,11 +1332,20 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
         >
           {t("shell.skip_to_content")}
         </a>
-        {isMobile && mobileSidebarOpen ? (
+        {isMobile ? (
           <button
             type="button"
-            className="fixed inset-0 z-30 bg-black/35 backdrop-blur-[1px]"
+            data-testid="app-shell-mobile-sidebar-backdrop"
+            className={[
+              "fixed inset-0 z-30 bg-black/35 backdrop-blur-[1px]",
+              "motion-reduce:transition-none motion-safe:transition-[opacity,backdrop-filter] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+              mobileSidebarOpen
+                ? "opacity-100"
+                : "pointer-events-none opacity-0",
+            ].join(" ")}
             aria-label={t("common.close")}
+            aria-hidden={!mobileSidebarOpen}
+            tabIndex={mobileSidebarOpen ? 0 : -1}
             onClick={() => setMobileSidebarOpen(false)}
           />
         ) : null}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1757,12 +1757,12 @@ export function AuthFilesFilesTab({
                         .join(" ")}
                     >
                       <div className={denseCards ? "space-y-2" : "space-y-2.5"}>
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="min-w-0 flex flex-1 items-center gap-1.5">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex min-w-0 flex-1 items-center gap-1.5">
                             <OverflowTooltip
                               content={displayTitle}
                               className={[
-                                "min-w-0 flex-1 truncate font-semibold tracking-tight text-slate-900 dark:text-white",
+                                "min-w-0 flex-1 truncate leading-5 font-semibold tracking-tight text-slate-900 dark:text-white",
                                 denseCards ? "text-xs" : "text-sm",
                               ].join(" ")}
                             >
@@ -1772,7 +1772,7 @@ export function AuthFilesFilesTab({
                               <span
                                 data-testid="auth-file-plan-badge"
                                 className={[
-                                  "inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-2xs font-bold tracking-wide",
+                                  "inline-flex h-5 shrink-0 items-center rounded-md px-1.5 text-2xs font-bold leading-none tracking-wide",
                                   resolvePlanBadgeClass(planType),
                                 ].join(" ")}
                               >
@@ -1782,11 +1782,11 @@ export function AuthFilesFilesTab({
                             ) : null}
                           </div>
 
-                          <div className="flex shrink-0 items-center gap-1.5">
+                          <div className="flex h-6 shrink-0 items-center gap-1.5">
                             {runtimeOnly ? null : (
                               <div
                                 className={[
-                                  "flex h-7 items-center justify-center px-0.5 transition-opacity",
+                                  "flex h-6 w-6 items-center justify-center transition-opacity",
                                   showSelectionControl
                                     ? "opacity-100 pointer-events-auto"
                                     : "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
@@ -1809,7 +1809,7 @@ export function AuthFilesFilesTab({
                               </div>
                             )}
                             {runtimeOnly ? (
-                              <span className="text-xs text-slate-400 dark:text-white/40">
+                              <span className="text-xs leading-none text-slate-400 dark:text-white/40">
                                 --
                               </span>
                             ) : denseCards ? (
@@ -1840,7 +1840,7 @@ export function AuthFilesFilesTab({
                             ) : (
                               <div
                                 className={[
-                                  "flex h-8 items-center justify-center transition-opacity",
+                                  "flex h-6 items-center justify-center transition-opacity",
                                   "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
                                 ].join(" ")}
                               >


### PR DESCRIPTION
## Summary
- AI 账号卡片标题行改为垂直居中：邮箱、PRO 徽章、勾选框、电源按钮同一中线
- 移动端侧栏遮罩常挂载并用 opacity 过渡；抽屉关闭时保留 slide 动画（`-translate-x-full`）

## Test plan
- [ ] 卡片视图：标题行控件垂直对齐
- [ ] 移动端打开/关闭侧栏：抽屉滑动 + 遮罩淡入淡出
- [ ] 桌面折叠侧栏行为无回归