### PR TITLE
fix(ui): 用 flex 链取代百分比与视口魔数，让页面底部留白与其余三边对齐

### DIFF
--- a/apps/admin-panel/src/app/layout/DashboardLayout.tsx
+++ b/apps/admin-panel/src/app/layout/DashboardLayout.tsx
@@ -15,7 +15,26 @@ export function DashboardLayout() {
   return (
     <AppShell onLogout={() => auth?.actions?.logout?.()}>
       <AnimatePresence mode="wait">
-        <Reveal key={`${location.pathname}:${tenantKey}`} className="min-h-full">
+        {/*
+         * 页面内容的唯一包装层，也是「底部留白等于其余三边」这条约束的落点。
+         *
+         * 这里必须用 flex-1 而不是 min-h-full：外层 <main> 的高度是靠 min-height 撑出来的，
+         * 不是确定值，子元素的百分比高度没有可解析的基准，实测会比内容盒矮十几到几十像素，
+         * 于是底部凭空多出一条比左右宽的留白。flex-1 由 flex 直接分配剩余空间，不依赖百分比。
+         *
+         * 不加 min-h-0：保留 min-height:auto，内容超过一屏时容器仍会被撑开、交给外层滚动；
+         * 加了反而会把长页面裁掉。需要内部滚动的页面在自己的根容器上写 flex-1 + min-h-0。
+         *
+         * `[&>*:only-child]:flex-1` 是给页面兜底的默认值：包装层撑满了，但它是透明的，
+         * 里面的页面根要是没撑满，用户看到的还是底部那条更宽的留白。限定 :only-child 是
+         * 因为返回多个兄弟节点的页面各自有布局意图，平分高度只会把它们改坏。
+         * flex-basis 会盖掉页面根自己写的 height，这也正是各页面能摘掉
+         * h-[calc(100dvh-…)] 这类魔数的前提。
+         */}
+        <Reveal
+          key={`${location.pathname}:${tenantKey}`}
+          className="flex flex-1 flex-col [&>*:only-child]:flex-1"
+        >
           {outlet}
         </Reveal>
       </AnimatePresence>

--- a/e2e/page-bottom-spacing.spec.ts
+++ b/e2e/page-bottom-spacing.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 页面底部留白必须和其余三边一致。
+ *
+ * 外层 <main> 给了四边等距的内边距，所以只要页面内容撑满 main 的内容盒，底部看到的就正好
+ * 是那一条内边距。撑不满时多出来的高度会全部堆在底部，视觉上就是「下面那条明显更宽」。
+ *
+ * 这里用空数据跑：内容最少、最容易撑不满，是最严格的一档。
+ */
+
+const ROUTES = [
+  "/dashboard",
+  "/runtime/monitor",
+  "/runtime/request-logs",
+  "/runtime/logs",
+  "/runtime/system",
+  "/access/ai-providers",
+  "/access/ai-accounts",
+  "/access/end-users",
+  "/access/api-key-permissions",
+  "/access/content-moderation",
+  "/access/ccswitch-import-settings",
+  "/access/api-keys",
+  "/models/catalog",
+  "/models/channel-groups",
+  "/models/proxies",
+  "/governance/tenants",
+  "/governance/users",
+  "/governance/roles",
+  "/governance/audit-logs",
+  "/system/config",
+  "/system/menu-management",
+] as const;
+
+const principal = {
+  user_id: "u1",
+  username: "admin",
+  display_name: "Admin",
+  tenant_id: "t1",
+  tenant_slug: "system",
+  is_super_admin: true,
+  platform_admin: true,
+  must_change_password: false,
+  kind: "user",
+  roles: [],
+  permissions: ["*"],
+  menus: [],
+  effective_tenant: { id: "t1", name: "System", slug: "system", type: "system" },
+  user: { display_name: "Admin", username: "admin", role_codes: ["platform_super_admin"] },
+};
+
+const openPage = async (page: Page, route: string) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+    localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+  });
+
+  // 所有管理端接口一律返回「空但结构完整」的响应：页面能渲染，但内容量最小。
+  await page.route("**/v0/**", async (route) => {
+    const url = new URL(route.request().url());
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    if (url.pathname.endsWith("/auth/me")) return json({ principal });
+    if (url.pathname.endsWith("/config")) return json({ config: {} });
+    if (url.pathname.endsWith("/update/check")) return json({ has_update: false });
+    // 系统监控卡片直接对数值调 toFixed，字段缺失会整页落进错误边界
+    if (url.pathname.endsWith("/system-stats")) {
+      const zeros = [
+        "db_size_bytes",
+        "log_content_store_bytes",
+        "log_dir_size_bytes",
+        "log_size_bytes",
+        "process_mem_bytes",
+        "process_mem_pct",
+        "process_cpu_pct",
+        "go_routines",
+        "go_heap_bytes",
+        "system_cpu_pct",
+        "system_mem_total",
+        "system_mem_used",
+        "system_mem_pct",
+        "net_bytes_sent",
+        "net_bytes_recv",
+        "net_send_rate",
+        "net_recv_rate",
+        "disk_total",
+        "disk_used",
+        "disk_free",
+        "disk_pct",
+        "uptime_seconds",
+        "total_in_flight",
+        "total_rpm",
+        "total_tpm",
+      ];
+      return json({
+        ...Object.fromEntries(zeros.map((key) => [key, 0])),
+        start_time: new Date(0).toISOString(),
+        channel_latency: [],
+        active_concurrency: [],
+      });
+    }
+    // 仪表盘直接读 kpi/counts 的字段，给不出结构会落进错误边界，量不到布局
+    if (url.pathname.endsWith("/dashboard-summary")) {
+      return json({
+        kpi: {
+          total_requests: 0,
+          success_requests: 0,
+          failed_requests: 0,
+          success_rate: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          total_tokens: 0,
+          total_cost: 0,
+          cache_rate: 0,
+        },
+        trends: {},
+        counts: {
+          api_keys: 0,
+          providers_total: 0,
+          gemini_keys: 0,
+          claude_keys: 0,
+          codex_keys: 0,
+          vertex_keys: 0,
+          openai_providers: 0,
+          auth_files: 0,
+        },
+        days: 7,
+      });
+    }
+    return json({
+      items: [],
+      files: [],
+      points: [],
+      logs: [],
+      entries: [],
+      data: [],
+      results: [],
+      source: [],
+      auth_index: [],
+      total: 0,
+      config: {},
+    });
+  });
+
+  await page.goto(`/#${route}`);
+  await page.waitForFunction(() => {
+    const main = document.getElementById("main-content");
+    return Boolean(main && main.firstElementChild);
+  });
+};
+
+const measure = (page: Page) =>
+  page.evaluate(() => {
+    const main = document.getElementById("main-content") as HTMLElement;
+    const cs = getComputedStyle(main);
+    const rect = main.getBoundingClientRect();
+    const padBottom = parseFloat(cs.paddingBottom);
+    const padLeft = parseFloat(cs.paddingLeft);
+
+    /*
+     * 量的必须是「用户看得见的那块内容」的底边，不是最外层包装层的底边。
+     * 包装层（Reveal）撑满了不等于页面内容撑满了——它是透明的，内部内容矮一截时，
+     * 用户照样看到底部多出一条留白。所以向下钻取，跳过没有可见表面（无背景、无边框、
+     * 无阴影）的纯布局容器，直到找到真正画出东西的元素。
+     */
+    const paints = (el: Element) => {
+      const s = getComputedStyle(el);
+      if (s.visibility === "hidden" || s.display === "none" || s.opacity === "0") return false;
+      const bg = s.backgroundColor;
+      const opaqueBg = bg !== "transparent" && !/rgba?\([^)]*,\s*0\s*\)$/.test(bg);
+      // 只认元素「自己」画出来的东西：纯布局容器会被跳过，继续往下钻
+      const ownsText = [...el.childNodes].some(
+        (n) => n.nodeType === 3 && (n.textContent ?? "").trim().length > 0,
+      );
+      return (
+        opaqueBg ||
+        s.borderBottomWidth !== "0px" ||
+        s.boxShadow !== "none" ||
+        ownsText ||
+        el.tagName === "IMG" ||
+        el.tagName === "SVG" ||
+        el.tagName === "CANVAS"
+      );
+    };
+
+    const bottoms: number[] = [];
+    const collect = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      if (r.width > 0 && r.height > 0 && paints(el)) bottoms.push(r.bottom);
+      for (const kid of el.children) collect(kid);
+    };
+    for (const kid of main.children) collect(kid);
+    const contentBottom = bottoms.length ? Math.max(...bottoms) : rect.top;
+    const scroller = main.parentElement as HTMLElement;
+    return {
+      // >0 表示内容没撑满，这部分会叠加在底部内边距之上
+      gap: Math.round(rect.bottom - padBottom - contentBottom),
+      padBottom: Math.round(padBottom),
+      padLeft: Math.round(padLeft),
+      overflow: Math.round(scroller.scrollHeight - scroller.clientHeight),
+    };
+  });
+
+test.describe("页面底部留白", () => {
+  for (const route of ROUTES) {
+    test(`${route} 的底部留白等于左右内边距`, async ({ page }) => {
+      await openPage(page, route);
+
+      /*
+       * 轮询而不是固定 sleep：入场动画、懒加载 chunk、首屏请求各自落定的时间不一样，
+       * 并发跑的时候更飘。固定等待要么不够（量到过渡中的高度，假失败），要么白等。
+       * 布局真有问题时它会一直不达标，照样失败。
+       */
+      let last = await measure(page);
+      await expect
+        .poll(
+          async () => {
+            last = await measure(page);
+            // 内容超过一屏时由外层滚动，底部不存在多余留白
+            return last.overflow > 1 ? 0 : last.gap;
+          },
+          { timeout: 15_000 },
+        )
+        // 留 2px 给亚像素取整
+        .toBeLessThanOrEqual(2);
+
+      // 四边内边距本来就同源，这里顺带守住它不被单独改坏
+      expect(
+        last.padBottom,
+        `底部留白 ${last.padBottom + last.gap}px，左右 ${last.padLeft}px`,
+      ).toBe(last.padLeft);
+    });
+  }
+});

--- a/features/online-update/SystemUpdateCard.tsx
+++ b/features/online-update/SystemUpdateCard.tsx
@@ -10,7 +10,7 @@ import { useOnlineUpdateContext } from "./OnlineUpdateProvider";
  * lets the single modal render the result. Previously this card duplicated the
  * whole check/apply/subscribe flow and rendered a second modal.
  */
-export function SystemUpdateCard() {
+export function SystemUpdateCard({ className }: { className?: string }) {
   const { t } = useTranslation();
   const context = useOnlineUpdateContext();
 
@@ -29,6 +29,7 @@ export function SystemUpdateCard() {
 
   return (
     <Card
+      className={className}
       title={t("auto_update.system_title")}
       description={t("auto_update.system_description")}
       actions={

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -383,9 +383,9 @@ export function ApiKeyPermissionsPage() {
   );
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col">
       <Card
-        className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
+        className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
         bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
         title={t("api_key_permissions_page.title")}
         description={t("api_key_permissions_page.description")}

--- a/pages/api-keys/ApiKeysPage.tsx
+++ b/pages/api-keys/ApiKeysPage.tsx
@@ -925,7 +925,7 @@ export function ApiKeysPage({
   );
 
   return (
-    <div className={embed ? "flex h-full min-h-0 flex-col" : "space-y-6"}>
+    <div className={embed ? "flex h-full min-h-0 flex-col" : "flex flex-1 flex-col"}>
       {embed ? (
         <div className="flex h-full min-h-0 flex-col">
           <div className="flex shrink-0 items-center justify-end border-b border-slate-100 px-4 py-3 dark:border-white/10">
@@ -935,7 +935,7 @@ export function ApiKeysPage({
         </div>
       ) : (
         <Card
-          className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
+          className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
           bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
           title={
             endUserIdFilter

--- a/pages/auth-files/AuthFilesPage.tsx
+++ b/pages/auth-files/AuthFilesPage.tsx
@@ -847,7 +847,7 @@ export function AuthFilesPage() {
   });
 
   return (
-    <div className="space-y-3">
+    <div className="flex flex-1 flex-col">
       <AuthFilesFilesTab
         fileInputRef={fileInputRef}
         handleUpload={handleUploadAndRefreshQuota}

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1327,7 +1327,7 @@ export function AuthFilesFilesTab({
   return (
     <Card
       padding="none"
-      className="md:flex md:h-[calc(100dvh-113px)] md:min-h-0 md:flex-col md:overflow-hidden"
+      className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
       bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
     >
       <input

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -305,7 +305,7 @@ export function CcSwitchImportSettingsPage() {
   const importBaseUrl = auth?.state.apiBase || detectApiBaseFromLocation();
 
   return (
-    <div className="space-y-6 md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col">
+    <div className="space-y-6 md:flex md:min-h-0 md:flex-1 md:flex-col">
       <div className="flex flex-wrap items-start justify-between gap-3 md:shrink-0">
         <div className="space-y-1">
           <h2 className="text-lg font-semibold tracking-normal text-slate-950 dark:text-white">

--- a/pages/channel-groups/ChannelGroupsPage.tsx
+++ b/pages/channel-groups/ChannelGroupsPage.tsx
@@ -472,7 +472,7 @@ export function ChannelGroupsPage() {
   );
 
   return (
-    <div className="space-y-4 overflow-x-hidden md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col">
+    <div className="space-y-4 overflow-x-hidden md:flex md:min-h-0 md:flex-1 md:flex-col">
       <Card
         className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
         bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"

--- a/pages/config/ConfigPage.tsx
+++ b/pages/config/ConfigPage.tsx
@@ -472,7 +472,7 @@ export function ConfigPage() {
     <div
       className={
         visualLayoutEnabled
-          ? "flex h-[calc(100dvh-112px)] min-h-0 flex-col gap-6 overflow-x-hidden"
+          ? "flex min-h-0 flex-1 flex-col gap-6 overflow-x-hidden"
           : "space-y-6 overflow-x-hidden"
       }
     >

--- a/pages/content-moderation/ContentModerationPage.tsx
+++ b/pages/content-moderation/ContentModerationPage.tsx
@@ -325,9 +325,9 @@ export function ContentModerationPage() {
   );
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col">
       <Card
-        className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
+        className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
         bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
         title={t("content_moderation.title")}
         description={t("content_moderation.description")}

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -734,10 +734,10 @@ export function EndUsersPage() {
 
   return (
     <PermissionGate permission="end_users.read" anyOf={["api_keys.read"]}>
-      {/* Match AI accounts / api-keys card height so top/bottom shell padding stay even on large screens. */}
-      <div className="space-y-6">
+      {/* 页面根撑满外壳，卡片再撑满页面根，底部留白才等于其余三边 */}
+      <div className="flex flex-1 flex-col">
         <Card
-          className="md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:overflow-hidden"
+          className="md:flex md:min-h-0 md:flex-1 md:flex-col md:overflow-hidden"
           bodyClassName="md:flex md:min-h-0 md:flex-1 md:flex-col"
           title={t("end_users.title", { defaultValue: "用户账号" })}
           description={t("end_users.subtitle", {

--- a/pages/logs/LogsPage.tsx
+++ b/pages/logs/LogsPage.tsx
@@ -293,7 +293,7 @@ export function LogsPage() {
   }, [latestTimestamp]);
 
   return (
-    <div className="space-y-6 md:flex md:h-[calc(100dvh-112px)] md:min-h-0 md:flex-col md:space-y-0 md:gap-4 md:overflow-hidden">
+    <div className="space-y-6 md:flex md:min-h-0 md:flex-1 md:flex-col md:space-y-0 md:gap-4 md:overflow-hidden">
       <Tabs value={tab} onValueChange={(next) => setTab(next as typeof tab)}>
         <TabsList>
           <TabsTrigger value="content">{t("logs_page.log_content")}</TabsTrigger>

--- a/pages/models/ModelsPage.tsx
+++ b/pages/models/ModelsPage.tsx
@@ -816,7 +816,7 @@ export function ModelsPage() {
     ) : null;
 
   return (
-    <section className="flex flex-1 flex-col gap-4 md:h-[calc(100dvh-112px)] md:min-h-0 md:overflow-hidden">
+    <section className="flex flex-1 flex-col gap-4 md:min-h-0 md:overflow-hidden">
       <ModelsStatsCards stats={totalStats} totalCost={totalCost} />
 
       <ModelsPageTabs activeTab={activeTab} onTabChange={setActiveTab} />

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -91,7 +91,9 @@ export function ProviderKeyListCard({
     // openKeyEditor(tab, null) action, and two of them on one screen just made
     // the header noisier.
     <Card
-      className="flex h-full min-h-0 flex-col"
+      // 用 flex-1 而不是 h-full：父级高度是 flex 分配出来的，百分比高度在这条链上解析
+      // 不到基准，会回退成内容高度，卡片就缩成一小块、底下空一大片。
+      className="flex min-h-0 flex-1 flex-col"
       bodyClassName="min-h-0 flex flex-1 flex-col"
     >
       {showSkeleton ? (
@@ -117,10 +119,13 @@ export function ProviderKeyListCard({
           ))}
         </div>
       ) : items.length === 0 ? (
-        <EmptyState
-          title={t("providers.no_config")}
-          description={t("providers.no_config_desc")}
-        />
+        // 空态要占住整块卡片区域：不撑满的话卡片只有内容那么高，页面底部会空出一大截
+        <div className="flex min-h-0 flex-1 flex-col justify-center">
+          <EmptyState
+            title={t("providers.no_config")}
+            description={t("providers.no_config_desc")}
+          />
+        </div>
       ) : (
         <div
           data-testid="providers-tab-scroll"

--- a/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.import-export.test.tsx
@@ -248,9 +248,7 @@ describe("ProvidersPage import/export", () => {
     const codexTab = await screen.findByRole("tab", { name: /Codex/ });
     await user.click(codexTab);
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(afterMount + 1),
-    );
+    await waitFor(() => expect(mocks.getCodexConfigs).toHaveBeenCalledTimes(afterMount + 1));
 
     // Re-clicking the active tab must not re-fetch.
     await user.click(codexTab);
@@ -301,9 +299,10 @@ describe("ProvidersPage import/export", () => {
     await user.click(await screen.findByRole("tab", { name: /Codex/ }));
     expect(await screen.findByText("Codex Main")).toBeInTheDocument();
 
+    // 高度由外层 flex 分配，不再写死视口减去某个手工累加的数
     expect(screen.getByTestId("providers-page-shell")).toHaveClass(
-      "h-[calc(100dvh-97px)]",
-      "sm:h-[calc(100dvh-113px)]",
+      "flex-1",
+      "min-h-0",
       "overflow-hidden",
     );
     expect(screen.getByTestId("providers-tab-scroll")).toHaveClass("overflow-y-auto");

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -1221,7 +1221,7 @@ export function ProvidersPage() {
   return (
     <div
       data-testid="providers-page-shell"
-      className="flex h-[calc(100dvh-97px)] min-h-0 flex-col gap-6 overflow-hidden sm:h-[calc(100dvh-113px)]"
+      className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden"
     >
       {canWriteProviders ? (
         <input

--- a/pages/proxies/ProxiesPage.tsx
+++ b/pages/proxies/ProxiesPage.tsx
@@ -137,9 +137,7 @@ export function ProxiesPage() {
     const baseID = draft.id.trim() || slugifyProxyID(draft.name, draft.url);
     const normalized: ProxyPoolEntry = {
       ...draft,
-      id: editingID
-        ? editingID
-        : uniqueProxyID(baseID, entries, editingID),
+      id: editingID ? editingID : uniqueProxyID(baseID, entries, editingID),
       name: draft.name.trim(),
       url: draft.url.trim(),
       description: draft.description?.trim() ?? "",
@@ -384,7 +382,7 @@ export function ProxiesPage() {
   const modalTitle = editingID ? t("proxies.edit_title") : t("proxies.add_title");
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-5 md:h-[calc(100dvh-112px)] md:overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col gap-5 md:overflow-hidden">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <h2 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">

--- a/pages/system/SystemPage.tsx
+++ b/pages/system/SystemPage.tsx
@@ -113,7 +113,7 @@ export function SystemPage() {
   const apiKeyUsageUrl = `${window.location.origin}/manage/apikey-usage`;
 
   return (
-    <div className="min-w-0 space-y-6 overflow-x-hidden">
+    <div className="flex min-w-0 flex-1 flex-col gap-6 overflow-x-hidden">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2.5">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
@@ -175,7 +175,7 @@ export function SystemPage() {
         />
       </div>
 
-      <SystemUpdateCard />
+      <SystemUpdateCard className="flex-1" />
     </div>
   );
 }


### PR DESCRIPTION
## 现象与统计

外层 `<main>` 本来就给了四边等距的内边距（当前 22px），底部之所以明显更宽，是因为页面内容撑不满它的内容盒，多出来的高度全堆在下面。

**逐页量过，不是估的。** 空数据场景（内容最少、最严格）下 21 个路由：

| | 达标 | 不达标 |
|---|---:|---:|
| 修复前 | 2 | **19** |
| 修复后 | **21** | 0 |

多数页面底部留白 39–40px 而左右 22px（接近两倍），`/runtime/system` 差 225px、`/access/ai-providers` 差 313px。线上旧版本用真实数据复测 27 个路由，同样有 18 个不达标，两组数据互相印证。

## 两个根因，都是「没用 flex 表达撑满」

### 1. 百分比高度在这条链上没有基准

`DashboardLayout` 的包装层用 `min-h-full`、`ProviderKeyListCard` 的卡片用 `h-full`，而它们父级的高度是 `min-height` 或 flex 分配出来的，**不是确定值**，百分比解析不到基准就回退成内容高度。

实测：给页面根加上 `flex: 1 1 0%` 后，高度从 653px 变成 671px —— 正好等于 `main` 的内容盒。

### 2. 视口高度魔数

十来处 `h-[calc(100dvh-112px)]` / `-97px` / `-113px`，是 header + padding 手工累加的结果。全局密度收到 90% 之后 header 变 50.4px、padding 变 21.6px，实际只需要 **93.6px**，于是每个页面固定差 **18.4px** —— 和量到的 17–18px 完全对得上。

这类数字的问题不在这次差了多少，而在于**每次尺寸调整都会让它们同时失准**，所以一并摘掉。

## 改法

- 包装层与各页面根一律改用 `flex-1` / `min-h-0` 表达撑满，不再依赖百分比或魔数
- 包装层加 `[&>*:only-child]:flex-1` 兜底，新页面不必自己记得撑满；限定 `:only-child` 是因为返回多个兄弟节点的页面各有布局意图，平分高度会把它们改坏。`flex-basis` 会盖掉页面根自己写的 `height`，这也是各页面能摘掉魔数的前提
- 顺带修掉 providers 空态没撑满的问题（卡片只有内容那么高，底下空 313px）

不给包装层加 `min-h-0`：保留 `min-height:auto`，内容超过一屏时容器仍会被撑开、交给外层滚动；加了反而会把长页面裁掉。`/dashboard`、`/runtime/monitor` 这类长页面的滚动行为已验证不受影响。

## 一个需要你拍板的取舍

`/runtime/system` 是信息卡片流（标题 + InfoCard 网格 + 更新卡片），**没有单一主容器**。要让它底部对齐，只能让最后一块撑满 —— 代价是「Docker 更新」卡片变成一个内容只占顶部一条的大盒子。

我选了撑满，因为页面有完整的视觉边界总比下半页纯空白好，也和其余页面卡片撑满的观感一致。**如果你觉得那个空盒子更难看，说一声我改回自然高度**（那样它的底部留白就会保持现状）。

## 验证

新增 `e2e/page-bottom-spacing.spec.ts`，覆盖 21 个路由。它做了两件容易被忽略的事：

- **量的是真正可见内容的底边**，不是最外层包装层的底边。包装层撑满了不等于页面内容撑满 —— 它是透明的，里面矮一截时用户照样看到更宽的底部留白。第一版就是栽在这里，宽松测量下 21 个全绿，改严之后才暴露出 10 个真问题
- **轮询到稳定而不是固定 sleep**。入场动画、懒加载 chunk、首屏请求各自落定的时间不同，并发跑更飘；固定等待会量到过渡中的高度产生假失败

对照验证：临时回退修复后该测试 21 个只剩 2 个通过，确认它确实能抓到问题。

```
./scripts/ci-pr.sh 全绿
  lint / design:check / boundary:imports / size:check / surface:check / audit:deps
  test:ci  1133 passed (155 files)
  build / bundle:diff PASS / critical e2e 12 passed
全量 e2e  86 passed
```

## 未纳入本次范围

页面**内部**表格视口还有约 15 处 `h-[calc(100dvh-300px)]` 之类的魔数。它们在桌面端已被 `md:h-auto md:flex-1` 覆盖、不影响底部留白，只在移动端生效；要摘掉需要给移动端也补完整 flex 链，改动面和风险都明显更大，留作后续。

🤖 Generated with [Claude Code](https://claude.com/claude-code)