### PR TITLE
fix(apikey-usage): show logs quota chips on public usage page

### DIFF
--- a/pages/api-key-usage/ApiKeyUsagePage.tsx
+++ b/pages/api-key-usage/ApiKeyUsagePage.tsx
@@ -13,14 +13,14 @@ import { ThemeToggleButton } from "@code-proxy/ui";
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 import { ModelTag } from "@features/model-tags";
-import { fetchPublicLogs } from "../api-key-lookup/api";
+import { fetchPublicLogs, fetchPublicUsageSummary } from "../api-key-lookup/api";
 import {
   LookupResultsToolbar,
   type ApiKeyLookupTab,
 } from "../api-key-lookup/components/LookupResultsToolbar";
 import { PublicLogsSection } from "../api-key-lookup/components/PublicLogsSection";
 import { QuickImportTabContent } from "../api-key-lookup/components/QuickImportTabContent";
-import type { PublicLogItem } from "../api-key-lookup/types";
+import type { PublicLogItem, PublicQuotaScope, PublicUsageLimits } from "../api-key-lookup/types";
 import {
   buildRequestLogsColumns,
   formatOptionalRequestLogLatencyMs,
@@ -211,10 +211,15 @@ export function ApiKeyUsagePage() {
   const paginationInFlightRef = useRef(false);
   const restoredLookupFetchedRef = useRef(false);
 
+  const [quotaLimits, setQuotaLimits] = useState<PublicUsageLimits | null>(null);
+  const [quotaScopes, setQuotaScopes] = useState<PublicQuotaScope[]>([]);
+  const summaryAbortControllerRef = useRef<AbortController | null>(null);
+  const summaryFetchIdRef = useRef(0);
+
   const logColumns = useMemo(
     () =>
       buildRequestLogsColumns((key) => t(key), undefined, undefined, {
-        identityColumn: "key",
+        identityColumn: "none",
         hideChannel: true,
       }),
     [t],
@@ -277,7 +282,9 @@ export function ApiKeyUsagePage() {
 
   const resetResults = useCallback(() => {
     abortControllerRef.current?.abort();
+    summaryAbortControllerRef.current?.abort();
     fetchIdRef.current += 1;
+    summaryFetchIdRef.current += 1;
     paginationInFlightRef.current = false;
     setLoading(false);
     setError(null);
@@ -293,6 +300,34 @@ export function ApiKeyUsagePage() {
     setSelectedModels(null);
     setSelectedStatuses(null);
     setApiKeyName("");
+    setQuotaLimits(null);
+    setQuotaScopes([]);
+  }, []);
+
+  const fetchQuotaLimits = useCallback(async (apiKey: string) => {
+    const trimmed = apiKey.trim();
+    if (!trimmed) return;
+    summaryAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    summaryAbortControllerRef.current = controller;
+    const myFetchId = ++summaryFetchIdRef.current;
+    try {
+      const summary = await fetchPublicUsageSummary({
+        apiKey: trimmed,
+        signal: controller.signal,
+      });
+      if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted) return;
+      setQuotaLimits(summary.limits ?? null);
+      setQuotaScopes(summary["quota-scopes"] ?? []);
+    } catch {
+      if (myFetchId !== summaryFetchIdRef.current || controller.signal.aborted) return;
+      setQuotaLimits(null);
+      setQuotaScopes([]);
+    } finally {
+      if (summaryAbortControllerRef.current === controller) {
+        summaryAbortControllerRef.current = null;
+      }
+    }
   }, []);
 
   const fetchLogs = useCallback(
@@ -343,6 +378,7 @@ export function ApiKeyUsagePage() {
         setApiKeyName(nextName);
         writeStoredUsageKey({ apiKey: trimmed, ...(nextName ? { name: nextName } : {}) });
         setKeyModalOpen(false);
+        void fetchQuotaLimits(trimmed);
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         if (myFetchId !== fetchIdRef.current) return;
@@ -350,12 +386,14 @@ export function ApiKeyUsagePage() {
         setRawItems([]);
         setTotalCount(0);
         setStats({ total: 0, success_rate: 0, total_tokens: 0, total_cost: 0 });
+        setQuotaLimits(null);
+        setQuotaScopes([]);
       } finally {
         paginationInFlightRef.current = false;
         if (myFetchId === fetchIdRef.current) setLoading(false);
       }
     },
-    [modelFilterParam, pageSize, statusFilterParam, t, timeRange],
+    [fetchQuotaLimits, modelFilterParam, pageSize, statusFilterParam, t, timeRange],
   );
 
   const rows = useMemo(() => rawItems.map((item) => toLogRow(item)), [rawItems]);
@@ -409,18 +447,23 @@ export function ApiKeyUsagePage() {
       setQuickImportReloadToken((value) => value + 1);
       return;
     }
+    void fetchQuotaLimits(queriedKey);
     fetchLogs(queriedKey, 1);
-  }, [activeTab, fetchLogs, queriedKey]);
+  }, [activeTab, fetchLogs, fetchQuotaLimits, queriedKey]);
 
   useEffect(() => {
-    if (queriedKey && activeTab === "logs") fetchLogs(queriedKey, 1);
+    if (queriedKey && activeTab === "logs") {
+      void fetchQuotaLimits(queriedKey);
+      fetchLogs(queriedKey, 1);
+    }
   }, [timeRange, selectedModels, selectedStatuses]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!bootstrap?.apiKey || restoredLookupFetchedRef.current) return;
     restoredLookupFetchedRef.current = true;
+    void fetchQuotaLimits(bootstrap.apiKey);
     fetchLogs(bootstrap.apiKey, 1);
-  }, [bootstrap, fetchLogs]);
+  }, [bootstrap, fetchLogs, fetchQuotaLimits]);
 
   useEffect(() => {
     try {
@@ -541,6 +584,8 @@ export function ApiKeyUsagePage() {
                 loading={loading}
                 chartLoading={false}
                 modelsLoading={false}
+                quotaLimits={quotaLimits}
+                quotaScopes={quotaScopes}
                 tabs={["logs", "quickImport"]}
               />
 

--- a/pages/api-key-usage/__tests__/ApiKeyUsagePage.test.tsx
+++ b/pages/api-key-usage/__tests__/ApiKeyUsagePage.test.tsx
@@ -8,10 +8,12 @@ import { ApiKeyUsagePage } from "../ApiKeyUsagePage";
 
 const mocks = vi.hoisted(() => ({
   fetchPublicLogs: vi.fn(),
+  fetchPublicUsageSummary: vi.fn(),
 }));
 
 vi.mock("../../api-key-lookup/api", () => ({
   fetchPublicLogs: mocks.fetchPublicLogs,
+  fetchPublicUsageSummary: mocks.fetchPublicUsageSummary,
 }));
 
 vi.mock("../../api-key-lookup/components/QuickImportTabContent", () => ({
@@ -36,6 +38,7 @@ describe("ApiKeyUsagePage", () => {
     window.history.replaceState({}, "", "/manage/apikey-usage");
     window.localStorage.clear();
     mocks.fetchPublicLogs.mockReset();
+    mocks.fetchPublicUsageSummary.mockReset();
     mocks.fetchPublicLogs.mockResolvedValue({
       items: [
         {
@@ -66,6 +69,16 @@ describe("ApiKeyUsagePage", () => {
         statuses: ["success", "failed"],
       },
     });
+    mocks.fetchPublicUsageSummary.mockResolvedValue({
+      found: true,
+      range: "today",
+      stats: { total_calls: 1, quota_cost: 0.12 },
+      limits: {
+        "daily-spending-limit": 10,
+        "daily-spending-used": 1.25,
+      },
+      "quota-scopes": [],
+    });
   });
 
   test("opens a key modal, stores the key in localStorage, and supports logout", async () => {
@@ -89,6 +102,13 @@ describe("ApiKeyUsagePage", () => {
     expect(screen.getByText("快捷导入")).toBeInTheDocument();
     expect(screen.getByText("张军宝")).toBeInTheDocument();
     expect(screen.queryByText("使用统计")).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: /KEY 名称|Key name/i })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.fetchPublicUsageSummary).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "sk-demo" }),
+      );
+    });
+    expect(await screen.findByTestId("apikey-lookup-logs-quota")).toBeInTheDocument();
     expect(JSON.parse(window.localStorage.getItem("apiKeyUsage.lastApiKey.v1") || "{}")).toEqual({
       apiKey: "sk-demo",
       name: "张军宝",


### PR DESCRIPTION
## Summary
- 公开页 `ApiKeyUsagePage` 请求日志 toolbar 展示配额 used/limit
- 拉取 `fetchPublicUsageSummary`；无配额不占位
- 隐藏 KEY 名称列（单 key 页）

## Test
- [x] `bun run test -- pages/api-key-usage/__tests__/ApiKeyUsagePage.test.tsx`
- [ ] GHA PR Test Build