### PR TITLE
fix(navigation): recover stale moderation routes

### DIFF
--- a/apps/admin-panel/src/app/AppRouter.test.ts
+++ b/apps/admin-panel/src/app/AppRouter.test.ts
@@ -16,6 +16,9 @@ describe("AppRouter", () => {
     const identityRoute = readRepoModule("pages/identity-fingerprint/route.tsx");
     const ccSwitchRoute = readRepoModule("pages/ccswitch-import-settings/route.tsx");
     const apiKeyPermissionsRoute = readRepoModule("pages/api-key-permissions/route.tsx");
+    const contentModerationRoute = readRepoModule("pages/content-moderation/route.tsx");
+    const authProvider = readAppModule("app/providers/AuthProvider.tsx");
+    const appShell = readAppModule("app/layout/AppShell.tsx");
 
     expect(source).toContain("pageRoutes");
     expect(modelsRoute).toMatch(/path:\s*"\/models\/catalog"/);
@@ -51,6 +54,19 @@ describe("AppRouter", () => {
     expect(apiKeyPermissionsRoute).toContain(
       '{ from: "/system/api-key-permissions", to: "/access/api-key-permissions" }',
     );
+
+    expect(contentModerationRoute).toMatch(/path:\s*"\/access\/content-moderation"/);
+    expect(contentModerationRoute).toContain(
+      '{ from: "/runtime/content-moderation", to: "/access/content-moderation" }',
+    );
+    expect(contentModerationRoute).toContain(
+      '{ from: "/manage/runtime/content-moderation", to: "/access/content-moderation" }',
+    );
+    expect(authProvider).toContain('code: "runtime.content-moderation"');
+    expect(authProvider).toContain('parent_code: "group.access"');
+    expect(authProvider).toContain('path: "/access/content-moderation"');
+    expect(appShell).toContain('pathname.startsWith("/access/content-moderation")');
+    expect(appShell).toContain('pathname.startsWith("/runtime/content-moderation")');
   });
 
   test("keeps the HTML app loader as the only initial page loader", () => {
@@ -69,5 +85,10 @@ describe("AppRouter", () => {
     expect(routerSource).not.toContain('variant="initial"');
     expect(routerSource).not.toContain('variant="inline"');
     expect(protectedRouteSource).toContain("if (hasAppLoader()) return null");
+    expect(routerSource).not.toContain(
+      '<Route path="*" element={<Navigate to="/dashboard" replace />} />',
+    );
+    expect(routerSource).toContain('<Route path="*" element={readyRoute(<StaleRoutePage />)} />');
+    expect(routerSource).toContain("window.location.reload()");
   });
 });

--- a/apps/admin-panel/src/app/AppRouter.test.tsx
+++ b/apps/admin-panel/src/app/AppRouter.test.tsx
@@ -167,4 +167,23 @@ describe("AppRouter", () => {
     );
     expect(await screen.findByTestId("embed-page")).toBeInTheDocument();
   });
+
+  test("shows stale-route recovery instead of silently redirecting unknown paths", async () => {
+    render(
+      <MemoryRouter initialEntries={["/access/route-from-newer-shell"]}>
+        <AppRouter />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: /Page not found|页面未找到|Страница не найдена/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Cmd\+Shift\+R/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Reload page|重新加载页面|Перезагрузить страницу/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-page")).not.toBeInTheDocument();
+  });
 });

--- a/apps/admin-panel/src/app/AppRouter.tsx
+++ b/apps/admin-panel/src/app/AppRouter.tsx
@@ -1,9 +1,11 @@
 import { Suspense, useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { FileQuestion } from "lucide-react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AuthProvider, useAuth } from "@app/providers/AuthProvider";
 import { ProtectedRoute } from "@/app/guards/ProtectedRoute";
 import { DashboardLayout } from "@app/layout/DashboardLayout";
-import { ThemeProvider, ToastProvider } from "@code-proxy/ui";
+import { Button, ThemeProvider, ToastProvider } from "@code-proxy/ui";
 import { AutoUpdatePrompt } from "@app/update/AutoUpdatePrompt";
 import { ChunkLoadErrorBoundary } from "@/app/bootstrap/ChunkLoadErrorBoundary";
 import { dismissAppLoader } from "@/app/bootstrap/dismissAppLoader";
@@ -108,6 +110,30 @@ function AuthorizedEmbedPage({ path }: { path: string }) {
   return readyRoute(<EmbedPage />);
 }
 
+function StaleRoutePage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mx-auto grid min-h-[60vh] max-w-xl place-items-center text-center">
+      <div>
+        <FileQuestion className="mx-auto mb-5 text-amber-500" size={48} />
+        <h2 className="text-2xl font-semibold text-slate-950 dark:text-white">
+          {t("shell.stale_route_title")}
+        </h2>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          {t("shell.stale_route_description")}
+        </p>
+        <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+          {t("shell.stale_route_shortcut")}
+        </p>
+        <Button className="mt-6" variant="primary" onClick={() => window.location.reload()}>
+          {t("shell.stale_route_reload")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /** Must render Routes itself so embed <Route>s are direct children of <Routes>. */
 function AuthenticatedRoutes() {
   const { state } = useAuth();
@@ -181,9 +207,9 @@ function AuthenticatedRoutes() {
                     />
                   ))}
                 <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                <Route path="*" element={readyRoute(<StaleRoutePage />)} />
               </Route>
             </Route>
-            <Route path="*" element={<Navigate to="/dashboard" replace />} />
           </Routes>
         </Suspense>
       </ChunkLoadErrorBoundary>

--- a/apps/admin-panel/src/app/layout/AppShell.test.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.test.tsx
@@ -121,6 +121,17 @@ const testMenus: MenuIdentity[] = [
     sort_order: 10,
   }),
   menu({
+    code: "runtime.content-moderation",
+    parent_code: "group.access",
+    type: "menu",
+    path: "/access/content-moderation",
+    component: "content-moderation",
+    label_key: "shell.nav_content_moderation",
+    icon: "shield-alert",
+    permission_code: "content_moderation.read",
+    sort_order: 45,
+  }),
+  menu({
     code: "group.models",
     type: "directory",
     path: "/models",
@@ -403,6 +414,45 @@ describe("AppShell route progress", () => {
     fireEvent.click(runtimeGroup);
     expect(runtimeGroup).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("link", { name: /Request Logs|请求日志/i })).not.toBeInTheDocument();
+  });
+
+  test("places content moderation under access and uses the shield-alert icon", () => {
+    renderShell("/access/content-moderation");
+
+    const accessGroup = screen.getByRole("button", {
+      name: /Access(?: & Credentials)?|接入(?:管理|与凭证)/i,
+    });
+    const runtimeGroup = screen.getByRole("button", {
+      name: /Operations|Observability|运行监控|运行观测/i,
+    });
+    expect(accessGroup).toHaveAttribute("aria-expanded", "true");
+
+    const moderation = screen.getByRole("link", {
+      name: /Content Moderation|内容审核|Модерация контента/i,
+    });
+    const accessItems = document.getElementById(accessGroup.getAttribute("aria-controls") ?? "");
+    const runtimeItems = document.getElementById(runtimeGroup.getAttribute("aria-controls") ?? "");
+    expect(accessItems).toContainElement(moderation);
+    expect(runtimeItems).not.toContainElement(moderation);
+    expect(moderation).toHaveAttribute("href", "/access/content-moderation");
+    expect(moderation).toHaveAttribute("aria-current", "page");
+    expect(moderation.querySelector("svg")).toHaveClass("lucide-shield-alert");
+    expect(
+      screen.getByRole("heading", {
+        name: /Content Moderation|内容审核|Модерация контента/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test("keeps the legacy moderation path title as a stale-shell safety fallback", () => {
+    authPrincipal = defaultPrincipal({ menus: [] });
+    renderShell("/runtime/content-moderation");
+
+    expect(
+      screen.getByRole("heading", {
+        name: /Content Moderation|内容审核|Модерация контента/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   test("renders system info as a top-level leaf after all nav groups", () => {

--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -198,7 +198,12 @@ const getPageTitleKey = (pathname: string, menus?: MenuIdentity[] | null): strin
     if (hit) return menuLabelKey(hit);
   }
   if (pathname.startsWith("/dashboard")) return "shell.nav_dashboard";
-  if (pathname.startsWith("/runtime/content-moderation")) return "shell.nav_content_moderation";
+  if (
+    pathname.startsWith("/access/content-moderation") ||
+    pathname.startsWith("/runtime/content-moderation")
+  ) {
+    return "shell.nav_content_moderation";
+  }
   if (
     pathname.startsWith("/access/ai-accounts") ||
     pathname.startsWith("/system/account-security") ||

--- a/apps/admin-panel/src/app/providers/AuthProvider.tsx
+++ b/apps/admin-panel/src/app/providers/AuthProvider.tsx
@@ -188,17 +188,6 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
     permission_code: "system.logs.read",
     sort_order: 30,
   }),
-  menu({
-    code: "runtime.content-moderation",
-    parent_code: "group.runtime",
-    type: "menu",
-    path: "/runtime/content-moderation",
-    component: "content-moderation",
-    label_key: "shell.nav_content_moderation",
-    icon: "shield-alert",
-    permission_code: "content_moderation.read",
-    sort_order: 40,
-  }),
   // Top-level leaf pinned after all groups (matches CliRelay MenuCatalog).
   menu({
     code: "runtime.system",
@@ -278,6 +267,18 @@ const LEGACY_SERVICE_MENUS: MenuIdentity[] = [
     icon: "shield-check",
     permission_code: "api_key_profiles.read",
     sort_order: 40,
+  }),
+  // Stable code matches CliRelay while the page now belongs to Access & Credentials.
+  menu({
+    code: "runtime.content-moderation",
+    parent_code: "group.access",
+    type: "menu",
+    path: "/access/content-moderation",
+    component: "content-moderation",
+    label_key: "shell.nav_content_moderation",
+    icon: "shield-alert",
+    permission_code: "content_moderation.read",
+    sort_order: 45,
   }),
   menu({
     code: "access.ccswitch",

--- a/packages/i18n/src/__tests__/translation-keys.test.ts
+++ b/packages/i18n/src/__tests__/translation-keys.test.ts
@@ -19,6 +19,10 @@ const REQUIRED_KEYS = [
   "providers.real_model_id",
   "providers.model_enabled",
   "common.model_alias_placeholder",
+  "shell.stale_route_title",
+  "shell.stale_route_description",
+  "shell.stale_route_shortcut",
+  "shell.stale_route_reload",
 ] as const;
 
 describe("translation keys", () => {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2077,7 +2077,11 @@
     "sidebar_account_role": "Super Admin",
     "nav_menu_management": "Menu Management",
     "forget_saved_account": "Forget saved account",
-    "nav_content_moderation": "Content Moderation"
+    "nav_content_moderation": "Content Moderation",
+    "stale_route_title": "Page not found or frontend version is outdated",
+    "stale_route_description": "This frontend may not include the requested page. Hard refresh to load the latest version and try again.",
+    "stale_route_shortcut": "Hard refresh: Cmd+Shift+R on macOS; Ctrl+Shift+R on Windows/Linux.",
+    "stale_route_reload": "Reload page"
   },
   "proxies": {
     "title": "Proxy Management",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -1716,7 +1716,11 @@
     "skip_to_content": "Skip to main content",
     "nav_menu_management": "Управление меню",
     "forget_saved_account": "Forget saved account",
-    "nav_content_moderation": "Модерация контента"
+    "nav_content_moderation": "Модерация контента",
+    "stale_route_title": "Страница не найдена или версия интерфейса устарела",
+    "stale_route_description": "В этой версии интерфейса может не быть запрошенной страницы. Выполните жёсткое обновление, чтобы загрузить последнюю версию.",
+    "stale_route_shortcut": "Жёсткое обновление: Cmd+Shift+R в macOS; Ctrl+Shift+R в Windows/Linux.",
+    "stale_route_reload": "Перезагрузить страницу"
   },
   "api_key_permissions_page": {
     "title": "API Key Permissions",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2094,7 +2094,11 @@
     "sidebar_account_role": "超级管理员",
     "nav_menu_management": "菜单管理",
     "forget_saved_account": "忘记此账号",
-    "nav_content_moderation": "内容审核"
+    "nav_content_moderation": "内容审核",
+    "stale_route_title": "页面未找到或前端版本过旧",
+    "stale_route_description": "当前前端可能没有这个页面。请硬刷新后重试，以加载最新版本。",
+    "stale_route_shortcut": "硬刷新：macOS 按 Cmd+Shift+R；Windows/Linux 按 Ctrl+Shift+R。",
+    "stale_route_reload": "重新加载页面"
   },
   "proxies": {
     "title": "代理管理",

--- a/pages/content-moderation/route.tsx
+++ b/pages/content-moderation/route.tsx
@@ -5,12 +5,16 @@ const { Page: ContentModerationPage, preload: preloadContentModerationPage } = p
 );
 
 export const contentModerationRoute = {
-  path: "/runtime/content-moderation",
+  path: "/access/content-moderation",
   component: "content-moderation",
   element: <ContentModerationPage />,
   auth: true,
   layout: "dashboard",
   nav: { labelKey: "nav.content_moderation" },
+  redirects: [
+    { from: "/runtime/content-moderation", to: "/access/content-moderation" },
+    { from: "/manage/runtime/content-moderation", to: "/access/content-moderation" },
+  ],
   requiredPermission: "content_moderation.read",
   preload: preloadContentModerationPage,
 };


### PR DESCRIPTION
## Summary
- move content moderation to `/access/content-moderation` and redirect legacy runtime URLs
- align management-key fallback menus with the backend parent/path while retaining the stable menu code
- preserve page titles for both new and legacy paths and keep the `shield-alert` icon binding
- replace the silent unknown-route dashboard redirect with a localized stale-version recovery page and reload action
- add router, shell placement/icon/title, and translation regression coverage

## Validation
- focused Vitest: `AppRouter.test.ts`, `AppRouter.test.tsx`, `AppShell.test.tsx`, `translation-keys.test.ts` — 28 passed
- `bun run lint` — passed with 9 pre-existing warnings, 0 errors
- `./scripts/ci-pr.sh` — lint, design check, full Vitest (907 tests), build, and bundle diff passed; the final Playwright stage initially attached to an unrelated local PDF app already occupying port 5173 because `reuseExistingServer` is enabled outside CI
- equivalent isolated critical Playwright smoke on port 5187 — 9 passed
