### PR TITLE
feat(request-logs): show thinking level in model

### DIFF
--- a/features/log-content-viewer/components/LogContentModal.tsx
+++ b/features/log-content-viewer/components/LogContentModal.tsx
@@ -662,10 +662,10 @@ function StructuredRequestCard({
     </div>
   );
 }
-
 export function LogContentModal({
   open,
   logId,
+  displayModel,
   initialTab = "input",
   onClose,
   showRequestDetails = false,
@@ -1457,7 +1457,7 @@ export function LogContentModal({
   return (
     <ContentModal
       open={open}
-      model={model}
+      model={displayModel?.trim() || model}
       onClose={onClose}
       tabs={tabBar}
       description={detailsOnly ? t("log_content.request_details") : undefined}

--- a/features/log-content-viewer/log-content/types.ts
+++ b/features/log-content-viewer/log-content/types.ts
@@ -6,6 +6,7 @@ export type LogContentPart = LogContentBodyPart | "details";
 export interface LogContentModalProps {
   open: boolean;
   logId: number | null;
+  displayModel?: string;
   initialTab?: LogContentBodyPart;
   onClose: () => void;
   showRequestDetails?: boolean;

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -45,6 +45,8 @@ export type RequestLogsRow = {
   channelAuthType?: string;
   maskedApiKey: string;
   model: string;
+  thinkingLevel?: string;
+  displayModel?: string;
   upstreamModel: string;
   visionFallbackModel: string;
   failed: boolean;
@@ -520,7 +522,6 @@ export const formatRequestLogLatencyMs = (value: number): string => {
   const trimmed = fixed.endsWith(".0") ? fixed.slice(0, -2) : fixed;
   return `${trimmed}s`;
 };
-
 export const formatOptionalRequestLogLatencyMs = (value: number): string => {
   if (!Number.isFinite(value) || value <= 0) return "--";
   return formatRequestLogLatencyMs(value);
@@ -529,6 +530,7 @@ export const formatOptionalRequestLogLatencyMs = (value: number): string => {
 export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
   const isSystemCall = isSystemRequestLogKey(item.api_key, item.api_key_name);
   const channelAuthType = normalizeChannelAuthType(item.auth_type);
+  const thinkingLevel = String(item.thinking_level ?? "").trim();
   return {
     id: String(item.id),
     timestamp: item.timestamp,
@@ -544,6 +546,8 @@ export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
     channelAuthType: channelAuthType || undefined,
     maskedApiKey: item.api_key_masked || maskRequestLogApiKey(item.api_key),
     model: item.model,
+    thinkingLevel,
+    displayModel: thinkingLevel ? `${item.model}(${thinkingLevel})` : item.model,
     upstreamModel: item.upstream_model || "",
     visionFallbackModel: item.vision_fallback_model || "",
     failed: item.failed,
@@ -558,7 +562,6 @@ export const toRequestLogsRow = (item: UsageLogItem): RequestLogsRow => {
     hasContent: item.has_content ?? false,
   };
 };
-
 export const isSystemRequestLogKey = (apiKey: string, apiKeyName?: string): boolean => {
   if (String(apiKeyName || "").trim()) return false;
   const trimmed = String(apiKey || "").trim();
@@ -640,13 +643,12 @@ export function RequestLogsTimeRangeSelector({
     </Tabs>
   );
 }
-
 // DataTable maps header text-center to flex justify-center on the label row.
 const CENTERED_REQUEST_LOG_HEADER_CLASS = "text-center";
 
 export function buildRequestLogsColumns(
   t: (key: string) => string,
-  onContentClick?: (logId: number, tab: "input" | "output") => void,
+  onContentClick?: (logId: number, tab: "input" | "output", model: string) => void,
   onErrorClick?: (logId: number, model: string) => void,
   options: { identityColumn?: "user" | "key" | "none"; hideChannel?: boolean } = {},
 ): RequestLogsTableColumn<RequestLogsRow>[] {
@@ -733,7 +735,7 @@ export function buildRequestLogsColumns(
         row.failed ? (
           <button
             type="button"
-            onClick={() => onErrorClick?.(Number(row.id), row.model)}
+            onClick={() => onErrorClick?.(Number(row.id), row.displayModel || row.model)}
             className="inline-flex min-w-[52px] cursor-pointer justify-center rounded-full bg-rose-50 px-2.5 py-1 text-xs font-semibold text-rose-600 transition hover:bg-rose-100 hover:shadow-sm dark:bg-rose-500/15 dark:text-rose-300 dark:hover:bg-rose-500/25"
             title={t("request_logs.view_error")}
           >
@@ -810,7 +812,7 @@ export function buildRequestLogsColumns(
         row.hasContent && onContentClick ? (
           <button
             type="button"
-            onClick={() => onContentClick(Number(row.id), "input")}
+            onClick={() => onContentClick(Number(row.id), "input", row.displayModel || row.model)}
             className="inline-block ml-auto cursor-pointer rounded px-1.5 py-0.5 transition hover:bg-sky-50 dark:hover:bg-sky-950/30"
             title={t("request_logs.view_input")}
           >
@@ -851,7 +853,7 @@ export function buildRequestLogsColumns(
         row.hasContent && onContentClick ? (
           <button
             type="button"
-            onClick={() => onContentClick(Number(row.id), "output")}
+            onClick={() => onContentClick(Number(row.id), "output", row.displayModel || row.model)}
             className="inline-block ml-auto cursor-pointer rounded px-1.5 py-0.5 transition hover:bg-emerald-50 dark:hover:bg-emerald-950/30"
             title={t("request_logs.view_output")}
           >
@@ -941,8 +943,8 @@ export function buildRequestLogsColumns(
       render: (row) =>
         row.model ? (
           <span className="inline-flex max-w-full items-center justify-center gap-1 align-middle">
-            <OverflowTooltip content={row.model} className="min-w-0">
-              <ModelTag id={row.model} size="sm" className="align-middle" />
+            <OverflowTooltip content={row.displayModel || row.model} className="min-w-0">
+              <ModelTag id={row.displayModel || row.model} size="sm" className="align-middle" />
             </OverflowTooltip>
             {row.upstreamModel && row.upstreamModel !== row.model ? (
               <HoverTooltip

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -540,6 +540,7 @@ export interface UsageLogItem {
   api_key_own_name?: string;
   end_user_display_name?: string;
   model: string;
+  thinking_level?: string | null;
   upstream_model?: string;
   vision_fallback_model?: string;
   source: string;

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -127,6 +127,7 @@ export function ApiKeysPage({
     usageContentModalOpen,
     setUsageContentModalOpen,
     usageContentModalLogId,
+    usageContentModalModel,
     usageContentModalTab,
     usageErrorModalOpen,
     setUsageErrorModalOpen,
@@ -1150,6 +1151,7 @@ export function ApiKeysPage({
       <LogContentModal
         open={usageContentModalOpen}
         logId={usageContentModalLogId}
+        displayModel={usageContentModalModel}
         initialTab={usageContentModalTab}
         onClose={() => setUsageContentModalOpen(false)}
       />

--- a/pages/api-keys/hooks/useApiKeyUsageView.tsx
+++ b/pages/api-keys/hooks/useApiKeyUsageView.tsx
@@ -66,6 +66,7 @@ export function useApiKeyUsageView() {
   const [usageStatusFilter, setUsageStatusFilter] = useState<StatusFilter>("");
   const [usageContentModalOpen, setUsageContentModalOpen] = useState(false);
   const [usageContentModalLogId, setUsageContentModalLogId] = useState<number | null>(null);
+  const [usageContentModalModel, setUsageContentModalModel] = useState("");
   const [usageContentModalTab, setUsageContentModalTab] = useState<"input" | "output">("input");
   const [usageErrorModalOpen, setUsageErrorModalOpen] = useState(false);
   const [usageErrorModalLogId, setUsageErrorModalLogId] = useState<number | null>(null);
@@ -77,11 +78,15 @@ export function useApiKeyUsageView() {
   /** First key — keeps ApiKeysPage mask display working. */
   const usageViewKey = usageViewKeys[0] ?? null;
 
-  const handleUsageContentClick = useCallback((logId: number, tab: "input" | "output") => {
-    setUsageContentModalLogId(logId);
-    setUsageContentModalTab(tab);
-    setUsageContentModalOpen(true);
-  }, []);
+  const handleUsageContentClick = useCallback(
+    (logId: number, tab: "input" | "output", model: string) => {
+      setUsageContentModalLogId(logId);
+      setUsageContentModalModel(model);
+      setUsageContentModalTab(tab);
+      setUsageContentModalOpen(true);
+    },
+    [],
+  );
 
   const handleUsageErrorClick = useCallback((logId: number, model: string) => {
     setUsageErrorModalLogId(logId);
@@ -381,6 +386,7 @@ export function useApiKeyUsageView() {
     usageContentModalOpen,
     setUsageContentModalOpen,
     usageContentModalLogId,
+    usageContentModalModel,
     usageContentModalTab,
     usageErrorModalOpen,
     setUsageErrorModalOpen,

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -165,6 +165,7 @@ export function EndUsersPage() {
     usageContentModalOpen,
     setUsageContentModalOpen,
     usageContentModalLogId,
+    usageContentModalModel,
     usageContentModalTab,
     usageErrorModalOpen,
     setUsageErrorModalOpen,
@@ -1314,10 +1315,10 @@ export function EndUsersPage() {
         usageTotalPages={usageTotalPages}
         setUsagePageSize={setUsagePageSize}
       />
-
       <LogContentModal
         open={usageContentModalOpen}
         logId={usageContentModalLogId}
+        displayModel={usageContentModalModel}
         initialTab={usageContentModalTab}
         onClose={() => setUsageContentModalOpen(false)}
       />

--- a/pages/request-logs/RequestLogsPage.tsx
+++ b/pages/request-logs/RequestLogsPage.tsx
@@ -92,6 +92,7 @@ export function RequestLogsPage() {
   // Content modal state
   const [contentModalOpen, setContentModalOpen] = useState(false);
   const [contentModalLogId, setContentModalLogId] = useState<number | null>(null);
+  const [contentModalModel, setContentModalModel] = useState("");
   const [contentModalTab, setContentModalTab] = useState<"input" | "output">("input");
   const [requestBodyStorageEnabled, setRequestBodyStorageEnabled] = useState(false);
 
@@ -108,11 +109,15 @@ export function RequestLogsPage() {
     };
   }, []);
 
-  const handleContentClick = useCallback((logId: number, tab: "input" | "output") => {
-    setContentModalLogId(logId);
-    setContentModalTab(tab);
-    setContentModalOpen(true);
-  }, []);
+  const handleContentClick = useCallback(
+    (logId: number, tab: "input" | "output", model: string) => {
+      setContentModalLogId(logId);
+      setContentModalModel(model);
+      setContentModalTab(tab);
+      setContentModalOpen(true);
+    },
+    [],
+  );
 
   // Error modal state
   const [errorModalOpen, setErrorModalOpen] = useState(false);
@@ -646,6 +651,7 @@ export function RequestLogsPage() {
       <LogContentModal
         open={contentModalOpen}
         logId={contentModalLogId}
+        displayModel={contentModalModel}
         initialTab={contentModalTab}
         onClose={() => setContentModalOpen(false)}
         showRequestDetails

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -326,6 +326,30 @@ describe("RequestLogsPage", () => {
     expect(screen.queryByLabelText("First Token Latency: --")).not.toBeInTheDocument();
   });
 
+  test("shows a non-empty thinking level in the model tag", async () => {
+    await i18n.changeLanguage("en");
+
+    mocks.getUsageLogs.mockResolvedValue(
+      responseWithRows([
+        buildUsageLogItem({ id: 1, model: "gpt-5.6-sol", thinking_level: " max " }),
+        buildUsageLogItem({ id: 2, model: "gpt-5.4", thinking_level: "" }),
+      ]),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const table = await screen.findByRole("table", { name: "Request Logs Table" });
+    expect(within(table).getByText("gpt-5.6-sol(max)")).toBeInTheDocument();
+    expect(within(table).getByText("gpt-5.4")).toBeInTheDocument();
+    expect(within(table).queryByText("gpt-5.4()")).not.toBeInTheDocument();
+  });
+
   test("shows vision fallback model separately from real model mapping", async () => {
     await i18n.changeLanguage("en");
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- add optional `thinking_level` to usage log items
- render request log models as `model(level)` only for non-empty levels
- keep filters on the base model and pass the display model into request-log detail modals

## Validation
- `bun run --filter @code-proxy/admin-panel test -- pages/request-logs/__tests__/RequestLogsPage.test.tsx pages/monitor/__tests__/requestLogsShared.test.ts pages/api-keys/hooks/__tests__/useApiKeyUsageView.test.tsx`
- `SKIP_E2E_CRITICAL=1 ./scripts/ci-pr.sh` (143 files / 1015 tests passed; critical Playwright smoke skipped)
- post-rebase lint, size check, targeted tests, and build passed