### PR TITLE
fix(identity): 禁止修改或删除租户管理员

### DIFF
--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -117,6 +117,26 @@ const memberUser = {
   version: 3,
 };
 
+const tenantAdminRole = {
+  ...operatorRole,
+  id: "r-tenant-admin",
+  code: "tenant_admin",
+  name: "Tenant Administrator",
+  system_protected: true,
+  permissions: administratorRole.permissions.filter((permission) =>
+    permission.startsWith("tenant."),
+  ),
+};
+
+const tenantAdminUser = {
+  ...memberUser,
+  id: "u-tenant-admin",
+  username: "tenant-admin",
+  display_name: "Tenant Admin User",
+  role_ids: [tenantAdminRole.id, operatorRole.id],
+  role_codes: [tenantAdminRole.code, operatorRole.code],
+};
+
 const menuItems = [
   {
     code: "group.system",
@@ -679,6 +699,46 @@ test("uses a switch for the two user availability states", async ({ page }) => {
   await expect(memberRow.getByRole("button", { name: "More actions" })).toHaveCount(0);
   await memberRow.getByRole("switch").click();
   await expect(page.getByRole("dialog", { name: "Disable user" })).toBeVisible();
+});
+
+test("protects tenant admin role assignment and deletion actions", async ({ page }) => {
+  await page.addInitScript(() =>
+    sessionStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "cps_test",
+        rememberPassword: false,
+        expiresAt: Date.now() + 60_000,
+      }),
+    ),
+  );
+  await mockIdentity(
+    page,
+    [principal.home_tenant],
+    [administratorRole, tenantAdminRole, operatorRole],
+    [principal.user, tenantAdminUser, memberUser],
+    menuItems,
+    roleMenuItems,
+  );
+
+  await page.goto("/#/governance/users");
+  const tenantAdminRow = page.locator('[data-vt-row-key="u-tenant-admin"]');
+  await expect(tenantAdminRow.getByRole("button", { name: "Set roles" })).toBeDisabled();
+  await expect(tenantAdminRow.getByRole("button", { name: "Delete" })).toBeDisabled();
+  await expect(tenantAdminRow.getByRole("button", { name: "Reset password" })).toBeEnabled();
+  await expect(tenantAdminRow.getByRole("switch")).toBeEnabled();
+
+  await page.goto("/#/roles");
+  const tenantAdminRoleRow = page.locator('[data-vt-row-key="r-tenant-admin"]');
+  await expect(tenantAdminRoleRow.getByRole("button", { name: "Assign users" })).toBeDisabled();
+
+  const operatorRoleRow = page.locator('[data-vt-row-key="r-operator"]');
+  await operatorRoleRow.getByRole("button", { name: "Assign users" }).click();
+  const dialog = page.getByRole("dialog", { name: "Assign users to Operator" });
+  const tenantAdminCheckbox = dialog.getByRole("checkbox", { name: /Tenant Admin User/ });
+  await expect(tenantAdminCheckbox).toBeChecked();
+  await expect(tenantAdminCheckbox).toBeDisabled();
 });
 
 test("edits role permissions and assigns users from action modals", async ({ page }) => {

--- a/pages/roles/RolesPage.tsx
+++ b/pages/roles/RolesPage.tsx
@@ -23,6 +23,8 @@ import { useAuth } from "@app/providers/AuthProvider";
 import { buildPermissionTree, PermissionTree } from "./PermissionTree";
 
 const emptyForm = { name: "", description: "" };
+const hasProtectedRoleAssignments = (user: UserIdentity) =>
+  user.role_codes?.some((code) => code === "platform_super_admin" || code === "tenant_admin");
 
 export function RolesPage() {
   const { notify } = useToast();
@@ -229,8 +231,10 @@ export function RolesPage() {
               <Button
                 size="xs"
                 variant="ghost"
+                disabled={role.system_protected}
                 tooltip={t("identity_admin.assign_users")}
                 onClick={() => {
+                  if (role.system_protected) return;
                   setUserRole(role);
                   setSelectedUsers(
                     new Set(
@@ -291,7 +295,7 @@ export function RolesPage() {
   };
 
   const saveUsers = async () => {
-    if (!userRole) return;
+    if (!userRole || userRole.system_protected) return;
     const success = await run(
       () => identityApi.replaceRoleUsers(userRole.id, [...selectedUsers], userRole.version),
       t("identity_admin.role_users_saved"),
@@ -419,7 +423,11 @@ export function RolesPage() {
         footer={
           <>
             <Button onClick={() => setUserRole(null)}>{t("common.cancel")}</Button>
-            <Button variant="primary" disabled={busy} onClick={() => void saveUsers()}>
+            <Button
+              variant="primary"
+              disabled={busy || Boolean(userRole?.system_protected)}
+              onClick={() => void saveUsers()}
+            >
               {t("identity_admin.save")}
             </Button>
           </>
@@ -428,7 +436,7 @@ export function RolesPage() {
         <div className="space-y-2">
           {users.map((user) => {
             const checked = selectedUsers.has(user.id);
-            const disabled = user.role_codes?.includes("platform_super_admin");
+            const disabled = hasProtectedRoleAssignments(user);
             return (
               <label
                 key={user.id}

--- a/pages/users/UsersPage.tsx
+++ b/pages/users/UsersPage.tsx
@@ -31,6 +31,8 @@ import {
   type CreateUserFormErrors,
 } from "./userForm";
 
+const isTenantAdmin = (user: UserIdentity) => user.role_codes?.includes("tenant_admin");
+
 export function UsersPage() {
   const { notify } = useToast();
   const { t, i18n } = useTranslation();
@@ -138,6 +140,14 @@ export function UsersPage() {
       user.id === principal?.user.id || user.role_codes?.includes("platform_super_admin"),
     [principal?.user.id],
   );
+  const cannotAssignRoles = useCallback(
+    (user: UserIdentity) => isProtected(user) || isTenantAdmin(user),
+    [isProtected],
+  );
+  const cannotDelete = useCallback(
+    (user: UserIdentity) => isProtected(user) || isTenantAdmin(user),
+    [isProtected],
+  );
 
   const closeCreate = () => {
     setCreateOpen(false);
@@ -242,15 +252,18 @@ export function UsersPage() {
         lockOrder: "end",
         render: (user) => {
           const protectedUser = isProtected(user);
+          const rolesDisabled = cannotAssignRoles(user);
+          const deleteDisabled = cannotDelete(user);
           return (
             <div className="flex items-center gap-1.5">
               <PermissionGate permission="tenant.users.assign_roles">
                 <Button
                   size="xs"
                   variant="ghost"
-                  disabled={protectedUser || busy || !canReadRoles}
+                  disabled={rolesDisabled || busy || !canReadRoles}
                   tooltip={t("identity_admin.set_roles")}
                   onClick={() => {
+                    if (cannotAssignRoles(user)) return;
                     setRolesUser(user);
                     setRolesDraft([...(user.role_ids ?? [])]);
                   }}
@@ -278,9 +291,11 @@ export function UsersPage() {
                   size="xs"
                   variant="ghost"
                   className="text-rose-600 hover:text-rose-700 dark:text-rose-300 dark:hover:text-rose-200"
-                  disabled={protectedUser || busy}
+                  disabled={deleteDisabled || busy}
                   tooltip={t("identity_admin.delete")}
-                  onClick={() => setDeleteUser(user)}
+                  onClick={() => {
+                    if (!cannotDelete(user)) setDeleteUser(user);
+                  }}
                 >
                   <Trash2 size={15} />
                 </Button>
@@ -290,7 +305,18 @@ export function UsersPage() {
         },
       },
     ],
-    [busy, canReadRoles, i18n.language, isProtected, roleNames, run, t, userName],
+    [
+      busy,
+      canReadRoles,
+      cannotAssignRoles,
+      cannotDelete,
+      i18n.language,
+      isProtected,
+      roleNames,
+      run,
+      t,
+      userName,
+    ],
   );
 
   const createUser = async (event: FormEvent) => {
@@ -342,7 +368,7 @@ export function UsersPage() {
 
   const submitRoles = async (event: FormEvent) => {
     event.preventDefault();
-    if (!rolesUser) return;
+    if (!rolesUser || cannotAssignRoles(rolesUser)) return;
     const success = await run(
       () => identityApi.assignUserRoles(rolesUser.id, rolesDraft),
       t("identity_admin.roles_saved"),
@@ -567,7 +593,12 @@ export function UsersPage() {
         footer={
           <>
             <Button onClick={() => setRolesUser(null)}>{t("common.cancel")}</Button>
-            <Button type="submit" form="set-user-roles-form" variant="primary" disabled={busy}>
+            <Button
+              type="submit"
+              form="set-user-roles-form"
+              variant="primary"
+              disabled={busy || Boolean(rolesUser && cannotAssignRoles(rolesUser))}
+            >
               {t("identity_admin.save")}
             </Button>
           </>
@@ -575,7 +606,12 @@ export function UsersPage() {
       >
         <Form id="set-user-roles-form" onSubmit={submitRoles}>
           <FormField label={t("identity_admin.roles")}>
-            <MultiSelect options={roleOptions} value={rolesDraft} onChange={setRolesDraft} />
+            <MultiSelect
+              options={roleOptions}
+              value={rolesDraft}
+              disabled={Boolean(rolesUser && cannotAssignRoles(rolesUser))}
+              onChange={setRolesDraft}
+            />
           </FormField>
         </Form>
       </Modal>
@@ -626,7 +662,7 @@ export function UsersPage() {
         busy={busy}
         onClose={() => setDeleteUser(null)}
         onConfirm={() => {
-          if (!deleteUser) return;
+          if (!deleteUser || cannotDelete(deleteUser)) return;
           void run(
             () => identityApi.deleteUser(deleteUser.id),
             t("identity_admin.user_deleted"),


### PR DESCRIPTION
## 变更

- 用户管理页将持有内置 `tenant_admin` 角色的账号视为角色/删除保护对象，禁用“设置角色”和“删除”按钮。
- 保留租户管理员的状态切换与密码重置能力；现有 self / `platform_super_admin` 全动作保护不变。
- 角色管理页禁用内置受保护角色的成员批量编辑，并禁止通过自定义角色成员弹窗增删租户管理员。
- 为弹窗提交与确认回调增加同等保护，避免绕过按钮禁用。
- 增加 Playwright 回归测试覆盖 UsersPage 与 RolesPage 两条 UI 路径。

## 本地验证

- `bun install --frozen-lockfile` — passed
- `bun run lint` — passed（0 errors，9 个仓库既有 warnings）
- `bun run design:check` — passed
- `bun run test:ci` — passed（126 files，887 tests）
- `bun run build` — passed
- `bunx playwright test e2e/multi-tenant-auth.spec.ts --grep 'protects tenant admin role assignment and deletion actions' --project=chromium --config=.playwright-tenant-admin.config.ts` — passed（临时 config 仅将本地 dev server 切到 52743，执行后已删除）

未声明本地完整 `./scripts/ci-pr.sh` 通过；等待 PR required check 执行完整门禁。

## 契约

与 CliRelay 后端 PR 配套：后端在 authority boundary 对租户管理员角色变更/删除返回 `ErrProtectedResource`。
