### PR TITLE
fix(ui): 修复下拉禁用态与点击闪白，收紧全局密度并自托管字体

### DIFF
--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -9,12 +9,6 @@
     <link rel="apple-touch-icon" href="/manage/apple-touch-icon.png" />
     <meta name="theme-color" content="#4F46E5" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#09090B" media="(prefers-color-scheme: dark)" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
     <script>
       (function () {
         try {
@@ -76,7 +70,7 @@
         background-color: var(--pl-bg);
         opacity: 1;
         transition: opacity 0.4s ease, visibility 0.4s ease;
-        font-family: "Inter", "SF Pro Text", system-ui, sans-serif;
+        font-family: "SF Pro Text", "Segoe UI", "PingFang SC", system-ui, sans-serif;
       }
       #app-loader.fade-out {
         opacity: 0;

--- a/apps/admin-panel/manage.html
+++ b/apps/admin-panel/manage.html
@@ -22,12 +22,6 @@
     />
     <meta property="og:image" content="/manage/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
     <!-- 阻塞渲染的主题恢复脚本：在 body 绘制前读取 localStorage 并应用暗色模式 -->
     <script>
       (function () {
@@ -91,7 +85,7 @@
         background-color: var(--pl-bg);
         opacity: 1;
         transition: opacity 0.4s ease, visibility 0.4s ease;
-        font-family: "Inter", "SF Pro Text", system-ui, sans-serif;
+        font-family: "SF Pro Text", "Segoe UI", "PingFang SC", system-ui, sans-serif;
       }
       #app-loader.fade-out {
         opacity: 0;

--- a/apps/admin-panel/package.json
+++ b/apps/admin-panel/package.json
@@ -13,6 +13,9 @@
     "check": "bun run lint && bun run build && bun run bundle:diff"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "5.3.0",
+    "@fontsource-variable/jetbrains-mono": "5.3.0",
+    "@fontsource-variable/noto-sans-sc": "5.3.0",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-virtual": "^3.13.18",

--- a/apps/admin-panel/src/styles/fonts.css
+++ b/apps/admin-panel/src/styles/fonts.css
@@ -1,0 +1,25 @@
+/*
+ * 自托管字体。
+ *
+ * 之前两个 HTML 入口都挂着 Google Fonts 的 Inter 外链，但 --font-sans 里根本没写 Inter，
+ * 于是外链纯属白下载，实际渲染全靠系统字体——同一个面板在 macOS 是苹方、Windows 是雅黑、
+ * Linux 上则看装了什么，字重和字宽都对不上。而且 fonts.googleapis.com 在部分网络下拿不到，
+ * 首屏还要为一个用不上的请求等 DNS。
+ *
+ * 现在三套字体全部随构建产物发布，不再有外部依赖：
+ *   - Inter：西文与数字。
+ *   - Noto Sans SC：中文。fontsource 已按 unicode-range 切成 97 个中文分片，
+ *     浏览器只下载页面真正用到的那几片，不是一次拉几 MB。
+ *   - JetBrains Mono：代码、日志与展示级标题。
+ *
+ * 都是可变字体（wght 轴 100-900），一个文件覆盖全部字重，比起按字重拆文件少很多请求。
+ * font-display: swap 由 fontsource 预置：先用系统字体把内容显示出来，字体到位再换，
+ * 中文分片体积较大时这条尤其重要。
+ *
+ * 这些 @font-face 声明有 100 KB 上下，会随入口样式表一起发布（Vite 会把同一入口的 CSS
+ * 合并，拆不开）。因此入口 CSS 的 gzip 体积会反超入口 JS——bundle 基线脚本据此区分了
+ * `index` 与 `index.css` 两行，否则样式表会把入口脚本从监控里顶掉。
+ */
+@import "@fontsource-variable/inter/wght.css";
+@import "@fontsource-variable/noto-sans-sc/wght.css";
+@import "@fontsource-variable/jetbrains-mono/wght.css";

--- a/apps/admin-panel/src/styles/index.css
+++ b/apps/admin-panel/src/styles/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./fonts.css";
 @plugin "@tailwindcss/typography";
 @source "../../../../apps/admin-panel/src";
 @source "../../../../pages";
@@ -13,15 +14,22 @@
    * 字号：10 / 12 / 14 / 16 / 18 / 20 / 24 / 30 / 36 / 48 / 60 px
    * 圆角：2 / 4 / 6 / 8 / 12 / 16 / 24 / 32 px，以及 full
    */
-  --font-sans: "SF Pro Text", "Segoe UI", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  /*
+   * 字体栈按「西文 → 中文 → 系统兜底」排列：Inter 不含汉字，浏览器逐字回退到
+   * Noto Sans SC，于是中西文各用各的最优字形。系统字体留在最后，只在自托管
+   * 字体加载失败时兜底（见 styles/fonts.css）。
+   */
+  --font-sans: "Inter Variable", "Noto Sans SC Variable", "SF Pro Text", "Segoe UI", "PingFang SC",
+    "Microsoft YaHei", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono Variable", "SFMono-Regular", Consolas, "Liberation Mono", Menlo,
+    monospace;
   /*
    * 展示级字体：落地页大标题、章节序号、eyebrow 标签统一用等宽。
    * CliRelay 是 CLI / 网关类基础设施产品，等宽字形本身就是这类产品的视觉母语；
    * 中文回落到 sans，避免等宽字体缺中文字形时出现豆腐块与参差基线。
    */
-  --font-display: "JetBrains Mono", "SFMono-Regular", Menlo, "PingFang SC", "Microsoft YaHei",
-    monospace;
+  --font-display: "JetBrains Mono Variable", "SFMono-Regular", Menlo, "Noto Sans SC Variable",
+    "PingFang SC", "Microsoft YaHei", monospace;
 
   --text-2xs: 0.625rem;
   --text-2xs--line-height: 0.875rem;
@@ -58,6 +66,36 @@
 }
 
 @layer base {
+  /*
+   * 全局视觉密度。间距、字号、圆角这套 token 全部建立在 rem 上，所以调根字号就等于
+   * 等比缩放整个面板，不必逐个组件改尺寸。
+   *
+   * 刻意不用 zoom / transform: scale——面板里的下拉、日期选择器、Tooltip 都是 portal 到
+   * body 再用 getBoundingClientRect 定位的，缩放上下文会让读到的坐标和写回去的坐标不在
+   * 同一个尺度上，浮层会整体偏移。改根字号没有这个问题。
+   *
+   * 用 % 而不是 px：用户在浏览器里调过默认字号时，这个比例仍然作用在他们自己的基准上。
+   */
+  :root {
+    --ui-scale: 0.9;
+  }
+
+  html {
+    font-size: calc(100% * var(--ui-scale));
+  }
+
+  /*
+   * 图标尺寸是以 px 写在 svg 的 width/height 属性上的（lucide 的 size prop），不吃根字号；
+   * 界面整体收紧后它们会相对显大，读起来比文字更抢眼。用同一个比例补回来。
+   *
+   * 用 zoom 而不是 transform: scale——zoom 会一并缩掉布局盒，图标周围的间距关系保持原样；
+   * scale 只改绘制，会在原尺寸的位置留下空洞。前面对整个页面排除 zoom 是因为浮层定位要读
+   * getBoundingClientRect，而图标是叶子节点，不参与任何定位计算，这里没有那个风险。
+   */
+  :where(svg.lucide) {
+    zoom: var(--ui-scale);
+  }
+
   body {
     font-family: var(--font-sans);
     font-size: var(--text-sm);

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,9 @@
       "name": "@code-proxy/admin-panel",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/inter": "5.3.0",
+        "@fontsource-variable/jetbrains-mono": "5.3.0",
+        "@fontsource-variable/noto-sans-sc": "5.3.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-virtual": "^3.13.18",
@@ -319,6 +322,12 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.3.0", "", {}, "sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw=="],
+
+    "@fontsource-variable/noto-sans-sc": ["@fontsource-variable/noto-sans-sc@5.3.0", "", {}, "sha512-lNar1dF7Ik/lHNPo/7JWG0TolXY29LtsqYgMvEysooZ5bsO9uH4shJmRrwyJ3PjyTPljhpMJEK0jDuLSU4vJ1w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/docs/internal-review/bundle-baseline.md
+++ b/docs/internal-review/bundle-baseline.md
@@ -1,6 +1,6 @@
 # codeProxy Bundle Baseline
 
-更新时间：2026-07-20 11:41:00 +0800
+更新时间：2026-08-08 14:30:00 +0800
 
 ## 当前构建命令
 
@@ -18,6 +18,7 @@ bun run build
 | `vendor-animation`   |  126.21 kB |  41.93 kB | 动画依赖独立 vendor chunk                                                   |
 | `vendor-charts`      |    0.07 kB |   0.08 kB | Chart.js 入口当前几乎未进入业务路径                                         |
 | `index`              |  396.29 kB | 121.04 kB | 多账号切换（AuthProvider vault + AppShell 账号菜单）进入 shell 入口；后续可再拆 account menu |
+| `index.css`          |  430.02 kB |  86.34 kB | 入口样式表；含 114 条自托管字体 @font-face 分片声明（Inter / Noto Sans SC / JetBrains Mono），字体文件本身按 unicode-range 懒加载不计入此行 |
 | `ConfigPage`         |  119.60 kB |  33.35 kB | 页面 chunk 低于预算                                                         |
 | `AuthFilesPage`      |  216.81 kB |  58.90 kB | 身份多档案与出站策略交互加入后仍低于页面 gzip 预算                          |
 | `ProvidersPage`      |  121.98 kB |  30.85 kB | 已低于 `< 80 kB gzip` 页面预算                                              |

--- a/e2e/control-surface-states.spec.ts
+++ b/e2e/control-surface-states.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * 控件表面状态回归：禁用态必须仍有可见填充，鼠标点击不得把触发器刷成白底加描边。
+ *
+ * 两个问题都出在共享的 controlSurface / selectTriggerDisabled 上，所以只要选一个
+ * 同时挂着「禁用 Select」和「可交互 Select」的页面即可覆盖全部下拉控件。
+ */
+
+const observedAt = new Date().toISOString();
+
+// 3 个同状态（全部启用）的账号：让「状态」筛选只剩一个选项，从而触发 Select 的禁用态。
+const authFiles = ["alias-a", "alias-b", "alias-c"].map((idx, i) => ({
+  id: `auth-${idx}`,
+  name: `account-${i}@example.com.json`,
+  label: `account-${i}@example.com`,
+  type: "codex",
+  provider: "codex",
+  account_type: "oauth",
+  auth_index: idx,
+  auth_subject_id: `sub-${idx}`,
+  disabled: false,
+  size: 1024,
+  modified: 1784534400000 + i,
+}));
+
+const statusItems = authFiles.map((f) => ({
+  auth_index: f.auth_index,
+  auth_subject_id: f.auth_subject_id,
+  provider: "codex",
+  status_scope: "shared_subject",
+  subject_scope: "shared",
+  share_eligible: true,
+  current_tenant_binding_count: 1,
+  refresh_state: "success",
+  health_status: "ok",
+  plan_type: "pro_20x",
+  subscription_expires_at: "2026-08-27T00:00:00Z",
+  subscription_source: "signed_claims",
+  quotas: [
+    {
+      quota_key: "code_week",
+      quota_label: "m_quota.code_weekly",
+      percent: 12,
+      reset_at: "2026-08-09T06:38:11Z",
+      window_seconds: 604800,
+      observed_at: observedAt,
+    },
+  ],
+  usage: {
+    request_total: 30568,
+    success_total: 30507,
+    failure_total: 61,
+    success_rate: 0.998,
+    cycle_request_total: 30568,
+    cycle_total_tokens: 3_900_000_000,
+    cycle_known: true,
+    updated_at: observedAt,
+  },
+  version: 4,
+  upstream_checked_at: observedAt,
+  quota_observed_at: observedAt,
+  updated_at: observedAt,
+}));
+
+const openPage = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+    localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+  });
+  await page.route("**/v0/management/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    if (path.endsWith("/ai-accounts/status")) return json({ items: statusItems });
+    if (path.includes("/ai-accounts/status-refresh")) {
+      return json({
+        job_id: "j",
+        state: "completed",
+        total: 0,
+        completed: 0,
+        failed: 0,
+        results: [],
+      });
+    }
+    if (path.endsWith("/auth-files")) return json({ files: authFiles });
+    if (path.endsWith("/usage/entity-stats")) return json({ source: [], auth_index: [] });
+    if (path.endsWith("/usage/auth-file-trend")) return json({ points: [] });
+    if (path.endsWith("/config")) return json({ config: {} });
+    if (path.endsWith("/update/check")) return json({ has_update: false });
+    return json({ items: [] });
+  });
+  await page.goto("/#/access/ai-accounts");
+  await expect(page.getByTestId("auth-files-cards")).toBeVisible();
+};
+
+/**
+ * Tailwind v4 输出的是 `oklab(...)`，直接正则取数会拿到 0-1 的分量而不是 sRGB 通道。
+ * 借页面内的 canvas 走一遍浏览器自己的颜色解析，再把控件底色合成到白色面板上——
+ * 这里要判的本来就是「叠在白卡片上还看不看得见」，所以必须比较合成后的结果。
+ */
+const compositedOnWhite = async (locator: Locator): Promise<[number, number, number]> =>
+  locator.evaluate((el) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, 1, 1);
+    ctx.fillStyle = getComputedStyle(el).backgroundColor;
+    ctx.globalAlpha = Number(getComputedStyle(el).opacity);
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    return [r, g, b] as [number, number, number];
+  });
+
+test.describe("下拉控件表面状态", () => {
+  test("禁用的 Select 仍保留可见填充，不会退化成白底", async ({ page }) => {
+    await openPage(page);
+
+    const statusSelect = page.getByRole("combobox", { name: "状态" });
+    await expect(statusSelect).toBeDisabled();
+    const disabledFill = await compositedOnWhite(statusSelect);
+
+    const enabledFill = await compositedOnWhite(page.getByRole("combobox", { name: "自动刷新" }));
+    const mean = (fill: [number, number, number]) => (fill[0] + fill[1] + fill[2]) / 3;
+
+    // 禁用态叠在白面板上必须仍然可辨（旧实现是 bg-white/70 + opacity-70，合成后就是纯白，控件消失）。
+    expect(mean(disabledFill)).toBeLessThan(252);
+    // 而且不该比可用态更浅——否则「不可用」读起来反而像「这里是空的」。
+    expect(mean(disabledFill)).toBeLessThanOrEqual(mean(enabledFill) + 1);
+  });
+
+  test("鼠标点击 Select 不会把触发器刷成白底加描边", async ({ page }) => {
+    await openPage(page);
+
+    const refreshSelect = page.getByRole("combobox", { name: "自动刷新" });
+    const idleFill = await compositedOnWhite(refreshSelect);
+
+    await refreshSelect.click();
+    await expect(page.getByRole("listbox", { name: "自动刷新" })).toBeVisible();
+
+    // 展开态只允许比静止态更深（hover/open 同色），一旦变亮就是用户看到的「闪一下白」。
+    const openFill = await compositedOnWhite(refreshSelect);
+    expect(Math.max(...openFill)).toBeLessThanOrEqual(Math.max(...idleFill));
+
+    // 焦点仍在按钮上，但鼠标交互不该留下描边环。
+    const shadow = await refreshSelect.evaluate((el) => getComputedStyle(el).boxShadow);
+    expect(shadow).not.toMatch(/0px 0px 0px [1-9]/);
+
+    await page.keyboard.press("Escape");
+    const closedFill = await compositedOnWhite(refreshSelect);
+    expect(Math.max(...closedFill)).toBeLessThanOrEqual(Math.max(...idleFill));
+  });
+});

--- a/e2e/multi-tenant-auth.spec.ts
+++ b/e2e/multi-tenant-auth.spec.ts
@@ -1447,8 +1447,22 @@ test("a second tab survives the first tab rotating the refresh token @critical",
     )
     .not.toBeNull();
 
-  const snapshot = await first.evaluate(() => localStorage.getItem("code-proxy-admin-auth"));
-  expect(snapshot).toBeTruthy();
-  expect(snapshot).not.toContain("cpr_adm_shared");
+  // The winner's snapshot has to be polled, not read once. `toHaveURL` above is not a
+  // synchronisation point for this tab: it already navigated to #/dashboard, so the
+  // assertion is satisfied the moment navigation settles — well before the refresh
+  // round-trip lands and the rotated token is written back. Reading immediately passes
+  // only because the rotation usually wins that race; under load (slow runner, many
+  // parallel requests) it reads back the seeded value and looks like the rotation never
+  // happened. Polling keeps the invariant identical and just stops guessing at timing.
+  await expect
+    .poll(
+      async () => {
+        const raw = await first.evaluate(() => localStorage.getItem("code-proxy-admin-auth"));
+        if (raw === null) return "session-destroyed";
+        return raw.includes("cpr_adm_shared") ? "still-stale" : "rotated";
+      },
+      { timeout: 20_000 },
+    )
+    .toBe("rotated");
   expect(refreshCalls, "the rotation path was never exercised").toBeGreaterThan(0);
 });

--- a/index.html
+++ b/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Code Proxy 管理后台</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <script>
       (function () {
         try {
@@ -73,7 +67,7 @@
         transition:
           opacity 0.4s ease,
           visibility 0.4s ease;
-        font-family: "Inter", "SF Pro Text", system-ui, sans-serif;
+        font-family: "SF Pro Text", "Segoe UI", "PingFang SC", system-ui, sans-serif;
       }
       #app-loader.fade-out {
         opacity: 0;

--- a/manage.html
+++ b/manage.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Code Proxy Admin Dashboard</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <!-- 阻塞渲染的主题恢复脚本：在 body 绘制前读取 localStorage 并应用暗色模式 -->
     <script>
       (function () {
@@ -78,7 +72,7 @@
         transition:
           opacity 0.4s ease,
           visibility 0.4s ease;
-        font-family: "Inter", "SF Pro Text", system-ui, sans-serif;
+        font-family: "SF Pro Text", "Segoe UI", "PingFang SC", system-ui, sans-serif;
       }
       #app-loader.fade-out {
         opacity: 0;

--- a/packages/ui/src/charts/EChartRenderer.tsx
+++ b/packages/ui/src/charts/EChartRenderer.tsx
@@ -1,7 +1,18 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ECBasicOption } from "echarts/types/dist/shared";
 import ReactECharts from "echarts-for-react";
 import { useTheme } from "../theme/ThemeProvider";
+
+/**
+ * 图表是 canvas 画出来的，读不到 CSS 的字体栈，echarts 默认退回系统 sans-serif——
+ * 于是同一屏里图表文字和界面文字是两套字形。这里把 `--font-sans` 取出来喂给顶层
+ * textStyle，凡是没单独指定 fontFamily 的图表组件都会继承它。
+ */
+const readSansFontFamily = (): string | undefined => {
+  if (typeof document === "undefined") return undefined;
+  const value = getComputedStyle(document.documentElement).getPropertyValue("--font-sans").trim();
+  return value || undefined;
+};
 
 export type EChartEvents = Record<string, (params: unknown, chart: unknown) => void>;
 
@@ -42,6 +53,33 @@ export function EChartRenderer({
   const initialAnimationGuardUntilRef = useRef(0);
   const didResizeOnceRef = useRef(false);
   const [hasMeasuredSize, setHasMeasuredSize] = useState(false);
+  const [fontRevision, setFontRevision] = useState(0);
+
+  /*
+   * webfont 到位之前 canvas 已经用回退字体把文字画完了，而且 echarts 不会自己重画。
+   * 等 document.fonts.ready 之后把版本号 +1，下面的 useMemo 会产出一个新的 option 引用，
+   * 逼 echarts 重新排一次文字——否则首次访问会一直停在系统字体上，直到下次交互重绘。
+   */
+  useEffect(() => {
+    const fonts = document.fonts;
+    if (!fonts || fonts.status === "loaded") return;
+    let cancelled = false;
+    fonts.ready.then(() => {
+      if (!cancelled) setFontRevision((current) => current + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const styledOption = useMemo(() => {
+    const fontFamily = readSansFontFamily();
+    if (!fontFamily) return option;
+    // 调用方自己写的 textStyle 优先，这里只补默认字体。
+    const ownTextStyle = (option as { textStyle?: Record<string, unknown> }).textStyle;
+    return { ...option, textStyle: { fontFamily, ...ownTextStyle } } as ECBasicOption;
+    // fontRevision 只用来在字体就绪后触发重算，不参与 option 内容。
+  }, [option, fontRevision]);
 
   const now = () => Date.now();
 
@@ -223,7 +261,7 @@ export function EChartRenderer({
       {hasMeasuredSize ? (
         <ReactECharts
           ref={chartRef}
-          option={option}
+          option={styledOption}
           theme={mode === "dark" ? "dark" : undefined}
           style={{ height: "100%", width: "100%" }}
           showLoading={loading}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -118,12 +118,12 @@ export {
   controlTextBySize,
   controlPaddingBySize,
   controlSurface,
+  controlSurfaceTrigger,
 } from "./utils/controlStyles";
 export {
   cn,
   floatingPanelSurface,
   getSelectTriggerBase,
   selectTriggerBase,
-  selectTriggerOpen,
-  selectTriggerDisabled,
+  selectTriggerState,
 } from "./utils/selectStyles";

--- a/packages/ui/src/primitives/MultiSelect.tsx
+++ b/packages/ui/src/primitives/MultiSelect.tsx
@@ -23,8 +23,7 @@ import {
   selectOptionIdle,
   selectOptionSelected,
   selectSearchInput,
-  selectTriggerDisabled,
-  selectTriggerOpen,
+  selectTriggerState,
 } from "../utils/selectStyles";
 import type { ControlSize } from "../utils/controlStyles";
 
@@ -184,7 +183,7 @@ export function MultiSelect({
       {open ? (
         <motion.div
           ref={dropdownRef}
-              data-side={dropdownPlacement}
+          data-side={dropdownPlacement}
           style={dropdownStyle}
           className={cn(searchableSelectPanel, "flex flex-col")}
           {...getSelectDropdownMotion(dropdownPlacement)}
@@ -272,6 +271,7 @@ export function MultiSelect({
         ref={triggerRef}
         type="button"
         disabled={disabled}
+        data-state={selectTriggerState(open)}
         onClick={() => {
           // Pre-compute position before opening so the portal renders at the correct spot
           if (!open) updatePosition();
@@ -280,8 +280,6 @@ export function MultiSelect({
         className={cn(
           getSelectTriggerBase(size),
           "h-auto min-h-9 w-full justify-between py-1 text-left",
-          open && selectTriggerOpen,
-          disabled && selectTriggerDisabled,
         )}
       >
         <div className="flex min-w-0 flex-1 flex-wrap gap-1">

--- a/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
+++ b/packages/ui/src/primitives/SearchableCheckboxMultiSelect.tsx
@@ -24,7 +24,7 @@ import {
   selectOptionSelected,
   selectSearchInput,
   selectSearchRow,
-  selectTriggerDisabled,
+  selectTriggerState,
 } from "../utils/selectStyles";
 import type { ControlSize } from "../utils/controlStyles";
 import { ScrollArea } from "./ScrollArea";
@@ -463,6 +463,7 @@ export function SearchableCheckboxMultiSelect({
           aria-haspopup="listbox"
           aria-label={ariaLabel}
           disabled={disabled}
+          data-state={selectTriggerState(open)}
           onClick={() => {
             if (!open) {
               if (manualApply) setDraftExplicitValue(sanitizedExplicitValue);
@@ -471,11 +472,7 @@ export function SearchableCheckboxMultiSelect({
             }
             setOpen((current) => !current);
           }}
-          className={cn(
-            getSelectTriggerBase(size),
-            "w-full justify-between text-left",
-            disabled && selectTriggerDisabled,
-          )}
+          className={cn(getSelectTriggerBase(size), "w-full justify-between text-left")}
         >
           <span
             className={cn(

--- a/packages/ui/src/primitives/SearchableSelect.tsx
+++ b/packages/ui/src/primitives/SearchableSelect.tsx
@@ -23,7 +23,7 @@ import {
   selectOptionSelected,
   selectSearchInput,
   selectSearchRow,
-  selectTriggerOpen,
+  selectTriggerState,
 } from "../utils/selectStyles";
 import type { ControlSize } from "../utils/controlStyles";
 
@@ -287,13 +287,9 @@ export function SearchableSelect({
               : undefined
         }
         disabled={disabled}
+        data-state={selectTriggerState(open)}
         onClick={() => setOpen((prev) => !prev)}
-        className={cn(
-          getSelectTriggerBase(size),
-          open && selectTriggerOpen,
-          "disabled:cursor-not-allowed disabled:opacity-60",
-          className,
-        )}
+        className={cn(getSelectTriggerBase(size), className)}
       >
         <span className="min-w-0 flex-1 truncate text-left">{selectedLabel ?? placeholder}</span>
         <ChevronDown

--- a/packages/ui/src/primitives/Select.tsx
+++ b/packages/ui/src/primitives/Select.tsx
@@ -21,8 +21,7 @@ import {
   selectOptionSelected,
   selectPanel,
   selectTriggerChip,
-  selectTriggerDisabled,
-  selectTriggerOpen,
+  selectTriggerState,
 } from "../utils/selectStyles";
 import type { ControlSize } from "../utils/controlStyles";
 
@@ -180,12 +179,11 @@ export function Select({
         aria-invalid={ariaInvalid}
         aria-describedby={ariaDescribedBy}
         disabled={disabled}
+        data-state={selectTriggerState(open)}
         onClick={() => setOpen((prev) => !prev)}
         className={cn(
           variant === "chip" ? selectTriggerChip : getSelectTriggerBase(size),
           variant !== "chip" && fullWidth ? "w-full" : null,
-          open && selectTriggerOpen,
-          disabled && selectTriggerDisabled,
           className,
         )}
       >

--- a/packages/ui/src/primitives/__tests__/selectTriggerSurface.test.tsx
+++ b/packages/ui/src/primitives/__tests__/selectTriggerSurface.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { MultiSelect } from "../MultiSelect";
+import { SearchableCheckboxMultiSelect } from "../SearchableCheckboxMultiSelect";
+import { SearchableSelect } from "../SearchableSelect";
+import { Select } from "../Select";
+
+/**
+ * 四个下拉触发器共用 controlSurfaceTrigger，展开态和禁用态都由 `data-state` 与原生
+ * `disabled` 属性驱动，而不是条件拼接类名——旧写法靠 Tailwind 的输出顺序决定谁覆盖谁，
+ * 禁用态的 `bg-white/70` 就是这样反过来盖住了静止态的填充，让控件在白面板上消失。
+ *
+ * 这里守住的是「属性挂对了」这一层；具体色值与合成后的可见度由
+ * e2e/control-surface-states.spec.ts 在真实渲染里验证。
+ */
+
+const options = [
+  { value: "off", label: "Off" },
+  { value: "on", label: "On" },
+];
+
+const renderTrigger = (name: string, disabled: boolean) => {
+  switch (name) {
+    case "Select":
+      return render(
+        <Select
+          value="off"
+          onChange={() => undefined}
+          options={options}
+          aria-label="Trigger"
+          disabled={disabled}
+        />,
+      );
+    case "SearchableSelect":
+      return render(
+        <SearchableSelect
+          value="off"
+          onChange={() => undefined}
+          options={options}
+          aria-label="Trigger"
+          disabled={disabled}
+        />,
+      );
+    case "SearchableCheckboxMultiSelect":
+      return render(
+        <SearchableCheckboxMultiSelect
+          value={[]}
+          onChange={() => undefined}
+          options={options}
+          placeholder="All"
+          searchPlaceholder="Search"
+          selectFilteredLabel="Select filtered"
+          deselectFilteredLabel="Deselect filtered"
+          selectedCountLabel={(count) => `${count} selected`}
+          noResultsLabel="No results"
+          aria-label="Trigger"
+          disabled={disabled}
+        />,
+      );
+    default:
+      return render(
+        <MultiSelect
+          value={[]}
+          onChange={() => undefined}
+          options={options}
+          aria-label="Trigger"
+          disabled={disabled}
+        />,
+      );
+  }
+};
+
+const TRIGGERS = ["Select", "SearchableSelect", "SearchableCheckboxMultiSelect"];
+
+describe("下拉触发器表面", () => {
+  test.each(TRIGGERS)("%s 静止时标记为 closed，且不带遗留的禁用类", (name) => {
+    renderTrigger(name, false);
+
+    const trigger = screen.getByRole("combobox", { name: "Trigger" });
+    expect(trigger).toHaveAttribute("data-state", "closed");
+    expect(trigger).not.toBeDisabled();
+    // 旧实现遗留：白底 + 半透明，会让控件在白面板上整个消失。
+    expect(trigger.className).not.toMatch(/\bbg-white\/70\b/);
+    expect(trigger.className).not.toMatch(/\bopacity-(?:60|70)\b/);
+  });
+
+  test.each(TRIGGERS)("%s 禁用时靠 disabled 变体表达，而不是覆盖静止底色", (name) => {
+    renderTrigger(name, true);
+
+    const trigger = screen.getByRole("combobox", { name: "Trigger" });
+    expect(trigger).toBeDisabled();
+    // disabled: 变体的特异性高于裸类，覆盖关系不再取决于 Tailwind 的输出顺序。
+    expect(trigger.className).toMatch(/\bdisabled:bg-slate-100\/80\b/);
+    expect(trigger.className).toMatch(/\bdisabled:text-slate-400\b/);
+  });
+
+  test.each(TRIGGERS)("%s 展开后把 data-state 切到 open", async (name) => {
+    const user = userEvent.setup();
+    renderTrigger(name, false);
+
+    const trigger = screen.getByRole("combobox", { name: "Trigger" });
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("data-state", "open");
+  });
+
+  test("MultiSelect 同样由属性驱动展开与禁用", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderTrigger("MultiSelect", false);
+
+    // MultiSelect 的触发器没有 combobox role，按可访问名之外的唯一 button 定位。
+    const trigger = screen.getAllByRole("button")[0];
+    expect(trigger).toHaveAttribute("data-state", "closed");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("data-state", "open");
+    unmount();
+
+    renderTrigger("MultiSelect", true);
+    const disabledTrigger = screen.getAllByRole("button")[0];
+    expect(disabledTrigger).toBeDisabled();
+    expect(disabledTrigger.className).toMatch(/\bdisabled:bg-slate-100\/80\b/);
+  });
+});

--- a/packages/ui/src/utils/controlStyles.ts
+++ b/packages/ui/src/utils/controlStyles.ts
@@ -19,10 +19,60 @@ export const controlPaddingBySize: Record<ControlSize, string> = {
 };
 
 /**
- * 输入类控件的统一表面。
+ * 禁用态：保留和静止态同强度的填充，只把文字和图标降到弱对比。
+ *
+ * 早期版本用 `bg-white/70 + opacity-70` 表达禁用，结果在白色面板上禁用控件比可用控件
+ * 还浅，整个控件看起来「消失」了——用户读到的不是「不可用」，而是「这里没有东西」。
+ * 禁用态必须仍然占住视觉位置，可用性差异靠文字对比度和 not-allowed 光标传达。
+ *
+ * 用 `disabled:` 变体而不是条件拼接类名：`.disabled\:x:disabled` 的特异性高于裸类，
+ * 覆盖关系由选择器决定，不再受 Tailwind 输出顺序影响（旧写法正是栽在这上面）。
+ */
+const controlDisabled = [
+  "disabled:cursor-not-allowed",
+  "disabled:bg-slate-100/80 disabled:text-slate-400 disabled:shadow-none",
+  "disabled:hover:bg-slate-100/80",
+  "dark:disabled:bg-white/[0.05] dark:disabled:text-white/30",
+  "dark:disabled:hover:bg-white/[0.05]",
+].join(" ");
+
+/**
+ * 输入类控件（input / textarea）的统一表面。
  *
  * 用「填充」而不是「描边」表达层级：静止态是一块柔和底色，聚焦时底色提亮、并补一条 1px
  * 中性描边。刻意不做彩色发光环——密集表单里那圈光晕会盖住相邻控件，也让界面显得吵。
+ * 输入框保留 `focus:` 提亮是有意为之：那一下变亮就是「光标在这里，可以打字了」。
  */
-export const controlSurface =
-  "rounded-2xl border-0 bg-slate-100/80 text-slate-800 shadow-none outline-none transition-[color,background-color,box-shadow] duration-150 placeholder:text-slate-400 hover:bg-slate-100 focus:bg-white focus:ring-1 focus:ring-slate-900/12 focus-visible:bg-white focus-visible:ring-1 focus-visible:ring-slate-900/12 dark:bg-white/[0.055] dark:text-slate-100 dark:placeholder:text-white/30 dark:hover:bg-white/[0.08] dark:focus:bg-white/[0.09] dark:focus:ring-white/15 dark:focus-visible:bg-white/[0.09] dark:focus-visible:ring-white/15";
+export const controlSurface = [
+  "rounded-2xl border-0 bg-slate-100/80 text-slate-800 shadow-none outline-none",
+  "transition-[color,background-color,box-shadow] duration-150",
+  "placeholder:text-slate-400 hover:bg-slate-100",
+  "focus:bg-white focus:ring-1 focus:ring-slate-900/12",
+  "focus-visible:bg-white focus-visible:ring-1 focus-visible:ring-slate-900/12",
+  "dark:bg-white/[0.055] dark:text-slate-100 dark:placeholder:text-white/30 dark:hover:bg-white/[0.08]",
+  "dark:focus:bg-white/[0.09] dark:focus:ring-white/15",
+  "dark:focus-visible:bg-white/[0.09] dark:focus-visible:ring-white/15",
+  controlDisabled,
+].join(" ");
+
+/**
+ * 触发器类控件（下拉、日期选择器等 button）的统一表面。
+ *
+ * 与输入框刻意不同：鼠标点开一个下拉不该把控件刷成白底加描边。那圈描边在筛选栏里读起来
+ * 像「这里出错了」，而且鼠标松开后焦点仍留在按钮上，白底会一直挂着，不是一闪而过。
+ * 所以焦点态只留给键盘（focus-visible），鼠标交互由 hover 和「已展开」两个态表达，
+ * 且这两个态共用同一块底色——从悬停到展开没有任何颜色跳变，也就没有「闪一下」。
+ *
+ * 展开态走 `data-[state=open]`，同样是为了让特异性而非类名顺序决定覆盖关系。
+ */
+export const controlSurfaceTrigger = [
+  "rounded-2xl border-0 bg-slate-100/80 text-slate-800 shadow-none outline-none",
+  "transition-[color,background-color,box-shadow] duration-150",
+  "hover:bg-slate-200/70",
+  "focus-visible:ring-1 focus-visible:ring-slate-900/12",
+  "data-[state=open]:bg-slate-200/70 data-[state=open]:text-slate-900",
+  "dark:bg-white/[0.055] dark:text-slate-100 dark:hover:bg-white/[0.10]",
+  "dark:focus-visible:ring-white/15",
+  "dark:data-[state=open]:bg-white/[0.10] dark:data-[state=open]:text-white",
+  controlDisabled,
+].join(" ");

--- a/packages/ui/src/utils/selectStyles.ts
+++ b/packages/ui/src/utils/selectStyles.ts
@@ -2,7 +2,7 @@ import "./FloatingPanel.css";
 import {
   controlHeightBySize,
   controlPaddingBySize,
-  controlSurface,
+  controlSurfaceTrigger,
   controlTextBySize,
   type ControlSize,
 } from "../utils/controlStyles";
@@ -16,18 +16,26 @@ export const getSelectTriggerBase = (size: ControlSize = "default") =>
     controlHeightBySize[size],
     controlTextBySize[size],
     controlPaddingBySize[size],
-    controlSurface,
+    controlSurfaceTrigger,
   ].join(" ");
 
 export const selectTriggerBase = getSelectTriggerBase();
 
-export const selectTriggerOpen = "";
+/**
+ * 触发器的展开/禁用态不再由组件条件拼接类名，改由 `data-state` 与原生 `disabled`
+ * 属性驱动（见 controlSurfaceTrigger）。每个下拉触发器只需带上这个属性即可。
+ */
+export const selectTriggerState = (open: boolean) => (open ? "open" : "closed");
 
-export const selectTriggerDisabled =
-  "cursor-not-allowed bg-white/70 text-[#A1A1AA] opacity-70 shadow-none dark:bg-[#27272A]/70 dark:text-[#71717A]";
-
-export const selectTriggerChip =
-  "inline-flex h-7 items-center justify-center gap-1.5 rounded-xl border-0 bg-white px-2.5 text-xs font-semibold text-[#71717A] shadow-[0_2px_8px_rgb(0_0_0_/_0.10)] outline-none transition-colors hover:bg-white hover:text-[#18181B] focus-visible:ring-2 focus-visible:ring-black/[0.08] dark:bg-[#27272A] dark:text-[#A1A1AA] dark:shadow-[0_6px_18px_rgb(0_0_0_/_0.22)] dark:hover:bg-[#303036] dark:hover:text-white dark:focus-visible:ring-white/10";
+export const selectTriggerChip = [
+  "inline-flex h-7 items-center justify-center gap-1.5 rounded-xl border-0 bg-white px-2.5",
+  "text-xs font-semibold text-[#71717A] shadow-[0_2px_8px_rgb(0_0_0_/_0.10)] outline-none transition-colors",
+  "hover:bg-white hover:text-[#18181B] focus-visible:ring-2 focus-visible:ring-black/[0.08]",
+  "disabled:cursor-not-allowed disabled:text-[#A1A1AA] disabled:shadow-none disabled:hover:text-[#A1A1AA]",
+  "dark:bg-[#27272A] dark:text-[#A1A1AA] dark:shadow-[0_6px_18px_rgb(0_0_0_/_0.22)]",
+  "dark:hover:bg-[#303036] dark:hover:text-white dark:focus-visible:ring-white/10",
+  "dark:disabled:text-[#71717A] dark:disabled:hover:bg-[#27272A] dark:disabled:hover:text-[#71717A]",
+].join(" ");
 
 export const selectChevron =
   "ml-auto shrink-0 text-[#71717A] transition-transform duration-200 dark:text-[#A1A1AA]";
@@ -35,11 +43,9 @@ export const selectChevron =
 export const floatingPanelSurface =
   "code-proxy-floating-surface rounded-xl border border-slate-900/8 bg-white shadow-[0_16px_40px_rgba(15,23,42,0.14)] dark:border-white/8 dark:bg-neutral-950 dark:shadow-[0_16px_40px_rgba(0,0,0,0.38)]";
 
-export const selectPanel =
-  `fixed z-[9999] overflow-hidden p-1 ${floatingPanelSurface}`;
+export const selectPanel = `fixed z-[9999] overflow-hidden p-1 ${floatingPanelSurface}`;
 
-export const searchableSelectPanel =
-  `fixed z-[9999] flex flex-col overflow-hidden ${floatingPanelSurface}`;
+export const searchableSelectPanel = `fixed z-[9999] flex flex-col overflow-hidden ${floatingPanelSurface}`;
 
 export const selectSearchRow =
   "flex items-center gap-2 border-b border-black/[0.06] px-3 py-2 dark:border-white/10";

--- a/scripts/bundle-diff.mjs
+++ b/scripts/bundle-diff.mjs
@@ -36,13 +36,25 @@ const readBaseline = () => {
   return rows;
 };
 
+const CSS_SUFFIX = ".css";
+
+/*
+ * 入口脚本和入口样式表同名（index-<hash>.js / index-<hash>.css），推导出的 stem 会撞在
+ * 一起，然后 gzip 更大的那个把另一个顶掉——监控对象是脚本还是样式表，取决于当下谁更大，
+ * 而不是基线写了什么。自托管字体让 index.css 反超 index.js 之后这一点才暴露出来。
+ * 所以样式表单独挂 `<stem>.css` 这个 key，两者各自对账。
+ */
 const findCurrentChunks = (baselineKeys) => {
   const chunks = new Map();
   for (const name of readdirSync(distAssetsDir)) {
     const path = join(distAssetsDir, name);
     if (!statSync(path).isFile()) continue;
-    const stem =
-      baselineKeys.find(
+    const isCss = name.endsWith(CSS_SUFFIX);
+    const comparableKeys = baselineKeys
+      .filter((key) => key.endsWith(CSS_SUFFIX) === isCss)
+      .map((key) => (isCss ? key.slice(0, -CSS_SUFFIX.length) : key));
+    const stemBase =
+      comparableKeys.find(
         (key) => name === key || name.startsWith(`${key}-`) || name.startsWith(`${key}.`),
       ) ??
       (() => {
@@ -50,6 +62,7 @@ const findCurrentChunks = (baselineKeys) => {
         const separatorIndex = withoutExt.lastIndexOf("-");
         return separatorIndex === -1 ? withoutExt : withoutExt.slice(0, separatorIndex);
       })();
+    const stem = isCss ? `${stemBase}${CSS_SUFFIX}` : stemBase;
     const data = readFileSync(path);
     const sizeKb = data.byteLength / 1024;
     const gzipKb = gzipSync(data).byteLength / 1024;
@@ -76,7 +89,10 @@ const rows = tracked.map((key) => {
   const base = baseline.get(key);
   const now = current.get(key);
   const deltaGzip = now.gzipKb - base.gzipKb;
-  const overPageBudget = key !== "index" && !key.startsWith("vendor-") && now.gzipKb > budgetGzipKb;
+  // 页面 gzip 预算只约束按页加载的 chunk；入口与 vendor 不受它管，样式表同理。
+  const stem = key.endsWith(CSS_SUFFIX) ? key.slice(0, -CSS_SUFFIX.length) : key;
+  const overPageBudget =
+    stem !== "index" && !stem.startsWith("vendor-") && now.gzipKb > budgetGzipKb;
   const overTolerance = deltaGzip > toleranceKb;
   return {
     key,


### PR DESCRIPTION
## 背景

用户反馈的三个前端问题，根因都落在同一处：**控件表面样式靠类名拼接顺序决定覆盖关系**，以及**字体与尺寸缺少单一真源**。

## 改了什么

### 1. 禁用的下拉在白面板上整个消失

`selectTriggerDisabled` 用 `bg-white/70 + opacity-70` 表达禁用，比静止态的 `bg-slate-100/80` 还浅，合成到白卡片上就是纯白 —— 用户读到的不是「不可用」，而是「这里没有东西」。

实测（改前）：禁用态 `backgroundColor: oklab(0.999994 … / 0.7)` + `opacity: 0.7`，叠白后 RGB 均值 255。

修复：禁用态保留与静止态同强度的填充，只把文字降到弱对比，并改用 `disabled:` 变体 —— `.disabled\:x:disabled` 的特异性高于裸类，覆盖关系由选择器决定，不再受 Tailwind 输出顺序影响（旧写法正是栽在这上面）。

### 2. 点开下拉时闪一下白底加描边

触发器复用了输入框的 `controlSurface`，带 `focus:bg-white` + `focus:ring-1`。鼠标点击后焦点留在按钮上，白底和描边会**一直挂着**，并不是一闪而过。

实测（改前）：展开后 `backgroundColor: rgb(255,255,255)`、`boxShadow: … 0px 0px 0px 1px`；关闭下拉后两者依旧。

修复：拆出 `controlSurfaceTrigger`，焦点态只留给键盘（`focus-visible`），hover 与展开态**共用同一块底色**，从悬停到展开没有任何颜色跳变。展开态由 `data-state` 驱动，四个下拉触发器（Select / SearchableSelect / MultiSelect / SearchableCheckboxMultiSelect）统一。顺带补齐了此前完全缺失的输入框禁用态，以及 chip 变体的禁用态。

### 3. 整体收紧 10% + 自托管字体

**密度**：新增 `--ui-scale`，根字号按比例缩放（`14.4px`，`text-sm` → `12.6px`）。间距、字号、圆角都建立在 rem 上，因此不必逐个组件改。

- 刻意不用 `zoom` / `transform: scale()` 作用于整页：浮层（下拉、日期选择器、Tooltip）都是 portal 到 body 再用 `getBoundingClientRect` 定位的，缩放上下文会让读到的坐标和写回去的坐标不在同一尺度，浮层会整体偏移。
- 图标尺寸写死在 svg 的 `width/height` 属性上（lucide 的 `size`），不吃根字号；单独给 `svg.lucide` 用 `zoom` 补同一比例 —— 图标是叶子节点，不参与任何定位计算，没有上面那个风险。页面内 95 个 svg 全部是 lucide 图标，覆盖完整。

**字体**：两个 HTML 入口原先挂着 Google Fonts 的 Inter 外链，但 `--font-sans` 里**根本没写 Inter** —— 外链纯属白下载，实际渲染全靠系统字体，同一个面板在 macOS 是苹方、Windows 是雅黑。

改为随构建产物发布三套可变字体，去掉全部外部依赖：

| 用途 | 字体 | 说明 |
|------|------|------|
| 西文 / 数字 | Inter Variable | wght 100–900 单文件 |
| 中文 | Noto Sans SC Variable | 按 unicode-range 切 97 个分片，按需加载 |
| 等宽 / 展示 | JetBrains Mono Variable | 代码、日志、落地页标题 |

图表是 canvas 渲染、读不到 CSS 字体栈，echarts 会退回系统 `sans-serif`；改为从 `--font-sans` 取值喂给顶层 `textStyle`，并在 `document.fonts.ready` 后重绘一次（canvas 不会像 DOM 那样自动换字）。

## 附带：修正 bundle-diff 的追踪精度

`index-<hash>.js` 和 `index-<hash>.css` 推导出同一个 stem，gzip 更大的会把另一个顶掉 —— 监控对象是脚本还是样式表，取决于当下谁更大。字体声明让入口 CSS 反超入口 JS 后这一点才暴露出来。样式表改挂独立的 `<stem>.css` key，两者各自对账；页面 gzip 预算同步排除入口样式表。

这是**收紧**而非放宽门禁：此前入口 CSS 完全没被独立追踪。baseline 相应新增 `index.css` 一行。

## 体积影响

- 构建产物新增 110 个 woff2 分片，共约 4.8 MB（按 unicode-range 懒加载）
- **首屏实测只拉 14 个分片**：`inter-latin` + `jetbrains-mono-latin` + 12 个中文分片
- `index.css` 86.34 kB gzip（含 114 条 `@font-face` 声明）；`index` JS 82.36 kB gzip，较 baseline **减少 38.68 kB**
- `bundle:diff` 结果 PASS

## 验证

`./scripts/ci-pr.sh` 全绿：

```
lint (5 warnings / 0 errors，与改动前基线一致)
design:check ✅  boundary:imports ✅  size:check ✅  surface:check ✅  audit:deps ✅
test:ci  1123 passed (154 files)
build ✅  bundle:diff PASS
critical e2e  12 passed
```

另外单独跑了全量 e2e：**67 passed**。

新增回归覆盖：

- `e2e/control-surface-states.spec.ts` — 在真实渲染里把控件底色合成到白面板上判可见度（Tailwind v4 输出 `oklab()`，直接正则取数会拿到 0–1 分量而非 sRGB 通道，所以借页面内 canvas 走浏览器自己的颜色解析）
- `packages/ui/src/primitives/__tests__/selectTriggerSurface.test.tsx` — 四个触发器的 `data-state` / `disabled` 属性与禁用变体，10 项

浏览器实测确认：`document.fonts.check` 对 Inter 与中文字形均为 `true`，页面外部样式表列表为**空**（Google Fonts 已彻底摘除）。浅色 / 深色两种主题均已截图确认。

## 未纳入本次范围

224 处 `w-[Npx]` / `min-h-[Npx]` 固定像素不随缩放变化。它们多是「最小尺寸保护」（图表最小高度、表格最小宽度），保持原值反而更安全 —— 跟着缩会让图表变扁、表格更挤。如需进一步收紧可另开一轮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)