### PR TITLE
fix(api-client): carry quota observation timestamps through normalization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -170,6 +170,7 @@
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",
     "immutable": "^5.1.9",
+    "nanoid": "^3.3.18",
     "picomatch": "^4.0.5",
     "postcss": "^8.5.23",
     "rollup": "^4.62.2",
@@ -997,7 +998,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "overrides": {
     "yaml": "^2.9.0",
     "postcss": "^8.5.23",
+    "nanoid": "^3.3.18",
     "undici": "^7.24.0",
     "form-data": "^4.0.6",
     "immutable": "^5.1.9",

--- a/packages/api-client/src/endpoints/__tests__/ai-accounts-status.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/ai-accounts-status.test.ts
@@ -104,6 +104,61 @@ describe("aiAccountsStatusApi (authoritative contract)", () => {
     expect(snapshot.items[1]?.usage?.cycle_total_tokens).toBeNull();
   });
 
+  // This allow-list is the runtime contract. A field the DTO type declares but
+  // that normalizeQuotaItem/normalizeLatestStatus never copies reaches the UI as
+  // undefined — which is how quota observation timestamps were silently dropped
+  // while every downstream test kept passing on mocked getStatus results.
+  test("carries quota observation timestamps through normalization", async () => {
+    const { aiAccountsStatusApi } = await import("../ai-accounts-status");
+    getMock.mockResolvedValue({
+      items: [
+        {
+          auth_index: "auth-1",
+          quota_observed_at: "2026-08-07T23:47:21.299320202Z",
+          quotas: [
+            {
+              quota_key: "code_week",
+              percent: 13,
+              observed_at: "2026-08-07T23:47:21.299320202Z",
+            },
+          ],
+        },
+      ],
+    });
+
+    const snapshot = await aiAccountsStatusApi.getStatus();
+    expect(snapshot.items[0]?.quota_observed_at).toBe("2026-08-07T23:47:21.299320202Z");
+    expect(snapshot.items[0]?.quotas[0]?.observed_at).toBe("2026-08-07T23:47:21.299320202Z");
+  });
+
+  test("accepts camelCase observation timestamps", async () => {
+    const { aiAccountsStatusApi } = await import("../ai-accounts-status");
+    getMock.mockResolvedValue({
+      items: [
+        {
+          auth_index: "auth-1",
+          quotaObservedAt: "2026-08-07T10:00:00Z",
+          quotas: [{ quota_key: "code_week", percent: 5, observedAt: "2026-08-07T10:00:00Z" }],
+        },
+      ],
+    });
+
+    const snapshot = await aiAccountsStatusApi.getStatus();
+    expect(snapshot.items[0]?.quota_observed_at).toBe("2026-08-07T10:00:00Z");
+    expect(snapshot.items[0]?.quotas[0]?.observed_at).toBe("2026-08-07T10:00:00Z");
+  });
+
+  test("leaves observation timestamps null when the backend omits them", async () => {
+    const { aiAccountsStatusApi } = await import("../ai-accounts-status");
+    getMock.mockResolvedValue({
+      items: [{ auth_index: "auth-1", quotas: [{ quota_key: "code_week", percent: 5 }] }],
+    });
+
+    const snapshot = await aiAccountsStatusApi.getStatus();
+    expect(snapshot.items[0]?.quota_observed_at).toBeNull();
+    expect(snapshot.items[0]?.quotas[0]?.observed_at).toBeNull();
+  });
+
   test("filters status snapshot by auth_index query params", async () => {
     const { aiAccountsStatusApi } = await import("../ai-accounts-status");
     getMock.mockResolvedValue({ items: [] });

--- a/packages/api-client/src/endpoints/ai-accounts-status.ts
+++ b/packages/api-client/src/endpoints/ai-accounts-status.ts
@@ -49,6 +49,9 @@ const normalizeQuotaItem = (value: unknown): AiAccountQuotaItemDto | null => {
     window_seconds: toFiniteNumber(value.window_seconds ?? value.windowSeconds),
     value: normalizeString(value.value) ?? undefined,
     meta: normalizeString(value.meta) ?? undefined,
+    // This allow-list is the runtime contract; a field the DTO type declares but
+    // that is not copied here silently reaches the UI as undefined.
+    observed_at: normalizeString(value.observed_at ?? value.observedAt),
   };
 };
 
@@ -184,6 +187,9 @@ export const normalizeAccountStatusView = (
     ),
     upstream_checked_at: normalizeString(
       value.upstream_checked_at ?? value.upstreamCheckedAt,
+    ),
+    quota_observed_at: normalizeString(
+      value.quota_observed_at ?? value.quotaObservedAt,
     ),
     usage_updated_at: normalizeString(value.usage_updated_at ?? value.usageUpdatedAt),
     expires_at: normalizeString(value.expires_at ?? value.expiresAt),


### PR DESCRIPTION
## 现象

AI 账号页所有配额条都渲染成降饱和度 + 「数据时间未知」，包括几秒前刚成功探测过的账号。

## 定位

沿着实时请求逐段验证：

| 环节 | 结果 |
|---|---|
| 生产库 `quota_json` | ✅ 每个窗口都有 `observed_at` |
| 线上后端二进制 | ✅ 含新代码（`strings` 命中特征串） |
| **API 实际响应体** | ✅ `"observed_at":"2026-08-07T23:47:21.299320202Z"` |
| **api-client 规范化** | ❌ **字段在这里被丢弃** |
| 页面 DOM | 两个窗口都带 `opacity-40 saturate-50` |

后端完全正常，字段是在再下一层丢的。

`normalizeQuotaItem` 与 `normalizeLatestStatus` 逐字段重建 DTO，**它们才是运行期契约** —— DTO *类型*声明了、而这两个函数没有拷贝的字段，会静默地以 `undefined` 到达 UI。#898 加了类型，#899 让「缺失时间戳」渲染为不可信，后者在本该有值的输入上是正确行为，只是输入从一开始就不该是 undefined。

## 修复

补上 `quota_observed_at` 与逐窗口 `observed_at`，并接受相邻字段已经支持的 camelCase 拼写。

## 测试盲区

现有测试**全部** mock `aiAccountsStatusApi.getStatus`，也就是 mock 在规范化**之后**，所以没有一个能发现这个问题。新增 3 个针对规范化层本身的测试（snake_case / camelCase / 缺失），这一层此前对这些字段没有任何针对性覆盖。

## 附带的依赖升级

通过既有的 `overrides` 把 nanoid 固定到 `^3.3.18`：postcss 引入的是 3.3.16，新发布的 advisory（GHSA-2v37-7h3g-55p8）将其标为 high。

与本修复无关、且 dev 上已经是红的，但 `audit:deps` 是 required check，不处理分支无法合入。选择**升级而非豁免** —— 存在已修复的 3.x 版本，符合仓库「不得用无理由豁免绕过」的约定。

## 验证

`./scripts/ci-pr.sh` 全绿：lint、design:check、**1123 tests / 154 files 全过**、build、bundle:diff、audit:deps。

🤖 Generated with [Claude Code](https://claude.com/claude-code)