### PR TITLE
fix: align manage keys tab card layout with request logs

### DIFF
--- a/features/period-spending/OwnedApiKeyTable.tsx
+++ b/features/period-spending/OwnedApiKeyTable.tsx
@@ -224,6 +224,7 @@ export function OwnedApiKeysTable({
   loading = false,
   canDelete,
   height = "h-[460px]",
+  minHeight = "min-h-[320px]",
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   keys: EndUserAPIKey[];
@@ -233,6 +234,7 @@ export function OwnedApiKeysTable({
   loading?: boolean;
   canDelete?: (key: EndUserAPIKey) => boolean;
   height?: string;
+  minHeight?: string;
 }) {
   // Avoid flashing the empty state while the owner-scoped list is still loading.
   if (loading && keys.length === 0) {
@@ -264,7 +266,7 @@ export function OwnedApiKeysTable({
       rowHeight={52}
       height={height}
       loading={loading}
-      minHeight="min-h-[320px]"
+      minHeight={minHeight}
       minWidth="min-w-[1580px]"
       caption={t("api_keys_page.table_caption")}
       emptyText={t("api_keys_page.no_api_keys")}

--- a/features/period-spending/__tests__/OwnedApiKeyTable.test.tsx
+++ b/features/period-spending/__tests__/OwnedApiKeyTable.test.tsx
@@ -48,6 +48,30 @@ describe("OwnedApiKeysTable", () => {
     expect(screen.getByText("No API keys")).toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
+
+  test("allows a parent viewport to make the table fill its available height", () => {
+    const { container } = render(
+      <OwnedApiKeysTable
+        t={t}
+        keys={[
+          {
+            id: "key-1",
+            tenant_id: "tenant-1",
+            end_user_id: "user-1",
+            name: "Primary",
+            key_masked: "sk-****",
+            disabled: false,
+            is_default: true,
+          },
+        ]}
+        actions={{}}
+        height="h-full"
+        minHeight="min-h-full"
+      />,
+    );
+
+    expect(container.firstElementChild).toHaveClass("h-full", "min-h-full");
+  });
 });
 
 describe("createOwnedApiKeyColumns", () => {

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1412,23 +1412,6 @@ export function ApiKeyLookupPage() {
                 quotaLimits={quotaLimits}
                 quotaScopes={quotaScopes}
                 showKeysTab={Boolean(portalUser)}
-                keysHeader={
-                  portalUser
-                    ? {
-                        loading: portalKeysLoading,
-                        busy: portalKeysBusy,
-                        onRefresh: () => void syncPortalKeys(),
-                        onCreate: () => {
-                          setPortalKeyForm({
-                            name: "",
-                            periods: emptyPeriodSpendingDraft(),
-                          });
-                          setPortalKeyQuotaError("");
-                          setCreateKeyOpen(true);
-                        },
-                      }
-                    : undefined
-                }
               />
 
               {activeTab === "usage" && usageReady ? (
@@ -1460,6 +1443,15 @@ export function ApiKeyLookupPage() {
                     keys={portalKeys}
                     busy={portalKeysBusy}
                     loading={portalKeysLoading}
+                    onRefresh={() => void syncPortalKeys()}
+                    onCreate={() => {
+                      setPortalKeyForm({
+                        name: "",
+                        periods: emptyPeriodSpendingDraft(),
+                      });
+                      setPortalKeyQuotaError("");
+                      setCreateKeyOpen(true);
+                    }}
                     onRotate={(key) => {
                       setPortalKeysBusy(true);
                       void portalApi

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -730,6 +730,21 @@ describe("ApiKeyLookupPage", () => {
     );
 
     expect(await screen.findByText("sk-new****999")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/manage all api keys under this account|管理本账号下全部 api key/i),
+    ).not.toBeInTheDocument();
+
+    const cardToolbar = screen.getByTestId("apikey-lookup-keys-card-toolbar");
+    expect(cardToolbar).toHaveClass("border-b", "px-3", "py-3", "sm:px-5");
+    expect(within(cardToolbar).getByRole("button", { name: /refresh|刷新/i })).toBeInTheDocument();
+    expect(
+      within(cardToolbar).getByRole("button", { name: /new key|新建 key/i }),
+    ).toBeInTheDocument();
+
+    const tableViewport = screen.getByTestId("apikey-lookup-keys-table-viewport");
+    expect(tableViewport).toHaveClass("min-h-[360px]", "h-[calc(100dvh-240px)]", "px-3", "sm:px-5");
+    expect(tableViewport.querySelector(".h-full.min-h-full")).not.toBeNull();
+
     await waitFor(() => {
       expect(portalApi.listKeys).toHaveBeenCalledTimes(2);
       expect(portalApi.keySecret).toHaveBeenLastCalledWith("k1");

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Plus, RefreshCw } from "lucide-react";
-import { Button, HoverTooltip, Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
+import { RefreshCw } from "lucide-react";
+import { HoverTooltip, Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { TimeRangeSelector } from "@features/monitor-widgets";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 import type { PublicQuotaScope, PublicUsageLimits } from "../types";
@@ -29,7 +29,6 @@ export function LookupResultsToolbar({
   quotaScopes,
   showKeysTab = false,
   tabs,
-  keysHeader,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   activeTab: ApiKeyLookupTab;
@@ -46,19 +45,11 @@ export function LookupResultsToolbar({
   showKeysTab?: boolean;
   /** Restrict visible tabs (e.g. public key usage page only needs logs + quick import). */
   tabs?: ApiKeyLookupTab[];
-  /** keys tab：标题 + 刷新/新建 与 tabs 同吸顶，避免滚动后消失。 */
-  keysHeader?: {
-    loading?: boolean;
-    busy?: boolean;
-    onRefresh: () => void;
-    onCreate: () => void;
-  };
 }) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const [stuck, setStuck] = useState(false);
   const visibleTabs = tabs?.length ? tabs : DEFAULT_TABS;
   const showTab = (tab: ApiKeyLookupTab) => visibleTabs.includes(tab);
-  const showKeysHeader = activeTab === "keys" && keysHeader && showTab("keys");
   const logsQuotaItems =
     activeTab === "logs" ? buildQuotaKpiItems(t, quotaLimits, quotaScopes) : [];
 
@@ -153,63 +144,27 @@ export function LookupResultsToolbar({
             </div>
           ) : null}
         </div>
-        {!showKeysHeader ? (
-          <div className="flex items-center gap-2">
-            <HoverTooltip content={t("common.refresh")}>
-              <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={loading || chartLoading || modelsLoading}
-                aria-label={t("common.refresh")}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
-              >
-                <RefreshCw
-                  size={16}
-                  className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
-                />
-              </button>
-            </HoverTooltip>
-          </div>
-        ) : null}
-      </div>
-
-      {showKeysHeader ? (
         <div
-          data-testid="apikey-lookup-keys-header-sticky"
-          className="flex flex-wrap items-start justify-between gap-3 px-0.5 pb-0.5"
+          className={
+            activeTab === "keys" ? "hidden items-center gap-2 sm:flex" : "flex items-center gap-2"
+          }
         >
-          <div>
-            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("apikey_lookup.manage_keys", { defaultValue: "管理 API Key" })}
-            </h3>
-            <p className="mt-1 text-xs text-slate-500 dark:text-white/55">
-              {t("apikey_lookup.manage_keys_desc", {
-                defaultValue: "管理本账号下全部 API Key。",
-              })}
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={keysHeader.onRefresh}
-              disabled={keysHeader.loading || keysHeader.busy}
+          <HoverTooltip content={t("common.refresh")}>
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={loading || chartLoading || modelsLoading}
+              aria-label={t("common.refresh")}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 disabled:opacity-40 dark:text-white/55 dark:hover:bg-white/10 dark:hover:text-white"
             >
-              <RefreshCw size={14} className={keysHeader.loading ? "animate-spin" : ""} />
-              {t("common.refresh")}
-            </Button>
-            <Button
-              size="sm"
-              variant="primary"
-              onClick={keysHeader.onCreate}
-              disabled={keysHeader.busy}
-            >
-              <Plus size={14} />
-              {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
-            </Button>
-          </div>
+              <RefreshCw
+                size={16}
+                className={loading || chartLoading || modelsLoading ? "animate-spin" : ""}
+              />
+            </button>
+          </HoverTooltip>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -1,5 +1,6 @@
+import { Plus, RefreshCw } from "lucide-react";
 import type { EndUserAPIKey } from "@code-proxy/api-client";
-import { Card } from "@code-proxy/ui";
+import { Button, Card } from "@code-proxy/ui";
 import { OwnedApiKeysTable } from "@features/period-spending";
 
 export function ManageKeysTabContent({
@@ -7,6 +8,8 @@ export function ManageKeysTabContent({
   keys,
   busy,
   loading = false,
+  onRefresh,
+  onCreate,
   onRotate,
   onDelete,
   onEdit,
@@ -17,6 +20,8 @@ export function ManageKeysTabContent({
   keys: EndUserAPIKey[];
   busy?: boolean;
   loading?: boolean;
+  onRefresh: () => void;
+  onCreate: () => void;
   onRotate: (key: EndUserAPIKey) => void;
   onDelete: (key: EndUserAPIKey) => void;
   onEdit: (key: EndUserAPIKey) => void;
@@ -25,14 +30,32 @@ export function ManageKeysTabContent({
 }) {
   return (
     <Card padding="none" className="overflow-hidden" bodyClassName="mt-0">
-      <div className="relative min-h-[320px] overflow-hidden px-3 sm:px-5">
+      <div
+        data-testid="apikey-lookup-keys-card-toolbar"
+        className="flex flex-wrap items-center justify-end gap-2 border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60"
+      >
+        <Button size="sm" variant="secondary" onClick={onRefresh} disabled={loading || busy}>
+          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          {t("common.refresh")}
+        </Button>
+        <Button size="sm" variant="primary" onClick={onCreate} disabled={busy}>
+          <Plus size={14} />
+          {t("apikey_lookup.create_key", { defaultValue: "新建 Key" })}
+        </Button>
+      </div>
+
+      <div
+        data-testid="apikey-lookup-keys-table-viewport"
+        className="relative min-h-[360px] h-[calc(100dvh-240px)] overflow-hidden px-3 sm:px-5"
+      >
         <OwnedApiKeysTable
           t={t}
           keys={keys}
           busy={busy}
           loading={loading}
           canDelete={() => keys.length > 1}
-          height="h-[min(58vh,540px)]"
+          height="h-full"
+          minHeight="min-h-full"
           actions={{
             onRotate,
             onDelete,


### PR DESCRIPTION
## Summary
- remove the duplicated manage-keys heading from the sticky tab toolbar
- move refresh and create actions into a card toolbar aligned with request logs
- make the managed-key table fill the viewport-height card without the large bottom gap
- preserve desktop refresh consistency while avoiding an extra wrapped refresh row on mobile

## Verification
- `bun run --filter @code-proxy/admin-panel test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx features/period-spending/__tests__/OwnedApiKeyTable.test.tsx`
- `bunx oxfmt --check ...` on changed files
- `bunx oxlint ...` on changed files
- `bun run --filter @code-proxy/admin-panel build`
- rendered `/manage/#/apikey-lookup` at 1440x900 and 375x812 with mocked portal responses through the real application code path