### PR TITLE
fix(quota): 累计消费限额输入框回归上限语义

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4690,7 +4690,6 @@
     "remaining_value": "{{remaining}} left",
     "lifetime_remaining_detail": "Lifetime: {{used}} used, {{limit}} cap, {{remaining}} left",
     "lifetime_remaining_hint": "Cap {{limit}} · Used {{used}}",
-    "lifetime_remaining_field_hint": "Saving stores the entered value as the new lifetime cap",
     "reset": {
       "account_title": "Reset account quota",
       "key_title": "Reset Key quota",
@@ -4710,7 +4709,8 @@
       "key_exceeds_account": "Key {{period}} quota {{keyLimit}} exceeds the account {{period}} quota {{accountLimit}}",
       "period_day_legacy_conflict": "Daily quota conflicts with the legacy daily spending limit.",
       "five_hour_projection_warming": "The 5-hour quota is temporarily unavailable while usage projection warms up."
-    }
+    },
+    "lifetime_usage_hint": "{{used}} used this cycle · {{remaining}} left; grant again from Reset quota"
   },
   "models": {
     "total_models_count": "{{count}} models"

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4707,7 +4707,6 @@
     "remaining_value": "剩 {{remaining}}",
     "lifetime_remaining_detail": "累计：已用 {{used}}，上限 {{limit}}，剩余 {{remaining}}",
     "lifetime_remaining_hint": "上限 {{limit}} · 已用 {{used}}",
-    "lifetime_remaining_field_hint": "填写后按新的累计上限保存",
     "reset": {
       "account_title": "重置账号配额",
       "key_title": "重置 Key 配额",
@@ -4727,7 +4726,8 @@
       "key_exceeds_account": "Key {{period}}额度 {{keyLimit}} 超过账号{{period}}额度 {{accountLimit}}",
       "period_day_legacy_conflict": "每日额度与旧版每日消费限额冲突。",
       "five_hour_projection_warming": "5 小时配额正在准备使用数据，请稍后再试。"
-    }
+    },
+    "lifetime_usage_hint": "本轮已用 {{used}} · 剩余 {{remaining}}；用完后可在「重置配额」中重新发放"
   },
   "identity_admin": {
     "operation_failed": "操作失败。",

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -48,7 +48,6 @@ import { EndUserEditModal } from "./components/EndUserEditModal";
 import {
   emptyForm,
   limitToText,
-  lifetimeRemainingText,
   requestLimitFromText,
   spendingLimitFromText,
 } from "./endUserForm";
@@ -511,7 +510,7 @@ export function EndUsersPage() {
                       displayName: row.display_name,
                       password: "",
                       permissionProfileId: row["permission-profile-id"] ?? "",
-                      spendingLimit: lifetimeRemainingText(row),
+                      spendingLimit: limitToText(row["spending-limit"]),
                       dailyLimit: limitToText(profile?.["daily-limit"] ?? row["daily-limit"]),
                       totalQuota: limitToText(profile?.["total-quota"] ?? row["total-quota"]),
                       concurrencyLimit: limitToText(
@@ -638,7 +637,7 @@ export function EndUsersPage() {
       const nextProfile = editForm.permissionProfileId.trim();
       const prevProfile = (editUser["permission-profile-id"] ?? "").trim();
       const nextSpendingLimit = spendingLimitFromText(editForm.spendingLimit);
-      const displayedSpendingLimit = spendingLimitFromText(lifetimeRemainingText(editUser));
+      const previousSpendingLimit = editUser["spending-limit"] ?? 0;
       const directLimits = {
         "daily-limit": requestLimitFromText(editForm.dailyLimit),
         "total-quota": requestLimitFromText(editForm.totalQuota),
@@ -650,7 +649,7 @@ export function EndUsersPage() {
       if (nextUsername && nextUsername !== editUser.username) body.username = nextUsername;
       if (nextDisplay && nextDisplay !== editUser.display_name) body.display_name = nextDisplay;
       if (editForm.password.trim()) body.password = editForm.password;
-      if (nextSpendingLimit !== displayedSpendingLimit) {
+      if (nextSpendingLimit !== previousSpendingLimit) {
         body["spending-limit"] = nextSpendingLimit;
       }
 

--- a/pages/end-users/__tests__/EndUsersPage.test.tsx
+++ b/pages/end-users/__tests__/EndUsersPage.test.tsx
@@ -484,17 +484,18 @@ describe("EndUsersPage lifetime allowance", () => {
     return screen.findByRole("dialog", { name: "Edit user account" });
   }
 
-  test("the lifetime field shows what is left, not the configured cap", async () => {
+  test("the lifetime field edits the cap, with usage shown alongside", async () => {
+    // Showing the remainder in a limit editor made "set 1000" read back as 405
+    // and forced operators to reverse-engineer what to type. The field is the
+    // cap; usage belongs next to it.
     const dialog = await openEditDialog();
 
     const field = within(dialog).getByRole("spinbutton", {
       name: "Lifetime spending limit (USD)",
     });
-    expect((field as HTMLInputElement).value).toBe("88");
-    // The cap itself must stay visible, otherwise the operator cannot tell what
-    // the number they are about to overwrite means.
-    expect(within(dialog).getByText(/\$100\.00/)).toBeTruthy();
-    expect(within(dialog).getByText(/\$12\.00/)).toBeTruthy();
+    expect((field as HTMLInputElement).value).toBe("100");
+    expect(within(dialog).getByText(/\$12\.00 used this cycle/)).toBeTruthy();
+    expect(within(dialog).getByText(/\$88\.00 left/)).toBeTruthy();
   });
 
   test("saving an untouched form sends nothing at all", async () => {
@@ -506,10 +507,7 @@ describe("EndUsersPage lifetime allowance", () => {
     expect(mocks.update).not.toHaveBeenCalled();
   });
 
-  test("editing another field does not silently rewrite the cap to the remaining amount", async () => {
-    // The real hazard: the field displays 88 while the stored cap is 100, so a
-    // naive "changed?" check treats every save as an edit and walks the cap down
-    // 100 → 88 → 76 each time an unrelated field is touched.
+  test("editing another field leaves the cap untouched", async () => {
     const dialog = await openEditDialog();
 
     await userEvent.type(within(dialog).getByRole("spinbutton", { name: "RPM limit" }), "60");

--- a/pages/end-users/components/EndUserEditModal.tsx
+++ b/pages/end-users/components/EndUserEditModal.tsx
@@ -5,6 +5,7 @@ import {
   PeriodSpendingFields,
   formatQuotaUsdAmount,
   limitsToPeriodSpendingDraft,
+  remainingQuotaUsd,
 } from "@features/period-spending";
 import type { EndUserForm } from "../endUserForm";
 import { limitToText } from "../endUserForm";
@@ -222,13 +223,15 @@ export function EndUserEditModal({
               />
               {(editUser?.["spending-limit"] ?? 0) > 0 ? (
                 <span className="block text-xs text-slate-500 tabular-nums dark:text-white/55">
-                  {t("quota.lifetime_remaining_hint", {
-                    limit: formatQuotaUsdAmount(editUser?.["spending-limit"]),
+                  {t("quota.lifetime_usage_hint", {
                     used: formatQuotaUsdAmount(editUser?.["lifetime-spending-used"]),
+                    remaining: formatQuotaUsdAmount(
+                      remainingQuotaUsd(
+                        editUser?.["spending-limit"],
+                        editUser?.["lifetime-spending-used"],
+                      ),
+                    ),
                   })}
-                  <span className="ml-1 text-slate-400 dark:text-white/40">
-                    {t("quota.lifetime_remaining_field_hint")}
-                  </span>
                 </span>
               ) : null}
               <span className="block text-xs text-slate-400 dark:text-white/40">


### PR DESCRIPTION
## 问题

设了 $1,000 累计额度的账号，打开编辑弹窗看到的是 `405.08498399999917`：

- 既不是运营填过的数字（上限 1000），也不是能直接理解的值
- 浮点数未做金额格式化

上一版把这个输入框改成显示剩余额度，但它是**额度编辑器**——填什么就该显示什么。显示剩余会让"设 1000"读回来变成 405，运营得反推该填多少。

## 改动

- 输入框回到显示已配置的累计上限。
- 已用与剩余移到下方提示行，按金额格式化；文案指明用完后可在「重置配额」中重新发放，与 [CliRelay#856](https://github.com/kittors/CliRelay/pull/856) 刚上线的额度发放能力衔接。
- 保存比较基准回到库中上限，此前为规避"显示剩余/保存上限"不对称而加的初始值比较随之移除，逻辑简化。

配合已上线的发放能力，完整体验是：输入框 = 本轮额度；下方 = 本轮已用与剩余；用完点「重置配额 → 累计」发放新一轮，剩余回到满额。

## 验证

更新 3 个测试：输入框显示上限、提示行含已用与剩余、改其它字段不动上限。`./scripts/ci-pr.sh` 完整通过（含 e2e）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)