### PR TITLE
fix(quota): 仅设累计额度的账号可打开重置配额

### DIFF
--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -47,6 +47,7 @@ import { EndUserResetHistoryModal } from "./components/EndUserResetHistoryModal"
 import { EndUserEditModal } from "./components/EndUserEditModal";
 import {
   emptyForm,
+  hasResettableQuota,
   limitToText,
   requestLimitFromText,
   spendingLimitFromText,
@@ -467,12 +468,7 @@ export function EndUsersPage() {
         headerClassName: stickyActionsHeaderClass,
         cellClassName: stickyActionsCellClass,
         render: (row) => {
-          const hasResettablePeriod = Object.values(
-            normalizePeriodSpendingLimits(
-              row["period-spending-limits"],
-              row["daily-spending-limit"],
-            ),
-          ).some((limit) => limit > 0);
+          const hasResettablePeriod = hasResettableQuota(row);
           const resetLabel = hasResettablePeriod
             ? t("end_users.reset_period_spending")
             : t("end_users.reset_period_spending_disabled");

--- a/pages/end-users/__tests__/EndUsersPage.test.tsx
+++ b/pages/end-users/__tests__/EndUsersPage.test.tsx
@@ -537,6 +537,20 @@ describe("EndUsersPage lifetime allowance", () => {
     });
   });
 
+  test("an account with only a lifetime allowance can reach the reset action", async () => {
+    // The dialog gained a lifetime option, but the menu entry that opens it was
+    // still gated on the rolling period limits, so the one account type that
+    // needs granting most could never open it.
+    renderPage();
+    await screen.findByText("Carol");
+    await openRowMoreActions("Carol");
+
+    // Enabled label is "Reset account quota"; the disabled state renders the
+    // "No resettable period quota" label instead.
+    const action = screen.getByRole("menuitem", { name: "Reset account quota" });
+    expect(action.getAttribute("aria-disabled")).not.toBe("true");
+  });
+
   test("the quota column surfaces a lifetime-only cap instead of reading unlimited", async () => {
     renderPage();
     await screen.findByText("Carol");

--- a/pages/end-users/endUserForm.ts
+++ b/pages/end-users/endUserForm.ts
@@ -1,6 +1,18 @@
 import type { EndUser } from "@code-proxy/api-client";
+import { normalizePeriodSpendingLimits } from "@code-proxy/api-client";
 import { emptyPeriodSpendingDraft, remainingQuotaUsd } from "@features/period-spending";
 import type { PeriodSpendingDraft } from "@features/period-spending";
+
+/**
+ * Whether the account has anything a reset can act on. The cumulative allowance
+ * counts: granting it again is the only way to make a spent-out account usable,
+ * yet it lives outside the rolling period limits, so gating on those alone left
+ * lifetime-only accounts with the action permanently disabled.
+ */
+export const hasResettableQuota = (user: EndUser): boolean =>
+  Object.values(
+    normalizePeriodSpendingLimits(user["period-spending-limits"], user["daily-spending-limit"]),
+  ).some((limit) => limit > 0) || (user["spending-limit"] ?? 0) > 0;
 
 export type EndUserForm = {
   username: string;

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -22,7 +22,7 @@
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 1218,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1455,
-    "pages/end-users/EndUsersPage.tsx": 1131,
+    "pages/end-users/EndUsersPage.tsx": 1126,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 1197,
     "pages/models/ModelsPage.tsx": 1358,


### PR DESCRIPTION
## 问题

弹窗已支持发放累计额度（[#888](https://github.com/kittors/codeProxy/pull/888)），但**打开它的菜单项**仍只按四个滚动周期判断是否可重置：

```ts
const hasResettablePeriod = Object.values(
  normalizePeriodSpendingLimits(row["period-spending-limits"], row["daily-spending-limit"]),
).some((limit) => limit > 0);
```

只设了累计额度的账号（线上 `kittors`：累计 $1,000、四周期全为 0），该项恒为禁用并显示「无可重置的周期配额，请编辑账号额度」——**最需要发放额度的账号恰恰点不进去**。

## 改动

判定改为「四周期任一有额度，**或**配置了累计额度」，并移入 `endUserForm` 的 `hasResettableQuota`：页面内联逻辑随之收敛，`EndUsersPage.tsx` 1131 → **1126** 行，基线同步锁定（只动该文件一条）。

## 验证

新增回归测试：仅设累计额度时该菜单项可用。回退判定后，该项渲染为禁用文案，用例报「找不到 Reset account quota」。

`./scripts/ci-pr.sh` 完整通过（含 e2e）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)