### PR TITLE
feat: public API key usage page + rename portal

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2576,7 +2576,7 @@
     "version": "Version",
     "build_time": "Build Time",
     "ui_version": "UI Version",
-    "api_key_lookup": "API Key Lookup",
+    "api_key_lookup": "User portal",
     "available_models": "Available Models",
     "search_models": "Search models…",
     "refresh": "Refresh",
@@ -2584,7 +2584,9 @@
     "no_models": "No model data",
     "no_match": "No results",
     "load_models_failed": "Failed to load models",
-    "other_vendor": "Other"
+    "other_vendor": "Other",
+    "api_key_portal": "User portal",
+    "api_key_usage": "API key usage"
   },
   "m_login": {
     "auto_connecting": "Auto connecting…",
@@ -2620,7 +2622,7 @@
     "exit_batch": "Exit Batch"
   },
   "m_apikey_lookup": {
-    "title": "API Key Lookup",
+    "title": "User portal",
     "input_placeholder": "Enter API Key to query usage",
     "query": "Query",
     "querying": "Querying…",
@@ -3306,7 +3308,7 @@
     "token": "Token",
     "model_filter": "Model filter",
     "status_filter": "Status filter",
-    "title": "API key usage",
+    "title": "User portal",
     "api_key_label": "API key",
     "query": "Query",
     "query_failed": "Query failed",
@@ -4130,13 +4132,14 @@
     "title": "System Info",
     "subtitle": "Service connection and version details",
     "api_base": "API Base",
-    "api_key_lookup": "API Key Lookup",
     "build_time": "Build Time",
     "version": "Version",
     "ui_version": "UI Version",
     "mgmt_endpoint": "Management Endpoint",
     "copy": "Copy",
-    "copied": "Copied"
+    "copied": "Copied",
+    "api_key_portal": "User portal",
+    "api_key_usage": "API key usage"
   },
   "model_plaza": {
     "title": "Model Plaza",
@@ -4819,5 +4822,9 @@
     "clear_audit_logs_confirm": "Clear all audit logs in your current visible scope? This cannot be undone.",
     "clear_audit_logs_confirm_button": "Clear all",
     "audit_logs_cleared": "Cleared {{count}} audit logs."
+  },
+  "apikey_usage": {
+    "title": "API key usage",
+    "subtitle": "Enter an API key to view request logs and quick import"
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2593,7 +2593,7 @@
     "version": "版本",
     "build_time": "构建时间",
     "ui_version": "UI 版本",
-    "api_key_lookup": "API Key 查询",
+    "api_key_lookup": "用户门户",
     "available_models": "可用模型",
     "search_models": "搜索模型…",
     "refresh": "刷新",
@@ -2601,7 +2601,9 @@
     "no_models": "暂无模型数据",
     "no_match": "无匹配结果",
     "load_models_failed": "加载模型失败",
-    "other_vendor": "其他"
+    "other_vendor": "其他",
+    "api_key_portal": "用户门户",
+    "api_key_usage": "API 密钥用量查询"
   },
   "m_login": {
     "auto_connecting": "正在自动连接…",
@@ -2637,7 +2639,7 @@
     "exit_batch": "退出批量"
   },
   "m_apikey_lookup": {
-    "title": "API Key 查询",
+    "title": "用户门户",
     "input_placeholder": "输入 API Key 查询用量",
     "query": "查询",
     "querying": "查询中…",
@@ -3603,7 +3605,7 @@
     "token": "Token",
     "model_filter": "模型过滤",
     "status_filter": "状态过滤",
-    "title": "API 密钥用量查询",
+    "title": "用户门户",
     "api_key_label": "API 密钥",
     "query": "查询",
     "query_failed": "查询失败",
@@ -4349,13 +4351,14 @@
     "title": "系统信息",
     "subtitle": "服务连接与版本信息",
     "api_base": "API 地址",
-    "api_key_lookup": "API 密钥查询",
     "build_time": "构建时间",
     "version": "版本",
     "ui_version": "UI 版本",
     "mgmt_endpoint": "管理端点",
     "copy": "复制",
-    "copied": "已复制"
+    "copied": "已复制",
+    "api_key_portal": "用户门户",
+    "api_key_usage": "API 密钥用量查询"
   },
   "model_plaza": {
     "title": "模型广场",
@@ -4833,5 +4836,9 @@
     "tenant_administrator_role": "租户管理员",
     "super_administrator": "超级管理员",
     "more_actions": "更多操作"
+  },
+  "apikey_usage": {
+    "title": "API 密钥用量查询",
+    "subtitle": "输入 API 密钥查看请求日志与快捷导入"
   }
 }

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -11,6 +11,8 @@ const STICKY_TOP_OFFSET_PX = 12;
 /** 亚像素容差，避免临界抖动 */
 const STUCK_EPSILON_PX = 1;
 
+const DEFAULT_TABS: ApiKeyLookupTab[] = ["usage", "keys", "logs", "models", "quickImport"];
+
 export function LookupResultsToolbar({
   t,
   activeTab,
@@ -22,6 +24,7 @@ export function LookupResultsToolbar({
   chartLoading,
   modelsLoading,
   showKeysTab = false,
+  tabs,
   keysHeader,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
@@ -35,6 +38,8 @@ export function LookupResultsToolbar({
   modelsLoading: boolean;
   /** Portal login: show “管理 API Key” as the 2nd tab. */
   showKeysTab?: boolean;
+  /** Restrict visible tabs (e.g. public key usage page only needs logs + quick import). */
+  tabs?: ApiKeyLookupTab[];
   /** keys tab：标题 + 刷新/新建 与 tabs 同吸顶，避免滚动后消失。 */
   keysHeader?: {
     loading?: boolean;
@@ -45,7 +50,9 @@ export function LookupResultsToolbar({
 }) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const [stuck, setStuck] = useState(false);
-  const showKeysHeader = activeTab === "keys" && keysHeader;
+  const visibleTabs = tabs?.length ? tabs : DEFAULT_TABS;
+  const showTab = (tab: ApiKeyLookupTab) => visibleTabs.includes(tab);
+  const showKeysHeader = activeTab === "keys" && keysHeader && showTab("keys");
 
   // 不要再用短 relative 包裹 sticky：sticky 只能在「包含块」高度内钉住，
   // 外层高度≈自身时，一滚就会整段被带走，表现为「没吸顶、飘走」。
@@ -97,15 +104,23 @@ export function LookupResultsToolbar({
             onValueChange={(value) => setActiveTab(value as typeof activeTab)}
           >
             <TabsList>
-              <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
-              {showKeysTab ? (
+              {showTab("usage") ? (
+                <TabsTrigger value="usage">{t("apikey_lookup.usage_stats")}</TabsTrigger>
+              ) : null}
+              {showTab("keys") && showKeysTab ? (
                 <TabsTrigger value="keys">
                   {t("apikey_lookup.manage_keys", { defaultValue: "管理 API Key" })}
                 </TabsTrigger>
               ) : null}
-              <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
-              <TabsTrigger value="models">{t("model_plaza.title")}</TabsTrigger>
-              <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
+              {showTab("logs") ? (
+                <TabsTrigger value="logs">{t("apikey_lookup.request_logs")}</TabsTrigger>
+              ) : null}
+              {showTab("models") ? (
+                <TabsTrigger value="models">{t("model_plaza.title")}</TabsTrigger>
+              ) : null}
+              {showTab("quickImport") ? (
+                <TabsTrigger value="quickImport">{t("apikey_lookup.quick_import")}</TabsTrigger>
+              ) : null}
             </TabsList>
           </Tabs>
           {activeTab === "usage" || activeTab === "logs" ? (

--- a/pages/api-key-usage/ApiKeyUsagePage.tsx
+++ b/pages/api-key-usage/ApiKeyUsagePage.tsx
@@ -1,0 +1,523 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Key, KeyRound } from "lucide-react";
+import { isApiClientError } from "@code-proxy/api-client";
+import { ThemeToggleButton } from "@code-proxy/ui";
+import { LanguageSelector } from "@code-proxy/ui";
+import { Reveal } from "@code-proxy/ui";
+import { PageBackground } from "@code-proxy/ui";
+import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
+import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
+import { ModelTag } from "@features/model-tags";
+import { fetchPublicLogs } from "../api-key-lookup/api";
+import {
+  LookupResultsToolbar,
+  type ApiKeyLookupTab,
+} from "../api-key-lookup/components/LookupResultsToolbar";
+import { LookupSearchSection } from "../api-key-lookup/components/LookupSearchSection";
+import { PublicLogsSection } from "../api-key-lookup/components/PublicLogsSection";
+import { QuickImportTabContent } from "../api-key-lookup/components/QuickImportTabContent";
+import type { PublicLogItem } from "../api-key-lookup/types";
+import {
+  buildRequestLogsColumns,
+  formatOptionalRequestLogLatencyMs,
+  formatRequestLogLatencyMs,
+  maskRequestLogApiKey,
+  normalizeChannelAuthType,
+  normalizeFilterSelection,
+  RequestLogFilterCount,
+  sortRequestLogKeyOptionsByCount,
+  toFilterParam,
+  toStatusFilterValues,
+  type MultiSelectFilterState,
+  type RequestLogsRow,
+  type StatusFilterValue,
+} from "@features/request-log-viewer";
+
+const DEFAULT_PAGE_SIZE = 50;
+
+type UsageTab = "logs" | "quickImport";
+
+const extractServerErrorMessage = (raw: unknown): string => {
+  if (isApiClientError(raw)) {
+    const data = raw.data;
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      const record = data as Record<string, unknown>;
+      const errorValue =
+        typeof record.error === "string"
+          ? record.error
+          : typeof record.message === "string"
+            ? record.message
+            : "";
+      if (errorValue.trim()) return errorValue.trim();
+    }
+    return raw.message;
+  }
+  if (raw instanceof Error) return raw.message;
+  if (typeof raw === "string") return raw;
+  return "";
+};
+
+const localizeLookupError = (
+  t: (key: string, options?: Record<string, unknown>) => string,
+  raw: unknown,
+  fallbackKey: string,
+): string => {
+  const message = extractServerErrorMessage(raw);
+  const normalized = message.toLowerCase();
+  if (!message) return t(fallbackKey);
+  if (
+    normalized.includes("invalid api key") ||
+    normalized.includes("invalid apikey") ||
+    normalized.includes("invalid token") ||
+    normalized.includes("unauthorized")
+  ) {
+    return t("apikey_lookup.error_invalid_api_key");
+  }
+  if (normalized.includes("missing management key")) {
+    return t("apikey_lookup.error_missing_management_key");
+  }
+  return message;
+};
+
+const readLookupKeyFromUrl = (): string => {
+  try {
+    const url = new URL(window.location.href);
+    return (url.searchParams.get("api_key") || url.searchParams.get("key") || "").trim();
+  } catch {
+    return "";
+  }
+};
+
+function toLogRow(item: PublicLogItem): RequestLogsRow {
+  const channelAuthType = normalizeChannelAuthType(item.auth_type);
+  return {
+    id: String(item.id),
+    timestamp: item.timestamp,
+    timestampMs: new Date(item.timestamp).getTime(),
+    apiKey: item.api_key || "",
+    apiKeyId: item.api_key_id || "",
+    apiKeyName: item.api_key_name || "",
+    apiKeyOwnName: item.api_key_own_name || "",
+    endUserDisplayName: item.end_user_display_name || item.api_key_name || "",
+    isSystemCall: false,
+    channelName: item.channel_name || "",
+    channelProvider: String(item.provider ?? "").trim() || undefined,
+    channelAuthType: channelAuthType || undefined,
+    maskedApiKey: item.api_key_masked || maskRequestLogApiKey(item.api_key || ""),
+    model: item.model,
+    upstreamModel: item.upstream_model || "",
+    visionFallbackModel: item.vision_fallback_model || "",
+    failed: item.failed,
+    streaming: item.streaming === true,
+    latencyText: formatRequestLogLatencyMs(item.latency_ms),
+    firstTokenText: formatOptionalRequestLogLatencyMs(item.first_token_ms ?? 0),
+    inputTokens: item.input_tokens,
+    cachedTokens: item.cached_tokens,
+    outputTokens: item.output_tokens,
+    totalTokens: item.total_tokens,
+    cost: item.cost ?? 0,
+    hasContent: item.has_content,
+  };
+}
+
+export function ApiKeyUsagePage() {
+  const { t, i18n } = useTranslation();
+
+  const initialKey = useMemo(() => readLookupKeyFromUrl(), []);
+  const [apiKeyInput, setApiKeyInput] = useState(initialKey);
+  const [queriedKey, setQueriedKey] = useState(initialKey);
+  const [apiKeyName, setApiKeyName] = useState("");
+  const [activeTab, setActiveTab] = useState<UsageTab>("logs");
+  const [quickImportReloadToken, setQuickImportReloadToken] = useState(0);
+  const [timeRange, setTimeRange] = useState<TimeRange>(7);
+
+  const [rawItems, setRawItems] = useState<PublicLogItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+  const [stats, setStats] = useState({
+    total: 0,
+    success_rate: 0,
+    total_tokens: 0,
+    total_cost: 0,
+  });
+  const [filterOptions, setFilterOptions] = useState<{
+    api_key_ids: string[];
+    api_key_id_names: Record<string, string>;
+    api_key_id_counts: Record<string, number>;
+    models: string[];
+    statuses: string[];
+  }>({
+    api_key_ids: [],
+    api_key_id_names: {},
+    api_key_id_counts: {},
+    models: [],
+    statuses: ["success", "failed"],
+  });
+  const [selectedApiKeyIds, setSelectedApiKeyIds] = useState<MultiSelectFilterState<string>>(null);
+  const [selectedModels, setSelectedModels] = useState<MultiSelectFilterState<string>>(null);
+  const [selectedStatuses, setSelectedStatuses] =
+    useState<MultiSelectFilterState<StatusFilterValue>>(null);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const fetchIdRef = useRef(0);
+  const paginationInFlightRef = useRef(false);
+  const restoredLookupFetchedRef = useRef(false);
+
+  const logColumns = useMemo(
+    () =>
+      buildRequestLogsColumns((key) => t(key), undefined, undefined, {
+        identityColumn: "key",
+        hideChannel: true,
+      }),
+    [t],
+  );
+
+  const keyOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    const options = (filterOptions.api_key_ids ?? []).map((id) => {
+      const name = filterOptions.api_key_id_names?.[id] || id;
+      return {
+        value: id,
+        label: name,
+        searchText: name,
+        count: filterOptions.api_key_id_counts?.[id] ?? 0,
+      };
+    });
+    return sortRequestLogKeyOptionsByCount(options, i18n.resolvedLanguage).map((option) => ({
+      value: option.value,
+      label: option.label,
+      searchText: option.searchText,
+      trailing: <RequestLogFilterCount count={option.count} />,
+    }));
+  }, [
+    filterOptions.api_key_id_counts,
+    filterOptions.api_key_id_names,
+    filterOptions.api_key_ids,
+    i18n.resolvedLanguage,
+  ]);
+
+  const modelOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    return filterOptions.models.map((model) => ({
+      value: model,
+      label: <ModelTag id={model} size="sm" />,
+      searchText: model,
+    }));
+  }, [filterOptions.models]);
+
+  const statusOptions = useMemo<SearchableCheckboxMultiSelectOption[]>(() => {
+    const statuses =
+      filterOptions.statuses.length > 0 ? filterOptions.statuses : ["success", "failed"];
+    return statuses.map((status) => ({
+      value: status,
+      label:
+        status === "success"
+          ? t("request_logs.status_success")
+          : status === "failed"
+            ? t("request_logs.status_failed")
+            : status,
+      searchText: status,
+    }));
+  }, [filterOptions.statuses, t]);
+
+  const apiKeyIdFilterValues = useMemo(
+    () => keyOptions.map((option) => option.value),
+    [keyOptions],
+  );
+  const modelFilterValues = useMemo(
+    () => modelOptions.map((option) => option.value),
+    [modelOptions],
+  );
+  const statusFilterValues = useMemo<StatusFilterValue[]>(
+    () => toStatusFilterValues(statusOptions.map((option) => option.value)),
+    [statusOptions],
+  );
+  const apiKeyIdFilterParam = useMemo(
+    () => toFilterParam(selectedApiKeyIds, apiKeyIdFilterValues),
+    [apiKeyIdFilterValues, selectedApiKeyIds],
+  );
+  const modelFilterParam = useMemo(
+    () => toFilterParam(selectedModels, modelFilterValues),
+    [modelFilterValues, selectedModels],
+  );
+  const statusFilterParam = useMemo(
+    () => toFilterParam(selectedStatuses, statusFilterValues),
+    [selectedStatuses, statusFilterValues],
+  );
+
+  const handleApiKeyIdsChange = useCallback(
+    (value: string[]) => {
+      setSelectedApiKeyIds(normalizeFilterSelection(value, apiKeyIdFilterValues));
+    },
+    [apiKeyIdFilterValues],
+  );
+  const handleModelsChange = useCallback(
+    (value: string[]) => {
+      setSelectedModels(normalizeFilterSelection(value, modelFilterValues));
+    },
+    [modelFilterValues],
+  );
+  const handleStatusesChange = useCallback(
+    (value: StatusFilterValue[]) => {
+      setSelectedStatuses(normalizeFilterSelection(value, statusFilterValues));
+    },
+    [statusFilterValues],
+  );
+  const clearApiKeyIdFilter = useCallback(() => setSelectedApiKeyIds(null), []);
+  const clearModelFilter = useCallback(() => setSelectedModels(null), []);
+  const clearStatusFilter = useCallback(() => setSelectedStatuses(null), []);
+
+  const fetchLogs = useCallback(
+    async (apiKey: string, page: number, size?: number) => {
+      const trimmed = apiKey.trim();
+      if (!trimmed || paginationInFlightRef.current) return;
+      paginationInFlightRef.current = true;
+
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const myFetchId = ++fetchIdRef.current;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const resp = await fetchPublicLogs({
+          apiKey: trimmed,
+          page,
+          size: size ?? pageSize,
+          days: timeRange,
+          apiKeyIds: apiKeyIdFilterParam.values,
+          models: modelFilterParam.values,
+          statuses: statusFilterParam.values,
+          apiKeyIdsEmpty: apiKeyIdFilterParam.matchesNone,
+          modelsEmpty: modelFilterParam.matchesNone,
+          statusesEmpty: statusFilterParam.matchesNone,
+          signal: controller.signal,
+        });
+        if (myFetchId !== fetchIdRef.current) return;
+
+        setRawItems(resp.items ?? []);
+        setTotalCount(resp.total ?? 0);
+        setCurrentPage(page);
+        setStats(
+          resp.stats ?? {
+            total: 0,
+            success_rate: 0,
+            total_tokens: 0,
+            total_cost: 0,
+          },
+        );
+        setFilterOptions({
+          api_key_ids: resp.filters?.api_key_ids ?? [],
+          api_key_id_names: resp.filters?.api_key_id_names ?? {},
+          api_key_id_counts: resp.filters?.api_key_id_counts ?? {},
+          models: resp.filters?.models ?? [],
+          statuses: resp.filters?.statuses ?? ["success", "failed"],
+        });
+        setLastUpdatedAt(Date.now());
+        setApiKeyName(resp.api_key_name?.trim() ?? "");
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (myFetchId !== fetchIdRef.current) return;
+        setError(localizeLookupError(t, err, "apikey_lookup.query_failed"));
+        setRawItems([]);
+        setTotalCount(0);
+        setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
+      } finally {
+        paginationInFlightRef.current = false;
+        if (myFetchId === fetchIdRef.current) setLoading(false);
+      }
+    },
+    [apiKeyIdFilterParam, modelFilterParam, pageSize, statusFilterParam, t, timeRange],
+  );
+
+  const rows = useMemo(() => rawItems.map((item) => toLogRow(item)), [rawItems]);
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      if (!queriedKey) return;
+      fetchLogs(queriedKey, Math.max(1, Math.min(page, totalPages)));
+    },
+    [fetchLogs, queriedKey, totalPages],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (newSize: number) => {
+      setPageSize(newSize);
+      if (queriedKey) fetchLogs(queriedKey, 1, newSize);
+    },
+    [fetchLogs, queriedKey],
+  );
+
+  const handleSubmit = useCallback(
+    (event?: React.FormEvent) => {
+      event?.preventDefault();
+      const next = apiKeyInput.trim();
+      if (!next) return;
+      setQueriedKey(next);
+      setActiveTab("logs");
+      setSelectedApiKeyIds(null);
+      setSelectedModels(null);
+      setSelectedStatuses(null);
+      setQuickImportReloadToken((value) => value + 1);
+      fetchLogs(next, 1);
+    },
+    [apiKeyInput, fetchLogs],
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (!queriedKey) return;
+    if (activeTab === "quickImport") {
+      setQuickImportReloadToken((value) => value + 1);
+      return;
+    }
+    fetchLogs(queriedKey, 1);
+  }, [activeTab, fetchLogs, queriedKey]);
+
+  useEffect(() => {
+    if (queriedKey && activeTab === "logs") fetchLogs(queriedKey, 1);
+  }, [timeRange, selectedApiKeyIds, selectedModels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!initialKey || restoredLookupFetchedRef.current) return;
+    restoredLookupFetchedRef.current = true;
+    fetchLogs(initialKey, 1);
+  }, [fetchLogs, initialKey]);
+
+  useEffect(() => {
+    try {
+      const url = new URL(window.location.href);
+      let changed = false;
+      if (url.searchParams.has("api_key")) {
+        url.searchParams.delete("api_key");
+        changed = true;
+      }
+      if (url.searchParams.has("key")) {
+        url.searchParams.delete("key");
+        changed = true;
+      }
+      if (changed) window.history.replaceState({}, "", url.toString());
+    } catch {
+      // ignore
+    }
+  }, [initialKey]);
+
+  const lastUpdatedText = useMemo(() => {
+    if (!lastUpdatedAt) return "";
+    const d = new Date(lastUpdatedAt);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }, [lastUpdatedAt]);
+
+  const displayName = apiKeyName || (queriedKey ? t("apikey_lookup.unnamed_key") : "");
+
+  return (
+    <PageBackground variant="app">
+      <div className="relative min-h-dvh bg-gradient-to-br from-slate-50 via-white to-slate-100 pt-14 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
+        <header
+          data-testid="apikey-usage-header"
+          className="fixed inset-x-0 top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70"
+        >
+          <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between px-4 sm:px-6">
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-slate-900 shadow-sm dark:bg-white">
+                <Key size={16} className="text-white dark:text-neutral-950" />
+              </div>
+              <span className="text-base font-bold tracking-tight text-slate-900 dark:text-white">
+                {t("apikey_usage.title")}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              {queriedKey ? (
+                <div className="inline-flex max-w-[34vw] items-center gap-1.5 rounded-xl px-1 py-1 text-sm font-medium text-slate-700 dark:text-white/80 sm:max-w-56">
+                  <KeyRound size={14} className="shrink-0" />
+                  <span className="min-w-0 truncate">{displayName}</span>
+                </div>
+              ) : null}
+              <LanguageSelector />
+              <ThemeToggleButton />
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-screen-xl space-y-4 px-4 py-6 sm:px-6">
+          <LookupSearchSection
+            t={t}
+            apiKeyInput={apiKeyInput}
+            setApiKeyInput={(value) => {
+              setApiKeyInput(value);
+              setError(null);
+            }}
+            handleSubmit={handleSubmit}
+            loading={loading}
+          />
+
+          {error ? (
+            <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-300">
+              {error}
+            </div>
+          ) : null}
+
+          {queriedKey && !error ? (
+            <>
+              <LookupResultsToolbar
+                t={t}
+                activeTab={activeTab as ApiKeyLookupTab}
+                setActiveTab={(value) => {
+                  if (value === "logs" || value === "quickImport") setActiveTab(value);
+                }}
+                timeRange={timeRange}
+                setTimeRange={setTimeRange}
+                handleRefresh={handleRefresh}
+                loading={loading}
+                chartLoading={false}
+                modelsLoading={false}
+                tabs={["logs", "quickImport"]}
+              />
+
+              {activeTab === "logs" ? (
+                <PublicLogsSection
+                  t={t}
+                  keyOptions={keyOptions}
+                  modelOptions={modelOptions}
+                  statusOptions={statusOptions}
+                  selectedApiKeyIds={selectedApiKeyIds}
+                  selectedModels={selectedModels}
+                  selectedStatuses={selectedStatuses}
+                  onApiKeyIdsChange={handleApiKeyIdsChange}
+                  onModelsChange={handleModelsChange}
+                  onStatusesChange={handleStatusesChange}
+                  onApiKeyIdsClear={clearApiKeyIdFilter}
+                  onModelsClear={clearModelFilter}
+                  onStatusesClear={clearStatusFilter}
+                  stats={stats}
+                  lastUpdatedText={lastUpdatedText}
+                  loading={loading}
+                  logColumns={logColumns}
+                  rows={rows}
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  totalCount={totalCount}
+                  pageSize={pageSize}
+                  onPageChange={handlePageChange}
+                  onPageSizeChange={handlePageSizeChange}
+                />
+              ) : null}
+
+              {activeTab === "quickImport" ? (
+                <Reveal>
+                  <QuickImportTabContent apiKey={queriedKey} reloadToken={quickImportReloadToken} />
+                </Reveal>
+              ) : null}
+            </>
+          ) : null}
+        </main>
+      </div>
+    </PageBackground>
+  );
+}

--- a/pages/api-key-usage/__tests__/ApiKeyUsagePage.test.tsx
+++ b/pages/api-key-usage/__tests__/ApiKeyUsagePage.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import i18n from "@code-proxy/i18n";
+import { ThemeProvider } from "@code-proxy/ui";
+import { ToastProvider } from "@code-proxy/ui";
+import { ApiKeyUsagePage } from "../ApiKeyUsagePage";
+
+const mocks = vi.hoisted(() => ({
+  fetchPublicLogs: vi.fn(),
+}));
+
+vi.mock("../../api-key-lookup/api", () => ({
+  fetchPublicLogs: mocks.fetchPublicLogs,
+}));
+
+vi.mock("../../api-key-lookup/components/QuickImportTabContent", () => ({
+  QuickImportTabContent: ({ apiKey }: { apiKey: string }) => (
+    <div data-testid="quick-import-stub">quick-import:{apiKey}</div>
+  ),
+}));
+
+function renderPage() {
+  return render(
+    <ThemeProvider>
+      <ToastProvider>
+        <ApiKeyUsagePage />
+      </ToastProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("ApiKeyUsagePage", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("zh-CN");
+    window.history.replaceState({}, "", "/manage/apikey-usage");
+    mocks.fetchPublicLogs.mockReset();
+    mocks.fetchPublicLogs.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          timestamp: "2026-07-22T01:00:00Z",
+          model: "gpt-test",
+          failed: false,
+          latency_ms: 100,
+          input_tokens: 1,
+          output_tokens: 2,
+          cached_tokens: 0,
+          total_tokens: 3,
+          cost: 0,
+          has_content: false,
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 50,
+      api_key_name: "demo-key",
+      stats: { total: 1, success_rate: 100, total_tokens: 3, total_cost: 0 },
+      filters: {
+        api_key_ids: [],
+        api_key_id_names: {},
+        api_key_id_counts: {},
+        models: ["gpt-test"],
+        channels: [],
+        statuses: ["success", "failed"],
+      },
+    });
+  });
+
+  test("queries logs with the entered API key and only shows logs + quick import tabs", async () => {
+    renderPage();
+
+    expect(screen.getByTestId("apikey-usage-header")).toHaveTextContent("API 密钥用量查询");
+    expect(screen.queryByText("使用统计")).not.toBeInTheDocument();
+    expect(screen.queryByText("模型广场")).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText(/输入 API 密钥|Enter API Key/i), "sk-demo");
+    await userEvent.click(screen.getByRole("button", { name: /查询|Query/i }));
+
+    await waitFor(() => {
+      expect(mocks.fetchPublicLogs).toHaveBeenCalled();
+    });
+    expect(mocks.fetchPublicLogs.mock.calls[0][0]).toMatchObject({
+      apiKey: "sk-demo",
+      page: 1,
+    });
+    expect(await screen.findByText("请求日志")).toBeInTheDocument();
+    expect(screen.getByText("快捷导入")).toBeInTheDocument();
+    expect(screen.getByText("demo-key")).toBeInTheDocument();
+  });
+});

--- a/pages/api-key-usage/index.ts
+++ b/pages/api-key-usage/index.ts
@@ -1,0 +1,2 @@
+export { ApiKeyUsagePage } from "./ApiKeyUsagePage";
+export { apiKeyUsageRoute } from "./route";

--- a/pages/api-key-usage/route.tsx
+++ b/pages/api-key-usage/route.tsx
@@ -1,0 +1,14 @@
+import { preloadablePage } from "../preloadablePage";
+
+const { Page: ApiKeyUsagePage, preload: preloadApiKeyUsagePage } = preloadablePage(() =>
+  import("./ApiKeyUsagePage").then((m) => ({ default: m.ApiKeyUsagePage })),
+);
+
+export const apiKeyUsageRoute = {
+  path: "/apikey-usage",
+  element: <ApiKeyUsagePage />,
+  auth: false,
+  layout: "none",
+  nav: null,
+  preload: preloadApiKeyUsagePage,
+};

--- a/pages/registry.ts
+++ b/pages/registry.ts
@@ -20,6 +20,7 @@ import { identityFingerprintRoute } from "./identity-fingerprint/route";
 import { imageGenerationRoute } from "./image-generation/route";
 import { ccswitchImportSettingsRoute } from "./ccswitch-import-settings/route";
 import { apiKeyLookupRoute } from "./api-key-lookup/route";
+import { apiKeyUsageRoute } from "./api-key-usage/route";
 import { tenantsRoute } from "./tenants/route";
 import { usersRoute } from "./users/route";
 import { rolesRoute } from "./roles/route";
@@ -71,6 +72,7 @@ export const pageRoutes: PageRoute[] = [
   imageGenerationRoute,
   ccswitchImportSettingsRoute,
   apiKeyLookupRoute,
+  apiKeyUsageRoute,
 ];
 
 const normalizePathname = (to: string) => to.split(/[?#]/, 1)[0] || "/";

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -115,7 +115,8 @@ export function SystemPage({
 } = {}) {
   const { t } = useTranslation();
   const auth = useAuth();
-  const apiKeyLookupUrl = `${window.location.origin}/manage/apikey-lookup`;
+  const apiKeyPortalUrl = `${window.location.origin}/manage/apikey-lookup`;
+  const apiKeyUsageUrl = `${window.location.origin}/manage/apikey-usage`;
 
   return (
     <div className="min-w-0 space-y-6 overflow-x-hidden">
@@ -168,8 +169,14 @@ export function SystemPage({
         />
         <InfoCard
           icon={KeyRound}
-          label={t("system_page.api_key_lookup")}
-          value={apiKeyLookupUrl}
+          label={t("system_page.api_key_portal")}
+          value={apiKeyPortalUrl}
+          link
+        />
+        <InfoCard
+          icon={KeyRound}
+          label={t("system_page.api_key_usage")}
+          value={apiKeyUsageUrl}
           link
         />
       </div>


### PR DESCRIPTION
## Summary
- Rename existing `/manage/apikey-lookup` (account portal) title from 「API 密钥用量查询」 to 「用户门户」 / User portal
- Add public `/manage/apikey-usage` page: enter API key only (no account login), with **请求日志** + **快捷导入** only
- System info shows two cards: portal link + real API key usage link

## Test plan
- [x] `bun run test -- pages/api-key-usage/__tests__/ApiKeyUsagePage.test.tsx pages/system/__tests__/SystemPage.test.tsx pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx`
- [ ] Open `/manage/apikey-usage`, query with a real key, confirm logs + quick import
- [ ] Confirm system page cards labels/links