### PR TITLE
fix(ui): owned-key table tooltip, actions width, empty flash

### DIFF
--- a/features/period-spending/OwnedApiKeyTable.tsx
+++ b/features/period-spending/OwnedApiKeyTable.tsx
@@ -61,6 +61,8 @@ export const createOwnedApiKeyColumns = ({
     key: "key",
     label: t("api_keys_page.col_key"),
     width: "w-[220px] min-w-[220px]",
+    // Masked secret is already shown in-cell; overflow tooltip only leaks noise.
+    overflowTooltip: false,
     render: (row) => (
       <code className="block truncate rounded-md bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700 dark:bg-neutral-800 dark:text-white/70">
         {row.key_masked || row.key || row.id}
@@ -131,8 +133,11 @@ export const createOwnedApiKeyColumns = ({
   {
     key: "actions",
     label: t("api_keys_page.col_actions"),
-    width: "w-[250px] min-w-[220px]",
+    // 7 icon buttons + gaps; keep sticky actions fully visible without squeeze.
+    width: "w-[304px] min-w-[304px]",
+    minWidthPx: 304,
     lockOrder: "end",
+    overflowTooltip: false,
     headerClassName: "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800",
     cellClassName: "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950",
     render: (row) => {
@@ -141,7 +146,7 @@ export const createOwnedApiKeyColumns = ({
         (row["period-spending-limits"]?.day ?? row["daily-spending-limit"] ?? 0) > 0;
       const deletable = canDelete(row);
       return (
-        <div className="flex items-center justify-center gap-1">
+        <div className="flex flex-nowrap items-center justify-center gap-0.5">
           {actions.onToggleDisabled ? (
             <HoverTooltip
               content={
@@ -259,6 +264,7 @@ export function OwnedApiKeysTable({
   actions,
   busyKeyId,
   busy = false,
+  loading = false,
   canDelete,
   height = "h-[460px]",
 }: {
@@ -267,10 +273,23 @@ export function OwnedApiKeysTable({
   actions: OwnedApiKeyActions;
   busyKeyId?: string | null;
   busy?: boolean;
+  loading?: boolean;
   canDelete?: (key: EndUserAPIKey) => boolean;
   height?: string;
 }) {
-  if (keys.length === 0) {
+  // Avoid flashing the empty state while the owner-scoped list is still loading.
+  if (loading && keys.length === 0) {
+    return (
+      <div
+        className="flex min-h-[240px] flex-1 items-center justify-center text-sm text-slate-500 dark:text-white/55"
+        role="status"
+        aria-live="polite"
+      >
+        {t("common.loading_ellipsis")}
+      </div>
+    );
+  }
+  if (!loading && keys.length === 0) {
     return (
       <EmptyState
         title={t("api_keys_page.no_keys")}
@@ -287,8 +306,9 @@ export function OwnedApiKeysTable({
       rowKey={(row) => row.id}
       rowHeight={52}
       height={height}
+      loading={loading}
       minHeight="min-h-[320px]"
-      minWidth="min-w-[1500px]"
+      minWidth="min-w-[1580px]"
       caption={t("api_keys_page.table_caption")}
       emptyText={t("api_keys_page.no_api_keys")}
       showAllLoadedMessage={false}

--- a/features/period-spending/__tests__/OwnedApiKeyTable.test.tsx
+++ b/features/period-spending/__tests__/OwnedApiKeyTable.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { createOwnedApiKeyColumns, OwnedApiKeysTable } from "../OwnedApiKeyTable";
+
+const t = (key: string) => {
+  const labels: Record<string, string> = {
+    "api_keys_page.col_name": "Name",
+    "api_keys_page.col_key": "Key",
+    "api_keys_page.col_status": "Status",
+    "api_keys_page.col_created": "Created",
+    "api_keys_page.col_actions": "Actions",
+    "api_keys_page.no_keys": "No API keys",
+    "api_keys_page.no_keys_desc": "Create the first key.",
+    "api_keys_page.no_api_keys": "No keys",
+    "api_keys_page.table_caption": "Owned keys",
+    "api_keys_page.unnamed": "Unnamed",
+    "common.enabled": "Enabled",
+    "common.disabled": "Disabled",
+    "common.loading_ellipsis": "Loading…",
+    "quota.period_spending_column": "Quota",
+    "quota.daily_spending_column": "Today",
+    "quota.lifetime_spending_column": "Lifetime",
+    "quota.total_resets": "Resets",
+    "quota.unlimited": "Unlimited",
+  };
+  return labels[key] ?? key;
+};
+
+describe("OwnedApiKeysTable", () => {
+  test("shows loading state instead of empty while first fetch is in flight", () => {
+    render(<OwnedApiKeysTable t={t} keys={[]} loading actions={{}} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading…");
+    expect(screen.queryByText("No API keys")).not.toBeInTheDocument();
+  });
+
+  test("shows empty state only after loading finishes with no keys", () => {
+    render(<OwnedApiKeysTable t={t} keys={[]} loading={false} actions={{}} />);
+    expect(screen.getByText("No API keys")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});
+
+describe("createOwnedApiKeyColumns", () => {
+  test("disables overflow tooltip on secret and actions columns", () => {
+    const columns = createOwnedApiKeyColumns({ t, actions: {} });
+    expect(columns.find((column) => column.key === "key")?.overflowTooltip).toBe(false);
+    expect(columns.find((column) => column.key === "actions")?.overflowTooltip).toBe(false);
+    expect(columns.find((column) => column.key === "actions")?.minWidthPx).toBe(304);
+  });
+});

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1513,6 +1513,7 @@ export function ApiKeyLookupPage() {
                     t={t}
                     keys={portalKeys}
                     busy={portalKeysBusy}
+                    loading={portalKeysLoading}
                     onRotate={(key) => {
                       setPortalKeysBusy(true);
                       void portalApi

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -5,6 +5,7 @@ export function ManageKeysTabContent({
   t,
   keys,
   busy,
+  loading = false,
   onRotate,
   onDelete,
   onEdit,
@@ -14,6 +15,7 @@ export function ManageKeysTabContent({
   t: (key: string, options?: Record<string, unknown>) => string;
   keys: EndUserAPIKey[];
   busy?: boolean;
+  loading?: boolean;
   onRotate: (key: EndUserAPIKey) => void;
   onDelete: (key: EndUserAPIKey) => void;
   onEdit: (key: EndUserAPIKey) => void;
@@ -25,6 +27,7 @@ export function ManageKeysTabContent({
       t={t}
       keys={keys}
       busy={busy}
+      loading={loading}
       canDelete={() => keys.length > 1}
       height="h-[min(58vh,540px)]"
       actions={{

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -893,6 +893,7 @@ export function ApiKeysPage({
         keys={ownedKeys}
         busyKeyId={resettingDailySpendingKey}
         busy={saving}
+        loading={loading}
         canDelete={() => ownedKeys.length > 1}
         height={embed ? "min-h-0 flex-1" : "h-[calc(100dvh-260px)]"}
         actions={{


### PR DESCRIPTION
## Summary
- Disable DataTable overflow tooltip on masked secret column (no more floating full mask bubble).
- Widen sticky actions column so 7 icon buttons fit without squeeze.
- While owner-scoped keys are loading, show loading instead of flashing “暂无 API 密钥”.

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- --run features/period-spending/__tests__/OwnedApiKeyTable.test.tsx pages/api-keys/__tests__/ApiKeysPage.test.tsx`
- [x] `bun run lint` (0 errors)
- [ ] Open 管理 Key modal for an account that already has keys: no empty flash, actions fully visible, no key tooltip