### PR TITLE
fix(apikey-lookup): disable request log input output clicks

### DIFF
--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -33,12 +33,10 @@ import { DropdownMenu } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
-import { LogContentModal } from "@features/log-content-viewer";
 import { ModelTag } from "@features/model-tags";
 import {
   fetchAvailableModels,
   fetchPublicChartData,
-  fetchPublicLogContent,
   fetchPublicLogs,
   fetchPublicUsageSummary,
   type PublicModelItem,
@@ -369,24 +367,13 @@ export function ApiKeyLookupPage() {
   // ponytail: landing first; open login only via CTA / header
   const [loginModalOpen, setLoginModalOpen] = useState(false);
 
-  // ── Content modal state ──
-  const [contentModalOpen, setContentModalOpen] = useState(false);
-  const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
-  const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
-
-  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
-    setContentModalLogId(logId);
-    setContentModalTab(tab);
-    setContentModalOpen(true);
-  }, []);
-
   const logColumns = useMemo(
     () =>
-      buildRequestLogsColumns((key) => t(key), handleContentClick, undefined, {
+      buildRequestLogsColumns((key) => t(key), undefined, undefined, {
         identityColumn: "key",
         hideChannel: true,
       }),
-    [t, handleContentClick],
+    [t],
   );
   // ── Tab state ──
   const [activeTab, setActiveTab] = useState<ApiKeyLookupTab>("usage");
@@ -1569,31 +1556,6 @@ export function ApiKeyLookupPage() {
               ) : null}
             </>
           )}
-
-          {/* Log Content Modal */}
-          <LogContentModal
-            open={contentModalOpen}
-            logId={contentModalLogId}
-            initialTab={contentModalTab}
-            onClose={() => setContentModalOpen(false)}
-            fetchPartFn={
-              usageSubject
-                ? async (
-                    id: number,
-                    part: "input" | "output",
-                    options?: { signal?: AbortSignal },
-                  ) => {
-                    return fetchPublicLogContent({
-                      id,
-                      apiKey: usageSubject.apiKey,
-                      portalAccount: usageSubject.mode === "portal",
-                      part,
-                      signal: options?.signal,
-                    });
-                  }
-                : undefined
-            }
-          />
 
           {showLanding ? <LookupEmptyState t={t} onLogin={() => setLoginModalOpen(true)} /> : null}
         </main>

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -372,7 +372,7 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.queryByText(/^default$|^默认$/i)).not.toBeInTheDocument();
   });
 
-  test("hides channel column and channel filter on public request logs", async () => {
+  test("hides channel controls and keeps input/output cells non-interactive on public logs", async () => {
     window.history.replaceState({}, "", "/manage/apikey-lookup?api_key=sk-restored-key");
     mocks.fetchPublicLogs.mockResolvedValueOnce({
       items: [
@@ -387,12 +387,12 @@ describe("ApiKeyLookupPage", () => {
           streaming: true,
           latency_ms: 1000,
           first_token_ms: 100,
-          input_tokens: 1,
+          input_tokens: 12_345,
           cached_tokens: 0,
-          output_tokens: 1,
-          total_tokens: 2,
+          output_tokens: 6_789,
+          total_tokens: 19_134,
           cost: 0,
-          has_content: false,
+          has_content: true,
         },
       ],
       total: 1,
@@ -402,7 +402,7 @@ describe("ApiKeyLookupPage", () => {
       stats: {
         total: 1,
         success_rate: 100,
-        total_tokens: 2,
+        total_tokens: 19_134,
         total_sessions: 1,
         total_cost: 0,
       },
@@ -437,6 +437,10 @@ describe("ApiKeyLookupPage", () => {
     expect(screen.queryByRole("columnheader", { name: /channel|渠道/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: /filter by channel/i })).not.toBeInTheDocument();
     expect(screen.queryByText("owner@example.com")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "12,345" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "6,789" })).not.toBeInTheDocument();
+    expect(screen.getByText("12,345")).toBeInTheDocument();
+    expect(screen.getByText("6,789")).toBeInTheDocument();
   });
 
   test("loads public logs only after switching to the request logs tab", async () => {


### PR DESCRIPTION
## Summary
- stop passing the request-log content click handler on `/manage/apikey-lookup`
- remove the now-unreachable content modal wiring from that page
- assert public log input/output token cells render as plain text even when content exists

## Verification
- `bun run test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx`
- `bun run lint` (passes with 6 pre-existing warnings)
- `./node_modules/.bin/oxfmt --check pages/api-key-lookup/ApiKeyLookupPage.tsx pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx`
- `bun run build`
