### PR TITLE
feat(quota): 累计消费限额展示剩余额度

### DIFF
--- a/features/period-spending/OwnedApiKeyTable.tsx
+++ b/features/period-spending/OwnedApiKeyTable.tsx
@@ -88,6 +88,8 @@ export const createOwnedApiKeyColumns = ({
     key: "quota",
     label: t("quota.period_spending_column"),
     width: "w-[360px] min-w-[260px]",
+    // Keys have no lifetime cap of their own — it lives on the account and is
+    // enforced across all of the account's keys — so this column stays periodic.
     render: (row) => <PeriodSpendingCell t={t} items={row["period-spending"]} />,
   },
   {

--- a/features/period-spending/PeriodSpendingCell.tsx
+++ b/features/period-spending/PeriodSpendingCell.tsx
@@ -26,6 +26,21 @@ export const formatQuotaUsd = (value: number): string =>
 export const formatQuotaUsdAmount = (value: number | null | undefined): string =>
   amountFormatter.format(Number.isFinite(value) ? Math.max(0, value ?? 0) : 0);
 
+/** Lifetime spend has no reset cycle, so an overspend must read as 0 left, never negative. */
+export const remainingQuotaUsd = (
+  limit: number | null | undefined,
+  used: number | null | undefined,
+): number => {
+  const safeLimit = Number.isFinite(limit) ? (limit ?? 0) : 0;
+  const safeUsed = Number.isFinite(used) ? (used ?? 0) : 0;
+  return Math.max(0, safeLimit - safeUsed);
+};
+
+export type LifetimeSpending = { used?: number | null; limit?: number | null };
+
+const hasLifetimeLimit = (lifetime: LifetimeSpending | undefined): boolean =>
+  Number.isFinite(lifetime?.limit) && (lifetime?.limit ?? 0) > 0;
+
 const periodLabel = (
   t: (key: string, options?: Record<string, unknown>) => string,
   period: PeriodSpendingPeriod,
@@ -53,12 +68,20 @@ const chipTone = (ratio: number) => {
 export function PeriodSpendingCell({
   t,
   items,
+  lifetime,
 }: {
   t: (key: string, options?: Record<string, unknown>) => string;
   items?: PeriodSpendingItem[];
+  /**
+   * Lifetime spending cap. It is not one of the rolling periods, so it used to be
+   * absent from this column entirely: an account with only a lifetime cap read as
+   * "unlimited" here while the lifetime column showed spend without its cap.
+   */
+  lifetime?: LifetimeSpending;
 }) {
   const visible = orderedItems(items);
-  if (visible.length === 0) {
+  const showLifetime = hasLifetimeLimit(lifetime);
+  if (visible.length === 0 && !showLifetime) {
     return (
       <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-300">
         <InfinityIcon size={13} aria-hidden="true" />
@@ -94,7 +117,48 @@ export function PeriodSpendingCell({
           </span>
         );
       })}
+      {showLifetime ? <LifetimeSpendingChip t={t} lifetime={lifetime as LifetimeSpending} /> : null}
     </div>
+  );
+}
+
+/**
+ * Rolling periods are shown as used/limit because they refill on their own; the
+ * lifetime cap only ever counts down, so what operators need from it is how much
+ * is left before the account stops.
+ */
+function LifetimeSpendingChip({
+  t,
+  lifetime,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  lifetime: LifetimeSpending;
+}) {
+  const limit = lifetime.limit ?? 0;
+  const used = lifetime.used ?? 0;
+  const remaining = remainingQuotaUsd(limit, used);
+  const ratio = limit > 0 ? used / limit : 0;
+  const danger = ratio >= 1;
+  const warning = ratio >= 0.9 && !danger;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium tabular-nums ${chipTone(ratio)}`}
+      title={t("quota.lifetime_remaining_detail", {
+        used: formatQuotaUsd(used),
+        limit: formatQuotaUsd(limit),
+        remaining: formatQuotaUsd(remaining),
+      })}
+    >
+      {danger ? <AlertCircle size={13} aria-hidden="true" /> : null}
+      {warning ? <AlertTriangle size={13} aria-hidden="true" /> : null}
+      <span className="font-semibold">{t("quota.lifetime_label")}</span>
+      <span>
+        {t("quota.remaining_value", { remaining: formatQuotaUsd(remaining) })} /{" "}
+        {formatQuotaUsd(limit)}
+      </span>
+      {danger ? <span className="sr-only">{t("quota.status.exceeded")}</span> : null}
+      {warning ? <span className="sr-only">{t("quota.status.warning")}</span> : null}
+    </span>
   );
 }
 

--- a/features/period-spending/__tests__/PeriodSpendingCell.test.tsx
+++ b/features/period-spending/__tests__/PeriodSpendingCell.test.tsx
@@ -70,3 +70,53 @@ describe("PeriodSpendingCell", () => {
     expect(container).not.toHaveTextContent("Week");
   });
 });
+
+describe("PeriodSpendingCell lifetime cap", () => {
+  const lifetimeT = (key: string, options?: Record<string, unknown>) => {
+    const labels: Record<string, string> = {
+      "quota.unlimited": "Unlimited",
+      "quota.lifetime_label": "Lifetime",
+      "quota.remaining_value": `${String(options?.remaining ?? "")} left`,
+      "quota.lifetime_remaining_detail": `Lifetime: ${String(options?.used ?? "")} used, ${String(options?.limit ?? "")} cap, ${String(options?.remaining ?? "")} left`,
+      "quota.status.warning": "Near quota limit",
+      "quota.status.exceeded": "Quota exceeded",
+    };
+    return labels[key] ?? key;
+  };
+
+  test("an account with only a lifetime cap no longer reads as unlimited", () => {
+    render(<PeriodSpendingCell t={lifetimeT} items={[]} lifetime={{ used: 12, limit: 100 }} />);
+
+    expect(screen.queryByText("Unlimited")).toBeNull();
+    expect(screen.getByText("Lifetime")).toBeTruthy();
+    expect(screen.getByText(/\$88 left/)).toBeTruthy();
+  });
+
+  test("shows remaining, not spent, because a lifetime cap never refills", () => {
+    const { container } = render(
+      <PeriodSpendingCell
+        t={lifetimeT}
+        items={[{ period: "day", limit: 300, used: 120, remaining: 180 }]}
+        lifetime={{ used: 12, limit: 100 }}
+      />,
+    );
+
+    // Rolling period keeps used/limit; lifetime switches to what is left.
+    expect(container.textContent).toContain("$120 / $300");
+    expect(container.textContent).toContain("$88 left / $100");
+  });
+
+  test("an overspent lifetime cap clamps to zero left instead of going negative", () => {
+    render(<PeriodSpendingCell t={lifetimeT} items={[]} lifetime={{ used: 140, limit: 100 }} />);
+
+    expect(screen.getByText(/\$0 left/)).toBeTruthy();
+    expect(screen.getByText("Quota exceeded")).toBeTruthy();
+  });
+
+  test("no lifetime cap configured keeps the column periodic only", () => {
+    render(<PeriodSpendingCell t={lifetimeT} items={[]} lifetime={{ used: 88, limit: 0 }} />);
+
+    expect(screen.getByText("Unlimited")).toBeTruthy();
+    expect(screen.queryByText("Lifetime")).toBeNull();
+  });
+});

--- a/features/period-spending/index.ts
+++ b/features/period-spending/index.ts
@@ -3,7 +3,9 @@ export {
   PeriodSpendingLimitsCell,
   formatQuotaUsd,
   formatQuotaUsdAmount,
+  remainingQuotaUsd,
 } from "./PeriodSpendingCell";
+export type { LifetimeSpending } from "./PeriodSpendingCell";
 export {
   PeriodSpendingFields,
   emptyPeriodSpendingDraft,

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4685,6 +4685,11 @@
     "account_limit_value": "Account limit {{value}}",
     "account_unlimited": "Account unlimited",
     "used_of_limit": "{{period}}: {{used}} of {{limit}} used",
+    "lifetime_label": "Lifetime",
+    "remaining_value": "{{remaining}} left",
+    "lifetime_remaining_detail": "Lifetime: {{used}} used, {{limit}} cap, {{remaining}} left",
+    "lifetime_remaining_hint": "Cap {{limit}} · Used {{used}}",
+    "lifetime_remaining_field_hint": "Saving stores the entered value as the new lifetime cap",
     "reset": {
       "account_title": "Reset account quota",
       "key_title": "Reset Key quota",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4702,6 +4702,11 @@
     "account_limit_value": "账号上限 {{value}}",
     "account_unlimited": "账号不限制",
     "used_of_limit": "{{period}}：已用 {{used}}，上限 {{limit}}",
+    "lifetime_label": "累计",
+    "remaining_value": "剩 {{remaining}}",
+    "lifetime_remaining_detail": "累计：已用 {{used}}，上限 {{limit}}，剩余 {{remaining}}",
+    "lifetime_remaining_hint": "上限 {{limit}} · 已用 {{used}}",
+    "lifetime_remaining_field_hint": "填写后按新的累计上限保存",
     "reset": {
       "account_title": "重置账号配额",
       "key_title": "重置 Key 配额",

--- a/pages/api-key-lookup/__tests__/QuotaLimitsBanner.test.tsx
+++ b/pages/api-key-lookup/__tests__/QuotaLimitsBanner.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { QuotaLimitKpiCards } from "../components/QuotaLimitsBanner";
+
+const t = (key: string, options?: Record<string, unknown>) => {
+  const labels: Record<string, string> = {
+    "apikey_lookup.quota_daily_requests": "Daily requests",
+    "apikey_lookup.quota_total_spending": "Lifetime spending",
+    "apikey_lookup.quota_used_of_limit": "Used of limit",
+    "quota.remaining_value": `${String(options?.remaining ?? "")} left`,
+    "quota.lifetime_remaining_hint": `Cap ${String(options?.limit ?? "")} · Used ${String(options?.used ?? "")}`,
+  };
+  return labels[key] ?? key;
+};
+
+describe("QuotaLimitKpiCards", () => {
+  test("the lifetime card leads with what is left while keeping the cap in the hint", () => {
+    render(
+      <QuotaLimitKpiCards
+        t={t}
+        limits={{ "spending-limit": 100, "spending-used": 12 }}
+        renderValue={(value) => value}
+      />,
+    );
+
+    const card = screen.getByTestId("api-key-lookup-quota-spending");
+    expect(card.textContent).toContain("$88.00 left");
+    expect(card.textContent).toContain("$100.00");
+    expect(card.textContent).toContain("Cap $100.00 · Used $12.00");
+  });
+
+  test("rolling quotas keep used/limit because they refill on their own", () => {
+    render(
+      <QuotaLimitKpiCards
+        t={t}
+        limits={{ "daily-limit": 1000, "daily-used": 120 }}
+        renderValue={(value) => value}
+      />,
+    );
+
+    const card = screen.getByTestId("api-key-lookup-quota-daily-limit");
+    expect(card.textContent).toContain("120");
+    expect(card.textContent).toContain("1,000");
+    expect(card.textContent).not.toContain("left");
+  });
+
+  test("an overspent lifetime cap reads as zero left, not a negative balance", () => {
+    render(
+      <QuotaLimitKpiCards
+        t={t}
+        limits={{ "spending-limit": 100, "spending-used": 140 }}
+        renderValue={(value) => value}
+      />,
+    );
+
+    expect(screen.getByTestId("api-key-lookup-quota-spending").textContent).toContain("$0.00 left");
+  });
+});

--- a/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
+++ b/pages/api-key-lookup/components/QuotaLimitsBanner.tsx
@@ -11,6 +11,12 @@ export type QuotaKpiItem = {
   limit: number;
   format: (value: number) => string;
   icon: ComponentType<{ size?: number; className?: string }>;
+  /**
+   * Rolling quotas refill on their own, so used/limit answers "how am I doing
+   * this period". The lifetime cap only counts down, so what matters is what is
+   * left before the key stops working.
+   */
+  showRemaining?: boolean;
 };
 
 export function buildQuotaKpiItems(
@@ -71,6 +77,7 @@ export function buildQuotaKpiItems(
       limit: limits["spending-limit"],
       format: formatQuotaUsd,
       icon: Coins,
+      showRemaining: true,
     });
   }
   return items;
@@ -94,7 +101,10 @@ export function QuotaLimitKpiCards({
   return (
     <>
       {items.map((item) => {
-        const usedText = item.format(item.used);
+        const remaining = Math.max(0, item.limit - item.used);
+        const usedText = item.showRemaining
+          ? t("quota.remaining_value", { remaining: item.format(remaining) })
+          : item.format(item.used);
         const limitText = item.format(item.limit);
         const display = `${usedText} / ${limitText}`;
         const sizeClass = kpiValueSizeClass(display);
@@ -104,7 +114,14 @@ export function QuotaLimitKpiCards({
           tone="portal"
               title={item.title}
               icon={item.icon}
-              hint={t("apikey_lookup.quota_used_of_limit")}
+              hint={
+                item.showRemaining
+                  ? t("quota.lifetime_remaining_hint", {
+                      limit: item.format(item.limit),
+                      used: item.format(item.used),
+                    })
+                  : t("apikey_lookup.quota_used_of_limit")
+              }
               valueClassName={sizeClass}
               value={renderValue(
                 <span className="block whitespace-nowrap tabular-nums leading-tight">

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -44,64 +44,28 @@ import { ErrorDetailModal, LogContentModal } from "@features/log-content-viewer"
 import { ApiKeyUsageModal } from "../api-keys/components/ApiKeyUsageModal";
 import { useApiKeyUsageView } from "../api-keys/hooks/useApiKeyUsageView";
 import { EndUserResetHistoryModal } from "./components/EndUserResetHistoryModal";
+import { EndUserEditModal } from "./components/EndUserEditModal";
+import {
+  emptyForm,
+  limitToText,
+  lifetimeRemainingText,
+  requestLimitFromText,
+  spendingLimitFromText,
+} from "./endUserForm";
+import type { EndUserForm } from "./endUserForm";
 import {
   PeriodSpendingCell,
-  PeriodSpendingFields,
   PeriodQuotaResetModal,
-  emptyPeriodSpendingDraft,
   formatQuotaValidationError,
   formatQuotaUsdAmount,
   limitsToPeriodSpendingDraft,
   periodSpendingDraftToLimits,
-  type PeriodSpendingDraft,
 } from "@features/period-spending";
 import { normalizePeriodSpendingLimits } from "@code-proxy/api-client";
 
-type EndUserForm = {
-  username: string;
-  displayName: string;
-  password: string;
-  permissionProfileId: string;
-  spendingLimit: string;
-  dailyLimit: string;
-  totalQuota: string;
-  concurrencyLimit: string;
-  rpmLimit: string;
-  tpmLimit: string;
-  periodSpending: PeriodSpendingDraft;
-};
-
 type EndUserStatusFilter = "all" | "active" | "frozen";
-
 const DEFAULT_END_USER_PAGE_SIZE = 20;
 const END_USER_PAGE_SIZE_OPTIONS = [20, 50, 100];
-
-const emptyForm = (): EndUserForm => ({
-  username: "",
-  displayName: "",
-  password: "",
-  permissionProfileId: "",
-  spendingLimit: "",
-  dailyLimit: "",
-  totalQuota: "",
-  concurrencyLimit: "",
-  rpmLimit: "",
-  tpmLimit: "",
-  periodSpending: emptyPeriodSpendingDraft(),
-});
-
-const spendingLimitFromText = (value: string): number => {
-  const parsed = Number.parseFloat(value.trim());
-  return Number.isFinite(parsed) && parsed > 0 ? Math.ceil(parsed) : 0;
-};
-
-const requestLimitFromText = (value: string): number => {
-  const parsed = Number.parseInt(value.trim(), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-};
-
-const limitToText = (value: number | undefined): string =>
-  value && value > 0 ? String(value) : "";
 
 const stickyActionsHeaderClass =
   "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
@@ -440,7 +404,16 @@ export function EndUsersPage() {
         key: "quota",
         label: t("quota.period_spending_column"),
         width: "w-[390px] min-w-[280px]",
-        render: (row) => <PeriodSpendingCell t={t} items={row["period-spending"]} />,
+        render: (row) => (
+          <PeriodSpendingCell
+            t={t}
+            items={row["period-spending"]}
+            lifetime={{
+              used: row["lifetime-spending-used"],
+              limit: row["spending-limit"],
+            }}
+          />
+        ),
       },
       {
         key: "dailySpending",
@@ -538,7 +511,7 @@ export function EndUsersPage() {
                       displayName: row.display_name,
                       password: "",
                       permissionProfileId: row["permission-profile-id"] ?? "",
-                      spendingLimit: limitToText(row["spending-limit"]),
+                      spendingLimit: lifetimeRemainingText(row),
                       dailyLimit: limitToText(profile?.["daily-limit"] ?? row["daily-limit"]),
                       totalQuota: limitToText(profile?.["total-quota"] ?? row["total-quota"]),
                       concurrencyLimit: limitToText(
@@ -665,7 +638,7 @@ export function EndUsersPage() {
       const nextProfile = editForm.permissionProfileId.trim();
       const prevProfile = (editUser["permission-profile-id"] ?? "").trim();
       const nextSpendingLimit = spendingLimitFromText(editForm.spendingLimit);
-      const previousSpendingLimit = editUser["spending-limit"] ?? 0;
+      const displayedSpendingLimit = spendingLimitFromText(lifetimeRemainingText(editUser));
       const directLimits = {
         "daily-limit": requestLimitFromText(editForm.dailyLimit),
         "total-quota": requestLimitFromText(editForm.totalQuota),
@@ -677,7 +650,7 @@ export function EndUsersPage() {
       if (nextUsername && nextUsername !== editUser.username) body.username = nextUsername;
       if (nextDisplay && nextDisplay !== editUser.display_name) body.display_name = nextDisplay;
       if (editForm.password.trim()) body.password = editForm.password;
-      if (nextSpendingLimit !== previousSpendingLimit) {
+      if (nextSpendingLimit !== displayedSpendingLimit) {
         body["spending-limit"] = nextSpendingLimit;
       }
 
@@ -965,199 +938,22 @@ export function EndUsersPage() {
         ) : null}
       </Modal>
 
-      <Modal
+      <EndUserEditModal
+        t={t}
         open={Boolean(editUser)}
+        user={editUser}
+        form={editForm}
+        onFormChange={setEditForm}
+        permissionProfiles={permissionProfiles}
+        permissionProfileOptions={permissionProfileOptions}
+        selectedProfile={selectedEditProfile}
+        busy={busy}
+        onSubmit={onEdit}
         onClose={() => {
           setEditUser(null);
           setEditForm(emptyForm());
         }}
-        title={t("end_users.edit", { defaultValue: "编辑用户账号" })}
-        maxWidth="max-w-2xl"
-        footer={
-          <>
-            <Button
-              onClick={() => {
-                setEditUser(null);
-                setEditForm(emptyForm());
-              }}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              type="submit"
-              form="edit-end-user-form"
-              variant="primary"
-              disabled={busy || !editForm.displayName.trim() || !editForm.username.trim()}
-            >
-              {t("common.save", { defaultValue: "保存" })}
-            </Button>
-          </>
-        }
-      >
-        <form id="edit-end-user-form" className="space-y-3" onSubmit={onEdit}>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium">
-              {t("end_users.display_name", { defaultValue: "昵称" })}
-            </span>
-            <TextInput
-              value={editForm.displayName}
-              onChange={(e) => setEditForm((f) => ({ ...f, displayName: e.target.value }))}
-              required
-            />
-          </label>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium">
-              {t("end_users.username", { defaultValue: "用户名" })}
-            </span>
-            <TextInput
-              value={editForm.username}
-              onChange={(e) => setEditForm((f) => ({ ...f, username: e.target.value }))}
-              required
-            />
-          </label>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium">
-              {t("end_users.password", { defaultValue: "新密码（可选）" })}
-            </span>
-            <TextInput
-              type="password"
-              value={editForm.password}
-              onChange={(e) => setEditForm((f) => ({ ...f, password: e.target.value }))}
-              placeholder={t("end_users.password_keep", { defaultValue: "留空则不改密码" })}
-              autoComplete="new-password"
-            />
-          </label>
-          <label className="block space-y-1.5">
-            <span className="text-sm font-medium">
-              {t("end_users.account_permission_profile", { defaultValue: "账户权限模板" })}
-            </span>
-            <Select
-              value={editForm.permissionProfileId}
-              onChange={(value) => {
-                const profile = permissionProfiles.find((item) => item.id === value);
-                setEditForm((current) => ({
-                  ...current,
-                  permissionProfileId: value,
-                  dailyLimit: profile ? limitToText(profile["daily-limit"]) : current.dailyLimit,
-                  totalQuota: profile ? limitToText(profile["total-quota"]) : current.totalQuota,
-                  concurrencyLimit: profile
-                    ? limitToText(profile["concurrency-limit"])
-                    : current.concurrencyLimit,
-                  rpmLimit: profile ? limitToText(profile["rpm-limit"]) : current.rpmLimit,
-                  tpmLimit: profile ? limitToText(profile["tpm-limit"]) : current.tpmLimit,
-                  periodSpending: profile
-                    ? limitsToPeriodSpendingDraft(profile["period-spending-limits"])
-                    : current.periodSpending,
-                }));
-              }}
-              options={permissionProfileOptions}
-              aria-label={t("end_users.account_permission_profile", {
-                defaultValue: "账户权限模板",
-              })}
-              placeholder={t("end_users.account_permission_profile_placeholder", {
-                defaultValue: "选择账户权限模板",
-              })}
-            />
-            <p className="text-xs text-slate-400 dark:text-white/40">
-              {t("end_users.quota_on_account_hint", {
-                defaultValue: "限额与模型/渠道权限挂在账号上，该用户所有密钥共用。",
-              })}
-            </p>
-          </label>
-          <section className="rounded-2xl border border-indigo-200/80 bg-indigo-50/45 p-4 dark:border-indigo-500/20 dark:bg-indigo-500/5">
-            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("end_users.quota_preview")}
-            </h3>
-            <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
-              {selectedEditProfile
-                ? t("end_users.quota_profile_readonly_hint", { profile: selectedEditProfile.name })
-                : t("end_users.quota_direct_edit_hint")}
-            </p>
-            <PeriodSpendingFields
-              t={t}
-              value={
-                selectedEditProfile
-                  ? limitsToPeriodSpendingDraft(selectedEditProfile["period-spending-limits"])
-                  : editForm.periodSpending
-              }
-              onChange={(periodSpending) =>
-                setEditForm((current) => ({ ...current, periodSpending }))
-              }
-              disabled={Boolean(selectedEditProfile)}
-              idPrefix="end-user-period"
-            />
-          </section>
-
-          <section className="rounded-2xl border border-slate-900/8 p-4 dark:border-white/10">
-            <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
-              {t("end_users.other_limits")}
-            </h3>
-            <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
-              {selectedEditProfile
-                ? t("end_users.other_limits_profile_readonly_hint", {
-                    profile: selectedEditProfile.name,
-                  })
-                : t("end_users.other_limits_direct_hint")}
-            </p>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {(
-                [
-                  ["dailyLimit", "api_keys_page.form_daily_limit"],
-                  ["totalQuota", "api_keys_page.form_total_quota"],
-                  ["concurrencyLimit", "api_keys_page.form_concurrency_limit"],
-                  ["rpmLimit", "api_keys_page.form_rpm_limit"],
-                  ["tpmLimit", "api_keys_page.form_tpm_limit"],
-                ] as const
-              ).map(([field, labelKey]) => (
-                <label key={field} className="block space-y-1.5">
-                  <span className="text-sm font-medium text-slate-700 dark:text-white/80">
-                    {t(labelKey)}
-                  </span>
-                  <TextInput
-                    type="number"
-                    min={0}
-                    step={1}
-                    inputMode="numeric"
-                    value={editForm[field]}
-                    disabled={Boolean(selectedEditProfile)}
-                    aria-label={t(labelKey)}
-                    placeholder={t("quota.input_unlimited")}
-                    onChange={(event) => {
-                      const raw = event.target.value;
-                      if (raw === "" || /^\d+$/.test(raw)) {
-                        setEditForm((current) => ({ ...current, [field]: raw }));
-                      }
-                    }}
-                  />
-                </label>
-              ))}
-              <label className="block space-y-1.5 sm:col-span-2 lg:col-span-1">
-                <span className="text-sm font-medium text-slate-700 dark:text-white/80">
-                  {t("end_users.lifetime_spending_limit")}
-                </span>
-                <TextInput
-                  type="number"
-                  min={0}
-                  step={1}
-                  inputMode="numeric"
-                  value={editForm.spendingLimit}
-                  aria-label={t("end_users.lifetime_spending_limit")}
-                  placeholder={t("quota.input_unlimited")}
-                  onChange={(event) => {
-                    const raw = event.target.value;
-                    if (raw === "" || /^\d*(?:\.\d*)?$/.test(raw)) {
-                      setEditForm((current) => ({ ...current, spendingLimit: raw }));
-                    }
-                  }}
-                />
-                <span className="block text-xs text-slate-400 dark:text-white/40">
-                  {t("end_users.lifetime_spending_limit_hint")}
-                </span>
-              </label>
-            </div>
-          </section>
-        </form>
-      </Modal>
+      />
 
       <SecretRevealModal
         open={Boolean(generatedReset)}

--- a/pages/end-users/__tests__/EndUsersPage.test.tsx
+++ b/pages/end-users/__tests__/EndUsersPage.test.tsx
@@ -457,3 +457,94 @@ describe("EndUsersPage account semantics", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("EndUsersPage lifetime allowance", () => {
+  // 100 cap with 12 spent is the operator-facing example: the field must read 88.
+  const cappedUser = {
+    ...users[0],
+    id: "user-capped",
+    username: "carol",
+    display_name: "Carol",
+    "spending-limit": 100,
+    "lifetime-spending-used": 12,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await i18n.changeLanguage("en");
+    mocks.permissionProfiles.mockResolvedValue([]);
+    mocks.list.mockResolvedValue({ items: [cappedUser] });
+    mocks.update.mockResolvedValue(cappedUser);
+  });
+
+  async function openEditDialog() {
+    renderPage();
+    await screen.findByText("Carol");
+    await userEvent.click(screen.getAllByRole("button", { name: "Edit user account" })[0]!);
+    return screen.findByRole("dialog", { name: "Edit user account" });
+  }
+
+  test("the lifetime field shows what is left, not the configured cap", async () => {
+    const dialog = await openEditDialog();
+
+    const field = within(dialog).getByRole("spinbutton", {
+      name: "Lifetime spending limit (USD)",
+    });
+    expect((field as HTMLInputElement).value).toBe("88");
+    // The cap itself must stay visible, otherwise the operator cannot tell what
+    // the number they are about to overwrite means.
+    expect(within(dialog).getByText(/\$100\.00/)).toBeTruthy();
+    expect(within(dialog).getByText(/\$12\.00/)).toBeTruthy();
+  });
+
+  test("saving an untouched form sends nothing at all", async () => {
+    const dialog = await openEditDialog();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("editing another field does not silently rewrite the cap to the remaining amount", async () => {
+    // The real hazard: the field displays 88 while the stored cap is 100, so a
+    // naive "changed?" check treats every save as an edit and walks the cap down
+    // 100 → 88 → 76 each time an unrelated field is touched.
+    const dialog = await openEditDialog();
+
+    await userEvent.type(within(dialog).getByRole("spinbutton", { name: "RPM limit" }), "60");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mocks.update).toHaveBeenCalled());
+    const body = mocks.update.mock.calls[0]![1];
+    expect(body).toMatchObject({ "rpm-limit": 60 });
+    expect(body).not.toHaveProperty("spending-limit");
+  });
+
+  test("an edited value is stored as the new cap", async () => {
+    const dialog = await openEditDialog();
+
+    const field = within(dialog).getByRole("spinbutton", {
+      name: "Lifetime spending limit (USD)",
+    });
+    await userEvent.clear(field);
+    await userEvent.type(field, "200");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.update).toHaveBeenCalledWith(
+        "user-capped",
+        expect.objectContaining({ "spending-limit": 200 }),
+      );
+    });
+  });
+
+  test("the quota column surfaces a lifetime-only cap instead of reading unlimited", async () => {
+    renderPage();
+    await screen.findByText("Carol");
+
+    const row = screen.getByText("Carol").closest("tr")!;
+    expect(within(row).getByText(/\$88 left/)).toBeTruthy();
+    expect(within(row).queryByText("Unlimited")).toBeNull();
+  });
+});

--- a/pages/end-users/components/EndUserEditModal.tsx
+++ b/pages/end-users/components/EndUserEditModal.tsx
@@ -1,0 +1,243 @@
+import type { Dispatch, FormEvent, SetStateAction } from "react";
+import type { ApiKeyPermissionProfile, EndUser } from "@code-proxy/api-client";
+import { Button, Modal, Select, TextInput } from "@code-proxy/ui";
+import {
+  PeriodSpendingFields,
+  formatQuotaUsdAmount,
+  limitsToPeriodSpendingDraft,
+} from "@features/period-spending";
+import type { EndUserForm } from "../endUserForm";
+import { limitToText } from "../endUserForm";
+
+/**
+ * Account edit dialog. Split out of EndUsersPage so the page keeps shrinking
+ * under the file-size gate; behaviour is unchanged.
+ */
+export function EndUserEditModal({
+  t,
+  open,
+  user,
+  form,
+  onFormChange,
+  permissionProfiles,
+  permissionProfileOptions,
+  selectedProfile,
+  busy,
+  onSubmit,
+  onClose,
+}: {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  open: boolean;
+  user: EndUser | null;
+  form: EndUserForm;
+  onFormChange: Dispatch<SetStateAction<EndUserForm>>;
+  permissionProfiles: ApiKeyPermissionProfile[];
+  permissionProfileOptions: { value: string; label: string }[];
+  selectedProfile: ApiKeyPermissionProfile | null;
+  busy: boolean;
+  onSubmit: (event: FormEvent) => void;
+  onClose: () => void;
+}) {
+  const editUser = user;
+  const editForm = form;
+  const setEditForm = onFormChange;
+  const selectedEditProfile = selectedProfile;
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={t("end_users.edit", { defaultValue: "编辑用户账号" })}
+      maxWidth="max-w-2xl"
+      footer={
+        <>
+          <Button onClick={onClose}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            type="submit"
+            form="edit-end-user-form"
+            variant="primary"
+            disabled={busy || !editForm.displayName.trim() || !editForm.username.trim()}
+          >
+            {t("common.save", { defaultValue: "保存" })}
+          </Button>
+        </>
+      }
+    >
+      <form id="edit-end-user-form" className="space-y-3" onSubmit={onSubmit}>
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">
+            {t("end_users.display_name", { defaultValue: "昵称" })}
+          </span>
+          <TextInput
+            value={editForm.displayName}
+            onChange={(e) => setEditForm((f) => ({ ...f, displayName: e.target.value }))}
+            required
+          />
+        </label>
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">
+            {t("end_users.username", { defaultValue: "用户名" })}
+          </span>
+          <TextInput
+            value={editForm.username}
+            onChange={(e) => setEditForm((f) => ({ ...f, username: e.target.value }))}
+            required
+          />
+        </label>
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">
+            {t("end_users.password", { defaultValue: "新密码（可选）" })}
+          </span>
+          <TextInput
+            type="password"
+            value={editForm.password}
+            onChange={(e) => setEditForm((f) => ({ ...f, password: e.target.value }))}
+            placeholder={t("end_users.password_keep", { defaultValue: "留空则不改密码" })}
+            autoComplete="new-password"
+          />
+        </label>
+        <label className="block space-y-1.5">
+          <span className="text-sm font-medium">
+            {t("end_users.account_permission_profile", { defaultValue: "账户权限模板" })}
+          </span>
+          <Select
+            value={editForm.permissionProfileId}
+            onChange={(value) => {
+              const profile = permissionProfiles.find((item) => item.id === value);
+              setEditForm((current) => ({
+                ...current,
+                permissionProfileId: value,
+                dailyLimit: profile ? limitToText(profile["daily-limit"]) : current.dailyLimit,
+                totalQuota: profile ? limitToText(profile["total-quota"]) : current.totalQuota,
+                concurrencyLimit: profile
+                  ? limitToText(profile["concurrency-limit"])
+                  : current.concurrencyLimit,
+                rpmLimit: profile ? limitToText(profile["rpm-limit"]) : current.rpmLimit,
+                tpmLimit: profile ? limitToText(profile["tpm-limit"]) : current.tpmLimit,
+                periodSpending: profile
+                  ? limitsToPeriodSpendingDraft(profile["period-spending-limits"])
+                  : current.periodSpending,
+              }));
+            }}
+            options={permissionProfileOptions}
+            aria-label={t("end_users.account_permission_profile", {
+              defaultValue: "账户权限模板",
+            })}
+            placeholder={t("end_users.account_permission_profile_placeholder", {
+              defaultValue: "选择账户权限模板",
+            })}
+          />
+          <p className="text-xs text-slate-400 dark:text-white/40">
+            {t("end_users.quota_on_account_hint", {
+              defaultValue: "限额与模型/渠道权限挂在账号上，该用户所有密钥共用。",
+            })}
+          </p>
+        </label>
+        <section className="rounded-2xl border border-indigo-200/80 bg-indigo-50/45 p-4 dark:border-indigo-500/20 dark:bg-indigo-500/5">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+            {t("end_users.quota_preview")}
+          </h3>
+          <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
+            {selectedEditProfile
+              ? t("end_users.quota_profile_readonly_hint", { profile: selectedEditProfile.name })
+              : t("end_users.quota_direct_edit_hint")}
+          </p>
+          <PeriodSpendingFields
+            t={t}
+            value={
+              selectedEditProfile
+                ? limitsToPeriodSpendingDraft(selectedEditProfile["period-spending-limits"])
+                : editForm.periodSpending
+            }
+            onChange={(periodSpending) =>
+              setEditForm((current) => ({ ...current, periodSpending }))
+            }
+            disabled={Boolean(selectedEditProfile)}
+            idPrefix="end-user-period"
+          />
+        </section>
+
+        <section className="rounded-2xl border border-slate-900/8 p-4 dark:border-white/10">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+            {t("end_users.other_limits")}
+          </h3>
+          <p className="mb-3 mt-1 text-xs text-slate-500 dark:text-white/50">
+            {selectedEditProfile
+              ? t("end_users.other_limits_profile_readonly_hint", {
+                  profile: selectedEditProfile.name,
+                })
+              : t("end_users.other_limits_direct_hint")}
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {(
+              [
+                ["dailyLimit", "api_keys_page.form_daily_limit"],
+                ["totalQuota", "api_keys_page.form_total_quota"],
+                ["concurrencyLimit", "api_keys_page.form_concurrency_limit"],
+                ["rpmLimit", "api_keys_page.form_rpm_limit"],
+                ["tpmLimit", "api_keys_page.form_tpm_limit"],
+              ] as const
+            ).map(([field, labelKey]) => (
+              <label key={field} className="block space-y-1.5">
+                <span className="text-sm font-medium text-slate-700 dark:text-white/80">
+                  {t(labelKey)}
+                </span>
+                <TextInput
+                  type="number"
+                  min={0}
+                  step={1}
+                  inputMode="numeric"
+                  value={editForm[field]}
+                  disabled={Boolean(selectedEditProfile)}
+                  aria-label={t(labelKey)}
+                  placeholder={t("quota.input_unlimited")}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    if (raw === "" || /^\d+$/.test(raw)) {
+                      setEditForm((current) => ({ ...current, [field]: raw }));
+                    }
+                  }}
+                />
+              </label>
+            ))}
+            <label className="block space-y-1.5 sm:col-span-2 lg:col-span-1">
+              <span className="text-sm font-medium text-slate-700 dark:text-white/80">
+                {t("end_users.lifetime_spending_limit")}
+              </span>
+              <TextInput
+                type="number"
+                min={0}
+                step={1}
+                inputMode="numeric"
+                value={editForm.spendingLimit}
+                aria-label={t("end_users.lifetime_spending_limit")}
+                placeholder={t("quota.input_unlimited")}
+                onChange={(event) => {
+                  const raw = event.target.value;
+                  if (raw === "" || /^\d*(?:\.\d*)?$/.test(raw)) {
+                    setEditForm((current) => ({ ...current, spendingLimit: raw }));
+                  }
+                }}
+              />
+              {(editUser?.["spending-limit"] ?? 0) > 0 ? (
+                <span className="block text-xs text-slate-500 tabular-nums dark:text-white/55">
+                  {t("quota.lifetime_remaining_hint", {
+                    limit: formatQuotaUsdAmount(editUser?.["spending-limit"]),
+                    used: formatQuotaUsdAmount(editUser?.["lifetime-spending-used"]),
+                  })}
+                  <span className="ml-1 text-slate-400 dark:text-white/40">
+                    {t("quota.lifetime_remaining_field_hint")}
+                  </span>
+                </span>
+              ) : null}
+              <span className="block text-xs text-slate-400 dark:text-white/40">
+                {t("end_users.lifetime_spending_limit_hint")}
+              </span>
+            </label>
+          </div>
+        </section>
+      </form>
+    </Modal>
+  );
+}

--- a/pages/end-users/endUserForm.ts
+++ b/pages/end-users/endUserForm.ts
@@ -1,0 +1,52 @@
+import type { EndUser } from "@code-proxy/api-client";
+import { emptyPeriodSpendingDraft, remainingQuotaUsd } from "@features/period-spending";
+import type { PeriodSpendingDraft } from "@features/period-spending";
+
+export type EndUserForm = {
+  username: string;
+  displayName: string;
+  password: string;
+  permissionProfileId: string;
+  spendingLimit: string;
+  dailyLimit: string;
+  totalQuota: string;
+  concurrencyLimit: string;
+  rpmLimit: string;
+  tpmLimit: string;
+  periodSpending: PeriodSpendingDraft;
+};
+export const emptyForm = (): EndUserForm => ({
+  username: "",
+  displayName: "",
+  password: "",
+  permissionProfileId: "",
+  spendingLimit: "",
+  dailyLimit: "",
+  totalQuota: "",
+  concurrencyLimit: "",
+  rpmLimit: "",
+  tpmLimit: "",
+  periodSpending: emptyPeriodSpendingDraft(),
+});
+export /**
+ * The lifetime input shows what is still spendable, not the configured cap.
+ * Saving stores the entered number as the new cap, so the "did the operator
+ * change it?" check below must compare against this displayed value — comparing
+ * against the stored cap would treat merely opening the modal as an edit and
+ * shrink the cap to the remaining amount on every save.
+ */
+const lifetimeRemainingText = (user: EndUser | null): string => {
+  const limit = user?.["spending-limit"] ?? 0;
+  if (!Number.isFinite(limit) || limit <= 0) return "";
+  return limitToText(remainingQuotaUsd(limit, user?.["lifetime-spending-used"]));
+};
+export const spendingLimitFromText = (value: string): number => {
+  const parsed = Number.parseFloat(value.trim());
+  return Number.isFinite(parsed) && parsed > 0 ? Math.ceil(parsed) : 0;
+};
+export const requestLimitFromText = (value: string): number => {
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+export const limitToText = (value: number | undefined): string =>
+  value && value > 0 ? String(value) : "";

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -22,7 +22,7 @@
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 1218,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1455,
-    "pages/end-users/EndUsersPage.tsx": 1334,
+    "pages/end-users/EndUsersPage.tsx": 1130,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 1197,
     "pages/models/ModelsPage.tsx": 1358,


### PR DESCRIPTION
## 问题

设了「累计消费限额」后，管理端只回答「花了多少」，不回答「还能用多少」：

- **配额列显示「不限制」**：该列按四个滚动周期（5h/日/周/月）判断有无限额，累计限额不属于其中。设了 100 刀累计上限的账号，配额列仍显示「不限制」。
- **累计消费列只有已用、没有上限**：于是整张表格没有任何位置能看出这个账号设了 100 刀。
- **编辑弹窗一个用量数字都没有**：只有输入框，看不到已花 12、还剩 88。

## 改动

### 展示剩余

- **配额列**并入「累计」chip，形如 `累计 剩 $88 / $100`。设了累计限额就不再误显示「不限制」。滚动周期保持 `已用/上限`（它们会自动回满，关心的是本周期进度）；累计只减不增，直接显示剩余。
- **编辑弹窗**的累计消费限额输入框显示剩余，下方补一行「上限 $100 · 已用 $12」。
- **apikey-lookup** 的累计消费 KPI 卡片同步改为剩余，上限与已用移入 hint。其余滚动类卡片不变。

### 关键防护

该输入框显示的是剩余、保存写入的是上限。现有「值有没有变」的判断是拿输入值与库中上限比较——改为显示剩余后，88 ≠ 100 会被判定成「改过了」，于是**每次保存都把上限改写成剩余**（100 → 88 → 76），只要顺手改了别的字段就会触发。

比较基准改为输入框的**初始显示值**：没动它就不提交该字段，动了才按填入值存为新上限。语义不变，堵住静默改写。

### 结构债门禁

改动后 `EndUsersPage.tsx` 达 1368 行，超过冻结基线。按规范拆分而非抬基线：编辑弹窗移入 `components/EndUserEditModal.tsx`，表单类型与 helper 移入 `endUserForm.ts`，主文件 **1334 → 1130** 行并锁定基线。仅改动该文件的基线条目。

## 范围说明

- **Key 层不做对应改动**：`EndUserAPIKey` 没有累计上限字段，累计天花板只存在于账号层、跨该账号全部 Key 生效。Key 表格的配额列保持周期性，已补注释说明。
- **纯前端**：账号、Key、lookup 三条链路的 DTO 都已同时提供累计上限与累计已用，无需后端改动。
- ru 语言包本身缺整个 `quota` 区块（走 fallback），未单独为其新增这几个 key。

## 验证

新增 11 个测试：

- 配额列：仅有累计上限时不再显示「不限制」；超支钳到 `剩 $0`；未设累计上限时保持周期性
- 编辑弹窗：显示剩余 88 而非上限 100；未改动表单不发请求；**改其它字段不得改写累计上限**（回退防护后该用例报 `spending-limit: 88`）；改动后按输入值存为新上限
- KPI 卡片：累计卡显示剩余并在 hint 保留上限/已用；滚动类卡片保持 `已用/上限`；超支钳到 0

`./scripts/ci-pr.sh` 本地完整通过（lint、design:check、全量 vitest 144 文件、build、bundle:diff、文件大小门禁）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)