### PR TITLE
fix(dashboard): drop double border on panel cards

### DIFF
--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -130,7 +130,7 @@ const formatThroughputValue = (value: number) =>
   throughputNumberFormatter.format(Number.isFinite(value) ? value : 0);
 const formatRate = (rate: number) => `${rate.toFixed(2)}%`;
 const PANEL_SURFACE =
-  "rounded-2xl border border-slate-900/8 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-white/8 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
+  "rounded-2xl bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
 
 const formatThroughputTooltip = (params: any) => {
   const items = Array.isArray(params) ? params : [params];

--- a/pages/dashboard/SystemMonitorSection.tsx
+++ b/pages/dashboard/SystemMonitorSection.tsx
@@ -18,7 +18,7 @@ import { Card } from "@code-proxy/ui";
 import type { SystemStats } from "./useSystemStats";
 
 const PANEL_SURFACE =
-  "rounded-2xl border border-slate-900/8 bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:border-white/8 dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
+  "rounded-2xl bg-white shadow-[0_10px_26px_rgba(15,23,42,0.05)] dark:bg-neutral-950/85 dark:shadow-[0_10px_26px_rgba(0,0,0,0.28)]";
 
 /* ═══════════════════════════════════════════════════════════
    Helpers


### PR DESCRIPTION
## Summary
- Dashboard `PANEL_SURFACE` stacked `border` on top of shared `Card` `ring-1`, making card edges look too thick.
- Removed the extra border from KPI / throughput / system-monitor panel surfaces; keep shadow + fill only.

## Test plan
- [x] `bun run test:ci -- pages/dashboard/__tests__/DashboardCards.test.ts pages/dashboard/__tests__/DashboardPage.test.tsx`
- [ ] Visual check `/manage/dashboard` light + dark: card outlines should be single thin ring