### PR TITLE
fix(models): inherit capabilities for provider wrappers

### DIFF
--- a/features/model-availability/modelCapabilities.ts
+++ b/features/model-availability/modelCapabilities.ts
@@ -18,6 +18,32 @@ export type ModelCapabilitySource = {
   supportsVision?: boolean | null;
 };
 
+// Keep candidate order aligned with usage.modelPricingLookupModelIDs so
+// provider wrappers and variants can reuse their canonical catalog metadata.
+export function modelConfigLookupIds(modelId: string): string[] {
+  const exact = modelId.trim().toLowerCase();
+  if (!exact) return [];
+
+  const candidates = [exact];
+  const add = (candidate: string) => {
+    const normalized = candidate.trim().toLowerCase();
+    if (normalized && !candidates.includes(normalized)) candidates.push(normalized);
+  };
+
+  const providerSeparator = exact.indexOf("/");
+  if (providerSeparator > 0) add(exact.slice(providerSeparator + 1));
+
+  const variantSeparator = exact.lastIndexOf(":");
+  if (variantSeparator > 0) add(exact.slice(0, variantSeparator));
+
+  if (providerSeparator < 0) {
+    const prefixSeparator = exact.indexOf("-");
+    if (prefixSeparator > 0) add(exact.slice(prefixSeparator + 1));
+  }
+
+  return candidates;
+}
+
 const CAPABILITY_ORDER: ModelCapabilityKey[] = [
   "text",
   "vision",

--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -18,6 +18,7 @@ import {
   hasModelPricing,
   loadConfiguredModelAvailability,
   loadModelPathAvailability,
+  modelConfigLookupIds,
   type ModelAvailabilityItem,
   type ModelAvailabilitySource,
   type ModelPricing,
@@ -314,14 +315,19 @@ function mergePlazaModels(
   return Array.from(new Set(nextIds))
     .sort((a, b) => a.localeCompare(b))
     .map((id) => {
-      const configured = configuredById.get(id.toLowerCase());
+      const exactConfigured = configuredById.get(id.toLowerCase());
+      let configured = exactConfigured;
+      for (const candidate of modelConfigLookupIds(id)) {
+        configured = configuredById.get(candidate);
+        if (configured) break;
+      }
       const inputModalities = configured?.inputModalities ?? [];
       const outputModalities = configured?.outputModalities ?? [];
       return {
         id,
         description: configured?.description?.trim() ?? "",
-        ownedBy: configured?.owned_by?.trim() ?? "",
-        sources: configured?.sources,
+        ownedBy: exactConfigured?.owned_by?.trim() ?? "",
+        sources: exactConfigured?.sources,
         pricing: configured?.pricing ?? emptyModelPricing(),
         inputModalities,
         outputModalities,

--- a/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
+++ b/pages/model-plaza/__tests__/ModelPlazaPage.test.tsx
@@ -350,6 +350,46 @@ describe("ModelPlazaPage", () => {
     expect(within(audioCard).getByText("Audio")).toBeInTheDocument();
   });
 
+  test("inherits canonical capabilities for provider-prefixed path models", async () => {
+    mocks.apiGet.mockImplementation((path: string) => {
+      if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });
+      if (path === "/models/configured-availability") {
+        return Promise.resolve({
+          scoped: false,
+          data: [
+            {
+              id: "kimi-k2.5",
+              description: "Vision chat",
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
+              supports_vision: true,
+            },
+          ],
+        });
+      }
+      if (path === "/model-path-availability") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "ollama/kimi-k2.5",
+              owned_by: "ollama",
+              paths: [{ scope: "root", method: "GET", path: "/v1/models" }],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    renderPage();
+
+    const visionCard = (await screen.findByText("ollama/kimi-k2.5")).closest(
+      '[data-testid="model-plaza-card"]',
+    ) as HTMLElement;
+    expect(within(visionCard).getByText("Text")).toBeInTheDocument();
+    expect(within(visionCard).getByText("Vision")).toBeInTheDocument();
+  });
+
   test("does not re-add path-only models when configured availability is scoped", async () => {
     mocks.apiGet.mockImplementation((path: string) => {
       if (path === "/auth-group-model-owner-mappings") return Promise.resolve({ items: [] });

--- a/pages/models/__tests__/modelAvailability.test.ts
+++ b/pages/models/__tests__/modelAvailability.test.ts
@@ -33,6 +33,17 @@ const pricedModel = (
   },
 });
 
+const capabilityModel = (
+  id: string,
+  inputModalities: string[],
+  outputModalities: string[],
+): ModelItem => ({
+  ...baseModel(id),
+  inputModalities,
+  outputModalities,
+  supportsVision: inputModalities.includes("image"),
+});
+
 const pathItem = (id: string, ownedBy: string): ModelPathAvailabilityItem => ({
   id,
   owned_by: ownedBy,
@@ -140,6 +151,20 @@ describe("mergeConfiguredModelAvailability path enrichment", () => {
     expect(merged.find((model) => model.id === "ollama/deepseek-v4-flash")?.pricing).toMatchObject({
       inputPricePerMillion: 0.098,
       outputPricePerMillion: 0.196,
+    });
+  });
+
+  test("inherits base capabilities for path-only provider-prefixed models", () => {
+    const merged = mergeConfiguredModelAvailability(
+      [capabilityModel("kimi-k2.5", ["text", "image"], ["text"])],
+      null,
+      [pathItem("ollama/kimi-k2.5", "ollama")],
+    );
+
+    expect(merged.find((model) => model.id === "ollama/kimi-k2.5")).toMatchObject({
+      inputModalities: ["text", "image"],
+      outputModalities: ["text"],
+      supportsVision: true,
     });
   });
 

--- a/pages/models/modelsUtils.ts
+++ b/pages/models/modelsUtils.ts
@@ -19,6 +19,7 @@ import {
   formatModelPrice,
   hasModelPricing,
   invalidateConfiguredModelAvailability,
+  modelConfigLookupIds,
   modelHasTextCapability as modelHasTextCapabilityFromMeta,
   normalizeModelConfigMetadataRows,
 } from "@features/model-availability";
@@ -154,31 +155,6 @@ function availabilityItemToModel(item: ModelAvailabilityItem): ModelItem {
   };
 }
 
-function modelPricingLookupIds(modelId: string): string[] {
-  // Keep candidate order aligned with usage.modelPricingLookupModelIDs.
-  const exact = modelId.trim().toLowerCase();
-  if (!exact) return [];
-
-  const candidates = [exact];
-  const add = (candidate: string) => {
-    const normalized = candidate.trim().toLowerCase();
-    if (normalized && !candidates.includes(normalized)) candidates.push(normalized);
-  };
-
-  const providerSeparator = exact.indexOf("/");
-  if (providerSeparator > 0) add(exact.slice(providerSeparator + 1));
-
-  const variantSeparator = exact.lastIndexOf(":");
-  if (variantSeparator > 0) add(exact.slice(0, variantSeparator));
-
-  if (providerSeparator < 0) {
-    const prefixSeparator = exact.indexOf("-");
-    if (prefixSeparator > 0) add(exact.slice(prefixSeparator + 1));
-  }
-
-  return candidates;
-}
-
 export function mergeConfiguredModelAvailability(
   data: ModelItem[],
   availability: ConfiguredModelAvailability | null,
@@ -198,9 +174,49 @@ export function mergeConfiguredModelAvailability(
 
   const attachPricing = (model: ModelItem): ModelItem => {
     if (hasModelPricing(model.pricing)) return model;
-    for (const candidate of modelPricingLookupIds(model.id)) {
+    for (const candidate of modelConfigLookupIds(model.id)) {
       const pricing = pricingById.get(candidate);
       if (pricing) return { ...model, pricing: { ...pricing } };
+    }
+    return model;
+  };
+
+  const capabilitiesById = new Map<
+    string,
+    Pick<ModelItem, "inputModalities" | "outputModalities" | "supportsVision">
+  >();
+  const indexCapabilities = (model: ModelItem) => {
+    if (
+      model.inputModalities.length === 0 &&
+      model.outputModalities.length === 0 &&
+      !model.supportsVision
+    ) {
+      return;
+    }
+    capabilitiesById.set(model.id.trim().toLowerCase(), model);
+  };
+  (availability?.items ?? []).forEach((item) =>
+    indexCapabilities(availabilityItemToModel(item)),
+  );
+  data.forEach(indexCapabilities);
+
+  const attachCapabilities = (model: ModelItem): ModelItem => {
+    if (
+      model.inputModalities.length > 0 ||
+      model.outputModalities.length > 0 ||
+      model.supportsVision
+    ) {
+      return model;
+    }
+    for (const candidate of modelConfigLookupIds(model.id)) {
+      const capabilities = capabilitiesById.get(candidate);
+      if (!capabilities) continue;
+      return {
+        ...model,
+        inputModalities: [...capabilities.inputModalities],
+        outputModalities: [...capabilities.outputModalities],
+        supportsVision: capabilities.supportsVision,
+      };
     }
     return model;
   };
@@ -218,13 +234,14 @@ export function mergeConfiguredModelAvailability(
       : [...data]
   )
     .map(attachSources)
+    .map(attachCapabilities)
     .map(attachPricing);
 
   const seen = new Set(visible.map((m) => m.id.toLowerCase()));
   for (const item of availability?.items ?? []) {
     const key = item.id.toLowerCase();
     if (seen.has(key)) continue;
-    visible.push(attachPricing(availabilityItemToModel(item)));
+    visible.push(attachPricing(attachCapabilities(availabilityItemToModel(item))));
     seen.add(key);
   }
   // Path-only rows enrich discovery when there is no scoped allow-list.
@@ -236,11 +253,13 @@ export function mergeConfiguredModelAvailability(
     if (availability?.scoped && !availabilityById.has(key)) continue;
     visible.push(
       attachPricing(
-        availabilityItemToModel({
-          id: item.id,
-          owned_by: item.owned_by,
-          source: item.kind || "path",
-        }),
+        attachCapabilities(
+          availabilityItemToModel({
+            id: item.id,
+            owned_by: item.owned_by,
+            source: item.kind || "path",
+          }),
+        ),
       ),
     );
     seen.add(key);


### PR DESCRIPTION
## Summary

- inherit canonical model modalities for provider-prefixed path models such as `ollama/kimi-k2.5`
- apply the same lookup in the model catalog and model plaza while keeping exact model configs authoritative
- add regression coverage for both UI data paths

## Root cause

Path-only provider wrapper IDs inherited canonical pricing but not canonical capability metadata, so missing modalities defaulted to text-only badges.

## Validation

- `bun run test -- pages/models/__tests__/modelAvailability.test.ts pages/model-plaza/__tests__/ModelPlazaPage.test.tsx`
- `bun run lint`
- `bun run boundary:imports`
- `bun run size:check`
- `bun run build`
- local Playwright mock verification on `/manage/#/models/catalog` and `/manage/#/models/plaza`