### PR TITLE
fix(ui): animate auth card reflow and mobile sidebar

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -464,6 +464,61 @@ describe("AppShell route progress", () => {
   });
 });
 
+describe("AppShell mobile sidebar", () => {
+  beforeEach(() => {
+    authPrincipal = defaultPrincipal();
+    tenantsMock.mockReset();
+    tenantsMock.mockResolvedValue({ items: [] });
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query) =>
+        ({
+          matches: query === "(max-width: 767px)",
+          media: query,
+          onchange: null,
+          addListener: () => undefined,
+          removeListener: () => undefined,
+          addEventListener: () => undefined,
+          removeEventListener: () => undefined,
+          dispatchEvent: () => false,
+        }) as MediaQueryList,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("keeps the mobile drawer mounted in a body portal while opening and closing", () => {
+    renderShell();
+
+    const aside = document.querySelector("aside");
+    const backdrop = screen.getByTestId("app-shell-mobile-sidebar-backdrop");
+    expect(aside?.parentElement).toBe(document.body);
+    expect(backdrop.parentElement).toBe(document.body);
+    expect(aside).toHaveAttribute("data-mobile-open", "false");
+    expect(aside).toHaveClass(
+      "-translate-x-full",
+      "will-change-transform",
+      "motion-safe:duration-[320ms]",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Expand Sidebar|展开侧边栏/i }),
+    );
+
+    expect(aside).toHaveAttribute("data-mobile-open", "true");
+    expect(aside).toHaveClass("translate-x-0");
+    expect(backdrop).toHaveClass("opacity-100", "motion-safe:duration-[320ms]");
+
+    fireEvent.click(backdrop);
+
+    expect(aside).toHaveAttribute("data-mobile-open", "false");
+    expect(aside).toHaveClass("-translate-x-full");
+    expect(backdrop).toHaveClass("pointer-events-none", "opacity-0");
+    expect(document.body.contains(aside)).toBe(true);
+  });
+});
+
 describe("AppShell tenant switcher", () => {
   beforeEach(() => {
     authPrincipal = defaultPrincipal({ platform_admin: true });

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -873,7 +874,9 @@ function ShellSidebar({
           "group/sidebar shrink-0 overflow-visible bg-white/94 dark:bg-neutral-950/88",
           isMobile ? "fixed inset-y-0 left-0 z-40 w-60" : "relative z-30 h-[100dvh]",
           "border-r border-slate-200 shadow-[12px_0_28px_rgba(15,23,42,0.04)] dark:border-neutral-800",
-          "motion-reduce:transition-none motion-safe:transition-[width,transform,background-color,border-color,box-shadow] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+          isMobile
+            ? "will-change-transform motion-reduce:transition-none motion-safe:transition-transform motion-safe:duration-[320ms] motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]"
+            : "motion-reduce:transition-none motion-safe:transition-[width,background-color,border-color,box-shadow] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
           isMobile
             ? collapsed
               ? "pointer-events-none -translate-x-full shadow-none"
@@ -1322,6 +1325,34 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
   );
 
   const sidebarCollapsed = isMobile ? !mobileSidebarOpen : desktopSidebarCollapsed;
+  const mobileSidebarLayer = isMobile
+    ? createPortal(
+        <>
+          <button
+            type="button"
+            data-testid="app-shell-mobile-sidebar-backdrop"
+            className={[
+              "fixed inset-0 z-30 bg-black/35 backdrop-blur-[1px]",
+              "motion-reduce:transition-none motion-safe:transition-[opacity,backdrop-filter] motion-safe:duration-[320ms] motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
+              mobileSidebarOpen
+                ? "opacity-100"
+                : "pointer-events-none opacity-0",
+            ].join(" ")}
+            aria-label={t("common.close")}
+            aria-hidden={!mobileSidebarOpen}
+            tabIndex={mobileSidebarOpen ? 0 : -1}
+            onClick={() => setMobileSidebarOpen(false)}
+          />
+          <ShellSidebar
+            collapsed={sidebarCollapsed}
+            mode="mobile"
+            onToggleSidebar={toggleSidebar}
+            onNavigate={() => setMobileSidebarOpen(false)}
+          />
+        </>,
+        document.body,
+      )
+    : null;
 
   return (
     <ShellContext value={value}>
@@ -1332,30 +1363,15 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
         >
           {t("shell.skip_to_content")}
         </a>
-        {isMobile ? (
-          <button
-            type="button"
-            data-testid="app-shell-mobile-sidebar-backdrop"
-            className={[
-              "fixed inset-0 z-30 bg-black/35 backdrop-blur-[1px]",
-              "motion-reduce:transition-none motion-safe:transition-[opacity,backdrop-filter] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
-              mobileSidebarOpen
-                ? "opacity-100"
-                : "pointer-events-none opacity-0",
-            ].join(" ")}
-            aria-label={t("common.close")}
-            aria-hidden={!mobileSidebarOpen}
-            tabIndex={mobileSidebarOpen ? 0 : -1}
-            onClick={() => setMobileSidebarOpen(false)}
-          />
-        ) : null}
+        {mobileSidebarLayer}
         <div className="flex h-[100dvh] overflow-hidden">
-          <ShellSidebar
-            collapsed={sidebarCollapsed}
-            mode={isMobile ? "mobile" : "desktop"}
-            onToggleSidebar={toggleSidebar}
-            onNavigate={isMobile ? () => setMobileSidebarOpen(false) : undefined}
-          />
+          {isMobile ? null : (
+            <ShellSidebar
+              collapsed={sidebarCollapsed}
+              mode="desktop"
+              onToggleSidebar={toggleSidebar}
+            />
+          )}
           <div className="flex min-w-0 flex-1 flex-col">
             <ShellHeader
               isMobile={isMobile}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1,7 +1,9 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
   type RefObject,
   type ReactNode,
@@ -94,6 +96,8 @@ const CARD_GRID_COLUMN_CLASS: Record<AuthFilesCardColumns, string> = {
   5: "xl:grid-cols-[repeat(5,minmax(0,1fr))]",
   6: "xl:grid-cols-[repeat(6,minmax(0,1fr))]",
 };
+const CARD_COLUMN_ANIMATION_MS = 240;
+const CARD_COLUMN_ANIMATION_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -792,9 +796,96 @@ export function AuthFilesFilesTab({
     DEFAULT_AUTH_FILES_CARD_COLUMNS,
   );
   const cardColumns = normalizeAuthFilesCardColumns(cardColumnsRaw);
+  const cardGridHostRef = useRef<HTMLDivElement>(null);
+  const cardColumnFirstRectsRef = useRef<DOMRect[] | null>(null);
+  const cardColumnAnimationsRef = useRef<Animation[]>([]);
   useEffect(() => {
     if (cardColumnsRaw !== cardColumns) setCardColumnsRaw(cardColumns);
   }, [cardColumns, cardColumnsRaw, setCardColumnsRaw]);
+  const cancelCardColumnAnimations = useCallback(() => {
+    cardColumnAnimationsRef.current.forEach((animation) => animation.cancel());
+    cardColumnAnimationsRef.current = [];
+  }, []);
+  const handleCardColumnsChange = useCallback(
+    (value: string) => {
+      const nextColumns = normalizeAuthFilesCardColumns(value);
+      if (nextColumns === cardColumns) return;
+
+      cancelCardColumnAnimations();
+      const reducedMotion =
+        typeof window !== "undefined" &&
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+      const grid = cardGridHostRef.current?.querySelector<HTMLElement>(
+        "[data-scroll-area-content]",
+      );
+
+      cardColumnFirstRectsRef.current =
+        !reducedMotion && grid
+          ? Array.from(grid.children)
+              .filter((element): element is HTMLElement => element instanceof HTMLElement)
+              .map((element) => element.getBoundingClientRect())
+          : null;
+      setCardColumnsRaw(nextColumns);
+    },
+    [cancelCardColumnAnimations, cardColumns, setCardColumnsRaw],
+  );
+
+  useLayoutEffect(() => {
+    const firstRects = cardColumnFirstRectsRef.current;
+    cardColumnFirstRectsRef.current = null;
+    if (!firstRects || firstRects.length === 0) return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+
+    const grid = cardGridHostRef.current?.querySelector<HTMLElement>(
+      "[data-scroll-area-content]",
+    );
+    if (!grid) return;
+
+    const animations: Animation[] = [];
+    Array.from(grid.children).forEach((element, index) => {
+      if (!(element instanceof HTMLElement) || typeof element.animate !== "function") return;
+      const first = firstRects[index];
+      if (!first) return;
+
+      const last = element.getBoundingClientRect();
+      if (last.width <= 0 || last.height <= 0) return;
+      const deltaX = first.left - last.left;
+      const deltaY = first.top - last.top;
+      const scaleX = first.width / last.width;
+      const scaleY = first.height / last.height;
+      if (
+        Math.abs(deltaX) < 0.5 &&
+        Math.abs(deltaY) < 0.5 &&
+        Math.abs(scaleX - 1) < 0.01 &&
+        Math.abs(scaleY - 1) < 0.01
+      ) {
+        return;
+      }
+
+      animations.push(
+        element.animate(
+          [
+            {
+              transform: `translate3d(${deltaX}px, ${deltaY}px, 0) scale(${scaleX}, ${scaleY})`,
+              transformOrigin: "top left",
+            },
+            {
+              transform: "translate3d(0, 0, 0) scale(1, 1)",
+              transformOrigin: "top left",
+            },
+          ],
+          {
+            duration: CARD_COLUMN_ANIMATION_MS,
+            easing: CARD_COLUMN_ANIMATION_EASING,
+          },
+        ),
+      );
+    });
+    cardColumnAnimationsRef.current = animations;
+
+    return cancelCardColumnAnimations;
+  }, [cancelCardColumnAnimations, cardColumns]);
+
   const denseCards = cardColumns >= 4;
   const cardColumnOptions = useMemo(
     () =>
@@ -1377,24 +1468,6 @@ export function AuthFilesFilesTab({
                   >
                     {renderFilesViewModeTabs}
                   </div>
-                  {filesViewMode === "cards" ? (
-                    <div
-                      className="hidden xl:block"
-                      data-testid="auth-files-card-columns"
-                    >
-                      <Select
-                        value={String(cardColumns)}
-                        onChange={(value) =>
-                          setCardColumnsRaw(normalizeAuthFilesCardColumns(value))
-                        }
-                        options={cardColumnOptions}
-                        aria-label={t("auth_files.card_columns")}
-                        variant="chip"
-                        size="sm"
-                        className="min-w-[6.25rem]"
-                      />
-                    </div>
-                  ) : null}
                   {modelOwnerToolbarButton}
                   {selectedCount === 0 ? selectionActionsMenu : null}
                 </div>
@@ -1495,6 +1568,22 @@ export function AuthFilesFilesTab({
                     </Button>
                   </HoverTooltip>
                   {configActionsMenu}
+                  {filesViewMode === "cards" ? (
+                    <div
+                      className="hidden xl:block"
+                      data-testid="auth-files-card-columns"
+                    >
+                      <Select
+                        value={String(cardColumns)}
+                        onChange={handleCardColumnsChange}
+                        options={cardColumnOptions}
+                        aria-label={t("auth_files.card_columns")}
+                        variant="chip"
+                        size="sm"
+                        className="min-w-[6.25rem]"
+                      />
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </div>
@@ -1539,6 +1628,7 @@ export function AuthFilesFilesTab({
       ) : (
         <>
           <div
+            ref={cardGridHostRef}
             className={[
               "md:min-h-0 md:flex-1 md:overflow-hidden",
               filesViewMode === "table" ? "p-4 sm:p-5" : "",
@@ -1741,7 +1831,7 @@ export function AuthFilesFilesTab({
 
                   return (
                     <Card
-                      key={file.name}
+                      key={`${file.name}:${cardColumns}`}
                       padding={denseCards ? "compact" : "default"}
                       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[


### PR DESCRIPTION
## Summary
- move the auth-file card column selector to the far right of the action group
- animate 2–6 column card reflow with a 240ms FLIP transition and reduced-motion fallback
- portal the mobile sidebar and backdrop to `document.body` with a visible 320ms slide/fade transition
- add a mobile sidebar portal/open/close regression test

## Verification
- `bunx vitest run src/app/layout/AppShell.test.tsx`
- `bun run build`
- `bunx oxlint apps/admin-panel/src/app/layout/AppShell.tsx apps/admin-panel/src/app/layout/AppShell.test.tsx pages/auth-files/components/AuthFilesFilesTab.tsx`