### PR TITLE
fix(models): inherit pricing for path-only rows

### DIFF
--- a/pages/models/__tests__/modelAvailability.test.ts
+++ b/pages/models/__tests__/modelAvailability.test.ts
@@ -20,6 +20,19 @@ const baseModel = (id: string, ownedBy = "xai"): ModelItem => ({
   supportsVision: false,
 });
 
+const pricedModel = (
+  id: string,
+  inputPricePerMillion: number,
+  outputPricePerMillion: number,
+): ModelItem => ({
+  ...baseModel(id),
+  pricing: {
+    ...emptyModelPricing(),
+    inputPricePerMillion,
+    outputPricePerMillion,
+  },
+});
+
 const pathItem = (id: string, ownedBy: string): ModelPathAvailabilityItem => ({
   id,
   owned_by: ownedBy,
@@ -115,5 +128,38 @@ describe("mergeConfiguredModelAvailability path enrichment", () => {
     );
 
     expect(merged.map((m) => m.id).sort()).toEqual(["gpt-5", "path-only-model"]);
+  });
+
+  test("inherits base pricing for path-only provider-prefixed models", () => {
+    const merged = mergeConfiguredModelAvailability(
+      [pricedModel("deepseek-v4-flash", 0.098, 0.196)],
+      null,
+      [pathItem("ollama/deepseek-v4-flash", "ollama")],
+    );
+
+    expect(merged.find((model) => model.id === "ollama/deepseek-v4-flash")?.pricing).toMatchObject({
+      inputPricePerMillion: 0.098,
+      outputPricePerMillion: 0.196,
+    });
+  });
+
+  test("inherits base pricing for unpriced variants without overriding exact custom pricing", () => {
+    const merged = mergeConfiguredModelAvailability(
+      [
+        pricedModel("deepseek-v4-flash", 0.098, 0.196),
+        baseModel("deepseek-v4-flash:free"),
+        pricedModel("deepseek-v4-flash:custom", 3, 12),
+      ],
+      null,
+    );
+
+    expect(merged.find((model) => model.id === "deepseek-v4-flash:free")?.pricing).toMatchObject({
+      inputPricePerMillion: 0.098,
+      outputPricePerMillion: 0.196,
+    });
+    expect(merged.find((model) => model.id === "deepseek-v4-flash:custom")?.pricing).toMatchObject({
+      inputPricePerMillion: 3,
+      outputPricePerMillion: 12,
+    });
   });
 });

--- a/pages/models/modelsUtils.ts
+++ b/pages/models/modelsUtils.ts
@@ -154,6 +154,31 @@ function availabilityItemToModel(item: ModelAvailabilityItem): ModelItem {
   };
 }
 
+function modelPricingLookupIds(modelId: string): string[] {
+  // Keep candidate order aligned with usage.modelPricingLookupModelIDs.
+  const exact = modelId.trim().toLowerCase();
+  if (!exact) return [];
+
+  const candidates = [exact];
+  const add = (candidate: string) => {
+    const normalized = candidate.trim().toLowerCase();
+    if (normalized && !candidates.includes(normalized)) candidates.push(normalized);
+  };
+
+  const providerSeparator = exact.indexOf("/");
+  if (providerSeparator > 0) add(exact.slice(providerSeparator + 1));
+
+  const variantSeparator = exact.lastIndexOf(":");
+  if (variantSeparator > 0) add(exact.slice(0, variantSeparator));
+
+  if (providerSeparator < 0) {
+    const prefixSeparator = exact.indexOf("-");
+    if (prefixSeparator > 0) add(exact.slice(prefixSeparator + 1));
+  }
+
+  return candidates;
+}
+
 export function mergeConfiguredModelAvailability(
   data: ModelItem[],
   availability: ConfiguredModelAvailability | null,
@@ -162,6 +187,23 @@ export function mergeConfiguredModelAvailability(
   const availabilityById = new Map(
     (availability?.items ?? []).map((item) => [item.id.toLowerCase(), item] as const),
   );
+
+  const pricingById = new Map<string, ModelItem["pricing"]>();
+  const indexPricing = (id: string, pricing: ModelItem["pricing"] | undefined) => {
+    if (!pricing || !hasModelPricing(pricing)) return;
+    pricingById.set(id.trim().toLowerCase(), pricing);
+  };
+  (availability?.items ?? []).forEach((item) => indexPricing(item.id, item.pricing));
+  data.forEach((model) => indexPricing(model.id, model.pricing));
+
+  const attachPricing = (model: ModelItem): ModelItem => {
+    if (hasModelPricing(model.pricing)) return model;
+    for (const candidate of modelPricingLookupIds(model.id)) {
+      const pricing = pricingById.get(candidate);
+      if (pricing) return { ...model, pricing: { ...pricing } };
+    }
+    return model;
+  };
 
   // Prefer config-row fields, but keep runtime channel sources from availability.
   const attachSources = (model: ModelItem): ModelItem => {
@@ -174,13 +216,15 @@ export function mergeConfiguredModelAvailability(
     availability?.scoped
       ? filterByConfiguredModelAvailability(data, availability)
       : [...data]
-  ).map(attachSources);
+  )
+    .map(attachSources)
+    .map(attachPricing);
 
   const seen = new Set(visible.map((m) => m.id.toLowerCase()));
   for (const item of availability?.items ?? []) {
     const key = item.id.toLowerCase();
     if (seen.has(key)) continue;
-    visible.push(availabilityItemToModel(item));
+    visible.push(attachPricing(availabilityItemToModel(item)));
     seen.add(key);
   }
   // Path-only rows enrich discovery when there is no scoped allow-list.
@@ -191,11 +235,13 @@ export function mergeConfiguredModelAvailability(
     if (seen.has(key)) continue;
     if (availability?.scoped && !availabilityById.has(key)) continue;
     visible.push(
-      availabilityItemToModel({
-        id: item.id,
-        owned_by: item.owned_by,
-        source: item.kind || "path",
-      }),
+      attachPricing(
+        availabilityItemToModel({
+          id: item.id,
+          owned_by: item.owned_by,
+          source: item.kind || "path",
+        }),
+      ),
     );
     seen.add(key);
   }


### PR DESCRIPTION
## Summary
- Models catalog merge now inherits effective pricing for unpriced path-only / variant rows from base IDs already present in the list
- Covers `ollama/deepseek-v4-flash`, `deepseek-v4-flash:free`, and similar prefix/variant cases
- Exact custom positive prices still win

## Context
Backend companion: CliRelay library pricing resolve. Frontend still injects path-only models without pricing; this fills those empty prices from base rows so 全部模型库 stops showing 未定价.

## Test plan
- [x] `pages/models/__tests__/modelAvailability.test.ts`
- [x] full frontend CI (lint/design/test/build/bundle:diff)