### PR TITLE
feat(ai-accounts): 状态筛选支持按「已启用」过滤账号

### DIFF
--- a/e2e/auth-files-status-filter.spec.ts
+++ b/e2e/auth-files-status-filter.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// 两启用一禁用：既验证「已启用」选项存在，也验证它确实按 disabled 的补集过滤。
+const authFiles = [
+  { idx: "alias-a", disabled: false },
+  { idx: "alias-b", disabled: true },
+  { idx: "alias-c", disabled: false },
+].map((entry, i) => ({
+  id: `auth-${entry.idx}`,
+  name: `account-${i}@example.com.json`,
+  label: `account-${i}@example.com`,
+  type: "codex",
+  provider: "codex",
+  account_type: "oauth",
+  auth_index: entry.idx,
+  auth_subject_id: `sub-${entry.idx}`,
+  disabled: entry.disabled,
+  size: 1024,
+  modified: 1784534400000 + i,
+}));
+
+const openPage = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+    localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+  });
+  await page.route("**/v0/management/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    if (path.endsWith("/ai-accounts/status")) return json({ items: [] });
+    if (path.includes("/ai-accounts/status-refresh"))
+      return json({
+        job_id: "j",
+        state: "completed",
+        total: 0,
+        completed: 0,
+        failed: 0,
+        results: [],
+      });
+    if (path.endsWith("/auth-files")) return json({ files: authFiles });
+    if (path.endsWith("/usage/entity-stats")) return json({ source: [], auth_index: [] });
+    if (path.endsWith("/usage/auth-file-trend")) return json({ points: [] });
+    if (path.endsWith("/config")) return json({ config: {} });
+    if (path.endsWith("/update/check")) return json({ has_update: false });
+    return json({ items: [] });
+  });
+  await page.goto("/#/access/ai-accounts");
+  await expect(page.getByTestId("auth-files-cards")).toBeVisible();
+};
+
+test("status filter can narrow AI accounts down to the enabled ones", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openPage(page);
+
+  const cards = page.getByTestId("auth-files-cards").locator("section");
+  await expect(cards).toHaveCount(3);
+
+  await page.getByRole("combobox", { name: "状态" }).click();
+  const enabledOption = page.getByRole("option", { name: /已启用/ });
+  await expect(enabledOption).toBeVisible();
+  await enabledOption.click();
+
+  await expect(cards).toHaveCount(2);
+  await expect(page.getByText("account-1@example.com")).toHaveCount(0);
+
+  await page.screenshot({ path: "/tmp/auth-files-status-enabled.png", fullPage: false });
+});

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -92,22 +92,20 @@ export type QuotaPreviewMode = "5h" | "week";
 export type QuotaAutoRefreshMs = 0 | 60000 | 300000;
 export type FilesViewMode = "table" | "cards";
 export type AuthFilesModelOwnerGroupMap = Record<string, string>;
-export type AuthFileStatusFilter =
-  | "all"
-  | "http-429"
-  | "http-auth"
-  | "http-5xx"
-  | "other-error"
-  | "disabled";
-
-export const AUTH_FILE_STATUS_FILTERS: AuthFileStatusFilter[] = [
+/**
+ * 下拉选项顺序即本数组顺序；类型由数组派生，避免选项与联合类型两处各自漂移。
+ * "enabled" / "disabled" 是调度开关的互补两面，其余桶是错误信号，可与两者并存。
+ */
+export const AUTH_FILE_STATUS_FILTERS = [
   "all",
   "http-429",
   "http-auth",
   "http-5xx",
   "other-error",
+  "enabled",
   "disabled",
-];
+] as const;
+export type AuthFileStatusFilter = (typeof AUTH_FILE_STATUS_FILTERS)[number];
 
 export type AuthFilesUiState = {
   tab?: "files" | "excluded" | "alias";
@@ -1035,7 +1033,8 @@ const hasRestrictionErrorSignal = (restriction: AuthFileRestriction): boolean =>
 
 export const resolveAuthFileStatusBuckets = (file: AuthFileItem): Set<AuthFileStatusFilter> => {
   const buckets = new Set<AuthFileStatusFilter>();
-  if (file.disabled === true) buckets.add("disabled");
+  // disabled 缺省表示账号仍参与调度，故「启用」取 disabled 的补集；错误桶只描述上游返回，可并存。
+  buckets.add(file.disabled === true ? "disabled" : "enabled");
   const claudeOAuthHealth = resolveClaudeOAuthHealth(file);
 
   const restrictions = getAuthLevelRestrictions(file);

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -589,6 +589,7 @@
     "status_filter_http-auth": "401 / 403",
     "status_filter_http-5xx": "5xx",
     "status_filter_other-error": "Other errors",
+    "status_filter_enabled": "Enabled",
     "status_filter_disabled": "Disabled",
     "batch_deleted_selected": "Deleted {{count}} auth files",
     "batch_delete_partial": "Bulk delete finished: {{success}} succeeded, {{failed}} failed",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -714,6 +714,7 @@
     "status_filter_http-auth": "401 / 403",
     "status_filter_http-5xx": "5xx",
     "status_filter_other-error": "Другие ошибки",
+    "status_filter_enabled": "Включённые",
     "status_filter_disabled": "Отключённые",
     "batch_deleted_selected": "Удалено файлов авторизации: {{count}}",
     "batch_delete_partial": "Пакетное удаление завершено: успешных {{success}}, ошибок {{failed}}",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -597,6 +597,7 @@
     "status_filter_http-auth": "401 / 403",
     "status_filter_http-5xx": "5xx",
     "status_filter_other-error": "其他错误",
+    "status_filter_enabled": "已启用",
     "status_filter_disabled": "已禁用",
     "batch_deleted_selected": "已删除 {{count}} 个认证文件",
     "batch_delete_partial": "批量删除完成，成功 {{success}} 个，失败 {{failed}} 个",

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -3,9 +3,11 @@ import { useState, type PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import {
+  AUTH_FILE_STATUS_FILTERS,
   AUTH_FILES_DATA_CACHE_KEY,
   AUTH_FILES_DATA_CACHE_TTL_MS,
   AUTH_FILES_UI_STATE_KEY,
+  authFileMatchesStatusFilter,
   buildUsageIndex,
   DEFAULT_CACHE_TENANT_ID,
   pickQuotaPreviewItem,
@@ -1177,7 +1179,8 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
     expect(resolveClaudeOAuthHealthBadges(file, Date.parse("2026-06-23T08:00:00.000Z"))).toEqual(
       [],
     );
-    expect(Array.from(resolveAuthFileStatusBuckets(file))).toEqual([]);
+    // 未被禁用的账号始终命中 enabled 桶，除此之外不应出现任何错误桶。
+    expect(Array.from(resolveAuthFileStatusBuckets(file))).toEqual(["enabled"]);
   });
 
   test("classifies Claude OAuth health into auth and 429 status buckets", () => {
@@ -1202,9 +1205,44 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
     } satisfies AuthFileItem;
 
     expect(Array.from(resolveAuthFileStatusBuckets(file)).sort()).toEqual([
+      "enabled",
       "http-429",
       "http-auth",
     ]);
+  });
+
+  test("classifies auth files into enabled / disabled status buckets", () => {
+    const enabledFile = {
+      name: "codex-enabled.json",
+      type: "codex",
+      provider: "codex",
+    } satisfies AuthFileItem;
+    const disabledFile = {
+      name: "codex-disabled.json",
+      type: "codex",
+      provider: "codex",
+      disabled: true,
+    } satisfies AuthFileItem;
+    // 启用但上游报错的账号：错误桶不该把它挤出「启用」筛选。
+    const enabledWithErrorFile = {
+      name: "codex-rate-limited.json",
+      type: "codex",
+      provider: "codex",
+      restrictions: [{ scope: "auth", http_status: 429, reason: "quota" }],
+    } satisfies AuthFileItem;
+
+    expect(Array.from(resolveAuthFileStatusBuckets(enabledFile))).toEqual(["enabled"]);
+    expect(Array.from(resolveAuthFileStatusBuckets(disabledFile))).toEqual(["disabled"]);
+    expect(Array.from(resolveAuthFileStatusBuckets(enabledWithErrorFile)).sort()).toEqual([
+      "enabled",
+      "http-429",
+    ]);
+
+    expect(authFileMatchesStatusFilter(enabledFile, "enabled")).toBe(true);
+    expect(authFileMatchesStatusFilter(enabledWithErrorFile, "enabled")).toBe(true);
+    expect(authFileMatchesStatusFilter(disabledFile, "enabled")).toBe(false);
+    expect(authFileMatchesStatusFilter(disabledFile, "disabled")).toBe(true);
+    expect(AUTH_FILE_STATUS_FILTERS).toContain("enabled");
   });
 
   test("prefers current auth-file plan metadata over cached quota plan", () => {
@@ -1382,6 +1420,48 @@ test("shows auth-level quota recovery records as 429 restriction badges", () => 
       expect(result.current.selectableFilteredFiles.map((file) => file.name)).toEqual([
         "alpha.json",
         "beta.json",
+      ]);
+    });
+  });
+
+  test("counts and filters enabled auth files", async () => {
+    const files = [
+      { name: "alpha.json", type: "codex", provider: "codex" },
+      { name: "beta.json", type: "codex", provider: "codex", disabled: true },
+      {
+        name: "gamma.json",
+        type: "codex",
+        provider: "codex",
+        restrictions: [{ scope: "auth", http_status: 429, reason: "quota" }],
+      },
+    ] as AuthFileItem[];
+
+    const { result } = renderHook(
+      () => {
+        const [page, setPage] = useState(1);
+        const [selectedFileNames, setSelectedFileNames] = useState<string[]>([]);
+        return useAuthFilesListState({
+          files,
+          filter: "all",
+          tagFilter: "",
+          statusFilter: "enabled",
+          search: "",
+          page,
+          pageSize: 10,
+          setPage,
+          selectedFileNames,
+          setSelectedFileNames,
+        });
+      },
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.statusFilterCounts.enabled).toBe(2);
+      expect(result.current.statusFilterCounts.disabled).toBe(1);
+      expect(result.current.filteredFiles.map((file) => file.name)).toEqual([
+        "alpha.json",
+        "gamma.json",
       ]);
     });
   });

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -10,7 +10,7 @@
     "features/request-log-viewer/requestLogsShared.tsx": 1020,
     "features/routing-config-editor/RoutingConfigEditor.tsx": 2044,
     "features/visual-config-editor/useVisualConfig.ts": 957,
-    "packages/domain/src/auth-files/authFiles.ts": 2199,
+    "packages/domain/src/auth-files/authFiles.ts": 2198,
     "packages/domain/src/ccswitch/ccswitchImport.ts": 845,
     "packages/ui/src/data-table/DataTable.tsx": 2632,
     "pages/api-key-lookup/ApiKeyLookupPage.tsx": 1743,


### PR DESCRIPTION
## 背景

kittors/CliRelay#864：接入与凭证 → AI 账号的状态筛选只有错误类桶和「已禁用」，没法反向筛出仍在参与调度的账号。

## 改动

- `resolveAuthFileStatusBuckets` 按 `disabled` 的补集补出 `enabled` 桶。错误桶描述的是上游返回、不是调度开关，所以两者并存：一个启用但被 429 的账号同时命中「已启用」和「429」，不会因为报错就从启用视图消失。
- `AUTH_FILE_STATUS_FILTERS` 改成 `as const` 并由它派生 `AuthFileStatusFilter`，下拉选项与联合类型不再两处各自维护。顺带把 `authFiles.ts` 压到结构债基线以下（2199 → 2198），基线同步下调一行。
- 三语言补齐 `status_filter_enabled`（已启用 / Enabled / Включённые）。

UI 层无需改动：状态下拉本来就遍历 `AUTH_FILE_STATUS_FILTERS` 渲染，计数也走同一套桶。

## 验证

本地在 `codeProxy/` 根目录执行完整 `./scripts/ci-pr.sh`，退出码 0：lint / design:check / boundary:imports / size:check / surface:check / audit:deps / `test:ci`（155 文件 1135 用例全绿）/ build / bundle:diff / @critical e2e 12 passed。

新增覆盖：

- 域层单测：启用、禁用、以及「启用 + 429」三种账号的桶分类与 `authFileMatchesStatusFilter` 结果。
- hook 单测：`statusFilterCounts.enabled/disabled` 计数与 `statusFilter="enabled"` 的过滤结果。
- 新增 `e2e/auth-files-status-filter.spec.ts`：真实下拉里选「已启用」，3 个账号收敛到 2 个（`bunx playwright test` 单跑通过）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)