### PR TITLE
feat(table): 按语义令牌统一各表默认列宽

### DIFF
--- a/e2e/api-keys-table.spec.ts
+++ b/e2e/api-keys-table.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const API_KEYS_COLUMN_WIDTH_STORAGE_KEY = "codeProxy.dataTable.columnWidths.v1.api-keys";
+const API_KEYS_COLUMN_WIDTH_STORAGE_KEY = "codeProxy.dataTable.columnWidths.v2.api-keys";
 const STICKY_EDGE_SHADOW_WIDTH = 28;
 
 type SetAuthedOptions = {
@@ -12,11 +12,11 @@ const setAuthed = async (page: Page, options: SetAuthedOptions = {}) => {
     localStorage.removeItem("codeProxy.dataTable.columnOrder.v1.api-keys");
     if (authOptions.columnWidths) {
       localStorage.setItem(
-        "codeProxy.dataTable.columnWidths.v1.api-keys",
+        "codeProxy.dataTable.columnWidths.v2.api-keys",
         JSON.stringify(authOptions.columnWidths),
       );
     } else {
-      localStorage.removeItem("codeProxy.dataTable.columnWidths.v1.api-keys");
+      localStorage.removeItem("codeProxy.dataTable.columnWidths.v2.api-keys");
     }
     localStorage.setItem(
       "code-proxy-admin-auth",

--- a/e2e/request-logs-column-reorder.spec.ts
+++ b/e2e/request-logs-column-reorder.spec.ts
@@ -3,7 +3,7 @@ import { expect, test, type Page } from "@playwright/test";
 const setAuthed = async (page: Page) => {
   await page.addInitScript(() => {
     localStorage.removeItem("codeProxy.dataTable.columnOrder.v1.request-logs");
-    localStorage.removeItem("codeProxy.dataTable.columnWidths.v1.request-logs");
+    localStorage.removeItem("codeProxy.dataTable.columnWidths.v2.request-logs");
     localStorage.setItem(
       "code-proxy-admin-auth",
       JSON.stringify({
@@ -253,7 +253,7 @@ const readResponseMetricsColumnState = async (page: Page) =>
     });
     const storedWidths = JSON.parse(
       localStorage.getItem(
-        "codeProxy.dataTable.columnWidths.v1.request-logs",
+        "codeProxy.dataTable.columnWidths.v2.request-logs",
       ) ?? "{}",
     ) as Record<string, unknown>;
 

--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -5,7 +5,7 @@ import iconClaude from "@code-proxy/assets/icons/claude.svg";
 import iconCodex from "@code-proxy/assets/icons/codex.svg";
 import iconGemini from "@code-proxy/assets/icons/gemini.svg";
 import { modelsApi } from "@code-proxy/api-client";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import {
   DataTable,
   TABLE_ROW_ACTIONS_COLUMN,
@@ -540,7 +540,7 @@ export function CcSwitchImportConfigModal({
           {
             key: "role",
             label: t("ccswitch.config_claude_model_role"),
-            width: "w-44",
+            width: COLUMN_WIDTH.badgeGroup,
             cellContentClassName: "font-medium text-slate-800 dark:text-white/80",
             render: (mapping) =>
               mapping.role ? t(`ccswitch.config_claude_role_${mapping.role}`) : "",
@@ -548,7 +548,7 @@ export function CcSwitchImportConfigModal({
           {
             key: "requestModel",
             label: t("ccswitch.config_request_model_name"),
-            width: "w-72",
+            width: COLUMN_WIDTH.nameStacked,
             sort: { getValue: (mapping) => mapping.requestModel },
             render: (mapping) => {
               const role = mapping.role;
@@ -567,7 +567,7 @@ export function CcSwitchImportConfigModal({
           {
             key: "targetModel",
             label: t("ccswitch.config_actual_channel_model"),
-            width: "w-80",
+            width: COLUMN_WIDTH.composite,
             sort: { getValue: (mapping) => mapping.targetModel },
             render: (mapping) => {
               const role = mapping.role;
@@ -594,7 +594,7 @@ export function CcSwitchImportConfigModal({
           {
             key: "targetModel",
             label: t("ccswitch.config_actual_channel_model"),
-            width: "w-72",
+            width: COLUMN_WIDTH.nameStacked,
             sort: { getValue: (mapping) => mapping.targetModel },
             render: (mapping, index) => (
               <SearchableSelect
@@ -615,7 +615,7 @@ export function CcSwitchImportConfigModal({
           {
             key: "requestModel",
             label: t("ccswitch.config_request_model_name"),
-            width: "w-72",
+            width: COLUMN_WIDTH.nameStacked,
             sort: { getValue: (mapping) => mapping.requestModel },
             render: (mapping, index) => (
               <TextInput
@@ -631,7 +631,7 @@ export function CcSwitchImportConfigModal({
             key: "contextWindow",
             // Header wraps below w-52 in en/ru, which reads as a truncated label.
             label: t("ccswitch.config_codex_context_window"),
-            width: "w-52",
+            width: COLUMN_WIDTH.name,
             render: (mapping, index) => (
               <TextInput
                 type="number"

--- a/features/period-spending/OwnedApiKeyResetHistoryModal.tsx
+++ b/features/period-spending/OwnedApiKeyResetHistoryModal.tsx
@@ -1,5 +1,5 @@
 import type { ApiKeyDailySpendingResetEvent } from "@code-proxy/api-client/endpoints/api-keys";
-import { DataTable, Modal, type DataTableColumn } from "@code-proxy/ui";
+import { COLUMN_WIDTH, DataTable, Modal, type DataTableColumn } from "@code-proxy/ui";
 import { formatQuotaUsdAmount } from "./PeriodSpendingCell";
 
 const formatResetAt = (value: string): string => {
@@ -28,19 +28,19 @@ export function OwnedApiKeyResetHistoryModal({
     {
       key: "reset_at",
       label: t("api_keys_page.reset_history_col_time"),
-      width: "w-[180px] min-w-[160px]",
+      width: COLUMN_WIDTH.badgeGroup,
       render: (row) => formatResetAt(row.reset_at),
     },
     {
       key: "day_key",
       label: t("api_keys_page.reset_history_col_day"),
-      width: "w-[130px] min-w-[120px]",
+      width: COLUMN_WIDTH.numericWide,
       render: (row) => row.day_key || "-",
     },
     {
       key: "actor",
       label: t("api_keys_page.reset_history_col_actor"),
-      width: "w-[140px] min-w-[120px]",
+      width: COLUMN_WIDTH.numericWide,
       render: (row) =>
         row.actor_username?.trim() ||
         (row.actor_kind === "service_credential"
@@ -50,19 +50,19 @@ export function OwnedApiKeyResetHistoryModal({
     {
       key: "effective_used_before",
       label: t("api_keys_page.reset_history_col_cleared"),
-      width: "w-[150px] min-w-[130px]",
+      width: COLUMN_WIDTH.timestamp,
       render: (row) => formatQuotaUsdAmount(row.effective_used_before),
     },
     {
       key: "raw_today_cost",
       label: t("api_keys_page.reset_history_col_raw_today"),
-      width: "w-[150px] min-w-[130px]",
+      width: COLUMN_WIDTH.timestamp,
       render: (row) => formatQuotaUsdAmount(row.raw_today_cost),
     },
     {
       key: "cost_baseline",
       label: t("api_keys_page.reset_history_col_baseline"),
-      width: "w-[150px] min-w-[130px]",
+      width: COLUMN_WIDTH.timestamp,
       render: (row) => formatQuotaUsdAmount(row.cost_baseline),
     },
   ];

--- a/features/period-spending/OwnedApiKeyTable.tsx
+++ b/features/period-spending/OwnedApiKeyTable.tsx
@@ -5,6 +5,7 @@ import {
   type EndUserAPIKey,
 } from "@code-proxy/api-client";
 import {
+  COLUMN_WIDTH,
   DataTable,
   EmptyState,
   OverflowTooltip,
@@ -40,7 +41,7 @@ export const createOwnedApiKeyColumns = ({
   {
     key: "name",
     label: t("api_keys_page.col_name"),
-    width: "w-[150px] min-w-[150px]",
+    width: COLUMN_WIDTH.numericWide,
     cellClassName: "font-medium",
     render: (row) => (
       <div className="min-w-0">
@@ -74,7 +75,7 @@ export const createOwnedApiKeyColumns = ({
   {
     key: "status",
     label: t("api_keys_page.col_status"),
-    width: "w-[92px] min-w-[92px]",
+    width: COLUMN_WIDTH.badge,
     cellClassName: "text-center",
     render: (row) => (
       <span
@@ -95,21 +96,21 @@ export const createOwnedApiKeyColumns = ({
   {
     key: "dailySpending",
     label: t("quota.daily_spending_column"),
-    width: "w-[130px] min-w-[130px]",
+    width: COLUMN_WIDTH.compact,
     cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
     render: (row) => formatQuotaUsdAmount(row["daily-spending-used"]),
   },
   {
     key: "lifetimeSpending",
     label: t("quota.lifetime_spending_column"),
-    width: "w-[130px] min-w-[130px]",
+    width: COLUMN_WIDTH.compact,
     cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
     render: (row) => formatQuotaUsdAmount(row["lifetime-spending-used"]),
   },
   {
     key: "resetCount",
     label: t("quota.total_resets"),
-    width: "w-[118px] min-w-[118px]",
+    width: COLUMN_WIDTH.numericWide,
     cellClassName: "text-center",
     render: (row) => {
       const count = row["daily-spending-reset-count"] ?? 0;
@@ -130,7 +131,7 @@ export const createOwnedApiKeyColumns = ({
   {
     key: "created",
     label: t("api_keys_page.col_created"),
-    width: "w-[150px] min-w-[150px]",
+    width: COLUMN_WIDTH.numericWide,
     cellClassName: "whitespace-nowrap text-xs text-slate-500 dark:text-white/50",
     render: (row) => (row.created_at ? new Date(row.created_at).toLocaleString() : "-"),
   },

--- a/features/routing-config-editor/RoutingConfigEditor.tsx
+++ b/features/routing-config-editor/RoutingConfigEditor.tsx
@@ -11,7 +11,7 @@ import type {
   VisualConfigValues,
 } from "@features/visual-config-editor";
 import { makeClientId } from "@features/visual-config-editor";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
 import { ConfirmModal } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
@@ -1000,7 +1000,7 @@ export function RoutingConfigEditor({
       {
         key: "name",
         label: t("channel_groups_page.table_group"),
-        width: "w-[150px] min-w-[150px]",
+        width: COLUMN_WIDTH.numericWide,
         cellClassName: "min-w-0 whitespace-nowrap font-medium",
         render: (group, index) => {
           const name = group.system
@@ -1032,7 +1032,7 @@ export function RoutingConfigEditor({
       {
         key: "channelCount",
         label: t("channel_groups_page.table_channel_count"),
-        width: "w-[104px] min-w-[104px]",
+        width: COLUMN_WIDTH.toggle,
         headerClassName: "text-center",
         cellClassName: "whitespace-nowrap text-center",
         render: (group) => {
@@ -1054,7 +1054,7 @@ export function RoutingConfigEditor({
       {
         key: "status",
         label: t("channel_groups_page.table_status"),
-        width: "w-[112px] min-w-[112px]",
+        width: COLUMN_WIDTH.badge,
         cellClassName: "whitespace-nowrap",
         render: (group) => {
           const staleChannels = staleChannelsByGroup.get(group.id) ?? [];
@@ -1088,7 +1088,7 @@ export function RoutingConfigEditor({
             tooltip={t("channel_groups_page.table_default_scope_tooltip")}
           />
         ),
-        width: "w-[128px] min-w-[128px]",
+        width: COLUMN_WIDTH.compact,
         cellClassName: "whitespace-nowrap",
         render: (group) => {
           if (group.system) {
@@ -1112,7 +1112,7 @@ export function RoutingConfigEditor({
       {
         key: "channels",
         label: t("channel_groups_page.table_channels"),
-        width: "w-[280px] min-w-[280px]",
+        width: COLUMN_WIDTH.nameStacked,
         cellClassName: "min-w-0 whitespace-nowrap text-slate-700 dark:text-white/75",
         render: (group) => {
           if (group.system) {
@@ -1311,7 +1311,7 @@ export function RoutingConfigEditor({
       {
         key: "priority",
         label: t("channel_groups_page.channel_priority_label"),
-        width: "w-[156px] min-w-[156px]",
+        width: COLUMN_WIDTH.badgeGroup,
         cellClassName: "whitespace-nowrap",
         render: (channel) => (
           <TextInput
@@ -1370,7 +1370,7 @@ export function RoutingConfigEditor({
       {
         key: "select",
         label: "",
-        width: "w-12",
+        width: COLUMN_WIDTH.checkbox,
         headerClassName: "text-center",
         cellClassName: "text-center",
         headerRender: () => (
@@ -1422,7 +1422,7 @@ export function RoutingConfigEditor({
       {
         key: "owner",
         label: t("models_page.col_owner"),
-        width: "w-36",
+        width: COLUMN_WIDTH.numericWide,
         minWidthPx: 120,
         maxWidthPx: 360,
         cellClassName: "min-w-0 whitespace-nowrap text-slate-600 dark:text-white/60",

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -2236,7 +2236,7 @@ export function DataTable<T>({
                           <span
                             className={`flex min-w-0 items-center gap-1.5 ${resolveHeaderContentJustifyClass(col.headerClassName)}`}
                           >
-                            <span className="min-w-0 truncate">
+                            <span className="min-w-0 truncate" title={col.headerRender ? undefined : col.label}>
                               {col.headerRender ? col.headerRender() : col.label}
                             </span>
                             {canSort ? (

--- a/packages/ui/src/data-table/columnWidths.ts
+++ b/packages/ui/src/data-table/columnWidths.ts
@@ -1,0 +1,50 @@
+/**
+ * 语义列宽令牌。
+ *
+ * 各页此前手写 Tailwind 宽度（`w-44` / `w-[220px]` …），同类内容在不同表里
+ * 宽度不一：开关列有的 96px 有的 176px，时间戳有的 144px 有的 208px。更常见的
+ * 问题是列窄于表头文字本身——英文文案普遍比中文长（"连通性" 36px vs
+ * "Connectivity" 82px），中文界面正常的列在英文界面会把表头截断。
+ *
+ * 取值口径（按 DataTable 实测：表头 text-xs、单元格左右 padding 各 16px、
+ * 表头还要留排序与拖拽图标）：
+ *
+ *     列宽 = max(表头文字, 内容) + 图标 24px + padding 32px
+ *
+ * 表头文字按 12px/中文字、6.8px/ASCII 估算，并取中英文中较宽的一侧，使同一份
+ * 列宽在两种语言下都不截断表头。多个令牌值相同是正常的——它们按语义分类，
+ * 将来某一类需要整体调整时只改这里一处。
+ *
+ * 用法：`width: COLUMN_WIDTH.timestamp`。内容确实超出令牌刻度时（复合单元格、
+ * 长描述）直接写具体值并在该列注明原因，不要为了套令牌牺牲可读性。
+ */
+export const COLUMN_WIDTH = {
+  /** 56px — 复选框列，无表头文字，只需容纳 16px 勾选框。 */
+  checkbox: "w-14 min-w-14",
+  /** 112px — 开关、单个图标按钮。表头 2-3 字（启用 / Enabled）。 */
+  toggle: "w-28 min-w-28",
+  /** 112px — 短数值：计数、百分比。表头 2-3 字（成功 / Success）。 */
+  numeric: "w-28 min-w-28",
+  /** 112px — 单个短徽章：类型、模式、状态。 */
+  badge: "w-28 min-w-28",
+  /** 128px — 短标识、枚举文本、金额（当日消费 / RPM）。 */
+  compact: "w-32 min-w-32",
+  /** 144px — 长数值：token 数、金额、重置次数。表头 4-6 字（累计消费）。 */
+  numericWide: "w-36 min-w-36",
+  /** 144px — 带进度条或状态条的指标列（成功率、连通性）。 */
+  metric: "w-36 min-w-36",
+  /** 160px — 日期时间戳（2026/8/6 10:41:47）。 */
+  timestamp: "w-40 min-w-40",
+  /** 160px — 徽章 + 副标签堆叠（类型 + 套餐、协议 + 地址）。 */
+  badgeStacked: "w-40 min-w-40",
+  /** 176px — 徽章组：多标签、多角色、权限集合。 */
+  badgeGroup: "w-44 min-w-44",
+  /** 208px — 常规名称、单行标题。 */
+  name: "w-52 min-w-52",
+  /** 288px — 名称 + 副标题（邮箱、ID、徽章）的双行单元格。 */
+  nameStacked: "w-72 min-w-72",
+  /** 320px — 复合内容：chip 网格、多列指标、长描述。 */
+  composite: "w-80 min-w-80",
+} as const;
+
+export type ColumnWidthToken = keyof typeof COLUMN_WIDTH;

--- a/packages/ui/src/data-table/dataTableModel.ts
+++ b/packages/ui/src/data-table/dataTableModel.ts
@@ -4,7 +4,9 @@ export const DEFAULT_ROW_HEIGHT = 44;
 export const DEFAULT_OVERSCAN = 12;
 export const DEFAULT_SCROLL_THRESHOLD = 100;
 export const DEFAULT_BOTTOM_DEBOUNCE_MS = 120;
-export const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v1";
+// v2：列宽默认值整体按语义令牌重排（见 columnWidths.ts）。v1 里保存的手动拖拽
+// 结果是针对旧默认值的，继续沿用会盖掉新默认值，因此换 key 让旧记录自然失效。
+export const COLUMN_WIDTH_STORAGE_PREFIX = "codeProxy.dataTable.columnWidths.v2";
 export const COLUMN_RESIZE_DEBUG_STORAGE_KEY = "codeProxy.dataTable.debugResize";
 export const DEFAULT_MIN_COLUMN_WIDTH = 72;
 export const DEFAULT_MAX_COLUMN_WIDTH = 640;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,8 @@ export {
   TABLE_ROW_ACTIONS_STICKY_END_COLUMN,
 } from "./data-table/TableRowActions";
 export type { TableRowAction } from "./data-table/TableRowActions";
+export { COLUMN_WIDTH } from "./data-table/columnWidths";
+export type { ColumnWidthToken } from "./data-table/columnWidths";
 export type {
   DataTableColumn,
   DataTableColumnSort,

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -18,7 +18,7 @@ import {
   type PeriodSpendingDraft,
 } from "@features/period-spending";
 import { useApiKeyPermissionOptions } from "@features/api-key-restrictions";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { ConfirmModal } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
@@ -298,7 +298,7 @@ export function ApiKeyPermissionsPage() {
       {
         key: "name",
         label: t("api_key_permissions_page.col_name"),
-        width: "w-[180px] min-w-[180px]",
+        width: COLUMN_WIDTH.badgeGroup,
         cellClassName: "font-medium text-slate-900 dark:text-white",
         render: (profile) => profile.name,
       },
@@ -347,7 +347,7 @@ export function ApiKeyPermissionsPage() {
       {
         key: "bound",
         label: t("api_key_permissions_page.col_bound_keys"),
-        width: "w-[120px] min-w-[120px]",
+        width: COLUMN_WIDTH.timestamp,
         render: (profile) =>
           t("api_key_permissions_page.bound_count", {
             count: boundProfileCount(profile, accounts),

--- a/pages/api-keys/components/ApiKeyColumns.tsx
+++ b/pages/api-keys/components/ApiKeyColumns.tsx
@@ -24,6 +24,7 @@ import {
   VendorIcon,
 } from "../apiKeyPageUtils";
 import {
+  COLUMN_WIDTH,
   Checkbox,
   HoverTooltip,
   OverflowTooltip,
@@ -139,7 +140,7 @@ export const createApiKeyColumns = ({
     {
       key: "select",
       label: t("api_keys_page.select_all_keys"),
-      width: "w-12 min-w-12",
+      width: COLUMN_WIDTH.checkbox,
       lockOrder: "start",
       headerClassName: stickySelectHeaderClass,
       cellClassName: stickySelectCellClass,
@@ -164,7 +165,7 @@ export const createApiKeyColumns = ({
     {
       key: "name",
       label: t("api_keys_page.col_name"),
-      width: "w-[120px] min-w-[120px]",
+      width: COLUMN_WIDTH.toggle,
       lockOrder: "start",
       headerClassName: stickyNameHeaderClass,
       cellClassName: stickyNameCellClass,
@@ -223,7 +224,7 @@ export const createApiKeyColumns = ({
     {
       key: "dailySpending",
       label: t("quota.daily_spending_column"),
-      width: "w-[130px] min-w-[130px]",
+      width: COLUMN_WIDTH.compact,
       cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       headerRender: () => (
         <HoverTooltip
@@ -239,7 +240,7 @@ export const createApiKeyColumns = ({
     {
       key: "lifetimeSpending",
       label: t("quota.lifetime_spending_column"),
-      width: "w-[140px] min-w-[140px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName: "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       headerRender: () => (
         <HoverTooltip
@@ -255,7 +256,7 @@ export const createApiKeyColumns = ({
     {
       key: "dailySpendingResetCount",
       label: t("quota.total_resets"),
-      width: "w-[110px] min-w-[100px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName: "whitespace-nowrap text-slate-700 dark:text-white/70",
       headerRender: () => (
         <HoverTooltip
@@ -286,7 +287,7 @@ export const createApiKeyColumns = ({
     {
       key: "key",
       label: t("api_keys_page.col_key"),
-      width: "w-[320px] min-w-[320px]",
+      width: COLUMN_WIDTH.composite,
       cellClassName: "whitespace-nowrap",
       render: (row) => <ApiKeyBadge value={maskApiKey(row.key)} />,
     },
@@ -327,7 +328,7 @@ export const createApiKeyColumns = ({
     {
       key: "spendingLimit",
       label: t("api_keys_page.col_spending_limit"),
-      width: "w-[148px] min-w-[148px]",
+      width: COLUMN_WIDTH.timestamp,
       cellClassName: "whitespace-nowrap text-slate-700 dark:text-white/70",
       headerRender: () => (
         <HoverTooltip
@@ -353,7 +354,7 @@ export const createApiKeyColumns = ({
     {
       key: "rpmLimit",
       label: "RPM",
-      width: "w-[108px] min-w-[108px]",
+      width: COLUMN_WIDTH.toggle,
       cellClassName: "whitespace-nowrap text-slate-700 dark:text-white/70",
       headerRender: () => (
         <HoverTooltip content={t("api_keys.rpm_full")} className="inline-flex items-center gap-1">
@@ -376,7 +377,7 @@ export const createApiKeyColumns = ({
     {
       key: "tpmLimit",
       label: "TPM",
-      width: "w-[108px] min-w-[108px]",
+      width: COLUMN_WIDTH.toggle,
       cellClassName: "whitespace-nowrap text-slate-700 dark:text-white/70",
       headerRender: () => (
         <HoverTooltip content={t("api_keys.tpm_full")} className="inline-flex items-center gap-1">
@@ -399,7 +400,7 @@ export const createApiKeyColumns = ({
     {
       key: "allowedModels",
       label: t("api_keys_page.col_models"),
-      width: "w-[150px] min-w-[150px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName: "min-w-0 overflow-hidden text-slate-700 dark:text-white/70",
       render: (row) =>
         row["allowed-models"]?.length ? (
@@ -430,7 +431,7 @@ export const createApiKeyColumns = ({
     {
       key: "allowedChannelGroups",
       label: t("api_keys_page.col_channel_groups"),
-      width: "w-[172px] min-w-[172px]",
+      width: COLUMN_WIDTH.badgeGroup,
       cellClassName: "min-w-0 overflow-hidden text-slate-700 dark:text-white/70",
       render: (row) =>
         row["allowed-channel-groups"]?.length ? (
@@ -460,7 +461,7 @@ export const createApiKeyColumns = ({
     {
       key: "allowedChannels",
       label: t("api_keys_page.col_channels"),
-      width: "w-[172px] min-w-[172px]",
+      width: COLUMN_WIDTH.badgeGroup,
       cellClassName: "min-w-0 overflow-hidden text-slate-700 dark:text-white/70",
       render: (row) =>
         row["allowed-channels"]?.length ? (
@@ -490,7 +491,7 @@ export const createApiKeyColumns = ({
     {
       key: "createdAt",
       label: t("api_keys_page.col_created"),
-      width: "w-[168px] min-w-[168px]",
+      width: COLUMN_WIDTH.timestamp,
       cellClassName: "whitespace-nowrap text-slate-500 dark:text-white/50",
       render: (row) => <>{formatApiKeyDate(row["created-at"])}</>,
     },

--- a/pages/api-keys/components/ApiKeyResetHistoryModal.tsx
+++ b/pages/api-keys/components/ApiKeyResetHistoryModal.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { DataTable, Modal } from "@code-proxy/ui";
+import { COLUMN_WIDTH, DataTable, Modal } from "@code-proxy/ui";
 import type { DataTableColumn } from "@code-proxy/ui";
 import type { ApiKeyDailySpendingResetEvent } from "@code-proxy/api-client/endpoints/api-keys";
 import { formatApiKeySpendingAmount } from "../apiKeyPageUtils";
@@ -44,7 +44,7 @@ export function ApiKeyResetHistoryModal({
     {
       key: "reset_at",
       label: t("api_keys_page.reset_history_col_time"),
-      width: "w-[180px] min-w-[160px]",
+      width: COLUMN_WIDTH.badgeGroup,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => formatResetAt(row.reset_at),
@@ -52,7 +52,7 @@ export function ApiKeyResetHistoryModal({
     {
       key: "day_key",
       label: t("api_keys_page.reset_history_col_day"),
-      width: "w-[130px] min-w-[120px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => row.day_key || "—",
@@ -60,14 +60,14 @@ export function ApiKeyResetHistoryModal({
     {
       key: "actor",
       label: t("api_keys_page.reset_history_col_actor"),
-      width: "w-[140px] min-w-[120px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName: "text-slate-700 dark:text-white/70",
       render: (row) => actorLabel(row, t),
     },
     {
       key: "effective_used_before",
       label: t("api_keys_page.reset_history_col_cleared"),
-      width: "w-[140px] min-w-[120px]",
+      width: COLUMN_WIDTH.timestamp,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) =>
@@ -84,7 +84,7 @@ export function ApiKeyResetHistoryModal({
     {
       key: "cost_baseline",
       label: t("api_keys_page.reset_history_col_baseline"),
-      width: "w-[150px] min-w-[130px]",
+      width: COLUMN_WIDTH.timestamp,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => formatApiKeySpendingAmount(row.cost_baseline ?? 0),

--- a/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
+++ b/pages/api-keys/components/__tests__/ApiKeyColumns.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ApiKeyEntry } from "@code-proxy/api-client/endpoints/api-keys";
 import { createApiKeyColumns } from "../ApiKeyColumns";
-import { GlobalIconButtonTooltip } from "@code-proxy/ui";
+import { COLUMN_WIDTH, GlobalIconButtonTooltip } from "@code-proxy/ui";
 
 const t = ((key: string, options?: Record<string, string>) => {
   const labels: Record<string, string> = {
@@ -114,7 +114,8 @@ describe("ApiKeyColumns", () => {
     const columns = createColumns();
     const keyColumn = columns.find((column) => column.key === "key");
 
-    expect(keyColumn?.width).toBe("w-[320px] min-w-[320px]");
+    // 仍是 320px，只是改用最宽的语义令牌表达，避免测试绑死具体类名
+    expect(keyColumn?.width).toBe(COLUMN_WIDTH.composite);
   });
 
   test("truncates API key text inside an intact rounded badge", () => {

--- a/pages/audit-logs/AuditLogsPage.tsx
+++ b/pages/audit-logs/AuditLogsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   ConfirmModal,
   DataTable,
   Modal,
@@ -193,13 +194,13 @@ export function AuditLogsPage() {
       {
         key: "time",
         label: t("identity_admin.time"),
-        width: "w-52",
+        width: COLUMN_WIDTH.timestamp,
         render: (item) => new Date(item.created_at).toLocaleString(i18n.language),
       },
       {
         key: "actor",
         label: t("identity_admin.actor"),
-        width: "w-72",
+        width: COLUMN_WIDTH.nameStacked,
         overflowTooltip: true,
         render: (item) => formatActor(item),
       },
@@ -212,7 +213,7 @@ export function AuditLogsPage() {
       {
         key: "result",
         label: t("identity_admin.result"),
-        width: "w-28",
+        width: COLUMN_WIDTH.badge,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (item) =>

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -18,7 +18,7 @@ import type {
   IdentityFingerprintFieldSource,
 } from "@code-proxy/api-client";
 import type { ProxyPoolEntry } from "@code-proxy/api-client/endpoints/proxies";
-import { DataTable, type DataTableColumn } from "@code-proxy/ui";
+import { COLUMN_WIDTH, DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { Button } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
 import { DateTimePicker } from "@code-proxy/ui";
@@ -737,7 +737,7 @@ export function AuthFileDetailModal({
     {
       key: "section",
       label: t("auth_files.identity_fingerprint_table_section"),
-      width: "w-40",
+      width: COLUMN_WIDTH.badgeStacked,
       resizable: false,
       reorderable: false,
       overflowTooltip: (row) => identityFieldSectionLabel(row.section),
@@ -776,7 +776,7 @@ export function AuthFileDetailModal({
     {
       key: "source",
       label: t("auth_files.identity_fingerprint_table_source"),
-      width: "w-36",
+      width: COLUMN_WIDTH.toggle,
       resizable: false,
       reorderable: false,
       overflowTooltip: (row) => formatIdentitySource(row.source),

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -16,7 +16,7 @@ import type { AuthFileItem } from "@code-proxy/api-client";
 import { formatLatency } from "@features/provider-latency";
 import { ProviderStatusBar } from "@features/provider-latency";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
-import { HoverTooltip } from "@code-proxy/ui";
+import { COLUMN_WIDTH, HoverTooltip } from "@code-proxy/ui";
 import { ToggleSwitch } from "@code-proxy/ui";
 import { TABLE_ROW_ACTIONS_COLUMN, TableRowActions, type DataTableColumn } from "@code-proxy/ui";
 import {
@@ -602,7 +602,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "select",
         label: "",
-        width: "w-14",
+        width: COLUMN_WIDTH.checkbox,
         headerClassName: "text-center",
         cellClassName: "text-center",
         headerRender: () => (
@@ -643,7 +643,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "name",
         label: t("auth_files.col_name"),
-        width: "w-72",
+        width: COLUMN_WIDTH.nameStacked,
         render: (file) => {
           const supplementalTags = resolveAuthFileSupplementalTags(
             file,
@@ -679,7 +679,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "type",
         label: t("auth_files.col_type"),
-        width: "w-32",
+        width: COLUMN_WIDTH.badgeStacked,
         render: (file) => {
           const typeKey = resolveFileType(file);
           const badgeClass = TYPE_BADGE_CLASSES[typeKey] ?? TYPE_BADGE_CLASSES.unknown;
@@ -728,7 +728,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "subscription",
         label: t("auth_files.col_subscription"),
-        width: "w-40",
+        width: COLUMN_WIDTH.metric,
         render: (file) =>
           renderSubscriptionBadge(file) ?? (
             <span className="text-xs text-slate-400 dark:text-white/40">--</span>
@@ -737,7 +737,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "modified",
         label: t("auth_files.file_modified"),
-        width: "w-36",
+        width: COLUMN_WIDTH.metric,
         render: (file) => (
           <span className="text-xs tabular-nums text-slate-700 dark:text-white/70">
             {formatModified(file)}
@@ -747,7 +747,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "connectivity",
         label: t("auth_files.col_connectivity"),
-        width: "w-28",
+        width: COLUMN_WIDTH.metric,
         render: (file) => {
           const state = connectivityState.get(file.name);
           return (
@@ -775,7 +775,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "cycle_calls",
         label: t("auth_files.col_cycle_calls"),
-        width: "w-24",
+        width: COLUMN_WIDTH.numericWide,
         headerClassName: "text-right",
         cellClassName: "text-right",
         render: (file) => {
@@ -797,7 +797,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "success",
         label: t("common.success"),
-        width: "w-20",
+        width: COLUMN_WIDTH.numeric,
         headerClassName: "text-right",
         cellClassName: "text-right",
         render: (file) => {
@@ -813,7 +813,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "failure",
         label: t("common.failure"),
-        width: "w-20",
+        width: COLUMN_WIDTH.numeric,
         headerClassName: "text-right",
         cellClassName: "text-right",
         render: (file) => {
@@ -829,7 +829,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "rate",
         label: t("common.success_rate"),
-        width: "w-44",
+        width: COLUMN_WIDTH.metric,
         render: (file) => {
           const statusData = resolveAuthFileStatusBar(file, usageIndex);
           const hasUsage = statusData.totalSuccess + statusData.totalFailure > 0;
@@ -849,9 +849,9 @@ export function useAuthFilesFilesPresentation({
       {
         key: "quota",
         label: t("auth_files.col_quota"),
-        width: "w-[36rem] min-w-[36rem]",
-        minWidthPx: 480,
-        maxWidthPx: 720,
+        width: COLUMN_WIDTH.composite, // chips 两列排布约 290px 够用；36rem 是旧进度条布局的尺寸
+        minWidthPx: 288,
+        maxWidthPx: 640,
         overflowTooltip: false,
         headerClassName: "text-center",
         render: (file) => {
@@ -894,7 +894,7 @@ export function useAuthFilesFilesPresentation({
       {
         key: "enabled",
         label: t("auth_files.enable"),
-        width: "w-24",
+        width: COLUMN_WIDTH.toggle,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (file) => {

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -12,7 +12,7 @@ import {
 import { normalizeProviderKey } from "@code-proxy/domain";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 import { ccSwitchImportConfigsApi } from "@code-proxy/api-client/endpoints/ccswitch-import-configs";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { ConfirmModal } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
@@ -213,7 +213,7 @@ export function CcSwitchImportSettingsPage() {
       {
         key: "provider",
         label: t("ccswitch.config_table_provider"),
-        width: "w-72",
+        width: COLUMN_WIDTH.nameStacked,
         overflowTooltip: (row) =>
           row.note ? `${row.providerName}\n${row.note}` : row.providerName,
         render: (row) => (
@@ -230,7 +230,7 @@ export function CcSwitchImportSettingsPage() {
       {
         key: "model",
         label: t("ccswitch.config_table_model"),
-        width: "w-52",
+        width: COLUMN_WIDTH.name,
         overflowTooltip: true,
         render: (row) => (
           <span className="inline-flex max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-md border border-slate-900/8 bg-white px-2 py-1 font-mono text-xs text-slate-600 dark:border-white/8 dark:bg-neutral-950 dark:text-white/65">
@@ -241,7 +241,7 @@ export function CcSwitchImportSettingsPage() {
       {
         key: "groups",
         label: t("ccswitch.config_table_groups"),
-        width: "w-72",
+        width: COLUMN_WIDTH.nameStacked,
         overflowTooltip: (row) =>
           row.allowedChannelGroups.length > 0 ? row.allowedChannelGroups.join(", ") : null,
         render: (row) =>

--- a/pages/content-moderation/ContentModerationPage.tsx
+++ b/pages/content-moderation/ContentModerationPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   Card,
   ConfirmModal,
   DataTable,
@@ -178,14 +179,14 @@ export function ContentModerationPage() {
       {
         key: "name",
         label: t("content_moderation.profile_name"),
-        width: "w-[180px] min-w-[180px]",
+        width: COLUMN_WIDTH.badgeGroup,
         cellClassName: "font-medium text-slate-900 dark:text-white",
         render: (profile) => profile.name,
       },
       {
         key: "mode",
         label: t("content_moderation.enabled"),
-        width: "w-[140px] min-w-[140px]",
+        width: COLUMN_WIDTH.toggle,
         render: (profile) => {
           const enabled = profile.mode === "pre_block";
           return (
@@ -208,7 +209,7 @@ export function ContentModerationPage() {
       {
         key: "method",
         label: t("content_moderation.moderation_method"),
-        width: "w-[180px] min-w-[180px]",
+        width: COLUMN_WIDTH.badgeGroup,
         cellClassName: "text-slate-700 dark:text-white/70",
         render: (profile) => t(`content_moderation.keyword_mode_${profile.keyword_mode}`),
       },
@@ -228,7 +229,7 @@ export function ContentModerationPage() {
       {
         key: "apiKey",
         label: t("content_moderation.api_key"),
-        width: "w-[120px] min-w-[120px]",
+        width: COLUMN_WIDTH.name,
         render: (profile) =>
           profile.api_key_configured ? (
             <span className="font-mono text-xs text-emerald-700 dark:text-emerald-200">
@@ -243,7 +244,7 @@ export function ContentModerationPage() {
       {
         key: "bindings",
         label: t("content_moderation.bindings"),
-        width: "w-[160px] min-w-[160px]",
+        width: COLUMN_WIDTH.badgeStacked,
         render: (profile) => (
           <div className="text-xs text-slate-700 dark:text-white/70">
             <p>{t("content_moderation.binding_total", { count: bindingCount(profile) })}</p>
@@ -260,7 +261,7 @@ export function ContentModerationPage() {
       {
         key: "updated",
         label: t("content_moderation.updated_at"),
-        width: "w-[160px] min-w-[160px]",
+        width: COLUMN_WIDTH.timestamp,
         render: (profile) => (
           <span className="text-xs tabular-nums text-slate-600 dark:text-white/60">
             {new Intl.DateTimeFormat(undefined, {

--- a/pages/content-moderation/components/ModerationChannelPickerModal.tsx
+++ b/pages/content-moderation/components/ModerationChannelPickerModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   Checkbox,
   ConfirmModal,
   DataTable,
@@ -351,7 +352,7 @@ export function ModerationChannelPickerModal({
       {
         key: "select",
         label: t("content_moderation.select"),
-        width: "w-16 min-w-16",
+        width: COLUMN_WIDTH.checkbox,
         resizable: false,
         reorderable: false,
         lockOrder: "start",
@@ -389,7 +390,7 @@ export function ModerationChannelPickerModal({
       {
         key: "provider",
         label: t("content_moderation.provider"),
-        width: "w-36 min-w-36",
+        width: COLUMN_WIDTH.numericWide,
         render: (row) => row.provider || "--",
       },
       {
@@ -420,7 +421,7 @@ export function ModerationChannelPickerModal({
       {
         key: "binding",
         label: t("content_moderation.current_profile"),
-        width: "w-[200px] min-w-[200px]",
+        width: COLUMN_WIDTH.name,
         render: (row) => {
           if (!row.profile_id) {
             return (
@@ -447,7 +448,7 @@ export function ModerationChannelPickerModal({
       {
         key: "status",
         label: t("content_moderation.status"),
-        width: "w-28 min-w-28",
+        width: COLUMN_WIDTH.badge,
         render: (row) =>
           row.disabled ? (
             <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-200">

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -24,6 +24,7 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   Card,
   ConfirmModal,
   DataTable,
@@ -34,8 +35,8 @@ import {
   TABLE_ROW_ACTIONS_COLUMN,
   TableRowActions,
   TextInput,
-  type DataTableColumn,
   useToast,
+  type DataTableColumn,
 } from "@code-proxy/ui";
 import { PermissionGate } from "@app/providers/PermissionGate";
 import { useAuth } from "@app/providers/AuthProvider";
@@ -354,7 +355,6 @@ export function EndUsersPage() {
         width: "w-56 min-w-[14rem]",
         minWidthPx: 160,
         maxWidthPx: 480,
-        headerClassName: "text-left",
         cellClassName: "text-left",
         render: (row) => (
           <div className="min-w-0">
@@ -373,7 +373,7 @@ export function EndUsersPage() {
       {
         key: "status",
         label: t("end_users.status"),
-        width: "w-28 min-w-[7rem]",
+        width: COLUMN_WIDTH.badge,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (row) => {
@@ -390,7 +390,7 @@ export function EndUsersPage() {
       {
         key: "permission",
         label: t("end_users.account_permission_profile"),
-        width: "w-40 min-w-[10rem]",
+        width: COLUMN_WIDTH.name,
         headerClassName: "text-center",
         cellClassName: "text-center text-slate-700 dark:text-white/70",
         render: (row) => {
@@ -418,7 +418,7 @@ export function EndUsersPage() {
       {
         key: "dailySpending",
         label: t("quota.daily_spending_column"),
-        width: "w-[130px] min-w-[130px]",
+        width: COLUMN_WIDTH.compact,
         cellClassName:
           "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
         render: (row) => formatQuotaUsdAmount(row["daily-spending-used"]),
@@ -426,7 +426,7 @@ export function EndUsersPage() {
       {
         key: "lifetimeSpending",
         label: t("quota.lifetime_spending_column"),
-        width: "w-[130px] min-w-[130px]",
+        width: COLUMN_WIDTH.compact,
         cellClassName:
           "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
         render: (row) => formatQuotaUsdAmount(row["lifetime-spending-used"]),
@@ -434,7 +434,7 @@ export function EndUsersPage() {
       {
         key: "totalResets",
         label: t("quota.total_resets"),
-        width: "w-[120px] min-w-[120px]",
+        width: COLUMN_WIDTH.numericWide,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (row) => {
@@ -456,7 +456,7 @@ export function EndUsersPage() {
       {
         key: "lastLogin",
         label: t("end_users.last_login"),
-        width: "w-[160px] min-w-[160px]",
+        width: COLUMN_WIDTH.timestamp,
         cellClassName: "text-center text-xs text-slate-500 dark:text-white/50",
         render: (row) => (row.last_login_at ? new Date(row.last_login_at).toLocaleString() : "-"),
       },

--- a/pages/end-users/components/EndUserResetHistoryModal.tsx
+++ b/pages/end-users/components/EndUserResetHistoryModal.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { EndUserDailySpendingResetEvent } from "@code-proxy/api-client";
-import { DataTable, Modal, type DataTableColumn } from "@code-proxy/ui";
+import { COLUMN_WIDTH, DataTable, Modal, type DataTableColumn } from "@code-proxy/ui";
 import { formatApiKeySpendingAmount } from "../../api-keys/apiKeyPageUtils";
 
 function formatResetAt(value: string | undefined): string {
@@ -61,7 +61,7 @@ export function EndUserResetHistoryModal({
     {
       key: "id",
       label: t("end_users.reset_history_col_id"),
-      width: "w-[90px] min-w-[80px]",
+      width: COLUMN_WIDTH.numeric,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => row.id,
@@ -77,7 +77,7 @@ export function EndUserResetHistoryModal({
     {
       key: "day_key",
       label: t("end_users.reset_history_col_day"),
-      width: "w-[130px] min-w-[120px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) => row.day_key || "—",
@@ -85,7 +85,7 @@ export function EndUserResetHistoryModal({
     {
       key: "effective_used_before",
       label: t("end_users.reset_history_col_cleared"),
-      width: "w-[160px] min-w-[140px]",
+      width: COLUMN_WIDTH.name,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) =>
@@ -94,7 +94,7 @@ export function EndUserResetHistoryModal({
     {
       key: "raw_today_cost",
       label: t("end_users.reset_history_col_raw_today"),
-      width: "w-[180px] min-w-[160px]",
+      width: COLUMN_WIDTH.name,
       cellClassName:
         "whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
       render: (row) =>
@@ -116,7 +116,7 @@ export function EndUserResetHistoryModal({
     {
       key: "actor",
       label: t("end_users.reset_history_col_actor"),
-      width: "w-[140px] min-w-[120px]",
+      width: COLUMN_WIDTH.numericWide,
       cellClassName: "text-slate-700 dark:text-white/70",
       render: (row) => actorLabel(row, t),
     },

--- a/pages/identity-fingerprint/CodexRecommendationsModal.tsx
+++ b/pages/identity-fingerprint/CodexRecommendationsModal.tsx
@@ -6,7 +6,14 @@ import {
   type CodexFingerprintRecommendation,
   type CodexIdentityFingerprint,
 } from "@code-proxy/api-client/endpoints/identity-fingerprint";
-import { Button, ConfirmModal, DataTable, Modal, type DataTableColumn } from "@code-proxy/ui";
+import {
+  Button,
+  COLUMN_WIDTH,
+  ConfirmModal,
+  DataTable,
+  Modal,
+  type DataTableColumn,
+} from "@code-proxy/ui";
 
 const RECOMMENDATIONS_TIMEOUT_MS = 15000;
 
@@ -134,7 +141,7 @@ export function CodexRecommendationsModal({
       {
         key: "last_seen",
         label: t("identity_fingerprint.recommend_last_seen"),
-        width: "w-36",
+        width: COLUMN_WIDTH.numericWide,
         resizable: false,
         reorderable: false,
         render: (item) => (
@@ -151,7 +158,7 @@ export function CodexRecommendationsModal({
       {
         key: "originator",
         label: t("identity_fingerprint.originator"),
-        width: "w-44",
+        width: COLUMN_WIDTH.badgeGroup,
         resizable: false,
         reorderable: false,
         overflowTooltip: (item) => item.headers.Originator || item.recommended.originator || "",

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } 
 import { ArrowUp, ChevronLeft, ChevronRight, CircleAlert, Plus, Trash2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { imageGenerationApi } from "@code-proxy/api-client";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { ImagePreviewOverlay } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
@@ -19,11 +19,7 @@ import {
   supportsImageEditing,
 } from "@features/image-model-picker";
 import { imageStageClassName } from "./stageStyles";
-import {
-  VISIBLE_ENDPOINT_DOCS,
-  type EndpointDoc,
-  type SpecRow,
-} from "./apiDocs";
+import { VISIBLE_ENDPOINT_DOCS, type EndpointDoc, type SpecRow } from "./apiDocs";
 
 /**
  * Fallback model id, used only until the server's catalog arrives and as the tab
@@ -282,21 +278,21 @@ function SpecTable({ tableId, title, rows }: { tableId: string; title: string; r
       {
         key: "name",
         label: t("image_generation.table_param"),
-        width: "w-40",
+        width: COLUMN_WIDTH.badgeStacked,
         cellClassName: "font-mono text-xs break-all leading-5 text-slate-900 dark:text-white",
         render: (row) => row.name,
       },
       {
         key: "type",
         label: t("image_generation.table_type"),
-        width: "w-28",
+        width: COLUMN_WIDTH.badge,
         cellClassName: "font-mono text-xs text-slate-600 dark:text-white/55",
         render: (row) => row.type,
       },
       {
         key: "required",
         label: t("image_generation.table_required"),
-        width: "w-20",
+        width: COLUMN_WIDTH.badge,
         cellClassName: "text-xs text-slate-600 dark:text-white/55",
         render: (row) => (row.required ? t("common.yes") : t("common.no")),
       },

--- a/pages/menu-management/MenuManagementPage.tsx
+++ b/pages/menu-management/MenuManagementPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   ConfirmModal,
   DataTable,
   Drawer,
@@ -27,9 +28,9 @@ import {
   TabsList,
   TabsTrigger,
   TextInput,
-  type DataTableColumn,
-  useToast,
   resolveMenuIcon,
+  useToast,
+  type DataTableColumn,
 } from "@code-proxy/ui";
 import { useAuth } from "@app/providers/AuthProvider";
 
@@ -352,7 +353,7 @@ export function MenuManagementPage() {
       {
         key: "permission",
         label: t("identity_admin.permission_code"),
-        width: "w-40",
+        width: COLUMN_WIDTH.badgeStacked,
         render: (menu) => (
           <span className="truncate text-xs text-slate-600 dark:text-slate-300">
             {displayCell(menu.permission_code)}
@@ -362,7 +363,7 @@ export function MenuManagementPage() {
       {
         key: "route",
         label: t("identity_admin.route_address"),
-        width: "w-40",
+        width: COLUMN_WIDTH.badgeStacked,
         render: (menu) => (
           <div className="min-w-0 text-xs">
             <div className="truncate text-slate-700 dark:text-slate-200">
@@ -375,7 +376,7 @@ export function MenuManagementPage() {
       {
         key: "component",
         label: t("identity_admin.page_component"),
-        width: "w-36",
+        width: COLUMN_WIDTH.timestamp,
         render: (menu) => (
           <span className="truncate text-xs text-slate-600 dark:text-slate-300">
             {menu.type === "directory"
@@ -387,7 +388,7 @@ export function MenuManagementPage() {
       {
         key: "status",
         label: t("identity_admin.status"),
-        width: "w-24",
+        width: COLUMN_WIDTH.badge,
         render: (menu) => (
           <span
             className={

--- a/pages/models/hooks/useModelColumns.tsx
+++ b/pages/models/hooks/useModelColumns.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Edit3, FlaskConical, Power, Trash2 } from "lucide-react";
 import {
+  COLUMN_WIDTH,
   Checkbox,
   OverflowTooltip,
   TABLE_ROW_ACTIONS_COLUMN,
@@ -55,7 +56,7 @@ export function useModelColumns({
             {
               key: "select",
               label: "",
-              width: "w-12",
+              width: COLUMN_WIDTH.checkbox,
               headerClassName: "text-center",
               cellClassName: "text-center",
               headerRender: () => (
@@ -102,33 +103,33 @@ export function useModelColumns({
       {
         key: "owner",
         label: t("models_page.col_owner"),
-        width: "w-32",
+        width: COLUMN_WIDTH.compact,
         render: (row) => row.owned_by || "-",
       },
       {
         key: "capabilities",
         label: t("models_page.col_capabilities"),
-        width: "w-40",
+        width: COLUMN_WIDTH.badgeStacked,
         render: (row) => <ModelCapabilityBadges model={row} />,
       },
       {
         key: "mode",
         label: t("models_page.col_pricing_mode"),
-        width: "w-36",
+        width: COLUMN_WIDTH.numericWide,
         render: (row) =>
           row.pricing.mode === "call" ? t("models_page.mode_call") : t("models_page.mode_token"),
       },
       {
         key: "price",
         label: t("models_page.col_price"),
-        width: "w-52",
+        width: COLUMN_WIDTH.name,
         cellClassName: "font-mono text-xs tabular-nums text-slate-700 dark:text-slate-200",
         render: (row) => formatPrice(row, t("models_page.not_priced")),
       },
       {
         key: "status",
         label: t("models_page.col_status"),
-        width: "w-28",
+        width: COLUMN_WIDTH.badge,
         headerClassName: "text-center",
         cellClassName: "text-center",
         render: (row) => (

--- a/pages/providers/components/ProviderKeyModelsTab.tsx
+++ b/pages/providers/components/ProviderKeyModelsTab.tsx
@@ -1,17 +1,13 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { RefreshCw } from "lucide-react";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import { Checkbox } from "@code-proxy/ui";
 import { DataTable, type DataTableColumn } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { SearchableSelect } from "@code-proxy/ui";
 import { type ProviderKeyDraft } from "../providers-helpers";
-import {
-  createEmptyModelEntry,
-  ModelInputList,
-  type ModelEntryDraft,
-} from "../ModelInputList";
+import { createEmptyModelEntry, ModelInputList, type ModelEntryDraft } from "../ModelInputList";
 import { ExcludedModelsEditor } from "./ExcludedModelsEditor";
 import { OpenAIModelDiscoveryPanel } from "./OpenAIModelDiscoveryPanel";
 
@@ -192,7 +188,7 @@ export function ProviderKeyModelsTab({
       {
         key: "enabled",
         label: t("providers.model_enabled"),
-        width: "w-36",
+        width: COLUMN_WIDTH.numericWide,
         minWidthPx: 144,
         headerClassName: "text-center",
         cellClassName: "text-center",

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -6,7 +6,7 @@ import {
   type ProxyCheckResult,
   type ProxyPoolEntry,
 } from "@code-proxy/api-client/endpoints/proxies";
-import { Button } from "@code-proxy/ui";
+import { Button, COLUMN_WIDTH } from "@code-proxy/ui";
 import { Card } from "@code-proxy/ui";
 import { ConfirmModal } from "@code-proxy/ui";
 import { HoverTooltip } from "@code-proxy/ui";
@@ -262,7 +262,7 @@ export function ProxiesPage() {
       {
         key: "name",
         label: t("proxies.name"),
-        width: "w-44",
+        width: COLUMN_WIDTH.badgeGroup,
         render: (entry) => (
           <div className="min-w-0">
             <p className="truncate font-semibold text-slate-950 dark:text-white">{entry.name}</p>
@@ -275,7 +275,7 @@ export function ProxiesPage() {
       {
         key: "endpoint",
         label: t("proxies.endpoint_label"),
-        width: "w-[180px]",
+        width: COLUMN_WIDTH.badgeGroup,
         render: (entry) => (
           <div className="flex min-w-0 items-center gap-2">
             <span className="rounded-full border border-slate-900/8 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:border-white/8 dark:bg-neutral-900 dark:text-slate-300">
@@ -290,7 +290,7 @@ export function ProxiesPage() {
       {
         key: "status",
         label: t("proxies.latency"),
-        width: "w-40",
+        width: COLUMN_WIDTH.badgeStacked,
         render: (entry) => {
           const result = checkState[entry.id];
           const hasCheckResult = typeof result?.ok === "boolean";
@@ -326,7 +326,7 @@ export function ProxiesPage() {
       {
         key: "description",
         label: t("proxies.remark_label"),
-        width: "w-[180px]",
+        width: COLUMN_WIDTH.badgeGroup,
         render: (entry) => (
           <p className="truncate text-xs text-slate-600 dark:text-white/60">
             {entry.description || "--"}

--- a/pages/roles/RolesPage.tsx
+++ b/pages/roles/RolesPage.tsx
@@ -9,14 +9,15 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   Checkbox,
   ConfirmModal,
   DataTable,
   Modal,
   TABLE_ROW_ACTIONS_COLUMN,
   TextInput,
-  type DataTableColumn,
   useToast,
+  type DataTableColumn,
 } from "@code-proxy/ui";
 import { PermissionGate } from "@app/providers/PermissionGate";
 import { useAuth } from "@app/providers/AuthProvider";
@@ -186,7 +187,7 @@ export function RolesPage() {
       {
         key: "scope",
         label: t("identity_admin.scope"),
-        width: "w-32",
+        width: COLUMN_WIDTH.compact,
         render: (role) =>
           role.scope === "platform"
             ? t("identity_admin.scope_platform")
@@ -195,13 +196,13 @@ export function RolesPage() {
       {
         key: "permissions",
         label: t("identity_admin.permissions"),
-        width: "w-32",
+        width: COLUMN_WIDTH.numericWide,
         render: (role) => t("identity_admin.permission_count", { count: role.permissions.length }),
       },
       {
         key: "users",
         label: t("identity_admin.assigned_users"),
-        width: "w-32",
+        width: COLUMN_WIDTH.timestamp,
         render: (role) =>
           t("identity_admin.user_count", { count: assignedUserCount.get(role.id) ?? 0 }),
       },

--- a/pages/tenants/TenantsPage.tsx
+++ b/pages/tenants/TenantsPage.tsx
@@ -4,6 +4,7 @@ import { Ban, CalendarClock, Eye, Pencil } from "lucide-react";
 import { identityApi, type TenantIdentity } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   ConfirmModal,
   DataTable,
   DateTimePicker,
@@ -13,10 +14,10 @@ import {
   Select,
   TABLE_ROW_ACTIONS_COLUMN,
   TableRowActions,
-  Textarea,
   TextInput,
-  type DataTableColumn,
+  Textarea,
   useToast,
+  type DataTableColumn,
 } from "@code-proxy/ui";
 import { PermissionGate } from "@app/providers/PermissionGate";
 import { useAuth } from "@app/providers/AuthProvider";
@@ -147,7 +148,7 @@ export function TenantsPage() {
       {
         key: "status",
         label: t("identity_admin.status"),
-        width: "w-32",
+        width: COLUMN_WIDTH.compact,
         render: (item) => (
           <span
             className={[
@@ -166,7 +167,7 @@ export function TenantsPage() {
       {
         key: "expires",
         label: t("identity_admin.expires"),
-        width: "w-52",
+        width: COLUMN_WIDTH.timestamp,
         render: (item) =>
           item.expires_at
             ? new Date(item.expires_at).toLocaleString(i18n.language)
@@ -175,7 +176,7 @@ export function TenantsPage() {
       {
         key: "version",
         label: t("identity_admin.version"),
-        width: "w-24",
+        width: COLUMN_WIDTH.badge,
         render: (item) => item.version,
       },
       {

--- a/pages/users/UsersPage.tsx
+++ b/pages/users/UsersPage.tsx
@@ -4,6 +4,7 @@ import { KeyRound, Shield, Trash2 } from "lucide-react";
 import { identityApi, type RoleIdentity, type UserIdentity } from "@code-proxy/api-client";
 import {
   Button,
+  COLUMN_WIDTH,
   ConfirmModal,
   DataTable,
   Form,
@@ -14,8 +15,8 @@ import {
   TABLE_ROW_ACTIONS_COLUMN,
   TextInput,
   ToggleSwitch,
-  type DataTableColumn,
   useToast,
+  type DataTableColumn,
 } from "@code-proxy/ui";
 import { PermissionGate } from "@app/providers/PermissionGate";
 import { useAuth } from "@app/providers/AuthProvider";
@@ -160,7 +161,7 @@ export function UsersPage() {
       {
         key: "user",
         label: t("identity_admin.user"),
-        width: "w-52",
+        width: COLUMN_WIDTH.name,
         render: (user) => (
           <div className="min-w-0">
             <div className="truncate font-medium text-slate-900 dark:text-white">
@@ -173,7 +174,7 @@ export function UsersPage() {
       {
         key: "status",
         label: t("identity_admin.status"),
-        width: "w-44",
+        width: COLUMN_WIDTH.toggle,
         render: (user) => {
           const protectedUser = isProtected(user);
           const checked = user.status === "active";
@@ -214,7 +215,7 @@ export function UsersPage() {
       {
         key: "roles",
         label: t("identity_admin.roles"),
-        width: "w-72",
+        width: COLUMN_WIDTH.nameStacked,
         render: (user) => {
           const labels = (user.role_ids ?? []).map(
             (roleId, index) => roleNames.get(roleId) ?? user.role_codes?.[index] ?? roleId,
@@ -239,7 +240,7 @@ export function UsersPage() {
       {
         key: "last_login",
         label: t("identity_admin.last_login"),
-        width: "w-52",
+        width: COLUMN_WIDTH.timestamp,
         render: (user) =>
           user.last_login_at
             ? new Date(user.last_login_at).toLocaleString(i18n.language)

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -24,7 +24,7 @@
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1455,
     "pages/end-users/EndUsersPage.tsx": 1126,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
-    "pages/image-generation/components/ImageGenerationPageContent.tsx": 1197,
+    "pages/image-generation/components/ImageGenerationPageContent.tsx": 1193,
     "pages/models/ModelsPage.tsx": 1251,
     "pages/providers/components/ProvidersPageContent.tsx": 1853
   }


### PR DESCRIPTION
## 背景

各页此前手写 Tailwind 列宽（`w-44` / `w-[220px]` …），同类内容在不同表里宽度不一：开关列有的 96px 有的 176px，时间戳有的 144px 有的 208px。

更常见的问题是**列窄于表头文字本身**。英文文案普遍比中文长（"连通性" 36px vs "Connectivity" 82px），中文界面正常的列到英文界面就会截断表头，而表头 `truncate` 后没有任何地方能看到完整列名。

## 改动

**新增语义令牌** `packages/ui/src/data-table/columnWidths.ts`

取值口径：

```
列宽 = max(表头文字, 内容) + 排序拖拽图标 24px + 单元格 padding 32px
```

表头文字按 12px/中文字、6.8px/ASCII 估算，取中英文中较宽的一侧，使同一份列宽在两种语言下都不截断。令牌自带配套 `min-w`，避免旧代码里 `w-[130px] min-w-[130px]` 那种成对手写再次跑偏。

**24 张表共 105 列收编**

| 类型 | 列数 | 说明 |
|------|------|------|
| 修表头截断 | 29 | 列宽放不下表头文字，必须加宽 |
| 收敛过宽 | 6 | 开关/时间戳列明显超出内容所需 |
| 对齐令牌 | 70 | 等宽或差距 ≤8px，只改表达不改宽度 |

**AI 账号表按线上实测重排**

配额列 chip 化后内容只需约 290px，从 `36rem`(576px) 降到 320px；连通性、本周期调用、成功、失败等 6 列此前放不下表头，相应加宽。该表默认总宽 **2152 → 2040px**，且不再有列截断表头或内容。

**表头补 `title` 兜底**

长列名截断后仍可悬停查看。因此超长英文表头不必把放数字的列撑到 288px —— 表头下限封顶 208px，再宽也换不来可读性。

**列宽存储 key 升到 v2**

v1 里保存的手动拖拽结果是针对旧默认值的，继续沿用会盖掉新默认值。⚠️ **所有人此前手动拖拽的列宽会作废，回到新默认值**，之后可重新拖。e2e 中硬编码的 v1 key 一并更新。

## 影响范围

仅 `codeProxy/`，不涉及 `CliRelay/`。

## 已执行验证

`./scripts/ci-pr.sh` 全绿：

- `bun run lint` — 0 errors（1 个 dev 上既有的 `no-control-regex` warning）
- `design:check` / `boundary:imports` / `size:check` / `audit:deps`
- `bun run test:ci` — 1035 passed (145 files)
- `bun run build` + `bundle:diff`
- 9 个 `@critical` e2e passed

全量 e2e 与 `origin/dev` 基线逐条比对（另建 worktree 跑基线）：

- dev 上原有 **25 项失败**（与本次改动无关的既有问题，例如 `api-keys-table.spec.ts` 的 8 项在基线同样全红）
- 本分支新增 6 项，其中 5 项单 worker 单跑均通过（并发 flaky）
- 1 项 `request-logs resize clamps` 是真失败 —— e2e 里硬编码了 `columnWidths.v1`，已随 key 升级更新并复测通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)