### PR TITLE
fix(proxies): unique ids for CJK proxy names

### DIFF
--- a/features/proxy-pool/__tests__/proxy-utils.test.ts
+++ b/features/proxy-pool/__tests__/proxy-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { slugifyProxyID, uniqueProxyID } from "../proxy-utils";
+
+describe("slugifyProxyID", () => {
+  test("uses ascii name when present", () => {
+    expect(slugifyProxyID("HK Proxy", "socks5://1.1.1.1:1080")).toBe("hk-proxy");
+  });
+
+  test("does not collapse CJK-only names to bare ip", () => {
+    const la = slugifyProxyID("洛杉矶 ip", "socks5://user:pass@1.2.3.4:1080");
+    const home = slugifyProxyID("住宅 ip", "socks5://user:pass@5.6.7.8:1080");
+    expect(la).not.toBe("ip");
+    expect(home).not.toBe("ip");
+    expect(la).not.toBe(home);
+    expect(la).toMatch(/^proxy-/);
+    expect(home).toMatch(/^proxy-/);
+  });
+});
+
+describe("uniqueProxyID", () => {
+  test("appends suffix when id already exists", () => {
+    const id = uniqueProxyID("ip", [{ id: "ip", name: "old", url: "socks5://1.1.1.1:1080", enabled: true }]);
+    expect(id).toBe("ip-2");
+  });
+
+  test("keeps candidate when free", () => {
+    expect(uniqueProxyID("la", [])).toBe("la");
+  });
+});

--- a/features/proxy-pool/proxy-utils.ts
+++ b/features/proxy-pool/proxy-utils.ts
@@ -118,13 +118,57 @@ export const writeCachedProxyCheckState = (
   });
 };
 
+const proxyIDFromURL = (url: string): string => {
+  const trimmed = (url || "").trim();
+  try {
+    const parsed = new URL(trimmed);
+    const hostPart = `${parsed.hostname}${parsed.port ? `-${parsed.port}` : ""}`
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (hostPart) return `proxy-${hostPart}`;
+  } catch {
+    // fall through to hash
+  }
+  if (!trimmed) return `proxy-${Date.now()}`;
+  let hash = 0;
+  for (let i = 0; i < trimmed.length; i += 1) {
+    hash = (Math.imul(31, hash) + trimmed.charCodeAt(i)) | 0;
+  }
+  return `proxy-${(hash >>> 0).toString(16)}`;
+};
+
+/** Stable proxy id from ASCII name; non-ASCII names use host/port so "洛杉矶 ip" ≠ "住宅 ip". */
 export const slugifyProxyID = (name: string, fallback: string): string => {
-  const base = (name || fallback)
-    .trim()
+  const rawName = (name || "").trim();
+  // CJK / mixed names strip to colliding fragments like "ip"; always key off the URL.
+  if (/[^\x00-\x7F]/.test(rawName)) {
+    return proxyIDFromURL(fallback);
+  }
+  const fromName = rawName
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-  return base || `proxy-${Date.now()}`;
+  if (fromName) return fromName;
+  return proxyIDFromURL(fallback);
+};
+
+/** Keep create ids unique within the current tenant list (editing id excluded). */
+export const uniqueProxyID = (
+  candidate: string,
+  existing: ProxyPoolEntry[],
+  editingID?: string | null,
+): string => {
+  const base = candidate.trim() || `proxy-${Date.now()}`;
+  const used = new Set(
+    existing
+      .map((entry) => entry.id.trim())
+      .filter((id) => id && id !== (editingID ?? "").trim()),
+  );
+  if (!used.has(base)) return base;
+  let n = 2;
+  while (used.has(`${base}-${n}`)) n += 1;
+  return `${base}-${n}`;
 };
 
 export const validateProxyDraft = (draft: ProxyPoolEntry): string | null => {

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -22,6 +22,7 @@ import {
   proxyProtocol,
   readCachedProxyCheckState,
   slugifyProxyID,
+  uniqueProxyID,
   validateProxyDraft,
   type ProxyCheckStateEntry,
   writeCachedProxyCheckState,
@@ -133,9 +134,12 @@ export function ProxiesPage() {
       return;
     }
 
+    const baseID = draft.id.trim() || slugifyProxyID(draft.name, draft.url);
     const normalized: ProxyPoolEntry = {
       ...draft,
-      id: draft.id.trim() || slugifyProxyID(draft.name, draft.url),
+      id: editingID
+        ? editingID
+        : uniqueProxyID(baseID, entries, editingID),
       name: draft.name.trim(),
       url: draft.url.trim(),
       description: draft.description?.trim() ?? "",
@@ -163,6 +167,7 @@ export function ProxiesPage() {
         const nextEntries = [...entries, normalized];
         await proxiesApi.saveAll(nextEntries);
         setEntries(nextEntries);
+        void refreshCheckResults([normalized]);
       }
       notify({ type: "success", message: t("proxies.saved") });
       closeModal();

--- a/pages/proxies/__tests__/ProxiesPage.test.tsx
+++ b/pages/proxies/__tests__/ProxiesPage.test.tsx
@@ -266,6 +266,43 @@ describe("ProxiesPage", () => {
     });
   });
 
+  test("creates CJK-named proxies without colliding on id=ip", async () => {
+    mocks.apiGet.mockResolvedValue({
+      items: [
+        {
+          id: "ip",
+          name: "住宅 ip",
+          url: "socks5://user:pass@69.17.3.25:1080",
+          enabled: true,
+        },
+      ],
+    });
+
+    renderPage();
+    await screen.findByText("住宅 ip");
+
+    await userEvent.click(await screen.findByRole("button", { name: /add proxy/i }));
+    const dialog = await screen.findByRole("dialog", { name: /add proxy/i });
+    await userEvent.type(within(dialog).getByLabelText(/name/i), "洛杉矶 ip");
+    await userEvent.type(
+      within(dialog).getByLabelText(/proxy url/i),
+      "socks5://user:pass@1.2.3.4:1080",
+    );
+    await userEvent.click(within(dialog).getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.apiPut).toHaveBeenCalled();
+    });
+    const putBody = mocks.apiPut.mock.calls.at(-1)?.[1] as {
+      items: Array<{ id: string; name: string }>;
+    };
+    const ids = putBody.items.map((item) => item.id);
+    expect(ids).toContain("ip");
+    expect(ids.filter((id) => id === "ip")).toHaveLength(1);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
   test("deletes a proxy only after confirmation", async () => {
     renderPage();
 


### PR DESCRIPTION
## Summary
- Non-ASCII proxy names no longer slug to colliding fragments like `ip`; id is derived from host/port.
- Create path suffixes ids that already exist in the tenant list; re-check latency for the new row after save.

## Related
Backend: CliRelay fix rebinds tenant executors after proxy URL edits and rejects duplicate ids on PUT.

## Test plan
- [x] `bun run test -- features/proxy-pool/__tests__/proxy-utils.test.ts pages/proxies/__tests__/ProxiesPage.test.tsx` (17 passed)
- [ ] GHA PR checks green