### PR TITLE
fix: hide portal apikey-lookup quota reset actions

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/end-users.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/end-users.test.ts
@@ -79,19 +79,6 @@ describe("endUsersApi", () => {
     );
   });
 
-  test("uses portal reset and reset-history endpoints", async () => {
-    const post = vi.spyOn(portalApi.client, "post").mockResolvedValue({ status: "ok" });
-    const get = vi.spyOn(portalApi.client, "get").mockResolvedValue({ items: [], total: 0 });
-
-    await portalApi.resetKeyDailySpending("key-1");
-    await portalApi.listKeyDailySpendingResetHistory("key-1", 100);
-
-    expect(post).toHaveBeenCalledWith("/v0/portal/api-keys/key-1/daily-spending/reset", {});
-    expect(get).toHaveBeenCalledWith(
-      "/v0/portal/api-keys/key-1/daily-spending/reset-history?limit=100",
-    );
-  });
-
   test("renames and rotates keys through owner-scoped endpoints", async () => {
     mocks.patch.mockResolvedValue({ id: "key-1", name: "Renamed" });
     mocks.post.mockResolvedValue({

--- a/packages/api-client/src/endpoints/end-users.ts
+++ b/packages/api-client/src/endpoints/end-users.ts
@@ -254,19 +254,6 @@ export const portalApi = {
     ),
   updateKey: (id: string, body: EndUserAPIKeyMutationBody) =>
     portalClient.patch<EndUserAPIKey>(`/v0/portal/api-keys/${id}`, body),
-  resetKeyDailySpending: (id: string) =>
-    portalClient.post<ApiKeyDailySpendingResetResult>(
-      `/v0/portal/api-keys/${id}/daily-spending/reset`,
-      {},
-    ),
-  listKeyDailySpendingResetHistory: (id: string, limit?: number) => {
-    const query = new URLSearchParams();
-    if (limit != null) query.set("limit", String(limit));
-    const suffix = query.size > 0 ? `?${query.toString()}` : "";
-    return portalClient.get<ApiKeyDailySpendingResetHistoryResponse>(
-      `/v0/portal/api-keys/${id}/daily-spending/reset-history${suffix}`,
-    );
-  },
   rotateKey: (id: string) =>
     portalClient.post<{ api_key: EndUserAPIKey; plaintext_key?: string }>(
       `/v0/portal/api-keys/${id}/rotate`,

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -17,7 +17,6 @@ import {
   isApiClientError,
   portalApi,
   normalizePeriodSpendingLimits,
-  type ApiKeyDailySpendingResetEvent,
   type EndUser,
   type EndUserAPIKey,
   type SavedPortalAccount,
@@ -38,7 +37,6 @@ import type { TimeRange } from "@features/monitor-widgets/monitor-constants";
 import { ModelTag } from "@features/model-tags";
 import {
   OwnedApiKeyQuotaModal,
-  OwnedApiKeyResetHistoryModal,
   emptyPeriodSpendingDraft,
   formatQuotaValidationError,
   limitsToPeriodSpendingDraft,
@@ -370,9 +368,6 @@ export function ApiKeyLookupPage() {
   });
   const [editKeyTarget, setEditKeyTarget] = useState<EndUserAPIKey | null>(null);
   const [portalKeyQuotaError, setPortalKeyQuotaError] = useState("");
-  const [resetHistoryTarget, setResetHistoryTarget] = useState<EndUserAPIKey | null>(null);
-  const [resetHistoryEvents, setResetHistoryEvents] = useState<ApiKeyDailySpendingResetEvent[]>([]);
-  const [resetHistoryLoading, setResetHistoryLoading] = useState(false);
   const [deleteKeyTarget, setDeleteKeyTarget] = useState<EndUserAPIKey | null>(null);
   const [portalKeysBusy, setPortalKeysBusy] = useState(false);
   const [portalKeysLoading, setPortalKeysLoading] = useState(false);
@@ -1480,39 +1475,6 @@ export function ApiKeyLookupPage() {
                         ),
                       });
                     }}
-                    onResetDailySpending={(key) => {
-                      setPortalKeysBusy(true);
-                      void portalApi
-                        .resetKeyDailySpending(key.id)
-                        .then(async () => {
-                          await refreshPortalKeys();
-                        })
-                        .catch((err) => {
-                          setError(
-                            err instanceof Error
-                              ? err.message
-                              : t("apikey_lookup.reset_daily_spending_failed"),
-                          );
-                        })
-                        .finally(() => setPortalKeysBusy(false));
-                    }}
-                    onViewResetHistory={(key) => {
-                      setResetHistoryTarget(key);
-                      setResetHistoryEvents([]);
-                      setResetHistoryLoading(true);
-                      void portalApi
-                        .listKeyDailySpendingResetHistory(key.id, 200)
-                        .then((response) => setResetHistoryEvents(response.items ?? []))
-                        .catch((err) => {
-                          setError(
-                            err instanceof Error
-                              ? err.message
-                              : t("api_keys_page.reset_history_load_failed"),
-                          );
-                          setResetHistoryTarget(null);
-                        })
-                        .finally(() => setResetHistoryLoading(false));
-                    }}
                     onDelete={(key) => {
                       if (portalKeys.length <= 1) return;
                       setDeleteKeyTarget(key);
@@ -1910,19 +1872,6 @@ export function ApiKeyLookupPage() {
               .catch((err) => setPortalKeyQuotaError(formatQuotaValidationError(err, t)))
               .finally(() => setPortalKeysBusy(false));
           }}
-        />
-
-        <OwnedApiKeyResetHistoryModal
-          t={t}
-          open={resetHistoryTarget !== null}
-          onClose={() => {
-            setResetHistoryTarget(null);
-            setResetHistoryEvents([]);
-          }}
-          keyName={resetHistoryTarget?.name || t("api_keys_page.unnamed")}
-          maskedKey={resetHistoryTarget?.key_masked ?? ""}
-          loading={resetHistoryLoading}
-          events={resetHistoryEvents}
         />
 
         <SecretRevealModal

--- a/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
+++ b/pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx
@@ -135,8 +135,6 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       keySecret: vi.fn(),
       createKey: vi.fn(),
       updateKey: vi.fn(),
-      resetKeyDailySpending: vi.fn(),
-      listKeyDailySpendingResetHistory: vi.fn(),
       rotateKey: vi.fn(),
       deleteKey: vi.fn(),
       changePassword: vi.fn(),
@@ -751,7 +749,7 @@ describe("ApiKeyLookupPage", () => {
     });
   });
 
-  test("edits, resets, and opens history from the shared managed-key table", async () => {
+  test("edits quota from the shared managed-key table without reset actions", async () => {
     const { portalApi } = await import("@code-proxy/api-client");
     const user = {
       id: "u1",
@@ -794,19 +792,6 @@ describe("ApiKeyLookupPage", () => {
     vi.mocked(portalApi.listKeys).mockResolvedValue({ items: [key] } as never);
     vi.mocked(portalApi.keySecret).mockResolvedValue({ id: "k1", key: "sk-primary" });
     vi.mocked(portalApi.updateKey).mockResolvedValue({ ...key, name: "renamed" } as never);
-    vi.mocked(portalApi.resetKeyDailySpending).mockResolvedValue({ status: "ok" });
-    vi.mocked(portalApi.listKeyDailySpendingResetHistory).mockResolvedValue({
-      items: [
-        {
-          id: 7,
-          reset_at: "2026-07-21T11:00:00Z",
-          actor_username: "alice",
-          effective_used_before: 20,
-          raw_today_cost: 30,
-        },
-      ],
-      total: 1,
-    });
 
     render(
       <ThemeProvider>
@@ -831,7 +816,8 @@ describe("ApiKeyLookupPage", () => {
     expect(await screen.findByRole("columnheader", { name: "Quota" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Today" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Lifetime" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Total resets" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reset today spending" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "View reset history" })).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Edit Key quota" }));
     const editDialog = await screen.findByRole("dialog", { name: "Edit Key quota" });
@@ -847,20 +833,6 @@ describe("ApiKeyLookupPage", () => {
         "period-spending-limits": { "5h": 50, day: 80, week: 300, month: 1000 },
       });
     });
-
-    await userEvent.click(screen.getByRole("button", { name: "Reset today spending" }));
-    await waitFor(() => {
-      expect(portalApi.resetKeyDailySpending).toHaveBeenCalledWith("k1");
-    });
-
-    await userEvent.click(screen.getAllByRole("button", { name: "View reset history" })[0]!);
-    await waitFor(() => {
-      expect(portalApi.listKeyDailySpendingResetHistory).toHaveBeenCalledWith("k1", 200);
-    });
-    expect(
-      await screen.findByRole("dialog", { name: "Reset history · primary" }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText("$20.00").length).toBeGreaterThan(0);
   });
 
   test("confirms before deleting a managed API key", async () => {
@@ -940,10 +912,10 @@ describe("ApiKeyLookupPage", () => {
     expect(await screen.findByText("secondary")).toBeInTheDocument();
     const secondaryRow = screen.getByText("secondary").closest("tr");
     expect(secondaryRow).not.toBeNull();
+    // Portal rows only expose rotate/edit/delete, so delete is a direct icon button.
     await userEvent.click(
-      within(secondaryRow as HTMLElement).getByRole("button", { name: "More actions" }),
+      within(secondaryRow as HTMLElement).getByRole("button", { name: /^(delete|删除)$/i }),
     );
-    await userEvent.click(await screen.findByRole("menuitem", { name: /^(delete|删除)$/i }));
 
     expect(portalApi.deleteKey).not.toHaveBeenCalled();
     const confirmDialog = await screen.findByRole("dialog");
@@ -957,9 +929,8 @@ describe("ApiKeyLookupPage", () => {
     expect(portalApi.deleteKey).not.toHaveBeenCalled();
 
     await userEvent.click(
-      within(secondaryRow as HTMLElement).getByRole("button", { name: "More actions" }),
+      within(secondaryRow as HTMLElement).getByRole("button", { name: /^(delete|删除)$/i }),
     );
-    await userEvent.click(await screen.findByRole("menuitem", { name: /^(delete|删除)$/i }));
     await userEvent.click(
       within(await screen.findByRole("dialog")).getByRole("button", {
         name: /^(delete|删除)$/i,

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -13,8 +13,6 @@ export function ManageKeysTabContent({
   onRotate,
   onDelete,
   onEdit,
-  onResetDailySpending,
-  onViewResetHistory,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   keys: EndUserAPIKey[];
@@ -25,8 +23,6 @@ export function ManageKeysTabContent({
   onRotate: (key: EndUserAPIKey) => void;
   onDelete: (key: EndUserAPIKey) => void;
   onEdit: (key: EndUserAPIKey) => void;
-  onResetDailySpending: (key: EndUserAPIKey) => void;
-  onViewResetHistory: (key: EndUserAPIKey) => void;
 }) {
   return (
     <Card padding="none" className="overflow-hidden" bodyClassName="mt-0">
@@ -60,8 +56,6 @@ export function ManageKeysTabContent({
             onRotate,
             onDelete,
             onEdit,
-            onResetDailySpending,
-            onViewResetHistory,
           }}
         />
       </div>


### PR DESCRIPTION
## Summary
- Portal `/manage/apikey-lookup` key management no longer exposes “reset today spending” or reset history.
- Remove `portalApi` client methods for daily spending reset / history.
- Admin management pages retain reset capability.

## Test plan
- [x] `bun run test -- pages/api-key-lookup/__tests__/ApiKeyLookupPage.test.tsx packages/api-client/src/endpoints/__tests__/end-users.test.ts`
- [ ] GHA `test-build` required check

Pairs with CliRelay PR: remove portal reset API routes.