### PR TITLE
fix(request-logs): preserve filters across empty ranges

### DIFF
--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -314,12 +314,10 @@ export function normalizeFilterSelection<T extends string>(
 
 export function toFilterParam<T extends string>(
   selected: MultiSelectFilterState<T>,
-  allowedValues: T[],
 ): { values?: T[]; matchesNone: boolean } {
-  const normalized = normalizeFilterSelection(selected, allowedValues);
-  if (normalized === null) return { values: undefined, matchesNone: false };
-  if (normalized.length === 0) return { values: undefined, matchesNone: true };
-  return { values: normalized, matchesNone: false };
+  if (selected === null) return { values: undefined, matchesNone: false };
+  if (selected.length === 0) return { values: undefined, matchesNone: true };
+  return { values: selected, matchesNone: false };
 }
 
 export function hasActiveFilterSelection<T extends string>(

--- a/pages/api-key-lookup/ApiKeyLookupPage.tsx
+++ b/pages/api-key-lookup/ApiKeyLookupPage.tsx
@@ -507,18 +507,9 @@ export function ApiKeyLookupPage() {
     [statusOptions],
   );
 
-  const apiKeyIdFilterParam = useMemo(
-    () => toFilterParam(selectedApiKeyIds, apiKeyIdFilterValues),
-    [apiKeyIdFilterValues, selectedApiKeyIds],
-  );
-  const modelFilterParam = useMemo(
-    () => toFilterParam(selectedModels, modelFilterValues),
-    [modelFilterValues, selectedModels],
-  );
-  const statusFilterParam = useMemo(
-    () => toFilterParam(selectedStatuses, statusFilterValues),
-    [selectedStatuses, statusFilterValues],
-  );
+  const apiKeyIdFilterParam = useMemo(() => toFilterParam(selectedApiKeyIds), [selectedApiKeyIds]);
+  const modelFilterParam = useMemo(() => toFilterParam(selectedModels), [selectedModels]);
+  const statusFilterParam = useMemo(() => toFilterParam(selectedStatuses), [selectedStatuses]);
 
   const handleApiKeyIdsChange = useCallback(
     (value: string[]) => {

--- a/pages/api-key-usage/ApiKeyUsagePage.tsx
+++ b/pages/api-key-usage/ApiKeyUsagePage.tsx
@@ -256,14 +256,8 @@ export function ApiKeyUsagePage() {
     () => toStatusFilterValues(statusOptions.map((option) => option.value)),
     [statusOptions],
   );
-  const modelFilterParam = useMemo(
-    () => toFilterParam(selectedModels, modelFilterValues),
-    [modelFilterValues, selectedModels],
-  );
-  const statusFilterParam = useMemo(
-    () => toFilterParam(selectedStatuses, statusFilterValues),
-    [selectedStatuses, statusFilterValues],
-  );
+  const modelFilterParam = useMemo(() => toFilterParam(selectedModels), [selectedModels]);
+  const statusFilterParam = useMemo(() => toFilterParam(selectedStatuses), [selectedStatuses]);
 
   const handleModelsChange = useCallback(
     (value: string[]) => {

--- a/pages/monitor/__tests__/requestLogsShared.test.ts
+++ b/pages/monitor/__tests__/requestLogsShared.test.ts
@@ -8,10 +8,20 @@ import {
   isSystemRequestLogKey,
   sortRequestLogKeyOptionsByCount,
   SYSTEM_REQUEST_LOG_FILTER_VALUE,
+  toFilterParam,
   toRequestLogsRow,
 } from "@features/request-log-viewer";
 
 describe("requestLogsShared", () => {
+  test("builds request filters from the committed selection", () => {
+    expect(toFilterParam(null)).toEqual({ values: undefined, matchesNone: false });
+    expect(toFilterParam([])).toEqual({ values: undefined, matchesNone: true });
+    expect(toFilterParam(["auth-codex"])).toEqual({
+      values: ["auth-codex"],
+      matchesNone: false,
+    });
+  });
+
   test("exposes the full channel name on the truncated identity label", () => {
     const name = "ryskt8qjfg@privaterelay.appleid.com";
 

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -280,22 +280,10 @@ export function RequestLogsPage() {
     [statusOptions],
   );
 
-  const apiKeyFilterParam = useMemo(
-    () => toFilterParam(selectedApiKeys, apiKeyFilterValues),
-    [apiKeyFilterValues, selectedApiKeys],
-  );
-  const modelFilterParam = useMemo(
-    () => toFilterParam(selectedModels, modelFilterValues),
-    [modelFilterValues, selectedModels],
-  );
-  const channelFilterParam = useMemo(
-    () => toFilterParam(selectedChannels, channelFilterValues),
-    [channelFilterValues, selectedChannels],
-  );
-  const statusFilterParam = useMemo(
-    () => toFilterParam(selectedStatuses, statusFilterValues),
-    [selectedStatuses, statusFilterValues],
-  );
+  const apiKeyFilterParam = useMemo(() => toFilterParam(selectedApiKeys), [selectedApiKeys]);
+  const modelFilterParam = useMemo(() => toFilterParam(selectedModels), [selectedModels]);
+  const channelFilterParam = useMemo(() => toFilterParam(selectedChannels), [selectedChannels]);
+  const statusFilterParam = useMemo(() => toFilterParam(selectedStatuses), [selectedStatuses]);
 
   const hasActiveFilters =
     hasActiveFilterSelection(selectedApiKeys, apiKeyFilterValues) ||

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -427,6 +427,78 @@ describe("RequestLogsPage", () => {
     await waitFor(() => expect(screen.queryByText("stale-model")).not.toBeInTheDocument());
   });
 
+  test("keeps the committed channel filter when a time range has no facet options", async () => {
+    await i18n.changeLanguage("en");
+    const user = userEvent.setup();
+    const restoredResponse = responseWithRows([
+      buildUsageLogItem({ id: 7, model: "restored-model" }),
+    ]);
+
+    mocks.getUsageLogs.mockImplementation((params) => {
+      if (params.days === 1 || params.channels_empty) {
+        return Promise.resolve(emptyLogsResponse);
+      }
+      return Promise.resolve(restoredResponse);
+    });
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    expect(await screen.findByText("restored-model")).toBeInTheDocument();
+
+    const [, , channelFilter] = await screen.findAllByRole("combobox");
+    await user.click(channelFilter);
+    await user.click(await screen.findByRole("option", { name: /Relay.*API/i }));
+    await user.click(screen.getByRole("button", { name: "Apply filters" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          days: 7,
+          channels: ["auth-codex"],
+          channels_empty: false,
+        }),
+        expectSignalOptions(),
+      ),
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Today" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          days: 1,
+          channels: ["auth-codex"],
+          channels_empty: false,
+        }),
+        expectSignalOptions(),
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText("restored-model")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("tab", { name: "7 days" }));
+
+    await waitFor(() =>
+      expect(mocks.getUsageLogs).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          days: 7,
+          channels: ["auth-codex"],
+          channels_empty: false,
+        }),
+        expectSignalOptions(),
+      ),
+    );
+    expect(await screen.findByText("restored-model")).toBeInTheDocument();
+  });
+
   test("shows request-log user counts in descending order with an unrestricted default", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- 请求日志筛选参数改为只认 committed selection（`null` / `[]` / 值），不再用当前时间范围返回的 facet 候选项推导 `*_empty`
- 修复：选中渠道/模型后切「今天」空数据，再切回「7 天」仍被 `channels_empty=1` 强制空表，需点刷新才恢复
- 同步修复 `ApiKeyUsagePage` / `ApiKeyLookupPage` 同模式调用
- 补回归测试：7 天选渠道 → 今天空 facets → 切回 7 天自动带原渠道且不带 `*_empty`

## Test plan
- [x] `bun run --filter @code-proxy/admin-panel test -- pages/request-logs/__tests__/RequestLogsPage.test.tsx pages/monitor/__tests__/requestLogsShared.test.ts`（29 passed）
- [x] 相关 `tsc` / `oxlint` / format check（agent 侧）
- [ ] GHA `PR Test Build` 全量门禁