### PR TITLE
feat(quota): add multi-period end-user quota UI

### DIFF
--- a/features/period-spending/OwnedApiKeyQuotaModal.tsx
+++ b/features/period-spending/OwnedApiKeyQuotaModal.tsx
@@ -1,0 +1,117 @@
+import type { PeriodSpendingLimits, PeriodSpendingPeriod } from "@code-proxy/api-client";
+import { Button, Modal, TextInput } from "@code-proxy/ui";
+import { formatQuotaUsd } from "./PeriodSpendingCell";
+import {
+  PeriodSpendingFields,
+  periodSpendingDraftToLimits,
+  validatePeriodSpendingDraft,
+  type PeriodSpendingDraft,
+} from "./PeriodSpendingFields";
+
+export interface OwnedApiKeyQuotaForm {
+  name: string;
+  periods: PeriodSpendingDraft;
+}
+
+export function OwnedApiKeyQuotaModal({
+  t,
+  open,
+  mode,
+  value,
+  accountLimits,
+  saving,
+  serverError,
+  onChange,
+  onClose,
+  onSubmit,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  open: boolean;
+  mode: "create" | "edit";
+  value: OwnedApiKeyQuotaForm;
+  accountLimits: PeriodSpendingLimits;
+  saving: boolean;
+  serverError?: string;
+  onChange: (next: OwnedApiKeyQuotaForm) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  const exceededPeriod = validatePeriodSpendingDraft(value.periods, accountLimits);
+  const limits = periodSpendingDraftToLimits(value.periods);
+  const errors: Partial<Record<PeriodSpendingPeriod, string>> = exceededPeriod
+    ? {
+        [exceededPeriod]: t("quota.validation.key_exceeds_account", {
+          period: t(`quota.period.${exceededPeriod}`),
+          keyLimit: formatQuotaUsd(limits[exceededPeriod]),
+          accountLimit: formatQuotaUsd(accountLimits[exceededPeriod]),
+        }),
+      }
+    : {};
+  const invalid = !value.name.trim() || Boolean(exceededPeriod);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={mode === "create" ? t("api_keys_page.create_key") : t("api_keys_page.edit_key_quota")}
+      description={t("api_keys_page.key_quota_account_hint")}
+      maxWidth="max-w-2xl"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={saving}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="primary" onClick={onSubmit} disabled={saving || invalid}>
+            {saving
+              ? t("api_keys_page.saving")
+              : mode === "create"
+                ? t("api_keys_page.create_btn")
+                : t("api_keys_page.save_btn")}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-5">
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium text-slate-700 dark:text-white/80">
+            {t("api_keys_page.form_name_label")} <span className="text-rose-500">*</span>
+          </span>
+          <TextInput
+            value={value.name}
+            onChange={(event) => onChange({ ...value, name: event.target.value })}
+            placeholder={t("api_keys_page.form_name_placeholder")}
+            autoFocus
+          />
+        </label>
+
+        <section className="rounded-2xl border border-indigo-200/80 bg-indigo-50/45 p-4 dark:border-indigo-500/20 dark:bg-indigo-500/5">
+          <div className="mb-3">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("api_keys_page.key_quota_title")}
+            </h3>
+            <p className="mt-1 text-xs text-slate-500 dark:text-white/50">
+              {t("quota.key_fields_hint")}
+            </p>
+          </div>
+          <PeriodSpendingFields
+            t={t}
+            value={value.periods}
+            onChange={(periods) => onChange({ ...value, periods })}
+            accountLimits={accountLimits}
+            errors={errors}
+            idPrefix={`owned-key-${mode}`}
+          />
+        </section>
+
+        {serverError ? (
+          <p
+            role="alert"
+            className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-200"
+          >
+            {serverError}
+          </p>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}

--- a/features/period-spending/OwnedApiKeyResetHistoryModal.tsx
+++ b/features/period-spending/OwnedApiKeyResetHistoryModal.tsx
@@ -1,29 +1,14 @@
-import { useTranslation } from "react-i18next";
-import { DataTable, Modal } from "@code-proxy/ui";
-import type { DataTableColumn } from "@code-proxy/ui";
 import type { ApiKeyDailySpendingResetEvent } from "@code-proxy/api-client/endpoints/api-keys";
-import { formatApiKeySpendingAmount } from "../apiKeyPageUtils";
+import { DataTable, Modal, type DataTableColumn } from "@code-proxy/ui";
+import { formatQuotaUsdAmount } from "./PeriodSpendingCell";
 
-function formatResetAt(value: string | undefined): string {
-  if (!value) return "—";
+const formatResetAt = (value: string): string => {
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString();
-}
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+};
 
-function actorLabel(
-  event: ApiKeyDailySpendingResetEvent,
-  t: (key: string) => string,
-): string {
-  const name = event.actor_username?.trim();
-  if (name) return name;
-  if (event.actor_kind === "service_credential") {
-    return t("api_keys_page.reset_history_actor_service");
-  }
-  return t("api_keys_page.reset_history_actor_unknown");
-}
-
-export function ApiKeyResetHistoryModal({
+export function OwnedApiKeyResetHistoryModal({
+  t,
   open,
   onClose,
   keyName,
@@ -31,6 +16,7 @@ export function ApiKeyResetHistoryModal({
   loading,
   events,
 }: {
+  t: (key: string, options?: Record<string, unknown>) => string;
   open: boolean;
   onClose: () => void;
   keyName: string;
@@ -38,56 +24,46 @@ export function ApiKeyResetHistoryModal({
   loading: boolean;
   events: ApiKeyDailySpendingResetEvent[];
 }) {
-  const { t } = useTranslation();
-
   const columns: DataTableColumn<ApiKeyDailySpendingResetEvent>[] = [
     {
       key: "reset_at",
       label: t("api_keys_page.reset_history_col_time"),
       width: "w-[180px] min-w-[160px]",
-      cellClassName:
-        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => formatResetAt(row.reset_at),
     },
     {
       key: "day_key",
       label: t("api_keys_page.reset_history_col_day"),
       width: "w-[130px] min-w-[120px]",
-      cellClassName:
-        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-      render: (row) => row.day_key || "—",
+      render: (row) => row.day_key || "-",
     },
     {
       key: "actor",
       label: t("api_keys_page.reset_history_col_actor"),
       width: "w-[140px] min-w-[120px]",
-      cellClassName: "text-slate-700 dark:text-white/70",
-      render: (row) => actorLabel(row, t),
+      render: (row) =>
+        row.actor_username?.trim() ||
+        (row.actor_kind === "service_credential"
+          ? t("api_keys_page.reset_history_actor_service")
+          : t("api_keys_page.reset_history_actor_unknown")),
     },
     {
       key: "effective_used_before",
       label: t("api_keys_page.reset_history_col_cleared"),
-      width: "w-[140px] min-w-[120px]",
-      cellClassName:
-        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-      render: (row) =>
-        formatApiKeySpendingAmount(row.effective_used_before ?? 0),
+      width: "w-[150px] min-w-[130px]",
+      render: (row) => formatQuotaUsdAmount(row.effective_used_before),
     },
     {
       key: "raw_today_cost",
       label: t("api_keys_page.reset_history_col_raw_today"),
-      width: "w-[160px] min-w-[140px]",
-      cellClassName:
-        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-      render: (row) => formatApiKeySpendingAmount(row.raw_today_cost ?? 0),
+      width: "w-[150px] min-w-[130px]",
+      render: (row) => formatQuotaUsdAmount(row.raw_today_cost),
     },
     {
       key: "cost_baseline",
       label: t("api_keys_page.reset_history_col_baseline"),
       width: "w-[150px] min-w-[130px]",
-      cellClassName:
-        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-      render: (row) => formatApiKeySpendingAmount(row.cost_baseline ?? 0),
+      render: (row) => formatQuotaUsdAmount(row.cost_baseline),
     },
   ];
 

--- a/features/period-spending/OwnedApiKeyTable.tsx
+++ b/features/period-spending/OwnedApiKeyTable.tsx
@@ -1,0 +1,298 @@
+import { Copy, History, KeyRound, Pencil, Power, RotateCcw, Trash2 } from "lucide-react";
+import type { EndUserAPIKey } from "@code-proxy/api-client";
+import {
+  DataTable,
+  EmptyState,
+  HoverTooltip,
+  OverflowTooltip,
+  type DataTableColumn,
+} from "@code-proxy/ui";
+import { PeriodSpendingCell, formatQuotaUsdAmount } from "./PeriodSpendingCell";
+
+const iconButtonClass =
+  "rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-35 dark:text-white/50 dark:hover:bg-neutral-800";
+
+export interface OwnedApiKeyActions {
+  onToggleDisabled?: (key: EndUserAPIKey) => void;
+  onCopy?: (key: EndUserAPIKey) => void;
+  onRotate?: (key: EndUserAPIKey) => void;
+  onEdit?: (key: EndUserAPIKey) => void;
+  onResetDailySpending?: (key: EndUserAPIKey) => void;
+  onViewResetHistory?: (key: EndUserAPIKey) => void;
+  onDelete?: (key: EndUserAPIKey) => void;
+}
+
+export const createOwnedApiKeyColumns = ({
+  t,
+  actions,
+  busyKeyId,
+  busy: busyAll = false,
+  canDelete = () => true,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  actions: OwnedApiKeyActions;
+  busyKeyId?: string | null;
+  busy?: boolean;
+  canDelete?: (key: EndUserAPIKey) => boolean;
+}): DataTableColumn<EndUserAPIKey>[] => [
+  {
+    key: "name",
+    label: t("api_keys_page.col_name"),
+    width: "w-[150px] min-w-[150px]",
+    cellClassName: "font-medium",
+    render: (row) => (
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <OverflowTooltip content={row.name || row.id} className="block min-w-0">
+            <span className="block truncate text-slate-900 dark:text-white">
+              {row.name || t("api_keys_page.unnamed")}
+            </span>
+          </OverflowTooltip>
+          {row.is_default ? (
+            <span className="shrink-0 rounded-full bg-emerald-50 px-1.5 py-0.5 text-2xs font-medium text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">
+              default
+            </span>
+          ) : null}
+        </div>
+      </div>
+    ),
+  },
+  {
+    key: "key",
+    label: t("api_keys_page.col_key"),
+    width: "w-[220px] min-w-[220px]",
+    render: (row) => (
+      <code className="block truncate rounded-md bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700 dark:bg-neutral-800 dark:text-white/70">
+        {row.key_masked || row.key || row.id}
+      </code>
+    ),
+  },
+  {
+    key: "status",
+    label: t("api_keys_page.col_status"),
+    width: "w-[92px] min-w-[92px]",
+    cellClassName: "text-center",
+    render: (row) => (
+      <span
+        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${row.disabled ? "bg-slate-100 text-slate-500 dark:bg-white/10 dark:text-white/50" : "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300"}`}
+      >
+        {row.disabled ? t("common.disabled") : t("common.enabled")}
+      </span>
+    ),
+  },
+  {
+    key: "quota",
+    label: t("quota.period_spending_column"),
+    width: "w-[360px] min-w-[260px]",
+    render: (row) => <PeriodSpendingCell t={t} items={row["period-spending"]} />,
+  },
+  {
+    key: "dailySpending",
+    label: t("quota.daily_spending_column"),
+    width: "w-[130px] min-w-[130px]",
+    cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+    render: (row) => formatQuotaUsdAmount(row["daily-spending-used"]),
+  },
+  {
+    key: "lifetimeSpending",
+    label: t("quota.lifetime_spending_column"),
+    width: "w-[130px] min-w-[130px]",
+    cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+    render: (row) => formatQuotaUsdAmount(row["lifetime-spending-used"]),
+  },
+  {
+    key: "resetCount",
+    label: t("quota.total_resets"),
+    width: "w-[118px] min-w-[118px]",
+    cellClassName: "text-center",
+    render: (row) => {
+      const count = row["daily-spending-reset-count"] ?? 0;
+      return actions.onViewResetHistory && count > 0 ? (
+        <button
+          type="button"
+          onClick={() => actions.onViewResetHistory?.(row)}
+          className="tabular-nums font-medium text-orange-600 underline-offset-2 hover:underline dark:text-orange-400"
+          aria-label={t("api_keys_page.view_reset_history")}
+        >
+          {count}
+        </button>
+      ) : (
+        <span className="tabular-nums text-slate-500 dark:text-white/55">{count}</span>
+      );
+    },
+  },
+  {
+    key: "created",
+    label: t("api_keys_page.col_created"),
+    width: "w-[150px] min-w-[150px]",
+    cellClassName: "whitespace-nowrap text-xs text-slate-500 dark:text-white/50",
+    render: (row) => (row.created_at ? new Date(row.created_at).toLocaleString() : "-"),
+  },
+  {
+    key: "actions",
+    label: t("api_keys_page.col_actions"),
+    width: "w-[250px] min-w-[220px]",
+    lockOrder: "end",
+    headerClassName: "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800",
+    cellClassName: "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950",
+    render: (row) => {
+      const busy = busyAll || busyKeyId === row.id;
+      const hasDayLimit =
+        (row["period-spending-limits"]?.day ?? row["daily-spending-limit"] ?? 0) > 0;
+      const deletable = canDelete(row);
+      return (
+        <div className="flex items-center justify-center gap-1">
+          {actions.onToggleDisabled ? (
+            <HoverTooltip
+              content={
+                row.disabled ? t("api_keys_page.click_enable") : t("api_keys_page.click_disable")
+              }
+            >
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => actions.onToggleDisabled?.(row)}
+                className={iconButtonClass}
+                aria-label={
+                  row.disabled ? t("api_keys_page.click_enable") : t("api_keys_page.click_disable")
+                }
+              >
+                <Power size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+          {actions.onCopy ? (
+            <HoverTooltip content={t("api_keys_page.copy_key")}>
+              <button
+                type="button"
+                disabled={busy || !row.key}
+                onClick={() => actions.onCopy?.(row)}
+                className={iconButtonClass}
+                aria-label={t("api_keys_page.copy_key")}
+              >
+                <Copy size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+          {actions.onRotate ? (
+            <HoverTooltip content={t("end_users.rotate_key")}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => actions.onRotate?.(row)}
+                className={`${iconButtonClass} hover:text-orange-600`}
+                aria-label={t("end_users.rotate_key")}
+              >
+                <RotateCcw size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+          {actions.onEdit ? (
+            <HoverTooltip content={t("api_keys_page.edit_key_quota")}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => actions.onEdit?.(row)}
+                className={`${iconButtonClass} hover:text-amber-600`}
+                aria-label={t("api_keys_page.edit_key_quota")}
+              >
+                <Pencil size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+          {actions.onResetDailySpending ? (
+            <HoverTooltip
+              content={
+                hasDayLimit
+                  ? t("api_keys_page.reset_today_spending")
+                  : t("api_keys_page.reset_today_spending_disabled")
+              }
+            >
+              <button
+                type="button"
+                disabled={busy || !hasDayLimit}
+                onClick={() => actions.onResetDailySpending?.(row)}
+                className={`${iconButtonClass} hover:text-orange-600`}
+                aria-label={t("api_keys_page.reset_today_spending")}
+              >
+                <RotateCcw size={15} className={busy ? "animate-spin" : ""} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+          {actions.onViewResetHistory ? (
+            <HoverTooltip content={t("api_keys_page.view_reset_history")}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => actions.onViewResetHistory?.(row)}
+                className={iconButtonClass}
+                aria-label={t("api_keys_page.view_reset_history")}
+              >
+                <History size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+          {actions.onDelete ? (
+            <HoverTooltip
+              content={deletable ? t("common.delete") : t("apikey_lookup.keep_one_key")}
+            >
+              <button
+                type="button"
+                disabled={busy || !deletable}
+                onClick={() => actions.onDelete?.(row)}
+                className={`${iconButtonClass} hover:bg-rose-50 hover:text-rose-600 dark:hover:bg-rose-900/20`}
+                aria-label={deletable ? t("common.delete") : t("apikey_lookup.keep_one_key")}
+              >
+                <Trash2 size={15} />
+              </button>
+            </HoverTooltip>
+          ) : null}
+        </div>
+      );
+    },
+  },
+];
+
+export function OwnedApiKeysTable({
+  t,
+  keys,
+  actions,
+  busyKeyId,
+  busy = false,
+  canDelete,
+  height = "h-[460px]",
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  keys: EndUserAPIKey[];
+  actions: OwnedApiKeyActions;
+  busyKeyId?: string | null;
+  busy?: boolean;
+  canDelete?: (key: EndUserAPIKey) => boolean;
+  height?: string;
+}) {
+  if (keys.length === 0) {
+    return (
+      <EmptyState
+        title={t("api_keys_page.no_keys")}
+        description={t("api_keys_page.no_keys_desc")}
+        icon={<KeyRound size={32} className="text-slate-400" />}
+      />
+    );
+  }
+  return (
+    <DataTable
+      tableId="owned-api-keys"
+      rows={keys}
+      columns={createOwnedApiKeyColumns({ t, actions, busyKeyId, busy, canDelete })}
+      rowKey={(row) => row.id}
+      rowHeight={52}
+      height={height}
+      minHeight="min-h-[320px]"
+      minWidth="min-w-[1500px]"
+      caption={t("api_keys_page.table_caption")}
+      emptyText={t("api_keys_page.no_api_keys")}
+      showAllLoadedMessage={false}
+      rowClassName={(row) => (row.disabled ? "opacity-55" : "")}
+    />
+  );
+}

--- a/features/period-spending/PeriodSpendingCell.tsx
+++ b/features/period-spending/PeriodSpendingCell.tsx
@@ -1,0 +1,131 @@
+import { AlertCircle, AlertTriangle, Infinity as InfinityIcon } from "lucide-react";
+import type {
+  PeriodSpendingItem,
+  PeriodSpendingLimits,
+  PeriodSpendingPeriod,
+} from "@code-proxy/api-client";
+import { PERIOD_SPENDING_PERIODS } from "@code-proxy/api-client";
+
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const amountFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export const formatQuotaUsd = (value: number): string =>
+  usdFormatter.format(Number.isFinite(value) ? Math.max(0, value) : 0);
+
+export const formatQuotaUsdAmount = (value: number | null | undefined): string =>
+  amountFormatter.format(Number.isFinite(value) ? Math.max(0, value ?? 0) : 0);
+
+const periodLabel = (
+  t: (key: string, options?: Record<string, unknown>) => string,
+  period: PeriodSpendingPeriod,
+) => t(`quota.period.${period}`);
+
+const orderedItems = (items: PeriodSpendingItem[] | undefined): PeriodSpendingItem[] => {
+  if (!items?.length) return [];
+  const byPeriod = new Map(items.map((item) => [item.period, item]));
+  return PERIOD_SPENDING_PERIODS.flatMap((period) => {
+    const item = byPeriod.get(period);
+    return item && item.limit > 0 ? [item] : [];
+  });
+};
+
+const chipTone = (ratio: number) => {
+  if (ratio >= 1) {
+    return "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200";
+  }
+  if (ratio >= 0.9) {
+    return "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100";
+  }
+  return "border-slate-200 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-white/75";
+};
+
+export function PeriodSpendingCell({
+  t,
+  items,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  items?: PeriodSpendingItem[];
+}) {
+  const visible = orderedItems(items);
+  if (visible.length === 0) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-300">
+        <InfinityIcon size={13} aria-hidden="true" />
+        {t("quota.unlimited")}
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex min-w-[12rem] flex-wrap gap-1.5">
+      {visible.map((item) => {
+        const ratio = item.limit > 0 ? item.used / item.limit : 0;
+        const danger = ratio >= 1;
+        const warning = ratio >= 0.9 && !danger;
+        return (
+          <span
+            key={item.period}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium tabular-nums ${chipTone(ratio)}`}
+            title={t("quota.used_of_limit", {
+              period: periodLabel(t, item.period),
+              used: formatQuotaUsd(item.used),
+              limit: formatQuotaUsd(item.limit),
+            })}
+          >
+            {danger ? <AlertCircle size={13} aria-hidden="true" /> : null}
+            {warning ? <AlertTriangle size={13} aria-hidden="true" /> : null}
+            <span className="font-semibold">{periodLabel(t, item.period)}</span>
+            <span>
+              {formatQuotaUsd(item.used)} / {formatQuotaUsd(item.limit)}
+            </span>
+            {danger ? <span className="sr-only">{t("quota.status.exceeded")}</span> : null}
+            {warning ? <span className="sr-only">{t("quota.status.warning")}</span> : null}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export function PeriodSpendingLimitsCell({
+  t,
+  limits,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  limits?: PeriodSpendingLimits;
+}) {
+  const visible = PERIOD_SPENDING_PERIODS.filter((period) => (limits?.[period] ?? 0) > 0);
+  if (visible.length === 0) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-300">
+        <InfinityIcon size={13} aria-hidden="true" />
+        {t("quota.unlimited")}
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex min-w-[12rem] flex-wrap gap-1.5">
+      {visible.map((period) => (
+        <span
+          key={period}
+          className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 dark:border-indigo-500/25 dark:bg-indigo-500/10 dark:text-indigo-200"
+        >
+          <span className="font-semibold">{periodLabel(t, period)}</span>
+          <span className="tabular-nums">{formatQuotaUsd(limits?.[period] ?? 0)}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/features/period-spending/PeriodSpendingFields.tsx
+++ b/features/period-spending/PeriodSpendingFields.tsx
@@ -1,0 +1,117 @@
+import type { PeriodSpendingLimits, PeriodSpendingPeriod } from "@code-proxy/api-client";
+import { PERIOD_SPENDING_PERIODS } from "@code-proxy/api-client";
+import { TextInput } from "@code-proxy/ui";
+import { formatQuotaUsd } from "./PeriodSpendingCell";
+
+export type PeriodSpendingDraft = Record<PeriodSpendingPeriod, string>;
+
+export const emptyPeriodSpendingDraft = (): PeriodSpendingDraft => ({
+  "5h": "",
+  day: "",
+  week: "",
+  month: "",
+});
+
+export const limitsToPeriodSpendingDraft = (
+  limits: PeriodSpendingLimits | undefined,
+): PeriodSpendingDraft => ({
+  "5h": limits?.["5h"] ? String(limits["5h"]) : "",
+  day: limits?.day ? String(limits.day) : "",
+  week: limits?.week ? String(limits.week) : "",
+  month: limits?.month ? String(limits.month) : "",
+});
+
+const normalizeDraftValue = (value: string): number => {
+  const parsed = Number.parseFloat(value.trim());
+  return Number.isFinite(parsed) && parsed > 0 ? Math.ceil(parsed) : 0;
+};
+
+export const periodSpendingDraftToLimits = (draft: PeriodSpendingDraft): PeriodSpendingLimits => ({
+  "5h": normalizeDraftValue(draft["5h"]),
+  day: normalizeDraftValue(draft.day),
+  week: normalizeDraftValue(draft.week),
+  month: normalizeDraftValue(draft.month),
+});
+
+export const validatePeriodSpendingDraft = (
+  draft: PeriodSpendingDraft,
+  accountLimits: PeriodSpendingLimits | undefined,
+): PeriodSpendingPeriod | null => {
+  if (!accountLimits) return null;
+  const limits = periodSpendingDraftToLimits(draft);
+  return (
+    PERIOD_SPENDING_PERIODS.find(
+      (period) =>
+        limits[period] > 0 && accountLimits[period] > 0 && limits[period] > accountLimits[period],
+    ) ?? null
+  );
+};
+
+export function PeriodSpendingFields({
+  t,
+  value,
+  onChange,
+  accountLimits,
+  disabled = false,
+  errors = {},
+  idPrefix = "period-spending",
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  value: PeriodSpendingDraft;
+  onChange: (next: PeriodSpendingDraft) => void;
+  accountLimits?: PeriodSpendingLimits;
+  disabled?: boolean;
+  errors?: Partial<Record<PeriodSpendingPeriod, string>>;
+  idPrefix?: string;
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {PERIOD_SPENDING_PERIODS.map((period) => {
+        const accountLimit = accountLimits?.[period] ?? 0;
+        const error = errors[period];
+        const inputId = `${idPrefix}-${period}`;
+        return (
+          <label key={period} htmlFor={inputId} className="block space-y-1.5">
+            <span className="flex items-center justify-between gap-2 text-sm font-medium text-slate-700 dark:text-white/80">
+              <span>{t(`quota.field.${period}`)}</span>
+              {accountLimits ? (
+                <span className="text-xs font-normal text-slate-400 dark:text-white/40">
+                  {accountLimit > 0
+                    ? t("quota.account_limit_value", { value: formatQuotaUsd(accountLimit) })
+                    : t("quota.account_unlimited")}
+                </span>
+              ) : null}
+            </span>
+            <TextInput
+              id={inputId}
+              type="number"
+              min={0}
+              step={1}
+              inputMode="numeric"
+              value={value[period]}
+              disabled={disabled}
+              aria-label={t(`quota.field.${period}`)}
+              aria-invalid={Boolean(error)}
+              aria-describedby={error ? `${inputId}-error` : undefined}
+              placeholder={t("quota.input_unlimited")}
+              onChange={(event) => {
+                const raw = event.target.value;
+                if (raw === "" || /^\d*(?:\.\d*)?$/.test(raw)) {
+                  onChange({ ...value, [period]: raw });
+                }
+              }}
+            />
+            {error ? (
+              <span
+                id={`${inputId}-error`}
+                className="block text-xs text-rose-600 dark:text-rose-300"
+              >
+                {error}
+              </span>
+            ) : null}
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/features/period-spending/__tests__/OwnedApiKeyResetHistoryModal.test.tsx
+++ b/features/period-spending/__tests__/OwnedApiKeyResetHistoryModal.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { OwnedApiKeyResetHistoryModal } from "../OwnedApiKeyResetHistoryModal";
+
+const t = (key: string, options?: Record<string, unknown>) => {
+  const labels: Record<string, string> = {
+    "api_keys_page.reset_history_title": `Reset history · ${String(options?.name ?? "")}`,
+    "api_keys_page.reset_history_desc": `History for ${String(options?.key ?? "")}`,
+    "api_keys_page.reset_history_col_time": "Reset time",
+    "api_keys_page.reset_history_col_day": "Project day",
+    "api_keys_page.reset_history_col_actor": "Operator",
+    "api_keys_page.reset_history_col_cleared": "Cleared amount",
+    "api_keys_page.reset_history_col_raw_today": "True day spend",
+    "api_keys_page.reset_history_col_baseline": "Stored baseline",
+    "api_keys_page.reset_history_actor_service": "Management key",
+    "api_keys_page.reset_history_actor_unknown": "Unknown",
+    "api_keys_page.reset_history_empty": "No reset history",
+  };
+  return labels[key] ?? key;
+};
+
+describe("OwnedApiKeyResetHistoryModal", () => {
+  test("shows the project day and stored baseline required for reset evidence", () => {
+    render(
+      <OwnedApiKeyResetHistoryModal
+        t={t}
+        open
+        onClose={vi.fn()}
+        keyName="Primary"
+        maskedKey="sk-***-1"
+        loading={false}
+        events={[
+          {
+            id: 7,
+            day_key: "2026-07-21",
+            reset_at: "2026-07-21T11:00:00Z",
+            actor_username: "admin",
+            cost_baseline: 148.25,
+            effective_used_before: 28.25,
+            raw_today_cost: 148.25,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Project day" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Stored baseline" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2026-07-21")).toBeInTheDocument();
+    expect(screen.getAllByText("$148.25")).toHaveLength(2);
+  });
+});

--- a/features/period-spending/__tests__/PeriodSpendingCell.test.tsx
+++ b/features/period-spending/__tests__/PeriodSpendingCell.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { PeriodSpendingCell, PeriodSpendingLimitsCell } from "../PeriodSpendingCell";
+
+const t = (key: string) => {
+  const labels: Record<string, string> = {
+    "quota.period.5h": "5 hours",
+    "quota.period.day": "Day",
+    "quota.period.week": "Week",
+    "quota.period.month": "Month",
+    "quota.unlimited": "Unlimited",
+    "quota.status.warning": "Near quota limit",
+    "quota.status.exceeded": "Quota exceeded",
+  };
+  return labels[key] ?? key;
+};
+
+describe("PeriodSpendingCell", () => {
+  test("renders finite periods in the fixed 5h to month order", () => {
+    const { container } = render(
+      <PeriodSpendingCell
+        t={t}
+        items={[
+          { period: "month", limit: 4000, used: 912.34, remaining: 3087.66 },
+          { period: "day", limit: 300, used: 39, remaining: 261 },
+          { period: "5h", limit: 100, used: 39, remaining: 61 },
+          { period: "week", limit: 800, used: 120, remaining: 680 },
+        ]}
+      />,
+    );
+
+    expect(container.textContent).toBe(
+      "5 hours$39 / $100Day$39 / $300Week$120 / $800Month$912.34 / $4,000",
+    );
+  });
+
+  test("adds warning and danger semantics at 90 and 100 percent", () => {
+    render(
+      <PeriodSpendingCell
+        t={t}
+        items={[
+          { period: "5h", limit: 100, used: 90, remaining: 10 },
+          { period: "day", limit: 100, used: 100, remaining: 0 },
+        ]}
+      />,
+    );
+
+    const warning = screen.getByText("Near quota limit").parentElement;
+    const danger = screen.getByText("Quota exceeded").parentElement;
+    expect(warning).toHaveClass("border-amber-200");
+    expect(danger).toHaveClass("border-rose-200");
+    expect(warning?.querySelector("svg")).not.toBeNull();
+    expect(danger?.querySelector("svg")).not.toBeNull();
+  });
+
+  test("shows unlimited when no finite period is configured", () => {
+    render(<PeriodSpendingCell t={t} items={[]} />);
+    expect(screen.getByText("Unlimited")).toBeInTheDocument();
+  });
+
+  test("renders template limits without fake used values", () => {
+    const { container } = render(
+      <PeriodSpendingLimitsCell t={t} limits={{ "5h": 100, day: 300, week: 0, month: 4000 }} />,
+    );
+
+    expect(screen.getByText("$100")).toBeInTheDocument();
+    expect(screen.getByText("$300")).toBeInTheDocument();
+    expect(screen.getByText("$4,000")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("/");
+    expect(container).not.toHaveTextContent("Week");
+  });
+});

--- a/features/period-spending/__tests__/formatQuotaValidationError.test.ts
+++ b/features/period-spending/__tests__/formatQuotaValidationError.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { ApiClientError } from "@code-proxy/api-client";
+import { formatQuotaValidationError } from "../formatQuotaValidationError";
+
+const quotaError = new ApiClientError({
+  message: "request failed",
+  status: 400,
+  payload: {
+    error: {
+      code: "key_period_limit_exceeds_account",
+      message: "server fallback",
+      details: {
+        period: "day",
+        key_limit: 200,
+        account_limit: 100,
+      },
+    },
+  },
+});
+
+describe("formatQuotaValidationError", () => {
+  test("formats the structured limit error in English", () => {
+    expect(formatQuotaValidationError(quotaError, i18n.getFixedT("en"))).toBe(
+      "Key Day quota $200 exceeds the account Day quota $100",
+    );
+  });
+
+  test("formats the structured limit error in Simplified Chinese", () => {
+    expect(formatQuotaValidationError(quotaError, i18n.getFixedT("zh-CN"))).toBe(
+      "Key 一天额度 $200 超过账号一天额度 $100",
+    );
+  });
+
+  test("localizes legacy day conflicts without parsing the server message", () => {
+    const error = new ApiClientError({
+      message: "request failed",
+      status: 400,
+      payload: {
+        error: {
+          code: "period_day_legacy_conflict",
+          message: "do not expose this message",
+        },
+      },
+    });
+
+    expect(formatQuotaValidationError(error, i18n.getFixedT("en"))).toBe(
+      "Daily quota conflicts with the legacy daily spending limit.",
+    );
+  });
+});

--- a/features/period-spending/formatQuotaValidationError.ts
+++ b/features/period-spending/formatQuotaValidationError.ts
@@ -1,0 +1,30 @@
+import type { TFunction } from "i18next";
+import { extractQuotaValidationError } from "@code-proxy/api-client";
+import { formatQuotaUsd } from "./PeriodSpendingCell";
+
+export const formatQuotaValidationError = (error: unknown, t: TFunction): string => {
+  const parsed = extractQuotaValidationError(error);
+  if (!parsed) {
+    return error instanceof Error ? error.message : t("common.operation_failed");
+  }
+
+  if (
+    parsed.code === "key_period_limit_exceeds_account" &&
+    parsed.details.period &&
+    parsed.details.keyLimit != null &&
+    parsed.details.accountLimit != null
+  ) {
+    return t("quota.validation.key_exceeds_account", {
+      period: t(`quota.period.${parsed.details.period}`),
+      keyLimit: formatQuotaUsd(parsed.details.keyLimit),
+      accountLimit: formatQuotaUsd(parsed.details.accountLimit),
+    });
+  }
+  if (parsed.code === "period_day_legacy_conflict") {
+    return t("quota.validation.period_day_legacy_conflict");
+  }
+  if (parsed.code === "five_hour_quota_projection_warming") {
+    return t("quota.validation.five_hour_projection_warming");
+  }
+  return parsed.message || t("common.operation_failed");
+};

--- a/features/period-spending/index.ts
+++ b/features/period-spending/index.ts
@@ -1,0 +1,20 @@
+export {
+  PeriodSpendingCell,
+  PeriodSpendingLimitsCell,
+  formatQuotaUsd,
+  formatQuotaUsdAmount,
+} from "./PeriodSpendingCell";
+export {
+  PeriodSpendingFields,
+  emptyPeriodSpendingDraft,
+  limitsToPeriodSpendingDraft,
+  periodSpendingDraftToLimits,
+  validatePeriodSpendingDraft,
+} from "./PeriodSpendingFields";
+export type { PeriodSpendingDraft } from "./PeriodSpendingFields";
+export { formatQuotaValidationError } from "./formatQuotaValidationError";
+export { OwnedApiKeyQuotaModal } from "./OwnedApiKeyQuotaModal";
+export type { OwnedApiKeyQuotaForm } from "./OwnedApiKeyQuotaModal";
+export { OwnedApiKeysTable, createOwnedApiKeyColumns } from "./OwnedApiKeyTable";
+export type { OwnedApiKeyActions } from "./OwnedApiKeyTable";
+export { OwnedApiKeyResetHistoryModal } from "./OwnedApiKeyResetHistoryModal";

--- a/packages/api-client/src/endpoints/__tests__/api-key-permission-profiles.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/api-key-permission-profiles.test.ts
@@ -65,6 +65,7 @@ describe("apiKeyPermissionProfilesApi", () => {
             "daily-limit": 15000,
             "total-quota": 0,
             "daily-spending-limit": 100.5,
+            "period-spending-limits": { "5h": 50, day: 100.5, week: 500, month: 2000 },
             "concurrency-limit": 0,
             "rpm-limit": 0,
             "tpm-limit": 0,
@@ -76,7 +77,7 @@ describe("apiKeyPermissionProfilesApi", () => {
         ],
         { syncAccounts: true },
       ),
-    ).resolves.toEqual({ appliedCount: 2 });
+    ).resolves.toEqual({ appliedCount: 2, cappedKeys: [] });
 
     expect(mocks.put).toHaveBeenCalledWith("/api-key-permission-profiles", {
       items: [
@@ -93,6 +94,41 @@ describe("apiKeyPermissionProfilesApi", () => {
     expect(mocks.putRawText).not.toHaveBeenCalled();
   });
 
+  test("returns validated capped key details from profile sync", async () => {
+    mocks.put.mockResolvedValue({
+      applied_count: 3,
+      "capped-keys": [
+        { id: "key-1", period: "day", from: 200, to: 100 },
+        { id: "key-2", period: "invalid", from: 20, to: 10 },
+        { id: "key-3", period: "week", from: "20", to: 10 },
+      ],
+    });
+
+    await expect(apiKeyPermissionProfilesApi.replace([], { syncAccounts: true })).resolves.toEqual({
+      appliedCount: 3,
+      cappedKeys: [{ id: "key-1", period: "day", from: 200, to: 100 }],
+    });
+  });
+
+  test("maps the legacy daily spending limit into the day period", async () => {
+    mocks.get.mockResolvedValue({
+      "api-key-permission-profiles": [
+        {
+          id: "legacy",
+          name: "Legacy",
+          "daily-spending-limit": 125,
+        },
+      ],
+    });
+
+    await expect(apiKeyPermissionProfilesApi.list()).resolves.toEqual([
+      expect.objectContaining({
+        "daily-spending-limit": 125,
+        "period-spending-limits": { "5h": 0, day: 125, week: 0, month: 0 },
+      }),
+    ]);
+  });
+
   test("uses explicit profile binding and does not infer unrestricted entries as bound", () => {
     const profiles = [
       {
@@ -101,6 +137,7 @@ describe("apiKeyPermissionProfilesApi", () => {
         "daily-limit": 0,
         "total-quota": 0,
         "daily-spending-limit": 0,
+        "period-spending-limits": { "5h": 0, day: 0, week: 0, month: 0 },
         "concurrency-limit": 0,
         "rpm-limit": 0,
         "tpm-limit": 0,

--- a/packages/api-client/src/endpoints/__tests__/end-users.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/end-users.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { endUsersApi } from "@code-proxy/api-client/endpoints/end-users";
+import { endUsersApi, portalApi } from "@code-proxy/api-client/endpoints/end-users";
 
 const mocks = vi.hoisted(() => ({
   get: vi.fn(),
@@ -32,6 +32,63 @@ describe("endUsersApi", () => {
 
     expect(mocks.get).toHaveBeenCalledWith(
       "/end-users/user-1/daily-spending/reset-history?limit=200",
+    );
+  });
+
+  test("creates and updates owned keys with period spending limits", async () => {
+    const limits = { "5h": 50, day: 100, week: 300, month: 1000 };
+    mocks.post.mockResolvedValue({ api_key: { id: "key-1" }, plaintext_key: "sk-secret" });
+    mocks.patch.mockResolvedValue({ id: "key-1", name: "Renamed" });
+
+    await endUsersApi.createKey("user-1", {
+      name: "Primary",
+      "daily-spending-limit": limits.day,
+      "period-spending-limits": limits,
+    });
+    await endUsersApi.updateKey("user-1", "key-1", {
+      name: "Renamed",
+      "daily-spending-limit": limits.day,
+      "period-spending-limits": limits,
+    });
+
+    expect(mocks.post).toHaveBeenCalledWith("/end-users/user-1/api-keys", {
+      name: "Primary",
+      "daily-spending-limit": 100,
+      "period-spending-limits": limits,
+    });
+    expect(mocks.patch).toHaveBeenCalledWith("/end-users/user-1/api-keys/key-1", {
+      name: "Renamed",
+      "daily-spending-limit": 100,
+      "period-spending-limits": limits,
+    });
+  });
+
+  test("uses owner-scoped reset and reset-history endpoints", async () => {
+    mocks.post.mockResolvedValue({ status: "ok" });
+    mocks.get.mockResolvedValue({ items: [], total: 0 });
+
+    await endUsersApi.resetKeyDailySpending("user-1", "key-1");
+    await endUsersApi.listKeyDailySpendingResetHistory("user-1", "key-1", 200);
+
+    expect(mocks.post).toHaveBeenCalledWith(
+      "/end-users/user-1/api-keys/key-1/daily-spending/reset",
+      {},
+    );
+    expect(mocks.get).toHaveBeenCalledWith(
+      "/end-users/user-1/api-keys/key-1/daily-spending/reset-history?limit=200",
+    );
+  });
+
+  test("uses portal reset and reset-history endpoints", async () => {
+    const post = vi.spyOn(portalApi.client, "post").mockResolvedValue({ status: "ok" });
+    const get = vi.spyOn(portalApi.client, "get").mockResolvedValue({ items: [], total: 0 });
+
+    await portalApi.resetKeyDailySpending("key-1");
+    await portalApi.listKeyDailySpendingResetHistory("key-1", 100);
+
+    expect(post).toHaveBeenCalledWith("/v0/portal/api-keys/key-1/daily-spending/reset", {});
+    expect(get).toHaveBeenCalledWith(
+      "/v0/portal/api-keys/key-1/daily-spending/reset-history?limit=100",
     );
   });
 

--- a/packages/api-client/src/endpoints/api-key-permission-profiles.ts
+++ b/packages/api-client/src/endpoints/api-key-permission-profiles.ts
@@ -1,5 +1,13 @@
 import type { ApiKeyEntry } from "./api-keys";
+import {
+  EMPTY_PERIOD_SPENDING_LIMITS,
+  isPeriodSpendingPeriod,
+  normalizePeriodSpendingLimits,
+  type CappedKey,
+  type PeriodSpendingLimits,
+} from "./period-spending";
 import { apiClient } from "../client/client";
+import { isRecord } from "../client/response";
 
 export const CUSTOM_PERMISSION_PROFILE_ID = "__custom__";
 
@@ -9,6 +17,7 @@ export interface ApiKeyPermissionProfile {
   "daily-limit": number;
   "total-quota": number;
   "daily-spending-limit": number;
+  "period-spending-limits": PeriodSpendingLimits;
   "concurrency-limit": number;
   "rpm-limit": number;
   "tpm-limit": number;
@@ -24,12 +33,8 @@ export interface ReplaceApiKeyPermissionProfilesOptions {
 
 export interface ReplaceApiKeyPermissionProfilesResult {
   appliedCount: number;
+  cappedKeys: CappedKey[];
 }
-
-const asRecord = (value: unknown): Record<string, unknown> | null =>
-  value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
 
 const normalizeString = (value: unknown): string => String(value ?? "").trim();
 
@@ -69,8 +74,8 @@ export function normalizeApiKeyPermissionProfiles(raw: unknown): ApiKeyPermissio
 
   return raw
     .map((item, index) => {
-      const record = asRecord(item);
-      if (!record) return null;
+      if (!isRecord(item)) return null;
+      const record = item;
       const name = normalizeString(record.name);
       const id = normalizeString(record.id) || `profile-${index + 1}`;
       if (!name) return null;
@@ -80,7 +85,12 @@ export function normalizeApiKeyPermissionProfiles(raw: unknown): ApiKeyPermissio
         name,
         "daily-limit": normalizeLimit(record["daily-limit"] ?? record.dailyLimit),
         "total-quota": normalizeLimit(record["total-quota"] ?? record.totalQuota),
-        "daily-spending-limit": normalizeSpendingLimit(
+        "daily-spending-limit": normalizePeriodSpendingLimits(
+          record["period-spending-limits"] ?? record.periodSpendingLimits,
+          record["daily-spending-limit"] ?? record.dailySpendingLimit,
+        ).day,
+        "period-spending-limits": normalizePeriodSpendingLimits(
+          record["period-spending-limits"] ?? record.periodSpendingLimits,
           record["daily-spending-limit"] ?? record.dailySpendingLimit,
         ),
         "concurrency-limit": normalizeLimit(record["concurrency-limit"] ?? record.concurrencyLimit),
@@ -104,7 +114,14 @@ export const serializeApiKeyPermissionProfile = (profile: ApiKeyPermissionProfil
   name: profile.name,
   "daily-limit": normalizeLimit(profile["daily-limit"]),
   "total-quota": normalizeLimit(profile["total-quota"]),
-  "daily-spending-limit": normalizeSpendingLimit(profile["daily-spending-limit"]),
+  "daily-spending-limit": normalizePeriodSpendingLimits(
+    profile["period-spending-limits"],
+    profile["daily-spending-limit"],
+  ).day,
+  "period-spending-limits": normalizePeriodSpendingLimits(
+    profile["period-spending-limits"],
+    profile["daily-spending-limit"],
+  ),
   "concurrency-limit": normalizeLimit(profile["concurrency-limit"]),
   "rpm-limit": normalizeLimit(profile["rpm-limit"]),
   "tpm-limit": normalizeLimit(profile["tpm-limit"]),
@@ -124,7 +141,7 @@ export function applyApiKeyPermissionProfile(
       "permission-profile-id": "",
       "daily-limit": 0,
       "total-quota": 0,
-      "spending-limit": 0,
+      "period-spending-limits": { ...EMPTY_PERIOD_SPENDING_LIMITS },
       "daily-spending-limit": 0,
       "concurrency-limit": 0,
       "rpm-limit": 0,
@@ -141,8 +158,8 @@ export function applyApiKeyPermissionProfile(
     "permission-profile-id": profile.id,
     "daily-limit": profile["daily-limit"],
     "total-quota": profile["total-quota"],
-    "spending-limit": 0,
-    "daily-spending-limit": profile["daily-spending-limit"],
+    "daily-spending-limit": profile["period-spending-limits"].day,
+    "period-spending-limits": { ...profile["period-spending-limits"] },
     "concurrency-limit": profile["concurrency-limit"],
     "rpm-limit": profile["rpm-limit"],
     "tpm-limit": profile["tpm-limit"],
@@ -158,7 +175,9 @@ export function hasApiKeyPermissionSettings(entry: ApiKeyEntry): boolean {
     (entry["daily-limit"] ?? 0) > 0 ||
     (entry["total-quota"] ?? 0) > 0 ||
     normalizeSpendingLimit(entry["spending-limit"]) > 0 ||
-    normalizeSpendingLimit(entry["daily-spending-limit"]) > 0 ||
+    Object.values(
+      normalizePeriodSpendingLimits(entry["period-spending-limits"], entry["daily-spending-limit"]),
+    ).some((limit) => limit > 0) ||
     (entry["concurrency-limit"] ?? 0) > 0 ||
     (entry["rpm-limit"] ?? 0) > 0 ||
     (entry["tpm-limit"] ?? 0) > 0 ||
@@ -184,8 +203,12 @@ export function findMatchingPermissionProfile(
       (profile) =>
         normalizeLimit(entry["daily-limit"]) === profile["daily-limit"] &&
         normalizeLimit(entry["total-quota"]) === profile["total-quota"] &&
-        normalizeSpendingLimit(entry["spending-limit"]) === 0 &&
-        normalizeSpendingLimit(entry["daily-spending-limit"]) === profile["daily-spending-limit"] &&
+        JSON.stringify(
+          normalizePeriodSpendingLimits(
+            entry["period-spending-limits"],
+            entry["daily-spending-limit"],
+          ),
+        ) === JSON.stringify(profile["period-spending-limits"]) &&
         normalizeLimit(entry["concurrency-limit"]) === profile["concurrency-limit"] &&
         normalizeLimit(entry["rpm-limit"]) === profile["rpm-limit"] &&
         normalizeLimit(entry["tpm-limit"]) === profile["tpm-limit"] &&
@@ -222,11 +245,24 @@ export const apiKeyPermissionProfilesApi = {
     options: ReplaceApiKeyPermissionProfilesOptions = {},
   ): Promise<ReplaceApiKeyPermissionProfilesResult> {
     const items = profiles.map(serializeApiKeyPermissionProfile);
-    const data = await apiClient.put<{ applied_count?: unknown }>(
+    const data = await apiClient.put<{ applied_count?: unknown; "capped-keys"?: unknown }>(
       "/api-key-permission-profiles",
       options.syncAccounts ? { items, "sync-accounts": true } : items,
     );
     const appliedCount = Number(data?.applied_count ?? 0);
-    return { appliedCount: Number.isFinite(appliedCount) ? appliedCount : 0 };
+    const cappedKeys = Array.isArray(data?.["capped-keys"])
+      ? data["capped-keys"].filter((item): item is CappedKey => {
+          if (!isRecord(item)) return false;
+          return (
+            typeof item.id === "string" &&
+            isPeriodSpendingPeriod(item.period) &&
+            typeof item.from === "number" &&
+            Number.isFinite(item.from) &&
+            typeof item.to === "number" &&
+            Number.isFinite(item.to)
+          );
+        })
+      : [];
+    return { appliedCount: Number.isFinite(appliedCount) ? appliedCount : 0, cappedKeys };
   },
 };

--- a/packages/api-client/src/endpoints/api-keys.ts
+++ b/packages/api-client/src/endpoints/api-keys.ts
@@ -1,4 +1,9 @@
 import { apiClient } from "../client/client";
+import type {
+  PeriodSpendingItem,
+  PeriodSpendingLimits,
+  PeriodSpendingLimitsPatch,
+} from "./period-spending";
 
 export interface ApiKeyEntry {
   id?: string;
@@ -10,10 +15,13 @@ export interface ApiKeyEntry {
   "spending-limit"?: number;
   /** Project-timezone daily USD cap; 0 = unlimited. Key-owned, independent of permission profiles. */
   "daily-spending-limit"?: number;
+  "period-spending-limits"?: PeriodSpendingLimits | PeriodSpendingLimitsPatch;
+  "period-spending"?: PeriodSpendingItem[];
   /** Effective today cost after same-day reset baseline (management list). */
   "daily-spending-used"?: number;
   /** Remaining daily budget; null/undefined = unlimited. */
   "daily-spending-remaining"?: number | null;
+  "lifetime-spending-used"?: number;
   /** How many times daily spending was manually reset (management list). */
   "daily-spending-reset-count"?: number;
   "concurrency-limit"?: number;
@@ -107,11 +115,7 @@ export const apiKeyEntriesApi = {
       payload,
     ),
 
-  listDailySpendingResetHistory: (params: {
-    id?: string;
-    key?: string;
-    limit?: number;
-  }) => {
+  listDailySpendingResetHistory: (params: { id?: string; key?: string; limit?: number }) => {
     const query = new URLSearchParams();
     if (params.id) query.set("id", params.id);
     else if (params.key) query.set("key", params.key);

--- a/packages/api-client/src/endpoints/end-users.ts
+++ b/packages/api-client/src/endpoints/end-users.ts
@@ -1,4 +1,14 @@
 import { apiClient } from "../client/client";
+import type {
+  ApiKeyDailySpendingResetHistoryResponse,
+  ApiKeyDailySpendingResetResult,
+} from "./api-keys";
+import type {
+  CappedKey,
+  PeriodSpendingItem,
+  PeriodSpendingLimits,
+  PeriodSpendingLimitsPatch,
+} from "./period-spending";
 import {
   buildPortalAccountKey,
   detectApiBaseFromLocation,
@@ -24,6 +34,10 @@ export interface EndUser {
   version: number;
   api_key_count?: number;
   "daily-spending-used"?: number;
+  "lifetime-spending-used"?: number;
+  "period-spending-limits"?: PeriodSpendingLimits;
+  "period-spending"?: PeriodSpendingItem[];
+  "capped-keys"?: CappedKey[];
   /** How many times daily spending was manually reset. */
   "daily-spending-reset-count"?: number;
   /** Account-level quota/permissions (shared by all keys). */
@@ -51,6 +65,7 @@ export type EndUserUpdateBody = {
   "total-quota"?: number;
   "spending-limit"?: number;
   "daily-spending-limit"?: number;
+  "period-spending-limits"?: PeriodSpendingLimitsPatch;
   "concurrency-limit"?: number;
   "rpm-limit"?: number;
   "tpm-limit"?: number;
@@ -94,12 +109,25 @@ export interface EndUserAPIKey {
   id: string;
   tenant_id: string;
   end_user_id: string;
+  key?: string;
   key_masked?: string;
   name: string;
   disabled: boolean;
   is_default: boolean;
   created_at?: string;
   updated_at?: string;
+  "daily-spending-limit"?: number;
+  "period-spending-limits"?: PeriodSpendingLimits;
+  "period-spending"?: PeriodSpendingItem[];
+  "daily-spending-used"?: number;
+  "lifetime-spending-used"?: number;
+  "daily-spending-reset-count"?: number;
+}
+
+export interface EndUserAPIKeyMutationBody {
+  name?: string;
+  "daily-spending-limit"?: number;
+  "period-spending-limits"?: PeriodSpendingLimitsPatch;
 }
 
 export interface CreateEndUserResult {
@@ -145,12 +173,25 @@ export const endUsersApi = {
     );
   },
   listKeys: (id: string) => apiClient.get<{ items: EndUserAPIKey[] }>(`/end-users/${id}/api-keys`),
-  createKey: (id: string, name?: string) =>
-    apiClient.post<EndUserAPIKeySecretResult>(`/end-users/${id}/api-keys`, {
-      name: name || "",
-    }),
+  createKey: (id: string, body: EndUserAPIKeyMutationBody) =>
+    apiClient.post<EndUserAPIKeySecretResult>(`/end-users/${id}/api-keys`, body),
+  updateKey: (userId: string, keyId: string, body: EndUserAPIKeyMutationBody) =>
+    apiClient.patch<EndUserAPIKey>(`/end-users/${userId}/api-keys/${keyId}`, body),
   updateKeyName: (userId: string, keyId: string, name: string) =>
     apiClient.patch<EndUserAPIKey>(`/end-users/${userId}/api-keys/${keyId}`, { name }),
+  resetKeyDailySpending: (userId: string, keyId: string) =>
+    apiClient.post<ApiKeyDailySpendingResetResult>(
+      `/end-users/${userId}/api-keys/${keyId}/daily-spending/reset`,
+      {},
+    ),
+  listKeyDailySpendingResetHistory: (userId: string, keyId: string, limit?: number) => {
+    const query = new URLSearchParams();
+    if (limit != null) query.set("limit", String(limit));
+    const suffix = query.size > 0 ? `?${query.toString()}` : "";
+    return apiClient.get<ApiKeyDailySpendingResetHistoryResponse>(
+      `/end-users/${userId}/api-keys/${keyId}/daily-spending/reset-history${suffix}`,
+    );
+  },
   rotateKey: (userId: string, keyId: string) =>
     apiClient.post<EndUserAPIKeySecretResult>(`/end-users/${userId}/api-keys/${keyId}/rotate`, {}),
   deleteKey: (userId: string, keyId: string) =>
@@ -206,12 +247,26 @@ export const portalApi = {
   listKeys: () => portalClient.get<{ items: EndUserAPIKey[] }>("/v0/portal/api-keys"),
   keySecret: (id: string) =>
     portalClient.get<{ id: string; key: string }>(`/v0/portal/api-keys/${id}/secret`),
-  createKey: (name?: string) =>
-    portalClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>("/v0/portal/api-keys", {
-      name: name || "",
-    }),
-  updateKey: (id: string, body: { name?: string }) =>
+  createKey: (body: EndUserAPIKeyMutationBody) =>
+    portalClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>(
+      "/v0/portal/api-keys",
+      body,
+    ),
+  updateKey: (id: string, body: EndUserAPIKeyMutationBody) =>
     portalClient.patch<EndUserAPIKey>(`/v0/portal/api-keys/${id}`, body),
+  resetKeyDailySpending: (id: string) =>
+    portalClient.post<ApiKeyDailySpendingResetResult>(
+      `/v0/portal/api-keys/${id}/daily-spending/reset`,
+      {},
+    ),
+  listKeyDailySpendingResetHistory: (id: string, limit?: number) => {
+    const query = new URLSearchParams();
+    if (limit != null) query.set("limit", String(limit));
+    const suffix = query.size > 0 ? `?${query.toString()}` : "";
+    return portalClient.get<ApiKeyDailySpendingResetHistoryResponse>(
+      `/v0/portal/api-keys/${id}/daily-spending/reset-history${suffix}`,
+    );
+  },
   rotateKey: (id: string) =>
     portalClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>(
       `/v0/portal/api-keys/${id}/rotate`,

--- a/packages/api-client/src/endpoints/period-spending.ts
+++ b/packages/api-client/src/endpoints/period-spending.ts
@@ -1,0 +1,106 @@
+import { extractApiErrorCode, isApiClientError } from "../client/errors";
+import { isRecord } from "../client/response";
+
+export const PERIOD_SPENDING_PERIODS = ["5h", "day", "week", "month"] as const;
+
+export type PeriodSpendingPeriod = (typeof PERIOD_SPENDING_PERIODS)[number];
+
+export const isPeriodSpendingPeriod = (value: unknown): value is PeriodSpendingPeriod =>
+  PERIOD_SPENDING_PERIODS.some((period) => period === value);
+
+export interface PeriodSpendingLimits {
+  "5h": number;
+  day: number;
+  week: number;
+  month: number;
+}
+
+export type PeriodSpendingLimitsPatch = Partial<PeriodSpendingLimits>;
+
+export interface PeriodSpendingItem {
+  period: PeriodSpendingPeriod;
+  limit: number;
+  used: number;
+  remaining: number;
+}
+
+export interface CappedKey {
+  id: string;
+  period: PeriodSpendingPeriod;
+  from: number;
+  to: number;
+}
+
+export type QuotaValidationErrorCode =
+  | "key_period_limit_exceeds_account"
+  | "period_day_legacy_conflict"
+  | "five_hour_quota_projection_warming";
+
+export interface QuotaValidationErrorDetails {
+  period?: PeriodSpendingPeriod;
+  keyLimit?: number;
+  accountLimit?: number;
+}
+
+export interface QuotaValidationError {
+  code: QuotaValidationErrorCode | string;
+  message: string;
+  details: QuotaValidationErrorDetails;
+}
+
+export const EMPTY_PERIOD_SPENDING_LIMITS: PeriodSpendingLimits = {
+  "5h": 0,
+  day: 0,
+  week: 0,
+  month: 0,
+};
+
+const finiteNonNegative = (value: unknown): number => {
+  const parsed = typeof value === "number" ? value : Number.parseFloat(String(value ?? ""));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+export const normalizePeriodSpendingLimits = (
+  value: unknown,
+  legacyDay?: unknown,
+): PeriodSpendingLimits => {
+  const record = isRecord(value) ? value : {};
+  return {
+    "5h": finiteNonNegative(record["5h"]),
+    day: finiteNonNegative(record.day ?? legacyDay),
+    week: finiteNonNegative(record.week),
+    month: finiteNonNegative(record.month),
+  };
+};
+
+export const hasPeriodSpendingLimits = (limits: PeriodSpendingLimits): boolean =>
+  PERIOD_SPENDING_PERIODS.some((period) => limits[period] > 0);
+
+export const extractQuotaValidationError = (error: unknown): QuotaValidationError | null => {
+  if (!isApiClientError(error)) return null;
+  const code = extractApiErrorCode(error.payload);
+  if (!code) return null;
+
+  const payload = isRecord(error.payload) ? error.payload : null;
+  const nested = payload && isRecord(payload.error) ? payload.error : null;
+  const detailsRecord = nested && isRecord(nested.details) ? nested.details : null;
+  const period = detailsRecord?.period;
+  const keyLimit = detailsRecord?.key_limit;
+  const accountLimit = detailsRecord?.account_limit;
+
+  return {
+    code,
+    message:
+      typeof nested?.message === "string" && nested.message.trim()
+        ? nested.message.trim()
+        : error.message,
+    details: {
+      period: isPeriodSpendingPeriod(period) ? period : undefined,
+      keyLimit: typeof keyLimit === "number" && Number.isFinite(keyLimit) ? keyLimit : undefined,
+      accountLimit:
+        typeof accountLimit === "number" && Number.isFinite(accountLimit)
+          ? accountLimit
+          : undefined,
+    },
+  };
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -75,6 +75,14 @@ export { modelsApi } from "./endpoints/models";
 export type * from "./endpoints/models";
 export { versionApi } from "./endpoints/version";
 export { quotaApi } from "./endpoints/quota";
+export type * from "./endpoints/period-spending";
+export {
+  EMPTY_PERIOD_SPENDING_LIMITS,
+  PERIOD_SPENDING_PERIODS,
+  extractQuotaValidationError,
+  hasPeriodSpendingLimits,
+  normalizePeriodSpendingLimits,
+} from "./endpoints/period-spending";
 export { aiAccountsStatusApi } from "./endpoints/ai-accounts-status";
 export type * from "./endpoints/ai-accounts-status";
 export { identityFingerprintApi } from "./endpoints/identity-fingerprint";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -87,7 +87,8 @@
     "sort_ascending": "Ascending",
     "sort_descending": "Descending",
     "no_data": "No data",
-    "disabled": "Disabled"
+    "disabled": "Disabled",
+    "enabled": "Enabled"
   },
   "title": {
     "main": "Code Proxy Admin Dashboard",
@@ -2904,9 +2905,11 @@
     "reset_history_empty": "No reset history yet",
     "reset_history_load_failed": "Failed to load reset history",
     "reset_history_col_time": "Reset time",
+    "reset_history_col_day": "Project day",
     "reset_history_col_actor": "Operator",
     "reset_history_col_cleared": "Cleared amount",
     "reset_history_col_raw_today": "True day spend",
+    "reset_history_col_baseline": "Stored baseline",
     "reset_history_actor_service": "Management key",
     "reset_history_actor_unknown": "Unknown",
     "col_models": "Models",
@@ -2987,7 +2990,14 @@
     "no_api_keys": "No API keys",
     "usage_table_caption": "Usage records",
     "no_usage_records": "No usage records",
-    "more_suffix": " more"
+    "more_suffix": " more",
+    "quota_help": "Configured USD period quotas and current usage.",
+    "daily_spending_fact_help": "Effective spending today after manual resets.",
+    "lifetime_spending_help": "Lifetime spending. Daily resets do not change this amount.",
+    "edit_key_quota": "Edit Key quota",
+    "key_quota_title": "Key sub-quota",
+    "key_quota_account_hint": "Key limits may not exceed a configured account limit.",
+    "quota_validation_failed": "Please correct the quota values before saving."
   },
   "api_key_permissions_page": {
     "title": "Account Permission Profiles",
@@ -3032,7 +3042,14 @@
     "delete_desc": "Delete {{name}}? User accounts using it will keep their copied settings as custom account configuration.",
     "load_failed": "Failed to load permission configs",
     "save_failed": "Failed to save permission config",
-    "delete_failed": "Failed to delete permission config"
+    "delete_failed": "Failed to delete permission config",
+    "quota_section": "Period spending",
+    "quota_section_desc": "Set account USD ceilings for four fixed periods.",
+    "request_limits_section": "Request limits",
+    "request_limits_desc": "Secondary request-count controls.",
+    "realtime_limits_section": "Real-time limits",
+    "saved_with_sync": "Permission config saved. Synced {{accounts}} accounts and adjusted {{keys}} key quota entries.",
+    "saved_with_caps": "Permission config saved. Adjusted {{keys}} key quota entries."
   },
   "channel_groups_page": {
     "title": "Channel Groups Management",
@@ -3193,8 +3210,8 @@
     "reset_today_spending": "Reset account today's spending",
     "reset_today_spending_disabled": "Set a daily spending limit in the permission config before resetting",
     "reset_today_spending_success": "Account today's spending reset",
-    "daily_reset_count": "Daily reset count",
-    "reset_count_help": "How many times this account's daily spending was manually reset today. Click to view history across all dates.",
+    "daily_reset_count": "Total resets",
+    "reset_count_help": "All-time count of manual daily-spending resets for this account. Click to view history.",
     "view_reset_history": "View reset history",
     "reset_history_title": "Reset history · {{name}}",
     "reset_history_desc": "All manual daily-spending reset records for this account. Request logs are kept.",
@@ -3203,8 +3220,10 @@
     "reset_history_load_failed": "Failed to load reset history",
     "reset_history_col_id": "Reset ID",
     "reset_history_col_time": "Reset time",
+    "reset_history_col_day": "Project day",
     "reset_history_col_cleared": "Usage before reset",
     "reset_history_col_raw_today": "True day spend snapshot",
+    "reset_history_col_baseline": "Stored baseline",
     "reset_history_col_actor": "Operator",
     "reset_history_raw_today_summary": "Today's true spend",
     "reset_history_effective_used_summary": "Current effective today usage",
@@ -3241,7 +3260,19 @@
     "copy_secret": "Copy API key",
     "copy_secret_hint": "This plaintext key is shown only once.",
     "back_to_users": "Back to user accounts",
-    "delete_title": "Delete user account"
+    "delete_title": "Delete user account",
+    "quota_preview": "Effective account quota",
+    "quota_direct_edit_hint": "No permission profile is selected. Edit the account quota directly.",
+    "quota_profile_readonly_hint": "This account uses {{profile}}. Period quotas come from the profile and are read-only here.",
+    "other_limits": "Other limits",
+    "lifetime_spending_limit": "Lifetime spending limit (USD)",
+    "lifetime_spending_limit_hint": "This limit is account-specific and is not managed by permission profiles.",
+    "daily_spending": "Today",
+    "lifetime_spending": "Lifetime",
+    "total_resets": "Total resets",
+    "reset_password": "Reset password",
+    "other_limits_profile_readonly_hint": "Request and realtime limits come from {{profile}} and are read-only here. The lifetime spending limit remains account-specific.",
+    "other_limits_direct_hint": "No permission profile is selected. Edit request and realtime limits directly; 0 means unlimited."
   },
   "apikey_lookup": {
     "available_models": "Model Plaza",
@@ -3342,7 +3373,16 @@
     "deleting": "Deleting…",
     "add_account": "Add account",
     "switch_account": "Switch account",
-    "current_account": "Current account"
+    "current_account": "Current account",
+    "edit_key_quota": "Edit Key quota",
+    "reset_daily_spending": "Reset today spending",
+    "reset_daily_spending_success": "Today spending reset",
+    "reset_daily_spending_failed": "Failed to reset today spending",
+    "view_reset_history": "View reset history",
+    "total_resets": "Total resets",
+    "account_scope": "Account quota",
+    "key_scope": "Key quota",
+    "quota_period_spending": "Period spending"
   },
   "auth_files_page": {
     "files_tab": "Files",
@@ -4519,7 +4559,39 @@
     "save": "Save"
   },
   "quota": {
-    "no_matching": "No matching auth files"
+    "no_matching": "No matching auth files",
+    "period": {
+      "5h": "5 hours",
+      "day": "Day",
+      "week": "Week",
+      "month": "Month"
+    },
+    "field": {
+      "5h": "5-hour quota (USD)",
+      "day": "Daily quota (USD)",
+      "week": "Weekly quota (USD)",
+      "month": "Monthly quota (USD)"
+    },
+    "period_spending_column": "Quota",
+    "daily_spending_column": "Today",
+    "lifetime_spending_column": "Lifetime",
+    "total_resets": "Total resets",
+    "unlimited": "Unlimited",
+    "input_unlimited": "0 = Unlimited",
+    "fields_hint": "Empty or 0 means unlimited.",
+    "key_fields_hint": "Empty or 0 means no key sub-limit. The account ceiling still applies.",
+    "account_limit_value": "Account limit {{value}}",
+    "account_unlimited": "Account unlimited",
+    "used_of_limit": "{{period}}: {{used}} of {{limit}} used",
+    "status": {
+      "warning": "Near quota limit",
+      "exceeded": "Quota exceeded"
+    },
+    "validation": {
+      "key_exceeds_account": "Key {{period}} quota {{keyLimit}} exceeds the account {{period}} quota {{accountLimit}}",
+      "period_day_legacy_conflict": "Daily quota conflicts with the legacy daily spending limit.",
+      "five_hour_projection_warming": "The 5-hour quota is temporarily unavailable while usage projection warms up."
+    }
   },
   "models": {
     "total_models_count": "{{count}} models"

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -89,7 +89,8 @@
     "sort_ascending": "升序",
     "sort_descending": "降序",
     "no_data": "暂无数据",
-    "disabled": "已停用"
+    "disabled": "已停用",
+    "enabled": "已启用"
   },
   "title": {
     "main": "Code Proxy 管理后台",
@@ -3201,9 +3202,11 @@
     "reset_history_empty": "暂无重置记录",
     "reset_history_load_failed": "加载重置历史失败",
     "reset_history_col_time": "重置时间",
+    "reset_history_col_day": "项目日期",
     "reset_history_col_actor": "操作人",
     "reset_history_col_cleared": "清零额度",
     "reset_history_col_raw_today": "真实当日消耗",
+    "reset_history_col_baseline": "存储基线",
     "reset_history_actor_service": "管理密钥",
     "reset_history_actor_unknown": "未知",
     "col_models": "模型",
@@ -3284,7 +3287,14 @@
     "no_api_keys": "暂无 API 密钥",
     "usage_table_caption": "使用记录",
     "no_usage_records": "暂无使用记录",
-    "more_suffix": " 等更多"
+    "more_suffix": " 等更多",
+    "quota_help": "各周期 USD 配额及当前用量。",
+    "daily_spending_fact_help": "应用手动重置后的当日有效消费。",
+    "lifetime_spending_help": "累计消费，不受每日重置影响。",
+    "edit_key_quota": "编辑 Key 配额",
+    "key_quota_title": "Key 子配额",
+    "key_quota_account_hint": "Key 配额不能超过已配置的账号上限。",
+    "quota_validation_failed": "请先修正配额输入再保存。"
   },
   "api_key_permissions_page": {
     "title": "账户权限模板",
@@ -3329,7 +3339,14 @@
     "delete_desc": "删除 {{name}}？使用它的用户账号会保留已复制的设置并转为自定义账户配置。",
     "load_failed": "加载权限配置失败",
     "save_failed": "保存权限配置失败",
-    "delete_failed": "删除权限配置失败"
+    "delete_failed": "删除权限配置失败",
+    "quota_section": "配额",
+    "quota_section_desc": "设置账号四个固定周期的 USD 消费天花板。",
+    "request_limits_section": "请求限额",
+    "request_limits_desc": "次要的请求次数限制。",
+    "realtime_limits_section": "实时限制",
+    "saved_with_sync": "权限配置已保存，已同步 {{accounts}} 个账号，并调整 {{keys}} 个 Key 周期额度。",
+    "saved_with_caps": "权限配置已保存，并调整 {{keys}} 个 Key 周期额度。"
   },
   "channel_groups_page": {
     "title": "渠道分组管理",
@@ -3490,8 +3507,8 @@
     "reset_today_spending": "重置账号今日消费",
     "reset_today_spending_disabled": "请先在权限配置中设置每日消费额度后再重置",
     "reset_today_spending_success": "已重置该账号今日消费",
-    "daily_reset_count": "当日重置次数",
-    "reset_count_help": "该用户今日消费额度被手动重置的次数。点击可查看所有日期的详细历史。",
+    "daily_reset_count": "累计重置次数",
+    "reset_count_help": "该账号手动重置每日消费的全历史累计次数。点击可查看详细历史。",
     "view_reset_history": "查看重置历史",
     "reset_history_title": "重置历史 · {{name}}",
     "reset_history_desc": "该账号所有时间段的手动重置记录，请求日志会保留。",
@@ -3500,8 +3517,10 @@
     "reset_history_load_failed": "加载重置历史失败",
     "reset_history_col_id": "重置 ID",
     "reset_history_col_time": "重置时间",
+    "reset_history_col_day": "项目日期",
     "reset_history_col_cleared": "重置前消耗额度",
     "reset_history_col_raw_today": "当日实际消耗快照",
+    "reset_history_col_baseline": "存储基线",
     "reset_history_col_actor": "操作人",
     "reset_history_raw_today_summary": "当日实际消耗",
     "reset_history_effective_used_summary": "当前有效今日用量",
@@ -3538,7 +3557,19 @@
     "copy_secret": "复制 API Key",
     "copy_secret_hint": "明文 Key 仅展示一次。",
     "back_to_users": "返回用户账号",
-    "delete_title": "删除用户账号"
+    "delete_title": "删除用户账号",
+    "quota_preview": "账号生效配额",
+    "quota_direct_edit_hint": "当前未绑定权限模板，可直接编辑账号配额。",
+    "quota_profile_readonly_hint": "当前账号使用 {{profile}}，周期配额由模板管理，此处只读。",
+    "other_limits": "其他限制",
+    "lifetime_spending_limit": "累计消费限额 (USD)",
+    "lifetime_spending_limit_hint": "该限制属于账号，不由权限模板管理。",
+    "daily_spending": "当日消费",
+    "lifetime_spending": "累计消费",
+    "total_resets": "累计重置次数",
+    "reset_password": "重置密码",
+    "other_limits_profile_readonly_hint": "请求与实时限制来自 {{profile}}，此处只读；累计消费限额仍由账号独立配置。",
+    "other_limits_direct_hint": "未绑定权限模板，可直接编辑请求与实时限制；0 表示不限制。"
   },
   "apikey_lookup": {
     "available_models": "模型广场",
@@ -3639,7 +3670,16 @@
     "deleting": "删除中…",
     "add_account": "添加账号",
     "switch_account": "切换账号",
-    "current_account": "当前账号"
+    "current_account": "当前账号",
+    "edit_key_quota": "编辑 Key 配额",
+    "reset_daily_spending": "重置当日消费",
+    "reset_daily_spending_success": "当日消费已重置",
+    "reset_daily_spending_failed": "重置当日消费失败",
+    "view_reset_history": "查看重置历史",
+    "total_resets": "累计重置次数",
+    "account_scope": "账号配额",
+    "key_scope": "Key 配额",
+    "quota_period_spending": "周期配额"
   },
   "config_page": {
     "save_warning_title": "确认高影响配置变更",
@@ -4536,7 +4576,39 @@
     "save": "保存"
   },
   "quota": {
-    "no_matching": "暂无匹配的认证文件"
+    "no_matching": "暂无匹配的认证文件",
+    "period": {
+      "5h": "5小时",
+      "day": "一天",
+      "week": "一周",
+      "month": "一月"
+    },
+    "field": {
+      "5h": "5 小时额度 (USD)",
+      "day": "每日额度 (USD)",
+      "week": "每周额度 (USD)",
+      "month": "每月额度 (USD)"
+    },
+    "period_spending_column": "配额",
+    "daily_spending_column": "当日消费",
+    "lifetime_spending_column": "累计消费",
+    "total_resets": "累计重置次数",
+    "unlimited": "不限制",
+    "input_unlimited": "0 = 不限制",
+    "fields_hint": "空或 0 表示不限制。",
+    "key_fields_hint": "空或 0 表示无 Key 子限，仍受账号天花板限制。",
+    "account_limit_value": "账号上限 {{value}}",
+    "account_unlimited": "账号不限制",
+    "used_of_limit": "{{period}}：已用 {{used}}，上限 {{limit}}",
+    "status": {
+      "warning": "即将达到配额",
+      "exceeded": "已达到或超过配额"
+    },
+    "validation": {
+      "key_exceeds_account": "Key {{period}}额度 {{keyLimit}} 超过账号{{period}}额度 {{accountLimit}}",
+      "period_day_legacy_conflict": "每日额度与旧版每日消费限额冲突。",
+      "five_hour_projection_warming": "5 小时配额正在准备使用数据，请稍后再试。"
+    }
   },
   "identity_admin": {
     "operation_failed": "操作失败。",

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -16,6 +16,8 @@ import {
   extractApiErrorCode,
   isApiClientError,
   portalApi,
+  normalizePeriodSpendingLimits,
+  type ApiKeyDailySpendingResetEvent,
   type EndUser,
   type EndUserAPIKey,
   type SavedPortalAccount,
@@ -35,6 +37,14 @@ import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 import { ModelTag } from "@features/model-tags";
 import {
+  OwnedApiKeyQuotaModal,
+  OwnedApiKeyResetHistoryModal,
+  emptyPeriodSpendingDraft,
+  formatQuotaValidationError,
+  limitsToPeriodSpendingDraft,
+  periodSpendingDraftToLimits,
+} from "@features/period-spending";
+import {
   fetchAvailableModels,
   fetchPublicChartData,
   fetchPublicLogs,
@@ -49,7 +59,12 @@ import { PublicLogsSection } from "./components/PublicLogsSection";
 import { QuickImportTabContent } from "./components/QuickImportTabContent";
 import { UsageTabSection } from "./components/UsageTabSection";
 import { useApiKeyLookupCharts } from "./hooks/useApiKeyLookupCharts";
-import type { ChartDataResponse, PublicLogItem, PublicUsageLimits } from "./types";
+import type {
+  ChartDataResponse,
+  PublicLogItem,
+  PublicQuotaScope,
+  PublicUsageLimits,
+} from "./types";
 import {
   buildRequestLogsColumns,
   formatOptionalRequestLogLatencyMs,
@@ -351,11 +366,27 @@ export function ApiKeyLookupPage() {
   const [pwdError, setPwdError] = useState<string | null>(null);
   const [secretOnce, setSecretOnce] = useState<string | null>(null);
   const [createKeyOpen, setCreateKeyOpen] = useState(false);
-  const [createKeyName, setCreateKeyName] = useState("");
-  const [createKeyError, setCreateKeyError] = useState<string | null>(null);
+  const [portalKeyForm, setPortalKeyForm] = useState({
+    name: "",
+    periods: emptyPeriodSpendingDraft(),
+  });
+  const [editKeyTarget, setEditKeyTarget] = useState<EndUserAPIKey | null>(null);
+  const [portalKeyQuotaError, setPortalKeyQuotaError] = useState("");
+  const [resetHistoryTarget, setResetHistoryTarget] = useState<EndUserAPIKey | null>(null);
+  const [resetHistoryEvents, setResetHistoryEvents] = useState<ApiKeyDailySpendingResetEvent[]>([]);
+  const [resetHistoryLoading, setResetHistoryLoading] = useState(false);
   const [deleteKeyTarget, setDeleteKeyTarget] = useState<EndUserAPIKey | null>(null);
   const [portalKeysBusy, setPortalKeysBusy] = useState(false);
   const [portalKeysLoading, setPortalKeysLoading] = useState(false);
+  const portalAccountPeriodLimits = useMemo(
+    () =>
+      normalizePeriodSpendingLimits(
+        portalUser?.["period-spending-limits"],
+        portalUser?.["daily-spending-limit"],
+      ),
+    [portalUser],
+  );
+
   const usageSubject = useMemo<UsageLookupSubject | null>(() => {
     if (portalUser) {
       return { mode: "portal", apiKey: "", cacheKey: `account:${portalUser.id}` };
@@ -392,6 +423,7 @@ export function ApiKeyLookupPage() {
   const [chartData, setChartData] = useState<ChartDataResponse | null>(null);
   const [chartLoading, setChartLoading] = useState(false);
   const [quotaLimits, setQuotaLimits] = useState<PublicUsageLimits | null>(null);
+  const [quotaScopes, setQuotaScopes] = useState<PublicQuotaScope[]>([]);
   const chartCacheRef = useRef<Record<string, ChartDataResponse>>({});
   const portalKeySyncIdRef = useRef(0);
   const chartAbortControllerRef = useRef<AbortController | null>(null);
@@ -626,9 +658,11 @@ export function ApiKeyLookupPage() {
       });
       if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted) return;
       setQuotaLimits(summary.limits ?? null);
+      setQuotaScopes(summary["quota-scopes"] ?? []);
     } catch {
       if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted) return;
       setQuotaLimits(null);
+      setQuotaScopes([]);
     } finally {
       if (summaryAbortControllerRef.current === controller) {
         summaryAbortControllerRef.current = null;
@@ -809,6 +843,7 @@ export function ApiKeyLookupPage() {
     setAvailableModels([]);
     setChartData(null);
     setQuotaLimits(null);
+    setQuotaScopes([]);
 
     setRawItems([]);
     setTotalCount(0);
@@ -1438,8 +1473,11 @@ export function ApiKeyLookupPage() {
                         busy: portalKeysBusy,
                         onRefresh: () => void syncPortalKeys(),
                         onCreate: () => {
-                          setCreateKeyName("");
-                          setCreateKeyError(null);
+                          setPortalKeyForm({
+                            name: "",
+                            periods: emptyPeriodSpendingDraft(),
+                          });
+                          setPortalKeyQuotaError("");
                           setCreateKeyOpen(true);
                         },
                       }
@@ -1454,6 +1492,7 @@ export function ApiKeyLookupPage() {
                   chartStats={chartStats}
                   chartLoading={chartLoading}
                   quotaLimits={quotaLimits}
+                  quotaScopes={quotaScopes}
                   modelMetric={modelMetric}
                   setModelMetric={setModelMetric}
                   heatmapSeries={heatmapSeries}
@@ -1488,6 +1527,52 @@ export function ApiKeyLookupPage() {
                           await refreshPortalKeys();
                         })
                         .finally(() => setPortalKeysBusy(false));
+                    }}
+                    onEdit={(key) => {
+                      setEditKeyTarget(key);
+                      setPortalKeyQuotaError("");
+                      setPortalKeyForm({
+                        name: key.name ?? "",
+                        periods: limitsToPeriodSpendingDraft(
+                          normalizePeriodSpendingLimits(
+                            key["period-spending-limits"],
+                            key["daily-spending-limit"],
+                          ),
+                        ),
+                      });
+                    }}
+                    onResetDailySpending={(key) => {
+                      setPortalKeysBusy(true);
+                      void portalApi
+                        .resetKeyDailySpending(key.id)
+                        .then(async () => {
+                          await refreshPortalKeys();
+                        })
+                        .catch((err) => {
+                          setError(
+                            err instanceof Error
+                              ? err.message
+                              : t("apikey_lookup.reset_daily_spending_failed"),
+                          );
+                        })
+                        .finally(() => setPortalKeysBusy(false));
+                    }}
+                    onViewResetHistory={(key) => {
+                      setResetHistoryTarget(key);
+                      setResetHistoryEvents([]);
+                      setResetHistoryLoading(true);
+                      void portalApi
+                        .listKeyDailySpendingResetHistory(key.id, 200)
+                        .then((response) => setResetHistoryEvents(response.items ?? []))
+                        .catch((err) => {
+                          setError(
+                            err instanceof Error
+                              ? err.message
+                              : t("api_keys_page.reset_history_load_failed"),
+                          );
+                          setResetHistoryTarget(null);
+                        })
+                        .finally(() => setResetHistoryLoading(false));
                     }}
                     onDelete={(key) => {
                       if (portalKeys.length <= 1) return;
@@ -1811,115 +1896,99 @@ export function ApiKeyLookupPage() {
           ) : null}
         </Modal>
 
-        <Modal
+        <OwnedApiKeyQuotaModal
+          t={t}
           open={createKeyOpen}
-          title={t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
-          description={t("apikey_lookup.create_key_desc", {
-            defaultValue: "为新 Key 填写名称，便于在请求日志中区分来源。",
-          })}
-          maxWidth="max-w-md"
+          mode="create"
+          value={portalKeyForm}
+          accountLimits={portalAccountPeriodLimits}
+          saving={portalKeysBusy}
+          serverError={portalKeyQuotaError}
+          onChange={setPortalKeyForm}
           onClose={() => {
             if (portalKeysBusy) return;
             setCreateKeyOpen(false);
-            setCreateKeyError(null);
+            setPortalKeyQuotaError("");
           }}
-          footer={
-            <>
-              <Button
-                variant="secondary"
-                disabled={portalKeysBusy}
-                onClick={() => {
-                  setCreateKeyOpen(false);
-                  setCreateKeyError(null);
-                }}
-              >
-                {t("common.cancel", { defaultValue: "取消" })}
-              </Button>
-              <Button
-                type="submit"
-                form="portal-create-key-form"
-                variant="primary"
-                disabled={portalKeysBusy || !createKeyName.trim()}
-              >
-                {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
-              </Button>
-            </>
-          }
-        >
-          <form
-            id="portal-create-key-form"
-            className="space-y-3"
-            onSubmit={(e) => {
-              e.preventDefault();
-              const name = createKeyName.trim();
-              if (!name) {
-                setCreateKeyError(
-                  t("apikey_lookup.key_name_required", { defaultValue: "请输入 Key 名称" }),
-                );
-                return;
-              }
-              const nameTaken = portalKeys.some(
-                (key) => (key.name || "").trim().toLowerCase() === name.toLowerCase(),
-              );
-              if (nameTaken) {
-                setCreateKeyError(
-                  t("apikey_lookup.key_name_duplicate", {
-                    defaultValue: "Key 名称已存在，请换一个。",
-                  }),
-                );
-                return;
-              }
-              setCreateKeyError(null);
-              setPortalKeysBusy(true);
-              void portalApi
-                .createKey(name)
-                .then(async (res) => {
-                  if (res.plaintext_key) {
-                    setSecretOnce(res.plaintext_key);
-                    setOperationalKeyId(res.api_key.id);
-                    setApiKeyInput(res.plaintext_key);
-                    setQueriedKey(res.plaintext_key);
-                  }
-                  setCreateKeyOpen(false);
-                  setCreateKeyName("");
-                  await refreshPortalKeys();
-                })
-                .catch((err) => {
-                  const code = isApiClientError(err) ? extractApiErrorCode(err.payload) : "";
-                  if (code === "duplicate_key_name") {
-                    setCreateKeyError(
-                      t("apikey_lookup.key_name_duplicate", {
-                        defaultValue: "Key 名称已存在，请换一个。",
-                      }),
-                    );
-                    return;
-                  }
-                  setCreateKeyError(err instanceof Error ? err.message : "failed");
-                })
-                .finally(() => setPortalKeysBusy(false));
-            }}
-          >
-            <label className="block space-y-1.5">
-              <span className="text-sm font-medium text-slate-700 dark:text-white/75">
-                {t("apikey_lookup.key_name", { defaultValue: "Key 名称" })}
-              </span>
-              <TextInput
-                value={createKeyName}
-                onChange={(e) => {
-                  setCreateKeyName(e.target.value);
-                  if (createKeyError) setCreateKeyError(null);
-                }}
-                autoFocus
-                placeholder={t("apikey_lookup.key_name_placeholder", {
-                  defaultValue: "例如：Claude Desktop / 生产环境",
-                })}
-              />
-            </label>
-            {createKeyError ? (
-              <p className="text-sm text-rose-600 dark:text-rose-300">{createKeyError}</p>
-            ) : null}
-          </form>
-        </Modal>
+          onSubmit={() => {
+            const name = portalKeyForm.name.trim();
+            if (!name) return;
+            if (
+              portalKeys.some((key) => (key.name || "").trim().toLowerCase() === name.toLowerCase())
+            ) {
+              setPortalKeyQuotaError(t("apikey_lookup.key_name_duplicate"));
+              return;
+            }
+            const limits = periodSpendingDraftToLimits(portalKeyForm.periods);
+            setPortalKeysBusy(true);
+            setPortalKeyQuotaError("");
+            void portalApi
+              .createKey({
+                name,
+                "daily-spending-limit": limits.day,
+                "period-spending-limits": limits,
+              })
+              .then(async (response) => {
+                if (response.plaintext_key) {
+                  setSecretOnce(response.plaintext_key);
+                  setOperationalKeyId(response.api_key.id);
+                  setApiKeyInput(response.plaintext_key);
+                  setQueriedKey(response.plaintext_key);
+                }
+                setCreateKeyOpen(false);
+                await refreshPortalKeys();
+              })
+              .catch((err) => setPortalKeyQuotaError(formatQuotaValidationError(err, t)))
+              .finally(() => setPortalKeysBusy(false));
+          }}
+        />
+
+        <OwnedApiKeyQuotaModal
+          t={t}
+          open={editKeyTarget !== null}
+          mode="edit"
+          value={portalKeyForm}
+          accountLimits={portalAccountPeriodLimits}
+          saving={portalKeysBusy}
+          serverError={portalKeyQuotaError}
+          onChange={setPortalKeyForm}
+          onClose={() => {
+            if (portalKeysBusy) return;
+            setEditKeyTarget(null);
+            setPortalKeyQuotaError("");
+          }}
+          onSubmit={() => {
+            if (!editKeyTarget) return;
+            const limits = periodSpendingDraftToLimits(portalKeyForm.periods);
+            setPortalKeysBusy(true);
+            setPortalKeyQuotaError("");
+            void portalApi
+              .updateKey(editKeyTarget.id, {
+                name: portalKeyForm.name.trim(),
+                "daily-spending-limit": limits.day,
+                "period-spending-limits": limits,
+              })
+              .then(async () => {
+                setEditKeyTarget(null);
+                await refreshPortalKeys();
+              })
+              .catch((err) => setPortalKeyQuotaError(formatQuotaValidationError(err, t)))
+              .finally(() => setPortalKeysBusy(false));
+          }}
+        />
+
+        <OwnedApiKeyResetHistoryModal
+          t={t}
+          open={resetHistoryTarget !== null}
+          onClose={() => {
+            setResetHistoryTarget(null);
+            setResetHistoryEvents([]);
+          }}
+          keyName={resetHistoryTarget?.name || t("api_keys_page.unnamed")}
+          maskedKey={resetHistoryTarget?.key_masked ?? ""}
+          loading={resetHistoryLoading}
+          events={resetHistoryEvents}
+        />
 
         <SecretRevealModal
           open={Boolean(secretOnce)}

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -133,6 +133,8 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       keySecret: vi.fn(),
       createKey: vi.fn(),
       updateKey: vi.fn(),
+      resetKeyDailySpending: vi.fn(),
+      listKeyDailySpendingResetHistory: vi.fn(),
       rotateKey: vi.fn(),
       deleteKey: vi.fn(),
       changePassword: vi.fn(),
@@ -753,6 +755,118 @@ describe("ApiKeyLookupPage", () => {
       expect(portalApi.listKeys).toHaveBeenCalledTimes(2);
       expect(portalApi.keySecret).toHaveBeenLastCalledWith("k1");
     });
+  });
+
+  test("edits, resets, and opens history from the shared managed-key table", async () => {
+    const { portalApi } = await import("@code-proxy/api-client");
+    const user = {
+      id: "u1",
+      tenant_id: "t1",
+      username: "alice",
+      display_name: "Alice",
+      status: "active",
+      must_change_password: false,
+      failed_login_count: 0,
+      lock_stage: 0,
+      created_at: "",
+      updated_at: "",
+      version: 1,
+      "daily-spending-limit": 300,
+      "period-spending-limits": { "5h": 100, day: 300, week: 800, month: 4000 },
+    };
+    const key = {
+      id: "k1",
+      tenant_id: "t1",
+      end_user_id: "u1",
+      name: "primary",
+      key_masked: "sk-****111",
+      disabled: false,
+      is_default: true,
+      created_at: "2026-07-20T00:00:00Z",
+      updated_at: "",
+      "daily-spending-limit": 100,
+      "period-spending-limits": { "5h": 50, day: 100, week: 300, month: 1000 },
+      "period-spending": [{ period: "day" as const, limit: 100, used: 20, remaining: 80 }],
+      "daily-spending-used": 20,
+      "lifetime-spending-used": 300.12,
+      "daily-spending-reset-count": 2,
+    };
+    vi.mocked(portalApi.login).mockResolvedValue({
+      user,
+      access_token: "cpt_test",
+      refresh_token: "cpr_test",
+      must_change_password: false,
+    } as never);
+    vi.mocked(portalApi.listKeys).mockResolvedValue({ items: [key] } as never);
+    vi.mocked(portalApi.keySecret).mockResolvedValue({ id: "k1", key: "sk-primary" });
+    vi.mocked(portalApi.updateKey).mockResolvedValue({ ...key, name: "renamed" } as never);
+    vi.mocked(portalApi.resetKeyDailySpending).mockResolvedValue({ status: "ok" });
+    vi.mocked(portalApi.listKeyDailySpendingResetHistory).mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          reset_at: "2026-07-21T11:00:00Z",
+          actor_username: "alice",
+          effective_used_before: 20,
+          raw_today_cost: 30,
+        },
+      ],
+      total: 1,
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ApiKeyLookupPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const landing = screen.getByTestId("apikey-lookup-landing");
+    await userEvent.click(within(landing).getByRole("button", { name: /^(login|sign in|登录)$/i }));
+    const loginDialog = await screen.findByRole("dialog");
+    await userEvent.type(screen.getByPlaceholderText(/enter username|请输入账号/i), "alice");
+    await userEvent.type(screen.getByPlaceholderText(/enter password|请输入密码/i), "password123");
+    await userEvent.click(
+      within(loginDialog).getByRole("button", { name: /^(login|sign in|登录)$/i }),
+    );
+    await userEvent.click(
+      await screen.findByRole("tab", { name: /manage api keys|管理 api key/i }),
+    );
+
+    expect(await screen.findByRole("columnheader", { name: "Quota" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Lifetime" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Total resets" })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit Key quota" }));
+    const editDialog = await screen.findByRole("dialog", { name: "Edit Key quota" });
+    const dayInput = within(editDialog).getByRole("spinbutton", { name: "Daily quota (USD)" });
+    await userEvent.clear(dayInput);
+    await userEvent.type(dayInput, "80");
+    await userEvent.click(within(editDialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(portalApi.updateKey).toHaveBeenCalledWith("k1", {
+        name: "primary",
+        "daily-spending-limit": 80,
+        "period-spending-limits": { "5h": 50, day: 80, week: 300, month: 1000 },
+      });
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset today spending" }));
+    await waitFor(() => {
+      expect(portalApi.resetKeyDailySpending).toHaveBeenCalledWith("k1");
+    });
+
+    await userEvent.click(screen.getAllByRole("button", { name: "View reset history" })[0]!);
+    await waitFor(() => {
+      expect(portalApi.listKeyDailySpendingResetHistory).toHaveBeenCalledWith("k1", 200);
+    });
+    expect(
+      await screen.findByRole("dialog", { name: "Reset history · primary" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("$20.00").length).toBeGreaterThan(0);
   });
 
   test("confirms before deleting a managed API key", async () => {

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -1,9 +1,5 @@
-import { KeyRound, RotateCcw, Trash2 } from "lucide-react";
-import { HoverTooltip } from "@code-proxy/ui";
 import type { EndUserAPIKey } from "@code-proxy/api-client";
-
-const iconBtnClass =
-  "rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/50 dark:hover:bg-neutral-800";
+import { OwnedApiKeysTable } from "@features/period-spending";
 
 export function ManageKeysTabContent({
   t,
@@ -11,83 +7,33 @@ export function ManageKeysTabContent({
   busy,
   onRotate,
   onDelete,
+  onEdit,
+  onResetDailySpending,
+  onViewResetHistory,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   keys: EndUserAPIKey[];
   busy?: boolean;
   onRotate: (key: EndUserAPIKey) => void;
   onDelete: (key: EndUserAPIKey) => void;
+  onEdit: (key: EndUserAPIKey) => void;
+  onResetDailySpending: (key: EndUserAPIKey) => void;
+  onViewResetHistory: (key: EndUserAPIKey) => void;
 }) {
-  if (keys.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-200 px-6 py-16 text-center dark:border-neutral-800">
-        <KeyRound size={28} className="mb-3 text-slate-400" />
-        <p className="text-sm text-slate-500 dark:text-white/55">
-          {t("apikey_lookup.no_keys", { defaultValue: "暂无 Key" })}
-        </p>
-      </div>
-    );
-  }
-
   return (
-    <div className="overflow-hidden rounded-2xl border border-slate-200/80 dark:border-white/10">
-      <div className="divide-y divide-slate-100 dark:divide-white/10">
-        {keys.map((k) => {
-          const rotateLabel = t("apikey_lookup.rotate_key", { defaultValue: "重置" });
-          const deleteLabel = t("common.delete", { defaultValue: "删除" });
-          const keepOneLabel = t("apikey_lookup.keep_one_key", {
-            defaultValue: "至少保留一把 Key",
-          });
-          const canDelete = keys.length > 1;
-
-          return (
-            <div
-              key={k.id}
-              className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="truncate font-medium text-slate-900 dark:text-white">
-                    {k.name || k.id.slice(0, 8)}
-                  </span>
-                  {k.disabled ? (
-                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-white/10 dark:text-white/50">
-                      {t("common.disabled", { defaultValue: "已停用" })}
-                    </span>
-                  ) : null}
-                </div>
-                <code className="mt-1 block truncate text-xs text-slate-500 dark:text-white/45">
-                  {k.key_masked}
-                </code>
-              </div>
-              <div className="flex shrink-0 items-center gap-1.5">
-                <HoverTooltip content={rotateLabel}>
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => onRotate(k)}
-                    className={`${iconBtnClass} hover:text-orange-600 dark:hover:text-orange-400`}
-                    aria-label={rotateLabel}
-                  >
-                    <RotateCcw size={15} />
-                  </button>
-                </HoverTooltip>
-                <HoverTooltip content={canDelete ? deleteLabel : keepOneLabel}>
-                  <button
-                    type="button"
-                    disabled={busy || !canDelete}
-                    onClick={() => onDelete(k)}
-                    className={`${iconBtnClass} hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400`}
-                    aria-label={canDelete ? deleteLabel : keepOneLabel}
-                  >
-                    <Trash2 size={15} />
-                  </button>
-                </HoverTooltip>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
+    <OwnedApiKeysTable
+      t={t}
+      keys={keys}
+      busy={busy}
+      canDelete={() => keys.length > 1}
+      height="h-[min(58vh,540px)]"
+      actions={{
+        onRotate,
+        onDelete,
+        onEdit,
+        onResetDailySpending,
+        onViewResetHistory,
+      }}
+    />
   );
 }

--- a/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
+++ b/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
@@ -1,12 +1,8 @@
 import type { ComponentType, ReactNode } from "react";
 import { Coins, Gauge, Hash, Wallet } from "lucide-react";
 import { KpiCard } from "@features/monitor-widgets";
-import type { PublicUsageLimits } from "../types";
-import {
-  formatQuotaCount,
-  formatQuotaUsd,
-  kpiValueSizeClass,
-} from "./kpiValueSize";
+import type { PublicQuotaScope, PublicUsageLimits } from "../types";
+import { formatQuotaCount, formatQuotaUsd, kpiValueSizeClass } from "./kpiValueSize";
 
 export type QuotaKpiItem = {
   key: string;
@@ -20,7 +16,20 @@ export type QuotaKpiItem = {
 export function buildQuotaKpiItems(
   t: (key: string, options?: Record<string, unknown>) => string,
   limits: PublicUsageLimits | null | undefined,
+  quotaScopes?: PublicQuotaScope[] | null,
 ): QuotaKpiItem[] {
+  if (quotaScopes?.length) {
+    return quotaScopes.flatMap((scope) =>
+      scope["period-spending"].map((period) => ({
+        key: `${scope.scope}-${period.period}`,
+        title: `${t(`apikey_lookup.${scope.scope}_scope`)} · ${t(`quota.period.${period.period}`)}`,
+        used: period.used,
+        limit: period.limit,
+        format: formatQuotaUsd,
+        icon: Wallet,
+      })),
+    );
+  }
   if (!limits) return [];
 
   const items: QuotaKpiItem[] = [];
@@ -44,10 +53,7 @@ export function buildQuotaKpiItems(
       icon: Gauge,
     });
   }
-  if (
-    typeof limits["daily-spending-limit"] === "number" &&
-    limits["daily-spending-limit"] > 0
-  ) {
+  if (typeof limits["daily-spending-limit"] === "number" && limits["daily-spending-limit"] > 0) {
     items.push({
       key: "daily-spending",
       title: t("apikey_lookup.quota_daily_spending"),
@@ -57,10 +63,7 @@ export function buildQuotaKpiItems(
       icon: Wallet,
     });
   }
-  if (
-    typeof limits["spending-limit"] === "number" &&
-    limits["spending-limit"] > 0
-  ) {
+  if (typeof limits["spending-limit"] === "number" && limits["spending-limit"] > 0) {
     items.push({
       key: "spending",
       title: t("apikey_lookup.quota_total_spending"),
@@ -77,13 +80,15 @@ export function buildQuotaKpiItems(
 export function QuotaLimitKpiCards({
   t,
   limits,
+  quotaScopes,
   renderValue,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   limits: PublicUsageLimits | null | undefined;
+  quotaScopes?: PublicQuotaScope[] | null;
   renderValue: (value: ReactNode) => ReactNode;
 }) {
-  const items = buildQuotaKpiItems(t, limits);
+  const items = buildQuotaKpiItems(t, limits, quotaScopes);
   if (items.length === 0) return null;
 
   return (
@@ -94,11 +99,7 @@ export function QuotaLimitKpiCards({
         const display = `${usedText} / ${limitText}`;
         const sizeClass = kpiValueSizeClass(display);
         return (
-          <div
-            key={item.key}
-            className="min-w-0"
-            data-testid={`api-key-lookup-quota-${item.key}`}
-          >
+          <div key={item.key} className="min-w-0" data-testid={`api-key-lookup-quota-${item.key}`}>
             <KpiCard
               title={item.title}
               icon={item.icon}
@@ -107,9 +108,7 @@ export function QuotaLimitKpiCards({
               value={renderValue(
                 <span className="block whitespace-nowrap tabular-nums leading-tight">
                   {usedText}
-                  <span className="mx-1 font-normal text-slate-400 dark:text-white/40">
-                    /
-                  </span>
+                  <span className="mx-1 font-normal text-slate-400 dark:text-white/40">/</span>
                   {limitText}
                 </span>,
               )}

--- a/pages/api-key-lookup/components/UsageTabSection.tsx
+++ b/pages/api-key-lookup/components/UsageTabSection.tsx
@@ -1,11 +1,5 @@
 import { useMemo, type ReactNode } from "react";
-import {
-  Activity,
-  Coins,
-  MessagesSquare,
-  ShieldCheck,
-  Sigma,
-} from "lucide-react";
+import { Activity, Coins, MessagesSquare, ShieldCheck, Sigma } from "lucide-react";
 import { AnimatedNumber } from "@code-proxy/ui";
 import { Reveal } from "@code-proxy/ui";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
@@ -17,7 +11,7 @@ import type {
   ModelDistributionDatum,
   DailySeriesPoint,
 } from "@features/monitor-widgets/chart-options/types";
-import type { PublicUsageLimits } from "../types";
+import type { PublicQuotaScope, PublicUsageLimits } from "../types";
 import { QuotaLimitKpiCards } from "./QuotaLimitsBanner";
 import { formatQuotaUsd, kpiValueSizeClass } from "./kpiValueSize";
 
@@ -59,11 +53,7 @@ function buildHeatmapDays() {
   start.setDate(end.getDate() - 364);
 
   const days: string[] = [];
-  for (
-    let current = new Date(start);
-    current <= end;
-    current.setDate(current.getDate() + 1)
-  ) {
+  for (let current = new Date(start); current <= end; current.setDate(current.getDate() + 1)) {
     days.push(localDateKey(current));
   }
   return { days, leadingEmptyCells: start.getDay() };
@@ -92,13 +82,9 @@ function HeatmapTooltip({
           <span>{t("apikey_lookup.requests")}</span>
           <span className="text-right">{requests.toLocaleString()}</span>
           <span>{t("apikey_lookup.total_sessions")}</span>
-          <span className="text-right">
-            {(point?.sessions ?? 0).toLocaleString()}
-          </span>
+          <span className="text-right">{(point?.sessions ?? 0).toLocaleString()}</span>
           <span>{t("apikey_lookup.token")}</span>
-          <span className="text-right">
-            {(point?.tokens ?? 0).toLocaleString()}
-          </span>
+          <span className="text-right">{(point?.tokens ?? 0).toLocaleString()}</span>
           <span>{t("apikey_lookup.total_cost")}</span>
           <span className="text-right">${(point?.cost ?? 0).toFixed(4)}</span>
         </span>
@@ -125,16 +111,12 @@ function CalendarHeatmap({
     return byDate;
   }, [heatmapSeries]);
   const maxRequests = useMemo(
-    () =>
-      heatmapSeries.reduce((max, point) => Math.max(max, point.requests), 0),
+    () => heatmapSeries.reduce((max, point) => Math.max(max, point.requests), 0),
     [heatmapSeries],
   );
-  const emptyCells: ReactNode[] = Array.from(
-    { length: leadingEmptyCells },
-    (_, index) => (
-      <span key={`empty-${index}`} className="h-3 w-3" aria-hidden="true" />
-    ),
-  );
+  const emptyCells: ReactNode[] = Array.from({ length: leadingEmptyCells }, (_, index) => (
+    <span key={`empty-${index}`} className="h-3 w-3" aria-hidden="true" />
+  ));
 
   return (
     <div className="space-y-3">
@@ -225,6 +207,7 @@ export function UsageTabSection({
   chartStats,
   chartLoading,
   quotaLimits,
+  quotaScopes,
   modelMetric,
   setModelMetric,
   heatmapSeries,
@@ -250,6 +233,7 @@ export function UsageTabSection({
     | undefined;
   chartLoading: boolean;
   quotaLimits?: PublicUsageLimits | null;
+  quotaScopes?: PublicQuotaScope[] | null;
   modelMetric: "requests" | "tokens";
   setModelMetric: (value: "requests" | "tokens") => void;
   heatmapSeries: HeatmapPoint[];
@@ -272,8 +256,7 @@ export function UsageTabSection({
   toggleDailyLegend: (key: string) => void;
 }) {
   const showInitialLoading = chartLoading && !chartStats;
-  const renderKpiValue = (value: ReactNode) =>
-    showInitialLoading ? <KpiValueSkeleton /> : value;
+  const renderKpiValue = (value: ReactNode) => (showInitialLoading ? <KpiValueSkeleton /> : value);
 
   return (
     <Reveal>
@@ -282,6 +265,7 @@ export function UsageTabSection({
           <QuotaLimitKpiCards
             t={t}
             limits={quotaLimits}
+            quotaScopes={quotaScopes}
             renderValue={renderKpiValue}
           />
           <div className="min-w-0">
@@ -289,15 +273,10 @@ export function UsageTabSection({
               title={t("apikey_lookup.total_requests")}
               icon={Activity}
               hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-              valueClassName={kpiValueSizeClass(
-                formatInteger(chartStats?.total ?? 0),
-              )}
+              valueClassName={kpiValueSizeClass(formatInteger(chartStats?.total ?? 0))}
               value={renderKpiValue(
                 <span className="block whitespace-nowrap tabular-nums">
-                  <AnimatedNumber
-                    value={chartStats?.total ?? 0}
-                    format={formatInteger}
-                  />
+                  <AnimatedNumber value={chartStats?.total ?? 0} format={formatInteger} />
                 </span>,
               )}
             />
@@ -307,9 +286,7 @@ export function UsageTabSection({
               title={t("common.success_rate")}
               icon={ShieldCheck}
               hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-              valueClassName={kpiValueSizeClass(
-                `${(chartStats?.success_rate ?? 0).toFixed(1)}%`,
-              )}
+              valueClassName={kpiValueSizeClass(`${(chartStats?.success_rate ?? 0).toFixed(1)}%`)}
               value={renderKpiValue(
                 <span className="block whitespace-nowrap tabular-nums">
                   <AnimatedNumber
@@ -325,15 +302,10 @@ export function UsageTabSection({
               title={t("apikey_lookup.total_tokens")}
               icon={Sigma}
               hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-              valueClassName={kpiValueSizeClass(
-                formatInteger(chartStats?.total_tokens ?? 0),
-              )}
+              valueClassName={kpiValueSizeClass(formatInteger(chartStats?.total_tokens ?? 0))}
               value={renderKpiValue(
                 <span className="block whitespace-nowrap tabular-nums">
-                  <AnimatedNumber
-                    value={chartStats?.total_tokens ?? 0}
-                    format={formatInteger}
-                  />
+                  <AnimatedNumber value={chartStats?.total_tokens ?? 0} format={formatInteger} />
                 </span>,
               )}
             />
@@ -343,15 +315,10 @@ export function UsageTabSection({
               title={t("apikey_lookup.total_sessions")}
               icon={MessagesSquare}
               hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-              valueClassName={kpiValueSizeClass(
-                formatInteger(chartStats?.total_sessions ?? 0),
-              )}
+              valueClassName={kpiValueSizeClass(formatInteger(chartStats?.total_sessions ?? 0))}
               value={renderKpiValue(
                 <span className="block whitespace-nowrap tabular-nums">
-                  <AnimatedNumber
-                    value={chartStats?.total_sessions ?? 0}
-                    format={formatInteger}
-                  />
+                  <AnimatedNumber value={chartStats?.total_sessions ?? 0} format={formatInteger} />
                 </span>,
               )}
             />
@@ -361,15 +328,10 @@ export function UsageTabSection({
               title={t("apikey_lookup.total_cost")}
               icon={Coins}
               hint={t("apikey_lookup.last_n_days", { days: timeRange })}
-              valueClassName={kpiValueSizeClass(
-                formatQuotaUsd(chartStats?.total_cost ?? 0),
-              )}
+              valueClassName={kpiValueSizeClass(formatQuotaUsd(chartStats?.total_cost ?? 0))}
               value={renderKpiValue(
                 <span className="block whitespace-nowrap tabular-nums">
-                  <AnimatedNumber
-                    value={chartStats?.total_cost ?? 0}
-                    format={formatQuotaUsd}
-                  />
+                  <AnimatedNumber value={chartStats?.total_cost ?? 0} format={formatQuotaUsd} />
                 </span>,
               )}
             />
@@ -399,17 +361,11 @@ export function UsageTabSection({
             actions={
               <Tabs
                 value={modelMetric}
-                onValueChange={(next) =>
-                  setModelMetric(next as "requests" | "tokens")
-                }
+                onValueChange={(next) => setModelMetric(next as "requests" | "tokens")}
               >
                 <TabsList>
-                  <TabsTrigger value="requests">
-                    {t("apikey_lookup.requests")}
-                  </TabsTrigger>
-                  <TabsTrigger value="tokens">
-                    {t("apikey_lookup.token")}
-                  </TabsTrigger>
+                  <TabsTrigger value="requests">{t("apikey_lookup.requests")}</TabsTrigger>
+                  <TabsTrigger value="tokens">{t("apikey_lookup.token")}</TabsTrigger>
                 </TabsList>
               </Tabs>
             }
@@ -419,10 +375,7 @@ export function UsageTabSection({
               <ChartSkeleton />
             ) : modelDistributionData.length > 0 ? (
               <div className="flex flex-col gap-4 sm:grid sm:h-72 sm:grid-cols-[minmax(0,1fr)_220px]">
-                <EChart
-                  option={modelDistributionOption}
-                  className="h-52 min-w-0 sm:h-72"
-                />
+                <EChart option={modelDistributionOption} className="h-52 min-w-0 sm:h-72" />
                 <div className="flex flex-row flex-wrap justify-center gap-2 overflow-y-auto pr-1 sm:h-72 sm:flex-col">
                   {modelDistributionLegend.map((item) => (
                     <div
@@ -479,9 +432,7 @@ export function UsageTabSection({
                             key: DAILY_LEGEND_KEYS.input,
                             label: t("apikey_lookup.input_token"),
                             colorClass: "bg-violet-400",
-                            enabled:
-                              dailyLegendSelected[DAILY_LEGEND_KEYS.input] ??
-                              true,
+                            enabled: dailyLegendSelected[DAILY_LEGEND_KEYS.input] ?? true,
                             onToggle: toggleDailyLegend,
                           },
                         ]
@@ -492,9 +443,7 @@ export function UsageTabSection({
                             key: DAILY_LEGEND_KEYS.output,
                             label: t("apikey_lookup.output_token"),
                             colorClass: "bg-emerald-400",
-                            enabled:
-                              dailyLegendSelected[DAILY_LEGEND_KEYS.output] ??
-                              true,
+                            enabled: dailyLegendSelected[DAILY_LEGEND_KEYS.output] ?? true,
                             onToggle: toggleDailyLegend,
                           },
                         ]
@@ -505,9 +454,7 @@ export function UsageTabSection({
                             key: DAILY_LEGEND_KEYS.requests,
                             label: t("apikey_lookup.requests"),
                             colorClass: "bg-blue-500",
-                            enabled:
-                              dailyLegendSelected[DAILY_LEGEND_KEYS.requests] ??
-                              true,
+                            enabled: dailyLegendSelected[DAILY_LEGEND_KEYS.requests] ?? true,
                             onToggle: toggleDailyLegend,
                           },
                         ]

--- a/pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx
+++ b/pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx
@@ -10,6 +10,12 @@ const t = (key: string) => {
     "apikey_lookup.quota_total_requests": "Total request quota",
     "apikey_lookup.quota_daily_spending": "Daily spending",
     "apikey_lookup.quota_total_spending": "Total spending",
+    "apikey_lookup.account_scope": "Account quota",
+    "apikey_lookup.key_scope": "Key quota",
+    "quota.period.5h": "5 hours",
+    "quota.period.day": "Day",
+    "quota.period.week": "Week",
+    "quota.period.month": "Month",
   };
   return labels[key] ?? key;
 };
@@ -46,6 +52,50 @@ describe("QuotaLimitKpiCards", () => {
     expect(screen.getByText("Total spending")).toBeInTheDocument();
     expect(screen.getByText(/12/)).toBeInTheDocument();
     expect(screen.getByText(/\$1\.25/)).toBeInTheDocument();
+  });
+
+  test("prefers scope-aware period quotas over legacy limits", () => {
+    render(
+      <div className="grid">
+        <QuotaLimitKpiCards
+          t={t}
+          limits={{
+            "daily-spending-limit": 999,
+            "daily-spending-used": 1,
+          }}
+          quotaScopes={[
+            {
+              scope: "account",
+              "period-spending": [{ period: "day", limit: 300, used: 39, remaining: 261 }],
+              "daily-spending-used": 39,
+              "lifetime-spending-used": 900,
+            },
+            {
+              scope: "key",
+              "period-spending": [{ period: "5h", limit: 50, used: 12, remaining: 38 }],
+              "daily-spending-used": 20,
+              "lifetime-spending-used": 300,
+            },
+          ]}
+          renderValue={(value) => value}
+        />
+      </div>,
+    );
+
+    expect(screen.getByText("Account quota · Day")).toBeInTheDocument();
+    expect(screen.getByText("Key quota · 5 hours")).toBeInTheDocument();
+    expect(screen.getByText(/\$39/)).toBeInTheDocument();
+    expect(screen.queryByText("Daily spending")).not.toBeInTheDocument();
+  });
+
+  test("falls back to legacy limits when quota scopes are absent", () => {
+    const items = buildQuotaKpiItems(
+      t,
+      { "daily-spending-limit": 10, "daily-spending-used": 2 },
+      undefined,
+    );
+
+    expect(items).toEqual([expect.objectContaining({ key: "daily-spending", used: 2, limit: 10 })]);
   });
 
   test("hides unset limits", () => {

--- a/pages/api-key-lookup/types.ts
+++ b/pages/api-key-lookup/types.ts
@@ -1,3 +1,5 @@
+import type { PeriodSpendingItem } from "@code-proxy/api-client";
+
 export interface PublicChannelFilterOption {
   value: string;
   label: string;
@@ -98,6 +100,13 @@ export interface PublicUsageLimits {
   "daily-spending-used"?: number;
 }
 
+export interface PublicQuotaScope {
+  scope: "account" | "key";
+  "period-spending": PeriodSpendingItem[];
+  "daily-spending-used": number;
+  "lifetime-spending-used": number;
+}
+
 export interface PublicUsageSummaryResponse {
   found: boolean;
   range: string;
@@ -106,6 +115,7 @@ export interface PublicUsageSummaryResponse {
     quota_cost: number;
   };
   limits?: PublicUsageLimits | null;
+  "quota-scopes"?: PublicQuotaScope[];
 }
 
 export interface TableColumn<T> {

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -1,17 +1,22 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pencil, Plus, RefreshCw, ShieldCheck, Trash2 } from "lucide-react";
-import {
-  endUsersApi,
-  type EndUser,
-  type EndUserUpdateBody,
-} from "@code-proxy/api-client/endpoints/end-users";
+import { endUsersApi, type EndUser } from "@code-proxy/api-client/endpoints/end-users";
 import {
   apiKeyPermissionProfilesApi,
   makePermissionProfileId,
   type ApiKeyPermissionProfile,
 } from "@code-proxy/api-client/endpoints/api-key-permission-profiles";
 import { RestrictionMultiSelect } from "@features/api-key-restrictions";
+import {
+  PeriodSpendingFields,
+  PeriodSpendingLimitsCell,
+  formatQuotaValidationError,
+  emptyPeriodSpendingDraft,
+  limitsToPeriodSpendingDraft,
+  periodSpendingDraftToLimits,
+  type PeriodSpendingDraft,
+} from "@features/period-spending";
 import { useApiKeyPermissionOptions } from "@features/api-key-restrictions";
 import { Button } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
@@ -28,7 +33,7 @@ type ProfileDraft = {
   name: string;
   dailyLimit: string;
   totalQuota: string;
-  dailySpendingLimit: string;
+  periodSpending: PeriodSpendingDraft;
   concurrencyLimit: string;
   rpmLimit: string;
   tpmLimit: string;
@@ -44,7 +49,7 @@ const emptyDraft = (): ProfileDraft => ({
   name: "",
   dailyLimit: "",
   totalQuota: "",
-  dailySpendingLimit: "",
+  periodSpending: emptyPeriodSpendingDraft(),
   concurrencyLimit: "",
   rpmLimit: "",
   tpmLimit: "",
@@ -62,28 +67,12 @@ const limitFromText = (value: string) => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 };
 
-const spendingLimitFromText = (value: string) => {
-  // Spending limits are whole USD dollars only.
-  const parsed = Number.parseInt(value.trim(), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-};
-
-const formatSpendingLimit = (value: number, unlimited: string) =>
-  value > 0
-    ? new Intl.NumberFormat("en-US", {
-        currency: "USD",
-        maximumFractionDigits: 2,
-        minimumFractionDigits: 2,
-        style: "currency",
-      }).format(value)
-    : unlimited;
-
 const readDraft = (profile: ApiKeyPermissionProfile): ProfileDraft => ({
   id: profile.id,
   name: profile.name,
   dailyLimit: limitToText(profile["daily-limit"]),
   totalQuota: limitToText(profile["total-quota"]),
-  dailySpendingLimit: limitToText(profile["daily-spending-limit"]),
+  periodSpending: limitsToPeriodSpendingDraft(profile["period-spending-limits"]),
   concurrencyLimit: limitToText(profile["concurrency-limit"]),
   rpmLimit: limitToText(profile["rpm-limit"]),
   tpmLimit: limitToText(profile["tpm-limit"]),
@@ -99,7 +88,8 @@ const draftToProfile = (draft: ProfileDraft): ApiKeyPermissionProfile => ({
   name: draft.name.trim(),
   "daily-limit": limitFromText(draft.dailyLimit),
   "total-quota": limitFromText(draft.totalQuota),
-  "daily-spending-limit": spendingLimitFromText(draft.dailySpendingLimit),
+  "daily-spending-limit": periodSpendingDraftToLimits(draft.periodSpending).day,
+  "period-spending-limits": periodSpendingDraftToLimits(draft.periodSpending),
   "concurrency-limit": limitFromText(draft.concurrencyLimit),
   "rpm-limit": limitFromText(draft.rpmLimit),
   "tpm-limit": limitFromText(draft.tpmLimit),
@@ -109,21 +99,18 @@ const draftToProfile = (draft: ProfileDraft): ApiKeyPermissionProfile => ({
   "system-prompt": draft.systemPrompt.trim(),
 });
 
-const formatLimit = (value: number, unlimited: string) =>
-  value > 0 ? value.toLocaleString() : unlimited;
-
 const formatRestrictionCount = (count: number, unlimited: string) =>
   count > 0 ? count.toLocaleString() : unlimited;
 
 const boundProfileCount = (profile: ApiKeyPermissionProfile, accounts: EndUser[]) =>
   accounts.filter((account) => account["permission-profile-id"] === profile.id).length;
 
-const profileToAccountUpdate = (profile: ApiKeyPermissionProfile): EndUserUpdateBody => ({
+const profileToAccountUpdate = (profile: ApiKeyPermissionProfile) => ({
   "permission-profile-id": profile.id,
   "daily-limit": profile["daily-limit"],
   "total-quota": profile["total-quota"],
-  "spending-limit": 0,
-  "daily-spending-limit": profile["daily-spending-limit"],
+  "daily-spending-limit": profile["period-spending-limits"].day,
+  "period-spending-limits": { ...profile["period-spending-limits"] },
   "concurrency-limit": profile["concurrency-limit"],
   "rpm-limit": profile["rpm-limit"],
   "tpm-limit": profile["tpm-limit"],
@@ -245,7 +232,9 @@ export function ApiKeyPermissionsPage() {
       const nextProfiles = isEdit
         ? profiles.map((item) => (item.id === profile.id ? profile : item))
         : [...profiles, profile];
-      await apiKeyPermissionProfilesApi.replace(nextProfiles, { syncAccounts: true });
+      const result = await apiKeyPermissionProfilesApi.replace(nextProfiles, {
+        syncAccounts: true,
+      });
 
       let nextAccounts = accounts;
       if (isEdit) {
@@ -258,11 +247,20 @@ export function ApiKeyPermissionsPage() {
       setProfiles(nextProfiles);
       setAccounts(nextAccounts);
       setModalOpen(false);
-      notify({ type: "success", message: t("api_key_permissions_page.profile_saved") });
+      notify({
+        type: "success",
+        message:
+          result.appliedCount > 0 || result.cappedKeys.length > 0
+            ? t("api_key_permissions_page.saved_with_sync", {
+                accounts: result.appliedCount,
+                keys: result.cappedKeys.length,
+              })
+            : t("api_key_permissions_page.profile_saved"),
+      });
     } catch (err: unknown) {
       notify({
         type: "error",
-        message: err instanceof Error ? err.message : t("api_key_permissions_page.save_failed"),
+        message: formatQuotaValidationError(err, t),
       });
     } finally {
       setSaving(false);
@@ -306,35 +304,10 @@ export function ApiKeyPermissionsPage() {
       },
       {
         key: "limits",
-        label: t("api_key_permissions_page.col_limits"),
-        width: "w-[220px] min-w-[220px]",
+        label: t("quota.period_spending_column"),
+        width: "w-[360px] min-w-[300px]",
         render: (profile) => (
-          <div className="space-y-1 text-xs text-slate-600 dark:text-white/60">
-            <div>
-              {t("api_key_permissions_page.limit_daily", {
-                value: formatLimit(profile["daily-limit"], t("api_keys_page.unlimited")),
-              })}
-            </div>
-            <div>
-              {t("api_key_permissions_page.limit_total", {
-                value: formatLimit(profile["total-quota"], t("api_keys_page.unlimited")),
-              })}
-            </div>
-            <div>
-              {t("api_key_permissions_page.limit_daily_spending", {
-                value: formatSpendingLimit(
-                  profile["daily-spending-limit"],
-                  t("api_keys_page.unlimited"),
-                ),
-              })}
-            </div>
-            <div>
-              {t("api_key_permissions_page.limit_rpm_tpm", {
-                rpm: formatLimit(profile["rpm-limit"], t("api_keys_page.unlimited")),
-                tpm: formatLimit(profile["tpm-limit"], t("api_keys_page.unlimited")),
-              })}
-            </div>
-          </div>
+          <PeriodSpendingLimitsCell t={t} limits={profile["period-spending-limits"]} />
         ),
       },
       {
@@ -496,40 +469,94 @@ export function ApiKeyPermissionsPage() {
             />
           </div>
 
-          <div className="grid gap-4 lg:grid-cols-3">
-            {(
-              [
-                ["dailyLimit", "form_daily_limit", "1"],
-                ["totalQuota", "form_total_quota", "1"],
-                ["dailySpendingLimit", "form_daily_spending_limit", "1"],
-                ["concurrencyLimit", "form_concurrency_limit", "1"],
-                ["rpmLimit", "form_rpm_limit", "1"],
-                ["tpmLimit", "form_tpm_limit", "1"],
-              ] as const
-            ).map(([key, labelKey, step]) => (
-              <div key={key}>
-                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
-                  {t(`api_key_permissions_page.${labelKey}`)}
-                </label>
-                <TextInput
-                  type="number"
-                  min={0}
-                  step={step}
-                  inputMode="numeric"
-                  value={draft[key]}
-                  aria-label={t(`api_key_permissions_page.${labelKey}`)}
-                  placeholder={t("api_key_permissions_page.form_unlimited_hint")}
-                  onChange={(event) => {
-                    const raw = event.target.value;
-                    // Keep empty for unlimited; otherwise only whole numbers.
-                    if (raw === "" || /^\d+$/.test(raw)) {
-                      setDraft((prev) => ({ ...prev, [key]: raw }));
-                    }
-                  }}
-                />
-              </div>
-            ))}
-          </div>
+          <section className="rounded-2xl border border-indigo-200/80 bg-indigo-50/45 p-4 dark:border-indigo-500/20 dark:bg-indigo-500/5">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("api_key_permissions_page.quota_section")}
+            </h3>
+            <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
+              {t("api_key_permissions_page.quota_section_desc")} {t("quota.fields_hint")}
+            </p>
+            <PeriodSpendingFields
+              t={t}
+              value={draft.periodSpending}
+              onChange={(periodSpending) => setDraft((prev) => ({ ...prev, periodSpending }))}
+              idPrefix="permission-profile-period"
+            />
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 p-4 dark:border-white/10">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("api_key_permissions_page.request_limits_section")}
+            </h3>
+            <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
+              {t("api_key_permissions_page.request_limits_desc")}
+            </p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {(
+                [
+                  ["dailyLimit", "form_daily_limit"],
+                  ["totalQuota", "form_total_quota"],
+                ] as const
+              ).map(([key, labelKey]) => (
+                <div key={key}>
+                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
+                    {t(`api_key_permissions_page.${labelKey}`)}
+                  </label>
+                  <TextInput
+                    type="number"
+                    min={0}
+                    step={1}
+                    inputMode="numeric"
+                    value={draft[key]}
+                    aria-label={t(`api_key_permissions_page.${labelKey}`)}
+                    placeholder={t("api_key_permissions_page.form_unlimited_hint")}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      if (raw === "" || /^\d+$/.test(raw)) {
+                        setDraft((prev) => ({ ...prev, [key]: raw }));
+                      }
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 p-4 dark:border-white/10">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("api_key_permissions_page.realtime_limits_section")}
+            </h3>
+            <div className="mt-3 grid gap-4 sm:grid-cols-3">
+              {(
+                [
+                  ["concurrencyLimit", "form_concurrency_limit"],
+                  ["rpmLimit", "form_rpm_limit"],
+                  ["tpmLimit", "form_tpm_limit"],
+                ] as const
+              ).map(([key, labelKey]) => (
+                <div key={key}>
+                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">
+                    {t(`api_key_permissions_page.${labelKey}`)}
+                  </label>
+                  <TextInput
+                    type="number"
+                    min={0}
+                    step={1}
+                    inputMode="numeric"
+                    value={draft[key]}
+                    aria-label={t(`api_key_permissions_page.${labelKey}`)}
+                    placeholder={t("api_key_permissions_page.form_unlimited_hint")}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      if (raw === "" || /^\d+$/.test(raw)) {
+                        setDraft((prev) => ({ ...prev, [key]: raw }));
+                      }
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
 
           <div>
             <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-white/80">

--- a/pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
+++ b/pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx
@@ -24,7 +24,23 @@ const mocks = vi.hoisted(() => ({
   endUsersUpdate: vi.fn(async (id: string, body: EndUserUpdateBody) => {
     const current = state.accounts.find((account) => account.id === id);
     if (!current) throw new Error(`missing account ${id}`);
-    const updated = { ...current, ...body };
+    const updated: EndUser = {
+      ...current,
+      ...body,
+      "period-spending-limits": body["period-spending-limits"]
+        ? {
+            "5h":
+              body["period-spending-limits"]["5h"] ??
+              current["period-spending-limits"]?.["5h"] ??
+              0,
+            day: body["period-spending-limits"].day ?? current["period-spending-limits"]?.day ?? 0,
+            week:
+              body["period-spending-limits"].week ?? current["period-spending-limits"]?.week ?? 0,
+            month:
+              body["period-spending-limits"].month ?? current["period-spending-limits"]?.month ?? 0,
+          }
+        : current["period-spending-limits"],
+    };
     state.accounts = state.accounts.map((account) => (account.id === id ? updated : account));
     return updated;
   }),
@@ -35,7 +51,7 @@ const mocks = vi.hoisted(() => ({
         : ((body as { items?: ApiKeyPermissionProfile[] } | null)?.items ?? []);
       state.permissionProfiles = items;
     }
-    return { applied_count: 2 };
+    return { applied_count: 2, "capped-keys": [] };
   }),
   authFilesList: vi.fn(async () => ({ files: [] })),
   getGeminiKeys: vi.fn(async (): Promise<unknown[]> => []),
@@ -98,7 +114,10 @@ vi.mock("@code-proxy/api-client/endpoints/api-key-permission-profiles", async (i
           "/api-key-permission-profiles",
           options?.syncAccounts ? { items: profiles, "sync-accounts": true } : profiles,
         );
-        return { appliedCount: response.applied_count };
+        return {
+          appliedCount: response.applied_count,
+          cappedKeys: response["capped-keys"] ?? [],
+        };
       },
     },
   };
@@ -170,6 +189,7 @@ describe("ApiKeyPermissionsPage", () => {
         "daily-limit": 15000,
         "total-quota": 0,
         "daily-spending-limit": 0,
+        "period-spending-limits": { "5h": 100, day: 300, week: 800, month: 4000 },
         "concurrency-limit": 0,
         "rpm-limit": 0,
         "tpm-limit": 0,
@@ -199,7 +219,10 @@ describe("ApiKeyPermissionsPage", () => {
 
     expect(await screen.findByText("标准配置")).toBeInTheDocument();
     expect(screen.queryByText("Team A")).not.toBeInTheDocument();
-    expect(screen.getByText("每日 15,000")).toBeInTheDocument();
+    expect(screen.getByText("$100")).toBeInTheDocument();
+    expect(screen.getByText("$300")).toBeInTheDocument();
+    expect(screen.getByText("$800")).toBeInTheDocument();
+    expect(screen.getByText("$4,000")).toBeInTheDocument();
     expect(screen.getByText("分组 1 · 渠道 无限制 · 模型 无限制")).toBeInTheDocument();
     expect(screen.getByText("已绑定 2 个账号")).toBeInTheDocument();
     expect(screen.getByText("标准系统提示词")).toBeInTheDocument();
@@ -208,6 +231,11 @@ describe("ApiKeyPermissionsPage", () => {
     const dialog = await screen.findByRole("dialog", { name: "新增权限配置" });
     await userEvent.type(within(dialog).getByRole("textbox", { name: "配置名称" }), "专业配置");
     await userEvent.type(within(dialog).getByRole("spinbutton", { name: "每日请求限额" }), "15000");
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "5 小时额度 (USD)" }),
+      "100",
+    );
+    await userEvent.type(within(dialog).getByRole("spinbutton", { name: "每日额度 (USD)" }), "300");
     await userEvent.type(
       within(dialog).getByRole("textbox", { name: "系统提示词" }),
       "专业系统提示词",
@@ -225,6 +253,8 @@ describe("ApiKeyPermissionsPage", () => {
             expect.objectContaining({
               name: "专业配置",
               "daily-limit": 15000,
+              "daily-spending-limit": 300,
+              "period-spending-limits": { "5h": 100, day: 300, week: 0, month: 0 },
               "allowed-channel-groups": ["pro"],
               "system-prompt": "专业系统提示词",
             }),

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -8,7 +8,7 @@ import {
   type ApiKeyEntry,
   type ApiKeyDailySpendingResetEvent,
 } from "@code-proxy/api-client/endpoints/api-keys";
-import { endUsersApi } from "@code-proxy/api-client/endpoints/end-users";
+import { endUsersApi, type EndUserAPIKey } from "@code-proxy/api-client/endpoints/end-users";
 import {
   applyApiKeyPermissionProfile,
   apiKeyPermissionProfilesApi,
@@ -17,7 +17,12 @@ import {
   type ApiKeyPermissionProfile,
 } from "@code-proxy/api-client/endpoints/api-key-permission-profiles";
 import { ccSwitchImportConfigsApi } from "@code-proxy/api-client/endpoints/ccswitch-import-configs";
-import { detectApiBaseFromLocation } from "@code-proxy/api-client";
+import {
+  detectApiBaseFromLocation,
+  EMPTY_PERIOD_SPENDING_LIMITS,
+  normalizePeriodSpendingLimits,
+  type PeriodSpendingLimits,
+} from "@code-proxy/api-client";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 import { generateApiKey, makeEmptyApiKeyForm, maskApiKey } from "./apiKeyPageUtils";
 import { createApiKeyColumns } from "./components/ApiKeyColumns";
@@ -46,12 +51,21 @@ import { ccSwitchConfigMatchesApiKeyPermissions } from "@code-proxy/domain/ccswi
 import { LogContentModal } from "@features/log-content-viewer";
 import { ErrorDetailModal } from "@features/log-content-viewer";
 import type { ApiKeyFormValues } from "./types";
+import {
+  OwnedApiKeyQuotaModal,
+  OwnedApiKeysTable,
+  formatQuotaValidationError,
+  limitsToPeriodSpendingDraft,
+  periodSpendingDraftToLimits,
+} from "@features/period-spending";
 
 export function ApiKeysPage({
   endUserId,
+  accountPeriodSpendingLimits = EMPTY_PERIOD_SPENDING_LIMITS,
   embed = false,
 }: {
   endUserId?: string;
+  accountPeriodSpendingLimits?: PeriodSpendingLimits;
   /** When true, hide outer card chrome for modal embedding. */
   embed?: boolean;
 } = {}) {
@@ -80,6 +94,7 @@ export function ApiKeysPage({
   const copiedCcSwitchImportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [saving, setSaving] = useState(false);
   const [createdSecretOnce, setCreatedSecretOnce] = useState<string | null>(null);
+  const [quotaFormError, setQuotaFormError] = useState("");
   const [resettingDailySpendingKey, setResettingDailySpendingKey] = useState<string | null>(null);
   const [resetHistoryEntry, setResetHistoryEntry] = useState<ApiKeyEntry | null>(null);
   const [resetHistoryLoading, setResetHistoryLoading] = useState(false);
@@ -131,6 +146,45 @@ export function ApiKeysPage({
   const loadEntries = useCallback(async () => {
     setLoading(true);
     try {
+      if (endUserIdFilter) {
+        const ownerResponse = await endUsersApi.listKeys(endUserIdFilter);
+        const ownerKeys = ownerResponse.items ?? [];
+        const secretById = new Map<string, string>();
+        try {
+          const compatibilityEntries = await apiKeyEntriesApi.list();
+          for (const entry of compatibilityEntries) {
+            if (entry.id && entry.end_user_id === endUserIdFilter && entry.key) {
+              secretById.set(entry.id, entry.key);
+            }
+          }
+        } catch {
+          // Owner-scoped rows are authoritative; secret enrichment is compatibility-only.
+        }
+        setEntries(
+          ownerKeys.map((key) => ({
+            id: key.id,
+            key: secretById.get(key.id) ?? key.key ?? "",
+            name: key.name,
+            disabled: key.disabled,
+            end_user_id: key.end_user_id,
+            is_default: key.is_default,
+            "created-at": key.created_at,
+            "daily-spending-limit": key["daily-spending-limit"],
+            "period-spending-limits": normalizePeriodSpendingLimits(
+              key["period-spending-limits"],
+              key["daily-spending-limit"],
+            ),
+            "period-spending": key["period-spending"],
+            "daily-spending-used": key["daily-spending-used"],
+            "lifetime-spending-used": key["lifetime-spending-used"],
+            "daily-spending-reset-count": key["daily-spending-reset-count"],
+          })),
+        );
+        setPermissionProfiles([]);
+        setCcSwitchImportConfigs([]);
+        return;
+      }
+
       const [entriesData, legacyKeys, profilesData, configsData] = await Promise.all([
         apiKeyEntriesApi.list(),
         apiKeysApi.list().catch(() => [] as string[]),
@@ -140,14 +194,12 @@ export function ApiKeysPage({
       setPermissionProfiles(profilesData);
       setCcSwitchImportConfigs(configsData);
 
-      // Auto-migrate: old api-keys not in api-key-entries get added as unnamed entries
-      const entryKeySet = new Set(entriesData.map((e) => e.key));
+      const entryKeySet = new Set(entriesData.map((entry) => entry.key));
       const newEntries = legacyKeys
-        .filter((k: string) => k && !entryKeySet.has(k))
-        .map((k: string): ApiKeyEntry => ({ key: k, "created-at": new Date().toISOString() }));
+        .filter((key) => key && !entryKeySet.has(key))
+        .map((key): ApiKeyEntry => ({ key, "created-at": new Date().toISOString() }));
 
-      let finalEntries: ApiKeyEntry[];
-      if (newEntries.length > 0 && !endUserIdFilter) {
+      if (newEntries.length > 0) {
         const merged = [...entriesData, ...newEntries];
         try {
           await apiKeyEntriesApi.replace(merged);
@@ -155,18 +207,13 @@ export function ApiKeysPage({
             type: "success",
             message: t("api_keys_page.auto_import", { count: newEntries.length }),
           });
-          finalEntries = merged;
+          setEntries(merged);
         } catch {
-          finalEntries = entriesData;
+          setEntries(entriesData);
         }
       } else {
-        finalEntries = entriesData;
+        setEntries(entriesData);
       }
-      if (endUserIdFilter) {
-        finalEntries = finalEntries.filter((e) => e.end_user_id === endUserIdFilter);
-      }
-      setEntries(finalEntries);
-      // Load models after entries are available (needs a valid API key)
       void refreshPermissionOptions();
     } catch (err: unknown) {
       notify({
@@ -245,6 +292,30 @@ export function ApiKeysPage({
     () => entries.filter((entry) => selectedKeys.has(entry.key)),
     [entries, selectedKeys],
   );
+  const ownedKeys = useMemo<EndUserAPIKey[]>(
+    () =>
+      entries.map((entry) => ({
+        id: entry.id ?? entry.key,
+        tenant_id: "",
+        end_user_id: endUserIdFilter,
+        key: entry.key || undefined,
+        key_masked: entry.key ? maskApiKey(entry.key) : undefined,
+        name: entry.name ?? "",
+        disabled: Boolean(entry.disabled),
+        is_default: Boolean(entry.is_default),
+        created_at: entry["created-at"],
+        "daily-spending-limit": entry["daily-spending-limit"],
+        "period-spending-limits": normalizePeriodSpendingLimits(
+          entry["period-spending-limits"],
+          entry["daily-spending-limit"],
+        ),
+        "period-spending": entry["period-spending"],
+        "daily-spending-used": entry["daily-spending-used"],
+        "lifetime-spending-used": entry["lifetime-spending-used"],
+        "daily-spending-reset-count": entry["daily-spending-reset-count"],
+      })),
+    [endUserIdFilter, entries],
+  );
   const allRowsSelected =
     entries.length > 0 && entries.every((entry) => selectedKeys.has(entry.key));
   const someRowsSelected = selectedEntries.length > 0 && !allRowsSelected;
@@ -311,8 +382,8 @@ export function ApiKeysPage({
   /* ─── create ─── */
 
   const handleOpenCreate = () => {
-    // User-scoped create: server generates the secret; do not show a client-side fake key.
     const next = makeEmptyApiKeyForm(endUserIdFilter ? "" : generateApiKey());
+    setQuotaFormError("");
     setForm(next);
     setShowCreate(true);
   };
@@ -325,8 +396,12 @@ export function ApiKeysPage({
     setSaving(true);
     try {
       if (endUserIdFilter) {
-        // Owner-scoped create: server generates unique key; quota lives on the account.
-        const created = await endUsersApi.createKey(endUserIdFilter, form.name.trim());
+        const limits = periodSpendingDraftToLimits(form.periodSpending);
+        const created = await endUsersApi.createKey(endUserIdFilter, {
+          name: form.name.trim(),
+          "daily-spending-limit": limits.day,
+          "period-spending-limits": limits,
+        });
         const plain = created.plaintext_key;
         if (plain) {
           setCreatedSecretOnce(plain);
@@ -353,10 +428,13 @@ export function ApiKeysPage({
       setShowCreate(false);
       await loadEntries();
     } catch (err: unknown) {
-      notify({
-        type: "error",
-        message: err instanceof Error ? err.message : t("api_keys_page.create_failed"),
-      });
+      const message = endUserIdFilter
+        ? formatQuotaValidationError(err, t)
+        : err instanceof Error
+          ? err.message
+          : t("api_keys_page.create_failed");
+      if (endUserIdFilter) setQuotaFormError(message);
+      else notify({ type: "error", message });
     } finally {
       setSaving(false);
     }
@@ -373,6 +451,12 @@ export function ApiKeysPage({
       dailyLimit: entry["daily-limit"]?.toString() || "",
       totalQuota: entry["total-quota"]?.toString() || "",
       spendingLimit: entry["spending-limit"]?.toString() || "",
+      periodSpending: limitsToPeriodSpendingDraft(
+        normalizePeriodSpendingLimits(
+          entry["period-spending-limits"],
+          entry["daily-spending-limit"],
+        ),
+      ),
       concurrencyLimit: entry["concurrency-limit"]?.toString() || "",
       rpmLimit: entry["rpm-limit"]?.toString() || "",
       tpmLimit: entry["tpm-limit"]?.toString() || "",
@@ -382,6 +466,7 @@ export function ApiKeysPage({
       useExactChannelRestrictions: (entry["allowed-channels"] || []).length > 0,
       systemPrompt: entry["system-prompt"] || "",
     };
+    setQuotaFormError("");
     setForm(next);
     setEditIndex(index);
   };
@@ -402,13 +487,17 @@ export function ApiKeysPage({
     }
     setSaving(true);
     try {
-      // Owned keys: only rename; account holds quota/permissions.
       if (endUserIdFilter) {
         if (!currentEntry.id) {
           notify({ type: "error", message: t("api_keys_page.update_failed") });
           return;
         }
-        await endUsersApi.updateKeyName(endUserIdFilter, currentEntry.id, form.name.trim());
+        const limits = periodSpendingDraftToLimits(form.periodSpending);
+        await endUsersApi.updateKey(endUserIdFilter, currentEntry.id, {
+          name: form.name.trim(),
+          "daily-spending-limit": limits.day,
+          "period-spending-limits": limits,
+        });
       } else {
         const permissionPatch =
           form.permissionProfileId === CUSTOM_PERMISSION_PROFILE_ID
@@ -418,6 +507,10 @@ export function ApiKeysPage({
                 "total-quota": currentEntry["total-quota"] ?? 0,
                 "spending-limit": currentEntry["spending-limit"] ?? 0,
                 "daily-spending-limit": currentEntry["daily-spending-limit"] ?? 0,
+                "period-spending-limits": normalizePeriodSpendingLimits(
+                  currentEntry["period-spending-limits"],
+                  currentEntry["daily-spending-limit"],
+                ),
                 "concurrency-limit": currentEntry["concurrency-limit"] ?? 0,
                 "rpm-limit": currentEntry["rpm-limit"] ?? 0,
                 "tpm-limit": currentEntry["tpm-limit"] ?? 0,
@@ -445,10 +538,13 @@ export function ApiKeysPage({
       setEditIndex(null);
       await loadEntries();
     } catch (err: unknown) {
-      notify({
-        type: "error",
-        message: err instanceof Error ? err.message : t("api_keys_page.update_failed"),
-      });
+      const message = endUserIdFilter
+        ? formatQuotaValidationError(err, t)
+        : err instanceof Error
+          ? err.message
+          : t("api_keys_page.update_failed");
+      if (endUserIdFilter) setQuotaFormError(message);
+      else notify({ type: "error", message });
     } finally {
       setSaving(false);
     }
@@ -487,10 +583,20 @@ export function ApiKeysPage({
   const handleResetDailySpending = useCallback(
     async (index: number) => {
       const entry = entries[index];
-      if (!entry || !((entry["daily-spending-limit"] ?? 0) > 0)) return;
-      setResettingDailySpendingKey(entry.key);
+      const dayLimit = normalizePeriodSpendingLimits(
+        entry?.["period-spending-limits"],
+        entry?.["daily-spending-limit"],
+      ).day;
+      if (!entry || dayLimit <= 0) return;
+      setResettingDailySpendingKey(entry.id ?? entry.key);
       try {
-        await apiKeyEntriesApi.resetDailySpending(entry.id ? { id: entry.id } : { key: entry.key });
+        if (endUserIdFilter && entry.id) {
+          await endUsersApi.resetKeyDailySpending(endUserIdFilter, entry.id);
+        } else {
+          await apiKeyEntriesApi.resetDailySpending(
+            entry.id ? { id: entry.id } : { key: entry.key },
+          );
+        }
         notify({ type: "success", message: t("api_keys_page.reset_today_spending_success") });
         await loadEntries();
       } catch (err: unknown) {
@@ -503,7 +609,7 @@ export function ApiKeysPage({
         setResettingDailySpendingKey(null);
       }
     },
-    [entries, loadEntries, notify, t],
+    [endUserIdFilter, entries, loadEntries, notify, t],
   );
 
   const handleViewResetHistory = useCallback(
@@ -512,9 +618,12 @@ export function ApiKeysPage({
       setResetHistoryEvents([]);
       setResetHistoryLoading(true);
       try {
-        const resp = await apiKeyEntriesApi.listDailySpendingResetHistory(
-          entry.id ? { id: entry.id, limit: 200 } : { key: entry.key, limit: 200 },
-        );
+        const resp =
+          endUserIdFilter && entry.id
+            ? await endUsersApi.listKeyDailySpendingResetHistory(endUserIdFilter, entry.id, 200)
+            : await apiKeyEntriesApi.listDailySpendingResetHistory(
+                entry.id ? { id: entry.id, limit: 200 } : { key: entry.key, limit: 200 },
+              );
         setResetHistoryEvents(Array.isArray(resp?.items) ? resp.items : []);
       } catch (err: unknown) {
         notify({
@@ -527,7 +636,7 @@ export function ApiKeysPage({
         setResetHistoryLoading(false);
       }
     },
-    [notify, t],
+    [endUserIdFilter, notify, t],
   );
 
   /* ─── delete ─── */
@@ -777,38 +886,70 @@ export function ApiKeysPage({
     </div>
   );
 
-  const tableBody =
-    entries.length === 0 ? (
-      <EmptyState
-        title={t("api_keys_page.no_keys")}
-        description={t("api_keys_page.no_keys_desc")}
-        icon={<KeyRound size={32} className="text-slate-400" />}
+  const tableBody = endUserIdFilter ? (
+    <div className={embed ? "flex min-h-0 flex-1 flex-col" : "space-y-3"}>
+      <OwnedApiKeysTable
+        t={t}
+        keys={ownedKeys}
+        busyKeyId={resettingDailySpendingKey}
+        busy={saving}
+        canDelete={() => ownedKeys.length > 1}
+        height={embed ? "min-h-0 flex-1" : "h-[calc(100dvh-260px)]"}
+        actions={{
+          onToggleDisabled: (key) => {
+            const index = entries.findIndex((entry) => entry.id === key.id);
+            if (index >= 0) void handleToggleDisable(index);
+          },
+          onCopy: (key) => {
+            if (key.key) void handleCopy(key.key);
+          },
+          onRotate: (key) => {
+            const index = entries.findIndex((entry) => entry.id === key.id);
+            if (index >= 0) setRotateIndex(index);
+          },
+          onEdit: (key) => {
+            const index = entries.findIndex((entry) => entry.id === key.id);
+            if (index >= 0) handleOpenEdit(index);
+          },
+          onResetDailySpending: (key) => {
+            const index = entries.findIndex((entry) => entry.id === key.id);
+            if (index >= 0) void handleResetDailySpending(index);
+          },
+          onViewResetHistory: (key) => {
+            const entry = entries.find((item) => item.id === key.id);
+            if (entry) void handleViewResetHistory(entry);
+          },
+          onDelete: (key) => {
+            const index = entries.findIndex((entry) => entry.id === key.id);
+            if (index >= 0) handleOpenDelete(index);
+          },
+        }}
       />
-    ) : (
-      <div
-        className={
-          embed
-            ? "flex min-h-0 flex-1 flex-col"
-            : "space-y-3 md:flex md:min-h-0 md:flex-1 md:flex-col"
-        }
-      >
-        <DataTable<ApiKeyEntry>
-          tableId={endUserIdFilter ? "api-keys-end-user" : "api-keys"}
-          rows={entries}
-          columns={apiKeyColumns}
-          rowKey={(row) => row.key}
-          rowHeight={44}
-          height={embed ? "min-h-0 flex-1" : "h-[calc(100dvh-260px)] md:h-auto md:flex-1"}
-          minHeight={embed ? "min-h-0" : "min-h-[320px] md:min-h-0"}
-          // Full key table needs all quota/permission columns; account-scoped embed only keeps credentials.
-          minWidth={endUserIdFilter ? "min-w-[876px]" : "min-w-[2314px]"}
-          caption={t("api_keys_page.table_caption")}
-          emptyText={t("api_keys_page.no_api_keys")}
-          showAllLoadedMessage={false}
-          rowClassName={(row) => (row.disabled ? "opacity-50" : "")}
-        />
-      </div>
-    );
+    </div>
+  ) : entries.length === 0 ? (
+    <EmptyState
+      title={t("api_keys_page.no_keys")}
+      description={t("api_keys_page.no_keys_desc")}
+      icon={<KeyRound size={32} className="text-slate-400" />}
+    />
+  ) : (
+    <div className="space-y-3 md:flex md:min-h-0 md:flex-1 md:flex-col">
+      <DataTable<ApiKeyEntry>
+        tableId="api-keys"
+        rows={entries}
+        columns={apiKeyColumns}
+        rowKey={(row) => row.key}
+        rowHeight={52}
+        height="h-[calc(100dvh-260px)] md:h-auto md:flex-1"
+        minHeight="min-h-[320px] md:min-h-0"
+        minWidth="min-w-[2500px]"
+        caption={t("api_keys_page.table_caption")}
+        emptyText={t("api_keys_page.no_api_keys")}
+        showAllLoadedMessage={false}
+        rowClassName={(row) => (row.disabled ? "opacity-50" : "")}
+      />
+    </div>
+  );
 
   return (
     <div className={embed ? "flex h-full min-h-0 flex-col" : "space-y-6"}>
@@ -842,35 +983,79 @@ export function ApiKeysPage({
         </Card>
       )}
 
-      <ApiKeyFormModal
-        t={t}
-        open={showCreate}
-        editMode={false}
-        saving={saving}
-        form={form}
-        setForm={setForm}
-        permissionProfileOptions={permissionProfileOptions}
-        onClose={() => setShowCreate(false)}
-        onSubmit={handleCreate}
-        regenerateKey={() => setForm((prev) => ({ ...prev, key: generateApiKey() }))}
-        serverGeneratesKey={Boolean(endUserIdFilter)}
-        hidePermissionProfile={Boolean(endUserIdFilter)}
-      />
-
-      <ApiKeyFormModal
-        t={t}
-        open={editIndex !== null}
-        editMode
-        saving={saving}
-        form={form}
-        setForm={setForm}
-        permissionProfileOptions={permissionProfileOptions}
-        onClose={() => setEditIndex(null)}
-        onSubmit={handleEdit}
-        regenerateKey={() => setForm((prev) => ({ ...prev, key: generateApiKey() }))}
-        serverGeneratesKey={Boolean(endUserIdFilter)}
-        hidePermissionProfile={Boolean(endUserIdFilter)}
-      />
+      {endUserIdFilter ? (
+        <>
+          <OwnedApiKeyQuotaModal
+            t={t}
+            open={showCreate}
+            mode="create"
+            value={{ name: form.name, periods: form.periodSpending }}
+            accountLimits={accountPeriodSpendingLimits}
+            saving={saving}
+            serverError={quotaFormError}
+            onChange={(next) =>
+              setForm((current) => ({
+                ...current,
+                name: next.name,
+                periodSpending: next.periods,
+              }))
+            }
+            onClose={() => {
+              setShowCreate(false);
+              setQuotaFormError("");
+            }}
+            onSubmit={() => void handleCreate()}
+          />
+          <OwnedApiKeyQuotaModal
+            t={t}
+            open={editIndex !== null}
+            mode="edit"
+            value={{ name: form.name, periods: form.periodSpending }}
+            accountLimits={accountPeriodSpendingLimits}
+            saving={saving}
+            serverError={quotaFormError}
+            onChange={(next) =>
+              setForm((current) => ({
+                ...current,
+                name: next.name,
+                periodSpending: next.periods,
+              }))
+            }
+            onClose={() => {
+              setEditIndex(null);
+              setQuotaFormError("");
+            }}
+            onSubmit={() => void handleEdit()}
+          />
+        </>
+      ) : (
+        <>
+          <ApiKeyFormModal
+            t={t}
+            open={showCreate}
+            editMode={false}
+            saving={saving}
+            form={form}
+            setForm={setForm}
+            permissionProfileOptions={permissionProfileOptions}
+            onClose={() => setShowCreate(false)}
+            onSubmit={handleCreate}
+            regenerateKey={() => setForm((prev) => ({ ...prev, key: generateApiKey() }))}
+          />
+          <ApiKeyFormModal
+            t={t}
+            open={editIndex !== null}
+            editMode
+            saving={saving}
+            form={form}
+            setForm={setForm}
+            permissionProfileOptions={permissionProfileOptions}
+            onClose={() => setEditIndex(null)}
+            onSubmit={handleEdit}
+            regenerateKey={() => setForm((prev) => ({ ...prev, key: generateApiKey() }))}
+          />
+        </>
+      )}
 
       <ConfirmModal
         open={rotateIndex !== null}

--- a/pages/api-keys/__tests__/ApiKeysPage.test.tsx
+++ b/pages/api-keys/__tests__/ApiKeysPage.test.tsx
@@ -62,24 +62,75 @@ const mocks = vi.hoisted(() => ({
     total: 0,
   })),
   apiKeysList: vi.fn(async (): Promise<string[]> => []),
-  endUserCreateKey: vi.fn(async (userId: string, name: string) => {
-    const entry = {
-      id: "owned-created",
-      key: "sk-owned-created-secret",
-      name,
-      end_user_id: userId,
-      disabled: false,
-      is_default: state.entries.length === 0,
-      "created-at": "2026-07-21T00:00:00Z",
-    };
-    state.entries.push(entry);
-    return { api_key: entry, plaintext_key: entry.key };
-  }),
-  endUserUpdateKeyName: vi.fn(async (userId: string, keyId: string, name: string) => {
-    const entry = state.entries.find((item) => item.id === keyId && item.end_user_id === userId);
-    if (entry) entry.name = name;
-    return entry;
-  }),
+  endUserListKeys: vi.fn(async (userId: string) => ({
+    items: state.entries
+      .filter((entry) => entry.end_user_id === userId)
+      .map((entry) => ({
+        id: entry.id,
+        tenant_id: "tenant-1",
+        end_user_id: userId,
+        key_masked: entry.key ? `${entry.key.slice(0, 5)}•••${entry.key.slice(-3)}` : "",
+        name: entry.name,
+        disabled: Boolean(entry.disabled),
+        is_default: Boolean(entry.is_default),
+        created_at: entry["created-at"],
+        "daily-spending-limit": entry["daily-spending-limit"] ?? 0,
+        "period-spending-limits": entry["period-spending-limits"] ?? {
+          "5h": 0,
+          day: 0,
+          week: 0,
+          month: 0,
+        },
+        "period-spending": entry["period-spending"] ?? [],
+        "daily-spending-used": entry["daily-spending-used"] ?? 0,
+        "lifetime-spending-used": entry["lifetime-spending-used"] ?? 0,
+        "daily-spending-reset-count": entry["daily-spending-reset-count"] ?? 0,
+      })),
+  })),
+  endUserCreateKey: vi.fn(
+    async (
+      userId: string,
+      body: { name?: string; "period-spending-limits"?: Record<string, number> },
+    ) => {
+      const entry = {
+        id: "owned-created",
+        key: "sk-owned-created-secret",
+        name: body.name ?? "",
+        end_user_id: userId,
+        disabled: false,
+        is_default: state.entries.length === 0,
+        "created-at": "2026-07-21T00:00:00Z",
+        "period-spending-limits": body["period-spending-limits"] ?? {
+          "5h": 0,
+          day: 0,
+          week: 0,
+          month: 0,
+        },
+      };
+      state.entries.push(entry);
+      return { api_key: entry, plaintext_key: entry.key };
+    },
+  ),
+  endUserUpdateKey: vi.fn(
+    async (
+      userId: string,
+      keyId: string,
+      body: { name?: string; "period-spending-limits"?: Record<string, number> },
+    ) => {
+      const entry = state.entries.find((item) => item.id === keyId && item.end_user_id === userId);
+      if (entry)
+        Object.assign(entry, {
+          name: body.name ?? entry.name,
+          "period-spending-limits":
+            body["period-spending-limits"] ?? entry["period-spending-limits"],
+          "daily-spending-limit":
+            body["period-spending-limits"]?.day ?? entry["daily-spending-limit"],
+        });
+      return entry;
+    },
+  ),
+  endUserResetKeyDailySpending: vi.fn(async () => ({ status: "ok" })),
+  endUserListKeyDailySpendingResetHistory: vi.fn(async () => ({ items: [], total: 0 })),
   endUserRotateKey: vi.fn(async (userId: string, keyId: string) => {
     const entry = state.entries.find((item) => item.id === keyId && item.end_user_id === userId);
     if (!entry) throw new Error("not found");
@@ -150,8 +201,11 @@ vi.mock("@code-proxy/api-client/endpoints/api-keys", () => ({
 
 vi.mock("@code-proxy/api-client/endpoints/end-users", () => ({
   endUsersApi: {
+    listKeys: mocks.endUserListKeys,
     createKey: mocks.endUserCreateKey,
-    updateKeyName: mocks.endUserUpdateKeyName,
+    updateKey: mocks.endUserUpdateKey,
+    resetKeyDailySpending: mocks.endUserResetKeyDailySpending,
+    listKeyDailySpendingResetHistory: mocks.endUserListKeyDailySpendingResetHistory,
     rotateKey: mocks.endUserRotateKey,
     deleteKey: mocks.endUserDeleteKey,
   },
@@ -316,7 +370,7 @@ describe("ApiKeysPage", () => {
     mocks.apiKeyEntriesDelete.mockClear();
     mocks.apiKeysList.mockClear();
     mocks.endUserCreateKey.mockClear();
-    mocks.endUserUpdateKeyName.mockClear();
+    mocks.endUserUpdateKey.mockClear();
     mocks.endUserRotateKey.mockClear();
     mocks.endUserDeleteKey.mockClear();
     mocks.fetchConfigYaml.mockClear();
@@ -448,6 +502,12 @@ describe("ApiKeysPage", () => {
         disabled: false,
         is_default: true,
         "created-at": "2026-07-21T00:00:00Z",
+        "daily-spending-limit": 100,
+        "period-spending-limits": { "5h": 50, day: 100, week: 300, month: 1000 },
+        "period-spending": [{ period: "day", limit: 100, used: 20, remaining: 80 }],
+        "daily-spending-used": 20,
+        "lifetime-spending-used": 300.12,
+        "daily-spending-reset-count": 2,
       },
     ];
 
@@ -455,14 +515,18 @@ describe("ApiKeysPage", () => {
       <MemoryRouter>
         <ThemeProvider>
           <ToastProvider>
-            <ApiKeysPage endUserId="end-user-1" embed />
+            <ApiKeysPage
+              endUserId="end-user-1"
+              accountPeriodSpendingLimits={{ "5h": 100, day: 300, week: 800, month: 4000 }}
+              embed
+            />
           </ToastProvider>
         </ThemeProvider>
       </MemoryRouter>,
     );
 
     expect(await screen.findByText("Owned Key")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await userEvent.click(screen.getByRole("button", { name: "Edit Key quota" }));
 
     const editDialog = await screen.findByRole("dialog");
     expect(
@@ -471,7 +535,8 @@ describe("ApiKeysPage", () => {
     expect(
       within(editDialog).queryByRole("button", { name: /refresh key/i }),
     ).not.toBeInTheDocument();
-    expect(editDialog).toHaveTextContent(/use the dedicated rotation action/i);
+    expect(editDialog).toHaveTextContent(/Key sub-quota/i);
+    expect(editDialog).toHaveTextContent(/Account limit \$300/i);
 
     const nameInput = within(editDialog).getByPlaceholderText(/team-a/i);
     await userEvent.clear(nameInput);
@@ -479,10 +544,13 @@ describe("ApiKeysPage", () => {
     await userEvent.click(within(editDialog).getByRole("button", { name: /save/i }));
 
     await waitFor(() => {
-      expect(mocks.endUserUpdateKeyName).toHaveBeenCalledWith(
+      expect(mocks.endUserUpdateKey).toHaveBeenCalledWith(
         "end-user-1",
         "owned-key-1",
-        "Renamed Owned Key",
+        expect.objectContaining({
+          name: "Renamed Owned Key",
+          "period-spending-limits": { "5h": 50, day: 100, week: 300, month: 1000 },
+        }),
       );
     });
     expect(mocks.apiKeyEntriesUpdate).not.toHaveBeenCalled();

--- a/pages/api-keys/apiKeyPageUtils.tsx
+++ b/pages/api-keys/apiKeyPageUtils.tsx
@@ -1,5 +1,6 @@
 import type { AuthFileItem } from "@code-proxy/api-client";
 import type { ApiKeyFormValues } from "./types";
+import { emptyPeriodSpendingDraft } from "@features/period-spending";
 
 import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
@@ -60,6 +61,7 @@ export const makeEmptyApiKeyForm = (key = ""): ApiKeyFormValues => ({
   dailyLimit: "",
   totalQuota: "",
   spendingLimit: "",
+  periodSpending: emptyPeriodSpendingDraft(),
   concurrencyLimit: "",
   rpmLimit: "",
   tpmLimit: "",

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -13,6 +13,8 @@ import {
   Upload,
 } from "lucide-react";
 import type { ApiKeyEntry } from "@code-proxy/api-client/endpoints/api-keys";
+import { normalizePeriodSpendingLimits } from "@code-proxy/api-client";
+import { PeriodSpendingCell } from "@features/period-spending";
 import {
   formatApiKeyDate,
   formatApiKeyLimit,
@@ -172,7 +174,7 @@ export const createApiKeyColumns = ({
               )}
             </span>
           </OverflowTooltip>
-          {!accountScoped && row.is_default ? (
+          {row.is_default ? (
             <span className="shrink-0 rounded-full bg-emerald-50 px-1.5 py-0.5 text-2xs font-medium text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">
               default
             </span>
@@ -181,45 +183,72 @@ export const createApiKeyColumns = ({
       ),
     },
     {
-      key: "dailySpending",
-      label: t("api_keys_page.col_daily_spending"),
-      width: "w-[180px] min-w-[180px]",
-      cellClassName: "whitespace-nowrap text-slate-700 dark:text-white/70",
+      key: "quota",
+      label: t("quota.period_spending_column"),
+      width: "w-[360px] min-w-[280px]",
       headerRender: () => (
         <HoverTooltip
-          content={t("api_keys_page.daily_spending_help")}
+          content={t("api_keys_page.quota_help")}
           className="inline-flex items-center gap-1"
         >
-          <span>{t("api_keys_page.col_daily_spending")}</span>
+          <span>{t("quota.period_spending_column")}</span>
           <Info size={12} className="text-slate-400 dark:text-white/40" />
         </HoverTooltip>
       ),
       render: (row) => {
-        const used = formatApiKeySpendingAmount(row["daily-spending-used"] ?? 0);
-        const limit = row["daily-spending-limit"] ?? 0;
-        if (!(limit > 0)) {
-          return (
-            <span className="inline-flex items-center gap-1 tabular-nums">
-              {used}
-              <span className="text-slate-400 dark:text-white/40">/</span>
-              <span className="inline-flex items-center gap-1">
-                <InfinityIcon size={14} className="text-green-500" /> {t("api_keys_page.unlimited")}
-              </span>
-            </span>
-          );
-        }
-        return (
-          <span className="tabular-nums">
-            {used}
-            <span className="text-slate-400 dark:text-white/40"> / </span>
-            {formatApiKeySpendingAmount(limit)}
-          </span>
+        const limits = normalizePeriodSpendingLimits(
+          row["period-spending-limits"],
+          row["daily-spending-limit"],
         );
+        const fallbackItems =
+          limits.day > 0
+            ? [
+                {
+                  period: "day" as const,
+                  limit: limits.day,
+                  used: row["daily-spending-used"] ?? 0,
+                  remaining: Math.max(limits.day - (row["daily-spending-used"] ?? 0), 0),
+                },
+              ]
+            : [];
+        return <PeriodSpendingCell t={t} items={row["period-spending"] ?? fallbackItems} />;
       },
     },
     {
+      key: "dailySpending",
+      label: t("quota.daily_spending_column"),
+      width: "w-[130px] min-w-[130px]",
+      cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      headerRender: () => (
+        <HoverTooltip
+          content={t("api_keys_page.daily_spending_fact_help")}
+          className="inline-flex items-center gap-1"
+        >
+          <span>{t("quota.daily_spending_column")}</span>
+          <Info size={12} className="text-slate-400 dark:text-white/40" />
+        </HoverTooltip>
+      ),
+      render: (row) => formatApiKeySpendingAmount(row["daily-spending-used"]),
+    },
+    {
+      key: "lifetimeSpending",
+      label: t("quota.lifetime_spending_column"),
+      width: "w-[140px] min-w-[140px]",
+      cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      headerRender: () => (
+        <HoverTooltip
+          content={t("api_keys_page.lifetime_spending_help")}
+          className="inline-flex items-center gap-1"
+        >
+          <span>{t("quota.lifetime_spending_column")}</span>
+          <Info size={12} className="text-slate-400 dark:text-white/40" />
+        </HoverTooltip>
+      ),
+      render: (row) => formatApiKeySpendingAmount(row["lifetime-spending-used"]),
+    },
+    {
       key: "dailySpendingResetCount",
-      label: t("api_keys_page.col_reset_count"),
+      label: t("quota.total_resets"),
       width: "w-[110px] min-w-[100px]",
       cellClassName: "whitespace-nowrap text-slate-700 dark:text-white/70",
       headerRender: () => (
@@ -227,7 +256,7 @@ export const createApiKeyColumns = ({
           content={t("api_keys_page.reset_count_help")}
           className="inline-flex items-center gap-1"
         >
-          <span>{t("api_keys_page.col_reset_count")}</span>
+          <span>{t("quota.total_resets")}</span>
           <Info size={12} className="text-slate-400 dark:text-white/40" />
         </HoverTooltip>
       ),
@@ -542,19 +571,18 @@ export const createApiKeyColumns = ({
                   <RotateCcw size={15} />
                 </button>
               </HoverTooltip>
-            ) : (
-              <HoverTooltip content={resetLabel}>
-                <button
-                  type="button"
-                  onClick={() => onResetDailySpending(idx)}
-                  disabled={!hasDailyLimit || isResetting}
-                  className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-orange-400"
-                  aria-label={resetLabel}
-                >
-                  <RotateCcw size={15} className={isResetting ? "animate-spin" : ""} />
-                </button>
-              </HoverTooltip>
-            )}
+            ) : null}
+            <HoverTooltip content={resetLabel}>
+              <button
+                type="button"
+                onClick={() => onResetDailySpending(idx)}
+                disabled={!hasDailyLimit || isResetting}
+                className="rounded-lg p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-orange-400"
+                aria-label={resetLabel}
+              >
+                <RotateCcw size={15} className={isResetting ? "animate-spin" : ""} />
+              </button>
+            </HoverTooltip>
             <HoverTooltip content={editLabel}>
               <button
                 type="button"
@@ -584,13 +612,11 @@ export const createApiKeyColumns = ({
   if (!accountScoped) {
     return columns;
   }
-  // Account-owned keys: quota lives on the end-user; only show credential columns.
+  // Owned keys keep their own period quota and spending facts; account-managed fields stay hidden.
   const hide = new Set([
     "dailyLimit",
     "totalQuota",
     "spendingLimit",
-    "dailySpending",
-    "dailySpendingResetCount",
     "rpmLimit",
     "tpmLimit",
     "allowedModels",

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -258,7 +258,7 @@ describe("ApiKeyColumns", () => {
     expect(screen.getByRole("button", { name: "Click to enable" })).toBeInTheDocument();
   });
 
-  test("account-scoped columns drop quota fields and usage/reset actions", () => {
+  test("account-scoped columns keep key quota and spending facts", () => {
     const row: ApiKeyEntry = {
       key: "sk-owned",
       name: "Owned",
@@ -269,52 +269,60 @@ describe("ApiKeyColumns", () => {
     const keys = columns.map((column) => column.key);
     const actionsColumn = columns.find((column) => column.key === "actions");
 
-    expect(keys).toEqual(["select", "name", "key", "createdAt", "actions"]);
+    expect(keys).toEqual([
+      "select",
+      "name",
+      "quota",
+      "dailySpending",
+      "lifetimeSpending",
+      "dailySpendingResetCount",
+      "key",
+      "createdAt",
+      "actions",
+    ]);
     expect(actionsColumn?.width).toBe("w-[220px] min-w-[220px]");
 
     render(<div>{actionsColumn?.render(row, 0)}</div>);
 
     expect(screen.queryByRole("button", { name: "View usage" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Reset today spending" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset today spending" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy key" })).toBeInTheDocument();
   });
 
-  test("places daily spending column immediately after name", () => {
+  test("places quota and spending fact columns immediately after name", () => {
     const columns = createColumns();
     const keys = columns.map((column) => column.key);
     const nameIndex = keys.indexOf("name");
-    expect(keys[nameIndex + 1]).toBe("dailySpending");
-    expect(keys[nameIndex + 2]).toBe("dailySpendingResetCount");
-    expect(keys[nameIndex + 3]).toBe("key");
+    expect(keys[nameIndex + 1]).toBe("quota");
+    expect(keys[nameIndex + 2]).toBe("dailySpending");
+    expect(keys[nameIndex + 3]).toBe("lifetimeSpending");
+    expect(keys[nameIndex + 4]).toBe("dailySpendingResetCount");
   });
 
-  test("renders daily spending used and limit amounts", () => {
+  test("renders quota separately from daily spending facts", () => {
     const limited: ApiKeyEntry = {
       key: "sk-limited",
       name: "Limited",
       "daily-spending-limit": 100,
+      "period-spending-limits": { "5h": 0, day: 100, week: 0, month: 0 },
+      "period-spending": [{ period: "day", limit: 100, used: 20, remaining: 80 }],
       "daily-spending-used": 20,
-      "daily-spending-remaining": 80,
-    };
-    const unlimited: ApiKeyEntry = {
-      key: "sk-free",
-      name: "Free",
-      "daily-spending-limit": 0,
-      "daily-spending-used": 5,
-      "daily-spending-remaining": null,
+      "lifetime-spending-used": 300.12,
     };
     const columns = createColumns();
-    const spendingColumn = columns.find((column) => column.key === "dailySpending");
-    const { container: limitedContainer } = render(
-      <div>{spendingColumn?.render(limited, 0)}</div>,
+    const quotaColumn = columns.find((column) => column.key === "quota");
+    const dailyColumn = columns.find((column) => column.key === "dailySpending");
+    const lifetimeColumn = columns.find((column) => column.key === "lifetimeSpending");
+    const { container } = render(
+      <div>
+        <div>{quotaColumn?.render(limited, 0)}</div>
+        <div>{dailyColumn?.render(limited, 0)}</div>
+        <div>{lifetimeColumn?.render(limited, 0)}</div>
+      </div>,
     );
-    const { container: unlimitedContainer } = render(
-      <div>{spendingColumn?.render(unlimited, 1)}</div>,
-    );
-    expect(limitedContainer.textContent).toContain("$20.00");
-    expect(limitedContainer.textContent).toContain("$100.00");
-    expect(unlimitedContainer.textContent).toContain("$5.00");
-    expect(unlimitedContainer.textContent).toContain("Unlimited");
+    expect(container.textContent).toContain("$20 / $100");
+    expect(container.textContent).toContain("$20.00");
+    expect(container.textContent).toContain("$300.12");
   });
 
   test("disables reset today spending without a daily limit and calls handler when enabled", async () => {
@@ -333,7 +341,9 @@ describe("ApiKeyColumns", () => {
     const actionsColumn = columns.find((column) => column.key === "actions");
 
     const { rerender } = render(<div>{actionsColumn?.render(unlimited, 0)}</div>);
-    expect(screen.getByRole("button", { name: "Set a daily spending limit before resetting" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Set a daily spending limit before resetting" }),
+    ).toBeDisabled();
 
     rerender(<div>{actionsColumn?.render(limited, 1)}</div>);
     const enabled = screen.getByRole("button", { name: "Reset today spending" });

--- a/pages/api-keys/types.ts
+++ b/pages/api-keys/types.ts
@@ -1,3 +1,5 @@
+import type { PeriodSpendingDraft } from "@features/period-spending";
+
 export interface ApiKeyFormValues {
   name: string;
   key: string;
@@ -5,6 +7,7 @@ export interface ApiKeyFormValues {
   dailyLimit: string;
   totalQuota: string;
   spendingLimit: string;
+  periodSpending: PeriodSpendingDraft;
   concurrencyLimit: string;
   rpmLimit: string;
   tpmLimit: string;

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -2,8 +2,6 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type FormEve
 import { useTranslation } from "react-i18next";
 import {
   BarChart3,
-  Infinity as InfinityIcon,
-  Info,
   Key,
   KeyRound,
   Pencil,
@@ -27,7 +25,6 @@ import {
   Card,
   ConfirmModal,
   DataTable,
-  HoverTooltip,
   Modal,
   SecretRevealModal,
   Select,
@@ -42,61 +39,58 @@ import { ErrorDetailModal, LogContentModal } from "@features/log-content-viewer"
 import { ApiKeyUsageModal } from "../api-keys/components/ApiKeyUsageModal";
 import { useApiKeyUsageView } from "../api-keys/hooks/useApiKeyUsageView";
 import { EndUserResetHistoryModal } from "./components/EndUserResetHistoryModal";
+import {
+  PeriodSpendingCell,
+  PeriodSpendingFields,
+  emptyPeriodSpendingDraft,
+  formatQuotaValidationError,
+  formatQuotaUsdAmount,
+  limitsToPeriodSpendingDraft,
+  periodSpendingDraftToLimits,
+  type PeriodSpendingDraft,
+} from "@features/period-spending";
+import { normalizePeriodSpendingLimits } from "@code-proxy/api-client";
 
-const emptyForm = { username: "", displayName: "", password: "", permissionProfileId: "" };
+type EndUserForm = {
+  username: string;
+  displayName: string;
+  password: string;
+  permissionProfileId: string;
+  spendingLimit: string;
+  dailyLimit: string;
+  totalQuota: string;
+  concurrencyLimit: string;
+  rpmLimit: string;
+  tpmLimit: string;
+  periodSpending: PeriodSpendingDraft;
+};
 
-function formatAccountLimit(limit: number | undefined, unlimitedLabel: string) {
-  if (!limit || limit <= 0) {
-    return (
-      <span className="inline-flex items-center justify-center gap-1 text-green-600 dark:text-green-400">
-        <InfinityIcon size={14} /> {unlimitedLabel}
-      </span>
-    );
-  }
-  return <span className="tabular-nums">{limit.toLocaleString()}</span>;
-}
+const emptyForm = (): EndUserForm => ({
+  username: "",
+  displayName: "",
+  password: "",
+  permissionProfileId: "",
+  spendingLimit: "",
+  dailyLimit: "",
+  totalQuota: "",
+  concurrencyLimit: "",
+  rpmLimit: "",
+  tpmLimit: "",
+  periodSpending: emptyPeriodSpendingDraft(),
+});
 
-function formatAccountSpending(limit: number | undefined, unlimitedLabel: string) {
-  if (!limit || limit <= 0 || !Number.isFinite(limit)) {
-    return (
-      <span className="inline-flex items-center justify-center gap-1 text-green-600 dark:text-green-400">
-        <InfinityIcon size={14} /> {unlimitedLabel}
-      </span>
-    );
-  }
-  return (
-    <span className="tabular-nums">
-      {new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-        maximumFractionDigits: 2,
-      }).format(limit)}
-    </span>
-  );
-}
+const spendingLimitFromText = (value: string): number => {
+  const parsed = Number.parseFloat(value.trim());
+  return Number.isFinite(parsed) && parsed > 0 ? Math.ceil(parsed) : 0;
+};
 
-function formatTodaySpending(
-  used: number | undefined,
-  limit: number | undefined,
-  unlimitedLabel: string,
-) {
-  if (!limit || limit <= 0 || !Number.isFinite(limit)) {
-    return (
-      <span className="inline-flex items-center justify-center gap-1 text-green-600 dark:text-green-400">
-        <InfinityIcon size={14} /> {unlimitedLabel}
-      </span>
-    );
-  }
-  const format = (value: number) =>
-    new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(
-      Number.isFinite(value) ? Math.max(0, value) : 0,
-    );
-  return (
-    <span className="tabular-nums">
-      {format(used ?? 0)}/{format(limit)}$
-    </span>
-  );
-}
+const requestLimitFromText = (value: string): number => {
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const limitToText = (value: number | undefined): string =>
+  value && value > 0 ? String(value) : "";
 
 const stickyActionsHeaderClass =
   "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
@@ -113,10 +107,10 @@ export function EndUsersPage() {
   const [users, setUsers] = useState<EndUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
-  const [form, setForm] = useState(emptyForm);
+  const [form, setForm] = useState<EndUserForm>(() => emptyForm());
   const [createdSecrets, setCreatedSecrets] = useState<CreateEndUserResult | null>(null);
   const [editUser, setEditUser] = useState<EndUser | null>(null);
-  const [editForm, setEditForm] = useState(emptyForm);
+  const [editForm, setEditForm] = useState<EndUserForm>(() => emptyForm());
   const [resetUser, setResetUser] = useState<EndUser | null>(null);
   const [generatedReset, setGeneratedReset] = useState("");
   const [deleteUser, setDeleteUser] = useState<EndUser | null>(null);
@@ -131,8 +125,6 @@ export function EndUsersPage() {
   const [busy, setBusy] = useState(false);
   const [permissionProfiles, setPermissionProfiles] = useState<ApiKeyPermissionProfile[]>([]);
   const canWrite = can("end_users.write");
-  const unlimitedLabel = t("api_keys_page.unlimited", { defaultValue: "无限制" });
-  const todayUnlimitedLabel = t("end_users.unlimited", { defaultValue: "未限制" });
   const { refreshPermissionOptions } = useApiKeyPermissionOptions();
   const {
     usageViewKey,
@@ -217,6 +209,15 @@ export function EndUsersPage() {
     [permissionProfiles, t],
   );
 
+  const selectedEditProfile = useMemo(
+    () =>
+      editForm.permissionProfileId
+        ? (permissionProfiles.find((profile) => profile.id === editForm.permissionProfileId) ??
+          null)
+        : null,
+    [editForm.permissionProfileId, permissionProfiles],
+  );
+
   const setFrozen = useCallback(
     async (row: EndUser, frozen: boolean) => {
       setBusy(true);
@@ -241,36 +242,21 @@ export function EndUsersPage() {
   const resetTodaySpending = useCallback(
     async (row: EndUser) => {
       // ponytail: same gate as API Key list — unlimited daily spending has nothing to reset
-      if (!((row["daily-spending-limit"] ?? 0) > 0)) return;
+      if (
+        normalizePeriodSpendingLimits(row["period-spending-limits"], row["daily-spending-limit"])
+          .day <= 0
+      )
+        return;
       setBusy(true);
       try {
-        const result = await endUsersApi.resetDailySpending(row.id);
+        await endUsersApi.resetDailySpending(row.id);
         notify({
           type: "success",
           message: t("end_users.reset_today_spending_success", {
             defaultValue: "已重置该账号今日消费",
           }),
         });
-        const resetCount = result["daily-spending-reset-count"];
-        if (typeof resetCount === "number" && Number.isFinite(resetCount)) {
-          const dailySpendingUsed = result["daily-spending-used"];
-          setUsers((current) =>
-            current.map((user) =>
-              user.id === row.id
-                ? {
-                    ...user,
-                    "daily-spending-reset-count": resetCount,
-                    "daily-spending-used":
-                      typeof dailySpendingUsed === "number" && Number.isFinite(dailySpendingUsed)
-                        ? dailySpendingUsed
-                        : user["daily-spending-used"],
-                  }
-                : user,
-            ),
-          );
-        } else {
-          await load();
-        }
+        await load();
       } catch (e) {
         notify({ type: "error", message: e instanceof Error ? e.message : "failed" });
       } finally {
@@ -349,214 +335,130 @@ export function EndUsersPage() {
   const columns = useMemo<DataTableColumn<EndUser>[]>(
     () => [
       {
-        key: "username",
-        label: t("end_users.username", { defaultValue: "用户名" }),
+        key: "account",
+        label: t("end_users.username"),
         width: "w-56 min-w-[14rem]",
         minWidthPx: 160,
         maxWidthPx: 480,
         headerClassName: "text-left",
         cellClassName: "text-left",
-        render: (row) => {
-          const extraKeys = Math.max(0, (row.api_key_count ?? 0) - 1);
-          return (
-            <div className="min-w-0">
-              <div className="flex min-w-0 items-center gap-1.5">
-                <span className="truncate font-medium text-slate-900 dark:text-white">
-                  {row.display_name}
-                </span>
-                {extraKeys > 0 ? (
-                  <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-2xs font-medium text-slate-600 dark:bg-white/10 dark:text-white/70">
-                    +{extraKeys}
-                  </span>
-                ) : null}
-              </div>
-              <div className="truncate text-xs text-slate-400">{row.username}</div>
+        render: (row) => (
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="truncate font-medium text-slate-900 dark:text-white">
+                {row.display_name}
+              </span>
+              <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-2xs font-medium text-slate-600 dark:bg-white/10 dark:text-white/70">
+                {row.api_key_count ?? 0} Key
+              </span>
             </div>
-          );
-        },
+            <div className="truncate text-xs text-slate-400">{row.username}</div>
+          </div>
+        ),
       },
       {
         key: "status",
-        label: t("end_users.status", { defaultValue: "状态" }),
+        label: t("end_users.status"),
         width: "w-28 min-w-[7rem]",
-        minWidthPx: 96,
-        maxWidthPx: 220,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (row) => {
           const active = row.status === "active";
           return (
             <span
-              className={[
-                "inline-flex rounded-full px-2.5 py-1 text-xs font-medium",
-                active
-                  ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300"
-                  : "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300",
-              ].join(" ")}
+              className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${active ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300" : "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300"}`}
             >
-              {active
-                ? t("end_users.status_active", { defaultValue: "激活" })
-                : t("end_users.status_frozen", { defaultValue: "冻结" })}
+              {active ? t("end_users.status_active") : t("end_users.status_frozen")}
             </span>
           );
         },
       },
       {
         key: "permission",
-        label: t("end_users.account_permission_profile", { defaultValue: "账户权限模板" }),
-        width: "w-36 min-w-[9rem]",
-        minWidthPx: 120,
-        maxWidthPx: 280,
+        label: t("end_users.account_permission_profile"),
+        width: "w-40 min-w-[10rem]",
         headerClassName: "text-center",
         cellClassName: "text-center text-slate-700 dark:text-white/70",
         render: (row) => {
           const id = row["permission-profile-id"]?.trim() ?? "";
-          if (!id) {
-            return (
-              <span className="text-green-600 dark:text-green-400">
-                {t("api_keys_page.permission_profile_unrestricted", { defaultValue: "不限制" })}
-              </span>
-            );
-          }
-          return profileNameById.get(id) || id;
+          return id
+            ? profileNameById.get(id) || id
+            : t("api_keys_page.permission_profile_unrestricted");
         },
       },
       {
-        key: "dailyLimit",
-        label: t("api_keys_page.col_daily_limit", { defaultValue: "每日限额" }),
-        width: "w-[120px] min-w-[110px]",
-        minWidthPx: 100,
-        maxWidthPx: 180,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) => formatAccountLimit(row["daily-limit"], unlimitedLabel),
+        key: "quota",
+        label: t("quota.period_spending_column"),
+        width: "w-[390px] min-w-[280px]",
+        render: (row) => <PeriodSpendingCell t={t} items={row["period-spending"]} />,
       },
       {
-        key: "todaySpending",
-        label: t("end_users.today_spending", { defaultValue: "今日用量" }),
-        width: "w-[140px] min-w-[130px]",
-        minWidthPx: 120,
-        maxWidthPx: 220,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) =>
-          formatTodaySpending(
-            row["daily-spending-used"],
-            row["daily-spending-limit"],
-            todayUnlimitedLabel,
-          ),
+        key: "dailySpending",
+        label: t("quota.daily_spending_column"),
+        width: "w-[130px] min-w-[130px]",
+        cellClassName:
+          "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+        render: (row) => formatQuotaUsdAmount(row["daily-spending-used"]),
       },
       {
-        key: "dailySpendingResetCount",
-        label: t("end_users.daily_reset_count", { defaultValue: "当日重置次数" }),
-        width: "w-[120px] min-w-[110px]",
-        minWidthPx: 100,
-        maxWidthPx: 180,
+        key: "lifetimeSpending",
+        label: t("quota.lifetime_spending_column"),
+        width: "w-[130px] min-w-[130px]",
+        cellClassName:
+          "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+        render: (row) => formatQuotaUsdAmount(row["lifetime-spending-used"]),
+      },
+      {
+        key: "totalResets",
+        label: t("quota.total_resets"),
+        width: "w-[120px] min-w-[120px]",
         headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        headerRender: () => (
-          <HoverTooltip
-            content={t("end_users.reset_count_help", {
-              defaultValue: "该用户今日消费额度被手动重置的次数。点击可查看所有日期的详细历史。",
-            })}
-            className="inline-flex items-center gap-1"
-          >
-            <span>{t("end_users.daily_reset_count", { defaultValue: "当日重置次数" })}</span>
-            <Info size={12} className="text-slate-400 dark:text-white/40" />
-          </HoverTooltip>
-        ),
+        cellClassName: "text-center",
         render: (row) => {
           const count = row["daily-spending-reset-count"] ?? 0;
-          if (count <= 0) {
-            return <span className="tabular-nums text-slate-400 dark:text-white/40">0</span>;
-          }
-          return (
+          return count > 0 ? (
             <button
               type="button"
               onClick={() => void handleViewResetHistory(row)}
               className="tabular-nums font-medium text-orange-600 underline-offset-2 hover:underline dark:text-orange-400"
-              aria-label={t("end_users.view_reset_history", { defaultValue: "查看重置历史" })}
+              aria-label={t("end_users.view_reset_history")}
             >
               {count}
             </button>
+          ) : (
+            <span className="tabular-nums text-slate-400 dark:text-white/40">0</span>
           );
         },
       },
       {
-        key: "totalQuota",
-        label: t("api_keys_page.col_total_quota", { defaultValue: "总配额" }),
-        width: "w-[120px] min-w-[110px]",
-        minWidthPx: 100,
-        maxWidthPx: 180,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) => formatAccountLimit(row["total-quota"], unlimitedLabel),
-      },
-      {
-        key: "spendingLimit",
-        label: t("api_keys_page.col_spending_limit", { defaultValue: "消费限额" }),
-        width: "w-[130px] min-w-[120px]",
-        minWidthPx: 110,
-        maxWidthPx: 200,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) => formatAccountSpending(row["spending-limit"], unlimitedLabel),
-      },
-      {
-        key: "rpmLimit",
-        label: "RPM",
-        width: "w-[100px] min-w-[90px]",
-        minWidthPx: 80,
-        maxWidthPx: 140,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) => formatAccountLimit(row["rpm-limit"], unlimitedLabel),
-      },
-      {
-        key: "tpmLimit",
-        label: "TPM",
-        width: "w-[100px] min-w-[90px]",
-        minWidthPx: 80,
-        maxWidthPx: 140,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) => formatAccountLimit(row["tpm-limit"], unlimitedLabel),
-      },
-      {
-        key: "last_login",
-        label: t("end_users.last_login", { defaultValue: "最近登录" }),
-        width: "w-48 min-w-[12rem]",
-        minWidthPx: 140,
-        maxWidthPx: 320,
-        headerClassName: "text-center",
-        cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
-        render: (row) => row.last_login_at?.slice(0, 19).replace("T", " ") || "—",
+        key: "lastLogin",
+        label: t("end_users.last_login"),
+        width: "w-[160px] min-w-[160px]",
+        cellClassName: "text-center text-xs text-slate-500 dark:text-white/50",
+        render: (row) => (row.last_login_at ? new Date(row.last_login_at).toLocaleString() : "-"),
       },
       {
         key: "actions",
-        label: t("common.actions", { defaultValue: "操作" }),
-        width: "w-64 min-w-[16rem]",
-        minWidthPx: 240,
-        maxWidthPx: 320,
-        resizable: false,
+        label: t("common.action"),
+        width: "w-[280px] min-w-[260px]",
         lockOrder: "end",
         headerClassName: stickyActionsHeaderClass,
         cellClassName: stickyActionsCellClass,
         render: (row) => {
-          const hasDailyLimit = (row["daily-spending-limit"] ?? 0) > 0;
+          const hasDailyLimit =
+            normalizePeriodSpendingLimits(
+              row["period-spending-limits"],
+              row["daily-spending-limit"],
+            ).day > 0;
           const resetLabel = hasDailyLimit
-            ? t("end_users.reset_today_spending", {
-                defaultValue: "重置账号今日消费",
-              })
-            : t("end_users.reset_today_spending_disabled", {
-                defaultValue: "请先在权限配置中设置每日消费额度后再重置",
-              });
+            ? t("end_users.reset_today_spending")
+            : t("end_users.reset_today_spending_disabled");
           return (
             <div className="flex items-center justify-center gap-1">
               <Button
                 size="sm"
                 variant="ghost"
-                title={t("end_users.view_usage", { defaultValue: "查看用量" })}
+                title={t("end_users.view_usage")}
                 onClick={() => void handleViewUserUsage(row)}
               >
                 <BarChart3 className="h-4 w-4" />
@@ -565,7 +467,7 @@ export function EndUsersPage() {
                 <Button
                   size="sm"
                   variant="ghost"
-                  title={t("end_users.manage_keys", { defaultValue: "管理密钥" })}
+                  title={t("end_users.manage_keys")}
                   onClick={() => setKeysUser(row)}
                 >
                   <Key className="h-4 w-4" />
@@ -575,14 +477,34 @@ export function EndUsersPage() {
                 <Button
                   size="sm"
                   variant="ghost"
-                  title={t("end_users.edit", { defaultValue: "编辑" })}
+                  title={t("end_users.edit")}
                   onClick={() => {
+                    const profile = row["permission-profile-id"]
+                      ? (permissionProfiles.find(
+                          (item) => item.id === row["permission-profile-id"],
+                        ) ?? null)
+                      : null;
                     setEditUser(row);
                     setEditForm({
                       username: row.username,
                       displayName: row.display_name,
                       password: "",
                       permissionProfileId: row["permission-profile-id"] ?? "",
+                      spendingLimit: limitToText(row["spending-limit"]),
+                      dailyLimit: limitToText(profile?.["daily-limit"] ?? row["daily-limit"]),
+                      totalQuota: limitToText(profile?.["total-quota"] ?? row["total-quota"]),
+                      concurrencyLimit: limitToText(
+                        profile?.["concurrency-limit"] ?? row["concurrency-limit"],
+                      ),
+                      rpmLimit: limitToText(profile?.["rpm-limit"] ?? row["rpm-limit"]),
+                      tpmLimit: limitToText(profile?.["tpm-limit"] ?? row["tpm-limit"]),
+                      periodSpending: limitsToPeriodSpendingDraft(
+                        profile?.["period-spending-limits"] ??
+                          normalizePeriodSpendingLimits(
+                            row["period-spending-limits"],
+                            row["daily-spending-limit"],
+                          ),
+                      ),
                     });
                   }}
                 >
@@ -595,7 +517,7 @@ export function EndUsersPage() {
                     size="sm"
                     variant="ghost"
                     disabled={busy}
-                    title={t("end_users.freeze", { defaultValue: "冻结账号" })}
+                    title={t("end_users.freeze")}
                     onClick={() => void setFrozen(row, true)}
                   >
                     <Snowflake className="h-4 w-4" />
@@ -605,7 +527,7 @@ export function EndUsersPage() {
                     size="sm"
                     variant="ghost"
                     disabled={busy}
-                    title={t("end_users.activate", { defaultValue: "激活账号" })}
+                    title={t("end_users.activate")}
                     onClick={() => void setFrozen(row, false)}
                   >
                     <Unlock className="h-4 w-4" />
@@ -627,14 +549,19 @@ export function EndUsersPage() {
                 <Button
                   size="sm"
                   variant="ghost"
-                  title="重置密码"
+                  title={t("end_users.reset_password")}
                   onClick={() => setResetUser(row)}
                 >
                   <KeyRound className="h-4 w-4" />
                 </Button>
               ) : null}
               {canWrite ? (
-                <Button size="sm" variant="ghost" title="删除" onClick={() => setDeleteUser(row)}>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  title={t("common.delete")}
+                  onClick={() => setDeleteUser(row)}
+                >
                   <Trash2 className="h-4 w-4" />
                 </Button>
               ) : null}
@@ -649,12 +576,11 @@ export function EndUsersPage() {
       canWrite,
       handleViewResetHistory,
       handleViewUserUsage,
+      permissionProfiles,
       profileNameById,
       resetTodaySpending,
       setFrozen,
       t,
-      todayUnlimitedLabel,
-      unlimitedLabel,
     ],
   );
 
@@ -668,7 +594,7 @@ export function EndUsersPage() {
         password: form.password || undefined,
       });
       setCreateOpen(false);
-      setForm(emptyForm);
+      setForm(emptyForm());
       if (result.generated_password || result.default_api_key?.key) {
         setCreatedSecrets(result);
       } else {
@@ -710,58 +636,88 @@ export function EndUsersPage() {
       const nextUsername = editForm.username.trim();
       const nextDisplay = editForm.displayName.trim();
       const nextProfile = editForm.permissionProfileId.trim();
+      const prevProfile = (editUser["permission-profile-id"] ?? "").trim();
+      const nextSpendingLimit = spendingLimitFromText(editForm.spendingLimit);
+      const previousSpendingLimit = editUser["spending-limit"] ?? 0;
+      const directLimits = {
+        "daily-limit": requestLimitFromText(editForm.dailyLimit),
+        "total-quota": requestLimitFromText(editForm.totalQuota),
+        "concurrency-limit": requestLimitFromText(editForm.concurrencyLimit),
+        "rpm-limit": requestLimitFromText(editForm.rpmLimit),
+        "tpm-limit": requestLimitFromText(editForm.tpmLimit),
+      };
+
       if (nextUsername && nextUsername !== editUser.username) body.username = nextUsername;
       if (nextDisplay && nextDisplay !== editUser.display_name) body.display_name = nextDisplay;
       if (editForm.password.trim()) body.password = editForm.password;
-      const prevProfile = (editUser["permission-profile-id"] ?? "").trim();
+      if (nextSpendingLimit !== previousSpendingLimit) {
+        body["spending-limit"] = nextSpendingLimit;
+      }
+
       if (nextProfile !== prevProfile) {
         body["permission-profile-id"] = nextProfile;
-        // Applying a profile: copy limits from template; empty = unrestricted account.
-        if (nextProfile) {
-          const profile = permissionProfiles.find((p) => p.id === nextProfile);
-          if (profile) {
-            body["daily-limit"] = profile["daily-limit"];
-            body["total-quota"] = profile["total-quota"];
-            body["spending-limit"] = 0;
-            body["daily-spending-limit"] = profile["daily-spending-limit"];
-            body["concurrency-limit"] = profile["concurrency-limit"];
-            body["rpm-limit"] = profile["rpm-limit"];
-            body["tpm-limit"] = profile["tpm-limit"];
-            body["allowed-models"] = [...profile["allowed-models"]];
-            body["allowed-channels"] = [...profile["allowed-channels"]];
-            body["allowed-channel-groups"] = [...profile["allowed-channel-groups"]];
-            body["system-prompt"] = profile["system-prompt"];
-          }
-        } else {
-          body["daily-limit"] = 0;
-          body["total-quota"] = 0;
-          body["spending-limit"] = 0;
-          body["daily-spending-limit"] = 0;
-          body["concurrency-limit"] = 0;
-          body["rpm-limit"] = 0;
-          body["tpm-limit"] = 0;
-          body["allowed-models"] = [];
-          body["allowed-channels"] = [];
-          body["allowed-channel-groups"] = [];
-          body["system-prompt"] = "";
+      }
+
+      const profile = nextProfile
+        ? (permissionProfiles.find((item) => item.id === nextProfile) ?? null)
+        : null;
+      if (profile && nextProfile !== prevProfile) {
+        body["daily-limit"] = profile["daily-limit"];
+        body["total-quota"] = profile["total-quota"];
+        body["concurrency-limit"] = profile["concurrency-limit"];
+        body["rpm-limit"] = profile["rpm-limit"];
+        body["tpm-limit"] = profile["tpm-limit"];
+        body["allowed-models"] = [...profile["allowed-models"]];
+        body["allowed-channels"] = [...profile["allowed-channels"]];
+        body["allowed-channel-groups"] = [...profile["allowed-channel-groups"]];
+        body["system-prompt"] = profile["system-prompt"];
+      }
+
+      if (!profile) {
+        if (directLimits["daily-limit"] !== (editUser["daily-limit"] ?? 0)) {
+          body["daily-limit"] = directLimits["daily-limit"];
+        }
+        if (directLimits["total-quota"] !== (editUser["total-quota"] ?? 0)) {
+          body["total-quota"] = directLimits["total-quota"];
+        }
+        if (directLimits["concurrency-limit"] !== (editUser["concurrency-limit"] ?? 0)) {
+          body["concurrency-limit"] = directLimits["concurrency-limit"];
+        }
+        if (directLimits["rpm-limit"] !== (editUser["rpm-limit"] ?? 0)) {
+          body["rpm-limit"] = directLimits["rpm-limit"];
+        }
+        if (directLimits["tpm-limit"] !== (editUser["tpm-limit"] ?? 0)) {
+          body["tpm-limit"] = directLimits["tpm-limit"];
+        }
+        const nextLimits = periodSpendingDraftToLimits(editForm.periodSpending);
+        const previousLimits = normalizePeriodSpendingLimits(
+          editUser["period-spending-limits"],
+          editUser["daily-spending-limit"],
+        );
+        if (JSON.stringify(nextLimits) !== JSON.stringify(previousLimits)) {
+          body["daily-spending-limit"] = nextLimits.day;
+          body["period-spending-limits"] = nextLimits;
         }
       }
-      if (
-        !body.username &&
-        !body.display_name &&
-        !body.password &&
-        body["permission-profile-id"] === undefined
-      ) {
+
+      if (Object.keys(body).length === 0) {
         setEditUser(null);
         return;
       }
-      await endUsersApi.update(editUser.id, body);
-      notify({ type: "success", message: t("end_users.updated", { defaultValue: "已保存" }) });
+      const updated = await endUsersApi.update(editUser.id, body);
+      notify({
+        type: "success",
+        message: updated["capped-keys"]?.length
+          ? t("api_key_permissions_page.saved_with_caps", {
+              keys: updated["capped-keys"].length,
+            })
+          : t("end_users.updated"),
+      });
       setEditUser(null);
-      setEditForm(emptyForm);
+      setEditForm(emptyForm());
       await load();
     } catch (err) {
-      notify({ type: "error", message: err instanceof Error ? err.message : "failed" });
+      notify({ type: "error", message: formatQuotaValidationError(err, t) });
     } finally {
       setBusy(false);
     }
@@ -811,7 +767,7 @@ export function EndUsersPage() {
             rowHeight={60}
             height="h-[calc(100dvh-260px)] md:h-auto md:flex-1"
             minHeight="min-h-[320px] md:min-h-0"
-            minWidth="min-w-[1100px]"
+            minWidth="min-w-[1720px]"
             emptyText={t("end_users.empty", { defaultValue: "暂无用户账号" })}
             showAllLoadedMessage={false}
             columnResizable
@@ -910,16 +866,16 @@ export function EndUsersPage() {
         open={Boolean(editUser)}
         onClose={() => {
           setEditUser(null);
-          setEditForm(emptyForm);
+          setEditForm(emptyForm());
         }}
         title={t("end_users.edit", { defaultValue: "编辑用户账号" })}
-        maxWidth="max-w-xl"
+        maxWidth="max-w-2xl"
         footer={
           <>
             <Button
               onClick={() => {
                 setEditUser(null);
-                setEditForm(emptyForm);
+                setEditForm(emptyForm());
               }}
             >
               {t("common.cancel")}
@@ -974,7 +930,23 @@ export function EndUsersPage() {
             </span>
             <Select
               value={editForm.permissionProfileId}
-              onChange={(value) => setEditForm((f) => ({ ...f, permissionProfileId: value }))}
+              onChange={(value) => {
+                const profile = permissionProfiles.find((item) => item.id === value);
+                setEditForm((current) => ({
+                  ...current,
+                  permissionProfileId: value,
+                  dailyLimit: profile ? limitToText(profile["daily-limit"]) : current.dailyLimit,
+                  totalQuota: profile ? limitToText(profile["total-quota"]) : current.totalQuota,
+                  concurrencyLimit: profile
+                    ? limitToText(profile["concurrency-limit"])
+                    : current.concurrencyLimit,
+                  rpmLimit: profile ? limitToText(profile["rpm-limit"]) : current.rpmLimit,
+                  tpmLimit: profile ? limitToText(profile["tpm-limit"]) : current.tpmLimit,
+                  periodSpending: profile
+                    ? limitsToPeriodSpendingDraft(profile["period-spending-limits"])
+                    : current.periodSpending,
+                }));
+              }}
               options={permissionProfileOptions}
               aria-label={t("end_users.account_permission_profile", {
                 defaultValue: "账户权限模板",
@@ -989,6 +961,98 @@ export function EndUsersPage() {
               })}
             </p>
           </label>
+          <section className="rounded-2xl border border-indigo-200/80 bg-indigo-50/45 p-4 dark:border-indigo-500/20 dark:bg-indigo-500/5">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("end_users.quota_preview")}
+            </h3>
+            <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
+              {selectedEditProfile
+                ? t("end_users.quota_profile_readonly_hint", { profile: selectedEditProfile.name })
+                : t("end_users.quota_direct_edit_hint")}
+            </p>
+            <PeriodSpendingFields
+              t={t}
+              value={
+                selectedEditProfile
+                  ? limitsToPeriodSpendingDraft(selectedEditProfile["period-spending-limits"])
+                  : editForm.periodSpending
+              }
+              onChange={(periodSpending) =>
+                setEditForm((current) => ({ ...current, periodSpending }))
+              }
+              disabled={Boolean(selectedEditProfile)}
+              idPrefix="end-user-period"
+            />
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 p-4 dark:border-white/10">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+              {t("end_users.other_limits")}
+            </h3>
+            <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
+              {selectedEditProfile
+                ? t("end_users.other_limits_profile_readonly_hint", {
+                    profile: selectedEditProfile.name,
+                  })
+                : t("end_users.other_limits_direct_hint")}
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {(
+                [
+                  ["dailyLimit", "api_keys_page.form_daily_limit"],
+                  ["totalQuota", "api_keys_page.form_total_quota"],
+                  ["concurrencyLimit", "api_keys_page.form_concurrency_limit"],
+                  ["rpmLimit", "api_keys_page.form_rpm_limit"],
+                  ["tpmLimit", "api_keys_page.form_tpm_limit"],
+                ] as const
+              ).map(([field, labelKey]) => (
+                <label key={field} className="block space-y-1.5">
+                  <span className="text-sm font-medium text-slate-700 dark:text-white/80">
+                    {t(labelKey)}
+                  </span>
+                  <TextInput
+                    type="number"
+                    min={0}
+                    step={1}
+                    inputMode="numeric"
+                    value={editForm[field]}
+                    disabled={Boolean(selectedEditProfile)}
+                    aria-label={t(labelKey)}
+                    placeholder={t("quota.input_unlimited")}
+                    onChange={(event) => {
+                      const raw = event.target.value;
+                      if (raw === "" || /^\d+$/.test(raw)) {
+                        setEditForm((current) => ({ ...current, [field]: raw }));
+                      }
+                    }}
+                  />
+                </label>
+              ))}
+              <label className="block space-y-1.5 sm:col-span-2 lg:col-span-1">
+                <span className="text-sm font-medium text-slate-700 dark:text-white/80">
+                  {t("end_users.lifetime_spending_limit")}
+                </span>
+                <TextInput
+                  type="number"
+                  min={0}
+                  step={1}
+                  inputMode="numeric"
+                  value={editForm.spendingLimit}
+                  aria-label={t("end_users.lifetime_spending_limit")}
+                  placeholder={t("quota.input_unlimited")}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    if (raw === "" || /^\d*(?:\.\d*)?$/.test(raw)) {
+                      setEditForm((current) => ({ ...current, spendingLimit: raw }));
+                    }
+                  }}
+                />
+                <span className="block text-xs text-slate-400 dark:text-white/40">
+                  {t("end_users.lifetime_spending_limit_hint")}
+                </span>
+              </label>
+            </div>
+          </section>
         </form>
       </Modal>
 
@@ -1053,7 +1117,14 @@ export function EndUsersPage() {
               </div>
             }
           >
-            <ApiKeysPage endUserId={keysUser.id} embed />
+            <ApiKeysPage
+              endUserId={keysUser.id}
+              accountPeriodSpendingLimits={normalizePeriodSpendingLimits(
+                keysUser["period-spending-limits"],
+                keysUser["daily-spending-limit"],
+              )}
+              embed
+            />
           </Suspense>
         ) : null}
       </Modal>

--- a/pages/end-users/__tests__/EndUsersPage.test.tsx
+++ b/pages/end-users/__tests__/EndUsersPage.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ThemeProvider, ToastProvider } from "@code-proxy/ui";
 import i18n from "@code-proxy/i18n";
+import type { ApiKeyPermissionProfile } from "@code-proxy/api-client";
 import { EndUsersPage } from "../EndUsersPage";
 
 const mocks = vi.hoisted(() => ({
@@ -10,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   update: vi.fn(),
   resetDailySpending: vi.fn(),
   listDailySpendingResetHistory: vi.fn(),
-  permissionProfiles: vi.fn(async () => []),
+  permissionProfiles: vi.fn(async (): Promise<ApiKeyPermissionProfile[]> => []),
 }));
 
 vi.mock("@app/guards/PermissionGate", () => ({
@@ -22,7 +23,8 @@ vi.mock("@app/providers/AuthProvider", () => ({
 }));
 
 vi.mock("@code-proxy/api-client", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@code-proxy/api-client")>();
+  const actual =
+    await importOriginal<typeof import("@code-proxy/api-client")>();
   return {
     ...actual,
     apiKeyPermissionProfilesApi: { list: mocks.permissionProfiles },
@@ -49,8 +51,11 @@ const users = [
     version: 1,
     api_key_count: 2,
     "daily-spending-used": 12,
+    "lifetime-spending-used": 88.7,
     "daily-spending-reset-count": 0,
     "daily-spending-limit": 0,
+    "period-spending-limits": { "5h": 0, day: 0, week: 0, month: 0 },
+    "period-spending": [],
   },
   {
     id: "user-frozen",
@@ -64,8 +69,16 @@ const users = [
     version: 1,
     api_key_count: 1,
     "daily-spending-used": 120,
+    "lifetime-spending-used": 912.34,
     "daily-spending-reset-count": 2,
     "daily-spending-limit": 300,
+    "period-spending-limits": { "5h": 100, day: 300, week: 800, month: 4000 },
+    "period-spending": [
+      { period: "5h", limit: 100, used: 95, remaining: 5 },
+      { period: "day", limit: 300, used: 120, remaining: 180 },
+      { period: "week", limit: 800, used: 220, remaining: 580 },
+      { period: "month", limit: 4000, used: 912.34, remaining: 3087.66 },
+    ],
   },
 ];
 
@@ -97,15 +110,19 @@ describe("EndUsersPage account semantics", () => {
       items: [
         {
           id: 41,
+          day_key: "2026-07-20",
           reset_at: "2026-07-20T10:00:00Z",
           actor_username: "admin-1",
+          cost_baseline: 92.25,
           effective_used_before: 12.5,
           raw_today_cost: 92.25,
         },
         {
           id: 42,
+          day_key: "2026-07-21",
           reset_at: "2026-07-21T11:00:00Z",
           actor_kind: "service_credential",
+          cost_baseline: 148.25,
           effective_used_before: 28.25,
           raw_today_cost: 148.25,
         },
@@ -123,10 +140,29 @@ describe("EndUsersPage account semantics", () => {
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getByText("Frozen")).toBeInTheDocument();
     expect(screen.getAllByText("Unlimited").length).toBeGreaterThan(0);
-    expect(screen.getByText("120/300$")).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Today usage" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Daily reset count" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "View reset history" })).toHaveTextContent("2");
+    expect(screen.getByText("$120 / $300")).toBeInTheDocument();
+    expect(screen.getByText("$95 / $100")).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Quota" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Today" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Lifetime" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Total resets" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Daily limit" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "RPM" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "View reset history" }),
+    ).toHaveTextContent("2");
     expect(
       screen.getByRole("columnheader", { name: "Account Permission Profile" }),
     ).toBeInTheDocument();
@@ -137,16 +173,162 @@ describe("EndUsersPage account semantics", () => {
       }),
     ).toBeDisabled();
 
-    await userEvent.click(screen.getByRole("button", { name: "Reset account today's spending" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Reset account today's spending" }),
+    );
     await waitFor(() => {
       expect(mocks.resetDailySpending).toHaveBeenCalledWith("user-frozen");
-      expect(screen.getByRole("button", { name: "View reset history" })).toHaveTextContent("3");
+      expect(mocks.list.mock.calls.length).toBeGreaterThan(1);
     });
 
-    await userEvent.click(screen.getByRole("button", { name: "Freeze account" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Freeze account" }),
+    );
     await waitFor(() => {
-      expect(mocks.update).toHaveBeenCalledWith("user-active", { status: "locked" });
+      expect(mocks.update).toHaveBeenCalledWith("user-active", {
+        status: "locked",
+      });
     });
+  });
+
+  test("edits unbound account quota and secondary limits directly", async () => {
+    renderPage();
+    await screen.findByText("Alice");
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Edit user account" })[0]!,
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Edit user account",
+    });
+
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "5-hour quota (USD)" }),
+      "50",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "Daily quota (USD)" }),
+      "100",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "Daily request limit" }),
+      "1000",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "Total request quota" }),
+      "9000",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", {
+        name: "Concurrent request limit",
+      }),
+      "3",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "RPM limit" }),
+      "60",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", { name: "TPM limit" }),
+      "12000",
+    );
+    await userEvent.type(
+      within(dialog).getByRole("spinbutton", {
+        name: "Lifetime spending limit (USD)",
+      }),
+      "500",
+    );
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.update).toHaveBeenCalledWith(
+        "user-active",
+        expect.objectContaining({
+          "daily-limit": 1000,
+          "total-quota": 9000,
+          "concurrency-limit": 3,
+          "rpm-limit": 60,
+          "tpm-limit": 12000,
+          "spending-limit": 500,
+          "daily-spending-limit": 100,
+          "period-spending-limits": { "5h": 50, day: 100, week: 0, month: 0 },
+        }),
+      );
+    });
+  });
+
+  test("binds a permission profile without sending a conflicting account period patch", async () => {
+    mocks.permissionProfiles.mockResolvedValueOnce([
+      {
+        id: "standard",
+        name: "Standard",
+        "daily-limit": 15000,
+        "total-quota": 50000,
+        "daily-spending-limit": 300,
+        "period-spending-limits": {
+          "5h": 100,
+          day: 300,
+          week: 800,
+          month: 4000,
+        },
+        "concurrency-limit": 4,
+        "rpm-limit": 120,
+        "tpm-limit": 50000,
+        "allowed-channel-groups": ["pro"],
+        "allowed-channels": [],
+        "allowed-models": ["gpt-5.4"],
+        "system-prompt": "Standard prompt",
+      },
+    ]);
+    renderPage();
+    await screen.findByText("Alice");
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Edit user account" })[0]!,
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Edit user account",
+    });
+    await userEvent.click(
+      within(dialog).getByRole("combobox", {
+        name: "Account Permission Profile",
+      }),
+    );
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Standard" }),
+    );
+
+    expect(
+      within(dialog).getByRole("spinbutton", { name: "Daily quota (USD)" }),
+    ).toBeDisabled();
+    expect(
+      within(dialog).getByRole("spinbutton", { name: "Daily request limit" }),
+    ).toBeDisabled();
+    expect(
+      within(dialog).getByRole("spinbutton", {
+        name: "Lifetime spending limit (USD)",
+      }),
+    ).not.toBeDisabled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.update).toHaveBeenCalledWith(
+        "user-active",
+        expect.objectContaining({
+          "permission-profile-id": "standard",
+          "daily-limit": 15000,
+          "total-quota": 50000,
+          "concurrency-limit": 4,
+          "rpm-limit": 120,
+          "tpm-limit": 50000,
+        }),
+      );
+    });
+    const updateBody = mocks.update.mock.calls.at(-1)?.[1];
+    expect(updateBody).not.toHaveProperty("daily-spending-limit");
+    expect(updateBody).not.toHaveProperty("period-spending-limits");
+    expect(updateBody).not.toHaveProperty("spending-limit");
   });
 
   test("reloads the list when reset response does not include a reset count", async () => {
@@ -158,7 +340,9 @@ describe("EndUsersPage account semantics", () => {
     renderPage();
 
     await screen.findByText("Alice");
-    await userEvent.click(screen.getByRole("button", { name: "Reset account today's spending" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Reset account today's spending" }),
+    );
 
     await waitFor(() => {
       expect(mocks.list).toHaveBeenCalledTimes(2);
@@ -168,26 +352,49 @@ describe("EndUsersPage account semantics", () => {
   test("opens all-date reset history with true and effective today spending summaries", async () => {
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: "View reset history" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View reset history" }),
+    );
 
     await waitFor(() => {
-      expect(mocks.listDailySpendingResetHistory).toHaveBeenCalledWith("user-frozen", 200);
+      expect(mocks.listDailySpendingResetHistory).toHaveBeenCalledWith(
+        "user-frozen",
+        200,
+      );
     });
-    expect(await screen.findByText("Reset history · Bob / bob")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Reset history · Bob / bob"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Today's true spend")).toBeInTheDocument();
     expect(screen.getByText("$175.50")).toBeInTheDocument();
-    expect(screen.getByText("Current effective today usage")).toBeInTheDocument();
+    expect(
+      screen.getByText("Current effective today usage"),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("$28.25").length).toBeGreaterThan(0);
-    expect(screen.getByText("$148.25")).toBeInTheDocument();
+    expect(screen.getAllByText("$148.25").length).toBeGreaterThan(0);
     expect(screen.getByText("Management key")).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Reset ID" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Reset time" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Usage before reset" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Reset ID" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Reset time" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Project day" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Usage before reset" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Stored baseline" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2026-07-21")).toBeInTheDocument();
 
     const newerId = screen.getByText("42");
     const olderId = screen.getByText("41");
     expect(
-      newerId.compareDocumentPosition(olderId) & Node.DOCUMENT_POSITION_FOLLOWING,
+      newerId.compareDocumentPosition(olderId) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 
@@ -198,10 +405,12 @@ describe("EndUsersPage account semantics", () => {
     });
     renderPage();
 
-    await userEvent.click(await screen.findByRole("button", { name: "View reset history" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "View reset history" }),
+    );
 
     expect(await screen.findByText("Not returned")).toBeInTheDocument();
-    expect(screen.getByText("$120.00")).toBeInTheDocument();
+    expect(screen.getAllByText("$120.00").length).toBeGreaterThan(0);
     expect(
       screen.getByText(
         "All manual daily-spending reset records for this account. Today's true spend was not returned, so only current effective today usage is available.",

--- a/pages/end-users/components/EndUserResetHistoryModal.tsx
+++ b/pages/end-users/components/EndUserResetHistoryModal.tsx
@@ -11,7 +11,10 @@ function formatResetAt(value: string | undefined): string {
   return date.toLocaleString();
 }
 
-function actorLabel(event: EndUserDailySpendingResetEvent, t: (key: string) => string): string {
+function actorLabel(
+  event: EndUserDailySpendingResetEvent,
+  t: (key: string) => string,
+): string {
   const name = event.actor_username?.trim();
   if (name) return name;
   if (event.actor_kind === "service_credential") {
@@ -47,7 +50,9 @@ export function EndUserResetHistoryModal({
     () =>
       [...events].sort((a, b) => {
         const timeDiff = Date.parse(b.reset_at) - Date.parse(a.reset_at);
-        return Number.isFinite(timeDiff) && timeDiff !== 0 ? timeDiff : b.id - a.id;
+        return Number.isFinite(timeDiff) && timeDiff !== 0
+          ? timeDiff
+          : b.id - a.id;
       }),
     [events],
   );
@@ -57,30 +62,56 @@ export function EndUserResetHistoryModal({
       key: "id",
       label: t("end_users.reset_history_col_id"),
       width: "w-[90px] min-w-[80px]",
-      cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      cellClassName:
+        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => row.id,
     },
     {
       key: "reset_at",
       label: t("end_users.reset_history_col_time"),
       width: "w-[190px] min-w-[170px]",
-      cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      cellClassName:
+        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => formatResetAt(row.reset_at),
+    },
+    {
+      key: "day_key",
+      label: t("end_users.reset_history_col_day"),
+      width: "w-[130px] min-w-[120px]",
+      cellClassName:
+        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      render: (row) => row.day_key || "—",
     },
     {
       key: "effective_used_before",
       label: t("end_users.reset_history_col_cleared"),
       width: "w-[160px] min-w-[140px]",
-      cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-      render: (row) => formatApiKeySpendingAmount(row.effective_used_before ?? 0),
+      cellClassName:
+        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      render: (row) =>
+        formatApiKeySpendingAmount(row.effective_used_before ?? 0),
     },
     {
       key: "raw_today_cost",
       label: t("end_users.reset_history_col_raw_today"),
       width: "w-[180px] min-w-[160px]",
-      cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      cellClassName:
+        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) =>
-        isAmount(row.raw_today_cost) ? formatApiKeySpendingAmount(row.raw_today_cost) : "—",
+        isAmount(row.raw_today_cost)
+          ? formatApiKeySpendingAmount(row.raw_today_cost)
+          : "—",
+    },
+    {
+      key: "cost_baseline",
+      label: t("end_users.reset_history_col_baseline"),
+      width: "w-[160px] min-w-[140px]",
+      cellClassName:
+        "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      render: (row) =>
+        isAmount(row.cost_baseline)
+          ? formatApiKeySpendingAmount(row.cost_baseline)
+          : "—",
     },
     {
       key: "actor",
@@ -135,7 +166,7 @@ export function EndUserResetHistoryModal({
         rowKey={(row) => String(row.id)}
         height="h-[360px]"
         minHeight="min-h-[200px]"
-        minWidth="min-w-[800px]"
+        minWidth="min-w-[1080px]"
       />
     </Modal>
   );


### PR DESCRIPTION
## Summary

- add typed multi-period USD quota contracts for end users, owned keys, permission profiles, portal reset/history, capped keys, and structured validation errors
- add shared quota chips, limits-only summaries, four-period fields, owned-key quota editor, owner/portal key table, and reset-history UI
- update End Users, account-scoped and standalone API Keys, permission profiles, and API key lookup to use the new period quota and usage contracts
- add zh-CN/en translations, cumulative reset wording, quota-scope KPIs, owner-scoped key loading, account ceiling validation, and capped-key sync toasts

## Validation

- `bun run --filter @code-proxy/admin-panel test -- packages/api-client/src/endpoints/__tests__/end-users.test.ts packages/api-client/src/endpoints/__tests__/api-key-permission-profiles.test.ts features/period-spending/__tests__/PeriodSpendingCell.test.tsx features/period-spending/__tests__/formatQuotaValidationError.test.ts features/period-spending/__tests__/OwnedApiKeyResetHistoryModal.test.tsx pages/end-users/__tests__/EndUsersPage.test.tsx pages/api-keys/__tests__/ApiKeysPage.test.tsx pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx pages/api-key-permissions/__tests__/ApiKeyPermissionsPage.test.tsx pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx pages/api-key-lookup/components/__tests__/QuotaLimitsBanner.test.tsx --reporter=dot` - 11 files, 78 tests passed
- `SKIP_E2E_CRITICAL=1 ./scripts/ci-pr.sh` - passed lint, design check, full Vitest suite (119 files, 849 tests), build, and bundle diff
- `bunx playwright test e2e/multi-tenant-auth.spec.ts e2e/login-lifecycle.spec.ts --grep '@critical' --config=playwright.ci-port.tmp.config.ts` - 9 critical browser tests passed on port 5198
- real application visual QA with Playwright management API mocks - End Users desktop/mobile, owned-key management modal, and permission profile quota editor passed
- `bun run boundary:imports` - reports 7 pre-existing import-boundary violations, including the existing `pages/end-users/EndUsersPage.tsx` to `@app/guards/PermissionGate` import

## Notes

- lint completed with 0 errors and 6 pre-existing warnings
- the default critical Playwright run initially reused an unrelated application already listening on port 5173; the same 9 tests passed against this worktree on port 5198
- no merge performed
