### PR TITLE
feat(auth-files): align page size with card columns

### DIFF
--- a/packages/domain/src/auth-files/__tests__/authFiles.pageSize.test.ts
+++ b/packages/domain/src/auth-files/__tests__/authFiles.pageSize.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  alignAuthFilesPageSizeToColumns,
+  AUTH_FILES_PAGE_SIZE,
+  AUTH_FILES_PAGE_SIZE_OPTIONS,
+  normalizeAuthFilesPageSize,
+} from "../authFiles";
+
+describe("auth files page size", () => {
+  it("normalizes persisted values to the configured range", () => {
+    expect(normalizeAuthFilesPageSize(9)).toBe(9);
+    expect(normalizeAuthFilesPageSize("12")).toBe(12);
+    expect(normalizeAuthFilesPageSize(10)).toBe(10);
+    expect(normalizeAuthFilesPageSize(11)).toBe(11);
+    expect(normalizeAuthFilesPageSize(1)).toBe(AUTH_FILES_PAGE_SIZE_OPTIONS[0]);
+    expect(normalizeAuthFilesPageSize(100)).toBe(
+      AUTH_FILES_PAGE_SIZE_OPTIONS[AUTH_FILES_PAGE_SIZE_OPTIONS.length - 1],
+    );
+  });
+
+  it("falls back to the default for invalid persisted values", () => {
+    expect(normalizeAuthFilesPageSize(null)).toBe(AUTH_FILES_PAGE_SIZE);
+    expect(normalizeAuthFilesPageSize(undefined)).toBe(AUTH_FILES_PAGE_SIZE);
+    expect(normalizeAuthFilesPageSize("")).toBe(AUTH_FILES_PAGE_SIZE);
+    expect(normalizeAuthFilesPageSize("nope")).toBe(AUTH_FILES_PAGE_SIZE);
+    expect(normalizeAuthFilesPageSize({})).toBe(AUTH_FILES_PAGE_SIZE);
+  });
+
+  it("aligns the page size to complete card rows", () => {
+    expect(alignAuthFilesPageSizeToColumns(9, 3)).toBe(9);
+    expect(alignAuthFilesPageSizeToColumns(9, 6)).toBe(12);
+    expect(alignAuthFilesPageSizeToColumns(10, 4)).toBe(12);
+    expect(alignAuthFilesPageSizeToColumns(15, 4)).toBe(16);
+    expect(alignAuthFilesPageSizeToColumns(24, 5)).toBe(25);
+    expect(alignAuthFilesPageSizeToColumns(6, 5)).toBe(5);
+  });
+
+  it("uses the default column count when the persisted value is invalid", () => {
+    expect(alignAuthFilesPageSizeToColumns(12, "nope")).toBe(12);
+  });
+});

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -61,11 +61,13 @@ export const AUTH_FILES_QUOTA_PREVIEW_KEY = "authFilesPage.quotaPreview.v1";
 export const AUTH_FILES_QUOTA_AUTO_REFRESH_KEY = "authFilesPage.quotaAutoRefreshMs.v1";
 export const AUTH_FILES_FILES_VIEW_MODE_KEY = "authFilesPage.filesViewMode.v1";
 export const AUTH_FILES_CARD_COLUMNS_KEY = "authFilesPage.cardColumns.v1";
+export const AUTH_FILES_PAGE_SIZE_KEY = "authFilesPage.pageSize.v1";
 export const AUTH_FILES_MODEL_OWNER_GROUP_MAP_KEY = "authFilesPage.modelOwnerGroupMap.v1";
 
 export const AUTH_FILES_CARD_COLUMN_OPTIONS = [2, 3, 4, 5, 6] as const;
 export type AuthFilesCardColumns = (typeof AUTH_FILES_CARD_COLUMN_OPTIONS)[number];
 export const DEFAULT_AUTH_FILES_CARD_COLUMNS: AuthFilesCardColumns = 3;
+export const AUTH_FILES_PAGE_SIZE_OPTIONS = [6, 9, 12, 15, 18, 24, 30, 36] as const;
 
 export type QuotaPreviewMode = "5h" | "week";
 /** Off / 60s / 300s only. Legacy 5s/10s/30s migrate safely via normalizeQuotaAutoRefreshMs. */
@@ -2032,6 +2034,30 @@ export const normalizeAuthFilesCardColumns = (value: unknown): AuthFilesCardColu
   return (AUTH_FILES_CARD_COLUMN_OPTIONS as readonly number[]).includes(rounded)
     ? (rounded as AuthFilesCardColumns)
     : DEFAULT_AUTH_FILES_CARD_COLUMNS;
+};
+
+export const normalizeAuthFilesPageSize = (value: unknown): number => {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : Number.NaN;
+  if (!Number.isFinite(parsed)) return AUTH_FILES_PAGE_SIZE;
+  const rounded = Math.round(parsed);
+  return Math.min(
+    AUTH_FILES_PAGE_SIZE_OPTIONS[AUTH_FILES_PAGE_SIZE_OPTIONS.length - 1],
+    Math.max(AUTH_FILES_PAGE_SIZE_OPTIONS[0], rounded),
+  );
+};
+
+export const alignAuthFilesPageSizeToColumns = (
+  pageSize: unknown,
+  columns: unknown,
+): number => {
+  const normalizedColumns = normalizeAuthFilesCardColumns(columns);
+  const normalizedPageSize = normalizeAuthFilesPageSize(pageSize);
+  return normalizedColumns * Math.max(1, Math.round(normalizedPageSize / normalizedColumns));
 };
 
 /** Read + migrate auto-refresh localStorage immediately (write-back allowed buckets only). */

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -806,6 +806,7 @@
     "shared_history_incomplete": "Shared history is projected from {{since}}; earlier retained detail was not reconstructed.",
     "success_count": "Success {{count}}",
     "failed_count": "Failed {{count}}",
+    "rows_per_page": "Rows per page",
     "total_page": "Total {{total}} · Page {{page}} / {{pages}}",
     "usage_stats_warning": "Usage stats loading failed: File management is not affected, but success/failed stats will show 0.",
     "view_file_title": "View: {{name}}",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -820,6 +820,7 @@
     "shared_history_incomplete": "共享统计从 {{since}} 开始投影；更早且已清理的明细未被虚构回填。",
     "success_count": "成功 {{count}}",
     "failed_count": "失败 {{count}}",
+    "rows_per_page": "每页条数",
     "total_page": "共 {{total}} 条 · 第 {{page}} / {{pages}} 页",
     "usage_stats_warning": "用量统计加载失败：文件管理不受影响，但成功/失败统计将显示 0。",
     "view_file_title": "查看：{{name}}",

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -10,6 +10,7 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  useLocalStorage,
   useToast,
 } from "@code-proxy/ui";
 import { quotaApi, type AuthFileItem } from "@code-proxy/api-client";
@@ -42,8 +43,14 @@ import {
   resolveQuotaProvider,
 } from "@features/quota-preview/quota-fetch";
 import {
+  alignAuthFilesPageSizeToColumns,
+  AUTH_FILES_CARD_COLUMNS_KEY,
+  AUTH_FILES_PAGE_SIZE,
+  AUTH_FILES_PAGE_SIZE_KEY,
   AUTH_FILE_STATUS_FILTERS,
+  DEFAULT_AUTH_FILES_CARD_COLUMNS,
   getActiveCacheTenantId,
+  normalizeAuthFilesCardColumns,
   normalizeAuthIndexValue,
   normalizeProviderKey,
   normalizeQuotaAutoRefreshMs,
@@ -54,6 +61,7 @@ import {
   resolveProviderLabel,
   writeAuthFilesUiState,
   type AuthFileStatusFilter,
+  type AuthFilesCardColumns,
   type OAuthDialogTab,
 } from "@code-proxy/domain";
 
@@ -195,6 +203,16 @@ export function AuthFilesPage() {
   const [statusFilter, setStatusFilter] = useState<AuthFileStatusFilter>("all");
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
+  const [cardColumnsRaw, setCardColumns] = useLocalStorage<AuthFilesCardColumns>(
+    AUTH_FILES_CARD_COLUMNS_KEY,
+    DEFAULT_AUTH_FILES_CARD_COLUMNS,
+  );
+  const cardColumns = normalizeAuthFilesCardColumns(cardColumnsRaw);
+  const [pageSizeRaw, setPageSize] = useLocalStorage<number>(
+    AUTH_FILES_PAGE_SIZE_KEY,
+    AUTH_FILES_PAGE_SIZE,
+  );
+  const pageSize = alignAuthFilesPageSizeToColumns(pageSizeRaw, cardColumns);
   const [selectedFileNames, setSelectedFileNames] = useState<string[]>([]);
   const [proxyPoolEntries, setProxyPoolEntries] = useState<ProxyPoolEntry[]>(
     [],
@@ -213,6 +231,14 @@ export function AuthFilesPage() {
   const previousConfigModalTabRef = useRef<AuthFilesConfigModalTab | null>(
     null,
   );
+
+  useEffect(() => {
+    if (cardColumnsRaw !== cardColumns) setCardColumns(cardColumns);
+  }, [cardColumns, cardColumnsRaw, setCardColumns]);
+
+  useEffect(() => {
+    if (pageSizeRaw !== pageSize) setPageSize(pageSize);
+  }, [pageSize, pageSizeRaw, setPageSize]);
 
   useEffect(() => {
     filesRef.current = files;
@@ -447,6 +473,7 @@ export function AuthFilesPage() {
     statusFilter,
     search,
     page,
+    pageSize,
     setPage,
     selectedFileNames,
     setSelectedFileNames,
@@ -872,6 +899,10 @@ export function AuthFilesPage() {
         pageItems={pageItems}
         fileColumns={fileColumns}
         filesViewMode={filesViewMode}
+        cardColumns={cardColumns}
+        setCardColumns={setCardColumns}
+        pageSize={pageSize}
+        setPageSize={setPageSize}
         selectedFileNameSet={selectedFileNameSet}
         quotaByFileName={quotaByFileName}
         cycleCallsByAuthIndex={callsByAuthIndex}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -12,7 +12,9 @@ import type {
   EntityStatsResponse,
 } from "@code-proxy/api-client";
 import {
+  AUTH_FILES_CARD_COLUMNS_KEY,
   AUTH_FILES_DATA_CACHE_KEY,
+  AUTH_FILES_PAGE_SIZE_KEY,
   AUTH_FILES_QUOTA_AUTO_REFRESH_KEY,
   DEFAULT_CACHE_TENANT_ID,
   setActiveCacheTenantId,
@@ -484,6 +486,36 @@ describe("AuthFilesPage files table", () => {
     expect(screen.queryByRole("button", { name: "Select current page" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Delete All" })).not.toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Enable/Disable" })).toBeInTheDocument();
+  });
+
+  test("persists page size and aligns it when card columns change", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/auth-files"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/auth-files" element={<AuthFilesPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("qwen.json")).toBeInTheDocument();
+    const rowsPerPage = screen.getByRole("combobox", { name: "Rows per page" });
+    expect(rowsPerPage).toHaveTextContent("9");
+
+    await user.click(rowsPerPage);
+    await user.click(screen.getByRole("option", { name: "12" }));
+    expect(window.localStorage.getItem(AUTH_FILES_PAGE_SIZE_KEY)).toBe("12");
+
+    await user.click(screen.getByRole("combobox", { name: "Cards per row" }));
+    await user.click(screen.getByRole("option", { name: "5 columns" }));
+
+    expect(screen.getByRole("combobox", { name: "Rows per page" })).toHaveTextContent("10");
+    expect(window.localStorage.getItem(AUTH_FILES_CARD_COLUMNS_KEY)).toBe("5");
+    expect(window.localStorage.getItem(AUTH_FILES_PAGE_SIZE_KEY)).toBe("10");
   });
 
   test("collapses filters behind a single mobile filter control", async () => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -1321,6 +1321,7 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
           statusFilter: "all",
           search: ".json",
           page,
+          pageSize: 2,
           setPage,
           selectedFileNames,
           setSelectedFileNames,
@@ -1330,12 +1331,13 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
     );
 
     await waitFor(() => {
-      expect(result.current.safePage).toBe(1);
+      expect(result.current.safePage).toBe(2);
       expect(result.current.filteredFiles.map((file) => file.name)).toEqual([
         "alpha.json",
         "beta.json",
         "runtime.json",
       ]);
+      expect(result.current.pageItems.map((file) => file.name)).toEqual(["runtime.json"]);
       expect(Array.from(result.current.selectedFileNameSet)).toEqual(["alpha.json"]);
       expect(result.current.filterCounts.counts.codex).toBe(3);
       expect(result.current.selectableFilteredFiles.map((file) => file.name)).toEqual([

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -42,7 +42,7 @@ import { ScrollArea } from "@code-proxy/ui";
 import { Select } from "@code-proxy/ui";
 import { SearchableSelect, type SearchableSelectOption } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
-import { ToggleSwitch, useLocalStorage } from "@code-proxy/ui";
+import { ToggleSwitch } from "@code-proxy/ui";
 import type { AuthFilesUploadProgress } from "@pages/auth-files/hooks/useAuthFilesFileActions";
 import type {
   AuthFileModelOwnerGroup,
@@ -54,11 +54,10 @@ import type {
   UsageIndex,
 } from "@code-proxy/domain";
 import {
+  alignAuthFilesPageSizeToColumns,
   AUTH_FILES_CARD_COLUMN_OPTIONS,
-  AUTH_FILES_CARD_COLUMNS_KEY,
-  AUTH_FILES_PAGE_SIZE,
+  AUTH_FILES_PAGE_SIZE_OPTIONS,
   AUTH_FILE_STATUS_FILTERS,
-  DEFAULT_AUTH_FILES_CARD_COLUMNS,
   TYPE_BADGE_CLASSES,
   formatCompactNumber,
   formatPlanBadgeLabel,
@@ -657,6 +656,10 @@ interface AuthFilesFilesTabProps {
   pageItems: AuthFileItem[];
   fileColumns: DataTableColumn<AuthFileItem>[];
   filesViewMode: FilesViewMode;
+  cardColumns: AuthFilesCardColumns;
+  setCardColumns: (value: AuthFilesCardColumns) => void;
+  pageSize: number;
+  setPageSize: (value: number) => void;
   selectedFileNameSet: Set<string>;
   quotaByFileName: Record<string, QuotaState>;
   cycleCallsByAuthIndex: Record<string, number>;
@@ -759,6 +762,10 @@ export function AuthFilesFilesTab({
   pageItems,
   fileColumns,
   filesViewMode,
+  cardColumns,
+  setCardColumns,
+  pageSize,
+  setPageSize,
   selectedFileNameSet,
   quotaByFileName,
   cycleCallsByAuthIndex,
@@ -796,17 +803,9 @@ export function AuthFilesFilesTab({
   const { t, i18n } = useTranslation();
   const [modelOwnerDialogOpen, setModelOwnerDialogOpen] = useState(false);
   const [draftModelOwner, setDraftModelOwner] = useState(selectedModelOwner);
-  const [cardColumnsRaw, setCardColumnsRaw] = useLocalStorage<AuthFilesCardColumns>(
-    AUTH_FILES_CARD_COLUMNS_KEY,
-    DEFAULT_AUTH_FILES_CARD_COLUMNS,
-  );
-  const cardColumns = normalizeAuthFilesCardColumns(cardColumnsRaw);
   const cardGridHostRef = useRef<HTMLDivElement>(null);
   const cardColumnFirstRectsRef = useRef<DOMRect[] | null>(null);
   const cardColumnAnimationsRef = useRef<Animation[]>([]);
-  useEffect(() => {
-    if (cardColumnsRaw !== cardColumns) setCardColumnsRaw(cardColumns);
-  }, [cardColumns, cardColumnsRaw, setCardColumnsRaw]);
   const cancelCardColumnAnimations = useCallback(() => {
     cardColumnAnimationsRef.current.forEach((animation) => animation.cancel());
     cardColumnAnimationsRef.current = [];
@@ -830,9 +829,11 @@ export function AuthFilesFilesTab({
               .filter((element): element is HTMLElement => element instanceof HTMLElement)
               .map((element) => element.getBoundingClientRect())
           : null;
-      setCardColumnsRaw(nextColumns);
+      setCardColumns(nextColumns);
+      setPageSize(alignAuthFilesPageSizeToColumns(pageSize, nextColumns));
+      setPage(1);
     },
-    [cancelCardColumnAnimations, cardColumns, setCardColumnsRaw],
+    [cancelCardColumnAnimations, cardColumns, pageSize, setCardColumns, setPage, setPageSize],
   );
 
   useLayoutEffect(() => {
@@ -909,6 +910,20 @@ export function AuthFilesFilesTab({
         };
       }),
     [t],
+  );
+  const pageSizeOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          [
+            pageSize,
+            ...AUTH_FILES_PAGE_SIZE_OPTIONS.map((size) =>
+              alignAuthFilesPageSizeToColumns(size, cardColumns),
+            ),
+          ].sort((a, b) => a - b),
+        ),
+      ),
+    [cardColumns, pageSize],
   );
   const [draftModelOwnerEnabled, setDraftModelOwnerEnabled] = useState(
     selectedModelOwner.trim() !== "",
@@ -1276,15 +1291,20 @@ export function AuthFilesFilesTab({
       currentPage={safePage}
       totalPages={totalPages}
       totalCount={filteredFiles.length}
-      pageSize={AUTH_FILES_PAGE_SIZE}
+      pageSize={pageSize}
       onPageChange={setPage}
-      showPageSize={false}
+      onPageSizeChange={(size) => {
+        setPageSize(alignAuthFilesPageSizeToColumns(size, cardColumns));
+        setPage(1);
+      }}
+      pageSizeOptions={pageSizeOptions}
       className="border-t border-slate-100 px-4 pb-4 pt-3 sm:px-5 sm:pb-5 dark:border-neutral-800/60"
       labels={{
         firstPage: t("request_logs.first_page"),
         previousPage: t("auth_files.prev"),
         nextPage: t("auth_files.next"),
         lastPage: t("request_logs.last_page"),
+        rowsPerPage: t("auth_files.rows_per_page"),
         pageInfo: ({ total, currentPage, totalPages: pages }) =>
           t("auth_files.total_page", {
             total,

--- a/pages/auth-files/hooks/useAuthFilesListState.ts
+++ b/pages/auth-files/hooks/useAuthFilesListState.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, type Dispatch, type SetStateAction } from "react";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import {
-  AUTH_FILES_PAGE_SIZE,
   authFileMatchesStatusFilter,
   authFilesSortCollator,
   normalizeProviderKey,
@@ -21,6 +20,7 @@ interface UseAuthFilesListStateOptions {
   statusFilter: AuthFileStatusFilter;
   search: string;
   page: number;
+  pageSize: number;
   setPage: Dispatch<SetStateAction<number>>;
   selectedFileNames: string[];
   setSelectedFileNames: Dispatch<SetStateAction<string[]>>;
@@ -33,6 +33,7 @@ export function useAuthFilesListState({
   statusFilter,
   search,
   page,
+  pageSize,
   setPage,
   selectedFileNames,
   setSelectedFileNames,
@@ -113,13 +114,13 @@ export function useAuthFilesListState({
       );
   }, [searchFilteredFiles, statusFilter, tagScopedFiles]);
 
-  const totalPages = Math.max(1, Math.ceil(filteredFiles.length / AUTH_FILES_PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(filteredFiles.length / pageSize));
   const safePage = Math.min(totalPages, Math.max(1, page));
 
   const pageItems = useMemo(() => {
-    const start = (safePage - 1) * AUTH_FILES_PAGE_SIZE;
-    return filteredFiles.slice(start, start + AUTH_FILES_PAGE_SIZE);
-  }, [filteredFiles, safePage]);
+    const start = (safePage - 1) * pageSize;
+    return filteredFiles.slice(start, start + pageSize);
+  }, [filteredFiles, pageSize, safePage]);
 
   const selectableFilteredFiles = useMemo(
     () => filteredFiles.filter((file) => !isRuntimeOnlyAuthFile(file)),


### PR DESCRIPTION
## Summary
- AI Accounts 卡片视图支持调整每页条数（PaginationBar pageSize 控件）
- 每页条数与当前列数对齐为整数倍，避免半行留白
- 改列数时自动 snap pageSize；table/cards 共用同一 pageSize 并持久化

## Test plan
- [x] domain pageSize normalize/align 单测
- [x] AuthFiles 相关 vitest（含 page size 持久化与列数对齐）
- [x] admin-panel lint + build
- [ ] 合入后确认 Deploy Frontend / 管理端卡片分页交互