### PR TITLE
fix(online-update): restore step counts and correct the version row labels

### DIFF
--- a/features/online-update/ui/UpdateModal.test.tsx
+++ b/features/online-update/ui/UpdateModal.test.tsx
@@ -99,6 +99,26 @@ describe("UpdateModal", () => {
     expect(screen.getByTestId("update-progress-bytes").textContent).toBe("3.7MB / 10.0MB");
   });
 
+  /**
+   * An older updater reports progress_current/progress_total but no stage timeline.
+   * Those deployments must still get step context rather than a bare percentage.
+   */
+  test("falls back to step counts when the updater sends no stage timeline", () => {
+    render(
+      <UpdateModal
+        open
+        candidate={candidate}
+        progress={runningProgress({ stages: undefined, progress_current: 3, progress_total: 5 })}
+        updating
+        onApply={noop}
+        onClose={noop}
+      />,
+    );
+
+    expect(screen.getByTestId("update-progress-details").textContent).toContain("3");
+    expect(screen.queryByTestId("update-stage-timeline")).toBeNull();
+  });
+
   test("renders the stage timeline reported by the updater", () => {
     render(
       <UpdateModal

--- a/features/online-update/ui/UpdateModal.tsx
+++ b/features/online-update/ui/UpdateModal.tsx
@@ -294,7 +294,7 @@ export function UpdateModal({
           <>
             <dl className="min-w-0 divide-y divide-slate-100 rounded-xl border border-slate-200 px-3 dark:divide-neutral-800 dark:border-neutral-800">
               <VersionRow
-                label={t("auto_update.current_service")}
+                label={t("auto_update.service_version")}
                 from={versionLabel(
                   display.current_version,
                   display.current_commit,
@@ -310,7 +310,7 @@ export function UpdateModal({
                 unchanged={serviceUnchanged}
               />
               <VersionRow
-                label={t("auto_update.current_ui")}
+                label={t("auto_update.ui_version")}
                 from={uiVersionLabel(
                   display.current_ui_version,
                   display.current_ui_commit,

--- a/features/online-update/ui/UpdateProgressPanel.tsx
+++ b/features/online-update/ui/UpdateProgressPanel.tsx
@@ -179,6 +179,19 @@ export function UpdateProgressPanel({
   const bytes = formatBytes(progress?.progress_bytes);
   const totalBytes = formatBytes(progress?.progress_total_bytes);
 
+  // Step counts are the only progress detail an older updater reports — it sends
+  // progress_current/progress_total but no stage timeline. Rendering them keeps
+  // those deployments from showing a bare percentage with no context.
+  const steps =
+    typeof progress?.progress_current === "number" &&
+    typeof progress.progress_total === "number" &&
+    progress.progress_total > 0
+      ? t("auto_update.progress_detail_steps", {
+          current: progress.progress_current,
+          total: progress.progress_total,
+        })
+      : "";
+
   return (
     <div data-testid="update-progress-console" className="min-w-0">
       <div className="flex items-baseline justify-between gap-3">
@@ -209,6 +222,15 @@ export function UpdateProgressPanel({
           className="mt-1.5 font-mono text-xs text-slate-500 dark:text-white/45"
         >
           {bytes} / {totalBytes}
+        </p>
+      ) : null}
+
+      {steps ? (
+        <p
+          data-testid="update-progress-details"
+          className="mt-1.5 text-xs text-slate-500 dark:text-white/45"
+        >
+          {steps}
         </p>
       ) : null}
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4596,7 +4596,9 @@
     "progress_stage_dependencies": "Starting dependencies",
     "progress_stage_application": "Recreating and waiting for health",
     "progress_message_stage_dependencies": "Starting the dependency services.",
-    "progress_message_stage_application": "Recreating the service container and waiting for its health check."
+    "progress_message_stage_application": "Recreating the service container and waiting for its health check.",
+    "service_version": "Service",
+    "ui_version": "Management panel"
   },
   "floating_save_bar": {
     "saved": "Saved",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2497,7 +2497,9 @@
     "progress_stage_dependencies": "Запуск зависимостей",
     "progress_stage_application": "Пересоздание и ожидание готовности",
     "progress_message_stage_dependencies": "Запуск зависимых служб.",
-    "progress_message_stage_application": "Пересоздание контейнера службы и ожидание проверки готовности."
+    "progress_message_stage_application": "Пересоздание контейнера службы и ожидание проверки готовности.",
+    "service_version": "Служба",
+    "ui_version": "Панель управления"
   },
   "identity_admin": {
     "operation_failed": "Операция не выполнена.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3930,7 +3930,9 @@
     "progress_stage_dependencies": "启动依赖",
     "progress_stage_application": "重建并等待健康",
     "progress_message_stage_dependencies": "正在启动依赖服务。",
-    "progress_message_stage_application": "正在重建业务容器并等待健康检查。"
+    "progress_message_stage_application": "正在重建业务容器并等待健康检查。",
+    "service_version": "服务版本",
+    "ui_version": "管理面板版本"
   },
   "auth_files_page": {
     "files_tab": "文件",


### PR DESCRIPTION
## 起因

上一个 PR 合并后，我实际把弹窗渲染出来看了一眼（而不是只看测试），发现两个问题。

## 1. 版本行标签自相矛盾

行内容是 `dev-1111111 → dev-abcdef1`，标签却写「**当前**服务版本」。我在重做弹窗时复用了 `auto_update.current_service` / `current_ui` 这两个旧 key，但新布局把 current 和 target 合并成一行了，标签就说不通了。改用中性标签「服务版本」/「管理面板版本」。

## 2. 步骤计数丢失（真实回归）

重做时我把 `progress_current / progress_total` 的展示删掉了，理由是新的 stage timeline 更好。但**旧版 updater sidecar 只上报 `progress_current/progress_total`，不上报 `stages`**——这些部署因此从「3 / 5 步」退化成只剩一个光秃秃的百分比，没有任何上下文。

现在在没有 timeline 时重新渲染步骤计数，并补了单测覆盖这条降级路径。

## 为什么之前没发现

这条回归让 `e2e/ota-sse-progress.spec.ts` 在 `dev` 上挂了。它没被拦住是因为 **`scripts/ci-pr.sh` 只跑 `@critical` 子集**，而这个 spec 不在其中。

## 验证

- 本地完整 `./scripts/ci-pr.sh`：通过（`exit=0`），992 个单测全绿
- `e2e/ota-sse-progress.spec.ts`：在 `dev` 上失败 → 本分支通过
- 完整 e2e 套件对比（同机、同条件）：`dev` 24 failed / 48 passed，本分支 23 failed / 49 passed，差异就是这条 spec。其余失败在干净 `dev` 上同样存在，与本次改动无关（已单独复跑确认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)