### PR TITLE
feat(image-generation): select provider and model instead of assuming codex

### DIFF
--- a/features/image-model-picker/ImageModelPicker.tsx
+++ b/features/image-model-picker/ImageModelPicker.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { FormField, Select } from "@code-proxy/ui";
+import {
+  modelLabel,
+  providerLabel,
+  type ImageModelCatalog,
+} from "./imageModels";
+
+/**
+ * Provider and model selectors for image generation.
+ *
+ * Both lists come from the server's catalog. The component deliberately holds no
+ * knowledge of which providers or models exist — adding one server-side makes it
+ * selectable here without a panel release.
+ */
+export function ImageModelPicker({
+  catalog,
+  provider,
+  model,
+  disabled = false,
+  onProviderChange,
+  onModelChange,
+}: {
+  catalog: ImageModelCatalog;
+  provider: string;
+  model: string;
+  disabled?: boolean;
+  onProviderChange: (provider: string) => void;
+  onModelChange: (model: string) => void;
+}) {
+  const { t } = useTranslation();
+
+  const providerOptions = useMemo(
+    () =>
+      catalog.providers.map((entry) => ({
+        value: entry.provider,
+        label: providerLabel(entry.provider),
+      })),
+    [catalog.providers],
+  );
+
+  const modelOptions = useMemo(() => {
+    const entry = catalog.providers.find((item) => item.provider === provider);
+    return (entry?.models ?? catalog.models).map((item) => ({
+      value: item.id,
+      label: modelLabel(item),
+    }));
+  }, [catalog, provider]);
+
+  // A deployment with a single provider gets no provider selector: a control with
+  // one option is noise, and the legacy server shape reports no provider at all.
+  const showProviderSelect = providerOptions.length > 1;
+
+  return (
+    <div
+      data-testid="image-model-picker"
+      className={showProviderSelect ? "grid gap-3 sm:grid-cols-2" : "grid gap-3"}
+    >
+      {showProviderSelect ? (
+        <FormField label={t("image_generation.provider")} htmlFor="image-provider">
+          <Select
+            id="image-provider"
+            value={provider}
+            options={providerOptions}
+            disabled={disabled}
+            onChange={onProviderChange}
+          />
+        </FormField>
+      ) : null}
+
+      <FormField label={t("image_generation.model")} htmlFor="image-model">
+        <Select
+          id="image-model"
+          value={model}
+          options={modelOptions}
+          disabled={disabled || modelOptions.length === 0}
+          placeholder={t("image_generation.model_placeholder")}
+          onChange={onModelChange}
+        />
+      </FormField>
+    </div>
+  );
+}

--- a/features/image-model-picker/imageModels.test.ts
+++ b/features/image-model-picker/imageModels.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "vitest";
+import type { ImageGenerationChannelsResponse } from "@code-proxy/api-client";
+import {
+  buildImageModelCatalog,
+  findImageModel,
+  providerLabel,
+  resolveInitialModel,
+  resolveInitialProvider,
+  supportsImageEditing,
+} from "./imageModels";
+
+const response: ImageGenerationChannelsResponse = {
+  model: "gpt-image-2",
+  channels: ["codex-a", "grok-a"],
+  providers: [
+    { provider: "codex", channels: ["codex-a"], models: ["gpt-image-2"] },
+    { provider: "xai", channels: ["grok-a"], models: ["grok-imagine-image", "grok-2-image-1212"] },
+  ],
+  models: [
+    { id: "gpt-image-2", provider: "codex", supports_edit: true, display_name: "GPT Image 2" },
+    { id: "grok-imagine-image", provider: "xai", supports_edit: true },
+    { id: "grok-2-image-1212", provider: "xai", supports_edit: false },
+  ],
+};
+
+describe("buildImageModelCatalog", () => {
+  test("groups models under the provider that serves them", () => {
+    const catalog = buildImageModelCatalog(response);
+
+    expect(catalog.legacy).toBe(false);
+    expect(catalog.providers.map((entry) => entry.provider)).toEqual(["codex", "xai"]);
+    expect(catalog.providers[1].models.map((model) => model.id)).toEqual([
+      "grok-imagine-image",
+      "grok-2-image-1212",
+    ]);
+  });
+
+  /**
+   * A provider with no usable channel cannot serve a request, so offering its
+   * models would only produce a confusing failure at submit time.
+   */
+  test("drops providers that have no usable channel", () => {
+    const catalog = buildImageModelCatalog({
+      ...response,
+      providers: [
+        { provider: "codex", channels: [], models: ["gpt-image-2"] },
+        { provider: "xai", channels: ["grok-a"], models: ["grok-imagine-image"] },
+      ],
+    });
+
+    expect(catalog.providers.map((entry) => entry.provider)).toEqual(["xai"]);
+    expect(findImageModel(catalog, "gpt-image-2")).toBeNull();
+  });
+
+  /**
+   * The panel and the backend deploy independently, so a server that only sends
+   * the old single-model shape has to keep producing a usable page.
+   */
+  test("falls back to a single-provider catalog on the legacy response shape", () => {
+    const catalog = buildImageModelCatalog({ model: "gpt-image-2", channels: ["codex-a"] });
+
+    expect(catalog.legacy).toBe(true);
+    expect(catalog.models.map((model) => model.id)).toEqual(["gpt-image-2"]);
+    // The legacy shape names no provider, and guessing "codex" would start lying
+    // the moment another provider is added server-side.
+    expect(catalog.models[0].provider).toBe("");
+  });
+
+  test("returns an empty catalog when nothing is configured", () => {
+    expect(buildImageModelCatalog(null).models).toEqual([]);
+    expect(buildImageModelCatalog({ model: "", channels: [] }).models).toEqual([]);
+  });
+});
+
+describe("selection", () => {
+  const catalog = buildImageModelCatalog(response);
+
+  test("prefers a previously used provider and model", () => {
+    expect(resolveInitialProvider(catalog, "xai")).toBe("xai");
+    expect(resolveInitialModel(catalog, "xai", "grok-2-image-1212")).toBe("grok-2-image-1212");
+  });
+
+  test("falls back to the first entry when the preference is unavailable", () => {
+    expect(resolveInitialProvider(catalog, "deleted-provider")).toBe("codex");
+    expect(resolveInitialModel(catalog, "xai", "gpt-image-2")).toBe("grok-imagine-image");
+  });
+
+  test("returns empty selections for an empty catalog", () => {
+    const empty = buildImageModelCatalog(null);
+    expect(resolveInitialProvider(empty, null)).toBe("");
+    expect(resolveInitialModel(empty, "", null)).toBe("");
+  });
+});
+
+describe("supportsImageEditing", () => {
+  const catalog = buildImageModelCatalog(response);
+
+  /**
+   * Driven by the server's declared capability rather than the model id: offering
+   * an edit form for a text-to-image-only model produces an upstream 404 instead
+   * of a useful error.
+   */
+  test("reflects the capability the server declared", () => {
+    expect(supportsImageEditing(catalog, "grok-imagine-image")).toBe(true);
+    expect(supportsImageEditing(catalog, "grok-2-image-1212")).toBe(false);
+  });
+
+  test("is false for a model that is not in the catalog", () => {
+    expect(supportsImageEditing(catalog, "not-a-model")).toBe(false);
+  });
+});
+
+describe("providerLabel", () => {
+  test("maps known providers to display names", () => {
+    expect(providerLabel("xai")).toBe("Grok");
+    expect(providerLabel("codex")).toBe("Codex");
+  });
+
+  /** An unknown provider stays usable rather than rendering as blank. */
+  test("falls back to the raw id for an unknown provider", () => {
+    expect(providerLabel("some-new-provider")).toBe("some-new-provider");
+  });
+});

--- a/features/image-model-picker/imageModels.ts
+++ b/features/image-model-picker/imageModels.ts
@@ -1,0 +1,132 @@
+import type {
+  ImageGenerationChannelsResponse,
+  ImageGenerationModel,
+} from "@code-proxy/api-client";
+
+/**
+ * Model and provider selection for image generation.
+ *
+ * The server is the authority on which models exist and which credential pool
+ * serves each one. Nothing here hardcodes a model id or a provider name: the page
+ * used to assume gpt-image-2 on codex, which is exactly why Grok models stayed
+ * unreachable after the runtime could already serve them.
+ */
+
+/** A provider with the channels and models available to the current tenant. */
+export interface ImageProviderOption {
+  provider: string;
+  channels: string[];
+  models: ImageGenerationModel[];
+}
+
+/** Everything the page needs to render its selectors. */
+export interface ImageModelCatalog {
+  providers: ImageProviderOption[];
+  models: ImageGenerationModel[];
+  /** True when the server predates provider-aware responses. */
+  legacy: boolean;
+}
+
+/**
+ * Human labels for known providers. An unknown provider falls back to its raw id
+ * rather than being hidden, so a provider added server-side is still usable before
+ * the panel ships a label for it.
+ */
+const PROVIDER_LABELS: Record<string, string> = {
+  codex: "Codex",
+  xai: "Grok",
+};
+
+export const providerLabel = (provider: string) =>
+  PROVIDER_LABELS[provider.trim().toLowerCase()] ?? provider;
+
+export const modelLabel = (model: ImageGenerationModel) =>
+  model.display_name?.trim() || model.id;
+
+/**
+ * Projects a channels response into the catalog the UI renders.
+ *
+ * A server that only sends the legacy `{model, channels}` shape still produces a
+ * usable single-provider catalog, so the panel can be deployed before or after the
+ * backend without a broken page in between.
+ */
+export const buildImageModelCatalog = (
+  response: ImageGenerationChannelsResponse | null,
+): ImageModelCatalog => {
+  if (!response) return { providers: [], models: [], legacy: false };
+
+  const models = response.models ?? [];
+  const providers = response.providers ?? [];
+
+  if (models.length === 0 || providers.length === 0) {
+    const fallbackModel = response.model?.trim();
+    if (!fallbackModel) return { providers: [], models: [], legacy: true };
+    // The legacy shape names no provider. It is left blank rather than guessed at:
+    // the page only needs it to group channels, and inventing "codex" here would
+    // start lying the moment another provider is added server-side.
+    const legacyModel: ImageGenerationModel = {
+      id: fallbackModel,
+      provider: "",
+      supports_edit: true,
+    };
+    return {
+      providers: [{ provider: "", channels: response.channels ?? [], models: [legacyModel] }],
+      models: [legacyModel],
+      legacy: true,
+    };
+  }
+
+  const usable = providers
+    .map((entry) => ({
+      provider: entry.provider,
+      channels: entry.channels ?? [],
+      models: models.filter((model) => model.provider === entry.provider),
+    }))
+    // A provider with no usable channel cannot serve a request, so offering its
+    // models would only produce a confusing failure at submit time.
+    .filter((entry) => entry.channels.length > 0 && entry.models.length > 0);
+
+  return {
+    providers: usable,
+    models: usable.flatMap((entry) => entry.models),
+    legacy: false,
+  };
+};
+
+/**
+ * Picks the provider to select initially, preferring one the caller used before.
+ */
+export const resolveInitialProvider = (
+  catalog: ImageModelCatalog,
+  preferred?: string | null,
+) => {
+  if (catalog.providers.length === 0) return "";
+  const match = catalog.providers.find((entry) => entry.provider === preferred?.trim());
+  return (match ?? catalog.providers[0]).provider;
+};
+
+/** Picks the model to select within a provider, preferring one used before. */
+export const resolveInitialModel = (
+  catalog: ImageModelCatalog,
+  provider: string,
+  preferred?: string | null,
+) => {
+  const entry = catalog.providers.find((item) => item.provider === provider);
+  const models = entry?.models ?? catalog.models;
+  if (models.length === 0) return "";
+  const match = models.find((model) => model.id === preferred?.trim());
+  return (match ?? models[0]).id;
+};
+
+export const findImageModel = (catalog: ImageModelCatalog, modelID: string) =>
+  catalog.models.find((model) => model.id === modelID) ?? null;
+
+/**
+ * Whether a reference-image control should be offered for a model.
+ *
+ * Driven by the server's declared capability rather than by the model id, because
+ * offering an edit form for a text-to-image-only model produces an upstream 404
+ * instead of a useful error.
+ */
+export const supportsImageEditing = (catalog: ImageModelCatalog, modelID: string) =>
+  findImageModel(catalog, modelID)?.supports_edit ?? false;

--- a/features/image-model-picker/index.ts
+++ b/features/image-model-picker/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Image model selection.
+ *
+ * Owns the projection from the server's channel/model catalog into the selectors
+ * the image-generation page renders, so the page holds no knowledge of which
+ * providers or models exist.
+ */
+export { ImageModelPicker } from "./ImageModelPicker";
+export {
+  buildImageModelCatalog,
+  findImageModel,
+  modelLabel,
+  providerLabel,
+  resolveInitialModel,
+  resolveInitialProvider,
+  supportsImageEditing,
+} from "./imageModels";
+export type { ImageModelCatalog, ImageProviderOption } from "./imageModels";

--- a/packages/api-client/src/endpoints/image-generation.ts
+++ b/packages/api-client/src/endpoints/image-generation.ts
@@ -58,9 +58,34 @@ export interface ImageGenerationSizePresetsResponse {
   sizes: string[];
 }
 
-export interface ImageGenerationChannelsResponse {
-  model: string;
+/** A credential provider that can serve at least one image model. */
+export interface ImageGenerationProviderChannels {
+  provider: string;
   channels: string[];
+  models: string[];
+}
+
+/** A selectable image model, as reported by the server. */
+export interface ImageGenerationModel {
+  id: string;
+  provider: string;
+  display_name?: string;
+  description?: string;
+  /** True when the model accepts reference images through the edits endpoint. */
+  supports_edit: boolean;
+  price_per_call?: number;
+}
+
+export interface ImageGenerationChannelsResponse {
+  /**
+   * The legacy single-model field. Retained because the server still sends it and
+   * older panels read it; new code should use `models`.
+   */
+  model: string;
+  /** Every usable channel across providers, flattened. Also legacy. */
+  channels: string[];
+  providers?: ImageGenerationProviderChannels[];
+  models?: ImageGenerationModel[];
 }
 
 export const imageGenerationApi = {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -90,6 +90,7 @@ export type * from "./endpoints/identity-fingerprint";
 export { updateApi } from "./endpoints/update";
 export type * from "./endpoints/update";
 export { imageGenerationApi } from "./endpoints/image-generation";
+export type * from "./endpoints/image-generation";
 export { proxiesApi } from "./endpoints/proxies";
 export type * from "./endpoints/proxies";
 export { contentModerationApi } from "./endpoints/content-moderation";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2211,7 +2211,11 @@
     "image_preview_title": "Image Preview",
     "revised_prompt_label": "Revised Prompt",
     "test_empty_result": "Upstream did not return an image result",
-    "test_failed_generic": "Image generation failed"
+    "test_failed_generic": "Image generation failed",
+    "provider": "Channel",
+    "model": "Model",
+    "model_placeholder": "Select a model",
+    "tab_label": "Image generation"
   },
   "identity_fingerprint": {
     "title": "Identity Fingerprint",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -1920,7 +1920,11 @@
     "image_preview_title": "Предпросмотр изображения",
     "revised_prompt_label": "Скорректированный prompt",
     "test_empty_result": "Верхний сервис не вернул изображение",
-    "test_failed_generic": "Не удалось сгенерировать изображение"
+    "test_failed_generic": "Не удалось сгенерировать изображение",
+    "provider": "Канал",
+    "model": "Модель",
+    "model_placeholder": "Выберите модель",
+    "tab_label": "Генерация изображений"
   },
   "identity_fingerprint": {
     "title": "Identity Fingerprint",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2228,7 +2228,11 @@
     "image_preview_title": "图片预览",
     "revised_prompt_label": "修订后的提示词",
     "test_empty_result": "上游未返回图片结果",
-    "test_failed_generic": "图片生成失败"
+    "test_failed_generic": "图片生成失败",
+    "provider": "渠道",
+    "model": "模型",
+    "model_placeholder": "选择模型",
+    "tab_label": "图片生成"
   },
   "identity_fingerprint": {
     "title": "身份指纹",

--- a/pages/image-generation/__tests__/ImageGenerationPage.test.tsx
+++ b/pages/image-generation/__tests__/ImageGenerationPage.test.tsx
@@ -69,7 +69,7 @@ describe("ImageGenerationPage", () => {
   test("renders text-to-image call docs with structured endpoint tables", async () => {
     renderPage();
 
-    expect(await screen.findByRole("tab", { name: "gpt-image-2" })).toBeInTheDocument();
+    expect(await screen.findByRole("tab", { name: "图片生成" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "生图模型" })).toBeInTheDocument();
     const callCard = screen.getByText("调用方式").closest("section");
     expect(callCard).not.toBeNull();
@@ -132,7 +132,7 @@ describe("ImageGenerationPage", () => {
 
     renderPage();
 
-    await screen.findByRole("tab", { name: "gpt-image-2" });
+    await screen.findByRole("tab", { name: "图片生成" });
     await user.click(screen.getByRole("button", { name: "测试生成" }));
 
     const dialog = await screen.findByRole("dialog", { name: "测试生成" });
@@ -307,7 +307,7 @@ describe("ImageGenerationPage", () => {
 
     renderPage();
 
-    await screen.findByRole("tab", { name: "gpt-image-2" });
+    await screen.findByRole("tab", { name: "图片生成" });
     await user.click(screen.getByRole("button", { name: "测试生成" }));
 
     const dialog = await screen.findByRole("dialog", { name: "测试生成" });
@@ -351,7 +351,7 @@ describe("ImageGenerationPage", () => {
 
     renderPage();
 
-    await screen.findByRole("tab", { name: "gpt-image-2" });
+    await screen.findByRole("tab", { name: "图片生成" });
     await user.click(screen.getByRole("button", { name: "测试生成" }));
 
     const dialog = await screen.findByRole("dialog", { name: "测试生成" });
@@ -385,7 +385,7 @@ describe("ImageGenerationPage", () => {
 
     renderPage();
 
-    await screen.findByRole("tab", { name: "gpt-image-2" });
+    await screen.findByRole("tab", { name: "图片生成" });
     await user.click(screen.getByRole("button", { name: "测试生成" }));
 
     const dialog = await screen.findByRole("dialog", { name: "测试生成" });
@@ -420,7 +420,7 @@ describe("ImageGenerationPage", () => {
 
     renderPage();
 
-    await screen.findByRole("tab", { name: "gpt-image-2" });
+    await screen.findByRole("tab", { name: "图片生成" });
     await user.click(screen.getByRole("button", { name: "测试生成" }));
 
     const dialog = await screen.findByRole("dialog", { name: "测试生成" });
@@ -469,7 +469,7 @@ describe("ImageGenerationPage", () => {
 
     renderPage();
 
-    await screen.findByRole("tab", { name: "gpt-image-2" });
+    await screen.findByRole("tab", { name: "图片生成" });
     await userEvent.click(screen.getByRole("button", { name: "测试生成" }));
 
     const dialog = await screen.findByRole("dialog", { name: "测试生成" });

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -12,8 +12,24 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { useImageGenerationChannels } from "../hooks/useImageGenerationChannels";
+import {
+  ImageModelPicker,
+  resolveInitialModel,
+  resolveInitialProvider,
+  supportsImageEditing,
+} from "@features/image-model-picker";
+import {
+  VISIBLE_ENDPOINT_DOCS,
+  type EndpointDoc,
+  type SpecRow,
+} from "./apiDocs";
 
-const GPT_IMAGE_MODEL = "gpt-image-2";
+/**
+ * Fallback model id, used only until the server's catalog arrives and as the tab
+ * key. The selected model itself comes from the catalog: hardcoding it here is what
+ * kept every non-codex image model unreachable from this page.
+ */
+const FALLBACK_IMAGE_MODEL = "gpt-image-2";
 const GENERATION_STATUS_KEYS = [
   "image_generation.generation_status_drafting",
   "image_generation.generation_status_creating",
@@ -46,30 +62,12 @@ const DEFAULT_SIZE_OPTIONS = new Set<string>(SIZE_OPTIONS);
 const QUALITY_OPTIONS = ["low", "medium", "high"] as const;
 const COUNT_OPTIONS = [1, 2, 3, 4] as const;
 const MAX_UPLOAD_IMAGES = 5;
-const IMAGE_EDITS_ENABLED = true;
 const IMAGE_GENERATION_SIZE_PATTERN = /^[1-9]\d*x[1-9]\d*$/;
 const IMAGE_GENERATION_MAX_SIZE_EDGE = 8192;
 const IMAGE_GENERATION_MAX_SIZE_PIXELS =
   IMAGE_GENERATION_MAX_SIZE_EDGE * IMAGE_GENERATION_MAX_SIZE_EDGE;
 
 type ImageMode = "generations" | "edits";
-type SpecRow = {
-  name: string;
-  type: string;
-  required: boolean;
-  descriptionKey: string;
-};
-type EndpointDoc = {
-  mode: ImageMode;
-  titleKey: string;
-  descriptionKey: string;
-  method: "POST";
-  path: string;
-  contentType: string;
-  requestRows: SpecRow[];
-  responseRows: SpecRow[];
-  curl: string;
-};
 type GeneratedImage = { src: string; revisedPrompt?: string };
 type UploadedImage = { id: string; file: File; previewUrl: string };
 
@@ -118,156 +116,17 @@ function mergeImageGenerationSizePresets(values: string[]): string[] {
   return merged;
 }
 
-const textToImageCurl = [
-  "curl http://127.0.0.1:8317/v1/images/generations \\",
-  '  -H "Authorization: Bearer $API_KEY" \\',
-  '  -H "Content-Type: application/json" \\',
-  "  -d '{",
-  '    "model": "gpt-image-2",',
-  '    "prompt": "你的中文描述",',
-  '    "size": "1024x1024",',
-  '    "quality": "high",',
-  '    "n": 1',
-  "  }'",
-].join("\n");
-
-const imageToImageCurl = [
-  "curl http://127.0.0.1:8317/v1/images/edits \\",
-  '  -H "Authorization: Bearer $API_KEY" \\',
-  '  -F "model=gpt-image-2" \\',
-  '  -F "prompt=把这张图改成蓝色图标风格" \\',
-  '  -F "size=1024x1024" \\',
-  '  -F "quality=high" \\',
-  '  -F "n=1" \\',
-  '  -F "image=@/path/to/image.png"',
-].join("\n");
-
-const RESPONSE_ROWS: SpecRow[] = [
-  {
-    name: "created",
-    type: "number",
-    required: false,
-    descriptionKey: "image_generation.response_created_desc",
-  },
-  {
-    name: "data[].b64_json",
-    type: "string",
-    required: true,
-    descriptionKey: "image_generation.response_b64_desc",
-  },
-  {
-    name: "data[].revised_prompt",
-    type: "string",
-    required: false,
-    descriptionKey: "image_generation.response_revised_prompt_desc",
-  },
-];
-
-const ENDPOINT_DOCS: EndpointDoc[] = [
-  {
-    mode: "generations",
-    titleKey: "image_generation.text_to_image_title",
-    descriptionKey: "image_generation.text_to_image_desc",
-    method: "POST",
-    path: "/v1/images/generations",
-    contentType: "application/json",
-    requestRows: [
-      {
-        name: "model",
-        type: "string",
-        required: true,
-        descriptionKey: "image_generation.param_model_desc",
-      },
-      {
-        name: "prompt",
-        type: "string",
-        required: true,
-        descriptionKey: "image_generation.param_prompt_desc",
-      },
-      {
-        name: "size",
-        type: "string",
-        required: false,
-        descriptionKey: "image_generation.param_size_desc",
-      },
-      {
-        name: "quality",
-        type: "string",
-        required: false,
-        descriptionKey: "image_generation.param_quality_desc",
-      },
-      {
-        name: "n",
-        type: "number",
-        required: false,
-        descriptionKey: "image_generation.param_n_desc",
-      },
-    ],
-    responseRows: RESPONSE_ROWS,
-    curl: textToImageCurl,
-  },
-  {
-    mode: "edits",
-    titleKey: "image_generation.image_to_image_title",
-    descriptionKey: "image_generation.image_to_image_desc",
-    method: "POST",
-    path: "/v1/images/edits",
-    contentType: "multipart/form-data",
-    requestRows: [
-      {
-        name: "model",
-        type: "string",
-        required: true,
-        descriptionKey: "image_generation.param_model_desc",
-      },
-      {
-        name: "prompt",
-        type: "string",
-        required: true,
-        descriptionKey: "image_generation.param_edit_prompt_desc",
-      },
-      {
-        name: "image",
-        type: "file",
-        required: true,
-        descriptionKey: "image_generation.param_images_desc",
-      },
-      {
-        name: "size",
-        type: "string",
-        required: false,
-        descriptionKey: "image_generation.param_size_desc",
-      },
-      {
-        name: "quality",
-        type: "string",
-        required: false,
-        descriptionKey: "image_generation.param_quality_desc",
-      },
-      {
-        name: "n",
-        type: "number",
-        required: false,
-        descriptionKey: "image_generation.param_n_desc",
-      },
-    ],
-    responseRows: RESPONSE_ROWS,
-    curl: imageToImageCurl,
-  },
-];
-const VISIBLE_ENDPOINT_DOCS = IMAGE_EDITS_ENABLED
-  ? ENDPOINT_DOCS
-  : ENDPOINT_DOCS.filter((doc) => doc.mode === "generations");
 
 export function ImageGenerationPage() {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState(GPT_IMAGE_MODEL);
+  const [activeTab, setActiveTab] = useState(FALLBACK_IMAGE_MODEL);
   const [activeMode, setActiveMode] = useState<ImageMode>("generations");
   const {
     loading: channelsLoading,
     channels: availableChannels,
     failed: channelsFailed,
   } = useImageGenerationChannels();
+
   const [testOpen, setTestOpen] = useState(false);
 
   const disabled = !channelsLoading && availableChannels.length === 0;
@@ -290,10 +149,10 @@ export function ImageGenerationPage() {
 
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <TabsList>
-            <TabsTrigger value={GPT_IMAGE_MODEL}>{GPT_IMAGE_MODEL}</TabsTrigger>
+            <TabsTrigger value={FALLBACK_IMAGE_MODEL}>{t("image_generation.tab_label")}</TabsTrigger>
           </TabsList>
 
-          <TabsContent value={GPT_IMAGE_MODEL} className="mt-4 space-y-4">
+          <TabsContent value={FALLBACK_IMAGE_MODEL} className="mt-4 space-y-4">
             {disabled ? (
               <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-100">
                 {channelsFailed
@@ -536,6 +395,35 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
   const [uploadPreviewOpen, setUploadPreviewOpen] = useState(false);
   const [uploadPreviewIndex, setUploadPreviewIndex] = useState(0);
   const [generationElapsedMs, setGenerationElapsedMs] = useState<number | null>(null);
+  const { loading: catalogLoading, catalog } = useImageGenerationChannels();
+  const [selectedProvider, setSelectedProvider] = useState("");
+  const [selectedModel, setSelectedModel] = useState("");
+
+  // The catalog arrives asynchronously, so the selection is seeded once it does and
+  // then left alone; re-deriving it on every render would fight the user's choice.
+  useEffect(() => {
+    if (catalog.models.length === 0) return;
+    setSelectedProvider((current) => resolveInitialProvider(catalog, current || null));
+  }, [catalog]);
+
+  useEffect(() => {
+    if (catalog.models.length === 0) return;
+    setSelectedModel((current) => resolveInitialModel(catalog, selectedProvider, current || null));
+  }, [catalog, selectedProvider]);
+
+  const activeModel = selectedModel || FALLBACK_IMAGE_MODEL;
+  const editingSupported = catalog.models.length === 0 || supportsImageEditing(catalog, activeModel);
+
+  const handleProviderChange = useCallback(
+    (provider: string) => {
+      setSelectedProvider(provider);
+      // The current model usually belongs to the previous provider, so it is
+      // reselected rather than left pointing at something this provider cannot serve.
+      setSelectedModel(resolveInitialModel(catalog, provider, null));
+    },
+    [catalog],
+  );
+
   const uploadedImagesRef = useRef<UploadedImage[]>([]);
   const resultSwipeRef = useRef<{ x: number; y: number } | null>(null);
   const generationStartedAtRef = useRef<number | null>(null);
@@ -629,7 +517,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
 
   const activeImage = images[activeImageIndex] ?? null;
   const requestMode: ImageMode =
-    IMAGE_EDITS_ENABLED && uploadedImages.length > 0 ? "edits" : "generations";
+    editingSupported && uploadedImages.length > 0 ? "edits" : "generations";
   const canSend = Boolean(prompt.trim()) && !submitting;
   const hasMultipleResults = images.length > 1;
   const canShowPrevImage = activeImageIndex > 0;
@@ -832,7 +720,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
         requestMode === "edits"
           ? await imageGenerationApi.startTestTask({
               mode: "edits",
-              model: GPT_IMAGE_MODEL,
+              model: activeModel,
               prompt: trimmedPrompt,
               size,
               quality,
@@ -841,7 +729,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
             })
           : await imageGenerationApi.startTestTask({
               mode: "generations",
-              model: GPT_IMAGE_MODEL,
+              model: activeModel,
               prompt: trimmedPrompt,
               size,
               quality,
@@ -915,7 +803,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
   };
 
   const stageSizeClassName =
-    IMAGE_EDITS_ENABLED && uploadedImages.length > 0
+    editingSupported && uploadedImages.length > 0
       ? "h-[clamp(220px,34vh,320px)] sm:h-[clamp(240px,36vh,360px)]"
       : "h-[clamp(240px,42vh,400px)] sm:h-[clamp(280px,44vh,440px)]";
   const stageClassName = [
@@ -1058,7 +946,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                             <img
                               src={image.src}
                               alt={t("image_generation.preview_alt", {
-                                model: GPT_IMAGE_MODEL,
+                                model: activeModel,
                               })}
                               className="block h-auto w-full cursor-zoom-in select-none"
                               draggable={false}
@@ -1165,7 +1053,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
             data-testid="image-generation-composer"
             className="relative shrink-0 overflow-hidden rounded-2xl border border-slate-200 bg-white px-2.5 pt-2.5 pb-11 shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
           >
-            {IMAGE_EDITS_ENABLED && uploadedImages.length > 0 ? (
+            {editingSupported && uploadedImages.length > 0 ? (
               <div
                 data-testid="image-generation-upload-strip"
                 className="absolute top-2.5 right-2.5 left-2.5 z-10 flex gap-2 overflow-x-auto overflow-y-hidden pb-1 [scrollbar-width:thin]"
@@ -1210,10 +1098,20 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                 ))}
               </div>
             ) : null}
+            <div className="mb-3">
+              <ImageModelPicker
+                catalog={catalog}
+                provider={selectedProvider}
+                model={activeModel}
+                disabled={submitting || catalogLoading}
+                onProviderChange={handleProviderChange}
+                onModelChange={setSelectedModel}
+              />
+            </div>
             <label htmlFor="image-generation-prompt" className="sr-only">
               {t("image_generation.prompt_label")}
             </label>
-            {IMAGE_EDITS_ENABLED ? (
+            {editingSupported ? (
               <input
                 id="image-generation-reference"
                 aria-label={t("image_generation.upload_images_label")}
@@ -1237,10 +1135,10 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
               rows={4}
               className={[
                 "min-h-[112px] w-full resize-none border-0 bg-transparent px-1 pr-8 pb-10 text-sm leading-6 text-slate-900 outline-none placeholder:text-slate-400 dark:text-white dark:placeholder:text-white/30",
-                IMAGE_EDITS_ENABLED && uploadedImages.length > 0 ? "pt-12" : "pt-0",
+                editingSupported && uploadedImages.length > 0 ? "pt-12" : "pt-0",
               ].join(" ")}
             />
-            {IMAGE_EDITS_ENABLED ? (
+            {editingSupported ? (
               <label
                 htmlFor="image-generation-reference"
                 data-testid="image-generation-upload-trigger"
@@ -1272,20 +1170,20 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
       <ImagePreviewOverlay
         open={previewOpen && Boolean(activeImage)}
         imageSrc={activeImage?.src ?? null}
-        imageAlt={t("image_generation.preview_alt", { model: GPT_IMAGE_MODEL })}
+        imageAlt={t("image_generation.preview_alt", { model: activeModel })}
         title={t("image_generation.image_preview_title")}
-        downloadName={`${GPT_IMAGE_MODEL}-${activeImageIndex + 1}.png`}
+        downloadName={`${activeModel}-${activeImageIndex + 1}.png`}
         images={images.map((image, index) => ({
           src: image.src,
-          alt: t("image_generation.preview_alt", { model: GPT_IMAGE_MODEL }),
-          downloadName: `${GPT_IMAGE_MODEL}-${index + 1}.png`,
+          alt: t("image_generation.preview_alt", { model: activeModel }),
+          downloadName: `${activeModel}-${index + 1}.png`,
         }))}
         activeIndex={activeImageIndex}
         onActiveIndexChange={setActiveImageIndex}
         onClose={() => setPreviewOpen(false)}
       />
       <ImagePreviewOverlay
-        open={IMAGE_EDITS_ENABLED && uploadPreviewOpen && uploadedImages.length > 0}
+        open={editingSupported && uploadPreviewOpen && uploadedImages.length > 0}
         imageSrc={uploadedImages[uploadPreviewIndex]?.previewUrl ?? null}
         imageAlt={
           uploadedImages[uploadPreviewIndex]?.file.name ?? t("image_generation.upload_images_label")

--- a/pages/image-generation/components/apiDocs.ts
+++ b/pages/image-generation/components/apiDocs.ts
@@ -1,0 +1,171 @@
+/**
+ * Static API reference shown on the image-generation page.
+ *
+ * Pure data: entries carry translation keys rather than translated strings, so this
+ * module stays free of React and i18n wiring. It lives apart from the page
+ * component because that file is at its frozen line budget and may only shrink.
+ */
+
+export type SpecRow = {
+  name: string;
+  type: string;
+  required: boolean;
+  descriptionKey: string;
+  defaultValue?: string;
+};
+
+export type EndpointDoc = {
+  mode: "generations" | "edits";
+  titleKey: string;
+  descriptionKey: string;
+  method: string;
+  path: string;
+  contentType: string;
+  requestRows: SpecRow[];
+  responseRows: SpecRow[];
+  curl: string;
+};
+
+/** Image editing is served by every currently supported provider. */
+export const IMAGE_EDITS_ENABLED = true;
+
+const textToImageCurl = [
+  "curl http://127.0.0.1:8317/v1/images/generations \\",
+  '  -H "Authorization: Bearer $API_KEY" \\',
+  '  -H "Content-Type: application/json" \\',
+  "  -d '{",
+  '    "model": "gpt-image-2",',
+  '    "prompt": "你的中文描述",',
+  '    "size": "1024x1024",',
+  '    "quality": "high",',
+  '    "n": 1',
+  "  }'",
+].join("\n");
+
+const imageToImageCurl = [
+  "curl http://127.0.0.1:8317/v1/images/edits \\",
+  '  -H "Authorization: Bearer $API_KEY" \\',
+  '  -F "model=gpt-image-2" \\',
+  '  -F "prompt=把这张图改成蓝色图标风格" \\',
+  '  -F "size=1024x1024" \\',
+  '  -F "quality=high" \\',
+  '  -F "n=1" \\',
+  '  -F "image=@/path/to/image.png"',
+].join("\n");
+
+export const RESPONSE_ROWS: SpecRow[] = [
+  {
+    name: "created",
+    type: "number",
+    required: false,
+    descriptionKey: "image_generation.response_created_desc",
+  },
+  {
+    name: "data[].b64_json",
+    type: "string",
+    required: true,
+    descriptionKey: "image_generation.response_b64_desc",
+  },
+  {
+    name: "data[].revised_prompt",
+    type: "string",
+    required: false,
+    descriptionKey: "image_generation.response_revised_prompt_desc",
+  },
+];
+
+const ENDPOINT_DOCS: EndpointDoc[] = [
+  {
+    mode: "generations",
+    titleKey: "image_generation.text_to_image_title",
+    descriptionKey: "image_generation.text_to_image_desc",
+    method: "POST",
+    path: "/v1/images/generations",
+    contentType: "application/json",
+    requestRows: [
+      {
+        name: "model",
+        type: "string",
+        required: true,
+        descriptionKey: "image_generation.param_model_desc",
+      },
+      {
+        name: "prompt",
+        type: "string",
+        required: true,
+        descriptionKey: "image_generation.param_prompt_desc",
+      },
+      {
+        name: "size",
+        type: "string",
+        required: false,
+        descriptionKey: "image_generation.param_size_desc",
+      },
+      {
+        name: "quality",
+        type: "string",
+        required: false,
+        descriptionKey: "image_generation.param_quality_desc",
+      },
+      {
+        name: "n",
+        type: "number",
+        required: false,
+        descriptionKey: "image_generation.param_n_desc",
+      },
+    ],
+    responseRows: RESPONSE_ROWS,
+    curl: textToImageCurl,
+  },
+  {
+    mode: "edits",
+    titleKey: "image_generation.image_to_image_title",
+    descriptionKey: "image_generation.image_to_image_desc",
+    method: "POST",
+    path: "/v1/images/edits",
+    contentType: "multipart/form-data",
+    requestRows: [
+      {
+        name: "model",
+        type: "string",
+        required: true,
+        descriptionKey: "image_generation.param_model_desc",
+      },
+      {
+        name: "prompt",
+        type: "string",
+        required: true,
+        descriptionKey: "image_generation.param_edit_prompt_desc",
+      },
+      {
+        name: "image",
+        type: "file",
+        required: true,
+        descriptionKey: "image_generation.param_images_desc",
+      },
+      {
+        name: "size",
+        type: "string",
+        required: false,
+        descriptionKey: "image_generation.param_size_desc",
+      },
+      {
+        name: "quality",
+        type: "string",
+        required: false,
+        descriptionKey: "image_generation.param_quality_desc",
+      },
+      {
+        name: "n",
+        type: "number",
+        required: false,
+        descriptionKey: "image_generation.param_n_desc",
+      },
+    ],
+    responseRows: RESPONSE_ROWS,
+    curl: imageToImageCurl,
+  },
+];
+export const VISIBLE_ENDPOINT_DOCS = IMAGE_EDITS_ENABLED
+  ? ENDPOINT_DOCS
+  : ENDPOINT_DOCS.filter((doc) => doc.mode === "generations");

--- a/pages/image-generation/hooks/useImageGenerationChannels.ts
+++ b/pages/image-generation/hooks/useImageGenerationChannels.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { imageGenerationApi } from "@code-proxy/api-client";
+import { buildImageModelCatalog, type ImageModelCatalog } from "@features/image-model-picker";
 
 export interface ImageGenerationChannelsState {
   loading: boolean;
@@ -7,7 +8,11 @@ export interface ImageGenerationChannelsState {
   channels: string[];
   /** True when availability could not be determined, which is not the same as "no channels". */
   failed: boolean;
+  /** Providers and models the tenant can actually use, derived from the same response. */
+  catalog: ImageModelCatalog;
 }
+
+const EMPTY_CATALOG: ImageModelCatalog = { providers: [], models: [], legacy: false };
 
 /**
  * Loads image-generation channel availability from the dedicated management endpoint.
@@ -27,6 +32,7 @@ export function useImageGenerationChannels(): ImageGenerationChannelsState {
     loading: true,
     channels: [],
     failed: false,
+    catalog: EMPTY_CATALOG,
   });
 
   useEffect(() => {
@@ -36,12 +42,17 @@ export function useImageGenerationChannels(): ImageGenerationChannelsState {
       try {
         const response = await imageGenerationApi.getChannels();
         if (cancelled) return;
-        setState({ loading: false, channels: response.channels ?? [], failed: false });
+        setState({
+          loading: false,
+          channels: response.channels ?? [],
+          failed: false,
+          catalog: buildImageModelCatalog(response),
+        });
       } catch {
         // A failed lookup must not masquerade as "no channels configured": the two need
         // different guidance, and conflating them is what made the original bug invisible.
         if (!cancelled) {
-          setState({ loading: false, channels: [], failed: true });
+          setState({ loading: false, channels: [], failed: true, catalog: EMPTY_CATALOG });
         }
       }
     };

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -24,7 +24,7 @@
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1455,
     "pages/end-users/EndUsersPage.tsx": 1334,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
-    "pages/image-generation/components/ImageGenerationPageContent.tsx": 1307,
+    "pages/image-generation/components/ImageGenerationPageContent.tsx": 1205,
     "pages/models/ModelsPage.tsx": 1358,
     "pages/providers/components/ProvidersPageContent.tsx": 1853
   }


### PR DESCRIPTION
## 问题

图生页把 `gpt-image-2` 写死，还把它当作 tab 标签。即使后端已经能服务其他图片模型，控制台也够不到。

## 改动

**选择来自服务端目录**：provider 和 model 都由后端下发，前端不持有任何模型或渠道名单。后端加一个模型就能直接选，不需要发前端版本；遇到前端还没配文案的 provider，按原始 id 渲染而不是消失。

**编辑能力按模型判定**：参考图上传现在根据所选模型声明的 `supports_edit` 显示。`grok-2-image-1212` 没有 edits 端点，给它渲染上传框只会换来一个上游 404 而不是有用的报错。

**组件封装**：选择逻辑落在 `features/image-model-picker/`，按项目 import 边界这一层只能依赖 `packages/`——它伸不进 app shell。`ImageModelPicker` 复用 `FormField` + `Select`，单 provider 部署不渲染 provider 选择器（只有一个选项的控件是噪音）。

**向后兼容**：服务端如果还只发旧的 `{model, channels}` 形状，会生成一个可用的单 provider 目录，因此前后端可以任意顺序上线，中间不会出现坏页面。

## 结构债

页面文件正好卡在冻结的行数基线上。把静态 API 文档（纯数据，带的是翻译 key 不是译文，本来也不该待在组件文件里）抽成独立模块后，页面从 1307 行降到 1206 行，已锁定新基线。

## 验证

- 本地完整 `./scripts/ci-pr.sh`：通过（`exit=0`），1003 个单测全绿
- 新增 11 条 picker 单测：provider 分组、无可用渠道的 provider 被剔除、legacy 形状降级、选择偏好与回退、编辑能力判定、未知 provider 标签
- 完整 e2e 套件对比（同机同条件）：`dev` 23 failed / 49 passed，本分支 22 failed / 50 passed，且**没有任何 spec 只在本分支失败**。剩余失败在干净 `dev` 上同样存在

tab 原本以硬编码模型 id 命名，现在命名功能本身，测试查询已相应更新。

后端配套：kittors/CliRelay#824

🤖 Generated with [Claude Code](https://claude.com/claude-code)