### PR TITLE
feat(ai-accounts): align the toolbar rows and stop it resizing mid-use

### DIFF
--- a/e2e/auth-files-toolbar-layout.spec.ts
+++ b/e2e/auth-files-toolbar-layout.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const observedAt = new Date().toISOString();
+
+const authFiles = ["alias-a", "alias-b", "alias-c"].map((idx, i) => ({
+  id: `auth-${idx}`,
+  name: `account-${i}@example.com.json`,
+  label: `account-${i}@example.com`,
+  type: "codex",
+  provider: "codex",
+  account_type: "oauth",
+  auth_index: idx,
+  auth_subject_id: `sub-${idx}`,
+  disabled: false,
+  size: 1024,
+  modified: 1784534400000 + i,
+}));
+
+const statusItems = authFiles.map((f) => ({
+  auth_index: f.auth_index,
+  auth_subject_id: f.auth_subject_id,
+  provider: "codex",
+  status_scope: "shared_subject",
+  subject_scope: "shared",
+  share_eligible: true,
+  current_tenant_binding_count: 1,
+  refresh_state: "success",
+  health_status: "ok",
+  plan_type: "pro_20x",
+  subscription_expires_at: "2026-08-27T00:00:00Z",
+  subscription_source: "signed_claims",
+  quotas: [
+    {
+      quota_key: "code_week",
+      quota_label: "m_quota.code_weekly",
+      percent: 12,
+      reset_at: "2026-08-09T06:38:11Z",
+      window_seconds: 604800,
+      observed_at: observedAt,
+    },
+  ],
+  usage: {
+    request_total: 30568,
+    success_total: 30507,
+    failure_total: 61,
+    success_rate: 0.998,
+    cycle_request_total: 30568,
+    cycle_total_tokens: 3_900_000_000,
+    cycle_known: true,
+    updated_at: observedAt,
+  },
+  version: 4,
+  upstream_checked_at: observedAt,
+  quota_observed_at: observedAt,
+  updated_at: observedAt,
+}));
+
+const openPage = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+    localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+  });
+  await page.route("**/v0/management/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    if (path.endsWith("/ai-accounts/status")) return json({ items: statusItems });
+    if (path.includes("/ai-accounts/status-refresh"))
+      return json({ job_id: "j", state: "completed", total: 0, completed: 0, failed: 0, results: [] });
+    if (path.endsWith("/auth-files")) return json({ files: authFiles });
+    if (path.endsWith("/usage/entity-stats")) return json({ source: [], auth_index: [] });
+    if (path.endsWith("/usage/auth-file-trend")) return json({ points: [] });
+    if (path.endsWith("/config")) return json({ config: {} });
+    if (path.endsWith("/update/check")) return json({ has_update: false });
+    return json({ items: [] });
+  });
+  await page.goto("/#/access/ai-accounts");
+  await expect(page.getByTestId("auth-files-cards")).toBeVisible();
+};
+
+const rowEdges = async (page: Page) =>
+  page.evaluate(() => {
+    const panel = document.querySelector('[data-testid="auth-files-mobile-filter-panel"]');
+    if (!panel) return null;
+    const stack = panel.firstElementChild;
+    if (!stack) return null;
+    const [filterRow, actionRow] = [...stack.children];
+    if (!filterRow || !actionRow) return null;
+    const toolbar = panel.closest("div.shrink-0");
+    return {
+      filterRight: Math.round(filterRow.getBoundingClientRect().right),
+      actionRight: Math.round(actionRow.getBoundingClientRect().right),
+      rowCount: stack.children.length,
+      toolbarHeight: toolbar ? Math.round(toolbar.getBoundingClientRect().height) : null,
+    };
+  });
+
+// The filter row used to stop a column short of the action row because the grid
+// declared a fixed five tracks while only four fields rendered, leaving the two
+// rows visibly misaligned at every desktop width.
+for (const width of [1280, 1440, 1920, 2560]) {
+  test(`filter and action rows end flush at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await openPage(page);
+
+    const edges = await rowEdges(page);
+    expect(edges).not.toBeNull();
+    expect(edges!.rowCount).toBe(2);
+    expect(Math.abs(edges!.filterRight - edges!.actionRight)).toBeLessThanOrEqual(1);
+
+    await page.screenshot({ path: `/tmp/toolbar-${width}.png`, fullPage: false });
+  });
+}
+
+// Selecting files used to append a third row, so the toolbar grew and pushed the
+// card grid down mid-interaction.
+test("selecting files does not change the toolbar height", async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 900 });
+  await openPage(page);
+
+  const before = await rowEdges(page);
+  expect(before).not.toBeNull();
+
+  const firstCard = page.getByTestId("auth-files-cards").locator("section").first();
+  await firstCard.hover();
+  await firstCard.getByRole("checkbox").first().check();
+  await expect(page.getByText(/已选/)).toBeVisible();
+
+  const after = await rowEdges(page);
+  expect(after!.rowCount).toBe(before!.rowCount);
+  expect(after!.toolbarHeight).toBe(before!.toolbarHeight);
+
+  await page.screenshot({ path: "/tmp/toolbar-selected.png", fullPage: false });
+});

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -10,9 +10,7 @@ import {
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
-  BarChart3,
   CircleOff,
-  ClipboardPaste,
   Columns3,
   Download,
   Ellipsis,
@@ -20,14 +18,12 @@ import {
   Gauge,
   ListChecks,
   Loader2,
-  Plus,
   Power,
   RefreshCw,
   Search,
   Settings2,
   SlidersHorizontal,
   Tags,
-  Upload,
 } from "lucide-react";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { VendorIcon } from "@code-proxy/assets";
@@ -81,13 +77,23 @@ import {
   type QuotaState,
 } from "@features/quota-preview/quota-helpers";
 import type { QuotaProvider } from "@features/quota-preview/quota-fetch";
+import { AuthFilesToolbarActions } from "./AuthFilesToolbarActions";
 
 const MAX_FILENAME_PART_LENGTH = 72;
 const FILTER_LABEL_CLASS =
   "truncate text-xs font-semibold uppercase tracking-[0.02em] text-slate-600 dark:text-white/65";
 const FILTER_FIELD_CLASS = "min-w-0 space-y-2";
-const FILTER_GRID_CLASS =
-  "grid min-w-0 grid-cols-1 items-end gap-x-5 gap-y-3 sm:grid-cols-2 xl:grid-cols-[repeat(4,minmax(0,1fr))_minmax(320px,1.8fr)]";
+// Column count has to track the number of fields actually rendered. A fixed
+// five-column track left an empty trailing cell whenever the tag filter was
+// absent, so the filter row stopped short while the action row below still ran
+// to the right edge — the two never lined up. Search keeps the last track in
+// both shapes so the row always ends flush.
+const FILTER_GRID_BASE =
+  "grid min-w-0 grid-cols-1 items-end gap-x-5 gap-y-3 sm:grid-cols-2";
+const FILTER_GRID_WITH_TAGS =
+  "xl:grid-cols-[repeat(4,minmax(0,1fr))_minmax(18rem,1.5fr)]";
+const FILTER_GRID_WITHOUT_TAGS =
+  "xl:grid-cols-[repeat(3,minmax(0,1fr))_minmax(18rem,1.5fr)]";
 // Tailwind must see full class strings — keep the map static.
 const CARD_GRID_COLUMN_CLASS: Record<AuthFilesCardColumns, string> = {
   2: "xl:grid-cols-[repeat(2,minmax(0,1fr))]",
@@ -950,6 +956,9 @@ export function AuthFilesFilesTab({
     search.trim() !== "",
     canSetModelOwnerGroup && selectedModelOwner.trim() !== "",
   ].filter(Boolean).length;
+  // Drives the filter grid track count as well as the field itself, so the two
+  // can never disagree about how many columns the row has.
+  const showTagFilter = customTagOptions.length > 0 || normalizedTagFilter !== "";
   const draftModelOwnerGroup =
     !draftModelOwnerEnabled || draftModelOwner === ""
       ? null
@@ -1363,7 +1372,12 @@ export function AuthFilesFilesTab({
             ].join(" ")}
           >
             <div className="flex flex-col gap-4">
-              <div className={FILTER_GRID_CLASS}>
+              <div
+                className={[
+                  FILTER_GRID_BASE,
+                  showTagFilter ? FILTER_GRID_WITH_TAGS : FILTER_GRID_WITHOUT_TAGS,
+                ].join(" ")}
+              >
                 <div className="w-full">
                   <div className={FILTER_FIELD_CLASS}>
                     <p className={FILTER_LABEL_CLASS}>
@@ -1383,7 +1397,7 @@ export function AuthFilesFilesTab({
                   </div>
                 </div>
 
-                {customTagOptions.length > 0 || normalizedTagFilter ? (
+                {showTagFilter ? (
                   <div className="w-full">
                     <div className={FILTER_FIELD_CLASS}>
                       <p className={FILTER_LABEL_CLASS}>
@@ -1482,6 +1496,9 @@ export function AuthFilesFilesTab({
                 </div>
               </div>
 
+              {/* Action row. The batch bar lives here rather than in a row of its
+                  own: selecting files used to append a third row and push the
+                  grid down, so the toolbar changed height as you worked. */}
               <div className="flex min-h-9 flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <div
@@ -1494,128 +1511,47 @@ export function AuthFilesFilesTab({
                     {renderFilesViewModeTabs}
                   </div>
                   {modelOwnerToolbarButton}
-                  {selectedCount === 0 ? selectionActionsMenu : null}
+                  {selectionToolbar}
                 </div>
 
-                <div className="flex shrink-0 flex-wrap items-center gap-2">
-                  <HoverTooltip content={t("auth_files.group_overview_button")}>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={openGroupOverview}
-                      disabled={groupOverviewLoading}
-                      aria-label={t("auth_files.group_overview_button")}
-                      title={t("auth_files.group_overview_button")}
-                    >
-                      {groupOverviewLoading ? (
-                        <Loader2 size={15} className="animate-spin" />
-                      ) : (
-                        <BarChart3 size={15} />
-                      )}
-                    </Button>
-                  </HoverTooltip>
-                  <HoverTooltip content={t("auth_files.refresh")}>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => void refreshFilesAndQuota()}
-                      disabled={loading || usageLoading || refreshingAll}
-                      aria-label={t("auth_files.refresh")}
-                      title={t("auth_files.refresh")}
-                    >
-                      <RefreshCw
-                        size={15}
-                        className={
-                          loading || usageLoading || refreshingAll || statusUsageLoading
-                            ? "animate-spin"
-                            : ""
-                        }
-                      />
-                    </Button>
-                  </HoverTooltip>
-                  <HoverTooltip content={t("auth_files.upload")}>
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={uploading}
-                      aria-label={t("auth_files.upload")}
-                      title={t("auth_files.upload")}
-                    >
-                      {uploading ? (
-                        <Loader2 size={15} className="animate-spin" />
-                      ) : (
-                        <Upload size={15} />
-                      )}
-                    </Button>
-                  </HoverTooltip>
-                  <HoverTooltip content={t("auth_files.paste_json")}>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => {
-                        setJsonImportError("");
-                        setJsonImportOpen(true);
-                      }}
-                      disabled={uploading}
-                      aria-label={t("auth_files.paste_json")}
-                      title={t("auth_files.paste_json")}
-                    >
-                      {uploading ? (
-                        <Loader2 size={15} className="animate-spin" />
-                      ) : (
-                        <ClipboardPaste size={15} />
-                      )}
-                    </Button>
-                  </HoverTooltip>
-                  <HoverTooltip content={t("auth_files_page.add_oauth")}>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => {
-                        const normalized = normalizeProviderKey(filter);
-                        const oauthTab =
-                          normalized === "codex" ||
-                          normalized === "anthropic" ||
-                          normalized === "antigravity" ||
-                          normalized === "gemini-cli" ||
-                          normalized === "kimi" ||
-                          normalized === "qwen"
-                            ? (normalized as OAuthDialogTab)
-                            : "codex";
-                        setOauthDialogDefaultTab(oauthTab);
-                        setOauthDialogOpen(true);
-                      }}
-                      aria-label={t("auth_files_page.add_oauth")}
-                      title={t("auth_files_page.add_oauth")}
-                    >
-                      <Plus size={15} />
-                    </Button>
-                  </HoverTooltip>
-                  {configActionsMenu}
-                  {filesViewMode === "cards" ? (
-                    <div
-                      className="hidden xl:block"
-                      data-testid="auth-files-card-columns"
-                    >
-                      <Select
-                        value={String(cardColumns)}
-                        onChange={handleCardColumnsChange}
-                        options={cardColumnOptions}
-                        aria-label={t("auth_files.card_columns")}
-                        variant="chip"
-                        size="sm"
-                        className="min-w-[6.25rem]"
-                      />
-                    </div>
-                  ) : null}
-                </div>
+                <AuthFilesToolbarActions
+                  t={t}
+                  onGroupOverview={openGroupOverview}
+                  groupOverviewLoading={groupOverviewLoading}
+                  onRefresh={() => void refreshFilesAndQuota()}
+                  refreshDisabled={loading || usageLoading || refreshingAll}
+                  refreshSpinning={
+                    loading || usageLoading || refreshingAll || statusUsageLoading
+                  }
+                  onUpload={() => fileInputRef.current?.click()}
+                  onPasteJson={() => {
+                    setJsonImportError("");
+                    setJsonImportOpen(true);
+                  }}
+                  onAddOAuth={() => {
+                    const normalized = normalizeProviderKey(filter);
+                    const oauthTab =
+                      normalized === "codex" ||
+                      normalized === "anthropic" ||
+                      normalized === "antigravity" ||
+                      normalized === "gemini-cli" ||
+                      normalized === "kimi" ||
+                      normalized === "qwen"
+                        ? (normalized as OAuthDialogTab)
+                        : "codex";
+                    setOauthDialogDefaultTab(oauthTab);
+                    setOauthDialogOpen(true);
+                  }}
+                  uploading={uploading}
+                  configActionsMenu={configActionsMenu}
+                  showCardColumns={filesViewMode === "cards"}
+                  cardColumns={cardColumns}
+                  cardColumnOptions={cardColumnOptions}
+                  onCardColumnsChange={handleCardColumnsChange}
+                />
               </div>
             </div>
           </div>
-          {selectedCount > 0 ? (
-            <div className="min-w-0 overflow-x-auto">{selectionToolbar}</div>
-          ) : null}
         </div>
       </div>
 

--- a/pages/auth-files/components/AuthFilesToolbarActions.tsx
+++ b/pages/auth-files/components/AuthFilesToolbarActions.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from "react";
+import type { TFunction } from "i18next";
+import {
+  BarChart3,
+  ClipboardPaste,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Upload,
+} from "lucide-react";
+import { Button, HoverTooltip, Select } from "@code-proxy/ui";
+
+export type AuthFilesToolbarActionsProps = {
+  t: TFunction;
+  onGroupOverview: () => void;
+  groupOverviewLoading: boolean;
+  onRefresh: () => void;
+  refreshDisabled: boolean;
+  refreshSpinning: boolean;
+  onUpload: () => void;
+  onPasteJson: () => void;
+  onAddOAuth: () => void;
+  uploading: boolean;
+  configActionsMenu: ReactNode;
+  showCardColumns: boolean;
+  cardColumns: number;
+  cardColumnOptions: { value: string; label: string }[];
+  onCardColumnsChange: (value: string) => void;
+};
+
+/**
+ * Right-hand action cluster of the auth-files toolbar.
+ *
+ * Extracted from AuthFilesFilesTab to keep that file under the size ratchet;
+ * it is presentational and takes every side effect as a callback.
+ */
+export function AuthFilesToolbarActions({
+  t,
+  onGroupOverview,
+  groupOverviewLoading,
+  onRefresh,
+  refreshDisabled,
+  refreshSpinning,
+  onUpload,
+  onPasteJson,
+  onAddOAuth,
+  uploading,
+  configActionsMenu,
+  showCardColumns,
+  cardColumns,
+  cardColumnOptions,
+  onCardColumnsChange,
+}: AuthFilesToolbarActionsProps) {
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-1 rounded-full bg-slate-50/90 px-1.5 py-1 dark:bg-white/[0.04]">
+      <HoverTooltip content={t("auth_files.group_overview_button")}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onGroupOverview}
+          disabled={groupOverviewLoading}
+          aria-label={t("auth_files.group_overview_button")}
+          title={t("auth_files.group_overview_button")}
+        >
+          {groupOverviewLoading ? (
+            <Loader2 size={15} className="animate-spin" />
+          ) : (
+            <BarChart3 size={15} />
+          )}
+        </Button>
+      </HoverTooltip>
+      <HoverTooltip content={t("auth_files.refresh")}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onRefresh}
+          disabled={refreshDisabled}
+          aria-label={t("auth_files.refresh")}
+          title={t("auth_files.refresh")}
+        >
+          <RefreshCw
+            size={15}
+            className={refreshSpinning ? "animate-spin" : ""}
+          />
+        </Button>
+      </HoverTooltip>
+      <HoverTooltip content={t("auth_files.upload")}>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onUpload}
+          disabled={uploading}
+          aria-label={t("auth_files.upload")}
+          title={t("auth_files.upload")}
+        >
+          {uploading ? (
+            <Loader2 size={15} className="animate-spin" />
+          ) : (
+            <Upload size={15} />
+          )}
+        </Button>
+      </HoverTooltip>
+      <HoverTooltip content={t("auth_files.paste_json")}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onPasteJson}
+          disabled={uploading}
+          aria-label={t("auth_files.paste_json")}
+          title={t("auth_files.paste_json")}
+        >
+          {uploading ? (
+            <Loader2 size={15} className="animate-spin" />
+          ) : (
+            <ClipboardPaste size={15} />
+          )}
+        </Button>
+      </HoverTooltip>
+      <HoverTooltip content={t("auth_files_page.add_oauth")}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onAddOAuth}
+          aria-label={t("auth_files_page.add_oauth")}
+          title={t("auth_files_page.add_oauth")}
+        >
+          <Plus size={15} />
+        </Button>
+      </HoverTooltip>
+      {configActionsMenu}
+      {showCardColumns ? (
+        <div
+          className="hidden xl:block"
+          data-testid="auth-files-card-columns"
+        >
+          <Select
+            value={String(cardColumns)}
+            onChange={onCardColumnsChange}
+            options={cardColumnOptions}
+            aria-label={t("auth_files.card_columns")}
+            variant="chip"
+            size="sm"
+            className="min-w-[6.25rem]"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -17,7 +17,7 @@
     "pages/api-keys/ApiKeysPage.tsx": 1167,
     "pages/auth-files/AuthFilesPage.tsx": 1210,
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,
-    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2643,
+    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2579,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 1003,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1304,


### PR DESCRIPTION
## 问题

筛选栏看起来乱，有三个独立成因：

**1. 筛选行比操作行短一整列。** 筛选网格在 xl 下写死 5 个轨道，但没有自定义标签时只渲染 4 个字段 —— 搜索框停在第 4 列，右边空出一整格。而下方操作行是满宽的，两行右边界对不齐，搜索框和它上方的按钮之间横着一片死空白。

**2. 选中文件会让工具栏长高。** 批量操作条原本是独立的第三行，一旦勾选就把卡片网格整个往下推，操作过程中布局跳动。

**3. 右侧按钮组孤立漂浮**，没有任何容器把它们收拢。

## 方案

- **筛选网格的轨道数跟随实际渲染的字段数**（是否有标签筛选），搜索框恒占最后一轨，任何组合下右边界都齐平
- **批量条移入操作行**，占据原本选择菜单的位置 —— 是替换而非新增，行数恒为 2
- **右侧按钮组收进胶囊容器**，与对面的批量条呼应，两端都成为有意的控件簇

## 验证

新增 e2e spec，断言两条量化指标（改动前两条都不成立）：

- 筛选行与操作行右边界在 **1280 / 1440 / 1920 / 2560** 四种宽度下误差 ≤ 1px
- 勾选文件前后工具栏高度与行数不变

`./scripts/ci-pr.sh` 全绿：lint、design:check、**1123 tests / 154 files**、build、bundle:diff、audit:deps。

## 结构

按钮组抽为独立展示组件 `AuthFilesToolbarActions`（纯 props 驱动），`AuthFilesFilesTab` 从 2643 降到 **2579** 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)