### PR TITLE
fix(ui): use Form fields in moderation profile editor

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -91,6 +91,7 @@ export { Tabs, TabsList, TabsTrigger, TabsContent } from "./primitives/Tabs";
 export { Textarea } from "./primitives/Textarea";
 export type { TextareaProps } from "./primitives/Textarea";
 export { ToggleSwitch } from "./primitives/ToggleSwitch";
+export type { ToggleSwitchProps } from "./primitives/ToggleSwitch";
 
 export { ThemeProvider, useTheme, ThemeToggleButton } from "./theme/ThemeProvider";
 export { LanguageSelector } from "./theme/LanguageSelector";

--- a/packages/ui/src/navigation/PaginationBar.tsx
+++ b/packages/ui/src/navigation/PaginationBar.tsx
@@ -192,6 +192,7 @@ export function PaginationBar({
             {labels.rowsPerPage}
           </span>
           <Select
+            fullWidth={false}
             value={String(pageSize)}
             onChange={(value) => onPageSizeChange(Number(value))}
             options={pageSizeOptions.map((size) => ({

--- a/packages/ui/src/primitives/Select.tsx
+++ b/packages/ui/src/primitives/Select.tsx
@@ -57,6 +57,8 @@ export interface SelectProps {
   name?: string;
   /** Extra className on the trigger button */
   className?: string;
+  /** Stretch the default trigger to its container width. Ignored by the compact chip variant. */
+  fullWidth?: boolean;
   /** Disable interactions */
   disabled?: boolean;
   /** Visual style variant */
@@ -80,6 +82,7 @@ export function Select({
   "aria-describedby": ariaDescribedBy,
   name,
   className,
+  fullWidth = true,
   disabled = false,
   variant = "default",
   size = "default",
@@ -180,6 +183,7 @@ export function Select({
         onClick={() => setOpen((prev) => !prev)}
         className={cn(
           variant === "chip" ? selectTriggerChip : getSelectTriggerBase(size),
+          variant !== "chip" && fullWidth ? "w-full" : null,
           open && selectTriggerOpen,
           disabled && selectTriggerDisabled,
           className,

--- a/packages/ui/src/primitives/ToggleSwitch.tsx
+++ b/packages/ui/src/primitives/ToggleSwitch.tsx
@@ -1,5 +1,17 @@
 import { useId, type ReactNode } from "react";
 
+export interface ToggleSwitchProps {
+  checked: boolean;
+  onCheckedChange: (next: boolean) => void;
+  label?: ReactNode;
+  description?: ReactNode;
+  disabled?: boolean;
+  ariaLabel?: string;
+  id?: string;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean | "true" | "false";
+}
+
 export function ToggleSwitch({
   checked,
   onCheckedChange,
@@ -7,24 +19,23 @@ export function ToggleSwitch({
   description,
   disabled = false,
   ariaLabel,
-}: {
-  checked: boolean;
-  onCheckedChange: (next: boolean) => void;
-  label?: ReactNode;
-  description?: ReactNode;
-  disabled?: boolean;
-  ariaLabel?: string;
-}) {
-  const id = useId();
+  id,
+  "aria-describedby": ariaDescribedBy,
+  "aria-invalid": ariaInvalid,
+}: ToggleSwitchProps) {
+  const generatedId = useId();
+  const resolvedId = id ?? generatedId;
   const hasText = Boolean(label || description);
 
   const button = (
     <button
-      id={id}
+      id={resolvedId}
       type="button"
       role="switch"
       aria-checked={checked}
       aria-label={ariaLabel ?? (typeof label === "string" ? label : undefined)}
+      aria-describedby={ariaDescribedBy}
+      aria-invalid={ariaInvalid}
       disabled={disabled}
       onClick={() => onCheckedChange(!checked)}
       className={[
@@ -62,7 +73,7 @@ export function ToggleSwitch({
       <div className="min-w-0">
         {label ? (
           <label
-            htmlFor={id}
+            htmlFor={resolvedId}
             className="block text-sm font-semibold text-slate-900 dark:text-white"
           >
             {label}

--- a/packages/ui/src/primitives/__tests__/Form.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Form.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { Form, FormField } from "../Form";
 import { TextInput } from "../Input";
 import { Textarea } from "../Textarea";
+import { ToggleSwitch } from "../ToggleSwitch";
 
 describe("FormField", () => {
   test("wires label, description, and control id for accessibility", () => {
@@ -88,6 +89,18 @@ describe("FormField", () => {
     );
     const input = screen.getByRole("textbox");
     expect(input.className).toMatch(/border-rose/);
+  });
+
+  test("wires FormField label and description to ToggleSwitch", () => {
+    render(
+      <FormField label="清除 API Key" description="保存后立即生效" htmlFor="clear-key">
+        <ToggleSwitch checked={false} onCheckedChange={() => undefined} />
+      </FormField>,
+    );
+
+    const toggle = screen.getByRole("switch", { name: "清除 API Key" });
+    expect(toggle).toHaveAttribute("id", "clear-key");
+    expect(toggle).toHaveAttribute("aria-describedby", "clear-key-description");
   });
 });
 

--- a/packages/ui/src/primitives/__tests__/Select.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Select.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { Select } from "../Select";
+
+const options = [
+  { value: "off", label: "Off" },
+  { value: "on", label: "On" },
+];
+
+describe("Select", () => {
+  test("stretches the default trigger to the container width", () => {
+    render(<Select value="off" onChange={() => undefined} options={options} aria-label="Mode" />);
+
+    expect(screen.getByRole("combobox", { name: "Mode" })).toHaveClass("w-full");
+  });
+
+  test("keeps the chip variant compact", () => {
+    render(
+      <Select
+        value="off"
+        onChange={() => undefined}
+        options={options}
+        aria-label="Mode"
+        variant="chip"
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Mode" })).not.toHaveClass("w-full");
+  });
+
+  test("allows compact default-style selects in toolbars", () => {
+    render(
+      <Select
+        value="off"
+        onChange={() => undefined}
+        options={options}
+        aria-label="Mode"
+        fullWidth={false}
+      />,
+    );
+
+    expect(screen.getByRole("combobox", { name: "Mode" })).not.toHaveClass("w-full");
+  });
+});

--- a/pages/ccswitch-import-settings/CcSwitchImportOptions.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportOptions.tsx
@@ -135,6 +135,7 @@ function ClaudeAuthFieldSelect({
         <span className="text-xs font-semibold text-slate-600 dark:text-white/55">{label}</span>
       )}
       <Select
+        fullWidth={!compact}
         value={settings.claude.apiKeyField ?? "ANTHROPIC_API_KEY"}
         onChange={onChange}
         options={options}

--- a/pages/content-moderation/__tests__/ProfileEditorModal.test.tsx
+++ b/pages/content-moderation/__tests__/ProfileEditorModal.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ContentModerationProfileView } from "@code-proxy/api-client";
+import i18n from "@code-proxy/i18n";
+import { ProfileEditorModal, type ProfileEditorModalProps } from "../components/ProfileEditorModal";
+
+const profile: ContentModerationProfileView = {
+  id: "profile-1",
+  name: "Strict prompts",
+  mode: "pre_block",
+  base_url: "https://api.openai.com",
+  model: "omni-moderation-latest",
+  timeout_ms: 3000,
+  keyword_mode: "keyword_only",
+  blocked_keywords: ["blocked"],
+  thresholds: { violence: 0.95 },
+  block_http_status: 403,
+  block_message: "Blocked",
+  version: 3,
+  created_at: "2026-07-22T01:00:00Z",
+  updated_at: "2026-07-22T02:00:00Z",
+  api_key_configured: true,
+  api_key_masked: "sk-a****z",
+  binding_counts: { auth_file: 2, provider_key: 1, provider: 1 },
+};
+
+function renderEditor({
+  editedProfile = null,
+  onSave = vi.fn<ProfileEditorModalProps["onSave"]>().mockResolvedValue(undefined),
+}: {
+  editedProfile?: ContentModerationProfileView | null;
+  onSave?: ProfileEditorModalProps["onSave"];
+} = {}) {
+  render(
+    <ProfileEditorModal
+      open
+      profile={editedProfile}
+      saving={false}
+      onClose={() => undefined}
+      onSave={onSave}
+    />,
+  );
+}
+
+describe("ProfileEditorModal", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  test("uses shared FormField wiring and full-width Select controls", () => {
+    renderEditor();
+
+    const form = document.querySelector("form[data-slot='form']");
+    expect(form).toHaveAttribute("id", "content-moderation-profile-form");
+    expect(document.querySelectorAll("[data-slot='form-field']")).toHaveLength(11);
+    expect(document.querySelector("[data-slot='form-field-info'].invisible")).toBeNull();
+
+    expect(screen.getByRole("combobox", { name: "Mode" })).toHaveClass("w-full");
+    expect(screen.getByRole("combobox", { name: "Check strategy" })).toHaveClass("w-full");
+
+    const keywords = screen.getByLabelText("Blocked keywords");
+    const keywordsHint = screen.getByText(
+      "Matches are case-insensitive substrings. Empty lines and duplicates are removed.",
+    );
+    expect(keywords).toHaveAttribute("aria-describedby", keywordsHint.id);
+
+    const thresholds = screen.getByLabelText("Category thresholds");
+    const thresholdsHint = screen.getByText(
+      "One category=value entry per line. Values must be between 0 and 1.",
+    );
+    expect(thresholds).toHaveAttribute("aria-describedby", thresholdsHint.id);
+  });
+
+  test("keeps moderation API fields disabled in keyword-only mode", () => {
+    renderEditor({ editedProfile: profile });
+
+    expect(screen.getByLabelText("Moderation base URL")).toBeDisabled();
+    expect(screen.getByLabelText("Moderation model")).toBeDisabled();
+    expect(screen.getByLabelText("Moderation API key")).toBeDisabled();
+    expect(screen.getByLabelText("Category thresholds")).toBeDisabled();
+    expect(screen.getByRole("switch", { name: "Clear the configured API key" })).not.toBeDisabled();
+  });
+
+  test("submits the existing create payload through the form", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn<ProfileEditorModalProps["onSave"]>().mockResolvedValue(undefined);
+    renderEditor({ onSave });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Profile name" }), {
+      target: { value: "  New Profile  " },
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "New Profile",
+        mode: "off",
+        base_url: "https://api.openai.com",
+        model: "omni-moderation-latest",
+        timeout_ms: 3000,
+        keyword_mode: "api_only",
+        blocked_keywords: [],
+        block_http_status: 403,
+        block_message: "Your request was blocked by the content moderation policy.",
+      }),
+    );
+    expect(onSave.mock.calls[0]?.[0]).not.toHaveProperty("version");
+    expect(onSave.mock.calls[0]?.[0]).not.toHaveProperty("clear_api_key");
+  });
+});

--- a/pages/content-moderation/components/ProfileEditorModal.tsx
+++ b/pages/content-moderation/components/ProfileEditorModal.tsx
@@ -7,7 +7,16 @@ import type {
   CreateContentModerationProfileInput,
   PatchContentModerationProfileInput,
 } from "@code-proxy/api-client";
-import { Button, Modal, Select, Textarea, TextInput, ToggleSwitch } from "@code-proxy/ui";
+import {
+  Button,
+  Form,
+  FormField,
+  Modal,
+  Select,
+  Textarea,
+  TextInput,
+  ToggleSwitch,
+} from "@code-proxy/ui";
 
 const DEFAULT_THRESHOLDS: Record<string, number> = {
   harassment: 0.98,
@@ -192,37 +201,48 @@ export function ProfileEditorModal({
       footer={
         <>
           {error ? (
-            <span className="mr-auto text-sm font-semibold text-rose-700 dark:text-rose-200">
+            <span
+              role="alert"
+              className="mr-auto text-sm font-semibold text-rose-700 dark:text-rose-200"
+            >
               {error}
             </span>
           ) : null}
-          <Button variant="secondary" onClick={onClose} disabled={saving}>
+          <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
             {t("common.cancel")}
           </Button>
-          <Button variant="primary" onClick={() => void submit()} disabled={saving}>
+          <Button
+            type="submit"
+            form="content-moderation-profile-form"
+            variant="primary"
+            disabled={saving}
+          >
             {saving ? t("common.saving") : t("common.save")}
           </Button>
         </>
       }
     >
-      <div className="space-y-5">
+      <Form
+        id="content-moderation-profile-form"
+        className="space-y-5"
+        noValidate
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+      >
         <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-2">
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.profile_name")}
-              </span>
+            <FormField label={t("content_moderation.profile_name")} required reserveMeta={false}>
               <TextInput
                 value={draft.name}
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, name: event.currentTarget.value }))
-                }
+                onChange={(event) => {
+                  const name = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, name }));
+                }}
               />
-            </label>
-            <div className="space-y-2">
-              <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.mode")}
-              </p>
+            </FormField>
+            <FormField label={t("content_moderation.mode")} reserveMeta={false}>
               <Select
                 value={draft.mode}
                 onChange={(value) => {
@@ -233,9 +253,8 @@ export function ProfileEditorModal({
                   { value: "off", label: t("content_moderation.mode_off") },
                   { value: "pre_block", label: t("content_moderation.mode_pre_block") },
                 ]}
-                aria-label={t("content_moderation.mode")}
               />
-            </div>
+            </FormField>
           </div>
           <p className="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
             {t("content_moderation.fail_open_notice")}
@@ -244,10 +263,7 @@ export function ProfileEditorModal({
 
         <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-2">
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.keyword_mode")}
-              </span>
+            <FormField label={t("content_moderation.keyword_mode")} reserveMeta={false}>
               <Select
                 value={draft.keywordMode}
                 onChange={(value) => {
@@ -271,80 +287,68 @@ export function ProfileEditorModal({
                     label: t("content_moderation.keyword_mode_keyword_and_api"),
                   },
                 ]}
-                aria-label={t("content_moderation.keyword_mode")}
               />
-            </label>
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.timeout_ms")}
-              </span>
+            </FormField>
+            <FormField label={t("content_moderation.timeout_ms")} reserveMeta={false}>
               <TextInput
                 value={draft.timeoutMs}
                 inputMode="numeric"
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    timeoutMs: event.currentTarget.value,
-                  }))
-                }
+                onChange={(event) => {
+                  const timeoutMs = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, timeoutMs }));
+                }}
               />
-            </label>
+            </FormField>
           </div>
 
-          <label className="mt-4 block space-y-2">
-            <span className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("content_moderation.blocked_keywords")}
-            </span>
+          <FormField
+            className="mt-4"
+            label={t("content_moderation.blocked_keywords")}
+            description={t("content_moderation.blocked_keywords_hint")}
+            reserveMeta={false}
+          >
             <Textarea
               value={draft.blockedKeywordsText}
-              onChange={(event) =>
-                setDraft((current) => ({
-                  ...current,
-                  blockedKeywordsText: event.currentTarget.value,
-                }))
-              }
+              onChange={(event) => {
+                const blockedKeywordsText = event.currentTarget.value;
+                setDraft((current) => ({ ...current, blockedKeywordsText }));
+              }}
               placeholder={t("content_moderation.blocked_keywords_placeholder")}
               className="min-h-28 font-mono text-xs"
             />
-            <span className="text-xs text-slate-500 dark:text-white/55">
-              {t("content_moderation.blocked_keywords_hint")}
-            </span>
-          </label>
+          </FormField>
         </section>
 
         <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-2">
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.base_url")}
-              </span>
+            <FormField label={t("content_moderation.base_url")} reserveMeta={false}>
               <TextInput
                 value={draft.baseUrl}
                 disabled={!apiModeEnabled}
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, baseUrl: event.currentTarget.value }))
-                }
+                onChange={(event) => {
+                  const baseUrl = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, baseUrl }));
+                }}
               />
-            </label>
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.model")}
-              </span>
+            </FormField>
+            <FormField label={t("content_moderation.model")} reserveMeta={false}>
               <TextInput
                 value={draft.model}
                 disabled={!apiModeEnabled}
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, model: event.currentTarget.value }))
-                }
+                onChange={(event) => {
+                  const model = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, model }));
+                }}
               />
-            </label>
+            </FormField>
           </div>
 
           <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.api_key")}
-              </span>
+            <FormField
+              label={t("content_moderation.api_key")}
+              description={configuredKeyLabel}
+              reserveMeta={false}
+            >
               <TextInput
                 type="password"
                 autoComplete="new-password"
@@ -355,82 +359,66 @@ export function ProfileEditorModal({
                     ? t("content_moderation.api_key_keep_placeholder")
                     : t("content_moderation.api_key_placeholder")
                 }
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, apiKey: event.currentTarget.value }))
-                }
+                onChange={(event) => {
+                  const apiKey = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, apiKey }));
+                }}
               />
-              <span className="text-xs text-slate-500 dark:text-white/55">
-                {configuredKeyLabel}
-              </span>
-            </label>
+            </FormField>
             {profile?.api_key_configured ? (
-              <div className="space-y-2 pt-7">
+              <FormField label={t("content_moderation.clear_api_key")} reserveMeta={false}>
                 <ToggleSwitch
                   checked={draft.clearApiKey}
                   onCheckedChange={(clearApiKey) =>
                     setDraft((current) => ({ ...current, clearApiKey, apiKey: "" }))
                   }
-                  label={t("content_moderation.clear_api_key")}
                 />
-              </div>
+              </FormField>
             ) : null}
           </div>
 
-          <label className="mt-4 block space-y-2">
-            <span className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("content_moderation.thresholds")}
-            </span>
+          <FormField
+            className="mt-4"
+            label={t("content_moderation.thresholds")}
+            description={t("content_moderation.thresholds_hint")}
+            reserveMeta={false}
+          >
             <Textarea
               value={draft.thresholdsText}
               disabled={!apiModeEnabled}
-              onChange={(event) =>
-                setDraft((current) => ({
-                  ...current,
-                  thresholdsText: event.currentTarget.value,
-                }))
-              }
+              onChange={(event) => {
+                const thresholdsText = event.currentTarget.value;
+                setDraft((current) => ({ ...current, thresholdsText }));
+              }}
               className="min-h-48 font-mono text-xs"
             />
-            <span className="text-xs text-slate-500 dark:text-white/55">
-              {t("content_moderation.thresholds_hint")}
-            </span>
-          </label>
+          </FormField>
         </section>
 
         <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-[180px_minmax(0,1fr)]">
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.block_http_status")}
-              </span>
+            <FormField label={t("content_moderation.block_http_status")} reserveMeta={false}>
               <TextInput
                 value={draft.blockHttpStatus}
                 inputMode="numeric"
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    blockHttpStatus: event.currentTarget.value,
-                  }))
-                }
+                onChange={(event) => {
+                  const blockHttpStatus = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, blockHttpStatus }));
+                }}
               />
-            </label>
-            <label className="space-y-2">
-              <span className="text-sm font-semibold text-slate-900 dark:text-white">
-                {t("content_moderation.block_message")}
-              </span>
+            </FormField>
+            <FormField label={t("content_moderation.block_message")} reserveMeta={false}>
               <TextInput
                 value={draft.blockMessage}
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    blockMessage: event.currentTarget.value,
-                  }))
-                }
+                onChange={(event) => {
+                  const blockMessage = event.currentTarget.value;
+                  setDraft((current) => ({ ...current, blockMessage }));
+                }}
               />
-            </label>
+            </FormField>
           </div>
         </section>
-      </div>
+      </Form>
     </Modal>
   );
 }

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -1009,6 +1009,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
               size="sm"
             />
             <Select
+              fullWidth={false}
               aria-label={t("image_generation.quality_label")}
               value={quality}
               onChange={(value) => setQuality(value as (typeof QUALITY_OPTIONS)[number])}
@@ -1020,6 +1021,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
               size="sm"
             />
             <Select
+              fullWidth={false}
               aria-label={t("image_generation.count_label")}
               value={String(count)}
               onChange={(value) => setCount(Number(value) as (typeof COUNT_OPTIONS)[number])}


### PR DESCRIPTION
## Summary
- Rewrite content-moderation `ProfileEditorModal` to use shared `Form` / `FormField` instead of hand-rolled labels.
- Make default `Select` full-width in form layouts (`fullWidth` default true; chip stays compact).
- Wire `ToggleSwitch` a11y props for FormField; keep validation/payload and keyword_only disable behavior unchanged.

## Why
Create/edit profile modal had inconsistent control widths (Select shrink-to-content vs TextInput full column) and bypassed the design-system form primitives.

## Test plan
- [x] Form/Select unit tests
- [x] ProfileEditorModal tests
- [x] Related compact Select regressions (pagination / image-gen / ccswitch)
- [x] oxlint on touched files
- [x] admin-panel production build
- [x] Browser width check: name Input and mode Select same column width

## Scope
codeProxy only. Commit: `6193aa8`.