### PR TITLE
fix(auth-files): prevent stale usage during status refresh

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -54,6 +54,8 @@ export const AUTH_FILES_UI_STATE_KEY = "authFilesPage.uiState.v3";
 /** Tenant-scoped auth-files list/quota cache (v3). Legacy v2 is read only for migration. */
 export const AUTH_FILES_DATA_CACHE_KEY = "authFilesPage.dataCache.v3";
 export const AUTH_FILES_DATA_CACHE_KEY_V2 = "authFilesPage.dataCache.v2";
+/** Cached status/usage is only a warm-paint hint; refetch after one minute. */
+export const AUTH_FILES_DATA_CACHE_TTL_MS = 60_000;
 export const AUTH_FILES_QUOTA_PREVIEW_KEY = "authFilesPage.quotaPreview.v1";
 export const AUTH_FILES_QUOTA_AUTO_REFRESH_KEY = "authFilesPage.quotaAutoRefreshMs.v1";
 export const AUTH_FILES_FILES_VIEW_MODE_KEY = "authFilesPage.filesViewMode.v1";
@@ -634,7 +636,8 @@ const parseAuthFilesDataCacheBucket = (
   const savedAtMs =
     typeof parsed.savedAtMs === "number" && Number.isFinite(parsed.savedAtMs)
       ? parsed.savedAtMs
-      : Date.now();
+      : null;
+  if (savedAtMs === null) return null;
   return {
     savedAtMs,
     files,
@@ -646,6 +649,11 @@ const parseAuthFilesDataCacheBucket = (
     cycleByAuthIndex: sanitizeCycleByAuthIndexForCache(parsed.cycleByAuthIndex),
   };
 };
+
+const isAuthFilesDataCacheFresh = (
+  cache: AuthFilesDataCacheBucket,
+  nowMs = Date.now(),
+): boolean => nowMs - cache.savedAtMs <= AUTH_FILES_DATA_CACHE_TTL_MS;
 
 /**
  * Read auth-files list/quota cache for a tenant.
@@ -663,7 +671,7 @@ export const readAuthFilesDataCache = (
     // v3 may still hold a single unscoped bucket mid-migration.
     acceptUnscopedCurrent: true,
   });
-  if (!bucket) return null;
+  if (!bucket || !isAuthFilesDataCacheFresh(bucket)) return null;
   return { tenantId: tenantKey, ...bucket };
 };
 
@@ -684,17 +692,18 @@ export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
       cycleByAuthIndex: cache.cycleByAuthIndex,
     },
     merge: (previous, next) => {
+      const freshPrevious = previous && isAuthFilesDataCacheFresh(previous) ? previous : null;
       const fileNames = new Set(next.files.map((file) => file.name).filter(Boolean));
       return {
         savedAtMs: next.savedAtMs,
         files: next.files,
-        usageData: next.usageData ?? previous?.usageData,
+        usageData: next.usageData ?? freshPrevious?.usageData,
         quotaByFileName: sanitizeQuotaByFileNameForCache(
-          next.quotaByFileName ?? previous?.quotaByFileName,
+          next.quotaByFileName ?? freshPrevious?.quotaByFileName,
           fileNames,
         ),
         cycleByAuthIndex: sanitizeCycleByAuthIndexForCache(
-          next.cycleByAuthIndex ?? previous?.cycleByAuthIndex,
+          next.cycleByAuthIndex ?? freshPrevious?.cycleByAuthIndex,
         ),
       };
     },

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -59,6 +59,8 @@ import {
 
 const OAUTH_AUTH_FILES_REFRESH_TIMEOUT_MS = 12_000;
 const OAUTH_AUTH_FILES_REFRESH_INTERVAL_MS = 600;
+const EMPTY_STATUS_USAGE_INDEX = { statsBySource: {}, statsByAuthIndex: {} };
+const EMPTY_STATUS_USAGE_MAP = {};
 type AuthFilesConfigModalTab = "excluded" | "alias";
 type AuthFilesConfirmAction =
   | { type: "deleteSelection"; names: string[] }
@@ -485,6 +487,8 @@ export function AuthFilesPage() {
     runQuotaRefreshBatch,
     callsByAuthIndex,
     cycleBudgetByAuthIndex,
+    statusUsageReady,
+    statusUsageLoading,
   } = useAuthFilesQuotaState({
     tab: "files",
     pageItems,
@@ -493,6 +497,14 @@ export function AuthFilesPage() {
     setDetailFile,
     setUsageDataFromStatus: setUsageData,
   });
+
+  const displayedCycleCallsByAuthIndex = statusUsageReady
+    ? callsByAuthIndex
+    : EMPTY_STATUS_USAGE_MAP;
+  const displayedCycleBudgetByAuthIndex = statusUsageReady
+    ? cycleBudgetByAuthIndex
+    : EMPTY_STATUS_USAGE_MAP;
+  const displayedUsageIndex = statusUsageReady ? usageIndex : EMPTY_STATUS_USAGE_INDEX;
 
   const refreshQuotaAndCycleUsage = useCallback(
     async (
@@ -795,8 +807,10 @@ export function AuthFilesPage() {
     checkAuthFileConnectivity,
     quotaByFileName,
     resolveQuotaCardSlots,
-    cycleCallsByAuthIndex: callsByAuthIndex,
-    cycleBudgetByAuthIndex,
+    cycleCallsByAuthIndex: displayedCycleCallsByAuthIndex,
+    cycleBudgetByAuthIndex: displayedCycleBudgetByAuthIndex,
+    statusUsageReady,
+    statusUsageLoading,
     refreshQuota,
     requestResetCredit,
     resettingCreditFileName,
@@ -805,7 +819,7 @@ export function AuthFilesPage() {
     openTagsEditor: (file) => setTagsEditorFileName(file.name),
     statusUpdating,
     setFileEnabled,
-    usageIndex,
+    usageIndex: displayedUsageIndex,
   });
 
   return (
@@ -869,8 +883,9 @@ export function AuthFilesPage() {
         filesViewMode={filesViewMode}
         selectedFileNameSet={selectedFileNameSet}
         quotaByFileName={quotaByFileName}
-        cycleCallsByAuthIndex={callsByAuthIndex}
-        cycleBudgetByAuthIndex={cycleBudgetByAuthIndex}
+        cycleCallsByAuthIndex={displayedCycleCallsByAuthIndex}
+        cycleBudgetByAuthIndex={displayedCycleBudgetByAuthIndex}
+        statusUsageLoading={statusUsageLoading}
         resolveQuotaProvider={resolveQuotaProvider}
         resolveQuotaCardSlots={resolveQuotaCardSlots}
         refreshQuota={refreshQuotaAndCycleUsage}
@@ -880,7 +895,7 @@ export function AuthFilesPage() {
         clearingStatusFileName={clearingStatusFileName}
         setFileEnabled={setFileEnabled}
         statusUpdating={statusUpdating}
-        usageIndex={usageIndex}
+        usageIndex={displayedUsageIndex}
         resolveAuthFileStats={resolveAuthFileStats}
         toggleFileSelection={toggleFileSelection}
         formatPlanTypeLabel={formatPlanTypeLabel}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -2172,7 +2172,7 @@ describe("AuthFilesPage files table", () => {
     expect(mocks.getStatus).toHaveBeenCalled();
   });
 
-  test("full reload seeds 本周期 from cache so first paint is not Cycle --", async () => {
+  test("cached cycle stays loading until the first status GET resolves", async () => {
     window.localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
     setActiveCacheTenantId(DEFAULT_CACHE_TENANT_ID);
     const file = {
@@ -2189,34 +2189,19 @@ describe("AuthFilesPage files table", () => {
       tenantId: DEFAULT_CACHE_TENANT_ID,
       savedAtMs: Date.now(),
       files: [file],
+      usageData: {
+        source: [],
+        auth_index: [
+          { entity_name: "cycle-93", requests: 93, failed: 1, avg_latency: 0, total_tokens: 0 },
+        ],
+      },
       cycleByAuthIndex: {
         "cycle-93": { calls: 93, cycleCostTotal: null, weeklyQuotaUsedPercent: null },
       },
     });
     mocks.list.mockImplementation(async () => ({ files: [file] }));
-    // Delay status so first paint must come from cache, not network.
-    mocks.getStatus.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          setTimeout(
-            () =>
-              resolve({
-                items: [
-                  {
-                    auth_index: "cycle-93",
-                    quotas: [],
-                    usage: {
-                      cycle_request_total: 98,
-                      cycle_known: true,
-                      request_total: 200,
-                    },
-                  },
-                ],
-              }),
-            80,
-          );
-        }),
-    );
+    const statusDeferred = createDeferred<{ items: Array<Record<string, unknown>> }>();
+    mocks.getStatus.mockImplementation(() => statusDeferred.promise);
 
     render(
       <MemoryRouter initialEntries={["/auth-files"]}>
@@ -2233,9 +2218,32 @@ describe("AuthFilesPage files table", () => {
     const title = await screen.findByText("Cycle Cached");
     const card = title.closest("section");
     expect(card).not.toBeNull();
-    expect(within(card as HTMLElement).getByText("Cycle 93")).toBeInTheDocument();
-    expect(within(card as HTMLElement).queryByText("Cycle --")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("Cycle 93")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText("98.9%")).not.toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText("Cycle --")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Refresh" })[0]?.querySelector("svg")).toHaveClass(
+      "animate-spin",
+    );
+
+    await act(async () => {
+      statusDeferred.resolve({
+        items: [
+          {
+            auth_index: "cycle-93",
+            quotas: [],
+            usage: {
+              cycle_request_total: 98,
+              cycle_known: true,
+              request_total: 200,
+            },
+          },
+        ],
+      });
+      await statusDeferred.promise;
+    });
+
     expect(await within(card as HTMLElement).findByText("Cycle 98")).toBeInTheDocument();
+    expect(await within(card as HTMLElement).findByText("100.0%")).toBeInTheDocument();
   });
 
   test("cards view shows unknown cycle without lifetime/scope noise when weekly cycle is unknown", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import {
   AUTH_FILES_DATA_CACHE_KEY,
+  AUTH_FILES_DATA_CACHE_TTL_MS,
   AUTH_FILES_UI_STATE_KEY,
   buildUsageIndex,
   DEFAULT_CACHE_TENANT_ID,
@@ -367,9 +368,10 @@ describe("Auth Files helper coverage", () => {
     ]);
     expect(JSON.stringify(sanitized)).not.toContain("should-not-persist");
 
+    const savedAtMs = Date.now();
     writeAuthFilesDataCache({
       tenantId: "tenant-a",
-      savedAtMs: 123,
+      savedAtMs,
       files: sanitized,
       quotaByFileName: {
         "codex.json": {
@@ -380,11 +382,13 @@ describe("Auth Files helper coverage", () => {
         },
       },
     });
-    expect(window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain('"savedAtMs":123');
+    expect(window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain(
+      `"savedAtMs":${savedAtMs}`,
+    );
     expect(window.localStorage.getItem(AUTH_FILES_DATA_CACHE_KEY)).toContain("byTenant");
     expect(readAuthFilesDataCache("tenant-a")).toEqual({
       tenantId: "tenant-a",
-      savedAtMs: 123,
+      savedAtMs,
       files: sanitized,
       quotaByFileName: {
         "codex.json": {
@@ -397,6 +401,35 @@ describe("Auth Files helper coverage", () => {
     });
     // Different tenant must not see tenant-a's list/quota payload.
     expect(readAuthFilesDataCache("tenant-b")).toBeNull();
+  });
+
+  test("treats expired auth-files cache as a miss without reviving stale status data", () => {
+    const now = Date.now();
+    writeAuthFilesDataCache({
+      tenantId: "tenant-a",
+      savedAtMs: now - AUTH_FILES_DATA_CACHE_TTL_MS - 1,
+      files: [{ name: "stale.json", type: "codex" } as AuthFileItem],
+      quotaByFileName: {
+        "stale.json": {
+          status: "success",
+          items: [{ key: "code_5h", label: "m_quota.code_5h", percent: 99 }],
+        },
+      },
+      cycleByAuthIndex: { stale: { calls: 99 } },
+    });
+
+    expect(readAuthFilesDataCache("tenant-a")).toBeNull();
+
+    writeAuthFilesDataCache({
+      tenantId: "tenant-a",
+      savedAtMs: now,
+      files: [{ name: "fresh.json", type: "codex" } as AuthFileItem],
+    });
+    expect(readAuthFilesDataCache("tenant-a")).toEqual({
+      tenantId: "tenant-a",
+      savedAtMs: now,
+      files: [{ name: "fresh.json", type: "codex" }],
+    });
   });
 
   test("keeps shared subscription status so the badge can warm-paint", () => {

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -660,6 +660,7 @@ interface AuthFilesFilesTabProps {
   quotaByFileName: Record<string, QuotaState>;
   cycleCallsByAuthIndex: Record<string, number>;
   cycleBudgetByAuthIndex: Record<string, AuthFileCycleBudgetStats>;
+  statusUsageLoading: boolean;
   resolveQuotaProvider: (file: AuthFileItem) => QuotaProvider | null;
   resolveQuotaCardSlots: (
     provider: QuotaProvider,
@@ -760,6 +761,7 @@ export function AuthFilesFilesTab({
   quotaByFileName,
   cycleCallsByAuthIndex,
   cycleBudgetByAuthIndex,
+  statusUsageLoading,
   resolveQuotaProvider,
   resolveQuotaCardSlots,
   refreshQuota,
@@ -1501,7 +1503,7 @@ export function AuthFilesFilesTab({
                       <RefreshCw
                         size={15}
                         className={
-                          loading || usageLoading || refreshingAll
+                          loading || usageLoading || refreshingAll || statusUsageLoading
                             ? "animate-spin"
                             : ""
                         }

--- a/pages/auth-files/hooks/__tests__/mapAccountStatusToUi.test.ts
+++ b/pages/auth-files/hooks/__tests__/mapAccountStatusToUi.test.ts
@@ -113,6 +113,43 @@ describe("mapAccountStatusToUi", () => {
     expect(isAccountStatusFresher({ version: 1, timeMs: null }, null)).toBe(true);
   });
 
+  test("allows usage updates when the status version does not change", () => {
+    const current = readAccountStatusFreshness({
+      version: 7,
+      updated_at: "2026-07-16T12:00:00.000Z",
+      usage: {
+        updated_at: "2026-07-16T11:00:00.000Z",
+        cycle_request_total: 10,
+      },
+    });
+    const newerUsage = readAccountStatusFreshness({
+      version: 7,
+      updated_at: "2026-07-16T10:00:00.000Z",
+      usage: {
+        updated_at: "2026-07-16T13:00:00.000Z",
+        cycle_request_total: 10,
+      },
+    });
+    const changedCycle = readAccountStatusFreshness({
+      version: 7,
+      updated_at: "2026-07-16T10:00:00.000Z",
+      usage: { cycle_request_total: 11 },
+    });
+
+    expect(isAccountStatusFresher(newerUsage, current)).toBe(true);
+    expect(isAccountStatusFresher(changedCycle, current)).toBe(true);
+    expect(
+      applyAccountStatuses([
+        {
+          auth_index: "77",
+          version: 7,
+          quotas: [],
+          usage: { cycle_known: true, cycle_request_total: 11 },
+        },
+      ]).cycleByKey["77"]?.calls,
+    ).toBe(11);
+  });
+
   test("readAccountStatusFreshness uses server fields only", () => {
     expect(
       readAccountStatusFreshness({
@@ -123,6 +160,8 @@ describe("mapAccountStatusToUi", () => {
     ).toEqual({
       version: 7,
       timeMs: Date.parse("2026-07-16T12:00:00.000Z"),
+      usageTimeMs: null,
+      cycleRequestTotal: null,
     });
   });
 });

--- a/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
@@ -183,6 +183,32 @@ describe("useAuthFilesStatusState batch refresh", () => {
     );
   });
 
+  test("visibility refresh uses GET status without starting a provider probe", async () => {
+    const setFiles = vi.fn();
+    const setDetailFile = vi.fn();
+    const { result } = renderHook(() =>
+      useAuthFilesStatusState({
+        tab: "files",
+        pageItems: files,
+        loading: false,
+        setFiles,
+        setDetailFile,
+      }),
+    );
+
+    await waitFor(() => expect(mocks.startStatusRefresh).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.refreshingPage).toBe(false));
+    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(2));
+    mocks.getStatus.mockClear();
+    mocks.startStatusRefresh.mockClear();
+
+    Object.defineProperty(document, "hidden", { configurable: true, value: false });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
+    expect(mocks.startStatusRefresh).not.toHaveBeenCalled();
+  });
+
   test("forceRefreshPage posts one batch job then polls once and reloads snapshot", async () => {
     const setFiles = vi.fn();
     const setDetailFile = vi.fn();

--- a/pages/auth-files/hooks/mapAccountStatusToUi.ts
+++ b/pages/auth-files/hooks/mapAccountStatusToUi.ts
@@ -20,12 +20,14 @@ const parseTimestampMs = (value: string | null | undefined): number | undefined 
 export type AccountStatusFreshness = {
   version: number | null;
   timeMs: number | null;
+  usageTimeMs?: number | null;
+  cycleRequestTotal?: number | null;
 };
 
 export const readAccountStatusFreshness = (
   account: Pick<
     AiAccountLatestStatusDto,
-    "version" | "upstream_checked_at" | "updated_at" | "usage_updated_at"
+    "version" | "upstream_checked_at" | "updated_at" | "usage_updated_at" | "usage"
   >,
 ): AccountStatusFreshness => {
   let version: number | null = null;
@@ -35,14 +37,25 @@ export const readAccountStatusFreshness = (
     const parsed = Number(account.version);
     if (Number.isFinite(parsed)) version = parsed;
   }
+  const usageTimes = [
+    parseTimestampMs(account.usage_updated_at),
+    parseTimestampMs(account.usage?.updated_at),
+  ].filter((value): value is number => typeof value === "number");
+  const usageTimeMs = usageTimes.length > 0 ? Math.max(...usageTimes) : null;
   const times = [
     parseTimestampMs(account.upstream_checked_at),
     parseTimestampMs(account.updated_at),
-    parseTimestampMs(account.usage_updated_at),
+    usageTimeMs ?? undefined,
   ].filter((value): value is number => typeof value === "number");
+  const cycleRequestTotal = account.usage?.cycle_request_total;
   return {
     version,
     timeMs: times.length > 0 ? Math.max(...times) : null,
+    usageTimeMs,
+    cycleRequestTotal:
+      typeof cycleRequestTotal === "number" && Number.isFinite(cycleRequestTotal)
+        ? cycleRequestTotal
+        : null,
   };
 };
 
@@ -61,6 +74,19 @@ export const isAccountStatusFresher = (
   if (incoming.version != null && current.version != null) {
     if (incoming.version !== current.version) {
       return incoming.version > current.version;
+    }
+    // Usage can advance without bumping the status row version.
+    if (
+      incoming.usageTimeMs != null &&
+      (current.usageTimeMs == null || incoming.usageTimeMs > current.usageTimeMs)
+    ) {
+      return true;
+    }
+    if (
+      incoming.cycleRequestTotal != null &&
+      incoming.cycleRequestTotal !== current.cycleRequestTotal
+    ) {
+      return true;
     }
     if (incoming.timeMs != null && current.timeMs != null) {
       return incoming.timeMs >= current.timeMs;

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -190,6 +190,8 @@ interface UseAuthFilesFilesPresentationOptions {
   ) => { id: string; label: string; item: QuotaItem | null }[];
   cycleCallsByAuthIndex: Record<string, number>;
   cycleBudgetByAuthIndex: Record<string, AuthFileCycleBudgetStats>;
+  statusUsageReady: boolean;
+  statusUsageLoading: boolean;
   refreshQuota: (file: AuthFileItem, provider: QuotaProvider) => Promise<void>;
   requestResetCredit: (file: AuthFileItem) => void;
   resettingCreditFileName: string | null;
@@ -217,6 +219,8 @@ export function useAuthFilesFilesPresentation({
   resolveQuotaCardSlots,
   cycleCallsByAuthIndex,
   cycleBudgetByAuthIndex,
+  statusUsageReady,
+  statusUsageLoading,
   refreshQuota,
   requestResetCredit,
   resettingCreditFileName,
@@ -910,8 +914,14 @@ export function useAuthFilesFilesPresentation({
           const authIndex = normalizeAuthIndexValue(file.auth_index ?? file.authIndex);
           const calls = authIndex ? cycleCallsByAuthIndex[authIndex] : undefined;
           return (
-            <span className="text-xs font-semibold tabular-nums text-slate-700 dark:text-white/70">
-              {typeof calls === "number" ? calls : "--"}
+            <span className="inline-flex items-center justify-end gap-1 text-xs font-semibold tabular-nums text-slate-700 dark:text-white/70">
+              {!statusUsageReady && statusUsageLoading ? (
+                <Loader2 size={12} className="animate-spin" aria-label={t("common.loading")} />
+              ) : statusUsageReady && typeof calls === "number" ? (
+                calls
+              ) : (
+                "--"
+              )}
             </span>
           );
         },
@@ -926,7 +936,7 @@ export function useAuthFilesFilesPresentation({
           const stats = resolveAuthFileStats(file, usageIndex);
           return (
             <span className="text-xs font-semibold tabular-nums text-emerald-700 dark:text-emerald-200">
-              {stats.success}
+              {statusUsageReady ? stats.success : "--"}
             </span>
           );
         },
@@ -941,7 +951,7 @@ export function useAuthFilesFilesPresentation({
           const stats = resolveAuthFileStats(file, usageIndex);
           return (
             <span className="text-xs font-semibold tabular-nums text-rose-700 dark:text-rose-200">
-              {stats.failure}
+              {statusUsageReady ? stats.failure : "--"}
             </span>
           );
         },
@@ -951,6 +961,16 @@ export function useAuthFilesFilesPresentation({
         label: t("common.success_rate"),
         width: "w-44",
         render: (file) => {
+          if (!statusUsageReady) {
+            return statusUsageLoading ? (
+              <span className="inline-flex items-center gap-1 text-xs text-slate-500 dark:text-white/45">
+                <Loader2 size={12} className="animate-spin" />
+                {t("common.loading")}
+              </span>
+            ) : (
+              <span className="text-xs text-slate-400 dark:text-white/40">--</span>
+            );
+          }
           const statusData = resolveAuthFileStatusBar(file, usageIndex);
           return <ProviderStatusBar data={statusData} compact />;
         },
@@ -1170,6 +1190,8 @@ export function useAuthFilesFilesPresentation({
     connectivityState,
     cycleBudgetByAuthIndex,
     cycleCallsByAuthIndex,
+    statusUsageLoading,
+    statusUsageReady,
     downloadAuthFile,
     formatQuotaItemDetailText,
     formatPlanTypeLabel,

--- a/pages/auth-files/hooks/useAuthFilesStatusState.ts
+++ b/pages/auth-files/hooks/useAuthFilesStatusState.ts
@@ -50,6 +50,8 @@ import type { AuthFileCycleUsageSnapshot } from "./useAuthFilesCycleUsageState";
 
 const STATUS_POLL_INTERVAL_MS = 1_500;
 const STATUS_REFRESH_TIMEOUT_MS = 120_000;
+/** Lightweight shared-status GET cadence; separate from 1.5s refresh-job polling. */
+const STATUS_SNAPSHOT_REFRESH_INTERVAL_MS = 60_000;
 
 export function isFatalQuotaRefreshError(error: unknown): boolean {
   if (!isApiClientError(error)) return false;
@@ -194,8 +196,13 @@ export function useAuthFilesStatusState({
   const [statusApiSupported, setStatusApiSupported] = useState(true);
   const [statusLoading, setStatusLoading] = useState(false);
   const [refreshingPage, setRefreshingPage] = useState(false);
+  const [readyVisibleScopeKey, setReadyVisibleScopeKey] = useState<string | null>(null);
+  const [settledVisibleScopeKey, setSettledVisibleScopeKey] = useState<string | null>(null);
   const [quotaRefreshHalted, setQuotaRefreshHalted] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
+  const [pageVisible, setPageVisible] = useState(
+    () => typeof document === "undefined" || !document.hidden,
+  );
 
   const quotaInFlightRef = useRef<Set<string>>(new Set());
   const quotaAutoRefreshingRef = useRef<Set<string>>(new Set());
@@ -214,6 +221,7 @@ export function useAuthFilesStatusState({
   const mountedRef = useRef(true);
   const tenantIdRef = useRef(cacheTenantId);
   const pageItemsRef = useRef(pageItems);
+  const visibleStatusScopeKey = `${cacheTenantId}::${buildVisibleScopeKey(pageItems)}`;
 
   const [quotaAutoRefreshMsRaw, setQuotaAutoRefreshMsRaw] = useLocalStorage<number>(
     AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
@@ -255,6 +263,8 @@ export function useAuthFilesStatusState({
     singleBatchRef.current = null;
     statusLoadSeqRef.current += 1;
     loadedVisibleScopeRef.current = null;
+    setReadyVisibleScopeKey(null);
+    setSettledVisibleScopeKey(null);
     appliedFreshnessRef.current.clear();
     const tenantCache = readAuthFilesDataCache(cacheTenantId);
     setQuotaByFileName(tenantCache?.quotaByFileName ?? {});
@@ -275,12 +285,13 @@ export function useAuthFilesStatusState({
       };
     }
     setCycleByAuthIndex(seeded);
+    setUsageDataFromStatus?.({ source: [], auth_index: [] });
     setRefreshingPage(false);
     setStatusLoading(false);
     setStatusApiSupported(true);
     quotaInFlightRef.current.clear();
     quotaAutoRefreshingRef.current.clear();
-  }, [cacheTenantId]);
+  }, [cacheTenantId, setUsageDataFromStatus]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -726,6 +737,64 @@ export function useAuthFilesStatusState({
     [applyStatusesToUi, haltQuotaAutoRefresh, notify, t],
   );
 
+  const loadVisibleStatusSnapshot = useCallback(async (): Promise<boolean> => {
+    if (tab !== "files" || loading || !statusApiSupported) return false;
+    const visibleFiles = pageItemsRef.current;
+    const tenantId = tenantIdRef.current;
+    const scopeKey = `${tenantId}::${buildVisibleScopeKey(visibleFiles)}`;
+    const authIndexes = Array.from(
+      new Set(
+        visibleFiles
+          .map((file) => resolveFileAuthIndex(file))
+          .filter((value): value is string => Boolean(value)),
+      ),
+    );
+    if (authIndexes.length === 0) return false;
+    const ok = await loadStatusSnapshot({
+      filesForMerge: visibleFiles,
+      authIndexes,
+      quiet: true,
+      markUnsupportedOn404: true,
+    });
+    if (
+      mountedRef.current &&
+      tenantIdRef.current === tenantId &&
+      `${tenantIdRef.current}::${buildVisibleScopeKey(pageItemsRef.current)}` === scopeKey
+    ) {
+      setSettledVisibleScopeKey(scopeKey);
+      if (ok) setReadyVisibleScopeKey(scopeKey);
+    }
+    return ok;
+  }, [loadStatusSnapshot, loading, statusApiSupported, tab]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+    const handleVisibilityChange = () => {
+      const visible = !document.hidden;
+      setPageVisible(visible);
+      if (
+        visible &&
+        !statusLoading &&
+        !pageBatchRef.current &&
+        !singleBatchRef.current
+      ) {
+        void loadVisibleStatusSnapshot();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [loadVisibleStatusSnapshot, statusLoading]);
+
+  useInterval(
+    () => {
+      if (statusLoading || pageBatchRef.current || singleBatchRef.current) return;
+      void loadVisibleStatusSnapshot();
+    },
+    pageVisible && tab === "files" && !loading && statusApiSupported
+      ? STATUS_SNAPSHOT_REFRESH_INTERVAL_MS
+      : null,
+  );
+
   const pollJobUntilDone = useCallback(
     async (
       jobId: string,
@@ -895,7 +964,15 @@ export function useAuthFilesStatusState({
             // page + single may finish together; both finals must be allowed to apply.
             allowConcurrentApply: true,
           });
-          if (!applied && !controller.signal.aborted && tenantIdRef.current === tenantId) {
+          if (applied && kind === "page") {
+            const scopeKey = `${tenantId}::${buildVisibleScopeKey(files)}`;
+            if (
+              `${tenantIdRef.current}::${buildVisibleScopeKey(pageItemsRef.current)}` === scopeKey
+            ) {
+              setReadyVisibleScopeKey(scopeKey);
+              setSettledVisibleScopeKey(scopeKey);
+            }
+          } else if (!applied && !controller.signal.aborted && tenantIdRef.current === tenantId) {
             // Keep previous snapshot values; only drop stuck loading spinners.
             clearFilesLoading(files);
           }
@@ -951,7 +1028,7 @@ export function useAuthFilesStatusState({
   useEffect(() => {
     if (tab !== "files" || loading) return;
     if (!statusApiSupported) return;
-    const scopeKey = `${tenantIdRef.current}::${buildVisibleScopeKey(pageItems)}`;
+    const scopeKey = visibleStatusScopeKey;
     if (loadedVisibleScopeRef.current === scopeKey) return;
 
     const authIndexes = Array.from(
@@ -963,6 +1040,8 @@ export function useAuthFilesStatusState({
     );
     if (authIndexes.length === 0) {
       loadedVisibleScopeRef.current = scopeKey;
+      setReadyVisibleScopeKey(scopeKey);
+      setSettledVisibleScopeKey(scopeKey);
       return;
     }
 
@@ -976,8 +1055,11 @@ export function useAuthFilesStatusState({
         quiet: true,
         markUnsupportedOn404: true,
       });
-      if (!ok || controller.signal.aborted) return;
+      if (controller.signal.aborted) return;
+      setSettledVisibleScopeKey(scopeKey);
+      if (!ok) return;
       loadedVisibleScopeRef.current = scopeKey;
+      setReadyVisibleScopeKey(scopeKey);
       // Probe after snapshot so re-entering /access/ai-accounts always refreshes visible cards,
       // even when quota auto-refresh interval is 0.
       if (pageBatchRef.current) return;
@@ -998,6 +1080,7 @@ export function useAuthFilesStatusState({
     statusApiSupported,
     loadStatusSnapshot,
     cacheTenantId,
+    visibleStatusScopeKey,
     runBatchStatusRefresh,
   ]);
 
@@ -1277,6 +1360,15 @@ export function useAuthFilesStatusState({
     return result;
   }, [cycleByAuthIndex]);
 
+  const hasVisibleStatusTargets = pageItems.some((file) => resolveFileAuthIndex(file));
+  const statusUsageReady =
+    !hasVisibleStatusTargets ||
+    (readyVisibleScopeKey === visibleStatusScopeKey && !statusLoading);
+  const statusUsageLoading =
+    tab === "files" &&
+    hasVisibleStatusTargets &&
+    (settledVisibleScopeKey !== visibleStatusScopeKey || statusLoading || refreshingPage);
+
   const cycleBudgetByAuthIndex: Record<string, AuthFileCycleBudgetStats> = useMemo(
     () =>
       Object.fromEntries(
@@ -1322,6 +1414,8 @@ export function useAuthFilesStatusState({
     resolveQuotaTargets,
     statusApiSupported,
     statusLoading,
+    statusUsageReady,
+    statusUsageLoading,
     refreshingPage,
     callsByAuthIndex,
     cycleBudgetByAuthIndex,


### PR DESCRIPTION
## Summary
- 60s TTL on auth-files local data cache; do not treat expired cycle/usage as authoritative.
- On enter, show cycle/success placeholders until the first `GET /ai-accounts/status` resolves (even when auto-refresh is off).
- Light status GET every 60s while visible; tenant switch clears stale usage; same status version can still update cycle via usage freshness.

## Test plan
- [x] vitest: mapAccountStatusToUi, auth-files-helpers, useAuthFilesStatusState.batch (58)
- [x] vitest: AuthFilesPage.files-table (83), including stale Cycle 93 → loading → Cycle 98
- [x] `tsc --noEmit` admin-panel
- [ ] GHA `test-build` required check