### PR TITLE
fix(image-generation): group the test modal controls and collapse the error state

### DIFF
--- a/features/image-model-picker/ImageModelPicker.tsx
+++ b/features/image-model-picker/ImageModelPicker.tsx
@@ -19,6 +19,7 @@ export function ImageModelPicker({
   provider,
   model,
   disabled = false,
+  variant = "labelled",
   onProviderChange,
   onModelChange,
 }: {
@@ -26,6 +27,12 @@ export function ImageModelPicker({
   provider: string;
   model: string;
   disabled?: boolean;
+  /**
+   * "compact" drops the field labels so the selectors can sit inline with other
+   * pill-shaped controls. Used in the test modal, where a labelled two-column block
+   * would split the controls across the dialog instead of grouping them.
+   */
+  variant?: "labelled" | "compact";
   onProviderChange: (provider: string) => void;
   onModelChange: (model: string) => void;
 }) {
@@ -51,6 +58,32 @@ export function ImageModelPicker({
   // A deployment with a single provider gets no provider selector: a control with
   // one option is noise, and the legacy server shape reports no provider at all.
   const showProviderSelect = providerOptions.length > 1;
+
+  if (variant === "compact") {
+    return (
+      <>
+        {showProviderSelect ? (
+          <Select
+            aria-label={t("image_generation.provider")}
+            value={provider}
+            options={providerOptions}
+            disabled={disabled}
+            fullWidth={false}
+            onChange={onProviderChange}
+          />
+        ) : null}
+        <Select
+          aria-label={t("image_generation.model")}
+          value={model}
+          options={modelOptions}
+          disabled={disabled || modelOptions.length === 0}
+          placeholder={t("image_generation.model_placeholder")}
+          fullWidth={false}
+          onChange={onModelChange}
+        />
+      </>
+    );
+  }
 
   return (
     <div

--- a/pages/image-generation/__tests__/ImageGenerationPage.test.tsx
+++ b/pages/image-generation/__tests__/ImageGenerationPage.test.tsx
@@ -449,7 +449,7 @@ describe("ImageGenerationPage", () => {
     });
   });
 
-  test("greys the preview area and shows the error message inside the modal when generation fails", async () => {
+  test("collapses the preview area into an alert when generation fails", async () => {
     const deferred = createDeferred<{
       task_id: string;
       status: "failed";
@@ -500,7 +500,13 @@ describe("ImageGenerationPage", () => {
 
     expect(await within(dialog).findByText("上游图片生成失败")).toBeInTheDocument();
     expect(within(dialog).getByText("00:02")).toBeInTheDocument();
-    expect(within(dialog).getByTestId("image-generation-preview")).toHaveClass("bg-slate-100");
+    // The failure now uses the panel's alert treatment and collapses the stage: a
+    // full-height grey canvas for one line of text is what forced the dialog to
+    // scroll. Asserting the tone on the stage keeps the intent without pinning the
+    // exact palette.
+    const stage = dialog.querySelector('[data-state="error"]');
+    expect(stage?.className).toContain("bg-rose-50");
+    expect(stage?.className).toContain("h-auto");
   });
 
   test("greys related actions and shows the empty hint when no channel is configured", async () => {

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
-import { ArrowUp, ChevronLeft, ChevronRight, Plus, Trash2, X } from "lucide-react";
+import { ArrowUp, ChevronLeft, ChevronRight, CircleAlert, Plus, Trash2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { imageGenerationApi } from "@code-proxy/api-client";
 import { Button } from "@code-proxy/ui";
@@ -18,6 +18,7 @@ import {
   resolveInitialProvider,
   supportsImageEditing,
 } from "@features/image-model-picker";
+import { imageStageClassName } from "./stageStyles";
 import {
   VISIBLE_ENDPOINT_DOCS,
   type EndpointDoc,
@@ -802,19 +803,11 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
     }
   };
 
-  const stageSizeClassName =
-    editingSupported && uploadedImages.length > 0
-      ? "h-[clamp(220px,34vh,320px)] sm:h-[clamp(240px,36vh,360px)]"
-      : "h-[clamp(240px,42vh,400px)] sm:h-[clamp(280px,44vh,440px)]";
-  const stageClassName = [
-    "relative overflow-hidden rounded-2xl border transition-all duration-200",
-    stageSizeClassName,
-    errorMessage
-      ? "border-slate-200 bg-slate-100 text-slate-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/85"
-      : activeImage
-        ? "border-slate-200 bg-slate-100 dark:border-neutral-800 dark:bg-black"
-        : "border-slate-200 bg-slate-50 text-slate-500 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/55",
-  ].join(" ");
+  const stageClassName = imageStageClassName({
+    errorMessage,
+    hasImage: Boolean(activeImage),
+    hasUploads: editingSupported && uploadedImages.length > 0,
+  });
   const statusText = t(GENERATION_STATUS_KEYS[statusIndex]);
   const showGeneratingState = submitting && !activeImage && !errorMessage;
   const showIdleCanvas = !submitting && !activeImage && !errorMessage;
@@ -838,7 +831,16 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
             void handleGenerate();
           }}
         >
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <ImageModelPicker
+              catalog={catalog}
+              provider={selectedProvider}
+              model={activeModel}
+              disabled={submitting || catalogLoading}
+              variant="compact"
+              onProviderChange={handleProviderChange}
+              onModelChange={setSelectedModel}
+            />
             <SearchableSelect
               aria-label={t("image_generation.size_label")}
               value={size}
@@ -998,10 +1000,11 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
               <div
                 data-testid="image-generation-preview"
                 className={[
-                  "relative flex h-full w-full overflow-hidden px-6 py-6 sm:px-8 sm:py-8",
-                  errorMessage
-                    ? "bg-slate-100 text-slate-700 dark:bg-neutral-900 dark:text-white"
-                    : "bg-transparent",
+                  "relative flex w-full overflow-hidden",
+                  errorMessage && !activeImage
+                    ? "px-4 py-3.5"
+                    : "h-full px-6 py-6 sm:px-8 sm:py-8",
+                  "bg-transparent",
                 ].join(" ")}
               >
                 <div className="relative z-10 flex h-full w-full items-start">
@@ -1029,10 +1032,9 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                   ) : null}
 
                   {errorMessage ? (
-                    <div className="max-w-md">
-                      <p className="text-2xl font-semibold tracking-tight text-slate-800 dark:text-white">
-                        {errorMessage}
-                      </p>
+                    <div className="flex min-w-0 items-start gap-2.5">
+                      <CircleAlert size={16} className="mt-0.5 shrink-0" />
+                      <p className="min-w-0 break-words text-sm leading-6">{errorMessage}</p>
                     </div>
                   ) : null}
                 </div>
@@ -1098,16 +1100,6 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                 ))}
               </div>
             ) : null}
-            <div className="mb-3">
-              <ImageModelPicker
-                catalog={catalog}
-                provider={selectedProvider}
-                model={activeModel}
-                disabled={submitting || catalogLoading}
-                onProviderChange={handleProviderChange}
-                onModelChange={setSelectedModel}
-              />
-            </div>
             <label htmlFor="image-generation-prompt" className="sr-only">
               {t("image_generation.prompt_label")}
             </label>

--- a/pages/image-generation/components/stageStyles.ts
+++ b/pages/image-generation/components/stageStyles.ts
@@ -1,0 +1,34 @@
+/**
+ * Result-stage styling for the image test modal.
+ *
+ * Extracted from the page component, which is at its frozen line budget and may
+ * only shrink. Keeping it here also isolates the one rule that is easy to get
+ * wrong: an error needs a single line, not the full canvas.
+ */
+export function imageStageClassName({
+  errorMessage,
+  hasImage,
+  hasUploads,
+}: {
+  errorMessage: string;
+  hasImage: boolean;
+  hasUploads: boolean;
+}): string {
+  const failed = Boolean(errorMessage) && !hasImage;
+
+  // A failure collapses the stage. Reserving the full canvas for one line of text
+  // is what pushed the dialog past the viewport and forced it to scroll.
+  const size = failed
+    ? "h-auto"
+    : hasUploads
+      ? "h-[clamp(220px,34vh,320px)] sm:h-[clamp(240px,36vh,360px)]"
+      : "h-[clamp(240px,42vh,400px)] sm:h-[clamp(280px,44vh,440px)]";
+
+  const tone = failed
+    ? "border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-100"
+    : hasImage
+      ? "border-slate-200 bg-slate-100 dark:border-neutral-800 dark:bg-black"
+      : "border-slate-200 bg-slate-50 text-slate-500 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/55";
+
+  return ["relative overflow-hidden rounded-2xl border transition-all duration-200", size, tone].join(" ");
+}

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -24,7 +24,7 @@
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1455,
     "pages/end-users/EndUsersPage.tsx": 1334,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
-    "pages/image-generation/components/ImageGenerationPageContent.tsx": 1205,
+    "pages/image-generation/components/ImageGenerationPageContent.tsx": 1197,
     "pages/models/ModelsPage.tsx": 1358,
     "pages/providers/components/ProvidersPageContent.tsx": 1853
   }


### PR DESCRIPTION
## 问题

弹窗要上下滚动，而且读起来像两个不相干的半截：尺寸/质量/数量在顶部，渠道/模型在底部，中间夹着一块**即使只显示一行报错也占满 440px** 的结果画布。报错本身用 `text-2xl` 渲染在灰色板上，看着像标题而不是错误。

## 改动

**控件收成一行**：渠道 | 模型 | 尺寸 | 质量 | 数量。为此给 picker 加了 `compact` 变体——带 label 的两列布局在设置页是对的，跟一排药丸控件并排就不合适。

**失败时折叠画布**，并改用面板其它地方一致的 alert 样式（rose 色 + 图标 + 正常字号）。这两项加起来才是滚动条消失的原因。

**结构债**：stage 样式抽成独立模块（页面组件卡在冻结行数基线上），页面 1205 → 1197 行。

## 验证

- 本地完整 `./scripts/ci-pr.sh`：通过（`exit=0`），1003 个单测全绿
- **把弹窗渲染出来看过**，不是只跑测试：用 mock 的失败上游复现了你截图里那个 `auth_not_found`，确认控件成行、报错是一行紧凑提示、整个弹窗不再需要滚动
- 错误态测试原本钉死旧的灰色配色，现在断言意图（画布折叠 + alert 色调），并改用 `data-state` 选中元素而不是层层 `parentElement`

后端配套修复：kittors/CliRelay#(见上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)