### PR TITLE
feat(ai-accounts): give account cards a fixed three-row header

### DIFF
--- a/e2e/auth-files-card-layout.spec.ts
+++ b/e2e/auth-files-card-layout.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Three accounts that between them exercise every row-3 combination: one plain,
+// one with a fault badge, one with neither subscription nor fault. The card
+// header must keep the same three-row shape in all of them.
+const accounts = [
+  { idx: "alias-a", name: "jd7njnb5nh@privaterelay.appleid.com", plan: "pro_20x", expires: "2026-08-27T00:00:00Z", error: false, pct: 12 },
+  { idx: "alias-b", name: "lanlanjiaxin@proton.me", plan: "pro_20x", expires: "2026-09-04T00:00:00Z", error: true, pct: 0 },
+  { idx: "alias-c", name: "tyktgyk@gmail.com", plan: "pro_20x", expires: "2026-08-18T00:00:00Z", error: false, pct: 8 },
+];
+
+const authFiles = accounts.map((a, i) => ({
+  id: `auth-${a.idx}`,
+  name: `${a.name}.json`,
+  label: a.name,
+  type: "codex",
+  provider: "codex",
+  account_type: "oauth",
+  auth_index: a.idx,
+  auth_subject_id: `sub-${a.idx}`,
+  disabled: false,
+  size: 1024,
+  modified: 1784534400000 + i,
+}));
+
+// Fresh enough that the staleness marker stays off and the layout is what a
+// healthy account actually looks like.
+const observedAt = new Date().toISOString();
+
+const statusItems = accounts.map((a) => ({
+  auth_index: a.idx,
+  auth_subject_id: `sub-${a.idx}`,
+  provider: "codex",
+  status_scope: "shared_subject",
+  subject_scope: "shared",
+  share_eligible: true,
+  subject_seed_kind: "account_id",
+  current_tenant_binding_count: 1,
+  refresh_state: a.error ? "error" : "success",
+  health_status: a.error ? "error" : "ok",
+  plan_type: a.plan,
+  subscription_expires_at: a.expires,
+  subscription_source: "signed_claims",
+  error_code: a.error ? "429" : undefined,
+  error_message: a.error ? "Requests are limited" : undefined,
+  quotas: [
+    {
+      quota_key: "code_week",
+      quota_label: "m_quota.code_weekly",
+      percent: a.pct,
+      reset_at: "2026-08-08T06:38:11Z",
+      window_seconds: 604800,
+      observed_at: observedAt,
+    },
+    {
+      quota_key: "additional:codex_bengalfox:week",
+      quota_label: "GPT-5.3-Codex-Spark: Weekly",
+      percent: 100,
+      reset_at: "2026-08-15T00:00:00Z",
+      window_seconds: 604800,
+      observed_at: observedAt,
+    },
+  ],
+  usage: {
+    request_total: 30568,
+    success_total: 30507,
+    failure_total: 61,
+    success_rate: 0.998,
+    cycle_request_total: 30568,
+    cycle_total_tokens: 3_900_000_000,
+    cycle_known: true,
+    updated_at: observedAt,
+  },
+  version: 4,
+  upstream_checked_at: observedAt,
+  quota_observed_at: observedAt,
+  updated_at: observedAt,
+}));
+
+const setAuthed = async (page: Page, columns: number) => {
+  await page.addInitScript(
+    ([cols]) => {
+      localStorage.setItem(
+        "code-proxy-admin-auth",
+        JSON.stringify({
+          apiBase: "http://127.0.0.1:8317",
+          managementKey: "test-management-key",
+          rememberPassword: true,
+          expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        }),
+      );
+      localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+      localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+      localStorage.setItem("authFilesPage.cardColumns.v1", JSON.stringify(cols));
+      localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+    },
+    [columns],
+  );
+};
+
+const routeMocks = async (page: Page) => {
+  await page.route("**/v0/management/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+    if (path.endsWith("/ai-accounts/status")) return json({ items: statusItems });
+    if (path.includes("/ai-accounts/status-refresh"))
+      return json({ job_id: "j", state: "completed", total: 0, completed: 0, failed: 0, results: [] });
+    if (path.endsWith("/auth-files")) return json({ files: authFiles });
+    if (path.endsWith("/usage/entity-stats")) return json({ source: [], auth_index: [] });
+    if (path.endsWith("/usage/auth-file-trend")) return json({ points: [] });
+    if (path.endsWith("/config")) return json({ config: {} });
+    if (path.endsWith("/model-configs")) return json({ items: [] });
+    if (path.endsWith("/model-owner-presets")) return json({ items: [] });
+    if (path.endsWith("/proxy-pool")) return json({ items: [] });
+    if (path.endsWith("/update/check")) return json({ has_update: false });
+    return json({});
+  });
+};
+
+const openCards = async (page: Page, columns: number) => {
+  await setAuthed(page, columns);
+  await routeMocks(page);
+  await page.goto("/#/access/ai-accounts");
+  await expect(page.getByTestId("auth-files-cards")).toBeVisible();
+  await expect(page.getByText("tyktgyk@gmail.com")).toBeVisible();
+};
+
+// The header rows must be structurally identical across widths. Before this
+// layout, "remaining days" sat in the metrics row on wide cards and wrapped down
+// to its own row on narrow ones, so no two card sizes agreed on the shape.
+for (const columns of [2, 4]) {
+  test(`card header keeps a stable three-row shape at ${columns} columns`, async ({ page }) => {
+    await page.setViewportSize({ width: 2000, height: 900 });
+    await openCards(page, columns);
+
+    const cards = page.getByTestId("auth-files-cards").locator("section");
+    await expect(cards).toHaveCount(3);
+
+    await page.screenshot({ path: `/tmp/card-layout-${columns}col.png`, fullPage: false });
+
+    for (let i = 0; i < 3; i += 1) {
+      const card = cards.nth(i);
+      // Plan badge belongs to the metrics row, never the title row.
+      await expect(card.getByTestId("auth-file-plan-badge")).toHaveCount(1);
+      await expect(card.getByTestId("auth-file-card-status-badges")).toHaveCount(1);
+    }
+  });
+}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1402,7 +1402,8 @@ describe("AuthFilesPage files table", () => {
     const card = title.closest("section");
     expect(card).not.toBeNull();
     expect(within(card as HTMLElement).queryByText("Restricted")).not.toBeInTheDocument();
-    const errorBadges = within(card as HTMLElement).getByTestId("auth-file-card-error-badges");
+    // Subscription, faults and tags now share one status row above the quota area.
+    const errorBadges = within(card as HTMLElement).getByTestId("auth-file-card-status-badges");
     const quota = within(card as HTMLElement).getByTestId("auth-file-card-quota");
     expect(
       Boolean(errorBadges.compareDocumentPosition(quota) & Node.DOCUMENT_POSITION_FOLLOWING),

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1890,31 +1890,20 @@ export function AuthFilesFilesTab({
                         .filter(Boolean)
                         .join(" ")}
                     >
+                      {/* Fixed three-row header: identity, plan + cycle metrics,
+                          status badges. Each row wraps within itself, so a narrow
+                          card never pulls a badge up into the row above. */}
                       <div className={denseCards ? "space-y-2" : "space-y-2.5"}>
                         <div className="flex items-center justify-between gap-2">
-                          <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                            <OverflowTooltip
-                              content={displayTitle}
-                              className={[
-                                "min-w-0 flex-1 truncate leading-5 font-semibold tracking-tight text-slate-900 dark:text-white",
-                                denseCards ? "text-xs" : "text-sm",
-                              ].join(" ")}
-                            >
-                              {displayTitle}
-                            </OverflowTooltip>
-                            {showPlanBadge && planType ? (
-                              <span
-                                data-testid="auth-file-plan-badge"
-                                className={[
-                                  "inline-flex h-5 shrink-0 items-center rounded-md px-1.5 text-2xs font-bold leading-none tracking-wide",
-                                  resolvePlanBadgeClass(planType),
-                                ].join(" ")}
-                              >
-                                {formatPlanTypeLabel(planType) ||
-                                  formatPlanBadgeLabel(planType)}
-                              </span>
-                            ) : null}
-                          </div>
+                          <OverflowTooltip
+                            content={displayTitle}
+                            className={[
+                              "min-w-0 flex-1 truncate leading-5 font-semibold tracking-tight text-slate-900 dark:text-white",
+                              denseCards ? "text-xs" : "text-sm",
+                            ].join(" ")}
+                          >
+                            {displayTitle}
+                          </OverflowTooltip>
 
                           <div className="flex h-6 shrink-0 items-center gap-1.5">
                             {runtimeOnly ? null : (
@@ -1992,6 +1981,18 @@ export function AuthFilesFilesTab({
                         </div>
 
                         <div className="min-w-0 flex flex-wrap items-center gap-1">
+                          {showPlanBadge && planType ? (
+                            <span
+                              data-testid="auth-file-plan-badge"
+                              className={[
+                                "inline-flex h-5 shrink-0 items-center rounded-md px-1.5 text-2xs font-bold leading-none tracking-wide",
+                                resolvePlanBadgeClass(planType),
+                              ].join(" ")}
+                            >
+                              {formatPlanTypeLabel(planType) ||
+                                formatPlanBadgeLabel(planType)}
+                            </span>
+                          ) : null}
                           {showTypeBadge ? (
                             denseCards ? (
                               <HoverTooltip content={typeKey} className="shrink-0">
@@ -2100,15 +2101,29 @@ export function AuthFilesFilesTab({
                               </span>
                             </HoverTooltip>
                           ) : null}
-                          {subscriptionBadge}
                           {runtimeOnly ? (
                             <span className="inline-flex shrink-0 items-center rounded-md bg-slate-900 px-2 py-0.5 text-2xs font-semibold text-white dark:bg-white dark:text-neutral-950">
                               {t("auth_files.virtual_auth_file")}
                             </span>
                           ) : null}
                         </div>
-                        {displayTags.length > 0 ? (
-                          <div className="min-w-0 flex flex-wrap gap-1">
+
+                        {/* Row 3: standing rather than usage — subscription, faults
+                            and tags together, so a card with an error does not gain
+                            an extra row the others lack. */}
+                        {subscriptionBadge ||
+                        cardErrorBadges.length > 0 ||
+                        displayTags.length > 0 ? (
+                          <div
+                            className="min-w-0 flex flex-wrap items-center gap-1"
+                            data-testid="auth-file-card-status-badges"
+                          >
+                            {subscriptionBadge}
+                            {cardErrorBadges.map((item) => (
+                              <div key={item.key} className="min-w-0">
+                                {item.node}
+                              </div>
+                            ))}
                             {visibleTags.map((tag) => (
                               <span
                                 key={tag}
@@ -2130,22 +2145,6 @@ export function AuthFilesFilesTab({
                           </div>
                         ) : null}
                       </div>
-
-                      {cardErrorBadges.length > 0 ? (
-                        <div
-                          className={[
-                            "min-w-0 flex flex-wrap items-center gap-1.5",
-                            denseCards ? "mt-2" : "mt-3",
-                          ].join(" ")}
-                          data-testid="auth-file-card-error-badges"
-                        >
-                          {cardErrorBadges.map((item) => (
-                            <div key={item.key} className="min-w-0">
-                              {item.node}
-                            </div>
-                          ))}
-                        </div>
-                      ) : null}
 
                       <div
                         className={[

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -17,7 +17,7 @@
     "pages/api-keys/ApiKeysPage.tsx": 1167,
     "pages/auth-files/AuthFilesPage.tsx": 1210,
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,
-    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2644,
+    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2643,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 1003,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1304,


### PR DESCRIPTION
## 问题

卡片头部的行结构没有固定形状，**由 flex-wrap 决定徽章落在哪一行**：

- 「剩余 N 天」在宽卡片上挤在指标行末尾，在窄卡片上掉到自己一行
- 错误徽章总是独占一行 → 有错误的卡片比邻居多一行，配额条起始高度对不齐

结果就是每张卡、每种列宽的头部都长得不一样。

## 方案

头部改为**按语义固定三行**，而不是按可用宽度：

| 行 | 内容 |
|---|---|
| 1 | 身份 —— 邮箱、选择框、启用开关 |
| 2 | 会员与周期指标 —— 会员标签、供应商、重置、本周期、Token、成功率 |
| 3 | 状态 —— 剩余订阅、错误、自定义标签 |

每行只在自身内部 wrap，窄卡片不会把徽章往上一行提，网格里每张卡结构一致。

会员标签移出标题行后，邮箱拿到完整宽度：4 列下原本截断成 `jd7njnb5nh@private…`，现在完整显示。

## 验证

新增 e2e spec，在 2000px 宽 + 中文界面下覆盖 2 列与 4 列 × 两种第三行形态（仅订阅 / 订阅+错误），逐卡断言会员标签与状态行存在，并截图留档。

`./scripts/ci-pr.sh` 全绿：lint、design:check、**1123 tests / 154 files**、build、bundle:diff、audit:deps。文件体积基线 2644 → 2643。

## 已知边界

在较窄窗口（约 1280px 的 2 列）下第二行的指标 chip 仍会 wrap 成两行 —— 这是内容量决定的，中英文皆然。但三张卡会一起 wrap，结构依然对齐，不会出现「这张两行那张三行」。若要窄屏也强制单行，需隐藏部分指标或改用图标，属另一次取舍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)