### PR TITLE
feat(ui): 统一组件表面语言并补齐交互动效

### DIFF
--- a/apps/admin-panel/src/app/layout/AppShell.tsx
+++ b/apps/admin-panel/src/app/layout/AppShell.tsx
@@ -880,7 +880,7 @@ function ShellSidebar({
         className={[
           "group/sidebar shrink-0 overflow-visible bg-white/94 dark:bg-neutral-950/88",
           isMobile ? "fixed inset-y-0 left-0 z-40 w-60" : "relative z-30 h-[100dvh]",
-          "border-r border-slate-200 shadow-[12px_0_28px_rgba(15,23,42,0.04)] dark:border-neutral-800",
+          "border-r border-slate-900/8 shadow-[12px_0_28px_rgba(15,23,42,0.04)] dark:border-white/8",
           isMobile
             ? "will-change-transform motion-reduce:transition-none motion-safe:transition-transform motion-safe:duration-[320ms] motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]"
             : "motion-reduce:transition-none motion-safe:transition-[width,background-color,border-color,box-shadow] motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
@@ -1190,7 +1190,7 @@ function ShellHeader({
   const sidebarLabel = sidebarCollapsed ? t("shell.expand_sidebar") : t("shell.collapse_sidebar");
 
   return (
-    <header className="z-20 shrink-0 border-b border-slate-200 bg-white/75 backdrop-blur-xl motion-reduce:transition-none motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:border-neutral-800 dark:bg-neutral-950/60">
+    <header className="z-20 shrink-0 border-b border-slate-900/8 bg-white/75 backdrop-blur-xl motion-reduce:transition-none motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:border-white/8 dark:bg-neutral-950/60">
       <h1 className="sr-only">{t(titleKey)}</h1>
       <div className="flex h-14 items-center justify-between gap-3 px-3 sm:px-6">
         <div className="flex h-9 w-9 items-center">
@@ -1366,7 +1366,7 @@ export function AppShell({ children, onLogout }: PropsWithChildren<{ onLogout?: 
       <ShellFrame>
         <a
           href="#main-content"
-          className="sr-only z-[200] rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm focus:not-sr-only focus:fixed focus:left-4 focus:top-4 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white"
+          className="sr-only z-[200] rounded-xl border border-slate-900/8 bg-white px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm focus:not-sr-only focus:fixed focus:left-4 focus:top-4 dark:border-white/8 dark:bg-neutral-950 dark:text-white"
         >
           {t("shell.skip_to_content")}
         </a>

--- a/apps/admin-panel/src/styles/index.css
+++ b/apps/admin-panel/src/styles/index.css
@@ -487,3 +487,52 @@ html.theme-transition-lock *::after {
     stroke-dashoffset: -12;
   }
 }
+
+/*
+ * Radix 浮层（下拉菜单、子菜单）的开合动画。
+ * 朝着触发元素的反方向滑入 4px，读起来像「从按钮长出来」；关闭更快收回。
+ */
+@keyframes ui-popover-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(var(--ui-popover-offset, -4px));
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes ui-popover-out {
+  to {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .ui-popover-motion[data-state="open"] {
+    animation: ui-popover-in 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .ui-popover-motion[data-state="closed"] {
+    animation: ui-popover-out 100ms cubic-bezier(0.4, 0, 1, 1) forwards;
+  }
+  .ui-popover-motion[data-side="top"] {
+    --ui-popover-offset: 4px;
+  }
+  .ui-popover-motion[data-side="left"],
+  .ui-popover-motion[data-side="right"] {
+    --ui-popover-offset: 0px;
+  }
+}
+
+/* 骨架屏微光：只改透明度，避免 background-position 动画在长列表里造成重绘压力 */
+@keyframes skeleton-sweep {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}

--- a/features/api-key-restrictions/RestrictionMultiSelect.tsx
+++ b/features/api-key-restrictions/RestrictionMultiSelect.tsx
@@ -206,7 +206,7 @@ export function RestrictionMultiSelect({
           data-side={dropdownPlacement}
           className={`flex flex-col overflow-hidden ${floatingPanelSurface}`}
         >
-          <div className="border-b border-slate-100 px-3 py-2 dark:border-neutral-800">
+          <div className="border-b border-slate-100 px-3 py-2 dark:border-white/8">
             <input
               ref={searchRef}
               type="text"
@@ -216,7 +216,7 @@ export function RestrictionMultiSelect({
               className="w-full rounded-lg bg-slate-50 px-2.5 py-2 text-sm text-slate-900 outline-none ring-0 placeholder:text-slate-400 focus:bg-white dark:bg-neutral-800 dark:text-white dark:placeholder:text-white/30 dark:focus:bg-neutral-900"
             />
           </div>
-          <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 dark:border-neutral-800">
+          <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 dark:border-white/8">
             <span
               className={`text-xs font-medium ${
                 selectedValues.length === 0
@@ -298,10 +298,10 @@ export function RestrictionMultiSelect({
         }}
         className={`flex min-h-[42px] w-full items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-all ${
           disabled
-            ? "cursor-not-allowed border-slate-200 bg-slate-100 text-slate-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white/40"
+            ? "cursor-not-allowed border-slate-900/8 bg-slate-100 text-slate-500 dark:border-neutral-700 dark:bg-neutral-800 dark:text-white/40"
             : open
               ? "border-indigo-400 bg-white ring-2 ring-indigo-400/20 dark:border-indigo-500 dark:bg-neutral-900"
-              : "border-slate-200 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600"
+              : "border-slate-900/8 bg-white hover:border-slate-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-neutral-600"
         }`}
       >
         <div className="min-w-0 flex-1">

--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -62,7 +62,7 @@ const iconByType: Record<CcSwitchClientType, string> = {
 const labelClassName =
   "text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
 const controlClassName =
-  "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
+  "h-10 rounded-xl border border-slate-900/8 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-white/8 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
 const fieldClassName = "flex flex-col gap-1.5";
 
 const CLAUDE_ROLE_ORDER: CcSwitchClaudeModelRole[] = ["main", "haiku", "sonnet", "opus", "fable"];
@@ -1023,7 +1023,7 @@ export function CcSwitchImportConfigModal({
       }
     >
       <div className="space-y-4">
-        <section className="space-y-3 rounded-3xl border border-slate-200/80 bg-white p-4 shadow-[0_18px_44px_rgb(15_23_42_/_0.06)] dark:border-neutral-800 dark:bg-neutral-950/80">
+        <section className="space-y-3 rounded-3xl border border-slate-900/8 bg-white p-4 shadow-[0_18px_44px_rgb(15_23_42_/_0.06)] dark:border-white/8 dark:bg-neutral-950/80">
           <label className={fieldClassName}>
             <span className={labelClassName}>{t("ccswitch.config_select_channel_group")}</span>
             <SearchableSelect
@@ -1059,7 +1059,7 @@ export function CcSwitchImportConfigModal({
             </div>
             <div
               data-testid="ccswitch-config-endpoint-preview"
-              className="overflow-x-auto rounded-2xl border border-slate-200/80 bg-slate-950 px-3 py-2.5 font-mono text-sm text-emerald-200 shadow-inner dark:border-neutral-800"
+              className="overflow-x-auto rounded-2xl border border-slate-900/8 bg-slate-950 px-3 py-2.5 font-mono text-sm text-emerald-200 shadow-inner dark:border-white/8"
             >
               {fullBaseUrl || "--"}
             </div>
@@ -1083,7 +1083,7 @@ export function CcSwitchImportConfigModal({
           </TabsList>
         </Tabs>
 
-        <section className="grid grid-cols-1 gap-3 rounded-3xl border border-slate-200/80 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/80 sm:grid-cols-2">
+        <section className="grid grid-cols-1 gap-3 rounded-3xl border border-slate-900/8 bg-white p-4 dark:border-white/8 dark:bg-neutral-950/80 sm:grid-cols-2">
           <label className={fieldClassName}>
             <span className={labelClassName}>{t("ccswitch.import_provider_name")}</span>
             <TextInput
@@ -1175,8 +1175,8 @@ export function CcSwitchImportConfigModal({
           </label>
         </section>
 
-        <section className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white shadow-[0_18px_44px_rgb(15_23_42_/_0.05)] dark:border-neutral-800 dark:bg-neutral-950/80">
-          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-200/75 px-4 py-3 dark:border-neutral-800">
+        <section className="overflow-hidden rounded-3xl border border-slate-900/8 bg-white shadow-[0_18px_44px_rgb(15_23_42_/_0.05)] dark:border-white/8 dark:bg-neutral-950/80">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-900/8 px-4 py-3 dark:border-white/8">
             <div>
               <div className="text-sm font-semibold text-slate-950 dark:text-white">
                 {t("ccswitch.config_model_mapping_title")}
@@ -1212,7 +1212,7 @@ export function CcSwitchImportConfigModal({
               data-testid="ccswitch-model-mapping-loading"
               className="px-4 py-5"
             >
-              <div className="flex items-center gap-3 rounded-2xl border border-slate-200/75 bg-slate-50/85 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900/55">
+              <div className="flex items-center gap-3 rounded-2xl border border-slate-900/8 bg-slate-50/85 px-4 py-3 dark:border-white/8 dark:bg-neutral-900/55">
                 <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white text-slate-500 shadow-sm ring-1 ring-slate-200/80 dark:bg-neutral-950 dark:text-white/60 dark:ring-neutral-800">
                   <LoaderCircle size={17} className="animate-spin" />
                 </span>
@@ -1229,7 +1229,7 @@ export function CcSwitchImportConfigModal({
                 {MODEL_MAPPING_LOADING_ROWS.map((row) => (
                   <div
                     key={row}
-                    className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)] gap-3 rounded-xl border border-slate-200/70 bg-white px-3 py-3 dark:border-neutral-800 dark:bg-neutral-950/70"
+                    className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)] gap-3 rounded-xl border border-slate-900/8 bg-white px-3 py-3 dark:border-white/8 dark:bg-neutral-950/70"
                   >
                     <span className="h-3 rounded-full bg-slate-200/80 dark:bg-white/10" />
                     <span

--- a/features/log-content-viewer/components/ErrorDetailModal.tsx
+++ b/features/log-content-viewer/components/ErrorDetailModal.tsx
@@ -212,7 +212,7 @@ export function ErrorDetailModal({ open, logId, model, onClose }: ErrorDetailMod
                   </button>
                 </div>
                 <pre
-                  className="max-h-[40vh] overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs leading-relaxed text-slate-800 dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-200"
+                  className="max-h-[40vh] overflow-auto rounded-xl border border-slate-900/8 bg-slate-50 p-4 text-xs leading-relaxed text-slate-800 dark:border-white/8 dark:bg-neutral-900 dark:text-slate-200"
                   style={{
                     whiteSpace: "pre-wrap",
                     wordBreak: "break-all",

--- a/features/log-content-viewer/components/LogContentModal.tsx
+++ b/features/log-content-viewer/components/LogContentModal.tsx
@@ -380,7 +380,7 @@ function RequestDetailRows({ rows }: { rows: RequestDetailRow[] }) {
 function RequestDetailGroupView({ group }: { group: RequestDetailGroup }) {
   if (group.rows.length === 0) return null;
   return (
-    <div className="border-t border-slate-100 dark:border-neutral-800/80">
+    <div className="border-t border-slate-100 dark:border-white/8">
       <div className="px-3 pt-3 pb-1.5 text-xs font-medium text-slate-400 dark:text-white/35">
         {group.title}
       </div>
@@ -397,9 +397,9 @@ function RequestDetailAttemptView({
   showTitle: boolean;
 }) {
   return (
-    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950/60">
+    <div className="overflow-hidden rounded-lg border border-slate-900/8 bg-white dark:border-white/8 dark:bg-neutral-950/60">
       {showTitle && attempt.title ? (
-        <div className="border-b border-slate-100 px-3 py-2 font-mono text-xs text-slate-400 dark:border-neutral-800/80 dark:text-white/35">
+        <div className="border-b border-slate-100 px-3 py-2 font-mono text-xs text-slate-400 dark:border-white/8 dark:text-white/35">
           {attempt.title}
         </div>
       ) : null}
@@ -444,7 +444,7 @@ function RequestDetailSection({
   return (
     <section
       data-testid={testId}
-      className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
+      className="overflow-hidden rounded-lg border border-slate-900/8 bg-white dark:border-white/8 dark:bg-neutral-950"
     >
       <button
         type="button"
@@ -479,7 +479,7 @@ function RequestDetailSection({
             transition={{ duration: 0.18, ease: [0.4, 0, 0.2, 1] }}
             className="overflow-hidden"
           >
-            <div className="space-y-2 border-t border-slate-100 bg-slate-50/40 p-2.5 dark:border-neutral-800/80 dark:bg-white/[0.02]">
+            <div className="space-y-2 border-t border-slate-100 bg-slate-50/40 p-2.5 dark:border-white/8 dark:bg-white/[0.02]">
               {visibleAttempts.length > 0 ? (
                 visibleAttempts.map((attempt, index) => (
                   <RequestDetailAttemptView
@@ -613,7 +613,7 @@ function StructuredRequestCard({
   return (
     <div
       data-testid={testId}
-      className="overflow-hidden rounded-3xl border border-slate-200 bg-slate-50/90 dark:border-neutral-800 dark:bg-neutral-900/75"
+      className="overflow-hidden rounded-3xl border border-slate-900/8 bg-slate-50/90 dark:border-white/8 dark:bg-neutral-900/75"
     >
       <div className="grid gap-0 divide-y divide-slate-200/90 dark:divide-neutral-800">
         {model ? (
@@ -645,7 +645,7 @@ function StructuredRequestCard({
               {parameters.map((item) => (
                 <div
                   key={item.key}
-                  className="rounded-2xl border border-slate-200 bg-white px-3 py-3 dark:border-neutral-800 dark:bg-neutral-950"
+                  className="rounded-2xl border border-slate-900/8 bg-white px-3 py-3 dark:border-white/8 dark:bg-neutral-950"
                 >
                   <p className="font-mono text-xs text-slate-500 dark:text-white/40">
                     {item.key}
@@ -1177,7 +1177,7 @@ export function LogContentModal({
           {imageGenerationOutput.images.map((image, index) => (
             <div
               key={`${image.src.slice(0, 48)}-${index}`}
-              className="rounded-2xl border border-slate-200 bg-slate-50 p-3 dark:border-neutral-800 dark:bg-neutral-900"
+              className="rounded-2xl border border-slate-900/8 bg-slate-50 p-3 dark:border-white/8 dark:bg-neutral-900"
             >
               <div className="relative min-h-[160px] overflow-hidden rounded-xl bg-slate-100 dark:bg-black">
                 <img
@@ -1220,7 +1220,7 @@ export function LogContentModal({
 
     const view = outputParsed.view;
     const imagePreviewCard = outputImagePreviewSrc ? (
-      <div className="mb-4 rounded-2xl border border-slate-200 bg-slate-50 p-3 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="mb-4 rounded-2xl border border-slate-900/8 bg-slate-50 p-3 dark:border-white/8 dark:bg-neutral-900">
         <div className="relative min-h-[160px] overflow-hidden rounded-xl bg-slate-100 dark:bg-black">
           <img
             src={outputImagePreviewSrc}

--- a/features/log-content-viewer/log-content/rendering.tsx
+++ b/features/log-content-viewer/log-content/rendering.tsx
@@ -165,7 +165,7 @@ function TagSection({
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   return (
-    <div className="overflow-hidden rounded-lg border border-slate-200/80 dark:border-neutral-700/60">
+    <div className="overflow-hidden rounded-lg border border-slate-900/8 dark:border-neutral-700/60">
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
@@ -340,7 +340,7 @@ export function PlainPre({ text }: { text: string }) {
   }
 
   return (
-    <pre className="whitespace-pre-wrap break-words rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs leading-relaxed font-mono dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-200">
+    <pre className="whitespace-pre-wrap break-words rounded-xl border border-slate-900/8 bg-slate-50 p-4 text-xs leading-relaxed font-mono dark:border-white/8 dark:bg-neutral-900 dark:text-slate-200">
       {text}
     </pre>
   );
@@ -378,7 +378,7 @@ function VirtualPlainPre({ rows }: { rows: string[] }) {
   return (
     <div
       ref={parentRef}
-      className="h-[min(58vh,620px)] overflow-y-auto overscroll-contain rounded-xl border border-slate-200 bg-slate-50 text-xs leading-relaxed font-mono [contain:layout_paint] dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-200"
+      className="h-[min(58vh,620px)] overflow-y-auto overscroll-contain rounded-xl border border-slate-900/8 bg-slate-50 text-xs leading-relaxed font-mono [contain:layout_paint] dark:border-white/8 dark:bg-neutral-900 dark:text-slate-200"
     >
       <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
         {virtualRows.map((virtualRow) => (
@@ -513,14 +513,14 @@ export function ContentModal({
           <motion.div
             role="dialog"
             aria-modal="true"
-            className="relative z-10 flex h-[min(82dvh,760px)] w-[min(calc(100vw-2rem),1040px)] max-w-none flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-950"
+            className="relative z-10 flex h-[min(82dvh,760px)] w-[min(calc(100vw-2rem),1040px)] max-w-none flex-col overflow-hidden rounded-2xl border border-slate-900/8 bg-white shadow-xl dark:border-white/8 dark:bg-neutral-950"
             variants={{
               hidden: { opacity: 0, y: 18, scale: 0.96, filter: "blur(2px)" },
               show: { opacity: 1, y: 0, scale: 1, filter: "blur(0px)" },
             }}
             transition={{ type: "spring", stiffness: 420, damping: 34, mass: 0.8 }}
           >
-            <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-neutral-800">
+            <div className="flex shrink-0 items-start justify-between gap-3 border-b border-slate-900/8 px-5 py-4 dark:border-white/8">
               <div className="min-w-0">
                 <h2 className="truncate text-base font-semibold tracking-tight text-slate-900 dark:text-white">
                   {t("log_content.message_content")}
@@ -540,7 +540,7 @@ export function ContentModal({
               </button>
             </div>
             {tabs ? (
-              <div className="shrink-0 border-b border-slate-100 bg-white px-5 py-2 dark:border-neutral-800/60 dark:bg-neutral-950">
+              <div className="shrink-0 border-b border-slate-100 bg-white px-5 py-2 dark:border-white/8 dark:bg-neutral-950">
                 {tabs}
               </div>
             ) : null}

--- a/features/model-tags/index.tsx
+++ b/features/model-tags/index.tsx
@@ -104,7 +104,7 @@ export const MODEL_VENDOR_COLORS: Record<ModelVendorKey, ModelVendorTone> = {
   grok: {
     bg: "bg-slate-50 dark:bg-slate-900/30",
     text: "text-slate-700 dark:text-slate-300",
-    border: "border-slate-200/60 dark:border-slate-700/30",
+    border: "border-slate-900/8 dark:border-slate-700/30",
   },
   hunyuan: {
     bg: "bg-blue-50 dark:bg-blue-950/20",
@@ -114,7 +114,7 @@ export const MODEL_VENDOR_COLORS: Record<ModelVendorKey, ModelVendorTone> = {
   kimi: {
     bg: "bg-slate-50 dark:bg-slate-900/30",
     text: "text-slate-700 dark:text-slate-300",
-    border: "border-slate-200/60 dark:border-slate-700/30",
+    border: "border-slate-900/8 dark:border-slate-700/30",
   },
   kiro: {
     bg: "bg-amber-50 dark:bg-amber-950/20",
@@ -154,7 +154,7 @@ export const MODEL_VENDOR_COLORS: Record<ModelVendorKey, ModelVendorTone> = {
   other: {
     bg: "bg-slate-50 dark:bg-neutral-900/40",
     text: "text-slate-600 dark:text-slate-300",
-    border: "border-slate-200/60 dark:border-neutral-700/40",
+    border: "border-slate-900/8 dark:border-neutral-700/40",
   },
 };
 

--- a/features/monitor-widgets/MonitorPagePieces.tsx
+++ b/features/monitor-widgets/MonitorPagePieces.tsx
@@ -178,10 +178,10 @@ export const MonitorCard = ({
             <div
               role="status"
               aria-live="polite"
-              className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/80"
+              className="inline-flex items-center gap-2 rounded-2xl border border-slate-900/8 bg-white/85 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-white/8 dark:bg-neutral-950/70 dark:text-white/80"
             >
               <span
-                className="h-4 w-4 rounded-full border-2 border-slate-300/80 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/85"
+                className="h-4 w-4 rounded-full border-2 border-slate-300/80 border-t-indigo-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/85"
                 aria-hidden="true"
               />
               <span className="tabular-nums">{t("common.loading")}</span>

--- a/features/oauth-login/components/OAuthLoginDialog.tsx
+++ b/features/oauth-login/components/OAuthLoginDialog.tsx
@@ -593,7 +593,7 @@ export function OAuthLoginDialog({
           }
         >
           {provider === "xai" ? (
-            <div className="mb-3 grid gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <div className="mb-3 grid gap-2 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                 {t("oauth.xai_endpoint_mode")}
               </p>
@@ -637,7 +637,7 @@ export function OAuthLoginDialog({
           ) : null}
 
           <div className="grid min-w-0 gap-3">
-            <div className="grid min-w-0 gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <div className="grid min-w-0 gap-2 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                   {t("oauth.auth_link")}
@@ -666,7 +666,7 @@ export function OAuthLoginDialog({
               </p>
             </div>
 
-            <div className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 text-sm shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <div className="flex items-center justify-between rounded-2xl border border-slate-900/8 bg-white/70 px-4 py-3 text-sm shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
               <div className="min-w-0">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                   {t("oauth.status")}
@@ -691,7 +691,7 @@ export function OAuthLoginDialog({
               </div>
             </div>
 
-            <div className="grid gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <div className="grid gap-2 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                   {t(manualCode ? "oauth.callback_code" : "oauth.callback")}
@@ -786,7 +786,7 @@ export function OAuthLoginDialog({
             <TabsTrigger value="vertex">{t("oauth.vertex_title")}</TabsTrigger>
           </TabsList>
 
-          <div className="mt-4 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="mt-4 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <ProxyPoolSelect
               value={selectedProxyID}
               onChange={setSelectedProxyID}
@@ -827,7 +827,7 @@ export function OAuthLoginDialog({
                 value={iflowCookie}
                 onChange={(e) => setIflowCookie(e.currentTarget.value)}
                 placeholder={t("oauth.cookie_placeholder")}
-                className="min-h-[160px] w-full resize-y rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
+                className="min-h-[160px] w-full resize-y rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-white/8 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
                 spellCheck={false}
                 aria-label={t("oauth.iflow_cookie")}
               />
@@ -870,7 +870,7 @@ export function OAuthLoginDialog({
                   onChange={(e) => setVertexLocation(e.currentTarget.value)}
                   placeholder={t("oauth.location_placeholder")}
                 />
-                <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+                <div className="rounded-2xl border border-slate-900/8 bg-white/70 p-4 text-sm shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                     {t("oauth.recent_import")}
                   </p>

--- a/features/oauth-login/components/OAuthPage.tsx
+++ b/features/oauth-login/components/OAuthPage.tsx
@@ -462,7 +462,7 @@ export function OAuthPage() {
               }
             >
               {provider.id === "xai" ? (
-                <div className="mb-3 grid gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+                <div className="mb-3 grid gap-2 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                     {t("oauth.xai_endpoint_mode")}
                   </p>
@@ -508,7 +508,7 @@ export function OAuthPage() {
               ) : null}
 
               <div className="grid min-w-0 gap-3">
-                <div className="grid min-w-0 gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+                <div className="grid min-w-0 gap-2 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                       {t("oauth.auth_link")}
@@ -534,7 +534,7 @@ export function OAuthPage() {
                       </Button>
                     </div>
                   </div>
-                  <div className="min-w-0 overflow-hidden break-all rounded-xl border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100">
+                  <div className="min-w-0 overflow-hidden break-all rounded-xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-xs text-slate-800 dark:border-white/8 dark:bg-neutral-950 dark:text-slate-100">
                     {url ? url : "--"}
                   </div>
                   <div className="text-xs text-slate-600 dark:text-white/65">
@@ -544,7 +544,7 @@ export function OAuthPage() {
                   </div>
                 </div>
 
-                <div className="grid gap-2 rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+                <div className="grid gap-2 rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                     {t(
                       manualCode
@@ -627,7 +627,7 @@ export function OAuthPage() {
             value={iflowCookie}
             onChange={(e) => setIflowCookie(e.currentTarget.value)}
             placeholder={t("oauth.cookie_placeholder")}
-            className="min-h-[140px] w-full resize-y rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
+            className="min-h-[140px] w-full resize-y rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-white/8 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
             spellCheck={false}
             aria-label={t("oauth.iflow_cookie")}
           />
@@ -663,7 +663,7 @@ export function OAuthPage() {
               placeholder={t("oauth.location_placeholder")}
               endAdornment={<KeyRound size={16} className="text-slate-400" />}
             />
-            <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 text-sm shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+            <div className="rounded-2xl border border-slate-900/8 bg-white/70 p-4 text-sm shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-white/55">
                 {t("oauth.recent_import")}
               </p>

--- a/features/online-update/ui/UpdateModal.tsx
+++ b/features/online-update/ui/UpdateModal.tsx
@@ -141,7 +141,7 @@ function ReleaseNotes({ candidate }: { candidate: UpdateCheckResponse }) {
 
       <div
         data-testid="update-release-notes"
-        className={`mt-2 overflow-y-auto break-words rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700 dark:border-neutral-800 dark:bg-neutral-900/50 dark:text-slate-200 ${
+        className={`mt-2 overflow-y-auto break-words rounded-lg border border-slate-900/8 bg-slate-50 p-3 text-sm text-slate-700 dark:border-white/8 dark:bg-neutral-900/50 dark:text-slate-200 ${
           expanded ? "max-h-72" : "max-h-32"
         }`}
       >
@@ -292,7 +292,7 @@ export function UpdateModal({
 
         {display ? (
           <>
-            <dl className="min-w-0 divide-y divide-slate-100 rounded-xl border border-slate-200 px-3 dark:divide-neutral-800 dark:border-neutral-800">
+            <dl className="min-w-0 divide-y divide-slate-100 rounded-xl border border-slate-900/8 px-3 dark:divide-neutral-800 dark:border-white/8">
               <VersionRow
                 label={t("auto_update.service_version")}
                 from={versionLabel(

--- a/features/online-update/ui/UpdateProgressPanel.tsx
+++ b/features/online-update/ui/UpdateProgressPanel.tsx
@@ -102,7 +102,7 @@ function LogConsole({ progress }: { progress?: UpdateProgressResponse | null }) 
   }, [expanded, logs.length]);
 
   return (
-    <div className="mt-4 border-t border-slate-200 pt-3 dark:border-neutral-800">
+    <div className="mt-4 border-t border-slate-900/8 pt-3 dark:border-white/8">
       <Button
         variant="ghost"
         size="xs"

--- a/features/period-spending/PeriodSpendingCell.tsx
+++ b/features/period-spending/PeriodSpendingCell.tsx
@@ -47,7 +47,7 @@ const chipTone = (ratio: number) => {
   if (ratio >= 0.9) {
     return "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100";
   }
-  return "border-slate-200 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-white/75";
+  return "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-white/75";
 };
 
 export function PeriodSpendingCell({

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -189,7 +189,7 @@ const hasRequestLogMetricText = (value: string): boolean => {
 const resolveLatencyToneClasses = (latencyText: string): string => {
   const seconds = parseLatencyTextToSeconds(latencyText);
   if (seconds === null) {
-    return "border-slate-200 bg-slate-50 text-slate-500 dark:border-neutral-800 dark:bg-neutral-950/45 dark:text-white/55";
+    return "border-slate-900/8 bg-slate-50 text-slate-500 dark:border-white/8 dark:bg-neutral-950/45 dark:text-white/55";
   }
 
   if (seconds < 10) {
@@ -229,7 +229,7 @@ function RequestLogModeChip({ label, streaming }: { label: string; streaming: bo
       className={
         streaming
           ? "inline-flex shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs font-semibold text-sky-600 dark:border-sky-500/25 dark:bg-sky-500/15 dark:text-sky-300"
-          : "inline-flex shrink-0 items-center justify-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 dark:border-white/10 dark:bg-neutral-900 dark:text-white/55"
+          : "inline-flex shrink-0 items-center justify-center rounded-full border border-slate-900/8 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 dark:border-white/10 dark:bg-neutral-900 dark:text-white/55"
       }
     >
       {label}
@@ -1005,7 +1005,7 @@ export function RequestLogsPaginationBar({
       onPageChange={onPageChange}
       onPageSizeChange={onPageSizeChange}
       pageSizeOptions={REQUEST_LOG_PAGE_SIZE_OPTIONS}
-      className="border-t border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60"
+      className="border-t border-slate-100 px-3 py-3 sm:px-5 dark:border-white/8"
       labels={{
         firstPage: t("request_logs.first_page"),
         previousPage: t("request_logs.prev_page"),

--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -1139,7 +1139,7 @@ export function RoutingConfigEditor({
                   {channels.map((channel) => (
                     <span
                       key={channel.id}
-                      className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                      className="inline-flex items-center rounded-md border border-slate-900/8 bg-slate-50 px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                     >
                       {channel.name}
                       {channel.priority.trim()
@@ -1206,7 +1206,7 @@ export function RoutingConfigEditor({
                   {routePaths.map((path) => (
                     <span
                       key={path}
-                      className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                      className="inline-flex items-center rounded-md border border-slate-900/8 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                     >
                       {path}
                     </span>
@@ -1620,7 +1620,7 @@ export function RoutingConfigEditor({
               </div>
             </div>
 
-            <div className="overflow-hidden rounded-2xl border border-slate-200 dark:border-neutral-800">
+            <div className="overflow-hidden rounded-2xl border border-slate-900/8 dark:border-white/8">
               <div className="grid grid-cols-[minmax(0,1fr)_88px] bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-500 dark:bg-neutral-900 dark:text-white/55">
                 <span>{t("channel_groups_page.table_channels")}</span>
                 <span>{t("channel_groups_page.table_status")}</span>
@@ -1645,7 +1645,7 @@ export function RoutingConfigEditor({
             </div>
           </div>
         ) : (
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
+          <div className="rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-white/8 dark:bg-neutral-900/60 dark:text-white/55">
             {t("channel_groups_page.issue_modal_empty")}
           </div>
         )}
@@ -1791,7 +1791,7 @@ export function RoutingConfigEditor({
 
                     {!editingSystemDefaultGroup ? (
                       <>
-                        <label className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 text-sm dark:border-neutral-800 dark:bg-neutral-900/60">
+                        <label className="flex items-start gap-3 rounded-lg border border-slate-900/8 bg-slate-50 px-3 py-3 text-sm dark:border-white/8 dark:bg-neutral-900/60">
                           <Checkbox
                             checked={groupDraft.excludeFromDefault}
                             onCheckedChange={(checked) =>
@@ -1986,7 +1986,7 @@ export function RoutingConfigEditor({
                   </div>
 
                   {!editingSystemDefaultGroup && resolvedDraftChannelValues.length === 0 ? (
-                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/55">
+                    <div className="rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-6 text-sm text-slate-500 dark:border-white/8 dark:bg-neutral-900/60 dark:text-white/55">
                       {t("channel_groups_page.models_need_channels")}
                     </div>
                   ) : modelsError ? (

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2448,7 +2448,7 @@ export function DataTable<T>({
                                 .join(" ");
                           const rowDividerClass =
                             rowDividers && globalIdx < rows.length - 1
-                              ? "border-b border-slate-200 dark:border-neutral-800"
+                              ? "border-b border-slate-900/8 dark:border-white/8"
                               : "";
                           const hoverChromeClass = naturalFlow
                             ? ""
@@ -2534,7 +2534,7 @@ export function DataTable<T>({
             <div className="flex items-center justify-center py-4">
               <div className="inline-flex items-center gap-2 text-sm text-slate-500 dark:text-white/55">
                 <span
-                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
+                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-indigo-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
                   aria-hidden="true"
                 />
                 {t("common.loading_more")}

--- a/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
+++ b/packages/ui/src/data-table/__tests__/DataTable.interactions.test.tsx
@@ -136,7 +136,7 @@ describe("DataTable sorting and row reordering", () => {
 
     const dragPreview = document.querySelector<HTMLElement>("[data-vt-row-reorder-preview]");
     expect(dragPreview).toHaveTextContent("alpha");
-    expect(dragPreview).toHaveClass("border", "border-slate-200/90");
+    expect(dragPreview).toHaveClass("border", "border-slate-900/8");
     expect(
       Array.from(dragPreview?.querySelectorAll("td") ?? []).every(
         (cell) => cell.style.borderTopWidth === "0px" && cell.style.borderBottomWidth === "0px",
@@ -373,7 +373,7 @@ describe("DataTable scroll chrome and row dividers", () => {
       const cells = Array.from(row.cells);
       expect(cells).toHaveLength(2);
       cells.forEach((cell) => {
-        expect(cell).toHaveClass("border-b", "border-slate-200");
+        expect(cell).toHaveClass("border-b", "border-slate-900/8");
         expect(cell).not.toHaveClass("first:rounded-l-lg", "last:rounded-r-lg");
       });
     });

--- a/packages/ui/src/data-table/rowReorder.ts
+++ b/packages/ui/src/data-table/rowReorder.ts
@@ -71,7 +71,7 @@ export function createRowReorderPreviewElement(sourceRow: HTMLTableRowElement) {
   preview.dataset.vtRowReorderPreview = "true";
   preview.setAttribute("aria-hidden", "true");
   preview.className =
-    "pointer-events-none fixed left-0 top-0 z-[1100] box-border overflow-hidden rounded-xl border border-slate-200/90 bg-white shadow-[0_0_20px_rgba(15,23,42,0.16)] dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-[0_0_20px_rgba(0,0,0,0.42)]";
+    "pointer-events-none fixed left-0 top-0 z-[1100] box-border overflow-hidden rounded-xl border border-slate-900/8 bg-white shadow-[0_0_20px_rgba(15,23,42,0.16)] dark:border-neutral-700 dark:bg-neutral-900 dark:shadow-[0_0_20px_rgba(0,0,0,0.42)]";
   preview.style.left = `${rowRect.left}px`;
   preview.style.width = `${Math.max(1, rowRect.width)}px`;
   preview.style.height = `${Math.max(1, rowRect.height)}px`;

--- a/packages/ui/src/feedback/PageLoader.tsx
+++ b/packages/ui/src/feedback/PageLoader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type FC } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { BRAND_NAME, LogoMark } from "@code-proxy/assets";
 
 export type PageLoaderVariant = "initial" | "restoring" | "inline";
 
@@ -42,12 +43,12 @@ export const PageLoader: FC<PageLoaderProps> = ({
       <span
         role="status"
         aria-label={text ?? "Loading"}
-        className="inline-block h-5 w-5 shrink-0 rounded-full border-2 border-slate-300 border-t-slate-700 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/30 dark:border-t-white"
+        className="inline-block h-5 w-5 shrink-0 rounded-full border-2 border-indigo-500/25 border-t-indigo-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-indigo-400/25 dark:border-t-indigo-400"
       />
     );
   }
 
-  const label = text ?? "CLI Proxy";
+  const label = text ?? BRAND_NAME;
 
   return (
     <AnimatePresence>
@@ -77,31 +78,30 @@ export const PageLoader: FC<PageLoaderProps> = ({
             transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
             className="relative z-10 flex flex-col items-center"
           >
-            {/* Spinner: two concentric rings */}
-            <div className="relative mb-5 h-12 w-12">
-              {/* Outer ring — slow, thick */}
+            {/* 品牌标记呼吸 + 外圈旋转进度环 */}
+            <div className="relative mb-6 flex h-16 w-16 items-center justify-center">
               <motion.span
                 aria-hidden="true"
                 className="absolute inset-0 rounded-full border-[3px] border-transparent"
                 style={{ borderTopColor: "var(--pl-ring-outer)" }}
                 animate={{ rotate: 360 }}
-                transition={{ duration: 1.6, repeat: Infinity, ease: "linear" }}
+                transition={{ duration: 1.4, repeat: Infinity, ease: "linear" }}
               />
-              {/* Inner ring — fast, thin */}
               <motion.span
                 aria-hidden="true"
-                className="absolute inset-1 rounded-full border-[2px] border-transparent"
-                style={{ borderTopColor: "var(--pl-ring-inner)" }}
-                animate={{ rotate: -360 }}
-                transition={{ duration: 0.9, repeat: Infinity, ease: "linear" }}
-              />
+                className="flex items-center justify-center"
+                animate={{ scale: [1, 1.08, 1], opacity: [0.75, 1, 0.75] }}
+                transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+              >
+                <LogoMark size={22} />
+              </motion.span>
             </div>
 
             {/* Brand text with breathing pulse */}
             <motion.span
               role="status"
               aria-label={label}
-              className="text-sm font-medium tracking-widest"
+              className="font-display text-sm font-medium tracking-[0.2em]"
               style={{ color: "var(--pl-text)" }}
               animate={{ opacity: [0.45, 1, 0.45] }}
               transition={{ duration: 2.4, repeat: Infinity, ease: "easeInOut" }}

--- a/packages/ui/src/feedback/Skeleton.tsx
+++ b/packages/ui/src/feedback/Skeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * 骨架屏占位。
+ *
+ * 相比转圈 spinner，骨架屏能提前把版面撑开，内容到位时不会整页跳动——
+ * 这对表格、卡片这类高度可预测的区域是更好的等待反馈。
+ *
+ * 微光扫过用 CSS 动画（`skeleton-sweep`），不进 JS 主线程；
+ * prefers-reduced-motion 下退化为静态底色，仍然保留占位作用。
+ */
+export function Skeleton({
+  className,
+  rounded = "md",
+}: {
+  className?: string;
+  rounded?: "sm" | "md" | "lg" | "full";
+}) {
+  const roundedClass = {
+    sm: "rounded-sm",
+    md: "rounded-lg",
+    lg: "rounded-2xl",
+    full: "rounded-full",
+  }[rounded];
+
+  return (
+    <span
+      aria-hidden
+      className={[
+        "block bg-slate-200/70 dark:bg-white/[0.07]",
+        "motion-safe:animate-[skeleton-sweep_1.6s_ease-in-out_infinite]",
+        roundedClass,
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    />
+  );
+}
+
+/** 表格/列表的多行骨架。行宽递减，读起来更像真实文本块而不是一排等长灰条。 */
+export function SkeletonLines({ rows = 3, className }: { rows?: number; className?: string }) {
+  const widths = ["w-full", "w-11/12", "w-9/12", "w-10/12", "w-8/12"];
+  return (
+    <div className={["space-y-2.5", className].filter(Boolean).join(" ")} role="presentation">
+      {Array.from({ length: rows }, (_, index) => (
+        <Skeleton key={index} className={`h-3.5 ${widths[index % widths.length]}`} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { AnimatedNumber } from "./feedback/AnimatedNumber";
 export { EmptyState } from "./feedback/EmptyState";
 export { PageLoader } from "./feedback/PageLoader";
+export { Skeleton, SkeletonLines } from "./feedback/Skeleton";
 export type { PageLoaderVariant } from "./feedback/PageLoader";
 export { Reveal } from "./feedback/Reveal";
 export { ToastProvider, useToast } from "./feedback/ToastProvider";

--- a/packages/ui/src/overlays/Drawer.tsx
+++ b/packages/ui/src/overlays/Drawer.tsx
@@ -75,9 +75,10 @@ export function Drawer({
         }}
         aria-label={t("common.close")}
         className={[
-          "absolute inset-0 cursor-default bg-slate-900/40 backdrop-blur-sm dark:bg-black/50",
-          "transition-opacity duration-200 ease-out motion-reduce:transition-none",
-          visible ? "opacity-100" : "opacity-0",
+          "absolute inset-0 cursor-default bg-slate-950/45 dark:bg-black/60",
+          // 与 Modal 用同一套遮罩语言：模糊度随淡入一起上，不是一开始就糊。
+          "transition-[opacity,backdrop-filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
+          visible ? "opacity-100 backdrop-blur-md" : "opacity-0 backdrop-blur-none",
         ].join(" ")}
       />
       <div
@@ -85,12 +86,12 @@ export function Drawer({
         aria-modal="true"
         aria-labelledby={titleId}
         className={[
-          `relative z-10 flex h-full ${widthClassName} flex-col border-l border-slate-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-950`,
-          "transition-transform duration-200 ease-out motion-reduce:transition-none",
+          `relative z-10 flex h-full ${widthClassName} flex-col bg-white shadow-[-24px_0_60px_-24px_rgba(15,23,42,0.35)] ring-1 ring-slate-900/10 dark:bg-[#0E0E12] dark:ring-white/10 dark:shadow-[-24px_0_60px_-24px_rgba(0,0,0,0.8)]`,
+          "transition-transform duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
           visible ? "translate-x-0" : "translate-x-full",
         ].join(" ")}
       >
-        <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-neutral-800">
+        <div className="flex items-start justify-between gap-3 border-b border-slate-900/8 px-6 py-4 dark:border-white/8">
           <div className="min-w-0">
             <h2
               id={titleId}
@@ -106,7 +107,7 @@ export function Drawer({
             type="button"
             onClick={onClose}
             disabled={!open}
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
+            className="group inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-400 shadow-none transition-colors hover:bg-slate-900/5 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-white/45 dark:hover:bg-white/10 dark:hover:text-white"
             aria-label={t("common.close")}
           >
             <X size={16} />
@@ -116,7 +117,7 @@ export function Drawer({
           {children}
         </div>
         {footer ? (
-          <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 px-5 py-4 dark:border-neutral-800">
+          <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-900/8 px-5 py-4 dark:border-white/8">
             {footer}
           </div>
         ) : null}

--- a/packages/ui/src/overlays/Modal.tsx
+++ b/packages/ui/src/overlays/Modal.tsx
@@ -9,10 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { X } from "lucide-react";
-
-/** Exit animation duration — keep content mounted until this finishes. */
-const ANIMATION_MS = 220;
-const EASE = "cubic-bezier(0.16, 1, 0.3, 1)";
+import { cssEase, EASE_IN, EASE_OUT, OVERLAY_ENTER_MS, OVERLAY_EXIT_MS } from "../utils/motion";
 
 export function Modal({
   open,
@@ -94,7 +91,7 @@ export function Modal({
     timeoutRef.current = window.setTimeout(() => {
       setMounted(false);
       timeoutRef.current = null;
-    }, ANIMATION_MS);
+    }, OVERLAY_EXIT_MS);
 
     return () => {
       if (timeoutRef.current) {
@@ -120,8 +117,8 @@ export function Modal({
   const bodyHeightCls = bodyHeightClassName ?? "max-h-[70vh]";
   const bodyOverflowCls = bodyOverflowClassName ?? "overflow-y-auto";
   const transitionStyle = {
-    transitionDuration: `${ANIMATION_MS}ms`,
-    transitionTimingFunction: EASE,
+    transitionDuration: `${visible ? OVERLAY_ENTER_MS : OVERLAY_EXIT_MS}ms`,
+    transitionTimingFunction: cssEase(visible ? EASE_OUT : EASE_IN),
   } as const;
 
   return createPortal(
@@ -136,9 +133,9 @@ export function Modal({
         tabIndex={-1}
         style={transitionStyle}
         className={[
-          "absolute inset-0 cursor-default bg-slate-900/40 backdrop-blur-sm dark:bg-black/50",
-          "transition-opacity motion-reduce:transition-none",
-          visible ? "opacity-100" : "opacity-0",
+          "absolute inset-0 cursor-default bg-slate-950/45 dark:bg-black/60",
+          "transition-[opacity,backdrop-filter] motion-reduce:transition-none",
+          visible ? "opacity-100 backdrop-blur-md" : "opacity-0 backdrop-blur-none",
         ].join(" ")}
       />
 
@@ -149,12 +146,10 @@ export function Modal({
         aria-labelledby={hideHeader ? undefined : titleId}
         style={transitionStyle}
         className={[
-          `relative z-10 w-full ${maxWidth} overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-950`,
-          // Animate opacity + subtle rise only — avoid scale that makes height feel like it collapses.
+          `relative z-10 w-full ${maxWidth} overflow-hidden rounded-3xl bg-white ring-1 ring-slate-900/10 shadow-[0_32px_80px_-24px_rgba(15,23,42,0.45)] dark:bg-[#0E0E12] dark:ring-white/10 dark:shadow-[0_32px_80px_-24px_rgba(0,0,0,0.8)]`,
+          // 放大幅度压到 0.97：再大就会让面板高度看着像「塌下去又弹起来」。
           "transition-[opacity,transform] will-change-transform motion-reduce:transition-none motion-reduce:transform-none",
-          visible
-            ? "opacity-100 translate-y-0"
-            : "opacity-0 translate-y-3",
+          visible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.97]",
           panelClassName,
         ].join(" ")}
       >
@@ -163,13 +158,16 @@ export function Modal({
             type="button"
             onClick={onClose}
             disabled={!open}
-            className="absolute top-4 right-4 z-20 inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
+            className="group absolute top-4 right-4 z-20 inline-flex h-9 w-9 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-400 shadow-none transition-colors hover:bg-slate-900/5 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-white/45 dark:hover:bg-white/10 dark:hover:text-white"
             aria-label={t("common.close")}
           >
-            <X size={16} />
+            <X
+              size={16}
+              className="transition-transform duration-200 motion-safe:group-hover:rotate-90"
+            />
           </button>
         ) : (
-          <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-neutral-800">
+          <div className="flex items-start justify-between gap-3 border-b border-slate-900/8 px-6 py-4 dark:border-white/8">
             <div className="min-w-0">
               <h2 className="flex min-w-0 items-center gap-2 text-base font-semibold tracking-tight text-slate-900 dark:text-white">
                 <span id={titleId} className="min-w-0 truncate">
@@ -191,23 +189,26 @@ export function Modal({
               type="button"
               onClick={onClose}
               disabled={!open}
-              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none transition-colors hover:bg-slate-100 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
+              className="group inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-400 shadow-none transition-colors hover:bg-slate-900/5 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 dark:text-white/45 dark:hover:bg-white/10 dark:hover:text-white"
               aria-label={t("common.close")}
             >
-              <X size={16} />
+              <X
+                size={16}
+                className="transition-transform duration-200 motion-safe:group-hover:rotate-90"
+              />
             </button>
           </div>
         )}
 
         <div
           data-testid={bodyTestId}
-          className={`${bodyHeightCls} ${bodyOverflowCls} overscroll-contain px-5 py-4 ${bodyClassName ?? ""}`}
+          className={`${bodyHeightCls} ${bodyOverflowCls} overscroll-contain px-6 py-5 ${bodyClassName ?? ""}`}
         >
           {snapshot.children}
         </div>
 
         {snapshot.footer ? (
-          <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 px-5 py-4 dark:border-neutral-800">
+          <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-900/8 px-6 py-4 dark:border-white/8">
             {snapshot.footer}
           </div>
         ) : null}

--- a/packages/ui/src/overlays/SecretRevealModal.tsx
+++ b/packages/ui/src/overlays/SecretRevealModal.tsx
@@ -80,7 +80,7 @@ export function SecretRevealModal({
               })}
           </p>
         </div>
-        <div className="relative rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-white/10 dark:bg-neutral-900">
+        <div className="relative rounded-xl border border-slate-900/8 bg-slate-50 p-3 dark:border-white/10 dark:bg-neutral-900">
           <code className="block select-all break-all pr-10 font-mono text-sm text-slate-900 dark:text-white">
             {secret}
           </code>

--- a/packages/ui/src/overlays/Tooltip.tsx
+++ b/packages/ui/src/overlays/Tooltip.tsx
@@ -209,7 +209,12 @@ export function TooltipBubble({
   placement?: TooltipPlacement;
 }) {
   const tooltipRef = useRef<HTMLSpanElement>(null);
-  const [style, setStyle] = useState<React.CSSProperties>({ position: "fixed", opacity: 0 });
+  // 初始带一点下沉与缩小，定位算完后归位，配合上面的过渡形成「浮出」的观感。
+  const [style, setStyle] = useState<React.CSSProperties>({
+    position: "fixed",
+    opacity: 0,
+    transform: "translateY(2px) scale(0.98)",
+  });
 
   const updatePosition = useCallback(() => {
     const anchor = anchorElement ?? anchorRef?.current;
@@ -237,6 +242,7 @@ export function TooltipBubble({
       left,
       zIndex: 99999,
       opacity: 1,
+      transform: "translateY(0) scale(1)",
       ["--tooltip-placement" as string]: resolvedPlacement,
     });
   }, [anchorElement, anchorRef, placement]);
@@ -263,7 +269,9 @@ export function TooltipBubble({
       role="tooltip"
       className={[
         interactive ? "pointer-events-auto select-text" : "pointer-events-none",
-        "w-max max-w-[calc(100vw-2rem)] rounded-xl border border-slate-200 bg-white/95 px-2 py-1.5 text-xs shadow-lg backdrop-blur transition-opacity duration-150 sm:max-w-md dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-white",
+        // 只淡入显得硬；补 2px 上浮与轻微放大后，提示读起来是「浮出来」而不是「闪出来」。
+        "w-max max-w-[calc(100vw-2rem)] rounded-xl bg-white/95 px-2.5 py-1.5 text-xs ring-1 ring-slate-900/10 shadow-[0_8px_24px_-8px_rgba(15,23,42,0.35)] backdrop-blur sm:max-w-md dark:bg-neutral-900/95 dark:text-white dark:ring-white/10",
+        "transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none",
       ].join(" ")}
       style={style}
       onMouseEnter={onMouseEnter}

--- a/packages/ui/src/primitives/Button.tsx
+++ b/packages/ui/src/primitives/Button.tsx
@@ -13,6 +13,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
+import { Loader2 } from "lucide-react";
 import { TooltipBubble, TooltipTriggerContext, type TooltipPlacement } from "../overlays/Tooltip";
 
 type ButtonVariant =
@@ -27,7 +28,7 @@ type ButtonVariant =
 type ButtonSize = "xs" | "sm" | "md";
 
 const BUTTON_BASE_CLASS =
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full border-0 font-semibold shadow-none transition-all duration-150 ease-out active:translate-y-px active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-45";
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full border-0 font-semibold shadow-none transition-all duration-150 ease-out motion-safe:hover:-translate-y-px active:translate-y-0 active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-45";
 
 const BUTTON_SIZE_CLASSES: Record<ButtonSize, { iconOnly: string; text: string }> = {
   xs: {
@@ -77,7 +78,7 @@ const BUTTON_VARIANT_CLASSES: Record<Exclude<ButtonVariant, "secondary" | "dange
   default:
     "bg-[#EBEBEC] text-[#18181B] hover:bg-[#E4E4E7] active:bg-[#D4D4D8] focus-visible:ring-black/10 dark:bg-[#27272A] dark:text-white dark:hover:bg-[#303036] dark:active:bg-[#3F3F46] dark:focus-visible:ring-white/15",
   primary:
-    "bg-[#18181B] text-white hover:bg-[#27272A] active:bg-[#09090B] focus-visible:ring-black/20 dark:bg-white dark:text-[#18181B] dark:hover:bg-[#E4E4E7] dark:active:bg-[#D4D4D8] dark:focus-visible:ring-white/15",
+    "bg-indigo-600 text-white hover:bg-indigo-500 active:bg-indigo-700 focus-visible:ring-indigo-500/35 dark:bg-indigo-500 dark:text-white dark:hover:bg-indigo-400 dark:active:bg-indigo-600 dark:focus-visible:ring-indigo-400/30",
   error:
     "bg-rose-600 text-white hover:bg-rose-500 active:bg-rose-700 focus-visible:ring-rose-400/35 dark:bg-rose-500 dark:hover:bg-rose-400 dark:active:bg-rose-600 dark:focus-visible:ring-rose-300/20",
   success:
@@ -122,6 +123,7 @@ export function Button({
   tooltipPlacement = "bottom",
   variant = "default",
   size = "md",
+  loading = false,
   ...props
 }: PropsWithChildren<
   ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -129,12 +131,15 @@ export function Button({
     tooltipPlacement?: TooltipPlacement;
     variant?: ButtonVariant;
     size?: ButtonSize;
+    /** 提交中：插入 spinner 并禁用点击，但保留标签，避免按钮宽度跳动。 */
+    loading?: boolean;
   }
 >) {
   const tooltipId = useId();
   const hasTooltipParent = useContext(TooltipTriggerContext);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const [tooltipOpen, setTooltipOpen] = useState(false);
+  // loading 时会额外插入 spinner，图标独占判定要按原始 children 算，否则会误判成图标按钮。
   const iconOnly = isIconOnlyButtonChildren(children);
 
   const tooltipContent = tooltip === false ? null : (tooltip ?? title ?? ariaLabel);
@@ -188,8 +193,13 @@ export function Button({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         title={shouldSuppressNativeTitle ? undefined : title}
+        disabled={props.disabled || loading}
+        aria-busy={loading ? true : props["aria-busy"]}
         className={buttonClassName({ className, iconOnly, size, variant })}
       >
+        {loading ? (
+          <Loader2 size={size === "xs" ? 13 : 15} className="shrink-0 animate-spin" aria-hidden />
+        ) : null}
         {children}
       </button>
       <TooltipBubble

--- a/packages/ui/src/primitives/Card.tsx
+++ b/packages/ui/src/primitives/Card.tsx
@@ -35,7 +35,7 @@ export function Card({
     <section
       ref={cardRef}
       className={[
-        "relative min-w-0 rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70 dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.22)]",
+        "relative min-w-0 rounded-3xl bg-white ring-1 ring-slate-900/8 dark:bg-white/[0.03] dark:ring-white/8",
         "motion-reduce:transition-none motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out",
         paddingClass,
         className,
@@ -63,9 +63,9 @@ export function Card({
         {children}
       </div>
       {loading ? (
-        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/70 backdrop-blur-sm motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:bg-neutral-950/55">
-          <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:border-neutral-800 dark:bg-neutral-950/80 dark:text-white">
-            <span className="h-4 w-4 animate-spin rounded-full border-2 border-slate-400 border-t-transparent dark:border-white/50 dark:border-t-transparent" />
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-white/70 backdrop-blur-sm motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:bg-neutral-950/55">
+          <div className="inline-flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-slate-700 ring-1 ring-slate-900/8 motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out dark:bg-neutral-900/85 dark:text-white dark:ring-white/10">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-indigo-500/30 border-t-indigo-600 dark:border-indigo-400/25 dark:border-t-indigo-400" />
             {t("common.loading_ellipsis")}
           </div>
         </div>

--- a/packages/ui/src/primitives/DateTimePicker.tsx
+++ b/packages/ui/src/primitives/DateTimePicker.tsx
@@ -394,7 +394,7 @@ export function DateTimePicker({
                     value={parsedValue ? pad2(parsedValue.getHours()) : ""}
                     onChange={(event) => updateTime("hour", event.currentTarget.value)}
                     aria-label={labels.hour}
-                    className="h-9 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm font-semibold tabular-nums text-[#18181B] shadow-none outline-none transition-colors focus-visible:border-slate-400 focus-visible:ring-0 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:focus-visible:border-neutral-500"
+                    className="h-9 w-full rounded-xl border border-slate-900/8 bg-white px-3 text-sm font-semibold tabular-nums text-[#18181B] shadow-none outline-none transition-colors focus-visible:border-slate-400 focus-visible:ring-0 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:focus-visible:border-neutral-500"
                   />
                 </label>
                 <label className="space-y-1">
@@ -408,7 +408,7 @@ export function DateTimePicker({
                     value={parsedValue ? pad2(parsedValue.getMinutes()) : ""}
                     onChange={(event) => updateTime("minute", event.currentTarget.value)}
                     aria-label={labels.minute}
-                    className="h-9 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm font-semibold tabular-nums text-[#18181B] shadow-none outline-none transition-colors focus-visible:border-slate-400 focus-visible:ring-0 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:focus-visible:border-neutral-500"
+                    className="h-9 w-full rounded-xl border border-slate-900/8 bg-white px-3 text-sm font-semibold tabular-nums text-[#18181B] shadow-none outline-none transition-colors focus-visible:border-slate-400 focus-visible:ring-0 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:focus-visible:border-neutral-500"
                   />
                 </label>
               </div>

--- a/packages/ui/src/primitives/DropdownMenu.tsx
+++ b/packages/ui/src/primitives/DropdownMenu.tsx
@@ -45,6 +45,15 @@ const ITEM_CLASS_BY_SIZE: Record<ControlSize, string> = {
   lg: "gap-2.5 rounded-lg px-3.5 py-2.5 text-sm",
 };
 
+/**
+ * 浮层进出动画的挂载点。
+ *
+ * 实现放在全局样式里（`.ui-popover-motion`）：Radix 用 data-state / data-side 暴露开合
+ * 状态与展开方向，用 CSS 属性选择器驱动比在类名里堆变体更直观，也不依赖
+ * tailwindcss-animate 这类本仓库没有引入的插件。
+ */
+const DROPDOWN_MOTION_CLASS = "ui-popover-motion";
+
 const Content = forwardRef<
   ComponentRef<typeof DropdownMenuPrimitive.Content>,
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
@@ -56,6 +65,7 @@ const Content = forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-[9999] overflow-hidden outline-none",
+        DROPDOWN_MOTION_CLASS,
         floatingPanelSurface,
         CONTENT_CLASS_BY_SIZE[size],
         className,
@@ -125,6 +135,7 @@ const SubContent = forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-[9999] overflow-hidden outline-none",
+        DROPDOWN_MOTION_CLASS,
         floatingPanelSurface,
         CONTENT_CLASS_BY_SIZE[size],
         className,

--- a/packages/ui/src/primitives/Input.tsx
+++ b/packages/ui/src/primitives/Input.tsx
@@ -23,8 +23,9 @@ const VARIANT_STYLES: Record<InputVariant, string> = {
   ghost: "bg-transparent text-inherit placeholder:text-inherit placeholder:opacity-60",
 };
 
+/** 无效态：同样只用 1px 描边，与 focus 态保持一致的克制程度。 */
 const INVALID_SOLID =
-  "border-rose-400 hover:border-rose-500 focus-visible:border-rose-500 dark:border-rose-500/70 dark:hover:border-rose-400 dark:focus-visible:border-rose-400";
+  "ring-1 ring-rose-500/55 focus:ring-rose-500/70 focus-visible:ring-rose-500/70 dark:ring-rose-400/55 dark:focus:ring-rose-400/70 dark:focus-visible:ring-rose-400/70";
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function TextInput(
   {
@@ -47,8 +48,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(function T
 
   const mergedClassName = [
     "w-full text-sm outline-none",
-    "focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0",
-    "transition",
+    "focus:outline-none focus-visible:outline-none",
     controlHeightBySize[size],
     controlTextBySize[size],
     variant === "solid" ? controlPaddingBySize[size] : null,

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -553,7 +553,7 @@ export function SearchableCheckboxMultiSelect({
                 />
               </div>
               {selectAllLabel || neutralAllSelection || showFilteredToggle || selectionHint ? (
-                <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 dark:border-neutral-800">
+                <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2 dark:border-white/8">
                   <span className="min-w-0">
                     <span
                       className={cn(
@@ -673,7 +673,7 @@ export function SearchableCheckboxMultiSelect({
                 )}
               </ScrollArea>
               {manualApply ? (
-                <div className="flex items-center justify-end gap-2 border-t border-slate-100 px-3 py-2 dark:border-neutral-800">
+                <div className="flex items-center justify-end gap-2 border-t border-slate-100 px-3 py-2 dark:border-white/8">
                   <button
                     type="button"
                     onClick={() => closeDropdown(true)}

--- a/packages/ui/src/primitives/ToggleSwitch.tsx
+++ b/packages/ui/src/primitives/ToggleSwitch.tsx
@@ -44,7 +44,7 @@ export function ToggleSwitch({
         disabled ? "opacity-60" : null,
         checked
           ? "border-slate-900 bg-slate-900 dark:border-white dark:bg-white"
-          : "border-slate-200 bg-slate-100 dark:border-neutral-800 dark:bg-neutral-900",
+          : "border-slate-900/8 bg-slate-100 dark:border-white/8 dark:bg-neutral-900",
       ]
         .filter(Boolean)
         .join(" ")}

--- a/packages/ui/src/primitives/__tests__/Form.test.tsx
+++ b/packages/ui/src/primitives/__tests__/Form.test.tsx
@@ -88,7 +88,7 @@ describe("FormField", () => {
       </FormField>,
     );
     const input = screen.getByRole("textbox");
-    expect(input.className).toMatch(/border-rose/);
+    expect(input.className).toMatch(/ring-rose/);
   });
 
   test("wires FormField label and description to ToggleSwitch", () => {

--- a/packages/ui/src/utils/controlStyles.ts
+++ b/packages/ui/src/utils/controlStyles.ts
@@ -18,5 +18,11 @@ export const controlPaddingBySize: Record<ControlSize, string> = {
   lg: "px-4",
 };
 
+/**
+ * 输入类控件的统一表面。
+ *
+ * 用「填充」而不是「描边」表达层级：静止态是一块柔和底色，聚焦时底色提亮、并补一条 1px
+ * 中性描边。刻意不做彩色发光环——密集表单里那圈光晕会盖住相邻控件，也让界面显得吵。
+ */
 export const controlSurface =
-  "rounded-xl border border-slate-200 bg-white text-slate-700 shadow-none outline-none transition-colors placeholder:text-slate-400 hover:border-slate-300 hover:bg-white hover:text-slate-900 focus-visible:border-slate-400 focus-visible:ring-0 focus-visible:ring-transparent dark:border-neutral-700 dark:bg-neutral-950 dark:text-slate-200 dark:shadow-none dark:placeholder:text-slate-500 dark:hover:border-neutral-600 dark:hover:bg-neutral-950 dark:hover:text-white dark:focus-visible:border-neutral-500 dark:focus-visible:ring-transparent";
+  "rounded-2xl border-0 bg-slate-100/80 text-slate-800 shadow-none outline-none transition-[color,background-color,box-shadow] duration-150 placeholder:text-slate-400 hover:bg-slate-100 focus:bg-white focus:ring-1 focus:ring-slate-900/12 focus-visible:bg-white focus-visible:ring-1 focus-visible:ring-slate-900/12 dark:bg-white/[0.055] dark:text-slate-100 dark:placeholder:text-white/30 dark:hover:bg-white/[0.08] dark:focus:bg-white/[0.09] dark:focus:ring-white/15 dark:focus-visible:bg-white/[0.09] dark:focus-visible:ring-white/15";

--- a/packages/ui/src/utils/motion.ts
+++ b/packages/ui/src/utils/motion.ts
@@ -1,0 +1,27 @@
+/**
+ * 全局动效常量。
+ *
+ * 目的是让弹窗、抽屉、toast、按钮、页面切换共用同一套时间与曲线——各处各写一套
+ * duration 与 cubic-bezier 时，界面会显得「每个控件性格不同」，这是廉价感的主要来源。
+ *
+ * 曲线选择：进场用 expo-out（起步快、收尾极缓，像滑到位而不是弹一下），
+ * 退场用更短的 ease-in（用户已经决定关闭，不该再等动画）。
+ */
+
+/** 进场缓动：起步快、收尾缓。 */
+export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+/** 退场缓动：略微加速离场。 */
+export const EASE_IN = [0.4, 0, 1, 1] as const;
+
+/** 覆盖层（弹窗 / 抽屉）进出时长，单位毫秒。退场刻意比进场短。 */
+export const OVERLAY_ENTER_MS = 260;
+export const OVERLAY_EXIT_MS = 160;
+
+/** 小控件（toast、提示条、行内展开）的时长。 */
+export const CONTROL_ENTER_MS = 200;
+
+/** 悬停/按压的弹簧参数。刚度高、阻尼足，手感是「跟手」而不是「晃」。 */
+export const PRESS_SPRING = { type: "spring", stiffness: 420, damping: 26 } as const;
+
+export const cssEase = (curve: readonly [number, number, number, number]): string =>
+  `cubic-bezier(${curve.join(", ")})`;

--- a/packages/ui/src/utils/selectStyles.ts
+++ b/packages/ui/src/utils/selectStyles.ts
@@ -33,7 +33,7 @@ export const selectChevron =
   "ml-auto shrink-0 text-[#71717A] transition-transform duration-200 dark:text-[#A1A1AA]";
 
 export const floatingPanelSurface =
-  "code-proxy-floating-surface rounded-xl border border-slate-200 bg-white shadow-[0_16px_40px_rgba(15,23,42,0.14)] dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-[0_16px_40px_rgba(0,0,0,0.38)]";
+  "code-proxy-floating-surface rounded-xl border border-slate-900/8 bg-white shadow-[0_16px_40px_rgba(15,23,42,0.14)] dark:border-white/8 dark:bg-neutral-950 dark:shadow-[0_16px_40px_rgba(0,0,0,0.38)]";
 
 export const selectPanel =
   `fixed z-[9999] overflow-hidden p-1 ${floatingPanelSurface}`;

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Eye, EyeOff, KeyRound, UserRound } from "lucide-react";
 import {
   extractApiErrorCode,
   isApiClientError,
@@ -35,9 +34,8 @@ import {
   fetchPublicUsageSummary,
   type PublicModelItem,
 } from "./api";
-import { LogoMark } from "@code-proxy/assets";
-import { LandingButton } from "./components/landing/LandingButton";
 import { LookupHeader } from "./components/LookupHeader";
+import { PortalLoginForm } from "./components/PortalLoginForm";
 import { LookupEmptyState } from "./components/LookupEmptyState";
 import { LookupResultsToolbar, type ApiKeyLookupTab } from "./components/LookupResultsToolbar";
 import { ManageKeysTabContent } from "./components/ManageKeysTabContent";
@@ -1447,7 +1445,7 @@ export function ApiKeyLookupPage() {
               {(activeTab === "models" || activeTab === "quickImport") &&
               !queriedKey &&
               portalUser ? (
-                <div className="rounded-2xl border border-dashed border-slate-200 px-6 py-12 text-center text-sm text-slate-500 dark:border-neutral-800 dark:text-white/55">
+                <div className="rounded-2xl border border-dashed border-slate-900/8 px-6 py-12 text-center text-sm text-slate-500 dark:border-white/8 dark:text-white/55">
                   {t("apikey_lookup.operational_key_required", {
                     defaultValue:
                       "请先创建一把可用 Key；模型列表和快速导入需要凭证，用量与日志仍按账号聚合。",
@@ -1465,88 +1463,23 @@ export function ApiKeyLookupPage() {
           title={t("apikey_lookup.login_title", { defaultValue: "账号登录" })}
           hideHeader
           maxWidth="max-w-md"
-          panelClassName="rounded-3xl border-white/70 bg-white/95 shadow-xl shadow-slate-300/25 backdrop-blur-xl dark:border-white/10 dark:bg-neutral-950/90 dark:shadow-black/25"
-          bodyClassName="!px-7 !py-8 sm:!px-9 sm:!py-9"
+          bodyClassName="!px-7 !py-9 sm:!px-9"
           bodyHeightClassName="max-h-none"
           bodyOverflowClassName="overflow-visible"
           onClose={closeLoginModal}
         >
-          <div className="space-y-6">
-            <div className="flex items-center gap-3 pr-8">
-              <LogoMark size={26} />
-              <h2 className="font-display text-xl font-bold tracking-tight text-slate-950 dark:text-white">
-                {t("apikey_lookup.login_title", { defaultValue: "登录" })}
-              </h2>
-            </div>
-            <form
-              className="space-y-4"
-              onSubmit={(e) => {
-                e.preventDefault();
-                void handlePortalLogin();
-              }}
-            >
-              <label className="block space-y-2">
-                <span className="text-xs font-medium text-slate-600 dark:text-white/60">
-                  {t("apikey_lookup.username", { defaultValue: "账号" })}
-                </span>
-                <TextInput
-                  value={loginUsername}
-                  onChange={(e) => setLoginUsername(e.target.value)}
-                  autoComplete="username"
-                  autoFocus
-                  className="rounded-full px-5"
-                  placeholder={t("apikey_lookup.username_placeholder", {
-                    defaultValue: "请输入账号",
-                  })}
-                  startAdornment={<UserRound size={17} />}
-                />
-              </label>
-              <label className="block space-y-2">
-                <span className="text-xs font-medium text-slate-600 dark:text-white/60">
-                  {t("apikey_lookup.password", { defaultValue: "密码" })}
-                </span>
-                <TextInput
-                  type={showLoginPassword ? "text" : "password"}
-                  value={loginPassword}
-                  onChange={(e) => setLoginPassword(e.target.value)}
-                  autoComplete="current-password"
-                  className="rounded-full px-5"
-                  placeholder={t("apikey_lookup.password_placeholder", {
-                    defaultValue: "请输入密码",
-                  })}
-                  startAdornment={<KeyRound size={17} />}
-                  endAdornment={
-                    <button
-                      type="button"
-                      onClick={() => setShowLoginPassword((value) => !value)}
-                      className="rounded-full p-2 text-slate-500 hover:bg-slate-100 dark:hover:bg-white/10"
-                      aria-label={
-                        showLoginPassword
-                          ? t("login.hide_key", { defaultValue: "隐藏密码" })
-                          : t("login.show_key", { defaultValue: "显示密码" })
-                      }
-                    >
-                      {showLoginPassword ? <EyeOff size={16} /> : <Eye size={16} />}
-                    </button>
-                  }
-                />
-              </label>
-              {loginError ? (
-                <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-300">
-                  {loginError}
-                </div>
-              ) : null}
-              <LandingButton
-                type="submit"
-                disabled={loginBusy || !loginUsername.trim() || !loginPassword}
-                className="h-11 w-full"
-              >
-                {loginBusy
-                  ? t("common.loading", { defaultValue: "登录中…" })
-                  : t("common.login", { defaultValue: "登录" })}
-              </LandingButton>
-            </form>
-          </div>
+          <PortalLoginForm
+            t={t}
+            username={loginUsername}
+            password={loginPassword}
+            showPassword={showLoginPassword}
+            error={loginError}
+            busy={loginBusy}
+            onUsernameChange={setLoginUsername}
+            onPasswordChange={setLoginPassword}
+            onTogglePassword={() => setShowLoginPassword((value) => !value)}
+            onSubmit={() => void handlePortalLogin()}
+          />
         </Modal>
 
         <Modal

--- a/pages/api-key-lookup/components/LookupResultsToolbar.tsx
+++ b/pages/api-key-lookup/components/LookupResultsToolbar.tsx
@@ -134,7 +134,7 @@ export function LookupResultsToolbar({
               {logsQuotaItems.map((item) => (
                 <div
                   key={item.key}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white/80 px-2 py-1 text-xs text-slate-600 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white/60"
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-900/8 bg-white/80 px-2 py-1 text-xs text-slate-600 shadow-sm dark:border-white/10 dark:bg-white/5 dark:text-white/60"
                 >
                   <span>{item.title}</span>
                   <span className="font-mono font-semibold tabular-nums text-slate-900 dark:text-white">

--- a/pages/api-key-lookup/components/LookupSearchSection.tsx
+++ b/pages/api-key-lookup/components/LookupSearchSection.tsx
@@ -43,7 +43,7 @@ export function LookupSearchSection({
         >
           {loading ? (
             <span
-              className="h-4 w-4 rounded-full border-2 border-white/30 border-t-white motion-reduce:animate-none motion-safe:animate-spin dark:border-neutral-950/30 dark:border-t-neutral-950"
+              className="h-4 w-4 rounded-full border-2 border-white/30 border-t-white motion-reduce:animate-none motion-safe:animate-spin dark:border-neutral-950/30 dark:border-t-indigo-400"
               aria-hidden="true"
             />
           ) : null}

--- a/pages/api-key-lookup/components/ManageKeysTabContent.tsx
+++ b/pages/api-key-lookup/components/ManageKeysTabContent.tsx
@@ -28,7 +28,7 @@ export function ManageKeysTabContent({
     <Card padding="none" className="overflow-hidden" bodyClassName="mt-0">
       <div
         data-testid="apikey-lookup-keys-card-toolbar"
-        className="flex flex-wrap items-center justify-end gap-2 border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60"
+        className="flex flex-wrap items-center justify-end gap-2 border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-white/8"
       >
         <Button size="sm" variant="secondary" onClick={onRefresh} disabled={loading || busy}>
           <RefreshCw size={14} className={loading ? "animate-spin" : ""} />

--- a/pages/api-key-lookup/components/ModelsTabContent.tsx
+++ b/pages/api-key-lookup/components/ModelsTabContent.tsx
@@ -28,8 +28,8 @@ function PriceChip({
       className={[
         "min-w-0 rounded-lg border px-2 py-1.5",
         muted
-          ? "border-slate-100 bg-slate-50/70 dark:border-neutral-800 dark:bg-neutral-900/40"
-          : "border-slate-200/80 bg-white dark:border-neutral-700/70 dark:bg-neutral-950/50",
+          ? "border-slate-100 bg-slate-50/70 dark:border-white/8 dark:bg-neutral-900/40"
+          : "border-slate-900/8 bg-white dark:border-neutral-700/70 dark:bg-neutral-950/50",
       ].join(" ")}
     >
       <div className="text-2xs font-medium uppercase tracking-wide text-slate-400 dark:text-white/35">
@@ -110,7 +110,7 @@ function ModelPlazaCard({ model, onCopied }: { model: PublicModelItem; onCopied:
         className="group h-full min-w-0 overflow-hidden transition hover:border-indigo-200/70 hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.06)] dark:hover:border-indigo-500/25 dark:hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.28)]"
       >
         <div className="flex items-start gap-3">
-          <div className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200/80 bg-slate-50 dark:border-neutral-700/70 dark:bg-neutral-900/70">
+          <div className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-slate-50 dark:border-neutral-700/70 dark:bg-neutral-900/70">
             <span className="pointer-events-none absolute text-sm font-bold text-slate-300 dark:text-white/25">
               {vendorGlyph}
             </span>

--- a/pages/api-key-lookup/components/PortalLoginForm.tsx
+++ b/pages/api-key-lookup/components/PortalLoginForm.tsx
@@ -1,0 +1,145 @@
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { Eye, EyeOff, KeyRound, Loader2, UserRound } from "lucide-react";
+import { LogoMark } from "@code-proxy/assets";
+import { TextInput } from "@code-proxy/ui";
+import { LandingButton } from "./landing/LandingButton";
+
+const EASE = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * 门户登录表单。
+ *
+ * 从页面里抽出来单独成组件，一是登录弹窗是访客见到的第一个交互界面，值得单独打磨；
+ * 二是这段表单原先散在 1800 行的页面文件里，改动成本高。
+ */
+export function PortalLoginForm({
+  t,
+  username,
+  password,
+  showPassword,
+  error,
+  busy,
+  onUsernameChange,
+  onPasswordChange,
+  onTogglePassword,
+  onSubmit,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  username: string;
+  password: string;
+  showPassword: boolean;
+  error: string | null;
+  busy: boolean;
+  onUsernameChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onTogglePassword: () => void;
+  onSubmit: () => void;
+}) {
+  const reduceMotion = useReducedMotion();
+  const canSubmit = !busy && Boolean(username.trim()) && Boolean(password);
+
+  const fieldClass = "h-12 rounded-2xl px-4 text-sm";
+  const labelClass =
+    "font-display text-2xs font-medium uppercase tracking-[0.1em] text-slate-400 dark:text-white/40";
+
+  return (
+    <div>
+      <div className="flex flex-col items-center pb-8 text-center">
+        {/* 标记外面套一层柔和方框，让它在纯白弹窗上有落点，而不是悬空 */}
+        <span className="mb-5 inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-indigo-50 ring-1 ring-indigo-500/15 dark:bg-indigo-500/10 dark:ring-indigo-400/20">
+          <LogoMark size={22} />
+        </span>
+        <h2 className="font-display text-2xl font-bold tracking-tight text-slate-950 dark:text-white">
+          {t("apikey_lookup.login_title", { defaultValue: "登录" })}
+        </h2>
+        <p className="mt-2 text-sm text-slate-500 dark:text-white/45">
+          {t("apikey_lookup.login_desc", { defaultValue: "使用你的账号登录。" })}
+        </p>
+      </div>
+
+      <form
+        className="space-y-5"
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <label className="block space-y-2">
+          <span className={labelClass}>
+            {t("apikey_lookup.username", { defaultValue: "账号" })}
+          </span>
+          <TextInput
+            value={username}
+            onChange={(event) => onUsernameChange(event.target.value)}
+            autoComplete="username"
+            autoFocus
+            className={fieldClass}
+            placeholder={t("apikey_lookup.username_placeholder", { defaultValue: "请输入账号" })}
+            startAdornment={<UserRound size={17} className="text-slate-400 dark:text-white/35" />}
+          />
+        </label>
+
+        <label className="block space-y-2">
+          <span className={labelClass}>
+            {t("apikey_lookup.password", { defaultValue: "密码" })}
+          </span>
+          <TextInput
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(event) => onPasswordChange(event.target.value)}
+            autoComplete="current-password"
+            className={fieldClass}
+            placeholder={t("apikey_lookup.password_placeholder", { defaultValue: "请输入密码" })}
+            startAdornment={<KeyRound size={17} className="text-slate-400 dark:text-white/35" />}
+            endAdornment={
+              <button
+                type="button"
+                onClick={onTogglePassword}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition-colors duration-150 hover:bg-slate-900/5 hover:text-slate-700 dark:text-white/35 dark:hover:bg-white/10 dark:hover:text-white/80"
+                aria-label={
+                  showPassword
+                    ? t("login.hide_key", { defaultValue: "隐藏密码" })
+                    : t("login.show_key", { defaultValue: "显示密码" })
+                }
+              >
+                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            }
+          />
+        </label>
+
+        {/* 错误条用高度动画展开，避免它突然出现把按钮顶下去 */}
+        <AnimatePresence initial={false}>
+          {error ? (
+            <motion.div
+              key="login-error"
+              initial={reduceMotion ? false : { opacity: 0, height: 0, y: -4 }}
+              animate={{ opacity: 1, height: "auto", y: 0 }}
+              exit={reduceMotion ? { opacity: 0 } : { opacity: 0, height: 0, y: -4 }}
+              transition={{ duration: 0.24, ease: EASE }}
+              className="overflow-hidden"
+            >
+              <p
+                role="alert"
+                className="rounded-2xl bg-rose-50 px-4 py-3 text-sm text-rose-700 ring-1 ring-rose-500/15 dark:bg-rose-500/10 dark:text-rose-300 dark:ring-rose-400/20"
+              >
+                {error}
+              </p>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+
+        <LandingButton type="submit" disabled={!canSubmit} className="h-12 w-full">
+          {busy ? (
+            <>
+              <Loader2 size={16} className="animate-spin" aria-hidden />
+              {t("common.loading", { defaultValue: "登录中…" })}
+            </>
+          ) : (
+            t("common.login", { defaultValue: "登录" })
+          )}
+        </LandingButton>
+      </form>
+    </div>
+  );
+}

--- a/pages/api-key-lookup/components/PublicLogsSection.tsx
+++ b/pages/api-key-lookup/components/PublicLogsSection.tsx
@@ -71,7 +71,7 @@ export function PublicLogsSection({
   return (
     <Reveal>
       <Card padding="none" className="overflow-hidden" bodyClassName="mt-0">
-        <div className="border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60">
+        <div className="border-b border-slate-100 px-3 py-3 sm:px-5 dark:border-white/8">
           <div className="grid gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-2">
             <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center sm:gap-2">
               {keyOptions.length > 0 ? (
@@ -175,9 +175,9 @@ export function PublicLogsSection({
           />
           {loading ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
-              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">
+              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-900/8 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-white/8 dark:bg-neutral-950/70 dark:text-white/75">
                 <span
-                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
+                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-indigo-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
                   aria-hidden="true"
                 />
                 <span role="status">{t("common.loading_ellipsis")}</span>

--- a/pages/api-key-lookup/components/QuickImportTabContent.tsx
+++ b/pages/api-key-lookup/components/QuickImportTabContent.tsx
@@ -158,14 +158,14 @@ function QuickImportCard({
       animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
       exit={reduceMotion ? undefined : { opacity: 0, y: -6, scale: 0.98 }}
       transition={reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 420, damping: 36 }}
-      className="group/card grid min-h-[116px] w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
+      className="group/card grid min-h-[116px] w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-900/8 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
     >
       <button
         type="button"
         onClick={() => onSelect(config)}
         className="flex min-w-0 items-start gap-4 rounded-l-2xl p-4 text-left transition active:translate-y-px"
       >
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-200/70 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-950">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-white shadow-xs dark:border-white/8 dark:bg-neutral-950">
           <img src={iconByType[clientType]} alt="" className="h-5 w-5" />
         </span>
         <span className="min-w-0 flex-1">
@@ -173,7 +173,7 @@ function QuickImportCard({
             <span className="truncate text-sm font-semibold text-slate-900 dark:text-white">
               {config.providerName}
             </span>
-            <span className="rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 text-2xs font-semibold text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+            <span className="rounded-md border border-slate-900/8 bg-slate-50 px-1.5 py-0.5 text-2xs font-semibold text-slate-500 dark:border-white/8 dark:bg-neutral-950 dark:text-white/45">
               {t(clientLabelKey[clientType])}
             </span>
           </span>
@@ -183,7 +183,7 @@ function QuickImportCard({
             </span>
           ) : null}
           <span className="mt-3 flex flex-wrap items-center gap-2">
-            <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+            <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-900/8 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-white/8 dark:bg-neutral-950 dark:text-white/45">
               {config.defaultModel || t("common.no_model_data")}
             </span>
             {config.allowedChannelGroups.length > 0 ? (
@@ -200,7 +200,7 @@ function QuickImportCard({
           size="xs"
           title={copied ? t("ccswitch.copy_import_link_copied") : t("ccswitch.copy_import_link")}
           onClick={() => onCopyLink(config)}
-          className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
+          className="rounded-lg border border-slate-900/8 bg-white text-slate-500 hover:text-slate-900 dark:border-white/8 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
         >
           {copied ? <Check size={14} /> : <Copy size={14} />}
         </Button>
@@ -215,7 +215,7 @@ function QuickImportLoadingSkeleton() {
   return (
     <Card
       padding="none"
-      className="overflow-hidden border-slate-200/70 bg-white/90 dark:border-white/[0.06] dark:bg-neutral-950/70"
+      className="overflow-hidden border-slate-900/8 bg-white/90 dark:border-white/[0.06] dark:bg-neutral-950/70"
     >
       <div
         data-testid="quick-import-loading-skeleton"
@@ -393,7 +393,7 @@ export function QuickImportTabContent({
 
   return (
     <div className="space-y-4">
-      <Card padding="compact" className="border-slate-200/70 bg-white/85 dark:bg-neutral-950/70">
+      <Card padding="compact" className="border-slate-900/8 bg-white/85 dark:bg-neutral-950/70">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-start gap-3">
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-900 text-white dark:bg-white dark:text-neutral-950">
@@ -412,7 +412,7 @@ export function QuickImportTabContent({
             href={CC_SWITCH_RELEASES_URL}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-white/10"
+            className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-xl border border-slate-900/8 bg-white px-3 text-xs font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-white/8 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-white/10"
           >
             {t("apikey_lookup.quick_import_download_latest")}
             <ExternalLink size={13} />

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -484,7 +484,7 @@ export function ApiKeyPermissionsPage() {
             />
           </section>
 
-          <section className="rounded-2xl border border-slate-200 p-4 dark:border-white/10">
+          <section className="rounded-2xl border border-slate-900/8 p-4 dark:border-white/10">
             <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
               {t("api_key_permissions_page.request_limits_section")}
             </h3>
@@ -522,7 +522,7 @@ export function ApiKeyPermissionsPage() {
             </div>
           </section>
 
-          <section className="rounded-2xl border border-slate-200 p-4 dark:border-white/10">
+          <section className="rounded-2xl border border-slate-900/8 p-4 dark:border-white/10">
             <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
               {t("api_key_permissions_page.realtime_limits_section")}
             </h3>
@@ -657,7 +657,7 @@ export function ApiKeyPermissionsPage() {
               }
               placeholder={t("api_keys_page.system_prompt_hint")}
               rows={3}
-              className="w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none transition-all focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/20 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:focus:border-indigo-500"
+              className="w-full resize-y rounded-xl border border-slate-900/8 bg-white px-3 py-2 text-sm outline-none transition-all focus:border-indigo-400 focus:ring-2 focus:ring-indigo-400/20 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white dark:focus:border-indigo-500"
             />
           </div>
         </div>

--- a/pages/api-key-usage/ApiKeyUsagePage.tsx
+++ b/pages/api-key-usage/ApiKeyUsagePage.tsx
@@ -499,7 +499,7 @@ export function ApiKeyUsagePage() {
       <div className="relative min-h-dvh bg-gradient-to-br from-slate-50 via-white to-slate-100 pt-14 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
         <header
           data-testid="apikey-usage-header"
-          className="fixed inset-x-0 top-0 z-30 border-b border-slate-200/60 bg-white/70 backdrop-blur-xl dark:border-neutral-800/60 dark:bg-neutral-950/70"
+          className="fixed inset-x-0 top-0 z-30 border-b border-slate-900/8 bg-white/70 backdrop-blur-xl dark:border-white/8 dark:bg-neutral-950/70"
         >
           <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-between gap-3 px-4 sm:px-6">
             <div className="flex min-w-0 items-center gap-2.5">
@@ -623,7 +623,7 @@ export function ApiKeyUsagePage() {
           ) : (
             <div
               data-testid="apikey-usage-empty"
-              className="rounded-3xl border border-dashed border-slate-200 px-6 py-16 text-center dark:border-neutral-800"
+              className="rounded-3xl border border-dashed border-slate-900/8 px-6 py-16 text-center dark:border-white/8"
             >
               <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 dark:bg-white/10 dark:text-white/60">
                 <KeyRound size={22} />
@@ -701,7 +701,7 @@ export function ApiKeyUsagePage() {
               >
                 {loading ? (
                   <span
-                    className="h-4 w-4 rounded-full border-2 border-white/30 border-t-white motion-reduce:animate-none motion-safe:animate-spin dark:border-neutral-950/30 dark:border-t-neutral-950"
+                    className="h-4 w-4 rounded-full border-2 border-white/30 border-t-white motion-reduce:animate-none motion-safe:animate-spin dark:border-neutral-950/30 dark:border-t-indigo-400"
                     aria-hidden="true"
                   />
                 ) : null}

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -860,7 +860,7 @@ export function ApiKeysPage({
       {endUserIdFilter && !embed ? (
         <Link
           to="/access/end-users"
-          className="inline-flex h-8 items-center rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-neutral-800"
+          className="inline-flex h-8 items-center rounded-xl border border-slate-900/8 bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/80 dark:hover:bg-neutral-800"
         >
           {t("end_users.back_to_users", { defaultValue: "返回用户账号" })}
         </Link>

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -412,7 +412,7 @@ export const createApiKeyColumns = ({
                 {row["allowed-models"].map((model) => (
                   <span
                     key={model}
-                    className="inline-flex items-center gap-1 rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                    className="inline-flex items-center gap-1 rounded-md border border-slate-900/8 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                   >
                     <VendorIcon modelId={model} size={12} />
                     {model}
@@ -443,7 +443,7 @@ export const createApiKeyColumns = ({
                 {row["allowed-channel-groups"].map((group) => (
                   <span
                     key={group}
-                    className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                    className="inline-flex items-center rounded-md border border-slate-900/8 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                   >
                     {group}
                   </span>
@@ -473,7 +473,7 @@ export const createApiKeyColumns = ({
                 {row["allowed-channels"].map((channel) => (
                   <span
                     key={channel}
-                    className="inline-flex items-center rounded-md border border-slate-200/60 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
+                    className="inline-flex items-center rounded-md border border-slate-900/8 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-neutral-700/40 dark:bg-neutral-800/60 dark:text-white/80"
                   >
                     {channel}
                   </span>
@@ -536,7 +536,7 @@ export const createApiKeyColumns = ({
                 icon: <BarChart3 size={15} />,
                 visible: !accountScoped,
                 className:
-                  "text-slate-500 hover:bg-slate-100 hover:text-blue-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-blue-400",
+                  "text-slate-500 hover:bg-slate-100 hover:text-indigo-600 dark:text-white/50 dark:hover:bg-neutral-800 dark:hover:text-indigo-400",
                 onClick: () => onViewUsage(row),
               },
               {

--- a/pages/api-keys/components/ApiKeyFormFields.tsx
+++ b/pages/api-keys/components/ApiKeyFormFields.tsx
@@ -40,7 +40,7 @@ export function ApiKeyFormFields({
       </div>
 
       {serverGeneratesKey ? (
-        <p className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-900/50 dark:text-white/60">
+        <p className="rounded-xl border border-slate-900/8 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-white/8 dark:bg-neutral-900/50 dark:text-white/60">
           {editMode
             ? t("end_users.key_rotate_only", {
                 defaultValue: "密钥值不能直接编辑。需要更换凭证时，请使用独立的“轮换密钥”操作。",

--- a/pages/api-keys/components/ApiKeyUsageModal.tsx
+++ b/pages/api-keys/components/ApiKeyUsageModal.tsx
@@ -93,7 +93,7 @@ export function ApiKeyUsageModal({
       bodyHeightClassName="h-[80vh]"
     >
       <div className="flex h-full flex-col">
-        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-1 pb-3 dark:border-neutral-800/60">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-1 pb-3 dark:border-white/8">
           <div className="flex flex-wrap items-center gap-2">
             <RequestLogsTimeRangeSelector value={usageTimeRange} onChange={setUsageTimeRange} />
             <button
@@ -116,7 +116,7 @@ export function ApiKeyUsageModal({
           <span className="text-xs text-slate-400 dark:text-white/40">{usageLastUpdatedText}</span>
         </div>
 
-        <div className="grid gap-2 border-b border-slate-100 py-3 dark:border-neutral-800/60 sm:flex sm:flex-wrap sm:items-center">
+        <div className="grid gap-2 border-b border-slate-100 py-3 dark:border-white/8 sm:flex sm:flex-wrap sm:items-center">
           <SearchableSelect
             value={usageKeyQuery}
             onChange={setUsageKeyQuery}
@@ -162,11 +162,11 @@ export function ApiKeyUsageModal({
 
         <div
           data-testid="api-key-usage-summary"
-          className="grid gap-2 border-b border-slate-100 py-3 dark:border-neutral-800/60 md:grid-cols-[minmax(0,2fr)_repeat(2,minmax(0,1fr))]"
+          className="grid gap-2 border-b border-slate-100 py-3 dark:border-white/8 md:grid-cols-[minmax(0,2fr)_repeat(2,minmax(0,1fr))]"
         >
           <section
             aria-label={t("api_keys_page.usage_summary_tokens")}
-            className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-neutral-800 dark:bg-white/[0.035]"
+            className="rounded-2xl border border-slate-900/8 bg-slate-50/80 px-4 py-3 dark:border-white/8 dark:bg-white/[0.035]"
           >
             <div className="text-xs font-medium text-slate-500 dark:text-white/50">
               {t("api_keys_page.usage_summary_tokens")}
@@ -216,7 +216,7 @@ export function ApiKeyUsageModal({
 
           <section
             aria-label={t("api_keys_page.usage_summary_requests")}
-            className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-neutral-800 dark:bg-white/[0.035]"
+            className="rounded-2xl border border-slate-900/8 bg-slate-50/80 px-4 py-3 dark:border-white/8 dark:bg-white/[0.035]"
           >
             <div className="text-xs font-medium text-slate-500 dark:text-white/50">
               {t("api_keys_page.usage_summary_requests")}
@@ -233,7 +233,7 @@ export function ApiKeyUsageModal({
 
           <section
             aria-label={t("api_keys_page.usage_summary_success_rate")}
-            className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-neutral-800 dark:bg-white/[0.035]"
+            className="rounded-2xl border border-slate-900/8 bg-slate-50/80 px-4 py-3 dark:border-white/8 dark:bg-white/[0.035]"
           >
             <div className="text-xs font-medium text-slate-500 dark:text-white/50">
               {t("api_keys_page.usage_summary_success_rate")}
@@ -264,8 +264,8 @@ export function ApiKeyUsageModal({
           />
           {usageLoading ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
-              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">
-                <span className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80" />
+              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-900/8 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-white/8 dark:bg-neutral-950/70 dark:text-white/75">
+                <span className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-indigo-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80" />
                 <span role="status">{t("common.loading_ellipsis")}</span>
               </div>
             </div>

--- a/pages/api-keys/components/CcSwitchImportCardList.tsx
+++ b/pages/api-keys/components/CcSwitchImportCardList.tsx
@@ -54,14 +54,14 @@ export function CcSwitchImportCardList({
             return (
               <div
                 key={config.id}
-                className="grid w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-200 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
+                className="grid w-full grid-cols-[minmax(0,1fr)_auto] rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] transition hover:border-slate-900/8 hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900 dark:hover:border-neutral-700"
               >
                 <button
                   type="button"
                   onClick={() => onSelect(config)}
                   className="flex min-w-0 items-start gap-4 rounded-l-2xl p-4 text-left transition active:translate-y-px"
                 >
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-200/70 bg-white shadow-xs dark:border-neutral-800 dark:bg-neutral-950">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-white shadow-xs dark:border-white/8 dark:bg-neutral-950">
                     <img src={iconByType[config.clientType]} alt="" className="h-5 w-5" />
                   </span>
                   <div className="min-w-0 flex-1">
@@ -70,7 +70,7 @@ export function CcSwitchImportCardList({
                         {config.providerName}
                       </span>
                       {config.clientType === "claude" && config.apiKeyField ? (
-                        <span className="shrink-0 rounded-md border border-slate-200/70 bg-slate-50 px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+                        <span className="shrink-0 rounded-md border border-slate-900/8 bg-slate-50 px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-white/8 dark:bg-neutral-950 dark:text-white/45">
                           {config.apiKeyField}
                         </span>
                       ) : null}
@@ -81,7 +81,7 @@ export function CcSwitchImportCardList({
                       </p>
                     ) : null}
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+                      <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-900/8 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-white/8 dark:bg-neutral-950 dark:text-white/45">
                         {config.defaultModel}
                       </span>
                       {config.allowedChannelGroups.length > 0 ? (
@@ -102,7 +102,7 @@ export function CcSwitchImportCardList({
                         : t("ccswitch.copy_import_link")
                     }
                     onClick={() => onCopyLink(config)}
-                    className="rounded-lg border border-slate-200/70 bg-white text-slate-500 hover:text-slate-900 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
+                    className="rounded-lg border border-slate-900/8 bg-white text-slate-500 hover:text-slate-900 dark:border-white/8 dark:bg-neutral-950 dark:text-white/55 dark:hover:text-white"
                   >
                     {isCopied ? <Check size={14} /> : <Copy size={14} />}
                   </Button>

--- a/pages/api-keys/components/DeleteApiKeyModal.tsx
+++ b/pages/api-keys/components/DeleteApiKeyModal.tsx
@@ -64,7 +64,7 @@ export function DeleteApiKeyModal({
             </div>
             <code className="text-xs text-red-600 dark:text-red-400">{maskApiKey(entry.key)}</code>
           </div>
-          <label className="flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-3 text-sm text-slate-700 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/75">
+          <label className="flex items-start gap-3 rounded-xl border border-slate-900/8 bg-slate-50/70 px-3 py-3 text-sm text-slate-700 dark:border-white/8 dark:bg-neutral-900/60 dark:text-white/75">
             <input
               type="checkbox"
               checked={deleteLogsOnDelete}

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -238,8 +238,8 @@ describe("ApiKeyColumns", () => {
       actionsColumn?.cellClassName,
     ].join(" ");
     expect(fixedColumnClassNames).not.toMatch(/\bmd:border-[lr]\b/);
-    expect(fixedColumnClassNames).not.toContain("md:border-slate-200");
-    expect(fixedColumnClassNames).not.toContain("md:dark:border-neutral-800");
+    expect(fixedColumnClassNames).not.toContain("md:border-slate-900/8");
+    expect(fixedColumnClassNames).not.toContain("md:dark:border-white/8");
     expect(selectColumn?.headerClassName).not.toMatch(/(^|\s)sticky(\s|$)/);
     expect(nameColumn?.cellClassName).not.toMatch(/(^|\s)sticky(\s|$)/);
     expect(actionsColumn?.cellClassName).not.toMatch(/(^|\s)sticky(\s|$)/);

--- a/pages/audit-logs/AuditLogsPage.tsx
+++ b/pages/audit-logs/AuditLogsPage.tsx
@@ -310,7 +310,7 @@ export function AuditLogsPage() {
           onPageChange={handlePageChange}
           onPageSizeChange={handlePageSizeChange}
           pageSizeOptions={PAGE_SIZE_OPTIONS}
-          className="border-t border-slate-100 px-3 py-3 sm:px-5 dark:border-neutral-800/60"
+          className="border-t border-slate-100 px-3 py-3 sm:px-5 dark:border-white/8"
           labels={{
             firstPage: t("request_logs.first_page"),
             previousPage: t("request_logs.prev_page"),
@@ -377,7 +377,7 @@ export function AuditLogsPage() {
                   {callChain.map((step, index) => (
                     <li
                       key={`${step.step ?? index}-${step.name ?? "step"}`}
-                      className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 dark:border-neutral-800 dark:bg-neutral-900/70"
+                      className="rounded-xl border border-slate-900/8 bg-slate-50 px-3 py-2 dark:border-white/8 dark:bg-neutral-900/70"
                     >
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-slate-200 px-1.5 text-2xs font-semibold text-slate-700 dark:bg-neutral-700 dark:text-white/80">
@@ -418,7 +418,7 @@ export function AuditLogsPage() {
               {detailLoading ? (
                 <p className="text-slate-500">{t("identity_admin.loading")}</p>
               ) : projectMethod ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 font-mono text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-900/70 dark:text-white/75">
+                <div className="rounded-xl border border-slate-900/8 bg-slate-50 px-3 py-2 font-mono text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-900/70 dark:text-white/75">
                   <div>
                     {[projectMethod.package, projectMethod.handler || projectMethod.method]
                       .filter(Boolean)

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -1017,7 +1017,7 @@ export function AuthFileDetailModal({
 
             <div
               className={
-                hasCodexProfiles ? "mt-5 border-t border-slate-200 pt-4 dark:border-white/10" : ""
+                hasCodexProfiles ? "mt-5 border-t border-slate-900/8 pt-4 dark:border-white/10" : ""
               }
             >
               <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">

--- a/pages/auth-files/components/AuthFilesExcludedTab.tsx
+++ b/pages/auth-files/components/AuthFilesExcludedTab.tsx
@@ -148,7 +148,7 @@ export function AuthFilesExcludedTab({
                         placeholder={t("auth_files.one_model_per_line")}
                         aria-label={`${provider} ${t("auth_files_page.excluded_tab")}`}
                         disabled={excludedUnsupported}
-                        className="mt-3 min-h-[120px] w-full resize-y rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition-colors duration-200 ease-out placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
+                        className="mt-3 min-h-[120px] w-full resize-y rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition-colors duration-200 ease-out placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-white/8 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
                       />
                     </div>
                   );

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1298,7 +1298,7 @@ export function AuthFilesFilesTab({
         setPage(1);
       }}
       pageSizeOptions={pageSizeOptions}
-      className="border-t border-slate-100 px-4 pb-4 pt-3 sm:px-5 sm:pb-5 dark:border-neutral-800/60"
+      className="border-t border-slate-100 px-4 pb-4 pt-3 sm:px-5 sm:pb-5 dark:border-white/8"
       labels={{
         firstPage: t("request_logs.first_page"),
         previousPage: t("auth_files.prev"),
@@ -1330,7 +1330,7 @@ export function AuthFilesFilesTab({
         onChange={(e) => void handleUpload(e.currentTarget.files)}
       />
 
-      <div className="shrink-0 border-b border-slate-100 p-3.5 dark:border-neutral-800/60">
+      <div className="shrink-0 border-b border-slate-100 p-3.5 dark:border-white/8">
         <div className="flex flex-col gap-3">
           <div className="flex items-center justify-between gap-2 md:hidden">
             <Button
@@ -1879,7 +1879,7 @@ export function AuthFilesFilesTab({
                       padding={denseCards ? "compact" : "default"}
                       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
                       className={[
-                        "group/card flex h-full w-full max-w-[34rem] flex-col border-slate-200/80 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+                        "group/card flex h-full w-full max-w-[34rem] flex-col border-slate-900/8 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
                         denseCards ? "rounded-2xl" : "rounded-3xl",
                         fileSelected
                           ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
@@ -2341,7 +2341,7 @@ export function AuthFilesFilesTab({
           data-testid="auth-files-upload-progress"
           aria-live="polite"
         >
-          <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.95),_rgba(241,245,249,0.95))] p-4 shadow-[0_20px_50px_rgb(15_23_42_/_0.08)] dark:border-white/10 dark:bg-[radial-gradient(circle_at_top_left,_rgba(39,39,42,0.98),_rgba(9,9,11,0.98))] dark:shadow-[0_24px_60px_rgb(0_0_0_/_0.28)]">
+          <div className="overflow-hidden rounded-3xl border border-slate-900/8 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.95),_rgba(241,245,249,0.95))] p-4 shadow-[0_20px_50px_rgb(15_23_42_/_0.08)] dark:border-white/10 dark:bg-[radial-gradient(circle_at_top_left,_rgba(39,39,42,0.98),_rgba(9,9,11,0.98))] dark:shadow-[0_24px_60px_rgb(0_0_0_/_0.28)]">
             <div className="flex items-start gap-3">
               <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-slate-900 text-white shadow-lg shadow-slate-900/15 dark:bg-white dark:text-neutral-950 dark:shadow-black/25">
                 <Loader2 size={18} className="animate-spin" />
@@ -2393,7 +2393,7 @@ export function AuthFilesFilesTab({
             ].map((label) => (
               <div
                 key={label}
-                className="rounded-2xl border border-slate-200 bg-slate-50/90 px-3 py-2 text-xs font-semibold text-slate-600 dark:border-white/10 dark:bg-white/[0.04] dark:text-white/65"
+                className="rounded-2xl border border-slate-900/8 bg-slate-50/90 px-3 py-2 text-xs font-semibold text-slate-600 dark:border-white/10 dark:bg-white/[0.04] dark:text-white/65"
               >
                 {label}
               </div>
@@ -2401,7 +2401,7 @@ export function AuthFilesFilesTab({
           </div>
 
           {uploadProgress.activeFileNames.length > 0 ? (
-            <div className="rounded-2xl border border-dashed border-slate-200 bg-white/80 px-3 py-3 dark:border-white/10 dark:bg-white/[0.02]">
+            <div className="rounded-2xl border border-dashed border-slate-900/8 bg-white/80 px-3 py-3 dark:border-white/10 dark:bg-white/[0.02]">
               <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400 dark:text-white/35">
                 {t("auth_files.upload")}
               </p>
@@ -2538,7 +2538,7 @@ export function AuthFilesFilesTab({
         }
       >
         <div className="space-y-4">
-          <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-white/[0.04]">
+          <div className="rounded-2xl border border-slate-900/8 bg-slate-50/70 p-4 dark:border-white/8 dark:bg-white/[0.04]">
             <ToggleSwitch
               checked={draftModelOwnerEnabled}
               onCheckedChange={setDraftModelOwnerEnabled}
@@ -2566,7 +2566,7 @@ export function AuthFilesFilesTab({
               />
             </div>
 
-            <div className="flex min-w-0 items-center rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3 dark:border-neutral-800 dark:bg-white/[0.04]">
+            <div className="flex min-w-0 items-center rounded-2xl border border-slate-900/8 bg-slate-50/70 px-4 py-3 dark:border-white/8 dark:bg-white/[0.04]">
               <div className="min-w-0">
                 <p className="text-xs font-semibold uppercase text-slate-400 dark:text-white/35">
                   {t("auth_files.type_filter")}
@@ -2578,7 +2578,7 @@ export function AuthFilesFilesTab({
             </div>
           </div>
 
-          <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <div className="mb-3 flex items-center justify-between gap-3">
               <p className="text-sm font-semibold text-slate-900 dark:text-white">
                 {t("auth_files.detail_tab_models")}
@@ -2614,7 +2614,7 @@ export function AuthFilesFilesTab({
                     return (
                       <div
                         key={model.id}
-                        className="rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2 dark:border-neutral-800 dark:bg-white/[0.03]"
+                        className="rounded-xl border border-slate-900/8 bg-slate-50/70 px-3 py-2 dark:border-white/8 dark:bg-white/[0.03]"
                       >
                         <p className="truncate font-mono text-xs font-semibold text-slate-900 dark:text-white">
                           {model.id}

--- a/pages/auth-files/components/GroupOverviewModal.tsx
+++ b/pages/auth-files/components/GroupOverviewModal.tsx
@@ -71,7 +71,7 @@ export function GroupOverviewModal({
             </TabsList>
           </Tabs>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex h-9 items-center rounded-2xl border border-slate-200 bg-slate-50 px-3 text-sm font-medium text-slate-700 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-white/75">
+            <span className="inline-flex h-9 items-center rounded-2xl border border-slate-900/8 bg-slate-50 px-3 text-sm font-medium text-slate-700 dark:border-white/8 dark:bg-neutral-900/60 dark:text-white/75">
               {t("auth_files.group_overview_fixed_7_days")}
             </span>
             <Button
@@ -93,7 +93,7 @@ export function GroupOverviewModal({
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {activeGroupTitle}
             </p>
@@ -104,7 +104,7 @@ export function GroupOverviewModal({
               {t("auth_files.group_overview_file_count")}
             </p>
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {t("auth_files.group_overview_total_calls_label")}
             </p>
@@ -115,7 +115,7 @@ export function GroupOverviewModal({
               {t("auth_files.group_overview_total_calls_help")}
             </p>
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {t("auth_files.group_overview_avg_week_label")}
             </p>
@@ -126,7 +126,7 @@ export function GroupOverviewModal({
               {t("auth_files.group_overview_avg_week_help")}
             </p>
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
               {t("auth_files.group_overview_sample_count", {
                 count: activeGroupOverview.quotaSampleCount,

--- a/pages/auth-files/components/ImportModelsModal.tsx
+++ b/pages/auth-files/components/ImportModelsModal.tsx
@@ -80,7 +80,7 @@ export function ImportModelsModal({
             endAdornment={<Search size={16} className="text-slate-400" />}
           />
 
-          <div className="rounded-2xl border border-slate-200 bg-white/70 p-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 p-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <p className="text-xs text-slate-600 dark:text-white/65 tabular-nums">
               {t("auth_files.models_selected", {
                 models: importFilteredModels.length,

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -84,7 +84,7 @@ const RESTRICTION_TONE_CLASSES = {
   warning:
     "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/20 dark:bg-amber-500/15 dark:text-amber-200",
   neutral:
-    "border-slate-200 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/70",
+    "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/70",
 } as const;
 
 const CLAUDE_OAUTH_HEALTH_TONE_CLASSES = {
@@ -865,7 +865,7 @@ export function useAuthFilesFilesPresentation({
             <button
               type="button"
               disabled={state?.loading}
-              className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-1 text-xs tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 disabled:cursor-default disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
+              className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-slate-900/8 bg-slate-50 px-2 py-1 text-xs tabular-nums text-slate-600 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 disabled:cursor-default disabled:opacity-40 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/60 dark:hover:border-blue-600 dark:hover:bg-blue-950 dark:hover:text-blue-300"
               onClick={() => void checkAuthFileConnectivity(file.name)}
               title={t("auth_files.check_connectivity")}
               aria-label={t("auth_files.check_connectivity")}

--- a/pages/ccswitch-import-settings/CcSwitchImportModal.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportModal.tsx
@@ -44,7 +44,7 @@ export interface CcSwitchImportConfigOption {
 const labelClassName =
   "text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45";
 const controlClassName =
-  "h-10 rounded-xl border border-slate-200/80 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
+  "h-10 rounded-xl border border-slate-900/8 bg-white px-3 text-sm text-slate-900 shadow-none hover:border-slate-300 hover:bg-white focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:border-white/8 dark:bg-neutral-900 dark:text-white dark:hover:border-neutral-700 dark:focus-visible:ring-white/15";
 const fieldClassName = "flex flex-col gap-1.5";
 
 const iconByType: Record<CcSwitchClientType, string> = {
@@ -192,13 +192,13 @@ export function CcSwitchImportModal({
 
         <section
           data-testid="ccswitch-client-specific-panel"
-          className="min-h-[76px] rounded-2xl border border-slate-200/75 bg-white p-3.5 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-neutral-800 dark:bg-neutral-950/70"
+          className="min-h-[76px] rounded-2xl border border-slate-900/8 bg-white p-3.5 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/8 dark:bg-neutral-950/70"
         >
           {clientType === "claude" ? (
             <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(220px,0.9fr)] sm:items-center">
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-slate-200/75 bg-slate-50 dark:border-neutral-800 dark:bg-neutral-900">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-slate-50 dark:border-white/8 dark:bg-neutral-900">
                     <img src={iconByType.claude} alt="" className="h-5 w-5" />
                   </span>
                   <div className="min-w-0">
@@ -226,7 +226,7 @@ export function CcSwitchImportModal({
             </div>
           ) : (
             <div className="flex min-h-[54px] items-center gap-3">
-              <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200/75 bg-slate-50 dark:border-neutral-800 dark:bg-neutral-900">
+              <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-slate-50 dark:border-white/8 dark:bg-neutral-900">
                 <img src={iconByType[clientType]} alt="" className="h-6 w-6" />
               </span>
               <div className="min-w-0 flex-1">
@@ -242,7 +242,7 @@ export function CcSwitchImportModal({
               </div>
             </div>
           )}
-          <div className="mt-3 rounded-xl border border-slate-200/70 bg-slate-50/70 px-3 py-2.5 dark:border-neutral-800 dark:bg-neutral-900/60">
+          <div className="mt-3 rounded-xl border border-slate-900/8 bg-slate-50/70 px-3 py-2.5 dark:border-white/8 dark:bg-neutral-900/60">
             <div className={labelClassName}>{t("ccswitch.import_base_url")}</div>
             <div className="mt-1.5 truncate rounded-lg bg-white px-2.5 py-2 font-mono text-xs text-slate-700 dark:bg-neutral-950 dark:text-white/70">
               {baseUrl || "--"}
@@ -306,7 +306,7 @@ export function CcSwitchImportModal({
             />
           </label>
 
-          <label className="inline-flex h-10 items-center gap-2 rounded-xl border border-slate-200/75 bg-white px-3 text-sm font-semibold text-slate-700 shadow-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/70">
+          <label className="inline-flex h-10 items-center gap-2 rounded-xl border border-slate-900/8 bg-white px-3 text-sm font-semibold text-slate-700 shadow-none dark:border-white/8 dark:bg-neutral-900 dark:text-white/70">
             <Checkbox
               checked={enabled}
               onCheckedChange={onEnabledChange}

--- a/pages/ccswitch-import-settings/CcSwitchImportOptions.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportOptions.tsx
@@ -53,8 +53,8 @@ function ImportOptionButton({
       className={[
         "group inline-flex min-w-0 items-center text-left transition active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/10 dark:focus-visible:ring-white/15",
         compact
-          ? "h-8 gap-1.5 rounded-lg border border-transparent bg-white/80 px-2 text-slate-700 hover:border-slate-200 hover:bg-white hover:text-slate-950 dark:bg-neutral-950/60 dark:text-white/70 dark:hover:border-neutral-700 dark:hover:bg-neutral-900 dark:hover:text-white"
-          : "gap-3 rounded-xl border border-black/[0.06] bg-slate-50/55 p-3 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] hover:border-slate-200 hover:bg-white hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900/55 dark:hover:border-neutral-700 dark:hover:bg-neutral-900",
+          ? "h-8 gap-1.5 rounded-lg border border-transparent bg-white/80 px-2 text-slate-700 hover:border-slate-900/8 hover:bg-white hover:text-slate-950 dark:bg-neutral-950/60 dark:text-white/70 dark:hover:border-neutral-700 dark:hover:bg-neutral-900 dark:hover:text-white"
+          : "gap-3 rounded-xl border border-black/[0.06] bg-slate-50/55 p-3 shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] hover:border-slate-900/8 hover:bg-white hover:shadow-sm dark:border-white/[0.06] dark:bg-neutral-900/55 dark:hover:border-neutral-700 dark:hover:bg-neutral-900",
       ].join(" ")}
     >
       <span
@@ -62,7 +62,7 @@ function ImportOptionButton({
           "inline-flex shrink-0 items-center justify-center rounded-lg border bg-white dark:bg-neutral-950",
           compact
             ? "h-5 w-5 border-transparent"
-            : "h-10 w-10 border-slate-200/70 shadow-xs dark:border-neutral-800",
+            : "h-10 w-10 border-slate-900/8 shadow-xs dark:border-white/8",
         ].join(" ")}
       >
         <img
@@ -87,7 +87,7 @@ function ImportOptionButton({
           </span>
         )}
         {model && !compact ? (
-          <span className="mt-2 inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/45">
+          <span className="mt-2 inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-900/8 bg-white px-1.5 py-0.5 font-mono text-2xs text-slate-500 dark:border-white/8 dark:bg-neutral-950 dark:text-white/45">
             {t("ccswitch.model_hint", { model })}
           </span>
         ) : null}
@@ -195,7 +195,7 @@ export function CcSwitchImportOptions({
     <div
       role="group"
       aria-label={t("ccswitch.import_to_ccswitch")}
-      className="inline-flex min-w-0 flex-wrap items-center gap-1 rounded-xl border border-slate-200/70 bg-slate-50/75 p-1 dark:border-neutral-800 dark:bg-neutral-900/45"
+      className="inline-flex min-w-0 flex-wrap items-center gap-1 rounded-xl border border-slate-900/8 bg-slate-50/75 p-1 dark:border-white/8 dark:bg-neutral-900/45"
     >
       <span className="px-1.5 text-xs font-semibold text-slate-500 dark:text-white/45">
         {t("ccswitch.import_to_ccswitch")}

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -195,7 +195,7 @@ export function CcSwitchImportSettingsPage() {
           const client = getCcSwitchClientConfig(row.clientType);
           return (
             <div className="flex min-w-0 items-center gap-3">
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-slate-200/75 bg-slate-50 dark:border-neutral-800 dark:bg-neutral-900">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-slate-50 dark:border-white/8 dark:bg-neutral-900">
                 <img src={iconByType[row.clientType]} alt="" className="h-5 w-5" />
               </span>
               <div className="min-w-0">
@@ -233,7 +233,7 @@ export function CcSwitchImportSettingsPage() {
         width: "w-52",
         overflowTooltip: true,
         render: (row) => (
-          <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-200/70 bg-white px-2 py-1 font-mono text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white/65">
+          <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-900/8 bg-white px-2 py-1 font-mono text-xs text-slate-600 dark:border-white/8 dark:bg-neutral-950 dark:text-white/65">
             {row.defaultModel}
           </span>
         ),
@@ -250,7 +250,7 @@ export function CcSwitchImportSettingsPage() {
               {row.allowedChannelGroups.map((group) => (
                 <span
                   key={group}
-                  className="rounded-full border border-slate-200/75 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/60"
+                  className="rounded-full border border-slate-900/8 bg-slate-50 px-2 py-1 text-xs font-medium text-slate-600 dark:border-white/8 dark:bg-neutral-900 dark:text-white/60"
                 >
                   {group}
                 </span>

--- a/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
+++ b/pages/ccswitch-import-settings/__tests__/CcSwitchImportSettingsPage.test.tsx
@@ -1430,7 +1430,7 @@ describe("CcSwitchImportSettingsPage", () => {
     );
     mappingRows.slice(0, -1).forEach((row) => {
       Array.from(row.cells).forEach((cell) => {
-        expect(cell).toHaveClass("border-b", "border-slate-200");
+        expect(cell).toHaveClass("border-b", "border-slate-900/8");
         expect(cell).not.toHaveClass("first:rounded-l-lg", "last:rounded-r-lg");
       });
     });

--- a/pages/change-password/ChangePasswordPage.tsx
+++ b/pages/change-password/ChangePasswordPage.tsx
@@ -55,7 +55,7 @@ export function ChangePasswordPage() {
   return (
     <PageBackground variant="login">
       <div className="absolute right-6 top-6 z-20">
-        <ThemeToggleButton className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white/70 text-slate-700 shadow-sm backdrop-blur transition hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-slate-200" />
+        <ThemeToggleButton className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-900/8 bg-white/70 text-slate-700 shadow-sm backdrop-blur transition hover:bg-white dark:border-white/8 dark:bg-neutral-950/60 dark:text-slate-200" />
       </div>
       <main className="relative flex min-h-[100dvh] items-center justify-center px-6 py-12">
         <div className="w-full max-w-md">

--- a/pages/config/FloatingSaveBar.tsx
+++ b/pages/config/FloatingSaveBar.tsx
@@ -26,13 +26,13 @@ const STATUS_TONE: Record<SaveBarStatus, { icon?: ReactNode; tone: string; dot?:
     tone: "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-400/20 dark:bg-sky-500/15 dark:text-sky-200",
   },
   loading: {
-    tone: "border-slate-200 bg-slate-50 text-slate-600 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-slate-300",
+    tone: "border-slate-900/8 bg-slate-50 text-slate-600 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-slate-300",
   },
   error: {
     tone: "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-400/20 dark:bg-rose-500/15 dark:text-rose-300",
   },
   offline: {
-    tone: "border-slate-200 bg-slate-100 text-slate-500 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-slate-400",
+    tone: "border-slate-900/8 bg-slate-100 text-slate-500 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-slate-400",
   },
 };
 
@@ -109,7 +109,7 @@ export function FloatingSaveBar({
           "pointer-events-auto flex items-center gap-3 rounded-2xl border px-4 py-2.5 shadow-lg shadow-black/5",
           "bg-white/85 backdrop-blur-xl backdrop-saturate-150",
           "dark:bg-neutral-950/80 dark:backdrop-blur-xl dark:backdrop-saturate-150",
-          "border-slate-200/80 dark:border-neutral-700/60",
+          "border-slate-900/8 dark:border-neutral-700/60",
           "transition-all duration-[400ms]",
           visible ? "translate-y-0 opacity-100 scale-100" : "translate-y-8 opacity-0 scale-[0.96]",
         ].join(" ")}

--- a/pages/config/YamlCodeEditor.tsx
+++ b/pages/config/YamlCodeEditor.tsx
@@ -467,7 +467,7 @@ export const YamlCodeEditor = forwardRef<
   return (
     <div
       className={[
-        "overflow-hidden rounded-2xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-950",
+        "overflow-hidden rounded-2xl border border-slate-900/8 bg-white dark:border-white/8 dark:bg-neutral-950",
         heightClass,
       ].join(" ")}
     >
@@ -476,7 +476,7 @@ export const YamlCodeEditor = forwardRef<
           ref={gutterRef}
           aria-hidden="true"
           className={[
-            "scrollbar-hidden w-14 shrink-0 overflow-y-scroll overflow-x-hidden border-r border-slate-200 bg-slate-50/70 px-3 py-3 text-right font-mono text-xs leading-6 text-slate-400 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/35",
+            "scrollbar-hidden w-14 shrink-0 overflow-y-scroll overflow-x-hidden border-r border-slate-900/8 bg-slate-50/70 px-3 py-3 text-right font-mono text-xs leading-6 text-slate-400 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/35",
             "pointer-events-none",
           ].join(" ")}
         >

--- a/pages/config/visual/PayloadRuleEditors.tsx
+++ b/pages/config/visual/PayloadRuleEditors.tsx
@@ -67,8 +67,8 @@ function TextArea({
       rows={rows}
       spellCheck={false}
       className={[
-        "w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2.5 font-mono text-xs text-slate-900 outline-none transition",
-        "focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-100 dark:focus-visible:ring-white/15",
+        "w-full resize-y rounded-xl border border-slate-900/8 bg-white px-3 py-2.5 font-mono text-xs text-slate-900 outline-none transition",
+        "focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-white/8 dark:bg-neutral-900 dark:text-slate-100 dark:focus-visible:ring-white/15",
         disabled ? "opacity-60" : null,
       ]
         .filter(Boolean)
@@ -199,7 +199,7 @@ export function PayloadRulesEditor({
       }
     >
       {rules.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-4 text-center text-sm text-slate-600 dark:border-neutral-800 dark:bg-neutral-950/40 dark:text-white/65">
+        <div className="rounded-2xl border border-dashed border-slate-900/8 bg-white/60 p-4 text-center text-sm text-slate-600 dark:border-white/8 dark:bg-neutral-950/40 dark:text-white/65">
           {t("visual_config.no_rules")}
         </div>
       ) : (
@@ -207,7 +207,7 @@ export function PayloadRulesEditor({
           {rules.map((rule, ruleIndex) => (
             <div
               key={rule.id}
-              className="space-y-3 rounded-2xl border border-slate-200 bg-white/60 p-4 dark:border-neutral-800 dark:bg-neutral-950/40"
+              className="space-y-3 rounded-2xl border border-slate-900/8 bg-white/60 p-4 dark:border-white/8 dark:bg-neutral-950/40"
             >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -293,7 +293,7 @@ export function PayloadRulesEditor({
                 </div>
 
                 {(rule.params || []).length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-3 text-center text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-950/40 dark:text-white/65">
+                  <div className="rounded-2xl border border-dashed border-slate-900/8 bg-white/60 p-3 text-center text-xs text-slate-600 dark:border-white/8 dark:bg-neutral-950/40 dark:text-white/65">
                     {t("visual_config.no_params")}
                   </div>
                 ) : (
@@ -301,7 +301,7 @@ export function PayloadRulesEditor({
                     {(rule.params || []).map((param, paramIndex) => (
                       <div
                         key={param.id}
-                        className="space-y-2 rounded-2xl border border-slate-200 bg-white/60 p-3 dark:border-neutral-800 dark:bg-neutral-950/40"
+                        className="space-y-2 rounded-2xl border border-slate-900/8 bg-white/60 p-3 dark:border-white/8 dark:bg-neutral-950/40"
                       >
                         <div className="grid gap-2 lg:grid-cols-[1fr_180px_auto]">
                           <TextInput
@@ -448,7 +448,7 @@ export function PayloadFilterRulesEditor({
       }
     >
       {rules.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-4 text-center text-sm text-slate-600 dark:border-neutral-800 dark:bg-neutral-950/40 dark:text-white/65">
+        <div className="rounded-2xl border border-dashed border-slate-900/8 bg-white/60 p-4 text-center text-sm text-slate-600 dark:border-white/8 dark:bg-neutral-950/40 dark:text-white/65">
           {t("visual_config.no_rules")}
         </div>
       ) : (
@@ -456,7 +456,7 @@ export function PayloadFilterRulesEditor({
           {rules.map((rule, ruleIndex) => (
             <div
               key={rule.id}
-              className="space-y-3 rounded-2xl border border-slate-200 bg-white/60 p-4 dark:border-neutral-800 dark:bg-neutral-950/40"
+              className="space-y-3 rounded-2xl border border-slate-900/8 bg-white/60 p-4 dark:border-white/8 dark:bg-neutral-950/40"
             >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -542,7 +542,7 @@ export function PayloadFilterRulesEditor({
                 </div>
 
                 {(rule.params || []).length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-slate-200 bg-white/60 p-3 text-center text-xs text-slate-600 dark:border-neutral-800 dark:bg-neutral-950/40 dark:text-white/65">
+                  <div className="rounded-2xl border border-dashed border-slate-900/8 bg-white/60 p-3 text-center text-xs text-slate-600 dark:border-white/8 dark:bg-neutral-950/40 dark:text-white/65">
                     {t("visual_config.no_paths")}
                   </div>
                 ) : (

--- a/pages/config/visual/ResourceEfficiencyPanel.tsx
+++ b/pages/config/visual/ResourceEfficiencyPanel.tsx
@@ -296,7 +296,7 @@ ${t("resource_config.stats_preserved")}`}
               }
             />
           </div>
-          <div className="mt-5 space-y-5 border-t border-slate-200 pt-5 dark:border-white/10">
+          <div className="mt-5 space-y-5 border-t border-slate-900/8 pt-5 dark:border-white/10">
             <ToggleSwitch
               label={t("resource_config.cleanup_enabled_title")}
               description={t("resource_config.cleanup_enabled_desc")}

--- a/pages/content-moderation/components/ModerationChannelPickerModal.tsx
+++ b/pages/content-moderation/components/ModerationChannelPickerModal.tsx
@@ -542,7 +542,7 @@ export function ModerationChannelPickerModal({
           </TabsList>
         </Tabs>
 
-        <div className="rounded-xl border border-slate-200/80 bg-slate-50/70 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+        <div className="rounded-xl border border-slate-900/8 bg-slate-50/70 p-3 dark:border-white/10 dark:bg-white/[0.035]">
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-8">
             <TextInput
               size="sm"
@@ -636,7 +636,7 @@ export function ModerationChannelPickerModal({
             />
           </div>
 
-          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-slate-200/80 pt-3 dark:border-white/10">
+          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-slate-900/8 pt-3 dark:border-white/10">
             <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
               {tags.length > 0 ? (
                 tags.map((tag) => (

--- a/pages/content-moderation/components/ModerationMetricsModal.tsx
+++ b/pages/content-moderation/components/ModerationMetricsModal.tsx
@@ -129,7 +129,7 @@ export function ModerationMetricsModal({ open, onClose }: ModerationMetricsModal
       onClose={onClose}
     >
       <div className="space-y-4" aria-busy={loading}>
-        <div className="flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-neutral-800 dark:bg-white/[0.04]">
+        <div className="flex flex-wrap items-start justify-between gap-3 rounded-2xl border border-slate-900/8 bg-slate-50/80 px-4 py-3 dark:border-white/8 dark:bg-white/[0.04]">
           <div className="min-w-0">
             <p className="text-sm font-semibold text-slate-900 dark:text-white">
               {t("content_moderation.metrics_card_title")}

--- a/pages/content-moderation/components/ModerationTestModal.tsx
+++ b/pages/content-moderation/components/ModerationTestModal.tsx
@@ -163,7 +163,7 @@ export function ModerationTestModal({ profile, onClose }: ModerationTestModalPro
                     {scoreRows.map(([category, score]) => (
                       <tr
                         key={category}
-                        className="border-t border-slate-200/70 dark:border-white/10"
+                        className="border-t border-slate-900/8 dark:border-white/10"
                       >
                         <td className="px-3 py-2 font-mono text-slate-700 dark:text-white/75">
                           {category}

--- a/pages/content-moderation/components/ProfileEditorModal.tsx
+++ b/pages/content-moderation/components/ProfileEditorModal.tsx
@@ -285,7 +285,7 @@ export function ProfileEditorModal({
           void submit();
         }}
       >
-        <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+        <section className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
           <FormField label={t("content_moderation.profile_name")} required reserveMeta={false}>
             <TextInput
               value={draft.name}
@@ -297,7 +297,7 @@ export function ProfileEditorModal({
           </FormField>
         </section>
 
-        <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+        <section className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-2">
             <FormField label={t("content_moderation.keyword_mode")} reserveMeta={false}>
               <Select
@@ -359,7 +359,7 @@ export function ProfileEditorModal({
           </p>
         </section>
 
-        <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+        <section className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-2">
             <FormField
               label={t("content_moderation.base_url")}
@@ -426,7 +426,7 @@ export function ProfileEditorModal({
             ) : null}
           </div>
 
-          <div className="mt-5 border-t border-slate-200 pt-4 dark:border-neutral-800">
+          <div className="mt-5 border-t border-slate-900/8 pt-4 dark:border-white/8">
             <div className="mb-4">
               <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">
                 {t("content_moderation.thresholds")}
@@ -488,7 +488,7 @@ export function ProfileEditorModal({
           </div>
         </section>
 
-        <section className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+        <section className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
           <div className="grid gap-4 md:grid-cols-[180px_minmax(0,1fr)]">
             <FormField
               label={t("content_moderation.block_http_status")}

--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -130,7 +130,7 @@ const formatThroughputValue = (value: number) =>
   throughputNumberFormatter.format(Number.isFinite(value) ? value : 0);
 const formatRate = (rate: number) => `${rate.toFixed(2)}%`;
 const PANEL_SURFACE =
-  "rounded-2xl border border-slate-200/85 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
+  "rounded-2xl border border-slate-900/8 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-white/8 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
 
 const formatThroughputTooltip = (params: any) => {
   const items = Array.isArray(params) ? params : [params];
@@ -418,7 +418,7 @@ function ThroughputTrendChart({
           <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
             RPM
           </div>
-          <div className="mt-1 text-xl font-semibold tabular-nums text-blue-600 dark:text-blue-400">
+          <div className="mt-1 text-xl font-semibold tabular-nums text-indigo-600 dark:text-indigo-400">
             <DashboardMetricValue value={rpm} />
           </div>
         </div>

--- a/pages/dashboard/SystemMonitorSection.tsx
+++ b/pages/dashboard/SystemMonitorSection.tsx
@@ -18,7 +18,7 @@ import { Card } from "@code-proxy/ui";
 import type { SystemStats } from "./useSystemStats";
 
 const PANEL_SURFACE =
-  "rounded-2xl border border-slate-200/85 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
+  "rounded-2xl border border-slate-900/8 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-white/8 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
 
 /* ═══════════════════════════════════════════════════════════
    Helpers

--- a/pages/dashboard/__tests__/DashboardCards.test.ts
+++ b/pages/dashboard/__tests__/DashboardCards.test.ts
@@ -52,10 +52,10 @@ describe("dashboard card composition", () => {
     expect(source).toContain("connected?: boolean");
     expect(source).not.toContain("useSystemStats(3)");
     expect(source).not.toContain("ConcurrencyCard");
-    expect(source).not.toContain('className="rounded-2xl border border-slate-200 bg-white/50');
-    expect(source).not.toContain('className="rounded-xl border border-slate-200/80 bg-white');
+    expect(source).not.toContain('className="rounded-2xl border border-slate-900/8 bg-white/50');
+    expect(source).not.toContain('className="rounded-xl border border-slate-900/8 bg-white');
     expect(source).not.toContain(
-      'className="min-w-0 overflow-hidden rounded-xl border border-slate-200/80 bg-white',
+      'className="min-w-0 overflow-hidden rounded-xl border border-slate-900/8 bg-white',
     );
   });
 

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -859,7 +859,7 @@ export function EndUsersPage() {
               setCurrentPage(1);
             }}
             pageSizeOptions={END_USER_PAGE_SIZE_OPTIONS}
-            className="mt-3 border-t border-slate-100 pt-3 dark:border-neutral-800/60"
+            className="mt-3 border-t border-slate-100 pt-3 dark:border-white/8"
             labels={{
               firstPage: t("end_users.first_page", { defaultValue: "首页" }),
               previousPage: t("end_users.previous_page", { defaultValue: "上一页" }),
@@ -1088,7 +1088,7 @@ export function EndUsersPage() {
             />
           </section>
 
-          <section className="rounded-2xl border border-slate-200 p-4 dark:border-white/10">
+          <section className="rounded-2xl border border-slate-900/8 p-4 dark:border-white/10">
             <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
               {t("end_users.other_limits")}
             </h3>

--- a/pages/end-users/components/EndUserResetHistoryModal.tsx
+++ b/pages/end-users/components/EndUserResetHistoryModal.tsx
@@ -146,7 +146,7 @@ export function EndUserResetHistoryModal({
               : t("end_users.reset_history_amount_unavailable")}
           </div>
         </div>
-        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="rounded-xl border border-slate-900/8 bg-slate-50 px-4 py-3 dark:border-white/8 dark:bg-neutral-900">
           <div className="text-xs font-medium text-slate-500 dark:text-white/50">
             {t("end_users.reset_history_effective_used_summary")}
           </div>

--- a/pages/identity-fingerprint/CodexRecommendationsModal.tsx
+++ b/pages/identity-fingerprint/CodexRecommendationsModal.tsx
@@ -270,7 +270,7 @@ function RecommendationDetail({
   const { t } = useTranslation();
   if (!item) {
     return (
-      <div className="rounded-xl border border-dashed border-slate-200 p-4 text-sm text-slate-500 dark:border-neutral-800 dark:text-white/50">
+      <div className="rounded-xl border border-dashed border-slate-900/8 p-4 text-sm text-slate-500 dark:border-white/8 dark:text-white/50">
         {t("identity_fingerprint.recommend_detail_empty")}
       </div>
     );

--- a/pages/identity-fingerprint/IdentityFingerprintPage.tsx
+++ b/pages/identity-fingerprint/IdentityFingerprintPage.tsx
@@ -851,7 +851,7 @@ export function IdentityFingerprintPage() {
 
           <TabsContent value="codex" className="mt-5">
             <div className="space-y-4">
-              <section className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/45">
+              <section className="rounded-2xl border border-slate-900/8 bg-slate-50/70 p-4 dark:border-white/8 dark:bg-neutral-900/45">
                 <div className="flex flex-col gap-4 2xl:flex-row 2xl:items-start 2xl:justify-between">
                   <ToggleSwitch
                     checked={Boolean(codex.enabled)}
@@ -995,7 +995,7 @@ export function IdentityFingerprintPage() {
                         onChange={(event) => setCustomHeadersText(event.target.value)}
                         disabled={saving}
                         spellCheck={false}
-                        className="min-h-24 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-100"
+                        className="min-h-24 w-full rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-white/8 dark:bg-neutral-900 dark:text-slate-100"
                       />
                       <p className="mt-2 text-xs text-slate-500 dark:text-white/50">
                         {t("identity_fingerprint.custom_headers_hint")}
@@ -1033,7 +1033,7 @@ export function IdentityFingerprintPage() {
 
           <TabsContent value="claude" className="mt-5">
             <div className="space-y-4">
-              <section className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/45">
+              <section className="rounded-2xl border border-slate-900/8 bg-slate-50/70 p-4 dark:border-white/8 dark:bg-neutral-900/45">
                 <div className="flex flex-col gap-4 2xl:flex-row 2xl:items-start 2xl:justify-between">
                   <ToggleSwitch
                     checked={Boolean(claude.enabled)}
@@ -1204,7 +1204,7 @@ export function IdentityFingerprintPage() {
                         onChange={(event) => setClaudeCustomHeadersText(event.target.value)}
                         disabled={saving}
                         spellCheck={false}
-                        className="min-h-24 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-100"
+                        className="min-h-24 w-full rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-white/8 dark:bg-neutral-900 dark:text-slate-100"
                       />
                       <p className="mt-2 text-xs text-slate-500 dark:text-white/50">
                         {t("identity_fingerprint.claude_custom_headers_hint")}
@@ -1240,7 +1240,7 @@ export function IdentityFingerprintPage() {
 
           <TabsContent value="gemini" className="mt-5">
             <div className="space-y-4">
-              <section className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/45">
+              <section className="rounded-2xl border border-slate-900/8 bg-slate-50/70 p-4 dark:border-white/8 dark:bg-neutral-900/45">
                 <div className="flex flex-col gap-4 2xl:flex-row 2xl:items-start 2xl:justify-between">
                   <ToggleSwitch
                     checked={Boolean(geminiFingerprint.enabled)}
@@ -1318,7 +1318,7 @@ export function IdentityFingerprintPage() {
                         onChange={(event) => setGeminiCustomHeadersText(event.target.value)}
                         disabled={saving}
                         spellCheck={false}
-                        className="min-h-24 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-100"
+                        className="min-h-24 w-full rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-white/8 dark:bg-neutral-900 dark:text-slate-100"
                       />
                       <p className="mt-2 text-xs text-slate-500 dark:text-white/50">
                         {t("identity_fingerprint.gemini_custom_headers_hint")}
@@ -1336,7 +1336,7 @@ export function IdentityFingerprintPage() {
                         onChange={(event) => setGeminiHeadersText(event.target.value)}
                         disabled={saving}
                         spellCheck={false}
-                        className="min-h-36 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-100"
+                        className="min-h-36 w-full rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-white/8 dark:bg-neutral-900 dark:text-slate-100"
                       />
                       <p className="mt-2 text-xs text-slate-500 dark:text-white/50">
                         {t("identity_fingerprint.gemini_headers_hint")}
@@ -1393,7 +1393,7 @@ export function IdentityFingerprintPage() {
 
           <TabsContent value="xai" className="mt-5">
             <div className="space-y-4">
-              <section className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4 dark:border-neutral-800 dark:bg-neutral-900/45">
+              <section className="rounded-2xl border border-slate-900/8 bg-slate-50/70 p-4 dark:border-white/8 dark:bg-neutral-900/45">
                 <div className="flex flex-col gap-4 2xl:flex-row 2xl:items-start 2xl:justify-between">
                   <ToggleSwitch
                     checked={Boolean(xaiFingerprint.enabled)}
@@ -1474,7 +1474,7 @@ export function IdentityFingerprintPage() {
                         onChange={(event) => setXAICustomHeadersText(event.target.value)}
                         disabled={saving}
                         spellCheck={false}
-                        className="min-h-24 w-full rounded-2xl border border-slate-200 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-100"
+                        className="min-h-24 w-full rounded-2xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-sm text-slate-900 shadow-sm outline-none dark:border-white/8 dark:bg-neutral-900 dark:text-slate-100"
                       />
                       <p className="mt-2 text-xs text-slate-500 dark:text-white/50">
                         {t("identity_fingerprint.xai_custom_headers_hint")}
@@ -1632,7 +1632,7 @@ function RuntimeStatePanel({
           {effective.map((record, index) => (
             <div
               key={`${record.account_key || "default"}-${index}`}
-              className="rounded-xl border border-slate-200 bg-slate-50/70 p-3 dark:border-neutral-800 dark:bg-neutral-900/60"
+              className="rounded-xl border border-slate-900/8 bg-slate-50/70 p-3 dark:border-white/8 dark:bg-neutral-900/60"
             >
               <RecordHeader
                 accountKey={record.account_key}
@@ -1672,7 +1672,7 @@ function RuntimeStatePanel({
           {learned.map((record) => (
             <div
               key={record.account_key}
-              className="rounded-xl border border-slate-200 bg-white p-3 dark:border-neutral-800 dark:bg-neutral-950"
+              className="rounded-xl border border-slate-900/8 bg-white p-3 dark:border-white/8 dark:bg-neutral-950"
             >
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <RecordHeader
@@ -1843,7 +1843,7 @@ function SimplePanel({
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-950/60">
+    <section className="rounded-2xl border border-slate-900/8 bg-white p-4 dark:border-white/8 dark:bg-neutral-950/60">
       <div className="mb-4">
         <h3 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h3>
         {description ? (

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -200,7 +200,7 @@ export function ImageGenerationPage() {
                       </TabsContent>
                     ))}
                   </Tabs>
-                  <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs leading-6 text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/55">
+                  <div className="rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-3 text-xs leading-6 text-slate-600 dark:border-white/8 dark:bg-neutral-900 dark:text-white/55">
                     {t("image_generation.active_endpoint_hint", {
                       method: activeDoc.method,
                       path: activeDoc.path,
@@ -236,7 +236,7 @@ function EndpointCallDoc({ doc }: { doc: EndpointDoc }) {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-3xl border border-slate-200 bg-slate-50 p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="rounded-3xl border border-slate-900/8 bg-slate-50 p-4 dark:border-white/8 dark:bg-neutral-900">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -246,7 +246,7 @@ function EndpointCallDoc({ doc }: { doc: EndpointDoc }) {
               {t(doc.descriptionKey)}
             </p>
           </div>
-          <div className="flex max-w-full items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 font-mono text-xs dark:border-neutral-800 dark:bg-neutral-950">
+          <div className="flex max-w-full items-center gap-2 rounded-full border border-slate-900/8 bg-white px-3 py-1.5 font-mono text-xs dark:border-white/8 dark:bg-neutral-950">
             <span className="rounded-full bg-slate-900 px-2 py-0.5 font-semibold text-white dark:bg-white dark:text-neutral-950">
               {doc.method}
             </span>
@@ -820,7 +820,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
         title={t("image_generation.test_title")}
         onClose={onClose}
         maxWidth="max-w-[640px]"
-        panelClassName="w-full border-slate-200 bg-white shadow-2xl dark:border-neutral-800 dark:bg-neutral-950"
+        panelClassName="w-full border-slate-900/8 bg-white shadow-2xl dark:border-white/8 dark:bg-neutral-950"
         bodyHeightClassName="max-h-[calc(100vh-10rem)]"
         bodyClassName="!overflow-y-auto !px-4 !py-4 sm:!px-5"
       >
@@ -1043,7 +1043,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
           </div>
 
           {activeImage?.revisedPrompt ? (
-            <div className="shrink-0 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-slate-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-200">
+            <div className="shrink-0 rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-3 text-slate-700 dark:border-white/8 dark:bg-neutral-900 dark:text-slate-200">
               <p className="text-xs font-medium text-slate-500 dark:text-white/40">
                 {t("image_generation.revised_prompt_label")}
               </p>
@@ -1053,7 +1053,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
 
           <div
             data-testid="image-generation-composer"
-            className="relative shrink-0 overflow-hidden rounded-2xl border border-slate-200 bg-white px-2.5 pt-2.5 pb-11 shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
+            className="relative shrink-0 overflow-hidden rounded-2xl border border-slate-900/8 bg-white px-2.5 pt-2.5 pb-11 shadow-sm dark:border-white/8 dark:bg-neutral-950"
           >
             {editingSupported && uploadedImages.length > 0 ? (
               <div
@@ -1064,7 +1064,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                   <div
                     key={item.id}
                     data-testid="image-generation-upload-chip"
-                    className="group flex h-10 max-w-[220px] shrink-0 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-2 py-1.5 dark:border-neutral-800 dark:bg-neutral-900"
+                    className="group flex h-10 max-w-[220px] shrink-0 items-center gap-2 rounded-xl border border-slate-900/8 bg-slate-50 px-2 py-1.5 dark:border-white/8 dark:bg-neutral-900"
                   >
                     <button
                       type="button"
@@ -1077,7 +1077,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
                         name: item.file.name,
                       })}
                     >
-                      <span className="h-8 w-8 shrink-0 overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-neutral-700 dark:bg-neutral-950">
+                      <span className="h-8 w-8 shrink-0 overflow-hidden rounded-lg border border-slate-900/8 bg-white dark:border-neutral-700 dark:bg-neutral-950">
                         <img
                           src={item.previewUrl}
                           alt={item.file.name}

--- a/pages/image-generation/components/stageStyles.ts
+++ b/pages/image-generation/components/stageStyles.ts
@@ -27,8 +27,8 @@ export function imageStageClassName({
   const tone = failed
     ? "border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-100"
     : hasImage
-      ? "border-slate-200 bg-slate-100 dark:border-neutral-800 dark:bg-black"
-      : "border-slate-200 bg-slate-50 text-slate-500 dark:border-neutral-800 dark:bg-neutral-900 dark:text-white/55";
+      ? "border-slate-900/8 bg-slate-100 dark:border-white/8 dark:bg-black"
+      : "border-slate-900/8 bg-slate-50 text-slate-500 dark:border-white/8 dark:bg-neutral-900 dark:text-white/55";
 
   return ["relative overflow-hidden rounded-2xl border transition-all duration-200", size, tone].join(" ");
 }

--- a/pages/login/LoginPage.tsx
+++ b/pages/login/LoginPage.tsx
@@ -8,7 +8,14 @@ import {
   isApiClientError,
 } from "@code-proxy/api-client";
 import { useAuth } from "@app/providers/AuthProvider";
-import { PageBackground, Reveal, TextInput, ThemeToggleButton, useToast } from "@code-proxy/ui";
+import {
+  Button,
+  PageBackground,
+  Reveal,
+  TextInput,
+  ThemeToggleButton,
+  useToast,
+} from "@code-proxy/ui";
 import {
   BRAND_NAME_PREFIX,
   BRAND_NAME_SUFFIX,
@@ -117,7 +124,7 @@ export function LoginPage() {
   return (
     <PageBackground variant="login">
       <div className="absolute right-6 top-6 z-20">
-        <ThemeToggleButton className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-200 bg-white/70 text-slate-700 shadow-sm backdrop-blur transition hover:bg-white dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-slate-200" />
+        <ThemeToggleButton className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-slate-900/8 bg-white/70 text-slate-700 shadow-sm backdrop-blur transition hover:bg-white dark:border-white/8 dark:bg-neutral-950/60 dark:text-slate-200" />
       </div>
       <div className="relative mx-auto flex min-h-screen w-full max-w-6xl items-center px-6 py-12">
         <Reveal className="w-full">
@@ -134,7 +141,7 @@ export function LoginPage() {
                 </div>
               </div>
               <div className="space-y-6">
-                <h1 className="text-5xl font-semibold leading-[1.05] tracking-tight text-slate-900 sm:text-6xl dark:text-white">
+                <h1 className="font-display text-5xl font-bold leading-[1.05] tracking-tight text-slate-900 sm:text-6xl dark:text-white">
                   {t("login.hero_title_line1")}
                   <br />
                   {t("login.hero_title_line2")}
@@ -147,7 +154,7 @@ export function LoginPage() {
                 {[OpenAILogo, GeminiLogo, ClaudeLogo, VertexLogo].map((Logo, index) => (
                   <span
                     key={index}
-                    className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-slate-200 bg-white/60 dark:border-white/10 dark:bg-white/5"
+                    className="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-slate-900/8 bg-white/60 dark:border-white/10 dark:bg-white/5"
                   >
                     <Logo size={22} />
                   </span>
@@ -226,13 +233,14 @@ export function LoginPage() {
                     className="rounded-full px-5"
                   />
                 ) : null}
-                <button
+                <Button
                   type="submit"
-                  disabled={loading}
-                  className="w-full rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:opacity-70 dark:bg-white/10 dark:hover:bg-white/15"
+                  variant="primary"
+                  loading={loading}
+                  className="h-12 w-full"
                 >
                   {loading ? t("login.signing_in") : t("login.submit_button")}
-                </button>
+                </Button>
               </form>
             </section>
           </div>

--- a/pages/login/__tests__/LoginPage.test.tsx
+++ b/pages/login/__tests__/LoginPage.test.tsx
@@ -70,6 +70,15 @@ vi.mock("@code-proxy/ui", () => ({
     </div>
   ),
   ThemeToggleButton: () => <button type="button">theme</button>,
+  Button: ({
+    children,
+    loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean }) => (
+    <button {...props} disabled={props.disabled || loading} aria-busy={loading || undefined}>
+      {children}
+    </button>
+  ),
   useToast: () => toastMocks,
 }));
 

--- a/pages/logs/components/ErrorLogsTab.tsx
+++ b/pages/logs/components/ErrorLogsTab.tsx
@@ -31,7 +31,7 @@ const formatTimestamp = (value: number | undefined): string | undefined => {
 
 const statusBadgeClass = (status: number | undefined): string => {
   if (typeof status !== "number" || !Number.isFinite(status)) {
-    return "border-slate-200 bg-slate-50 text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70";
+    return "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70";
   }
   if (status >= 500) {
     return "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-200";
@@ -39,11 +39,11 @@ const statusBadgeClass = (status: number | undefined): string => {
   if (status >= 400) {
     return "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-200";
   }
-  return "border-slate-200 bg-slate-50 text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70";
+  return "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70";
 };
 
 const neutralBadgeClass =
-  "border-slate-200 bg-slate-50 text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70";
+  "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70";
 
 const buildDiagnosticBadges = (file: ErrorLogItem, t: Translate) => {
   const status = numberValue(file.status);
@@ -173,7 +173,7 @@ export function ErrorLogsTab({
       }
     >
       <div className="space-y-4 md:flex md:min-h-0 md:flex-1 md:flex-col md:space-y-0 md:gap-4">
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:shrink-0 dark:border-neutral-800 dark:bg-neutral-950/60">
+        <div className="rounded-2xl border border-slate-900/8 bg-white p-4 shadow-sm md:shrink-0 dark:border-white/8 dark:bg-neutral-950/60">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="min-w-0">
               <p className="text-sm font-semibold text-slate-900 dark:text-white">
@@ -205,7 +205,7 @@ export function ErrorLogsTab({
           </div>
         </div>
 
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:flex md:min-h-0 md:flex-1 md:flex-col dark:border-neutral-800 dark:bg-neutral-950/60">
+        <div className="rounded-2xl border border-slate-900/8 bg-white p-4 shadow-sm md:flex md:min-h-0 md:flex-1 md:flex-col dark:border-white/8 dark:bg-neutral-950/60">
           <p className="text-sm font-semibold text-slate-900 dark:text-white">
             {t("logs_page.error_log_files")}
           </p>
@@ -235,7 +235,7 @@ export function ErrorLogsTab({
                   return (
                     <div
                       key={file.name}
-                      className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm sm:flex-row sm:items-start sm:justify-between dark:border-neutral-800 dark:bg-neutral-950/60"
+                      className="flex flex-col gap-3 rounded-2xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm sm:flex-row sm:items-start sm:justify-between dark:border-white/8 dark:bg-neutral-950/60"
                     >
                       <div className="min-w-0 flex-1 space-y-2">
                         <div className="min-w-0">

--- a/pages/logs/components/LiveLogsTab.tsx
+++ b/pages/logs/components/LiveLogsTab.tsx
@@ -22,7 +22,7 @@ function Badge({ children, className }: { children: React.ReactNode; className: 
 
 function RequestPath({ children }: { children: string }) {
   return (
-    <code className="inline-block max-w-full rounded-md border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-xs font-medium leading-relaxed text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70">
+    <code className="inline-block max-w-full rounded-md border border-slate-900/8 bg-slate-50 px-2 py-1 font-mono text-xs font-medium leading-relaxed text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70">
       <span className="break-all">{children}</span>
     </code>
   );
@@ -133,7 +133,7 @@ export function LiveLogsTab({
           spellCheck={false}
         />
 
-        <div className="rounded-2xl border border-slate-200 bg-white/60 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/40">
+        <div className="rounded-2xl border border-slate-900/8 bg-white/60 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/40">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="text-xs text-slate-600 dark:text-white/65">{quotaSummary}</div>
             <Button
@@ -147,7 +147,7 @@ export function LiveLogsTab({
           </div>
 
           {optionsOpen ? (
-            <div className="mt-3 grid gap-4 border-t border-slate-200 pt-4 dark:border-neutral-800 sm:grid-cols-2">
+            <div className="mt-3 grid gap-4 border-t border-slate-900/8 pt-4 dark:border-white/8 sm:grid-cols-2">
               <ToggleSwitch
                 label={t("logs_page.auto_refresh")}
                 description={t("logs_page.auto_refresh_desc")}
@@ -174,8 +174,8 @@ export function LiveLogsTab({
         </div>
       </div>
 
-      <div className="mt-4 overflow-hidden rounded-2xl border border-slate-200 bg-white/70 shadow-sm md:flex md:min-h-0 md:flex-1 md:flex-col dark:border-neutral-800 dark:bg-neutral-950/60">
-        <div className="flex min-h-11 items-center justify-between gap-3 border-b border-slate-200 px-4 py-3 text-xs text-slate-600 dark:border-neutral-800 dark:text-white/65">
+      <div className="mt-4 overflow-hidden rounded-2xl border border-slate-900/8 bg-white/70 shadow-sm md:flex md:min-h-0 md:flex-1 md:flex-col dark:border-white/8 dark:bg-neutral-950/60">
+        <div className="flex min-h-11 items-center justify-between gap-3 border-b border-slate-900/8 px-4 py-3 text-xs text-slate-600 dark:border-white/8 dark:text-white/65">
           <div className="min-w-0">
             <span className="block whitespace-pre-wrap break-words tabular-nums">
               {t("logs_page.showing_lines", {
@@ -220,7 +220,7 @@ export function LiveLogsTab({
             </pre>
           ) : (
             <div className="overflow-x-auto">
-              <div className="min-w-[640px] divide-y divide-slate-200 rounded-xl border border-slate-200 bg-white/70 dark:divide-neutral-800 dark:border-neutral-800 dark:bg-neutral-950/40">
+              <div className="min-w-[640px] divide-y divide-slate-200 rounded-xl border border-slate-900/8 bg-white/70 dark:divide-neutral-800 dark:border-white/8 dark:bg-neutral-950/40">
                 {parsedVisibleLines.map((line, index) => {
                   const levelStyles = line.level ? getLevelStyles(line.level) : null;
                   const rowClassName = [
@@ -248,12 +248,12 @@ export function LiveLogsTab({
                               </Badge>
                             ) : null}
                             {line.source ? (
-                              <Badge className="border-slate-200 bg-white text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/70">
+                              <Badge className="border-slate-900/8 bg-white text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/70">
                                 {line.source}
                               </Badge>
                             ) : null}
                             {line.requestId ? (
-                              <Badge className="border-slate-200 bg-slate-50 font-mono text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70">
+                              <Badge className="border-slate-900/8 bg-slate-50 font-mono text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70">
                                 {line.requestId}
                               </Badge>
                             ) : null}
@@ -263,17 +263,17 @@ export function LiveLogsTab({
                               </Badge>
                             ) : null}
                             {line.latency ? (
-                              <Badge className="border-slate-200 bg-white text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/70">
+                              <Badge className="border-slate-900/8 bg-white text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/70">
                                 {line.latency}
                               </Badge>
                             ) : null}
                             {line.ip ? (
-                              <Badge className="border-slate-200 bg-white font-mono text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/70">
+                              <Badge className="border-slate-900/8 bg-white font-mono text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/70">
                                 {line.ip}
                               </Badge>
                             ) : null}
                             {line.method ? (
-                              <Badge className="border-slate-200 bg-white text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/70">
+                              <Badge className="border-slate-900/8 bg-white text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/70">
                                 {line.method}
                               </Badge>
                             ) : null}

--- a/pages/logs/logsHelpers.ts
+++ b/pages/logs/logsHelpers.ts
@@ -222,19 +222,19 @@ export const getLevelStyles = (level: LogLevel): { badge: string; row: string } 
     case "debug":
       return {
         badge:
-          "border-slate-200 bg-slate-100 text-slate-700 dark:border-neutral-800 dark:bg-white/10 dark:text-white/70",
+          "border-slate-900/8 bg-slate-100 text-slate-700 dark:border-white/8 dark:bg-white/10 dark:text-white/70",
         row: "",
       };
     case "trace":
       return {
         badge:
-          "border-slate-200 bg-slate-50 text-slate-600 dark:border-neutral-800 dark:bg-white/5 dark:text-white/55",
+          "border-slate-900/8 bg-slate-50 text-slate-600 dark:border-white/8 dark:bg-white/5 dark:text-white/55",
         row: "",
       };
     default:
       return {
         badge:
-          "border-slate-200 bg-slate-50 text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70",
+          "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70",
         row: "",
       };
   }
@@ -253,5 +253,5 @@ export const getStatusStyles = (statusCode: number): string => {
   if (statusCode >= 500) {
     return "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-200";
   }
-  return "border-slate-200 bg-slate-50 text-slate-700 dark:border-neutral-800 dark:bg-white/5 dark:text-white/70";
+  return "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/8 dark:bg-white/5 dark:text-white/70";
 };

--- a/pages/menu-management/MenuIconPicker.tsx
+++ b/pages/menu-management/MenuIconPicker.tsx
@@ -211,7 +211,7 @@ export function MenuIconPicker({
         <button
           type="button"
           disabled={disabled}
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-500 transition-colors hover:border-slate-300 hover:text-slate-800 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-950 dark:hover:border-neutral-600 dark:hover:text-white"
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-white text-slate-500 transition-colors hover:border-slate-300 hover:text-slate-800 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-950 dark:hover:border-neutral-600 dark:hover:text-white"
           aria-label={t("identity_admin.menu_icon_picker")}
           onClick={() => {
             if (!disabled) setOpen((current) => !current);
@@ -225,10 +225,10 @@ export function MenuIconPicker({
         ? createPortal(
             <div
               ref={panelRef}
-              className="fixed z-[9999] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-[0_16px_40px_rgba(15,23,42,0.14)] dark:border-neutral-800 dark:bg-neutral-950 dark:shadow-[0_16px_40px_rgba(0,0,0,0.38)]"
+              className="fixed z-[9999] overflow-hidden rounded-xl border border-slate-900/8 bg-white shadow-[0_16px_40px_rgba(15,23,42,0.14)] dark:border-white/8 dark:bg-neutral-950 dark:shadow-[0_16px_40px_rgba(0,0,0,0.38)]"
               style={{ top: pos.top, left: pos.left, width: pos.width }}
             >
-              <div className="flex items-center gap-2 border-b border-slate-200 px-3 py-2 dark:border-neutral-800">
+              <div className="flex items-center gap-2 border-b border-slate-900/8 px-3 py-2 dark:border-white/8">
                 <Search size={14} className="shrink-0 text-slate-400" aria-hidden="true" />
                 <input
                   autoFocus

--- a/pages/menu-management/MenuManagementPage.tsx
+++ b/pages/menu-management/MenuManagementPage.tsx
@@ -732,7 +732,7 @@ export function MenuManagementPage() {
             </div>
           </div>
 
-          <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-slate-200 pt-4 dark:border-neutral-800">
+          <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-slate-900/8 pt-4 dark:border-white/8">
             <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
               <input
                 type="checkbox"

--- a/pages/model-plaza/ModelPlazaPage.tsx
+++ b/pages/model-plaza/ModelPlazaPage.tsx
@@ -97,8 +97,8 @@ function PriceChip({
       className={[
         "min-w-0 rounded-lg border px-2 py-1.5",
         muted
-          ? "border-slate-100 bg-slate-50/70 dark:border-neutral-800 dark:bg-neutral-900/40"
-          : "border-slate-200/80 bg-white dark:border-neutral-700/70 dark:bg-neutral-950/50",
+          ? "border-slate-100 bg-slate-50/70 dark:border-white/8 dark:bg-neutral-900/40"
+          : "border-slate-900/8 bg-white dark:border-neutral-700/70 dark:bg-neutral-950/50",
       ].join(" ")}
     >
       <div className="text-2xs font-medium uppercase tracking-wide text-slate-400 dark:text-white/35">
@@ -196,7 +196,7 @@ function ModelPlazaCard({
         className="group h-full transition hover:border-indigo-200/70 hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.06)] dark:hover:border-indigo-500/25 dark:hover:shadow-[2px_2px_10px_rgb(0_0_0_/_0.28)]"
       >
         <div className="flex items-start gap-3">
-          <div className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200/80 bg-slate-50 dark:border-neutral-700/70 dark:bg-neutral-900/70">
+          <div className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-900/8 bg-slate-50 dark:border-neutral-700/70 dark:bg-neutral-900/70">
             <span className="pointer-events-none absolute text-sm font-bold text-slate-300 dark:text-white/25">
               {vendorGlyph}
             </span>

--- a/pages/models/ModelsPage.tsx
+++ b/pages/models/ModelsPage.tsx
@@ -983,11 +983,11 @@ export function ModelsPage() {
                 className="-mx-1 min-h-0 flex-1 space-y-2 overflow-x-hidden overflow-y-auto px-1 py-1"
               >
                 {libraryOwners.length === 0 ? (
-                  <div className="rounded-xl border border-dashed border-slate-200 px-3 py-6 text-center text-sm text-slate-500 dark:border-neutral-800 dark:text-white/45">
+                  <div className="rounded-xl border border-dashed border-slate-900/8 px-3 py-6 text-center text-sm text-slate-500 dark:border-white/8 dark:text-white/45">
                     {t("models_page.no_owner_presets")}
                   </div>
                 ) : filteredLibraryOwners.length === 0 ? (
-                  <div className="rounded-xl border border-dashed border-slate-200 px-3 py-6 text-center text-sm text-slate-500 dark:border-neutral-800 dark:text-white/45">
+                  <div className="rounded-xl border border-dashed border-slate-900/8 px-3 py-6 text-center text-sm text-slate-500 dark:border-white/8 dark:text-white/45">
                     {t("models_page.no_owner_search_results")}
                   </div>
                 ) : (
@@ -1095,7 +1095,7 @@ export function ModelsPage() {
               {canManageOpenRouterSync ? (
                 <div
                   data-testid="openrouter-sync-section"
-                  className="mb-3 border-b border-slate-200 pb-3 dark:border-neutral-800"
+                  className="mb-3 border-b border-slate-900/8 pb-3 dark:border-white/8"
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">

--- a/pages/models/components/ModelFormModal.tsx
+++ b/pages/models/components/ModelFormModal.tsx
@@ -169,7 +169,7 @@ export function ModelFormModal({
               value={form.description}
               onChange={(event) => onUpdateForm({ description: event.target.value })}
               rows={3}
-              className="min-h-20 w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-300 focus:ring-2 focus:ring-slate-200/70 dark:border-neutral-800 dark:bg-neutral-950 dark:text-white dark:focus:border-neutral-700 dark:focus:ring-white/10"
+              className="min-h-20 w-full resize-y rounded-xl border border-slate-900/8 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-300 focus:ring-2 focus:ring-slate-200/70 dark:border-white/8 dark:bg-neutral-950 dark:text-white dark:focus:border-neutral-700 dark:focus:ring-white/10"
               placeholder={t("models_page.description_placeholder")}
             />
           </div>

--- a/pages/models/components/ModelTestModal.tsx
+++ b/pages/models/components/ModelTestModal.tsx
@@ -182,7 +182,7 @@ export function ModelTestModal({
               {t("models_page.test_channel")}
             </label>
             {noChannels ? (
-              <p className="rounded-lg border border-dashed border-slate-200 px-3 py-2 text-sm text-slate-500 dark:border-neutral-800 dark:text-white/45">
+              <p className="rounded-lg border border-dashed border-slate-900/8 px-3 py-2 text-sm text-slate-500 dark:border-white/8 dark:text-white/45">
                 {t("models_page.test_no_channels")}
               </p>
             ) : (

--- a/pages/monitor/MonitorDashboardSections.tsx
+++ b/pages/monitor/MonitorDashboardSections.tsx
@@ -79,7 +79,7 @@ export function MonitorKpiSection({
 
       {!hasData && !isLoading ? (
         <Reveal>
-          <section className="rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-center shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <section className="rounded-2xl border border-dashed border-slate-900/8 bg-white p-10 text-center shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <div className="mx-auto flex max-w-md flex-col items-center gap-3">
               <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-900/5 text-slate-700 dark:bg-white/10 dark:text-white/70">
                 <ChartSpline size={20} />

--- a/pages/monitor/MonitorToolbarSection.tsx
+++ b/pages/monitor/MonitorToolbarSection.tsx
@@ -51,7 +51,7 @@ export function MonitorToolbarSection({
           <button
             type="button"
             onClick={applyFilter}
-            className="inline-flex items-center gap-1.5 rounded-2xl border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/80 dark:hover:bg-white/10"
+            className="inline-flex items-center gap-1.5 rounded-2xl border border-slate-900/8 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/80 dark:hover:bg-white/10"
           >
             <Filter size={14} />
             {t("monitor.apply")}

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -59,8 +59,8 @@ export function ProviderCard({
           ? "h-fit self-start min-h-0"
           : "min-h-[220px] max-h-[260px]",
         selected
-          ? "border-blue-400 bg-blue-50/50 ring-1 ring-blue-200 dark:border-blue-500/50 dark:bg-blue-950/20 dark:ring-blue-500/20"
-          : "border-slate-200 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-neutral-800 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
+          ? "border-indigo-400 bg-indigo-50/50 ring-1 ring-indigo-200 dark:border-indigo-500/50 dark:bg-indigo-950/20 dark:ring-indigo-500/20"
+          : "border-slate-900/8 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-white/8 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
         dimmed ? "opacity-50" : "",
         className,
       ]
@@ -175,7 +175,7 @@ export function ProviderCardSkeleton({
   return (
     <div
       className={[
-        "flex flex-col rounded-xl border border-slate-200 bg-white/70 px-4 py-3 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60",
+        "flex flex-col rounded-xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60",
         naturalHeight
           ? "h-fit min-h-[220px] w-full max-w-[22rem] flex-none self-start"
           : "h-[220px]",

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -304,7 +304,7 @@ export function ProviderKeyListCard({
                     {headerEntries.map(([k, v]) => (
                       <span
                         key={k}
-                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-900/8 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/75"
                         title={`${k}: ${String(v)}`}
                       >
                         <span className="shrink-0 font-semibold">{k}:</span>

--- a/pages/providers/components/AmpcodePanel.tsx
+++ b/pages/providers/components/AmpcodePanel.tsx
@@ -67,7 +67,7 @@ export function AmpcodePanel({
             onChange={(e) => setAmpUpstreamApiKey(e.currentTarget.value)}
             placeholder={t("providers.upstream_key_hint")}
           />
-          <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <ToggleSwitch
               label={t("providers.force_mapping")}
               description={t("providers.force_mapping_desc")}
@@ -75,7 +75,7 @@ export function AmpcodePanel({
               onCheckedChange={setAmpForceMappings}
             />
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+          <div className="rounded-2xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
             <p className="text-xs text-slate-600 dark:text-white/65">
               {t("providers.current_status", {
                 status: ampcode ? t("providers.status_loaded") : t("providers.status_not_loaded"),

--- a/pages/providers/components/ExcludedModelsEditor.tsx
+++ b/pages/providers/components/ExcludedModelsEditor.tsx
@@ -4,7 +4,7 @@ import { Button } from "@code-proxy/ui";
 import type { ProviderKeyDraft } from "../providers-helpers";
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
     {children}
   </div>
 );
@@ -53,7 +53,7 @@ export function ExcludedModelsEditor({
         }}
         placeholder={t("providers.excluded_placeholder")}
         aria-label="excludedModels"
-        className="mt-3 min-h-[140px] w-full resize-y rounded-xl border border-slate-200 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-800 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
+        className="mt-3 min-h-[140px] w-full resize-y rounded-xl border border-slate-900/8 bg-white px-3 py-2 font-mono text-xs text-slate-900 outline-none transition placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-white/8 dark:bg-neutral-950 dark:text-slate-100 dark:placeholder:text-neutral-500 dark:focus-visible:ring-white/15"
       />
 
       <p className="mt-2 text-xs text-slate-500 dark:text-white/55">

--- a/pages/providers/components/OpenAIKeyEntriesEditor.tsx
+++ b/pages/providers/components/OpenAIKeyEntriesEditor.tsx
@@ -11,7 +11,7 @@ import { ModerationProfileSelect } from "@features/content-moderation";
 import { useModerationPermissions } from "@app/providers/useModerationPermissions";
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
     {children}
   </div>
 );

--- a/pages/providers/components/OpenAIKeyEntrySummary.tsx
+++ b/pages/providers/components/OpenAIKeyEntrySummary.tsx
@@ -36,7 +36,7 @@ export function OpenAIKeyEntrySummary({
           return (
             <div
               key={`${entry.apiKey}:${entryIndex}`}
-              className="grid gap-2 rounded-xl border border-slate-200 bg-white/70 px-3 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-950/60 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+              className="grid gap-2 rounded-xl border border-slate-900/8 bg-white/70 px-3 py-2 text-xs dark:border-white/8 dark:bg-neutral-950/60 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
             >
               <div className="min-w-0">
                 <p className="truncate font-mono text-slate-900 dark:text-white">

--- a/pages/providers/components/OpenAIModelDiscoveryPanel.tsx
+++ b/pages/providers/components/OpenAIModelDiscoveryPanel.tsx
@@ -102,7 +102,7 @@ export function OpenAIModelDiscoveryPanel({
       {discoveredModels.length ? (
         <div
           ref={discoveredSectionRef}
-          className="rounded-xl border border-slate-200 bg-slate-50/50 p-4 dark:border-neutral-800 dark:bg-neutral-900/40"
+          className="rounded-xl border border-slate-900/8 bg-slate-50/50 p-4 dark:border-white/8 dark:bg-neutral-900/40"
         >
           <div className="flex flex-wrap items-center justify-between gap-2">
             <p className="text-xs font-medium text-slate-700 dark:text-white/70">
@@ -153,7 +153,7 @@ export function OpenAIModelDiscoveryPanel({
 
           <div
             ref={discoveredListRef}
-            className="mt-2.5 max-h-52 overflow-y-auto rounded-xl border border-slate-200/80 bg-white dark:border-neutral-800/60 dark:bg-neutral-950/60"
+            className="mt-2.5 max-h-52 overflow-y-auto rounded-xl border border-slate-900/8 bg-white dark:border-white/8 dark:bg-neutral-950/60"
             role="list"
             aria-label={t("providers.found_models", {
               count: discoveredModels.length,
@@ -185,7 +185,7 @@ export function OpenAIModelDiscoveryPanel({
                         type="checkbox"
                         checked={checked}
                         onChange={() => handleCheckboxChange(model.id)}
-                        className="h-3.5 w-3.5 shrink-0 rounded border-slate-300 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-400/35 dark:border-neutral-600 dark:bg-neutral-900 dark:text-blue-400 dark:focus-visible:ring-blue-400/20"
+                        className="h-3.5 w-3.5 shrink-0 rounded border-slate-300 text-indigo-600 focus-visible:ring-2 focus-visible:ring-indigo-400/35 dark:border-neutral-600 dark:bg-neutral-900 dark:text-indigo-400 dark:focus-visible:ring-indigo-400/20"
                       />
                       <span className="truncate">{model.id}</span>
                     </label>

--- a/pages/providers/components/OpenAIProviderBasicSection.tsx
+++ b/pages/providers/components/OpenAIProviderBasicSection.tsx
@@ -5,7 +5,7 @@ import { buildModelsEndpoint } from "../providers-helpers";
 import type { OpenAIDraft } from "../providers-helpers";
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
     {children}
   </div>
 );

--- a/pages/providers/components/OpenAIProviderModal.tsx
+++ b/pages/providers/components/OpenAIProviderModal.tsx
@@ -87,7 +87,7 @@ export function OpenAIProviderModal({
       <div className="space-y-5">
         <OpenAIProviderBasicSection openaiDraft={openaiDraft} setOpenaiDraft={setOpenaiDraft} />
 
-        <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+        <div className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
           <ModerationProfileSelect
         canRead={moderationPerms.canRead}
         canWrite={moderationPerms.canWrite}
@@ -99,7 +99,7 @@ export function OpenAIProviderModal({
           />
         </div>
 
-        <div className="border-t border-slate-200/60 pt-5 dark:border-neutral-800/60">
+        <div className="border-t border-slate-900/8 pt-5 dark:border-white/8">
           <OpenAIKeyEntriesEditor
             openaiDraft={openaiDraft}
             setOpenaiDraft={setOpenaiDraft}
@@ -109,7 +109,7 @@ export function OpenAIProviderModal({
           />
         </div>
 
-        <div className="border-t border-slate-200/60 pt-5 dark:border-neutral-800/60">
+        <div className="border-t border-slate-900/8 pt-5 dark:border-white/8">
           <OpenAIProviderModelsSection
             openaiDraft={openaiDraft}
             setOpenaiDraft={setOpenaiDraft}

--- a/pages/providers/components/OpenAIProviderModelsSection.tsx
+++ b/pages/providers/components/OpenAIProviderModelsSection.tsx
@@ -4,7 +4,7 @@ import type { OpenAIDraft } from "../providers-helpers";
 import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
     {children}
   </div>
 );

--- a/pages/providers/components/OpenAIProvidersTab.tsx
+++ b/pages/providers/components/OpenAIProvidersTab.tsx
@@ -152,7 +152,7 @@ export function OpenAIProvidersTab({
                     {headerEntries.map(([key, value]) => (
                       <span
                         key={key}
-                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-900/8 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/75"
                         title={`${key}: ${String(value)}`}
                       >
                         <span className="shrink-0 font-semibold">{key}:</span>

--- a/pages/providers/components/ProviderAccessChips.tsx
+++ b/pages/providers/components/ProviderAccessChips.tsx
@@ -12,7 +12,7 @@ export function ProviderAccessChips({ accessSummary }: ProviderAccessChipsProps)
 
   const accessTone =
     accessSummary.totalKeys === 0
-      ? "border-slate-200 bg-slate-50 text-slate-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/65"
+      ? "border-slate-900/8 bg-slate-50 text-slate-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-white/65"
       : accessSummary.reachableKeys === 0
         ? "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200"
         : accessSummary.reachableKeys < accessSummary.totalKeys

--- a/pages/providers/components/ProviderKeyBasicTab.tsx
+++ b/pages/providers/components/ProviderKeyBasicTab.tsx
@@ -7,7 +7,7 @@ import { ToggleSwitch } from "@code-proxy/ui";
 import type { ProviderKeyDraft } from "../providers-helpers";
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
     {children}
   </div>
 );
@@ -137,7 +137,7 @@ export function ProviderKeyBasicTab({
                   type="button"
                   onClick={() => void copyText(keyDraft.apiKey.trim())}
                   disabled={!keyDraft.apiKey.trim()}
-                  className="inline-flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 bg-white/80 text-slate-700 shadow-sm transition hover:bg-white disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-slate-200 dark:hover:bg-neutral-950"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-lg border border-slate-900/8 bg-white/80 text-slate-700 shadow-sm transition hover:bg-white disabled:opacity-50 dark:border-white/8 dark:bg-neutral-950/70 dark:text-slate-200 dark:hover:bg-neutral-950"
                   aria-label={t("providers.copy_api_key")}
                   title={t("providers.copy")}
                 >

--- a/pages/providers/components/ProviderKeyModal.tsx
+++ b/pages/providers/components/ProviderKeyModal.tsx
@@ -680,7 +680,7 @@ export function ProviderKeyModal({
         value={modalTab}
         onValueChange={(next) => setModalTab(next as ProviderKeyModalTab)}
       >
-        <div className="sticky top-0 z-20 border-b border-slate-200 bg-white/95 px-5 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/95">
+        <div className="sticky top-0 z-20 border-b border-slate-900/8 bg-white/95 px-5 py-3 backdrop-blur dark:border-white/8 dark:bg-neutral-950/95">
           <TabsList>
             <TabsTrigger value="basic">
               {t("providers.modal_tab_basic")}

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -18,7 +18,7 @@ import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 type ModelAccessRow = { id: string; owned_by?: string };
 
 const SectionCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-lg border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60">
+  <div className="rounded-lg border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60">
     {children}
   </div>
 );

--- a/pages/providers/components/ProviderKeyRequestTab.tsx
+++ b/pages/providers/components/ProviderKeyRequestTab.tsx
@@ -19,7 +19,7 @@ const SectionCard = ({
 }) => (
   <div
     className={[
-      "rounded-xl border border-slate-200 bg-white/70 p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/60",
+      "rounded-xl border border-slate-900/8 bg-white/70 p-4 shadow-sm dark:border-white/8 dark:bg-neutral-950/60",
       className,
     ]
       .filter(Boolean)

--- a/pages/providers/components/ProviderKeyStatusBadges.tsx
+++ b/pages/providers/components/ProviderKeyStatusBadges.tsx
@@ -38,20 +38,20 @@ export function ProviderKeyStatusBadges({
       >
         {editKeyEnabled ? t("providers.enabled") : t("providers.disabled")}
       </span>
-      <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75">
+      <span className="rounded-full border border-slate-900/8 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/75">
         {t("providers.headers_optional")}:{" "}
         <span className="font-semibold tabular-nums">{editKeyHeaderCount}</span>
       </span>
       {showModelBadges ? (
         <>
-          <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75">
+          <span className="rounded-full border border-slate-900/8 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/75">
             {t("providers.models_label")}:{" "}
             <span className="font-semibold tabular-nums">
               {editKeyModelCount}
             </span>
           </span>
           {showExcludedBadge ? (
-            <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-neutral-800 dark:bg-neutral-950/60 dark:text-white/75">
+            <span className="rounded-full border border-slate-900/8 bg-white px-2.5 py-1 text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/75">
               {t("providers.excluded_models_label")}:{" "}
               <span className="font-semibold tabular-nums">
                 {editKeyExcludedCount}

--- a/pages/providers/components/ProviderSummaryStrip.tsx
+++ b/pages/providers/components/ProviderSummaryStrip.tsx
@@ -16,7 +16,7 @@ export function ProviderSummaryStrip({
   if (count === 0) return null;
 
   return (
-    <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-2 text-xs dark:border-neutral-800">
+    <div className="flex items-center gap-3 border-b border-slate-100 px-4 py-2 text-xs dark:border-white/8">
       <span className="font-medium text-slate-500 dark:text-white/55">
         {t("providers.total_configs", { count })}
       </span>

--- a/pages/providers/components/ProviderTabsWithCounts.tsx
+++ b/pages/providers/components/ProviderTabsWithCounts.tsx
@@ -86,7 +86,7 @@ export function ProviderTabsWithCounts({ tabs, value }: ProviderTabsWithCountsPr
                     className={
                       value === tab.id
                         ? "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[#18181B] px-1 text-2xs font-semibold leading-none tabular-nums text-white shadow-sm ring-1 ring-black/10 dark:bg-white dark:text-[#18181B] dark:ring-white/15"
-                        : "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-100 px-1 text-2xs font-semibold leading-none tabular-nums text-blue-700 shadow-sm ring-1 ring-blue-200/80 dark:bg-blue-500/25 dark:text-blue-100 dark:ring-blue-300/25"
+                        : "absolute -right-0.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-indigo-100 px-1 text-2xs font-semibold leading-none tabular-nums text-indigo-700 shadow-sm ring-1 ring-indigo-200/80 dark:bg-indigo-500/25 dark:text-indigo-100 dark:ring-indigo-300/25"
                     }
                   >
                     {tab.count}

--- a/pages/providers/components/ProviderWorkspace.tsx
+++ b/pages/providers/components/ProviderWorkspace.tsx
@@ -16,8 +16,8 @@ export function ProviderWorkspace({
   actions,
 }: ProviderWorkspaceProps) {
   return (
-    <section className="flex min-h-0 flex-1 flex-col rounded-xl border border-slate-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 px-4 py-3 dark:border-neutral-800">
+    <section className="flex min-h-0 flex-1 flex-col rounded-xl border border-slate-900/8 bg-white dark:border-white/8 dark:bg-neutral-900">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 px-4 py-3 dark:border-white/8">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <h3 className="truncate text-sm font-semibold text-slate-900 dark:text-white">

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1759,7 +1759,7 @@ export function ProvidersPage() {
         {importPreview ? (
           <div className="space-y-4 text-sm text-slate-700 dark:text-white/75">
             <div className="grid gap-2 sm:grid-cols-2">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
+              <div className="rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-3 dark:border-white/8 dark:bg-neutral-900">
                 <div>
                   {t("providers.diff_added", {
                     count: importPreview.diff.added,
@@ -1771,7 +1771,7 @@ export function ProvidersPage() {
                   })}
                 </div>
               </div>
-              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-neutral-800 dark:bg-neutral-900">
+              <div className="rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-3 dark:border-white/8 dark:bg-neutral-900">
                 <div>
                   {t("providers.diff_removed", {
                     count: importPreview.diff.removed,

--- a/pages/providers/components/ProvidersToolbar.tsx
+++ b/pages/providers/components/ProvidersToolbar.tsx
@@ -99,7 +99,7 @@ export function ProvidersToolbar({
                 ? t("providers.batch_deselect_all")
                 : t("providers.batch_select_all")}
               {hasSelection ? (
-                <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-2xs font-semibold leading-none text-white">
+                <span className="absolute -right-1.5 -top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-indigo-600 px-1 text-2xs font-semibold leading-none text-white">
                   {selectedExportCount}
                 </span>
               ) : null}

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -273,7 +273,7 @@ export function ProxiesPage() {
         width: "w-[180px]",
         render: (entry) => (
           <div className="flex min-w-0 items-center gap-2">
-            <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-slate-300">
+            <span className="rounded-full border border-slate-900/8 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:border-white/8 dark:bg-neutral-900 dark:text-slate-300">
               {proxyProtocol(entry.url)}
             </span>
             <span className="truncate font-mono text-xs text-slate-700 dark:text-white/70">

--- a/pages/request-logs/RequestLogsFilters.tsx
+++ b/pages/request-logs/RequestLogsFilters.tsx
@@ -53,7 +53,7 @@ export function RequestLogsFilters({
   const { t } = useTranslation();
 
   return (
-    <div className="border-t border-slate-100 px-5 py-3 dark:border-neutral-800/60">
+    <div className="border-t border-slate-100 px-5 py-3 dark:border-white/8">
       <div className="flex flex-wrap items-center gap-2">
         <div className="w-full min-[480px]:w-auto sm:w-[180px]">
           <SearchableCheckboxMultiSelect

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -633,9 +633,9 @@ export function RequestLogsPage() {
           {/* Loading overlay */}
           {loading ? (
             <div className="absolute inset-0 z-10 flex items-center justify-center rounded-b-2xl bg-white/70 backdrop-blur-sm dark:bg-neutral-950/55">
-              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/70 dark:text-white/75">
+              <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-900/8 bg-white/85 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm dark:border-white/8 dark:bg-neutral-950/70 dark:text-white/75">
                 <span
-                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-slate-900 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
+                  className="h-4 w-4 rounded-full border-2 border-slate-300 border-t-indigo-600 motion-reduce:animate-none motion-safe:animate-spin dark:border-white/20 dark:border-t-white/80"
                   aria-hidden="true"
                 />
                 <span role="status">{t("common.loading_ellipsis")}</span>
@@ -704,11 +704,11 @@ export function RequestLogsPage() {
         }
       >
         <div className="space-y-4">
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-neutral-800 dark:bg-neutral-900/80 dark:text-white/65">
+          <div className="rounded-2xl border border-slate-900/8 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-white/8 dark:bg-neutral-900/80 dark:text-white/65">
             {t("request_logs.clear_database_logs_keep_records_hint")}
           </div>
 
-          <label className="flex items-start gap-3 rounded-2xl border border-slate-200 px-4 py-3 dark:border-neutral-800">
+          <label className="flex items-start gap-3 rounded-2xl border border-slate-900/8 px-4 py-3 dark:border-white/8">
             <Checkbox
               checked={clearOptions.clear_body_content}
               onCheckedChange={handleClearBodyContentChange}
@@ -725,7 +725,7 @@ export function RequestLogsPage() {
             </span>
           </label>
 
-          <label className="flex items-start gap-3 rounded-2xl border border-slate-200 px-4 py-3 dark:border-neutral-800">
+          <label className="flex items-start gap-3 rounded-2xl border border-slate-900/8 px-4 py-3 dark:border-white/8">
             <Checkbox
               checked={clearOptions.clear_detail_content}
               onCheckedChange={handleClearDetailContentChange}

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -14,7 +14,7 @@
     "packages/domain/src/auth-files/authFiles.ts": 2291,
     "packages/domain/src/ccswitch/ccswitchImport.ts": 845,
     "packages/ui/src/data-table/DataTable.tsx": 2632,
-    "pages/api-key-lookup/ApiKeyLookupPage.tsx": 1810,
+    "pages/api-key-lookup/ApiKeyLookupPage.tsx": 1743,
     "pages/api-keys/ApiKeysPage.tsx": 1186,
     "pages/auth-files/AuthFilesPage.tsx": 1210,
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,


### PR DESCRIPTION
## 修改范围

只涉及 `codeProxy/`，不波及 `CliRelay/`。122 个文件，其中 103 个是描边颜色的机械替换。

## 登录体验

- 门户登录弹窗抽出为 `PortalLoginForm`：品牌标记 + 居中标题、填充式大圆角输入、全宽主按钮、提交态 spinner、错误条用高度动画展开而不是硬插入把按钮顶下去。
- 管理后台登录页的提交按钮改走 `Button variant="primary"`——此前是手写的黑色按钮，是后台唯一还在用旧主色的入口；hero 标题跟落地页共用展示字体。

## 共享组件

| 组件 | 改动 |
|---|---|
| `Modal` | 大圆角 + ring + 深阴影；进场 opacity/scale(0.97)/位移；**退场 160ms 短于进场 260ms**；遮罩模糊随淡入一起上；关闭按钮 hover 转 90° |
| `Drawer` | 与 Modal 共用同一套遮罩与曲线 |
| `Button` | primary 由黑白改为品牌靛蓝；新增 `loading`（spinner + 保留标签，宽度不跳） |
| `Input` / `controlSurface` | 改为**填充式**表面；focus 只提亮填充 + 1px 中性描边 |
| `Card` | `rounded-3xl` + ring，去掉描边与投影的双重堆叠 |
| `DropdownMenu` | 补开合动画（此前完全没有，只有 hover 变色） |
| `Tooltip` | 补上浮与缩放（此前只有淡入） |
| `PageLoader` | 双环换成品牌标记呼吸 + 单圈进度环 |
| 新增 | `Skeleton` / `SkeletonLines`、统一动效常量 `utils/motion.ts` |

## 几个实现判断

**下拉动画不用 `tailwindcss-animate`。** 该插件本仓库未引入，`animate-in` / `fade-in-0` 这类 class 写了不生效。改为自定义 keyframes（`.ui-popover-motion`），由 Radix 的 `data-state` / `data-side` 驱动。

**描边只改颜色，不改 `border` → `ring` 机制。** 机制一改，散落在别处的 `dark:border-*` 会变成孤儿，且 1px 占位变化会影响布局。统一为半透明中性描边后，与落地页/门户的表面语言一致，风险最低。

**focus 不做彩色发光环。** 密集表单里光晕会盖住相邻控件，也让界面显得吵。只提亮填充 + 1px 中性描边。

**部分蓝色刻意保留。** 图表图例、模型能力标签、健康度状态的蓝色承担的是**区分信息**而非品牌表达——图表需要多个可区分颜色，全改靛蓝会与主色混淆。只统一了真正属于交互强调的 6 处：选中态、计数徽章、复选框主色、hover、强调数值。

## 本 PR 未做

**管理后台页面级布局没有重排。** 改的是共享组件层，Dashboard / Providers / AuthFiles 等页面的信息架构与排版仍是原样，只是控件外观跟上了。逐页重排是更大的范围。

## 已执行的验证

在 `codeProxy/` 根目录执行 `./scripts/ci-pr.sh`，全部通过：

- `bun run lint` — 0 warnings / 0 errors
- `bun run design:check` — 通过
- `bun run test:ci` — **141 files / 1003 tests 全通过**
- `bun run build` — 通过
- `bun run bundle:diff` — PASS

额外：`boundary:imports`、`size:check`、`audit:deps` 均通过；e2e 8 项通过。

浅色与暗色下已实地核对门户登录弹窗与管理后台登录页。

🤖 Generated with [Claude Code](https://claude.com/claude-code)