### PR TITLE
fix: stop restoring cleared auth restrictions

### DIFF
--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -466,7 +466,7 @@ export const writeAuthFilesModelOwnerGroupMap = (map: AuthFilesModelOwnerGroupMa
   }
 };
 
-/** Keep status-owned fields when the list endpoint returns a partial file shell. */
+/** Keep optional projections from partial shells; runtime restriction absence means cleared. */
 export const mergeAuthFileWithLastGoodStatus = (
   fresh: AuthFileItem,
   previous?: AuthFileItem,
@@ -517,8 +517,8 @@ export const mergeAuthFileWithLastGoodStatus = (
       fresh.subscriptionRemainingMinutes ?? previous.subscriptionRemainingMinutes,
     subscription_expired: fresh.subscription_expired ?? previous.subscription_expired,
     subscriptionExpired: fresh.subscriptionExpired ?? previous.subscriptionExpired,
-    restrictions: fresh.restrictions ?? previous.restrictions,
-    claude_oauth_health: fresh.claude_oauth_health ?? previous.claude_oauth_health,
+    restrictions: fresh.restrictions,
+    claude_oauth_health: fresh.claude_oauth_health,
   };
 };
 

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -550,6 +550,45 @@ describe("Auth Files helper coverage", () => {
     ).toMatchObject(previous);
   });
 
+  test("list refresh treats omitted runtime restrictions as cleared", () => {
+    const previous = {
+      name: "xai.json",
+      type: "xai",
+      status: "error",
+      unavailable: true,
+      restrictions: [
+        {
+          scope: "auth",
+          status: "error",
+          unavailable: true,
+          http_status: 401,
+          next_retry_after: "2026-07-27T05:49:08.000Z",
+        },
+      ],
+      claude_oauth_health: {
+        status: "refresh_pending",
+        temporary_unschedulable_reason: "oauth_401",
+      },
+    } as AuthFileItem;
+
+    const merged = mergeAuthFileWithLastGoodStatus(
+      {
+        name: "xai.json",
+        type: "xai",
+        status: "active",
+        status_message: "",
+        unavailable: false,
+      },
+      previous,
+    );
+
+    expect(merged.restrictions).toBeUndefined();
+    expect(merged.claude_oauth_health).toBeUndefined();
+    expect(resolveAuthFileRestrictionBadges(merged, Date.parse("2026-07-27T05:38:28.000Z"))).toEqual(
+      [],
+    );
+  });
+
   test("keeps shared subscription status so the badge can warm-paint", () => {
     const [cachedFile] = sanitizeAuthFilesForCache([
       {


### PR DESCRIPTION
## 根因

- 后端旧版 `ClearQuotaStatus` 受 `hasQuotaRuntimeState` 门槛限制，只识别 quota / rate-limit / cooldown 等配额信号；纯 `StatusError + LastError{HTTPStatus: 401}` 会被挡在清除逻辑之外。
- 后端清空 restriction 后，`BuildEntry` 会省略空的 `restrictions` 字段；前端 `mergeAuthFileWithLastGoodStatus` 使用 `fresh.restrictions ?? previous.restrictions`，把省略字段误判为“本轮未返回”，从缓存回填旧 restriction，导致 401 徽章及原恢复时间原样“复活”。
- Claude OAuth 的 `claude_oauth_health` 是旁路调度状态；配套后端旧实现没有清除该状态，主 restriction 清除后仍可能保持 refresh-pending/临时不可调度。

## 改动范围

- 将 `restrictions` 视为后端权威快照：直接采用 `fresh.restrictions`，字段缺失即表示已清除，不再回填旧值。
- 同样将 `claude_oauth_health` 作为后端权威快照，避免已清除的旁路状态被前端缓存恢复。
- 补充 helper 回归测试，覆盖 fresh payload 省略上述字段时旧状态不会复活，同时保留其他 last-good 字段的既有合并语义。

## 验证

- `bun run test`：通过（140 test files，978 tests；目标 helper 39 tests）。
- `bun run size:check`：通过。
- `bun run boundary:imports`：通过。
- `./scripts/ci-pr.sh`：通过（frozen install、lint、design/import/size/dependency gates、全量 `test:ci` 140 files / 978 tests、production build、bundle diff、9 项 critical browser tests）。

## 跨仓依赖

配套后端 PR：kittors/CliRelay#821

后端 PR 负责真正清除 auth/model 运行时状态与 `claude_oauth_health`，本 PR 负责让前端接受后端的“已清除”权威快照；**两侧必须一起上线才算完整修复**。
