### PR TITLE
fix: wrap manage keys table in card on apikey-lookup

### DIFF
--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -1,4 +1,5 @@
 import type { EndUserAPIKey } from "@code-proxy/api-client";
+import { Card } from "@code-proxy/ui";
 import { OwnedApiKeysTable } from "@features/period-spending";
 
 export function ManageKeysTabContent({
@@ -23,20 +24,24 @@ export function ManageKeysTabContent({
   onViewResetHistory: (key: EndUserAPIKey) => void;
 }) {
   return (
-    <OwnedApiKeysTable
-      t={t}
-      keys={keys}
-      busy={busy}
-      loading={loading}
-      canDelete={() => keys.length > 1}
-      height="h-[min(58vh,540px)]"
-      actions={{
-        onRotate,
-        onDelete,
-        onEdit,
-        onResetDailySpending,
-        onViewResetHistory,
-      }}
-    />
+    <Card padding="none" className="overflow-hidden" bodyClassName="mt-0">
+      <div className="relative min-h-[320px] overflow-hidden px-3 sm:px-5">
+        <OwnedApiKeysTable
+          t={t}
+          keys={keys}
+          busy={busy}
+          loading={loading}
+          canDelete={() => keys.length > 1}
+          height="h-[min(58vh,540px)]"
+          actions={{
+            onRotate,
+            onDelete,
+            onEdit,
+            onResetDailySpending,
+            onViewResetHistory,
+          }}
+        />
+      </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap `ManageKeysTabContent` table in the same `Card padding="none"` shell used by request logs tab.
- Keep horizontal padding (`px-3 sm:px-5`) so table edges match logs tab.

## Test plan
- [ ] Open `/manage/apikey-lookup` → 管理 API Key tab; table sits inside card with rounded border.
- [ ] Compare with 请求日志 tab; outer shell style consistent.
- [ ] Empty / loading states still render inside the card.