### PR TITLE
fix(auth-files): hide zero usage summary cards

### DIFF
--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -317,7 +317,7 @@ describe("AuthFileDetailModal", () => {
     expect(chartOptions.at(-1)?.series?.every((item: any) => item.animation === true)).toBe(true);
   });
 
-  test("renders zero predicted quota values when Codex trend data is incomplete", () => {
+  test("hides zero and empty summary cards when Codex trend data is incomplete", () => {
     renderDetailModal({
       detailTrend: {
         auth_index: "auth-1",
@@ -334,8 +334,12 @@ describe("AuthFileDetailModal", () => {
       },
     });
 
-    expectSummaryCard("Predicted 5-hour window quota", "$0.0000");
-    expectSummaryCard("Predicted weekly window quota", "$0.0000");
+    expectSummaryCard("Current weekly cycle", "2");
+    expect(screen.queryByText("Current cycle cost")).not.toBeInTheDocument();
+    expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
+    expect(screen.queryByText("Predicted weekly window quota")).not.toBeInTheDocument();
+    expect(screen.queryByText("Weekly quota used")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cycle start")).not.toBeInTheDocument();
   });
 
   test("disables trend chart animation after the first render completes", () => {
@@ -450,8 +454,8 @@ describe("AuthFileDetailModal", () => {
     expectSummaryCard("Current weekly cycle", "116");
     // Remaining snapshot percent 75% => used 25%.
     expectSummaryCard("Weekly quota used", "25%");
-    // xAI shows weekly prediction (zero when cycle cost is missing), never the Codex 5h card.
-    expectSummaryCard("Predicted weekly window quota", "$0.0000");
+    // xAI predicted weekly is 0 without cycle cost — hide the card; never show Codex 5h.
+    expect(screen.queryByText("Predicted weekly window quota")).not.toBeInTheDocument();
     expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
   });
 

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -1225,11 +1225,22 @@ export function AuthFileDetailModal({
       fiveHourQuotaUsedPercent,
     );
     const estimatedWeeklyQuota = estimateQuotaBudget(displayCycleCostTotal, weeklyQuotaUsedPercent);
+    // ponytail: hide zero noise; null/"--" is already non-zero display path
+    const showLast7DaysRequests = !isCodexDetail && detailTrend.request_total > 0;
+    const showCycleRequests = displayCycleRequestTotal > 0;
+    const showCycleCost = displayCycleCostTotal > 0;
+    const showFiveHourQuota = isCodexDetail && estimatedFiveHourQuota > 0;
+    const showWeeklyQuota = showPredictedWeeklyQuota && estimatedWeeklyQuota > 0;
+    const showWeeklyUsed =
+      typeof weeklyQuotaUsedPercent === "number" &&
+      Number.isFinite(weeklyQuotaUsedPercent) &&
+      weeklyQuotaUsedPercent > 0;
+    const showCycleStart = Boolean(detailTrend.cycle_start);
 
     return (
       <div className="space-y-4">
         <div className={summaryGridClassName}>
-          {!isCodexDetail ? (
+          {showLast7DaysRequests ? (
             <div className={SUMMARY_CARD_CLASS_NAME}>
               <p className={SUMMARY_LABEL_CLASS_NAME}>
                 {t("auth_files.trend_last_7_days_requests")}
@@ -1237,15 +1248,19 @@ export function AuthFileDetailModal({
               <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCount(detailTrend.request_total)}</p>
             </div>
           ) : null}
-          <div className={SUMMARY_CARD_CLASS_NAME}>
-            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_weekly_cycle")}</p>
-            <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCount(displayCycleRequestTotal)}</p>
-          </div>
-          <div className={SUMMARY_CARD_CLASS_NAME}>
-            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_cycle_cost")}</p>
-            <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(displayCycleCostTotal)}</p>
-          </div>
-          {isCodexDetail ? (
+          {showCycleRequests ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_weekly_cycle")}</p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCount(displayCycleRequestTotal)}</p>
+            </div>
+          ) : null}
+          {showCycleCost ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_current_cycle_cost")}</p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(displayCycleCostTotal)}</p>
+            </div>
+          ) : null}
+          {showFiveHourQuota ? (
             <div className={SUMMARY_CARD_CLASS_NAME}>
               <p className={SUMMARY_LABEL_CLASS_NAME}>
                 {t("auth_files.trend_predicted_5h_window_quota")}
@@ -1253,7 +1268,7 @@ export function AuthFileDetailModal({
               <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedFiveHourQuota)}</p>
             </div>
           ) : null}
-          {showPredictedWeeklyQuota ? (
+          {showWeeklyQuota ? (
             <div className={SUMMARY_CARD_CLASS_NAME}>
               <p className={SUMMARY_LABEL_CLASS_NAME}>
                 {t("auth_files.trend_predicted_week_window_quota")}
@@ -1261,16 +1276,20 @@ export function AuthFileDetailModal({
               <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
             </div>
           ) : null}
-          <div className={SUMMARY_CARD_CLASS_NAME}>
-            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_weekly_quota_used")}</p>
-            <p className={SUMMARY_VALUE_CLASS_NAME}>{weeklyQuotaUsed}</p>
-          </div>
-          <div className={SUMMARY_CARD_CLASS_NAME}>
-            <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_cycle_start")}</p>
-            <p className="mt-2 truncate text-sm font-semibold text-slate-800 dark:text-white/85">
-              {cycleStart}
-            </p>
-          </div>
+          {showWeeklyUsed ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_weekly_quota_used")}</p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{weeklyQuotaUsed}</p>
+            </div>
+          ) : null}
+          {showCycleStart ? (
+            <div className={SUMMARY_CARD_CLASS_NAME}>
+              <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_cycle_start")}</p>
+              <p className="mt-2 truncate text-sm font-semibold text-slate-800 dark:text-white/85">
+                {cycleStart}
+              </p>
+            </div>
+          ) : null}
         </div>
 
         <div className="flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Summary
- Hide auth-file usage summary cards when the displayed value is 0 (or cycle start is empty)
- Update unit tests for incomplete Codex/xAI trend data

## Test plan
- [x] `bun run test -- pages/auth-files/__tests__/AuthFileDetailModal.test.tsx` (24 passed)
- [ ] Open account detail usage tab with incomplete 5h/weekly estimate → zero cards hidden
- [ ] Open account with non-zero cycle cost / weekly used → cards still shown