### PR TITLE
fix(ip-access): stop the page overflowing, and edit trusted proxies in the panel

### DIFF
--- a/packages/api-client/src/endpoints/ip-access.ts
+++ b/packages/api-client/src/endpoints/ip-access.ts
@@ -60,6 +60,10 @@ export interface IpAccessStatus {
   dropped_events?: number;
   /** Addresses no rule may ever deny (host, reverse proxy, egress proxies). */
   protected?: ProtectedEntry[];
+  /** Reverse proxies whose forwarding headers are believed. */
+  trusted_proxies?: string[];
+  /** Where that list came from: panel-managed, config.yaml, or nothing. */
+  trusted_proxies_source?: "database" | "config" | "none";
 }
 
 export type AutoBanMode = "off" | "observe" | "enforce";
@@ -84,6 +88,12 @@ export interface ProtectionPolicy {
   lockdown: boolean;
   auto_ban: AutoBanPolicy;
   throttle: ThrottleOverride;
+  /**
+   * Reverse proxies whose forwarding headers may be believed. Stored in the
+   * database so it can be fixed from the panel without editing config.yaml and
+   * restarting; leaving it empty falls back to the configured value.
+   */
+  trusted_proxies?: string[];
 }
 
 /** Effective limits as the running limiter sees them, not as configured. */

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5394,6 +5394,14 @@
     "protected_loopback": "Loopback",
     "protected_local_address": "Host address",
     "protected_trusted_proxy": "Reverse proxy",
-    "protected_outbound_proxy": "Egress proxy"
+    "protected_outbound_proxy": "Egress proxy",
+    "section_trusted_proxies": "Trusted reverse proxies",
+    "section_trusted_proxies_desc": "Only forwarding headers from these addresses are believed when recovering the real client IP. Stored in the database, so edits apply immediately without a restart.",
+    "proxies_empty": "None configured, so the server only sees the address it is talking to — neither the IP list nor per-IP throttling can tell clients apart.",
+    "proxies_from_config": "Currently using the value from config.yaml: {{list}}. Adding one here takes precedence.",
+    "proxy_add": "Add",
+    "proxy_remove": "Remove {{cidr}}",
+    "proxy_add_detected": "Add detected {{cidr}}",
+    "banner_fix_hint": "Add it on the Protection tab to take effect"
   }
 }

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -3285,6 +3285,14 @@
     "protected_loopback": "Loopback",
     "protected_local_address": "Host address",
     "protected_trusted_proxy": "Reverse proxy",
-    "protected_outbound_proxy": "Egress proxy"
+    "protected_outbound_proxy": "Egress proxy",
+    "section_trusted_proxies": "Trusted reverse proxies",
+    "section_trusted_proxies_desc": "Only forwarding headers from these addresses are believed when recovering the real client IP. Stored in the database, so edits apply immediately without a restart.",
+    "proxies_empty": "None configured, so the server only sees the address it is talking to — neither the IP list nor per-IP throttling can tell clients apart.",
+    "proxies_from_config": "Currently using the value from config.yaml: {{list}}. Adding one here takes precedence.",
+    "proxy_add": "Add",
+    "proxy_remove": "Remove {{cidr}}",
+    "proxy_add_detected": "Add detected {{cidr}}",
+    "banner_fix_hint": "Add it on the Protection tab to take effect"
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -5408,6 +5408,14 @@
     "protected_loopback": "本机回环",
     "protected_local_address": "服务器地址",
     "protected_trusted_proxy": "反向代理",
-    "protected_outbound_proxy": "出站代理"
+    "protected_outbound_proxy": "出站代理",
+    "section_trusted_proxies": "可信反向代理",
+    "section_trusted_proxies_desc": "只有来自这些地址的转发头才会被采信，用于还原真实客户端 IP。配置保存在数据库，改完立即生效、无需重启。",
+    "proxies_empty": "尚未配置，服务端只能看到直连地址——IP 名单与按 IP 限流都无法区分真实来源。",
+    "proxies_from_config": "当前沿用配置文件中的值：{{list}}。在此添加后将以这里为准。",
+    "proxy_add": "添加",
+    "proxy_remove": "移除 {{cidr}}",
+    "proxy_add_detected": "添加检测到的 {{cidr}}",
+    "banner_fix_hint": "到「防护策略」页一键添加即可生效"
   }
 }

--- a/pages/ip-access/AccessRulesTab.tsx
+++ b/pages/ip-access/AccessRulesTab.tsx
@@ -276,7 +276,7 @@ export function AccessRulesTab({
         </div>
       </div>
 
-      <div className="relative min-h-[420px] px-5">
+      <div className="relative min-h-0 flex-1 overflow-hidden px-5">
         <DataTable<IpAccessRule>
           tableId="ip-access-rules"
           rows={items}
@@ -284,6 +284,8 @@ export function AccessRulesTab({
           rowKey={(item) => item.id}
           loading={loading}
           virtualize={false}
+          height="h-full"
+          minHeight="min-h-full"
           minWidth="min-w-[1040px]"
           emptyText={t("ip_access.no_rules")}
           showAllLoadedMessage={false}

--- a/pages/ip-access/AttemptsTab.tsx
+++ b/pages/ip-access/AttemptsTab.tsx
@@ -196,7 +196,7 @@ export function AttemptsTab({
         </div>
       </div>
 
-      <div className="relative min-h-[420px] px-5">
+      <div className="relative min-h-0 flex-1 overflow-hidden px-5">
         <DataTable<AuthAttempt>
           tableId="ip-access-attempts"
           rows={items}
@@ -204,6 +204,8 @@ export function AttemptsTab({
           rowKey={(item) => String(item.id)}
           loading={loading}
           virtualize={false}
+          height="h-full"
+          minHeight="min-h-full"
           minWidth="min-w-[1100px]"
           emptyText={t("ip_access.no_attempts")}
           showAllLoadedMessage={false}

--- a/pages/ip-access/IpAccessPage.tsx
+++ b/pages/ip-access/IpAccessPage.tsx
@@ -63,10 +63,10 @@ export function IpAccessPage() {
   }, [loadStatus]);
 
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex min-h-0 flex-1 flex-col gap-3">
       <TrustBanner status={status} />
 
-      <div className="flex flex-col rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70 dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.22)]">
+      <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-black/[0.06] bg-white shadow-[0_1px_2px_rgb(15_23_42_/_0.035)] dark:border-white/[0.06] dark:bg-neutral-950/70 dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.22)]">
         <div className="flex flex-wrap items-center justify-between gap-3 px-5 pt-5 pb-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h2 className="flex items-center gap-2 text-base font-semibold text-slate-950 dark:text-white">
@@ -127,7 +127,7 @@ export function IpAccessPage() {
             </TabsList>
           </div>
 
-          <TabsContent value="overview">
+          <TabsContent value="overview" className="flex min-h-0 flex-1 flex-col">
             <ThreatOverviewTab
               refreshToken={refreshToken}
               onBan={(cidr) => openRuleForm(cidr, "deny")}
@@ -136,7 +136,7 @@ export function IpAccessPage() {
             />
           </TabsContent>
 
-          <TabsContent value="rules">
+          <TabsContent value="rules" className="flex min-h-0 flex-1 flex-col">
             <AccessRulesTab
               pendingRule={pendingRule}
               onPendingRuleHandled={() => setPendingRule(null)}
@@ -146,11 +146,11 @@ export function IpAccessPage() {
             />
           </TabsContent>
 
-          <TabsContent value="policy">
+          <TabsContent value="policy" className="flex min-h-0 flex-1 flex-col">
             <ProtectionPolicyTab status={status} onPolicySaved={afterRulesChanged} />
           </TabsContent>
 
-          <TabsContent value="attempts">
+          <TabsContent value="attempts" className="flex min-h-0 flex-1 flex-col">
             <AttemptsTab ipFilter={inspectIp} refreshToken={refreshToken} />
           </TabsContent>
         </Tabs>

--- a/pages/ip-access/ProtectionPolicyTab.tsx
+++ b/pages/ip-access/ProtectionPolicyTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Save } from "lucide-react";
+import { Save, Wand2, X } from "lucide-react";
 import {
   ipAccessApi,
   type AutoBanMode,
@@ -30,6 +30,7 @@ export function ProtectionPolicyTab({ status, onPolicySaved }: ProtectionPolicyT
   const [throttle, setThrottle] = useState<ThrottleScopeView[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [proxyDraft, setProxyDraft] = useState("");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -80,8 +81,103 @@ export function ProtectionPolicyTab({ status, onPolicySaved }: ProtectionPolicyT
 
   const lockdownBlocked = !status?.trusted || status?.self_allowed === false;
 
+  const proxies = policy.trusted_proxies ?? [];
+
+  const addProxy = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed || proxies.includes(trimmed)) return;
+    setPolicy({ ...policy, trusted_proxies: [...proxies, trimmed] });
+  };
+
   return (
-    <div className="flex flex-col gap-4 border-t border-slate-100 px-5 py-4 dark:border-white/8">
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto border-t border-slate-100 px-5 py-4 dark:border-white/8">
+      {/* First, because nothing below it takes effect until this is right. */}
+      <Section
+        title={t("ip_access.section_trusted_proxies")}
+        description={t("ip_access.section_trusted_proxies_desc")}
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          {proxies.length === 0 ? (
+            <span className="text-xs text-slate-500 dark:text-white/50">
+              {status?.trusted_proxies_source === "config"
+                ? t("ip_access.proxies_from_config", {
+                    list: (status.trusted_proxies ?? []).join(", "),
+                  })
+                : t("ip_access.proxies_empty")}
+            </span>
+          ) : (
+            proxies.map((proxy) => (
+              <span
+                key={proxy}
+                className="inline-flex items-center gap-1 rounded-full bg-slate-100 py-0.5 pr-1 pl-2 font-mono text-xs text-slate-700 dark:bg-white/10 dark:text-white/80"
+              >
+                {proxy}
+                <PermissionGate permission="platform.ip_access.write">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setPolicy({
+                        ...policy,
+                        trusted_proxies: proxies.filter((item) => item !== proxy),
+                      })
+                    }
+                    aria-label={t("ip_access.proxy_remove", { cidr: proxy })}
+                    className="inline-flex h-4 w-4 items-center justify-center rounded-full transition hover:bg-black/10 dark:hover:bg-white/15"
+                  >
+                    <X size={11} aria-hidden="true" />
+                  </button>
+                </PermissionGate>
+              </span>
+            ))
+          )}
+        </div>
+        <PermissionGate permission="platform.ip_access.write">
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <div className="w-full min-[480px]:w-[220px]">
+              <TextInput
+                value={proxyDraft}
+                onChange={(event) => setProxyDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addProxy(proxyDraft);
+                    setProxyDraft("");
+                  }
+                }}
+                placeholder="104.194.69.137 / 10.0.0.0/24"
+                size="sm"
+                className="font-mono"
+              />
+            </div>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!proxyDraft.trim()}
+              onClick={() => {
+                addProxy(proxyDraft);
+                setProxyDraft("");
+              }}
+            >
+              {t("ip_access.proxy_add")}
+            </Button>
+            {status && !status.trusted && status.suggested_trusted_proxies?.[0] ? (
+              // The one action that turns this feature on, offered where the
+              // problem is visible instead of as a config snippet to go paste.
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => addProxy(status.suggested_trusted_proxies?.[0] ?? "")}
+              >
+                <Wand2 size={14} />
+                {t("ip_access.proxy_add_detected", {
+                  cidr: status.suggested_trusted_proxies[0],
+                })}
+              </Button>
+            ) : null}
+          </div>
+        </PermissionGate>
+      </Section>
+
       <Section
         title={t("ip_access.section_lockdown")}
         description={t("ip_access.section_lockdown_desc")}

--- a/pages/ip-access/ThreatOverviewTab.tsx
+++ b/pages/ip-access/ThreatOverviewTab.tsx
@@ -184,7 +184,7 @@ export function ThreatOverviewTab({
         </div>
       </div>
 
-      <div className="relative min-h-[420px] px-5 pb-4">
+      <div className="relative min-h-0 flex-1 overflow-hidden px-5">
         <DataTable<AuthSourceSummary>
           tableId="ip-access-threat-overview"
           rows={items}
@@ -192,6 +192,8 @@ export function ThreatOverviewTab({
           rowKey={(item) => item.ip_prefix}
           loading={loading}
           virtualize={false}
+          height="h-full"
+          minHeight="min-h-full"
           minWidth="min-w-[900px]"
           emptyText={t("ip_access.no_threats")}
           showAllLoadedMessage={false}

--- a/pages/ip-access/TrustBanner.tsx
+++ b/pages/ip-access/TrustBanner.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, Copy, ShieldAlert, TriangleAlert } from "lucide-react";
+import { ShieldAlert, TriangleAlert } from "lucide-react";
 import type { IpAccessStatus } from "@code-proxy/api-client";
 
 /**
@@ -8,29 +7,14 @@ import type { IpAccessStatus } from "@code-proxy/api-client";
  *
  * The state it reports is genuinely important — with trusted-proxies unset every
  * rule is stored, listed and enforces nothing — but importance is not a licence
- * to occupy a quarter of the viewport on every visit. The fix is a single
- * copyable config line, so that is what the banner shows; the reasoning lives in
- * the tooltip and the docs.
+ * to occupy a quarter of the viewport on every visit. The remedy is now a button
+ * on the Protection tab rather than a config snippet to go paste, so the banner
+ * only has to point at it.
  */
 export function TrustBanner({ status }: { status: IpAccessStatus | null }) {
   const { t } = useTranslation();
-  const [copied, setCopied] = useState(false);
 
   if (!status) return null;
-
-  const suggestion = status.suggested_trusted_proxies?.[0] ?? "";
-  const configLine = suggestion ? `trusted-proxies: ["${suggestion}"]` : "";
-
-  const copySuggestion = async () => {
-    if (!configLine) return;
-    try {
-      await navigator.clipboard.writeText(configLine);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard access can be denied; the line stays selectable on screen.
-    }
-  };
 
   if (!status.storage_available) {
     return (
@@ -47,21 +31,7 @@ export function TrustBanner({ status }: { status: IpAccessStatus | null }) {
         <span className="text-xs opacity-80">
           {t("ip_access.banner_untrusted_hint", { ip: status.client_ip || "-" })}
         </span>
-        {configLine ? (
-          <>
-            <code className="rounded-lg bg-black/5 px-2 py-0.5 font-mono text-xs dark:bg-white/10">
-              {configLine}
-            </code>
-            <button
-              type="button"
-              onClick={copySuggestion}
-              className="inline-flex items-center gap-1 rounded-lg px-1.5 py-0.5 text-xs font-medium transition hover:bg-black/5 dark:hover:bg-white/10"
-            >
-              {copied ? <Check size={12} aria-hidden="true" /> : <Copy size={12} aria-hidden="true" />}
-              {copied ? t("ip_access.copied") : t("ip_access.copy_config")}
-            </button>
-          </>
-        ) : null}
+        <span className="text-xs opacity-80">{t("ip_access.banner_fix_hint")}</span>
       </Banner>
     );
   }

--- a/pages/ip-access/__tests__/IpAccessPage.test.tsx
+++ b/pages/ip-access/__tests__/IpAccessPage.test.tsx
@@ -82,7 +82,9 @@ describe("TrustBanner", () => {
       />,
     );
     expect(screen.getByText("ip_access.banner_untrusted")).toBeInTheDocument();
-    expect(screen.getByText('trusted-proxies: ["172.17.0.1/32"]')).toBeInTheDocument();
+    // The remedy is a button on the Protection tab now, so the banner points there
+    // instead of printing a config snippet to paste.
+    expect(screen.getByText("ip_access.banner_fix_hint")).toBeInTheDocument();
   });
 
   test("stays silent when enforcement is healthy", () => {


### PR DESCRIPTION
## 起因

两个问题，都是我造成的。

**底部内容溢出窗口。** 上一轮我把页面根改成了自然流，结果它脱离了布局的高度链：内容直接冲出窗口底部、没有留白，而其他页面底部留白都与另外三边相等。

现在卡片重新占据剩余高度，每个 Tab 在自己的窗格内滚动，外框固定，间距完全由 layout 提供——**横幅出现或消失都不影响**。

实测两种状态：底部间距 22px，左右各 22px，文档零溢出。

**可信代理只能改配置文件。** 所以横幅能做的只有打印一段配置让人去粘贴 + 重启。现在「防护策略」页可以直接编辑这个列表（存数据库），检测到的代理地址提供一键添加，横幅只负责指向它。该分区放在该页最上方，因为它不对，下面所有设置都不生效。

## 验证

- `lint` / `design:check` / `boundary` / `size` / `surface` 全过
- `test:ci`：**1148 通过**
- `build` + `bundle:diff`：PASS
- 用 Playwright 在真实页面上量化验证溢出与四边间距（两种横幅状态）

🤖 Generated with [Claude Code](https://claude.com/claude-code)