### PR TITLE
feat(providers): use SearchableSelect for vision fallback model

### DIFF
--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -712,7 +712,9 @@ describe("ProvidersPage OpenCode Go tab", () => {
       name: /Vision fallback model/i,
     });
     await user.click(fallbackSelect);
-    await user.click(await screen.findByRole("option", { name: /qwen3\.5-plus/ }));
+    await user.type(await screen.findByPlaceholderText(/Search models/i), "qwen3.5");
+    expect(screen.queryByRole("option", { name: /deepseek-v4-flash/ })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: /qwen3\.5-plus/ }));
 
     await user.click(within(dialog).getByRole("tab", { name: /Basic/i }));
     await user.type(within(dialog).getByPlaceholderText("e.g. Gemini Primary"), "OpenCode Go");

--- a/pages/providers/components/ProviderKeyRequestTab.tsx
+++ b/pages/providers/components/ProviderKeyRequestTab.tsx
@@ -1,7 +1,7 @@
 import { type Dispatch, type SetStateAction, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { TextInput } from "@code-proxy/ui";
-import { Select } from "@code-proxy/ui";
+import { SearchableSelect } from "@code-proxy/ui";
 import { ToggleSwitch } from "@code-proxy/ui";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
 import { ProxyPoolSelect } from "@features/proxy-pool";
@@ -190,10 +190,12 @@ export function ProviderKeyRequestTab({
             {t("providers.opencode_go_vision_fallback_title")}
           </p>
           <div className="mt-3">
-            <Select
+            <SearchableSelect
               value={keyDraft.visionFallbackModel}
               onChange={(value) => setKeyDraft((prev) => ({ ...prev, visionFallbackModel: value }))}
               options={openCodeVisionFallbackOptions}
+              placeholder={t("providers.opencode_go_vision_fallback_none")}
+              searchPlaceholder={t("providers.models_search_placeholder")}
               aria-label={t("providers.opencode_go_vision_fallback_title")}
               disabled={openCodeModelsLoading || openCodeVisionFallbackOptions.length <= 1}
             />


### PR DESCRIPTION
## Summary
- AI Providers 编辑弹窗「请求配置」中的 vision fallback 模型下拉改为可搜索的 `SearchableSelect`
- 复用 `@code-proxy/ui` 已有封装；覆盖 OpenCode Go / Cline / Ollama Cloud
- 补充搜索过滤交互测试，保留保存路径断言

## Test plan
- [x] `bun run test -- pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx` (28/28)
- [x] `bun run lint`
- [ ] GHA `PR Test Build` required check