### PR TITLE
test(auth-files): align partial quota fixture with null semantics

### DIFF
--- a/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx
@@ -528,7 +528,9 @@ describe("useAuthFilesStatusState batch refresh", () => {
           auth_subject_id: "sub-a",
           plan_type: null,
           reset_credit_count: null,
-          quotas: [{ quota_key: "code_5h", percent: null }],
+          // Empty quotas model a partial payload that omitted provider metrics.
+          // An explicit percent: null intentionally clears stale cached values.
+          quotas: [],
           usage: { request_total: 200 },
         },
         {


### PR DESCRIPTION
## Summary
- update the batch refresh fixture to model omitted provider quota metrics with an empty quota list
- preserve the established contract that an explicit `percent: null` clears stale cached values
- unblock the existing `dev` test baseline without changing production behavior

## Root cause
The test combined two different API states: it sent an explicit null percentage, which production intentionally treats as a clear signal, while asserting the cache-preserving behavior for an omitted quota payload.

## Verification
- `bun run test:ci ../../pages/auth-files/hooks/__tests__/useAuthFilesStatusState.batch.test.tsx` (19 passed)
- `bun run test:ci` (140 files, 978 tests passed)
- `bun run lint`
- `bun run size:check`
- `bun run boundary:imports`