### PR TITLE
fix(channel-groups): pin actions column to the right

### DIFF
--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -22,7 +22,7 @@ import { Select } from "@code-proxy/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
-import { DataTable, TABLE_ROW_ACTIONS_COLUMN, type DataTableColumn } from "@code-proxy/ui";
+import { DataTable, TABLE_ROW_ACTIONS_COLUMN, TABLE_ROW_ACTIONS_STICKY_END_COLUMN, type DataTableColumn } from "@code-proxy/ui";
 import { VendorIcon } from "@code-proxy/assets";
 import {
   emptyModelPricing,
@@ -1224,8 +1224,7 @@ export function RoutingConfigEditor({
       {
         key: "actions",
         label: t("common.action"),
-        ...TABLE_ROW_ACTIONS_COLUMN,
-        cellClassName: "whitespace-nowrap",
+        ...TABLE_ROW_ACTIONS_STICKY_END_COLUMN,
         render: (group) => (
           <div className="flex items-center gap-1.5">
             <button

--- a/packages/ui/src/data-table/TableRowActions.tsx
+++ b/packages/ui/src/data-table/TableRowActions.tsx
@@ -23,6 +23,13 @@ export const TABLE_ROW_ACTIONS_COLUMN = {
   overflowTooltip: false,
 } as const;
 
+export const TABLE_ROW_ACTIONS_STICKY_END_COLUMN = {
+  ...TABLE_ROW_ACTIONS_COLUMN,
+  lockOrder: "end",
+  headerClassName: "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800",
+  cellClassName: "whitespace-nowrap md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950",
+} as const;
+
 const alignClassNames = {
   start: "justify-start",
   center: "justify-center",

--- a/packages/ui/src/data-table/index.ts
+++ b/packages/ui/src/data-table/index.ts
@@ -1,5 +1,9 @@
 export { DataTable } from "./DataTable";
-export { TableRowActions, TABLE_ROW_ACTIONS_COLUMN } from "./TableRowActions";
+export {
+  TableRowActions,
+  TABLE_ROW_ACTIONS_COLUMN,
+  TABLE_ROW_ACTIONS_STICKY_END_COLUMN,
+} from "./TableRowActions";
 export type { TableRowAction } from "./TableRowActions";
 export type {
   DataTableColumn,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,7 +6,11 @@ export { Reveal } from "./feedback/Reveal";
 export { ToastProvider, useToast } from "./feedback/ToastProvider";
 
 export { DataTable } from "./data-table/DataTable";
-export { TableRowActions, TABLE_ROW_ACTIONS_COLUMN } from "./data-table/TableRowActions";
+export {
+  TableRowActions,
+  TABLE_ROW_ACTIONS_COLUMN,
+  TABLE_ROW_ACTIONS_STICKY_END_COLUMN,
+} from "./data-table/TableRowActions";
 export type { TableRowAction } from "./data-table/TableRowActions";
 export type {
   DataTableColumn,

--- a/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
+++ b/pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx
@@ -225,6 +225,36 @@ describe("RoutingConfigEditor", () => {
     expect(row).toHaveTextContent("会话粘性");
   });
 
+  test("pins the group actions column to the right edge", async () => {
+    await i18n.changeLanguage("zh-CN");
+
+    render(
+      <Harness
+        initialValues={{
+          ...DEFAULT_VISUAL_VALUES,
+          routingChannelGroups: [
+            {
+              id: "group-sticky-actions",
+              name: "sticky-actions",
+              description: "",
+              strategy: "round-robin",
+              channels: [{ id: "channel-main", name: "Main Codex", priority: "" }],
+              allowedModels: [],
+            },
+          ],
+        }}
+      />,
+    );
+
+    const actionsHeader = document.querySelector('th[data-vt-column-key="actions"]');
+    const actionsCell = document.querySelector('td[data-vt-column-key="actions"]');
+
+    expect(actionsHeader).toHaveClass("md:sticky", "md:right-[var(--vt-sticky-right)]", "z-[70]");
+    expect(actionsHeader).toHaveStyle({ zIndex: "70" });
+    expect(actionsCell).toHaveClass("md:sticky", "md:right-[var(--vt-sticky-right)]");
+    expect(actionsCell).toHaveStyle({ zIndex: "30" });
+  });
+
 
   test("defaults model tab selections to every channel-scoped model", async () => {
     await i18n.changeLanguage("zh-CN");

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -9,7 +9,7 @@
     "features/model-availability/modelAvailability.ts": 1275,
     "features/oauth-login/components/OAuthLoginDialog.tsx": 912,
     "features/request-log-viewer/requestLogsShared.tsx": 1020,
-    "features/routing-config-editor/RoutingConfigEditor.tsx": 2045,
+    "features/routing-config-editor/RoutingConfigEditor.tsx": 2044,
     "features/visual-config-editor/useVisualConfig.ts": 957,
     "packages/domain/src/auth-files/authFiles.ts": 2291,
     "packages/domain/src/ccswitch/ccswitchImport.ts": 845,


### PR DESCRIPTION
## Summary
- pin the Channel Groups action column to the right edge during horizontal scrolling
- reuse a shared sticky action-column preset so the behavior matches Portal Accounts
- add a regression test for sticky header and cell placement
- lock the one-line reduction in the routing editor file-size baseline

## Root cause
The action column was order-locked at the end by `DataTable`, but its header and cells did not have sticky positioning classes, so the controls scrolled out of view.

## Verification
- red-green regression: the new sticky-column assertion failed before the fix and passed after it
- `bun run test:ci ../../pages/channel-groups/__tests__/RoutingConfigEditor.test.tsx ../../pages/channel-groups/__tests__/ChannelGroupsPage.test.tsx ../../packages/ui/src/data-table/__tests__/TableRowActions.test.tsx` (3 files, 46 tests passed)
- `bun run lint`
- `bun run design:check`
- `bun run boundary:imports`
- `bun run size:check`
- `bun run build`
- real Playwright mock page: after scrolling the table 694px horizontally, action header and cell stayed at the same x-coordinate with computed `position: sticky`

## Context
Follow-up to https://github.com/kittors/CliRelay/issues/235#issuecomment-5100304424