### PR TITLE
fix(ai-accounts): treat an unknown quota age as untrustworthy, not fresh

### DIFF
--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -269,6 +269,7 @@ describe("AuthFilesPage files table", () => {
             meta?: string;
             resetAtMs?: number;
             windowSeconds?: number;
+            observedAtMs?: number;
           }) => ({
             quota_key: item.key ?? item.label ?? "quota",
             quota_label: item.label,
@@ -280,6 +281,9 @@ describe("AuthFilesPage files table", () => {
                 ? new Date(item.resetAtMs).toISOString()
                 : undefined,
             window_seconds: item.windowSeconds,
+            // The backend stamps every window it returns; an unstamped window
+            // means "age unknown" and is deliberately rendered as untrustworthy.
+            observed_at: new Date(item.observedAtMs ?? Date.now()).toISOString(),
           }),
         ),
         planType: (result as { planType?: string } | null)?.planType ?? null,

--- a/pages/auth-files/hooks/__tests__/quotaBar.test.tsx
+++ b/pages/auth-files/hooks/__tests__/quotaBar.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { QUOTA_STALE_AFTER_MS } from "@code-proxy/domain";
+import type { QuotaItem } from "@features/quota-preview/quota-helpers";
+import { renderQuotaBarNode, type QuotaBarDeps } from "../quotaBar";
+
+const NOW = 1_800_000_000_000;
+
+const deps = (): QuotaBarDeps => ({
+  t: ((key: string, vars?: Record<string, unknown>) =>
+    vars?.age ? `${key}:${String(vars.age)}` : key) as unknown as QuotaBarDeps["t"],
+  nowMs: NOW,
+  translateQuotaText: (text: string) => text,
+  formatQuotaItemDetailText: () => null,
+  formatQuotaAgeCompact: (observedAtMs?: number) =>
+    typeof observedAtMs === "number" ? `${Math.round((NOW - observedAtMs) / 3_600_000)}h` : null,
+});
+
+const bar = (item: QuotaItem) =>
+  render(<div>{renderQuotaBarNode("m_quota.code_weekly", item, false, deps())}</div>);
+
+const item = (overrides: Partial<QuotaItem> = {}): QuotaItem => ({
+  key: "code_week",
+  label: "m_quota.code_weekly",
+  percent: 15,
+  ...overrides,
+});
+
+describe("renderQuotaBarNode staleness", () => {
+  test("a freshly observed value renders plainly", () => {
+    const { container } = bar(item({ observedAtMs: NOW - 60_000 }));
+
+    expect(screen.queryByText(/stale_observed/)).toBeNull();
+    expect(screen.queryByText("m_quota.stale_never_observed")).toBeNull();
+    expect(container.querySelector(".saturate-50")).toBeNull();
+  });
+
+  test("a value unconfirmed past the threshold is desaturated and dated", () => {
+    const { container } = bar(item({ observedAtMs: NOW - QUOTA_STALE_AFTER_MS - 3_600_000 }));
+
+    expect(screen.getByText(/m_quota\.stale_observed:/)).toBeInTheDocument();
+    expect(container.querySelector(".saturate-50")).not.toBeNull();
+  });
+
+  // Accounts failing since before quota observation existed carry values with no
+  // timestamp, and their snapshot history is past retention. Treating a missing
+  // age as "fresh" would leave exactly those accounts unmarked.
+  test("a value with an unknown age is degraded rather than trusted", () => {
+    const { container } = bar(item({ observedAtMs: undefined }));
+
+    expect(screen.getByText("m_quota.stale_never_observed")).toBeInTheDocument();
+    expect(container.querySelector(".saturate-50")).not.toBeNull();
+  });
+
+  test("a window with no value at all is not marked stale", () => {
+    const { container } = bar(item({ percent: null, observedAtMs: undefined }));
+
+    expect(screen.queryByText("m_quota.stale_never_observed")).toBeNull();
+    expect(container.querySelector(".saturate-50")).toBeNull();
+  });
+});

--- a/pages/auth-files/hooks/quotaBar.tsx
+++ b/pages/auth-files/hooks/quotaBar.tsx
@@ -38,12 +38,26 @@ export const renderQuotaBarNode = (
     // A value the upstream stopped confirming keeps its countdown ticking off a
     // frozen reset time, which reads as live data. Desaturate it and state its
     // age so an unrefreshed number can never pass for a current one.
+    //
+    // "How old is it" has three answers, and only the first is safe to render
+    // plainly. An unknown age is not evidence of freshness: accounts that have
+    // been failing since before quota observation existed have values but no
+    // timestamp, and their snapshot history is long past its retention window —
+    // exactly the accounts most in need of the marker.
+    const hasValue = item?.percent != null || Boolean(item?.value);
+    const ageUnknown = hasValue && item?.observedAtMs === undefined;
     const stale = isQuotaObservationStale(item?.observedAtMs, nowMs);
+    const degraded = stale || ageUnknown;
     const ageText = stale ? formatQuotaAgeCompact(item?.observedAtMs) : null;
-    const staleText = ageText ? t("m_quota.stale_observed", { age: ageText }) : null;
+    const staleText = ageText
+      ? t("m_quota.stale_observed", { age: ageText })
+      : ageUnknown
+        ? t("m_quota.stale_never_observed")
+        : null;
     const tooltipParts = [translatedLabel, percentText];
     if (detailText) tooltipParts.push(detailText);
     if (ageText) tooltipParts.push(t("m_quota.stale_tooltip", { age: ageText }));
+    else if (ageUnknown) tooltipParts.push(t("m_quota.stale_never_observed"));
     const bar = (
       <div className={compact ? "space-y-1" : "space-y-1.5"}>
         <div className="flex items-center justify-between gap-1.5">
@@ -64,7 +78,7 @@ export const renderQuotaBarNode = (
             className={[
               "shrink-0 font-semibold tabular-nums",
               compact ? "text-2xs" : "text-xs",
-              stale ? "text-slate-400 dark:text-white/40" : tone.percentClass,
+              degraded ? "text-slate-400 dark:text-white/40" : tone.percentClass,
             ].join(" ")}
           >
             {percentText}
@@ -80,7 +94,7 @@ export const renderQuotaBarNode = (
             className={[
               "h-full rounded-full",
               tone.fillClass,
-              stale ? "opacity-40 saturate-50" : "",
+              degraded ? "opacity-40 saturate-50" : "",
             ]
               .filter(Boolean)
               .join(" ")}


### PR DESCRIPTION
## 背景

#898 的后续修复，在拿生产库验证迁移回填时发现的洞。

推动这次修复的那 4 个账号（最久的一个 **16 天**未被确认），回填后 `quota_observed_at` 是 **NULL**：

```
authsub_29b975703f03bde1 | codex  | error | 2026-07-30 | (null)
authsub_e03810a7750ba287 | xai    | error | 2026-07-22 | (null)
authsub_a807ecd6b0ea1afb | claude | error | 2026-08-01 | (null)
authsub_cb97811a9f57b707 | xai    | error | 2026-07-31 | (null)
```

两个快照表都查不到它们的历史 —— 这些账号从共享 subject 配额点机制引入之前就在失败，租户侧的快照点也早过了保留期。**它们的年龄确实无从得知。**

## 问题

陈旧标识的判定是「观测时间太久之前」，而缺失的时间戳不满足这个条件，于是这些卡片以满饱和度渲染、不带任何年龄标签 —— **最需要这个标识的账号恰恰没有拿到**。

`stale_never_observed` 文案在 #898 里已经加了，但没接上。

## 方案

「年龄未知」现在是独立的一种状态，而不是被当作新鲜：

| 状态 | 表现 |
|---|---|
| 有值 + 有观测时间 + 在阈值内 | 正常渲染 |
| 有值 + 有观测时间 + 超阈值 | 降饱和度 + 显示年龄 |
| **有值 + 无观测时间** | **降饱和度 + 显示「数据时间未知」** |
| 无值 | 不标记（没有可疑对象） |

另外把共享的 status DTO 测试辅助改为对每个返回的窗口打 `observed_at` 戳，与后端真实行为一致 —— 这样 UI 测试走的是真实契约，而不是未打戳的路径。这也是原先那个 kimi 用例失败的真正原因：它测的是「耗尽配额显示红色」，却因为 mock 不带时间戳而被正确地判成了不可信。

## 验证

`./scripts/ci-pr.sh` 全绿：lint、design:check、**1120 tests / 154 files 全过**、build、bundle:diff。新增 4 个测试覆盖 fresh / stale / unknown-age / no-value 四种状态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)