### PR TITLE
fix(auth-files): warm-paint membership plan badges across remounts

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -55,7 +55,8 @@ export const AUTH_FILES_UI_STATE_KEY = "authFilesPage.uiState.v3";
 export const AUTH_FILES_DATA_CACHE_KEY = "authFilesPage.dataCache.v3";
 export const AUTH_FILES_DATA_CACHE_KEY_V2 = "authFilesPage.dataCache.v2";
 /** Cached status/usage is only a warm-paint hint; refetch after one minute. */
-export const AUTH_FILES_DATA_CACHE_TTL_MS = 60_000;
+/** Warm paint for membership badges / quota / cycle across route remounts. */
+export const AUTH_FILES_DATA_CACHE_TTL_MS = 30 * 60_000;
 export const AUTH_FILES_QUOTA_PREVIEW_KEY = "authFilesPage.quotaPreview.v1";
 export const AUTH_FILES_QUOTA_AUTO_REFRESH_KEY = "authFilesPage.quotaAutoRefreshMs.v1";
 export const AUTH_FILES_FILES_VIEW_MODE_KEY = "authFilesPage.filesViewMode.v1";
@@ -113,6 +114,8 @@ export type AuthFilesDataCache = {
   quotaByFileName?: Record<string, QuotaState>;
   /** Seed card cycle badges so full reload is 93→98, not --→98. */
   cycleByAuthIndex?: Record<string, AuthFileCycleCacheSnapshot>;
+  /** Last-good membership chip (PRO / PRO 5X / PRO 20X) for first paint after remount. */
+  displayPlanByFileName?: Record<string, string>;
 };
 
 type AuthFilesDataCacheBucket = Omit<AuthFilesDataCache, "tenantId">;
@@ -626,6 +629,29 @@ const sanitizeCycleByAuthIndexForCache = (
   return Object.keys(output).length > 0 ? output : undefined;
 };
 
+const sanitizeDisplayPlanByFileNameForCache = (
+  displayPlanByFileName: unknown,
+  fileNames?: Set<string>,
+): Record<string, string> | undefined => {
+  if (
+    !displayPlanByFileName ||
+    typeof displayPlanByFileName !== "object" ||
+    Array.isArray(displayPlanByFileName)
+  ) {
+    return undefined;
+  }
+  const output: Record<string, string> = {};
+  for (const [fileName, raw] of Object.entries(
+    displayPlanByFileName as Record<string, unknown>,
+  )) {
+    if (!fileName || (fileNames && !fileNames.has(fileName))) continue;
+    const planType = normalizePlanType(raw);
+    if (!planType) continue;
+    output[fileName] = planType;
+  }
+  return Object.keys(output).length > 0 ? output : undefined;
+};
+
 const parseAuthFilesDataCacheBucket = (
   value: unknown,
 ): AuthFilesDataCacheBucket | null => {
@@ -647,6 +673,7 @@ const parseAuthFilesDataCacheBucket = (
         : undefined,
     quotaByFileName: sanitizeQuotaByFileNameForCache(parsed.quotaByFileName),
     cycleByAuthIndex: sanitizeCycleByAuthIndexForCache(parsed.cycleByAuthIndex),
+    displayPlanByFileName: sanitizeDisplayPlanByFileNameForCache(parsed.displayPlanByFileName),
   };
 };
 
@@ -690,6 +717,7 @@ export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
       usageData: cache.usageData,
       quotaByFileName: cache.quotaByFileName,
       cycleByAuthIndex: cache.cycleByAuthIndex,
+      displayPlanByFileName: cache.displayPlanByFileName,
     },
     merge: (previous, next) => {
       const freshPrevious = previous && isAuthFilesDataCacheFresh(previous) ? previous : null;
@@ -704,6 +732,10 @@ export const writeAuthFilesDataCache = (cache: AuthFilesDataCache) => {
         ),
         cycleByAuthIndex: sanitizeCycleByAuthIndexForCache(
           next.cycleByAuthIndex ?? freshPrevious?.cycleByAuthIndex,
+        ),
+        displayPlanByFileName: sanitizeDisplayPlanByFileNameForCache(
+          next.displayPlanByFileName ?? freshPrevious?.displayPlanByFileName,
+          fileNames,
         ),
       };
     },

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -365,7 +365,7 @@ describe("AuthFileDetailModal", () => {
 
     expect(screen.getByRole("tab", { name: "Usage" })).toBeInTheDocument();
     expect(screen.getByRole("dialog", { name: "pcamtu927@gmail.com" })).toBeInTheDocument();
-    expect(screen.getByText("Plus")).toBeInTheDocument();
+    expect(screen.getByText("PLUS")).toBeInTheDocument();
     expect(screen.getByText("Current cycle cost")).toBeInTheDocument();
     expect(screen.getByText("$1.2345")).toBeInTheDocument();
   });
@@ -409,6 +409,46 @@ describe("AuthFileDetailModal", () => {
     expect(screen.queryByText(/resets/)).not.toBeInTheDocument();
   });
 
+  test("title membership chip matches card style and codex pro multiplier", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "codex-pro.json",
+        label: "Codex Pro",
+        type: "codex",
+        provider: "codex",
+        plan_type: "pro",
+        size: 256,
+      },
+      modelsFileType: "codex",
+      quotaState: {
+        status: "success",
+        planType: "pro",
+        items: [],
+        updatedAt: Date.now(),
+      },
+      detailTrend: {
+        auth_index: "auth-pro",
+        days: 7,
+        hours: 5,
+        request_total: 100,
+        cycle_request_total: 100,
+        cycle_cost_total: 333.9,
+        weekly_quota_used_percent: 13,
+        cycle_known: true,
+        cycle_start: "2026-07-22T00:00:00Z",
+        daily_usage: [],
+        hourly_usage: [],
+        quota_series: [],
+      },
+    });
+
+    // $333.9 / 13% ≈ $2568 budget → PRO 20X solid chip, not soft "Pro".
+    const badge = screen.getByTestId("auth-file-plan-badge");
+    expect(badge).toHaveTextContent("PRO 20X");
+    expect(badge.className).toContain("from-yellow-300");
+    expect(badge.className).not.toContain("bg-amber-50");
+  });
+
   test("shows SuperGrok plan badge and falls back cycle totals for xAI when cycle is unknown", () => {
     renderDetailModal({
       detailFile: {
@@ -448,7 +488,8 @@ describe("AuthFileDetailModal", () => {
       },
     });
 
-    expect(screen.getByText("SuperGrok")).toBeInTheDocument();
+    expect(screen.getByText("SUPERGROK")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-file-plan-badge")).toHaveClass("from-neutral-900");
     expectSummaryCard("Last 7 days requests", "116");
     // When cycle_known is false, fall back to request_total instead of showing 0.
     expectSummaryCard("Current weekly cycle", "116");

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -3383,7 +3383,7 @@ describe("AuthFilesPage files table", () => {
     const dialog = await screen.findByRole("dialog", {
       name: "pcamtu927@gmail.com",
     });
-    expect(within(dialog).getByText("Plus")).toBeInTheDocument();
+    expect(within(dialog).getByText("PLUS")).toBeInTheDocument();
     expect(within(dialog).getByRole("tab", { name: "Usage" })).toBeInTheDocument();
     expect(await within(dialog).findByText("Current cycle cost")).toBeInTheDocument();
     expect(within(dialog).getByText("$1.2345")).toBeInTheDocument();

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -432,6 +432,36 @@ describe("Auth Files helper coverage", () => {
     });
   });
 
+  test("persists display plan tiers so membership chips warm-paint after remount", () => {
+    const savedAtMs = Date.now();
+    writeAuthFilesDataCache({
+      tenantId: "tenant-a",
+      savedAtMs,
+      files: [{ name: "codex.json", type: "codex" } as AuthFileItem],
+      displayPlanByFileName: {
+        "codex.json": "pro_20x",
+        "skip-me.json": "pro",
+      },
+    });
+    expect(readAuthFilesDataCache("tenant-a")).toEqual({
+      tenantId: "tenant-a",
+      savedAtMs,
+      files: [{ name: "codex.json", type: "codex" }],
+      displayPlanByFileName: { "codex.json": "pro_20x" },
+    });
+
+    // Partial write without displayPlan keeps last-good tiers (list refresh path).
+    writeAuthFilesDataCache({
+      tenantId: "tenant-a",
+      savedAtMs: savedAtMs + 1,
+      files: [{ name: "codex.json", type: "codex" } as AuthFileItem],
+      usageData: { source: [], auth_index: [] },
+    });
+    expect(readAuthFilesDataCache("tenant-a")?.displayPlanByFileName).toEqual({
+      "codex.json": "pro_20x",
+    });
+  });
+
   test("keeps shared subscription status so the badge can warm-paint", () => {
     const [cachedFile] = sanitizeAuthFilesForCache([
       {

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -34,14 +34,20 @@ import { useProxyPoolChecks } from "@features/proxy-pool";
 import {
   canRenameAuthFileChannel,
   downloadTextAsFile,
+  formatPlanBadgeLabel,
+  getActiveCacheTenantId,
   matchesModelPattern,
   normalizeProviderKey,
   parseAdditionalQuotaWindowLabel,
   readAuthFileChannelName,
+  readAuthFilesDataCache,
   resolveClaudeOAuthHealth,
   resolveAuthFileDisplayName,
+  resolveAuthFileDisplayPlanType,
   resolveAuthFilePlanType,
   resolveFileType,
+  resolvePlanBadgeClass,
+  shouldShowAuthFilePlanBadge,
   type AuthFileModelItem,
   type AuthFileModelOwnerGroup,
   type ChannelEditorState,
@@ -315,24 +321,33 @@ export function AuthFileDetailModal({
     ? resolveAuthFileDisplayName(detailFile) || String(detailFile.name || "")
     : t("auth_files.view_auth_file");
   const claudeOAuthHealth = detailFile ? resolveClaudeOAuthHealth(detailFile) : null;
-  const detailPlanType = detailFile ? resolveAuthFilePlanType(detailFile, quotaState) : null;
-  const detailPlanLabel = useMemo(() => {
-    if (!detailPlanType) return "";
-    const normalized = detailPlanType.trim().toLowerCase();
-    if (!normalized) return "";
-    if (normalized === "plus" || normalized === "team" || normalized === "free") {
-      return t(`codex_quota.plan_${normalized}`);
-    }
-    if (normalized === "supergrok") return t("xai_quota.plan_supergrok");
-    if (
-      normalized === "supergrok-heavy" ||
-      normalized === "supergrok_heavy" ||
-      normalized === "supergrokheavy"
-    ) {
-      return t("xai_quota.plan_supergrok_heavy");
-    }
-    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
-  }, [detailPlanType, t]);
+  // Same membership chip as cards/table: display tier + solid gradient, not soft amber title pill.
+  const detailBasePlanType = detailFile ? resolveAuthFilePlanType(detailFile, quotaState) : null;
+  const detailPlanType = useMemo(() => {
+    if (!detailFile) return null;
+    const cachedPlan =
+      readAuthFilesDataCache(getActiveCacheTenantId())?.displayPlanByFileName?.[detailFile.name] ??
+      null;
+    return resolveAuthFileDisplayPlanType(
+      detailFile,
+      quotaState,
+      {
+        cycleCostTotal: detailTrend?.cycle_cost_total ?? null,
+        weeklyQuotaUsedPercent: detailTrend?.weekly_quota_used_percent ?? null,
+      },
+      cachedPlan ?? detailBasePlanType,
+    );
+  }, [
+    detailBasePlanType,
+    detailFile,
+    detailTrend?.cycle_cost_total,
+    detailTrend?.weekly_quota_used_percent,
+    quotaState,
+  ]);
+  const detailPlanLabel = detailPlanType ? formatPlanBadgeLabel(detailPlanType) : "";
+  const showDetailPlanBadge = detailFile
+    ? shouldShowAuthFilePlanBadge(detailFile, detailBasePlanType)
+    : false;
   const excludedModels = excluded[providerKey] ?? [];
   const canRenameChannel = detailFile ? canRenameAuthFileChannel(detailFile) : false;
   const channelBaseline = detailFile ? readAuthFileChannelName(detailFile) : "";
@@ -1333,8 +1348,14 @@ export function AuthFileDetailModal({
       open={open}
       title={detailTitle}
       titleAccessory={
-        detailPlanLabel ? (
-          <span className="inline-flex shrink-0 items-center rounded-full bg-amber-50 px-2 py-0.5 text-2xs font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+        showDetailPlanBadge && detailPlanLabel ? (
+          <span
+            data-testid="auth-file-plan-badge"
+            className={[
+              "inline-flex shrink-0 items-center rounded-md px-2 py-0.5 text-2xs font-bold tracking-wide",
+              resolvePlanBadgeClass(detailPlanType),
+            ].join(" ")}
+          >
             {detailPlanLabel}
           </span>
         ) : undefined

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -26,6 +26,8 @@ import {
   formatAuthFileRestrictionRemaining,
   formatModified,
   formatPlanBadgeLabel,
+  getActiveCacheTenantId,
+  readAuthFilesDataCache,
   resolveClaudeOAuthHealthBadges,
   isRuntimeOnlyAuthFile,
   normalizeAuthIndexValue,
@@ -43,6 +45,7 @@ import {
   resolvePlanBadgeClass,
   shouldShowAuthFileDisplayTag,
   shouldShowAuthFilePlanBadge,
+  writeAuthFilesDataCache,
   type AuthFileCycleBudgetStats,
 } from "@code-proxy/domain";
 import { resolveQuotaProvider, type QuotaProvider } from "@features/quota-preview/quota-fetch";
@@ -231,20 +234,60 @@ export function useAuthFilesFilesPresentation({
   setFileEnabled,
   usageIndex,
 }: UseAuthFilesFilesPresentationOptions) {
-  // Sticky last-good plan tier so PRO / PRO 5X / PRO 20X do not flash on partial refresh.
-  const stickyDisplayPlanRef = useRef<Map<string, string>>(new Map());
+  // Sticky last-good plan tier so PRO / PRO 5X / PRO 20X do not flash on partial refresh
+  // or full remount. Seed from tenant cache; memory alone dies on route leave / F5.
+  const stickyDisplayPlanRef = useRef<Map<string, string> | null>(null);
+  if (stickyDisplayPlanRef.current === null) {
+    const seeded = new Map<string, string>();
+    const cached = readAuthFilesDataCache(getActiveCacheTenantId());
+    for (const [name, plan] of Object.entries(cached?.displayPlanByFileName ?? {})) {
+      if (name && plan) seeded.set(name, plan);
+    }
+    stickyDisplayPlanRef.current = seeded;
+  }
+  const persistDisplayPlanTimerRef = useRef<number | null>(null);
+  const schedulePersistDisplayPlans = useCallback(() => {
+    if (typeof window === "undefined") return;
+    if (persistDisplayPlanTimerRef.current != null) {
+      window.clearTimeout(persistDisplayPlanTimerRef.current);
+    }
+    persistDisplayPlanTimerRef.current = window.setTimeout(() => {
+      const tenantId = getActiveCacheTenantId();
+      const current = readAuthFilesDataCache(tenantId);
+      if (!current || !Array.isArray(current.files)) return;
+      const sticky = stickyDisplayPlanRef.current;
+      if (!sticky || sticky.size === 0) return;
+      const displayPlanByFileName: Record<string, string> = {
+        ...(current.displayPlanByFileName ?? {}),
+      };
+      for (const [name, plan] of sticky) {
+        if (name && plan) displayPlanByFileName[name] = plan;
+      }
+      writeAuthFilesDataCache({
+        ...current,
+        tenantId,
+        savedAtMs: Date.now(),
+        displayPlanByFileName,
+      });
+    }, 250);
+  }, []);
   const resolveStickyDisplayPlanType = useCallback(
     (
       file: AuthFileItem,
       quotaState?: QuotaState | null,
       cycleStats?: AuthFileCycleBudgetStats | null,
     ) => {
-      const previous = stickyDisplayPlanRef.current.get(file.name) ?? null;
+      const sticky = stickyDisplayPlanRef.current ?? new Map<string, string>();
+      stickyDisplayPlanRef.current = sticky;
+      const previous = sticky.get(file.name) ?? null;
       const next = resolveAuthFileDisplayPlanType(file, quotaState, cycleStats, previous);
-      if (next) stickyDisplayPlanRef.current.set(file.name, next);
+      if (next && sticky.get(file.name) !== next) {
+        sticky.set(file.name, next);
+        schedulePersistDisplayPlans();
+      }
       return next;
     },
-    [],
+    [schedulePersistDisplayPlans],
   );
   const { t } = useTranslation();
 


### PR DESCRIPTION
## Summary
- Persist last-good membership display plan tiers (`displayPlanByFileName`) in the auth-files tenant cache and seed sticky plan resolution from it on remount/full reload.
- Extend auth-files data cache TTL so warm paint survives normal route leave / refresh.
- Unify detail modal title plan chip with cards/table: same `resolveAuthFileDisplayPlanType` / `formatPlanBadgeLabel` / solid gradient `resolvePlanBadgeClass` (no soft amber "Pro" pill).

## Root cause
Membership chip sticky state lived only in an in-memory `useRef`. Leaving `/access/ai-accounts` or hard-refreshing dropped it; list reload then re-resolved from incomplete base plan (e.g. plain `pro` instead of `pro_20x`). Detail modal also used a separate soft-pill + title-case path.

## Test plan
- [x] `bun run test -- pages/auth-files/__tests__/auth-files-helpers.test.tsx pages/auth-files/__tests__/AuthFileDetailModal.test.tsx` (61 passed)
- [ ] Manual: open AI accounts, note PRO 5X/20X chips, leave and re-enter route — chips should warm-paint without flashing to plain PRO; open detail modal chip matches card style/label.