### PR TITLE
fix: show full channel name tooltip in request-log filters

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -128,7 +128,12 @@ export function ChannelIdentityLabel({
           <VendorIcon modelId={vendor} size={iconSize} />
         </span>
       ) : null}
-      <span className={["min-w-0 truncate", resolvedNameClassName].join(" ")}>{displayName}</span>
+      <span
+        className={["min-w-0 truncate", resolvedNameClassName].join(" ")}
+        title={trimmedName ? displayName : undefined}
+      >
+        {displayName}
+      </span>
       {badgeLabel ? (
         <span
           className={[

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -33,6 +33,8 @@ export interface SearchableCheckboxMultiSelectOption {
   value: string;
   label: ReactNode;
   searchText?: string;
+  /** Full text shown by the native tooltip when the rendered label is truncated. */
+  title?: string;
   /** Optional fixed trailing content, such as a request count. */
   trailing?: ReactNode;
 }
@@ -650,7 +652,10 @@ export function SearchableCheckboxMultiSelect({
                         </span>
                         <span
                           className="min-w-0 flex-1 truncate text-left"
-                          title={typeof option.label === "string" ? option.label : undefined}
+                          title={
+                            option.title ??
+                            (typeof option.label === "string" ? option.label : undefined)
+                          }
                         >
                           {option.label}
                         </span>

--- a/packages/ui/src/primitives/__tests__/SearchableCheckboxMultiSelect.test.tsx
+++ b/packages/ui/src/primitives/__tests__/SearchableCheckboxMultiSelect.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { SearchableCheckboxMultiSelect } from "../SearchableCheckboxMultiSelect";
+
+describe("SearchableCheckboxMultiSelect", () => {
+  test("uses an explicit title for ReactNode option labels", () => {
+    const title = "ryskt8qjfg@privaterelay.appleid.com";
+
+    render(
+      <SearchableCheckboxMultiSelect
+        value={[]}
+        onChange={() => undefined}
+        options={[
+          {
+            value: "auth-index",
+            label: <span>OAuth account</span>,
+            searchText: title,
+            title,
+          },
+        ]}
+        placeholder="All channels"
+        searchPlaceholder="Search channels"
+        selectFilteredLabel="Select filtered"
+        deselectFilteredLabel="Deselect filtered"
+        selectedCountLabel={(count) => `${count} selected`}
+        noResultsLabel="No results"
+        aria-label="Channel filter"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Channel filter" }));
+
+    expect(screen.getByText("OAuth account").parentElement).toHaveAttribute("title", title);
+  });
+});

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import {
   buildRequestLogsColumns,
   buildRequestLogKeyOptions,
+  ChannelIdentityLabel,
   isSystemRequestLogKey,
   sortRequestLogKeyOptionsByCount,
   SYSTEM_REQUEST_LOG_FILTER_VALUE,
@@ -11,6 +12,22 @@ import {
 } from "@features/request-log-viewer";
 
 describe("requestLogsShared", () => {
+  test("exposes the full channel name on the truncated identity label", () => {
+    const name = "ryskt8qjfg@privaterelay.appleid.com";
+
+    render(
+      createElement(ChannelIdentityLabel, {
+        name,
+        provider: "codex",
+        authType: "oauth",
+        apiLabel: "API",
+        oauthLabel: "OAuth",
+      }),
+    );
+
+    expect(screen.getByText(name)).toHaveAttribute("title", name);
+  });
+
   test("recognizes management-triggered system request logs", () => {
     expect(isSystemRequestLogKey("POST /image-generation/test", "")).toBe(true);
     expect(isSystemRequestLogKey("", "")).toBe(true);

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -248,6 +248,7 @@ export function RequestLogsPage() {
           />
         ),
         searchText: [option.label, provider, authType, option.value].filter(Boolean).join(" "),
+        title: option.label,
       };
     });
   }, [filterOptions.channel_options, filterOptions.channels, t]);


### PR DESCRIPTION
## Summary
- add an explicit optional title to `SearchableCheckboxMultiSelectOption` for ReactNode labels
- expose full channel names on the shared truncated `ChannelIdentityLabel`, covering dropdown and table usage
- pass the channel account name as the request-log dropdown option title

## Tests
- `bun run --filter @code-proxy/admin-panel test -- ../../pages/monitor/__tests__/requestLogsShared.test.ts ../../packages/ui/src/primitives/__tests__/SearchableCheckboxMultiSelect.test.tsx` (11 passed)
- `./scripts/ci-pr.sh`: lint, design check, all 931 unit tests, build, and bundle diff passed; local critical Playwright smoke could not start the project server because port 5173 was occupied by an unrelated Vite app, so required GHA checks remain the authoritative browser gate