### PR TITLE
feat(quota): 配额列改为内联 chip 布局并显示模型测试耗时

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3622,6 +3622,7 @@
     "test_run": "Run test",
     "test_running": "Testing…",
     "test_response": "Response",
+    "test_duration": "Took {{duration}}",
     "test_no_channels": "No channel sources are available for this model.",
     "test_no_api_key": "No usable API key found. Create an enabled key first; ideally allow the selected channel in allowed-channels.",
     "test_empty_response": "(empty response)",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4128,6 +4128,7 @@
     "test_run": "开始测试",
     "test_running": "测试中…",
     "test_response": "响应",
+    "test_duration": "耗时 {{duration}}",
     "test_no_channels": "当前模型没有可用渠道来源。",
     "test_no_api_key": "未找到可用的 API Key。请先在 API Keys 中创建未禁用的 Key，最好将该渠道加入 allowed-channels。",
     "test_empty_response": "(空响应)",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -3952,7 +3952,7 @@ describe("AuthFilesPage files table", () => {
     expect(within(cards).queryByText(/model=MODEL_PLACEHOLDER_M37/)).not.toBeInTheDocument();
   });
 
-  test("table quota hover does not show cached antigravity model metadata", async () => {
+  test("table quota chips do not show cached antigravity model metadata", async () => {
     useTableFilesView();
     const now = Date.now();
     const file = {
@@ -4006,23 +4006,18 @@ describe("AuthFilesPage files table", () => {
 
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
-    fireEvent.mouseEnter(within(row as HTMLElement).getByText("Gemini 3 Pro"));
 
-    const tooltip = await screen.findByRole("tooltip");
-    expect(within(tooltip).getByText("Gemini 3 Pro")).toBeInTheDocument();
+    const cell = within(row as HTMLElement);
+    expect(cell.getByText("Gemini 3 Pro")).toBeInTheDocument();
     expect(
-      within(tooltip).queryByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
+      cell.queryByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
     ).not.toBeInTheDocument();
-    expect(within(tooltip).queryByText(/maxTokens=1048576/)).not.toBeInTheDocument();
-    expect(
-      within(tooltip).queryByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/),
-    ).not.toBeInTheDocument();
-    expect(
-      within(tooltip).queryByText(/modelProvider=MODEL_PROVIDER_GOOGLE/),
-    ).not.toBeInTheDocument();
+    expect(cell.queryByText(/maxTokens=1048576/)).not.toBeInTheDocument();
+    expect(cell.queryByText(/apiProvider=API_PROVIDER_GOOGLE_GEMINI/)).not.toBeInTheDocument();
+    expect(cell.queryByText(/modelProvider=MODEL_PROVIDER_GOOGLE/)).not.toBeInTheDocument();
   });
 
-  test("table quota hover opens only the quota details tooltip", async () => {
+  test("table quota chips stay inline and open no hover tooltip", async () => {
     useTableFilesView();
     vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(80);
     vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(320);
@@ -4084,23 +4079,28 @@ describe("AuthFilesPage files table", () => {
 
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
-    fireEvent.mouseEnter(within(row as HTMLElement).getByText("Gemini 3 Pro"));
 
-    const tooltips = await screen.findAllByRole("tooltip");
-    expect(tooltips).toHaveLength(1);
-    expect(within(tooltips[0]).getByText("Claude")).toBeInTheDocument();
-    const resetText = Array.from(tooltips[0].querySelectorAll("span")).find(
+    // Both metrics are readable in the row itself, so no overlay is needed.
+    const geminiChip = within(row as HTMLElement).getByText("Gemini 3 Pro");
+    expect(within(row as HTMLElement).getByText("Claude")).toBeInTheDocument();
+
+    fireEvent.mouseEnter(geminiChip);
+    await Promise.resolve();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    // Countdown sits beside the percent unclipped instead of inside a tooltip.
+    const chips = Array.from(
+      (row as HTMLElement).querySelectorAll("[data-testid='auth-file-quota-metric']"),
+    );
+    expect(chips).toHaveLength(2);
+    const resetText = Array.from(chips[0].querySelectorAll("span")).find(
       (element) => element.textContent?.includes("s") && element.className.includes("tabular-nums"),
     );
     expect(resetText).toBeTruthy();
     expect(resetText).not.toHaveClass("truncate");
-    expect(tooltips[0]).not.toHaveClass("sm:max-w-[34rem]");
-    expect(tooltips[0].querySelector(".quota-tooltip-grid")).toHaveClass(
-      "w-[min(26rem,calc(100vw-2rem))]",
-    );
   });
 
-  test("table quota preview and hover hide cached antigravity models skipped by the reference implementation", async () => {
+  test("table quota chips hide cached antigravity models skipped by the reference implementation", async () => {
     useTableFilesView();
 
     const now = Date.now();
@@ -4155,19 +4155,9 @@ describe("AuthFilesPage files table", () => {
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
     expect(within(row as HTMLElement).queryByText("chat_20706")).not.toBeInTheDocument();
-    const visibleModel = within(row as HTMLElement).getByText("Gemini 3 Pro");
-    expect(visibleModel).toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText("Gemini 3 Pro")).toBeInTheDocument();
     expect(
       within(row as HTMLElement).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
-    ).not.toBeInTheDocument();
-
-    fireEvent.mouseEnter(visibleModel);
-
-    const tooltip = await screen.findByRole("tooltip");
-    expect(within(tooltip).queryByText("chat_20706")).not.toBeInTheDocument();
-    expect(within(tooltip).getByText("Gemini 3 Pro")).toBeInTheDocument();
-    expect(
-      within(tooltip).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
     ).not.toBeInTheDocument();
   });
 
@@ -5180,10 +5170,13 @@ describe("AuthFilesPage files table", () => {
     const previewZero = within(row as HTMLElement).getByText("0%");
     expect(previewZero).toHaveClass("text-rose-700");
 
+    // Every chip carries its own countdown inline, so hovering opens nothing.
+    for (const metric of metrics) {
+      expect(within(metric).getByTestId("auth-file-quota-reset")).toBeInTheDocument();
+    }
     fireEvent.mouseEnter(within(row as HTMLElement).getByText("Code: Weekly"));
-    const tooltip = await screen.findByRole("tooltip");
-    const tooltipPercents = within(tooltip).getAllByText("0%");
-    expect(tooltipPercents[0]).toHaveClass("text-rose-700");
+    await Promise.resolve();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 
     const actionsHeader = table.querySelector<HTMLElement>('th[data-vt-column-key="actions"]');
     const actionsCell = row?.querySelector<HTMLElement>('td[data-vt-column-key="actions"]');

--- a/pages/auth-files/components/QuotaMetricChips.tsx
+++ b/pages/auth-files/components/QuotaMetricChips.tsx
@@ -1,0 +1,216 @@
+import type { ReactNode } from "react";
+import { Clock } from "lucide-react";
+import { clampPercent, type QuotaItem } from "@features/quota-preview/quota-helpers";
+
+export type QuotaVisualTone = {
+  normalized: number | null;
+  fillClass: string;
+  percentClass: string;
+  fillHex: string;
+  /** Chip surface (border + background) mirroring the percent tone. */
+  chipClass: string;
+  /** Muted label color that stays legible on the chip surface. */
+  chipLabelClass: string;
+};
+
+export const resolveQuotaVisualTone = (percent: number | null | undefined): QuotaVisualTone => {
+  const normalized = percent === null || percent == null ? null : clampPercent(percent);
+
+  if (normalized === null) {
+    return {
+      normalized,
+      fillClass: "bg-slate-300/50 dark:bg-white/10",
+      percentClass: "text-slate-900 dark:text-white",
+      fillHex: "#cbd5e1",
+      chipClass: "border-slate-900/8 bg-slate-50 dark:border-white/10 dark:bg-white/[0.06]",
+      chipLabelClass: "text-slate-600 dark:text-white/70",
+    };
+  }
+
+  if (normalized >= 60) {
+    return {
+      normalized,
+      fillClass: "bg-emerald-500",
+      percentClass: "text-emerald-700 dark:text-emerald-200",
+      fillHex: "#10b981",
+      chipClass:
+        "border-emerald-200/70 bg-emerald-50/70 dark:border-emerald-500/20 dark:bg-emerald-500/[0.08]",
+      chipLabelClass: "text-emerald-900/70 dark:text-emerald-100/70",
+    };
+  }
+
+  if (normalized >= 20) {
+    return {
+      normalized,
+      fillClass: "bg-amber-500",
+      percentClass: "text-amber-700 dark:text-amber-200",
+      fillHex: "#f59e0b",
+      chipClass:
+        "border-amber-200/70 bg-amber-50/70 dark:border-amber-500/20 dark:bg-amber-500/[0.08]",
+      chipLabelClass: "text-amber-900/70 dark:text-amber-100/70",
+    };
+  }
+
+  return {
+    normalized,
+    fillClass: "bg-rose-500",
+    percentClass: "text-rose-700 dark:text-rose-200",
+    fillHex: "#f43f5e",
+    chipClass: "border-rose-200/70 bg-rose-50/70 dark:border-rose-500/20 dark:bg-rose-500/[0.08]",
+    chipLabelClass: "text-rose-900/70 dark:text-rose-100/70",
+  };
+};
+
+/** Ring that mirrors the percent without spending a full progress-bar row. */
+export function QuotaProgressRing({ percent }: { percent: number | null }) {
+  const tone = resolveQuotaVisualTone(percent);
+  const normalized = tone.normalized;
+  const deg = normalized === null ? 0 : Math.max(0, Math.min(360, (normalized / 100) * 360));
+
+  return (
+    <span
+      className="relative inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center"
+      aria-hidden="true"
+    >
+      <span
+        className="absolute inset-0 rounded-full dark:hidden"
+        style={{
+          background: `conic-gradient(${tone.fillHex} ${deg}deg, rgba(148, 163, 184, 0.35) 0deg)`,
+        }}
+      />
+      <span
+        className="absolute inset-0 hidden rounded-full dark:block"
+        style={{
+          background: `conic-gradient(${tone.fillHex} ${deg}deg, rgba(255, 255, 255, 0.14) 0deg)`,
+        }}
+      />
+      <span className="absolute inset-[2px] rounded-full bg-white dark:bg-neutral-950" />
+    </span>
+  );
+}
+
+// Chips pack label, reset countdown and percent onto one line, so a half-width
+// chip fits far less label text than the old stacked bar did.
+const QUOTA_METRIC_WIDE_LABEL_UNITS = 16;
+
+const getQuotaMetricDisplayUnits = (value: string | null | undefined): number =>
+  Array.from(value ?? "").reduce(
+    (total, char) => total + ((char.codePointAt(0) ?? 0) > 0xff ? 2 : 1),
+    0,
+  );
+
+export const resolveQuotaMetricWideFlags = (
+  metrics: { label: string; metaText: string | null }[],
+): boolean[] => {
+  const wideFlags = metrics.map(
+    ({ label, metaText }) =>
+      metrics.length === 1 ||
+      // Money meta ("$1452.81 / $1500.00") never fits beside label + countdown.
+      Boolean(metaText) ||
+      getQuotaMetricDisplayUnits(label) > QUOTA_METRIC_WIDE_LABEL_UNITS,
+  );
+
+  let compactSegmentStart = 0;
+  for (let index = 0; index <= wideFlags.length; index += 1) {
+    if (index < wideFlags.length && !wideFlags[index]) continue;
+    const compactSegmentLength = index - compactSegmentStart;
+    if (compactSegmentLength % 2 === 1) {
+      wideFlags[index - 1] = true;
+    }
+    compactSegmentStart = index + 1;
+  }
+
+  return wideFlags;
+};
+
+export type QuotaMetricSlot = { id: string; label: string; item: QuotaItem | null };
+
+export interface QuotaMetricChipsProps {
+  slots: QuotaMetricSlot[];
+  /** Rendered above the chips when the last refresh failed but stale data remains. */
+  errorBadge?: ReactNode;
+  /** Money-style meta ("$40 / $50"); other meta is dropped by the caller. */
+  resolveMetaText: (item: QuotaItem | null) => string | null;
+  /** Two-unit countdown to the window reset ("2d19h"). */
+  resolveResetText: (item: QuotaItem | null) => string | null;
+  resolvePercentText: (item: QuotaItem | null, tone: QuotaVisualTone) => string;
+}
+
+/**
+ * Quota metrics as inline chips: label, optional money meta, reset countdown and
+ * percent all read directly in the row, so the grid needs no hover layer.
+ */
+export function QuotaMetricChips({
+  slots,
+  errorBadge,
+  resolveMetaText,
+  resolveResetText,
+  resolvePercentText,
+}: QuotaMetricChipsProps) {
+  const metaTexts = slots.map((slot) => resolveMetaText(slot.item));
+  const wideFlags = resolveQuotaMetricWideFlags(
+    slots.map((slot, index) => ({ label: slot.label, metaText: metaTexts[index] ?? null })),
+  );
+
+  return (
+    <div
+      className="grid w-full min-w-0 grid-cols-2 gap-1.5 py-0.5"
+      data-testid="auth-file-quota-grid"
+    >
+      {errorBadge ? <div className="col-span-2">{errorBadge}</div> : null}
+      {slots.map((slot, index) => {
+        const tone = resolveQuotaVisualTone(slot.item?.percent);
+        const metaText = metaTexts[index] ?? null;
+        const resetText = resolveResetText(slot.item);
+        const wide = wideFlags[index] ?? false;
+
+        return (
+          <div
+            key={slot.id}
+            className={[
+              "flex min-w-0 items-center gap-1.5 rounded-md border px-2 py-1",
+              tone.chipClass,
+              wide ? "col-span-2" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            data-layout={wide ? "wide" : "compact"}
+            data-testid="auth-file-quota-metric"
+          >
+            <QuotaProgressRing percent={slot.item?.percent ?? null} />
+            <span
+              title={slot.label}
+              className={["min-w-0 flex-1 truncate text-2xs font-semibold", tone.chipLabelClass].join(
+                " ",
+              )}
+            >
+              {slot.label}
+            </span>
+            {metaText ? (
+              <span className="shrink-0 whitespace-nowrap text-2xs tabular-nums text-slate-500 dark:text-white/45">
+                {metaText}
+              </span>
+            ) : null}
+            {resetText ? (
+              <span
+                data-testid="auth-file-quota-reset"
+                className="inline-flex shrink-0 items-center gap-0.5 whitespace-nowrap text-2xs tabular-nums text-slate-500 dark:text-white/45"
+              >
+                <Clock size={10} className="shrink-0 opacity-70" aria-hidden />
+                {resetText}
+              </span>
+            ) : null}
+            <span
+              className={[
+                "shrink-0 whitespace-nowrap text-2xs font-semibold tabular-nums",
+                tone.percentClass,
+              ].join(" ")}
+            >
+              {resolvePercentText(slot.item, tone)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -48,8 +48,8 @@ import {
 } from "@code-proxy/domain";
 import { resolveQuotaProvider, type QuotaProvider } from "@features/quota-preview/quota-fetch";
 import { useStickyDisplayPlans } from "./useStickyDisplayPlans";
+import { QuotaMetricChips, resolveQuotaVisualTone } from "../components/QuotaMetricChips";
 import {
-  clampPercent,
   filterAntigravityQuotaItems,
   type QuotaItem,
   type QuotaState,
@@ -97,81 +97,6 @@ const CLAUDE_OAUTH_HEALTH_TONE_CLASSES = {
 const STICKY_ACTIONS_HEADER_CLASS =
   "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
 const STICKY_ACTIONS_CELL_CLASS = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
-const QUOTA_METRIC_WIDE_LABEL_UNITS = 30;
-
-const getQuotaMetricDisplayUnits = (value: string | null | undefined): number =>
-  Array.from(value ?? "").reduce(
-    (total, char) => total + ((char.codePointAt(0) ?? 0) > 0xff ? 2 : 1),
-    0,
-  );
-
-const resolveQuotaMetricWideFlags = (
-  metrics: { label: string; detailText: string | null }[],
-): boolean[] => {
-  const wideFlags = metrics.map(
-    ({ label, detailText }) =>
-      metrics.length === 1 ||
-      getQuotaMetricDisplayUnits(label) > QUOTA_METRIC_WIDE_LABEL_UNITS ||
-      getQuotaMetricDisplayUnits(detailText) > QUOTA_METRIC_WIDE_LABEL_UNITS,
-  );
-
-  let compactSegmentStart = 0;
-  for (let index = 0; index <= wideFlags.length; index += 1) {
-    if (index < wideFlags.length && !wideFlags[index]) continue;
-    const compactSegmentLength = index - compactSegmentStart;
-    if (compactSegmentLength % 2 === 1) {
-      wideFlags[index - 1] = true;
-    }
-    compactSegmentStart = index + 1;
-  }
-
-  return wideFlags;
-};
-
-type QuotaVisualTone = {
-  normalized: number | null;
-  fillClass: string;
-  percentClass: string;
-  fillHex: string;
-};
-
-const resolveQuotaVisualTone = (percent: number | null | undefined): QuotaVisualTone => {
-  const normalized = percent === null || percent == null ? null : clampPercent(percent);
-
-  if (normalized === null) {
-    return {
-      normalized,
-      fillClass: "bg-slate-300/50 dark:bg-white/10",
-      percentClass: "text-slate-900 dark:text-white",
-      fillHex: "#cbd5e1",
-    };
-  }
-
-  if (normalized >= 60) {
-    return {
-      normalized,
-      fillClass: "bg-emerald-500",
-      percentClass: "text-emerald-700 dark:text-emerald-200",
-      fillHex: "#10b981",
-    };
-  }
-
-  if (normalized >= 20) {
-    return {
-      normalized,
-      fillClass: "bg-amber-500",
-      percentClass: "text-amber-700 dark:text-amber-200",
-      fillHex: "#f59e0b",
-    };
-  }
-
-  return {
-    normalized,
-    fillClass: "bg-rose-500",
-    percentClass: "text-rose-700 dark:text-rose-200",
-    fillHex: "#f43f5e",
-  };
-};
 
 interface UseAuthFilesFilesPresentationOptions {
   filesViewMode: FilesViewMode;
@@ -472,6 +397,39 @@ export function useAuthFilesFilesPresentation({
     [nowMs, t],
   );
 
+  // Chips keep only the two largest units ("2d19h") so the countdown never
+  // squeezes the percent out of a half-width chip.
+  const formatQuotaResetTextChip = useCallback(
+    (resetAtMs?: number) => {
+      if (typeof resetAtMs !== "number" || !Number.isFinite(resetAtMs)) return null;
+
+      const diffMs = resetAtMs - nowMs;
+      if (diffMs <= 0) return t("m_quota.refresh_due");
+
+      let seconds = Math.max(1, Math.ceil(diffMs / 1000));
+      const days = Math.floor(seconds / 86400);
+      seconds -= days * 86400;
+      const hours = Math.floor(seconds / 3600);
+      seconds -= hours * 3600;
+      const minutes = Math.floor(seconds / 60);
+      seconds -= minutes * 60;
+
+      const units = [
+        days ? t("m_quota.duration_day_compact", { count: days }) : "",
+        hours ? t("m_quota.duration_hour_compact", { count: hours }) : "",
+        minutes ? t("m_quota.duration_minute_compact", { count: minutes }) : "",
+        seconds ? t("m_quota.duration_second_compact", { count: seconds }) : "",
+      ];
+      const firstIndex = units.findIndex(Boolean);
+      if (firstIndex < 0) return t("m_quota.duration_second_compact", { count: 0 });
+      return units
+        .slice(firstIndex, firstIndex + 2)
+        .filter(Boolean)
+        .join("");
+    },
+    [nowMs, t],
+  );
+
   const renderFilesViewModeTabs = useMemo(() => {
     const options: { value: FilesViewMode; label: string }[] = [
       { value: "table", label: t("common.view_mode_list") },
@@ -496,33 +454,6 @@ export function useAuthFilesFilesPresentation({
     );
   }, [filesViewMode, setFilesViewMode, t]);
 
-  const quotaProgressCircle = useCallback((percent: number | null) => {
-    const tone = resolveQuotaVisualTone(percent);
-    const normalized = tone.normalized;
-    const deg = normalized === null ? 0 : Math.max(0, Math.min(360, (normalized / 100) * 360));
-
-    return (
-      <span
-        className="relative inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center"
-        aria-hidden="true"
-      >
-        <span
-          className="absolute inset-0 rounded-full dark:hidden"
-          style={{
-            background: `conic-gradient(${tone.fillHex} ${deg}deg, rgba(148, 163, 184, 0.35) 0deg)`,
-          }}
-        />
-        <span
-          className="absolute inset-0 hidden rounded-full dark:block"
-          style={{
-            background: `conic-gradient(${tone.fillHex} ${deg}deg, rgba(255, 255, 255, 0.14) 0deg)`,
-          }}
-        />
-        <span className="absolute inset-[2px] rounded-full bg-white dark:bg-neutral-950" />
-      </span>
-    );
-  }, []);
-
   const formatQuotaItemDetailText = useCallback(
     (item: QuotaItem | null | undefined) => {
       const reset = formatQuotaResetTextCompact(item?.resetAtMs);
@@ -540,6 +471,21 @@ export function useAuthFilesFilesPresentation({
       return resetLabel ?? meta ?? null;
     },
     [formatQuotaResetTextCompact, t, translateQuotaText],
+  );
+
+  // Chips render meta and countdown in separate slots, so the meta half is
+  // resolved on its own instead of the merged "meta · reset" detail string.
+  const resolveQuotaItemMetaText = useCallback(
+    (item: QuotaItem | null | undefined) => {
+      const rawMeta = item?.meta?.trim() ? translateQuotaText(item.meta) : null;
+      // Drop raw ISO period ranges (e.g. "2026-07-16T06:45:51+00:00 - …").
+      if (!rawMeta || /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(rawMeta)) return null;
+      const hasReset = typeof item?.resetAtMs === "number" && Number.isFinite(item.resetAtMs);
+      // Non-money meta only restates the period the countdown already shows.
+      if (hasReset && !rawMeta.includes("$")) return null;
+      return rawMeta;
+    },
+    [translateQuotaText],
   );
 
   const resolveQuotaErrorBadgeLabel = useCallback(
@@ -574,63 +520,6 @@ export function useAuthFilesFilesPresentation({
       );
     },
     [resolveQuotaErrorBadgeLabel, t, translateQuotaText],
-  );
-
-  const renderQuotaHoverContent = useCallback(
-    (state: QuotaState, options?: { suppressItemMeta?: boolean }) => {
-      const items = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
-      const hasError = state.status === "error" || Boolean(state.error);
-
-      return (
-        <div className="space-y-1">
-          {hasError ? (
-            <p className="max-w-80 whitespace-pre-wrap break-words text-xs font-semibold text-rose-700 dark:text-rose-200">
-              {translateQuotaText(state.error ?? t("common.error"))}
-            </p>
-          ) : null}
-
-          {items.length > 0 ? (
-            <div className="quota-tooltip-grid grid w-[min(26rem,calc(100vw-2rem))] grid-cols-[minmax(0,1fr)_0.875rem_max-content_max-content] items-center gap-x-2 gap-y-1">
-              {items.map((item) => {
-                const tone = resolveQuotaVisualTone(item.percent);
-                const percentText =
-                  (item.value ? translateQuotaText(item.value) : undefined) ??
-                  (tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`);
-                const resetText = formatQuotaItemDetailText(item);
-                const itemMeta = options?.suppressItemMeta || resetText ? undefined : item.meta;
-                return (
-                  <div key={item.label} className="contents">
-                    <span className="min-w-0 truncate text-2xs font-semibold text-slate-600 dark:text-white/70">
-                      {translateQuotaText(item.label)}
-                    </span>
-                    <span className="flex items-center justify-center">
-                      {quotaProgressCircle(item.percent)}
-                    </span>
-                    <span
-                      className={[
-                        "justify-self-end whitespace-nowrap text-2xs font-semibold tabular-nums",
-                        tone.percentClass,
-                      ].join(" ")}
-                    >
-                      {percentText}
-                    </span>
-                    <span className="whitespace-nowrap text-right text-2xs tabular-nums text-slate-500 dark:text-white/40">
-                      {resetText ?? "--"}
-                    </span>
-                    {itemMeta ? (
-                      <span className="col-span-4 truncate text-2xs text-slate-500 dark:text-white/55">
-                        {itemMeta}
-                      </span>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </div>
-          ) : null}
-        </div>
-      );
-    },
-    [formatQuotaItemDetailText, quotaProgressCircle, t, translateQuotaText],
   );
 
   const renderQuotaBar = useCallback(
@@ -975,88 +864,30 @@ export function useAuthFilesFilesPresentation({
           const rawItems = Array.isArray(state.items) ? (state.items as QuotaItem[]) : [];
           const items =
             provider === "antigravity" ? filterAntigravityQuotaItems(rawItems) : rawItems;
-          const displayState = items === rawItems ? state : { ...state, items };
           const slots = resolveQuotaCardSlots(provider, items);
-          const quotaMetricDetails = slots.map((slot) => formatQuotaItemDetailText(slot.item));
-          const quotaMetricWideFlags = resolveQuotaMetricWideFlags(
-            slots.map((slot, index) => ({
-              label: slot.label,
-              detailText: quotaMetricDetails[index] ?? null,
-            })),
-          );
           const hasError = state.status === "error" || Boolean(state.error);
 
           if (hasError && slots.length === 0) {
             return renderQuotaErrorBadge(state.error ?? t("common.error"));
           }
 
-          return (
-            <HoverTooltip
-              disabled={items.length === 0}
-              className="w-full min-w-0"
-              content={renderQuotaHoverContent(displayState, {
-                suppressItemMeta: provider === "antigravity",
-              })}
-            >
-              <div className="w-full min-w-0">
-                {slots.length === 0 ? (
-                  <span className="text-xs text-slate-400 dark:text-white/40">--</span>
-                ) : (
-                  <div
-                    className="grid w-full min-w-0 grid-cols-2 gap-x-4 gap-y-3 py-0.5"
-                    data-testid="auth-file-quota-grid"
-                  >
-                    {hasError ? (
-                      <div className="col-span-2">
-                        {renderQuotaErrorBadge(state.error ?? t("common.error"))}
-                      </div>
-                    ) : null}
-                    {slots.map((slot, index) => {
-                      const tone = resolveQuotaVisualTone(slot.item?.percent);
-                      const normalized = tone.normalized;
-                      const percentText =
-                        (slot.item?.value ? translateQuotaText(slot.item.value) : undefined) ??
-                        (normalized === null ? "--" : `${Math.round(normalized)}%`);
-                      const detailText = quotaMetricDetails[index] ?? null;
-                      const wide = quotaMetricWideFlags[index] ?? false;
+          if (slots.length === 0) {
+            return <span className="text-xs text-slate-400 dark:text-white/40">--</span>;
+          }
 
-                      return (
-                        <div
-                          key={slot.id}
-                          className={wide ? "col-span-2 min-w-0" : "min-w-0"}
-                          data-layout={wide ? "wide" : "compact"}
-                          data-testid="auth-file-quota-metric"
-                        >
-                          <div className="flex min-w-0 items-start justify-between gap-2">
-                            <span className="min-w-0 break-words text-2xs font-semibold leading-4 text-slate-600 dark:text-white/70">
-                              {slot.label}
-                            </span>
-                            <span
-                              className={[
-                                "shrink-0 text-2xs font-semibold tabular-nums",
-                                tone.percentClass,
-                              ].join(" ")}
-                            >
-                              {percentText}
-                            </span>
-                          </div>
-                          <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-white/10">
-                            <div
-                              className={["h-full rounded-full", tone.fillClass].join(" ")}
-                              style={{ width: `${normalized ?? 0}%` }}
-                              aria-hidden="true"
-                            />
-                          </div>
-                          <div className="mt-1 min-h-[14px] whitespace-nowrap text-right text-2xs tabular-nums text-slate-500 dark:text-white/40">
-                            {detailText ?? "\u00A0"}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            </HoverTooltip>
+          return (
+            <QuotaMetricChips
+              slots={slots}
+              errorBadge={
+                hasError ? renderQuotaErrorBadge(state.error ?? t("common.error")) : undefined
+              }
+              resolveMetaText={resolveQuotaItemMetaText}
+              resolveResetText={(item) => formatQuotaResetTextChip(item?.resetAtMs)}
+              resolvePercentText={(item, tone) =>
+                (item?.value ? translateQuotaText(item.value) : undefined) ??
+                (tone.normalized === null ? "--" : `${Math.round(tone.normalized)}%`)
+              }
+            />
           );
         },
       },
@@ -1175,12 +1006,12 @@ export function useAuthFilesFilesPresentation({
     statusUsageLoading,
     statusUsageReady,
     downloadAuthFile,
-    formatQuotaItemDetailText,
+    formatQuotaResetTextChip,
     formatPlanTypeLabel,
     openDetail,
     openTagsEditor,
     quotaByFileName,
-    quotaProgressCircle,
+    resolveQuotaItemMetaText,
     resolveQuotaCardSlots,
     refreshQuota,
     requestResetCredit,

--- a/pages/models/ModelsPage.tsx
+++ b/pages/models/ModelsPage.tsx
@@ -9,12 +9,7 @@ import type { SearchableSelectOption } from "@code-proxy/ui";
 import { ToggleSwitch } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { DataTable } from "@code-proxy/ui";
-import {
-  apiClient,
-  apiKeyEntriesApi,
-  detectApiBaseFromLocation,
-  normalizeApiBase,
-} from "@code-proxy/api-client";
+import { apiClient } from "@code-proxy/api-client";
 import { getActiveCacheTenantId } from "@code-proxy/domain";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 import { ModelFormModal } from "./components/ModelFormModal";
@@ -23,6 +18,7 @@ import { ModelsPageTabs } from "./components/ModelsPageTabs";
 import { ModelsStatsCards } from "./components/ModelsStatsCards";
 import { OwnerFormModal } from "./components/OwnerFormModal";
 import { useModelColumns } from "./hooks/useModelColumns";
+import { useModelTestRunner } from "./hooks/useModelTestRunner";
 import {
   invalidateConfiguredModelAvailability,
   loadConfiguredModelAvailability,
@@ -102,10 +98,7 @@ export function ModelsPage() {
   const [bulkDeleteTargetIds, setBulkDeleteTargetIds] = useState<string[] | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
-  const [testTarget, setTestTarget] = useState<ModelItem | null>(null);
-  const [testRunning, setTestRunning] = useState(false);
-  const [testResultText, setTestResultText] = useState<string | null>(null);
-  const [testErrorText, setTestErrorText] = useState<string | null>(null);
+  const modelTest = useModelTestRunner(auth?.state.apiBase);
   const [selectedModelIds, setSelectedModelIds] = useState<Set<string>>(() => new Set());
   const cachedOpenRouter = readOpenRouterSyncCache(cacheTenantKey);
   const [openRouterSyncState, setOpenRouterSyncState] = useState<OpenRouterModelSyncState>(
@@ -562,102 +555,6 @@ export function ModelsPage() {
     [modelScope, notify, t, togglingModelId],
   );
 
-  const openTestModel = useCallback((model: ModelItem) => {
-    setTestTarget(model);
-    setTestResultText(null);
-    setTestErrorText(null);
-  }, []);
-
-  const handleRunModelTest = useCallback(
-    async (input: { channel: string; prompt: string }) => {
-      if (!testTarget) return;
-      setTestRunning(true);
-      setTestResultText(null);
-      setTestErrorText(null);
-      try {
-        const entries = await apiKeyEntriesApi.list();
-        const channelNeedle = input.channel.trim().toLowerCase();
-        const enabledKeys = entries.filter((entry) => !entry.disabled && entry.key?.trim());
-        // Prefer keys whose allowed-channels pin the selected channel; fall back to unrestricted keys.
-        const scoreKey = (entry: (typeof enabledKeys)[number]): number => {
-          const allowed = (entry["allowed-channels"] ?? [])
-            .map((name) => name.trim().toLowerCase())
-            .filter(Boolean);
-          if (allowed.length === 0) return 1;
-          if (!allowed.includes(channelNeedle)) return -1;
-          // Exact single-channel restriction is the strongest pin available without a dedicated test API.
-          return allowed.length === 1 ? 3 : 2;
-        };
-        const matchingKey =
-          enabledKeys
-            .map((entry) => ({ entry, score: scoreKey(entry) }))
-            .filter((item) => item.score > 0)
-            .sort((a, b) => b.score - a.score)[0]?.entry ?? null;
-        if (!matchingKey) {
-          throw new Error(t("models_page.test_no_api_key"));
-        }
-
-        const base = normalizeApiBase(auth?.state.apiBase || detectApiBaseFromLocation());
-        const endpoint = `${base}/v1/chat/completions`;
-        const response = await fetch(endpoint, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${matchingKey.key}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            model: testTarget.id,
-            messages: [{ role: "user", content: input.prompt }],
-            stream: false,
-          }),
-        });
-        const rawText = await response.text();
-        let payload: unknown = null;
-        try {
-          payload = rawText ? JSON.parse(rawText) : null;
-        } catch {
-          payload = rawText;
-        }
-        if (!response.ok) {
-          const fallback = rawText || `HTTP ${response.status}`;
-          const message =
-            payload &&
-            typeof payload === "object" &&
-            payload !== null &&
-            "error" in payload
-              ? typeof (payload as { error: unknown }).error === "string"
-                ? (payload as { error: string }).error
-                : ((payload as { error?: { message?: string } }).error?.message ?? fallback)
-              : fallback;
-          throw new Error(message);
-        }
-
-        const content =
-          payload &&
-          typeof payload === "object" &&
-          payload !== null &&
-          Array.isArray((payload as { choices?: unknown }).choices)
-            ? (() => {
-                const choice = (payload as { choices: Array<{ message?: { content?: unknown } }> })
-                  .choices[0];
-                const text = choice?.message?.content;
-                return typeof text === "string" ? text : JSON.stringify(payload, null, 2);
-              })()
-            : typeof payload === "string"
-              ? payload
-              : JSON.stringify(payload, null, 2);
-        setTestResultText(content || t("models_page.test_empty_response"));
-      } catch (err: unknown) {
-        setTestErrorText(
-          err instanceof Error ? err.message : t("models_page.test_failed"),
-        );
-      } finally {
-        setTestRunning(false);
-      }
-    },
-    [auth?.state.apiBase, t, testTarget],
-  );
-
   const handleDelete = useCallback(async () => {
     if (!deleteTarget) return;
     setDeleting(true);
@@ -897,7 +794,7 @@ export function ModelsPage() {
     onEditModel: openEditModel,
     onDeleteModel: setDeleteTarget,
     onToggleEnabled: (model) => void handleToggleEnabled(model),
-    onTestModel: openTestModel,
+    onTestModel: modelTest.open,
     togglingModelId,
   });
   const selectionToolbar =
@@ -1340,17 +1237,13 @@ export function ModelsPage() {
       />
 
       <ModelTestModal
-        model={testTarget}
-        running={testRunning}
-        resultText={testResultText}
-        errorText={testErrorText}
-        onClose={() => {
-          if (testRunning) return;
-          setTestTarget(null);
-          setTestResultText(null);
-          setTestErrorText(null);
-        }}
-        onRun={(input) => void handleRunModelTest(input)}
+        model={modelTest.target}
+        running={modelTest.running}
+        resultText={modelTest.resultText}
+        errorText={modelTest.errorText}
+        durationMs={modelTest.durationMs}
+        onClose={modelTest.close}
+        onRun={(input) => void modelTest.run(input)}
       />
     </section>
   );

--- a/pages/models/components/ModelTestModal.tsx
+++ b/pages/models/components/ModelTestModal.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Timer } from "lucide-react";
 import { Button, Modal, Select, Textarea } from "@code-proxy/ui";
+import { formatLatency } from "@features/provider-latency";
 import {
   DEFAULT_MODEL_TEST_PROMPT,
   formatModelSourceLabel,
@@ -98,6 +100,8 @@ export interface ModelTestModalProps {
   running: boolean;
   resultText: string | null;
   errorText: string | null;
+  /** Upstream round-trip duration of the last run, or null before one completes. */
+  durationMs?: number | null;
   onClose: () => void;
   onRun: (input: { channel: string; prompt: string }) => void;
 }
@@ -107,6 +111,7 @@ export function ModelTestModal({
   running,
   resultText,
   errorText,
+  durationMs = null,
   onClose,
   onRun,
 }: ModelTestModalProps) {
@@ -115,13 +120,15 @@ export function ModelTestModal({
   const [displayModel, setDisplayModel] = useState<ModelItem | null>(model);
   const [displayResult, setDisplayResult] = useState<string | null>(resultText);
   const [displayError, setDisplayError] = useState<string | null>(errorText);
+  const [displayDurationMs, setDisplayDurationMs] = useState<number | null>(durationMs);
 
   useEffect(() => {
     if (!model) return;
     setDisplayModel(model);
     setDisplayResult(resultText);
     setDisplayError(errorText);
-  }, [model, resultText, errorText]);
+    setDisplayDurationMs(durationMs);
+  }, [model, resultText, errorText, durationMs]);
 
   const channelOptions = useMemo(
     () => buildChannelOptions(displayModel),
@@ -142,6 +149,17 @@ export function ModelTestModal({
   const noChannels = Boolean(displayModel) && channelOptions.length === 0;
   const showSuccess = Boolean(displayResult) && !displayError;
   const showError = Boolean(displayError);
+
+  const durationBadge =
+    typeof displayDurationMs === "number" && Number.isFinite(displayDurationMs) ? (
+      <span
+        data-testid="model-test-duration"
+        className="inline-flex shrink-0 items-center gap-1 rounded-full border border-slate-900/8 bg-slate-50 px-2 py-0.5 text-2xs font-semibold tabular-nums text-slate-600 dark:border-white/10 dark:bg-white/[0.06] dark:text-white/70"
+      >
+        <Timer size={11} className="shrink-0" aria-hidden />
+        {t("models_page.test_duration", { duration: formatLatency(displayDurationMs) })}
+      </span>
+    ) : null;
 
   return (
     <Modal
@@ -230,8 +248,11 @@ export function ModelTestModal({
             <div className="min-h-0 overflow-hidden">
               {showError ? (
                 <div data-testid="model-test-error">
-                  <div className="mb-1 text-sm font-medium text-rose-700 dark:text-rose-300">
-                    {t("models_page.test_response")}
+                  <div className="mb-1 flex items-center gap-2">
+                    <span className="text-sm font-medium text-rose-700 dark:text-rose-300">
+                      {t("models_page.test_response")}
+                    </span>
+                    {durationBadge}
                   </div>
                   <div
                     role="alert"
@@ -244,8 +265,11 @@ export function ModelTestModal({
 
               {showSuccess ? (
                 <div data-testid="model-test-success">
-                  <div className="mb-1 text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                    {t("models_page.test_response")}
+                  <div className="mb-1 flex items-center gap-2">
+                    <span className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                      {t("models_page.test_response")}
+                    </span>
+                    {durationBadge}
                   </div>
                   <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
                     {displayResult}

--- a/pages/models/hooks/useModelTestRunner.ts
+++ b/pages/models/hooks/useModelTestRunner.ts
@@ -1,0 +1,132 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  apiKeyEntriesApi,
+  detectApiBaseFromLocation,
+  normalizeApiBase,
+} from "@code-proxy/api-client";
+import type { ModelItem } from "../types";
+
+type ApiKeyEntry = Awaited<ReturnType<typeof apiKeyEntriesApi.list>>[number];
+
+/**
+ * Prefer keys whose allowed-channels pin the selected channel; fall back to
+ * unrestricted keys. Returns a negative score for keys that cannot reach it.
+ */
+function scoreKeyForChannel(entry: ApiKeyEntry, channelNeedle: string): number {
+  const allowed = (entry["allowed-channels"] ?? [])
+    .map((name) => name.trim().toLowerCase())
+    .filter(Boolean);
+  if (allowed.length === 0) return 1;
+  if (!allowed.includes(channelNeedle)) return -1;
+  // Exact single-channel restriction is the strongest pin available without a dedicated test API.
+  return allowed.length === 1 ? 3 : 2;
+}
+
+function extractErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object" && "error" in payload) {
+    const error = (payload as { error: unknown }).error;
+    if (typeof error === "string") return error;
+    return (payload as { error?: { message?: string } }).error?.message ?? fallback;
+  }
+  return fallback;
+}
+
+function extractResponseContent(payload: unknown): string {
+  if (payload && typeof payload === "object" && Array.isArray((payload as { choices?: unknown }).choices)) {
+    const choice = (payload as { choices: Array<{ message?: { content?: unknown } }> }).choices[0];
+    const text = choice?.message?.content;
+    if (typeof text === "string") return text;
+    return JSON.stringify(payload, null, 2);
+  }
+  if (typeof payload === "string") return payload;
+  return JSON.stringify(payload, null, 2);
+}
+
+/** Owns the "test this model" modal state and its one-shot chat completion call. */
+export function useModelTestRunner(apiBase?: string) {
+  const { t } = useTranslation();
+  const [target, setTarget] = useState<ModelItem | null>(null);
+  const [running, setRunning] = useState(false);
+  const [resultText, setResultText] = useState<string | null>(null);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const [durationMs, setDurationMs] = useState<number | null>(null);
+
+  const open = useCallback((model: ModelItem) => {
+    setTarget(model);
+    setResultText(null);
+    setErrorText(null);
+    setDurationMs(null);
+  }, []);
+
+  const close = useCallback(() => {
+    if (running) return;
+    setTarget(null);
+    setResultText(null);
+    setErrorText(null);
+    setDurationMs(null);
+  }, [running]);
+
+  const run = useCallback(
+    async (input: { channel: string; prompt: string }) => {
+      if (!target) return;
+      setRunning(true);
+      setResultText(null);
+      setErrorText(null);
+      setDurationMs(null);
+      // Only the upstream round-trip is timed; the local API-key lookup would
+      // otherwise inflate the number the user reads as model latency.
+      let requestStartedAt: number | null = null;
+      try {
+        const entries = await apiKeyEntriesApi.list();
+        const channelNeedle = input.channel.trim().toLowerCase();
+        const matchingKey =
+          entries
+            .filter((entry) => !entry.disabled && entry.key?.trim())
+            .map((entry) => ({ entry, score: scoreKeyForChannel(entry, channelNeedle) }))
+            .filter((item) => item.score > 0)
+            .sort((a, b) => b.score - a.score)[0]?.entry ?? null;
+        if (!matchingKey) {
+          throw new Error(t("models_page.test_no_api_key"));
+        }
+
+        const base = normalizeApiBase(apiBase || detectApiBaseFromLocation());
+        requestStartedAt = performance.now();
+        const response = await fetch(`${base}/v1/chat/completions`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${matchingKey.key}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: target.id,
+            messages: [{ role: "user", content: input.prompt }],
+            stream: false,
+          }),
+        });
+        const rawText = await response.text();
+        let payload: unknown = null;
+        try {
+          payload = rawText ? JSON.parse(rawText) : null;
+        } catch {
+          payload = rawText;
+        }
+        if (!response.ok) {
+          throw new Error(extractErrorMessage(payload, rawText || `HTTP ${response.status}`));
+        }
+        setResultText(extractResponseContent(payload) || t("models_page.test_empty_response"));
+      } catch (err: unknown) {
+        setErrorText(err instanceof Error ? err.message : t("models_page.test_failed"));
+      } finally {
+        // Failed round-trips still carry a useful timing; pre-request failures do not.
+        if (requestStartedAt !== null) {
+          setDurationMs(Math.round(performance.now() - requestStartedAt));
+        }
+        setRunning(false);
+      }
+    },
+    [apiBase, t, target],
+  );
+
+  return { target, running, resultText, errorText, durationMs, open, close, run };
+}

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -20,12 +20,12 @@
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,
     "pages/auth-files/components/AuthFilesFilesTab.tsx": 2644,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
-    "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 1218,
+    "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 1049,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1455,
     "pages/end-users/EndUsersPage.tsx": 1126,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 1197,
-    "pages/models/ModelsPage.tsx": 1358,
+    "pages/models/ModelsPage.tsx": 1251,
     "pages/providers/components/ProvidersPageContent.tsx": 1853
   }
 }


### PR DESCRIPTION
## 背景

AI 账号表格的配额列此前是「进度条 + hover 浮层」：重置倒计时、金额余量这些关键信息只有悬停才看得到，行内那条进度条又占掉大半列宽，多个配额窗口叠起来很难扫读。

## 改动

**配额列（`pages/auth-files/`）**

- 每个配额窗口渲染成一个 chip：环形指示 + 标签 + 倒计时 + 百分比排在一行，两列网格；带金额 meta（`$1452.81 / $1500.00`）或长标签的指标跨两列。
- 移除配额列的 hover 浮层——信息已经在行内可读，浮层不再有存在价值。
- chip 内倒计时只保留最大的两个单位（`2天19小时`），避免把百分比挤出半宽 chip；wide 判定阈值相应从 30 显示单位降到 16。
- 卡片视图的 `renderQuotaBar` 保持不变，本次只改列表视图。

**模型测试弹窗（`pages/models/`）**

- 「响应」标题旁新增耗时徽章。只计上游往返，不含本地 API Key 查找，避免把准备时间读成模型延迟。
- 请求失败也保留耗时；请求发出前就失败（如没有可用 Key）则不显示。
- 复用既有 `formatLatency`，新增 `models_page.test_duration` 文案（zh-CN / en；ru 无 `models_page` 段，回落 en）。

**结构债**

配额 chip 与模型测试逻辑分别提取到 `QuotaMetricChips.tsx` 和 `useModelTestRunner.ts`，两个宿主文件同步缩小并锁定基线：

| 文件 | 行数 |
|------|------|
| `pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx` | 1218 → 1049 |
| `pages/models/ModelsPage.tsx` | 1358 → 1251 |

## 影响范围

仅 `codeProxy/`，不涉及 `CliRelay/`。

## 测试改动

3 个断言 hover 浮层的表格测试改为断言 chip 内容直接可见 + 悬停不再打开浮层；布局测试改为校验每个 chip 都带倒计时槽（新增 `auth-file-quota-reset` testid）。

## 已执行验证

`./scripts/ci-pr.sh` 全绿：

- `bun run lint` — 0 errors（1 个 dev 上既有的 `no-control-regex` warning，与本次无关）
- `bun run design:check` / `bun run boundary:imports` / `bun run size:check` / `bun run audit:deps`
- `bun run test:ci` — 1035 passed (145 files)
- `bun run build` + `bun run bundle:diff`
- 9 个 `@critical` e2e passed

另单独跑过 `e2e/account-security-identity-fingerprint.spec.ts` 的配额布局用例，确认新阈值下 compact/wide 分布与断言一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)