### PR TITLE
fix: clear stale apikey usage header name on re-query

### DIFF
--- a/pages/api-key-usage/ApiKeyUsagePage.tsx
+++ b/pages/api-key-usage/ApiKeyUsagePage.tsx
@@ -439,6 +439,8 @@ export function ApiKeyUsagePage() {
       const next = apiKeyInput.trim();
       if (!next) return;
       setQueriedKey(next);
+      // Drop previous key label immediately so a stale localStorage/account name cannot flash.
+      setApiKeyName("");
       setActiveTab("logs");
       setSelectedApiKeyIds(null);
       setSelectedModels(null);


### PR DESCRIPTION
## Summary
- Clear previous header label when submitting a new API key so a stale localStorage/account name cannot flash before the response

## Test plan
- [ ] After backend #778 deploy: re-query key, header should update to key own name