### PR TITLE
fix(config): search scroll + visual hint tooltips

### DIFF
--- a/e2e/config-editor-and-sidebar.spec.ts
+++ b/e2e/config-editor-and-sidebar.spec.ts
@@ -38,8 +38,12 @@ test("Config: page should not horizontally scroll; editor should allow horizonta
 }) => {
   await setAuthed(page);
 
-  const longValue = "a".repeat(2500);
-  const yaml = `long_key: "${longValue}"\n`;
+  const longValue = `${"a".repeat(2500)}horizontal-target`;
+  const yaml = [
+    `long_key: "${longValue}"`,
+    ...Array.from({ length: 80 }, (_, index) => `key-${index}: value-${index}`),
+    "target-key: target-value",
+  ].join("\n");
 
   await page.route("**/v0/management/config.yaml", async (route) => {
     await route.fulfill({
@@ -80,6 +84,55 @@ test("Config: page should not horizontally scroll; editor should allow horizonta
 
   expect(editorCanScroll.canOverflow).toBe(true);
   expect(editorCanScroll.moved).toBe(true);
+
+  const search = page.getByPlaceholder(/Search config content|搜索配置内容/i);
+  await editor.evaluate((element) => {
+    element.scrollLeft = 0;
+  });
+  await search.fill("horizontal-target");
+  await search.press("Enter");
+  await expect
+    .poll(async () => editor.evaluate((element) => element.scrollLeft))
+    .toBeGreaterThan(0);
+
+  await search.fill("target-key");
+  await search.press("Enter");
+  await expect
+    .poll(async () => editor.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  const syncedScroll = await editor.evaluate((element) => ({
+    editor: element.scrollTop,
+    highlight: element.parentElement?.querySelector("pre")?.scrollTop,
+    gutter: element.parentElement?.previousElementSibling?.scrollTop,
+  }));
+  expect(syncedScroll.highlight).toBe(syncedScroll.editor);
+  expect(syncedScroll.gutter).toBe(syncedScroll.editor);
+});
+
+test("Config visual editor keeps descriptions in info tooltips", async ({ page }) => {
+  await setAuthed(page);
+
+  await page.route("**/v0/management/config.yaml", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/yaml; charset=utf-8",
+      body: "host: 0.0.0.0\nport: 8318\n",
+    });
+  });
+  await page.route("**/v0/management/config", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto("/#/system/config");
+
+  const description = "Host/port, auth directory & API Keys.";
+  await expect(page.getByText(description, { exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: description }).hover();
+  await expect(page.getByRole("tooltip")).toContainText(description);
 });
 
 test("Sidebar: collapse/expand should keep nav items nowrap and slide out of view", async ({

--- a/packages/ui/src/primitives/ToggleSwitch.tsx
+++ b/packages/ui/src/primitives/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useId, type ReactNode } from "react";
 
 export function ToggleSwitch({
   checked,
@@ -10,8 +10,8 @@ export function ToggleSwitch({
 }: {
   checked: boolean;
   onCheckedChange: (next: boolean) => void;
-  label?: string;
-  description?: string;
+  label?: ReactNode;
+  description?: ReactNode;
   disabled?: boolean;
   ariaLabel?: string;
 }) {
@@ -24,7 +24,7 @@ export function ToggleSwitch({
       type="button"
       role="switch"
       aria-checked={checked}
-      aria-label={label || ariaLabel}
+      aria-label={ariaLabel ?? (typeof label === "string" ? label : undefined)}
       disabled={disabled}
       onClick={() => onCheckedChange(!checked)}
       className={[

--- a/pages/config/ConfigPage.tsx
+++ b/pages/config/ConfigPage.tsx
@@ -325,20 +325,43 @@ export function ConfigPage() {
   );
 
   const jumpToMatch = useCallback(
-    (index: number, query: string) => {
+    (index: number, query: string, positions = searchPositions) => {
       const el = textareaRef.current;
       if (!el) return;
       const q = query.trim();
-      if (!q) return;
-      const positions = searchPositions;
-      if (!positions.length) return;
+      if (!q || !positions.length) return;
       const safe = ((index % positions.length) + positions.length) % positions.length;
       const start = positions[safe];
+      const beforeMatch = yamlText.slice(0, start);
+      const lineStart = beforeMatch.lastIndexOf("\n") + 1;
+      const line = beforeMatch.split("\n").length - 1;
+      const column = beforeMatch.length - lineStart;
+      const styles = window.getComputedStyle(el);
+      const fontSize = Number.parseFloat(styles.fontSize) || 12;
+      const lineHeight = Number.parseFloat(styles.lineHeight) || fontSize * 2;
+      const paddingTop = Number.parseFloat(styles.paddingTop) || 0;
+      const paddingLeft = Number.parseFloat(styles.paddingLeft) || 0;
+      const targetTop = paddingTop + line * lineHeight;
+      const targetLeft = paddingLeft + column * fontSize * 0.6;
+      const verticalMargin = lineHeight * 2;
+      const horizontalMargin = fontSize * 4;
+
       el.focus();
       el.setSelectionRange(start, start + q.length);
+      if (targetTop < el.scrollTop + verticalMargin) {
+        el.scrollTop = Math.max(0, targetTop - verticalMargin);
+      } else if (targetTop + lineHeight > el.scrollTop + el.clientHeight - verticalMargin) {
+        el.scrollTop = Math.max(0, targetTop + lineHeight - el.clientHeight + verticalMargin);
+      }
+      if (targetLeft < el.scrollLeft + horizontalMargin) {
+        el.scrollLeft = Math.max(0, targetLeft - horizontalMargin);
+      } else if (targetLeft > el.scrollLeft + el.clientWidth - horizontalMargin) {
+        el.scrollLeft = Math.max(0, targetLeft - el.clientWidth + horizontalMargin);
+      }
+      el.dispatchEvent(new Event("scroll"));
       setSearchIndex(safe);
     },
-    [searchPositions],
+    [searchPositions, yamlText],
   );
 
   const executeSearch = useCallback(
@@ -355,7 +378,7 @@ export function ConfigPage() {
           notify({ type: "info", message: t("config_page.no_match_found") });
           return;
         }
-        jumpToMatch(0, q);
+        jumpToMatch(0, q, positions);
         return;
       }
 
@@ -367,7 +390,7 @@ export function ConfigPage() {
           notify({ type: "info", message: t("config_page.no_match_found") });
           return;
         }
-        jumpToMatch(0, q);
+        jumpToMatch(0, q, positions);
         return;
       }
 

--- a/pages/config/YamlCodeEditor.tsx
+++ b/pages/config/YamlCodeEditor.tsx
@@ -520,6 +520,7 @@ export const YamlCodeEditor = forwardRef<
             aria-label={ariaLabel}
             className={[
               "absolute inset-0 resize-none overflow-auto bg-transparent px-4 py-3 font-mono text-xs leading-6 outline-none",
+              "[scrollbar-color:#C7C7C7_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-corner]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[#C7C7C7] [&::-webkit-scrollbar-track]:bg-transparent",
               "text-transparent caret-slate-900 dark:caret-white",
               "selection:bg-sky-200/60 dark:selection:bg-white/15",
               disabled ? "cursor-not-allowed" : null,

--- a/pages/config/__tests__/ConfigPage.test.tsx
+++ b/pages/config/__tests__/ConfigPage.test.tsx
@@ -101,6 +101,41 @@ describe("ConfigPage", () => {
     });
   });
 
+  test("scrolls the source editor to the active search match", async () => {
+    const user = userEvent.setup();
+    const yaml = [
+      "target-key: first",
+      ...Array.from({ length: 80 }, (_, index) => `key-${index}: value-${index}`),
+      "target-key: last",
+    ].join("\n");
+    mocks.fetchConfigYaml.mockResolvedValue(yaml);
+    renderPage();
+
+    await user.click(await screen.findByRole("tab", { name: /source editor/i }));
+    const editor = screen.getByRole("textbox", { name: "config.yaml editor" });
+    Object.defineProperties(editor, {
+      clientHeight: { configurable: true, value: 120 },
+      clientWidth: { configurable: true, value: 480 },
+    });
+
+    const search = screen.getByPlaceholderText(/search config content/i);
+    await user.type(search, "target-key{Enter}");
+
+    expect(editor).toHaveProperty("selectionStart", yaml.indexOf("target-key"));
+
+    await user.click(screen.getByRole("button", { name: /next match/i }));
+    await waitFor(() => {
+      expect(editor.scrollTop).toBeGreaterThan(0);
+      expect(editor).toHaveProperty("selectionStart", yaml.lastIndexOf("target-key"));
+    });
+
+    await user.click(screen.getByRole("button", { name: /previous match/i }));
+    await waitFor(() => {
+      expect(editor.scrollTop).toBe(0);
+      expect(editor).toHaveProperty("selectionStart", yaml.indexOf("target-key"));
+    });
+  });
+
   test("removes the duplicate runtime tab and confirms destructive body cleanup on save", async () => {
     const user = userEvent.setup();
     mocks.fetchConfigYaml.mockResolvedValue(

--- a/pages/config/visual/PayloadRuleEditors.tsx
+++ b/pages/config/visual/PayloadRuleEditors.tsx
@@ -14,9 +14,9 @@ import {
   VISUAL_CONFIG_PROTOCOL_OPTIONS,
 } from "@features/visual-config-editor";
 import { Button } from "@code-proxy/ui";
-import { Card } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Select } from "@code-proxy/ui";
+import { HintCard as Card } from "./VisualHint";
 
 function SelectInput({
   value,

--- a/pages/config/visual/ResourceEfficiencyPanel.tsx
+++ b/pages/config/visual/ResourceEfficiencyPanel.tsx
@@ -1,8 +1,9 @@
-import { Gauge, Leaf, ShieldCheck } from "lucide-react";
+import { Gauge, Leaf } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { VisualConfigValues } from "@features/visual-config-editor";
-import { Button, Card, TextInput, ToggleSwitch } from "@code-proxy/ui";
+import { Button, TextInput } from "@code-proxy/ui";
+import { HintCard as Card, HintLabel, HintToggle as ToggleSwitch } from "./VisualHint";
 
 type ResourceEfficiencyPanelProps = {
   values: VisualConfigValues;
@@ -27,8 +28,9 @@ function ResourceField({
 }) {
   return (
     <div className="space-y-1.5">
-      <div className="text-sm font-semibold text-slate-900 dark:text-white">{label}</div>
-      <p className="text-xs leading-5 text-slate-600 dark:text-white/65">{hint}</p>
+      <div className="text-sm font-semibold text-slate-900 dark:text-white">
+        <HintLabel label={label} hint={hint} />
+      </div>
       <TextInput
         value={value}
         placeholder={placeholder}
@@ -106,7 +108,15 @@ export function ResourceEfficiencyPanel({
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
                 <h3 className="text-base font-semibold text-emerald-950 dark:text-emerald-100">
-                  {t("resource_config.title")}
+                  <HintLabel
+                    label={t("resource_config.title")}
+                    hint={`${t("resource_config.description")}
+
+${t("resource_config.stats_preserved", {
+  defaultValue:
+    "清理明细不会清理统计。KPI/限额/public usage 等已切到小型聚合投影的指标不受 request_logs 清理影响；仍依赖明细的趋势/诊断能力仅覆盖保留期内数据。",
+})}`}
+                  />
                 </h3>
                 <span className="rounded-full bg-emerald-200/80 px-2.5 py-1 text-2xs font-semibold text-emerald-900 dark:bg-emerald-300/15 dark:text-emerald-200">
                   {recommendedActive
@@ -114,9 +124,6 @@ export function ResourceEfficiencyPanel({
                     : t("resource_config.profile_custom")}
                 </span>
               </div>
-              <p className="mt-1 max-w-3xl text-sm leading-6 text-emerald-900/75 dark:text-emerald-100/70">
-                {t("resource_config.description")}
-              </p>
             </div>
           </div>
           <Button
@@ -331,16 +338,6 @@ export function ResourceEfficiencyPanel({
             />
           </div>
         </Card>
-      </div>
-
-      <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-700 dark:border-white/10 dark:bg-white/[0.04] dark:text-white/70">
-        <ShieldCheck size={18} className="mt-0.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
-        <p>
-          {t("resource_config.stats_preserved", {
-            defaultValue:
-              "清理明细不会清理统计。KPI/限额/public usage 等已切到小型聚合投影的指标不受 request_logs 清理影响；仍依赖明细的趋势/诊断能力仅覆盖保留期内数据。",
-          })}
-        </p>
       </div>
     </div>
   );

--- a/pages/config/visual/VisualConfigEditor.tsx
+++ b/pages/config/visual/VisualConfigEditor.tsx
@@ -1,12 +1,11 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { VisualConfigValues } from "@features/visual-config-editor";
-import { Card } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Select } from "@code-proxy/ui";
-import { ToggleSwitch } from "@code-proxy/ui";
 import { PayloadFilterRulesEditor, PayloadRulesEditor } from "./PayloadRuleEditors";
 import { ResourceEfficiencyPanel } from "./ResourceEfficiencyPanel";
+import { HintCard as Card, HintLabel, HintToggle as ToggleSwitch } from "./VisualHint";
 
 function Field({
   label,
@@ -19,8 +18,9 @@ function Field({
 }) {
   return (
     <div className="space-y-1">
-      <div className="text-sm font-semibold text-slate-900 dark:text-white">{label}</div>
-      {hint ? <div className="text-xs text-slate-600 dark:text-white/65">{hint}</div> : null}
+      <div className="text-sm font-semibold text-slate-900 dark:text-white">
+        <HintLabel label={label} hint={hint} />
+      </div>
       <div className="pt-1">{children}</div>
     </div>
   );
@@ -198,10 +198,13 @@ export function VisualConfigEditor({
       </Card>
 
       <Card title={t("visual_config.cors_title")} description={t("visual_config.cors_desc")}>
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div>
           <Field
             label={t("visual_config.cors_origins_label")}
-            hint={t("visual_config.cors_origins_hint")}
+            hint={`${t("visual_config.cors_origins_hint")}
+
+${t("visual_config.cors_default_title")}: ${t("visual_config.cors_default_desc")}
+chrome-extension://<extension-id>`}
           >
             <MultilineField
               value={values.corsAllowOriginsText}
@@ -215,13 +218,6 @@ export function VisualConfigEditor({
               ].join("\n")}
             />
           </Field>
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-xs leading-5 text-emerald-900 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-100">
-            <div className="font-semibold">{t("visual_config.cors_default_title")}</div>
-            <p className="mt-1">{t("visual_config.cors_default_desc")}</p>
-            <p className="mt-3 rounded-xl bg-white/65 px-3 py-2 font-mono text-xs text-emerald-950 dark:bg-black/20 dark:text-emerald-100">
-              chrome-extension://&lt;extension-id&gt;
-            </p>
-          </div>
         </div>
       </Card>
 
@@ -340,7 +336,8 @@ export function VisualConfigEditor({
 
       <Card
         title={t("visual_config.kimi_headers")}
-        description={t("visual_config.kimi_headers_desc")}
+        description={`${t("visual_config.kimi_headers_desc")}
+${t("visual_config.kimi_headers_note")}`}
       >
         <div className="grid gap-4 lg:grid-cols-3">
           <Field label="User-Agent" hint={t("visual_config.kimi_user_agent_hint")}>
@@ -389,9 +386,6 @@ export function VisualConfigEditor({
             />
           </Field>
         </div>
-        <p className="mt-4 text-xs text-slate-600 dark:text-white/65">
-          {t("visual_config.kimi_headers_note")}
-        </p>
       </Card>
 
       <div className="grid gap-6 lg:grid-cols-2">

--- a/pages/config/visual/VisualHint.tsx
+++ b/pages/config/visual/VisualHint.tsx
@@ -1,0 +1,49 @@
+import { Info } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { Card as BaseCard, HoverTooltip, ToggleSwitch as BaseToggleSwitch } from "@code-proxy/ui";
+
+export function HintLabel({ label, hint }: { label: ReactNode; hint?: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span>{label}</span>
+      {hint ? (
+        <HoverTooltip content={hint} placement="top">
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={typeof hint === "string" ? hint : undefined}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-400 transition hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:text-white/40 dark:hover:text-white/75 dark:focus-visible:ring-white/15"
+          >
+            <Info size={14} aria-hidden="true" />
+          </span>
+        </HoverTooltip>
+      ) : null}
+    </span>
+  );
+}
+
+export function HintCard({ title, description, ...props }: ComponentProps<typeof BaseCard>) {
+  return (
+    <BaseCard {...props} title={title ? <HintLabel label={title} hint={description} /> : title} />
+  );
+}
+
+export function HintToggle({
+  label,
+  description,
+  ...props
+}: ComponentProps<typeof BaseToggleSwitch>) {
+  if (!label && !description) return <BaseToggleSwitch {...props} />;
+
+  return (
+    <BaseToggleSwitch
+      {...props}
+      label={<HintLabel label={label} hint={description} />}
+      ariaLabel={typeof label === "string" ? label : props.ariaLabel}
+    />
+  );
+}

--- a/pages/config/visual/__tests__/VisualConfigEditor.test.tsx
+++ b/pages/config/visual/__tests__/VisualConfigEditor.test.tsx
@@ -28,6 +28,16 @@ describe("VisualConfigEditor auto update config", () => {
     await i18n.changeLanguage("en");
   });
 
+  test("moves persistent descriptions into info tooltips", async () => {
+    renderEditor();
+
+    const description = "Host/port, auth directory & API Keys.";
+    expect(screen.queryByText(description)).not.toBeInTheDocument();
+
+    await userEvent.hover(screen.getByRole("button", { name: description }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(description);
+  });
+
   test("shows automatic update settings and exposes main/dev source branches", async () => {
     const onChange = renderEditor();
 


### PR DESCRIPTION
## Summary
- Fix source editor search jump: scroll match into view (vertical + horizontal) and pass fresh match positions on first search.
- Align textarea scrollbar styling with project ScrollArea look without introducing Monaco or new deps.
- Simplify visual config editor: replace long card/field/toggle descriptions with info icon + HoverTooltip; keep all controls and YAML mapping.

## Test plan
- [x] Config-related vitest (24)
- [x] tsc --noEmit, oxlint, design:check, production build
- [x] Chromium e2e for config editor search scroll + visual tooltips (5)