### PR TITLE
fix(ai-accounts): 额度为 $0.00 / $0.00 时不再占一行

### DIFF
--- a/e2e/auth-files-zero-money-meta.spec.ts
+++ b/e2e/auth-files-zero-money-meta.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// xAI reports an unfunded balance as "$0.00 / $0.00". The card used to print it
+// next to the countdown, spending a line to say the account has no budget out of
+// no budget. A funded balance must still show.
+const authFiles = [
+  {
+    id: "auth-alias-a",
+    name: "grok-zero@example.com.json",
+    label: "grok-zero@example.com",
+    type: "xai",
+    provider: "xai",
+    account_type: "oauth",
+    auth_index: "alias-a",
+    auth_subject_id: "sub-alias-a",
+    disabled: false,
+    size: 1024,
+    modified: 1784534400000,
+  },
+];
+
+const resetAt = new Date(Date.now() + 20 * 86_400_000).toISOString();
+const observedAt = new Date().toISOString();
+
+const statusItems = [
+  {
+    auth_index: "alias-a",
+    auth_subject_id: "sub-alias-a",
+    provider: "xai",
+    status_scope: "shared_subject",
+    subject_scope: "shared",
+    share_eligible: true,
+    current_tenant_binding_count: 1,
+    refresh_state: "success",
+    health_status: "ok",
+    quotas: [
+      {
+        quota_key: "monthly_credits",
+        quota_label: "xai_quota.monthly_credits",
+        percent: 100,
+        reset_at: resetAt,
+        window_seconds: 2592000,
+        meta: "$0.00 / $0.00",
+        observed_at: observedAt,
+      },
+      {
+        quota_key: "pay_as_you_go",
+        quota_label: "xai_quota.pay_as_you_go",
+        percent: 40,
+        reset_at: resetAt,
+        window_seconds: 2592000,
+        meta: "$12.50 / $50.00",
+        observed_at: observedAt,
+      },
+    ],
+    version: 4,
+    upstream_checked_at: observedAt,
+    quota_observed_at: observedAt,
+    updated_at: observedAt,
+  },
+];
+
+const openPage = async (page: Page) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "code-proxy-admin-auth",
+      JSON.stringify({
+        apiBase: "http://127.0.0.1:8317",
+        managementKey: "test-management-key",
+        rememberPassword: true,
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+      }),
+    );
+    localStorage.setItem("authFilesPage.filesViewMode.v1", JSON.stringify("cards"));
+    localStorage.setItem("authFilesPage.quotaAutoRefreshMs.v1", JSON.stringify(0));
+    localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+  });
+  await page.route("**/v0/management/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    if (path.endsWith("/ai-accounts/status")) return json({ items: statusItems });
+    if (path.includes("/ai-accounts/status-refresh"))
+      return json({ job_id: "j", state: "completed", total: 1, completed: 1, failed: 0, results: [] });
+    if (path.endsWith("/auth-files")) return json({ files: authFiles });
+    if (path.endsWith("/usage/entity-stats")) return json({ source: [], auth_index: [] });
+    if (path.endsWith("/usage/auth-file-trend")) return json({ points: [] });
+    if (path.endsWith("/config")) return json({ config: {} });
+    if (path.endsWith("/update/check")) return json({ has_update: false });
+    return json({ items: [] });
+  });
+  await page.goto("/#/access/ai-accounts");
+  await expect(page.getByTestId("auth-files-cards")).toBeVisible();
+};
+
+test("an all-zero balance is dropped while a funded one still shows", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openPage(page);
+
+  const card = page.getByTestId("auth-files-cards").locator("section").first();
+  await expect(card.getByText("$12.50 / $50.00")).toBeVisible();
+  await expect(card.getByText("$0.00 / $0.00")).toHaveCount(0);
+  // The countdown that shared the line stays.
+  await expect(card.getByText(/重置/).first()).toBeVisible();
+
+  await page.screenshot({ path: "/tmp/auth-files-zero-money.png", fullPage: false });
+});

--- a/features/quota-preview/__tests__/quota-meta.test.ts
+++ b/features/quota-preview/__tests__/quota-meta.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+  isZeroMoneyQuotaMeta,
+  quotaMetaHasMoney,
+  resolveDisplayableQuotaMeta,
+} from "../quota-meta";
+
+describe("resolveDisplayableQuotaMeta", () => {
+  test("keeps a funded balance", () => {
+    expect(resolveDisplayableQuotaMeta("$40.00 / $50.00")).toBe("$40.00 / $50.00");
+  });
+
+  // xAI reports an unfunded balance as "$0.00 / $0.00", which occupied a line on
+  // the card while saying nothing the countdown beside it did not.
+  test.each(["$0.00 / $0.00", "$0 / $0", "$0.000 / $0.00", "$0.00/$0.00"])(
+    "drops the all-zero balance %s",
+    (meta) => {
+      expect(isZeroMoneyQuotaMeta(meta)).toBe(true);
+      expect(resolveDisplayableQuotaMeta(meta)).toBeNull();
+    },
+  );
+
+  test("keeps a balance that is only partly spent down to zero", () => {
+    expect(resolveDisplayableQuotaMeta("$0.00 / $50.00")).toBe("$0.00 / $50.00");
+    expect(isZeroMoneyQuotaMeta("$0.00 / $50.00")).toBe(false);
+  });
+
+  test("handles thousands separators", () => {
+    expect(resolveDisplayableQuotaMeta("$0.00 / $1,200.00")).toBe("$0.00 / $1,200.00");
+    expect(isZeroMoneyQuotaMeta("$0 / $0,000.00")).toBe(true);
+  });
+
+  test("drops raw ISO period ranges", () => {
+    expect(resolveDisplayableQuotaMeta("2026-07-16T06:45:51+00:00 - 2026-07-23T06:45:51+00:00")).toBeNull();
+  });
+
+  test("keeps non-money text and reports it as non-money", () => {
+    expect(resolveDisplayableQuotaMeta("weekly window")).toBe("weekly window");
+    expect(quotaMetaHasMoney("weekly window")).toBe(false);
+    expect(quotaMetaHasMoney("$5 left")).toBe(true);
+  });
+
+  test("treats blank meta as nothing to render", () => {
+    expect(resolveDisplayableQuotaMeta("   ")).toBeNull();
+    expect(resolveDisplayableQuotaMeta(null)).toBeNull();
+    expect(resolveDisplayableQuotaMeta(undefined)).toBeNull();
+  });
+});

--- a/features/quota-preview/quota-meta.ts
+++ b/features/quota-preview/quota-meta.ts
@@ -1,0 +1,38 @@
+/**
+ * Quota meta lines ("$40.00 / $50.00", period ranges) as rendered next to a
+ * window's countdown. Extracted from useAuthFilesFilesPresentation so the card
+ * detail line and the chip meta slot share one set of rules.
+ */
+
+/** Raw ISO period ranges, e.g. "2026-07-16T06:45:51+00:00 - …". */
+const ISO_PERIOD_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+const MONEY_PATTERN = /\$\s*(-?[\d,]+(?:\.\d+)?)/g;
+
+export const quotaMetaHasMoney = (meta: string): boolean => meta.includes("$");
+
+/**
+ * True when every amount in the line is zero, e.g. "$0.00 / $0.00".
+ *
+ * Upstreams report an unfunded balance this way, so the line states no budget
+ * out of no budget — it costs a row on the card and tells the reader nothing
+ * the countdown next to it does not already say.
+ */
+export const isZeroMoneyQuotaMeta = (meta: string): boolean => {
+  const amounts = [...meta.matchAll(MONEY_PATTERN)];
+  if (amounts.length === 0) return false;
+  return amounts.every((match) => {
+    const value = Number.parseFloat(match[1].replaceAll(",", ""));
+    return Number.isFinite(value) && value === 0;
+  });
+};
+
+/** Meta worth rendering: not an ISO period range, not an all-zero money line. */
+export const resolveDisplayableQuotaMeta = (
+  meta: string | null | undefined,
+): string | null => {
+  const trimmed = meta?.trim();
+  if (!trimmed) return null;
+  if (ISO_PERIOD_PATTERN.test(trimmed)) return null;
+  if (isZeroMoneyQuotaMeta(trimmed)) return null;
+  return trimmed;
+};

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -46,6 +46,7 @@ import {
   type AuthFileCycleBudgetStats,
 } from "@code-proxy/domain";
 import { resolveQuotaProvider, type QuotaProvider } from "@features/quota-preview/quota-fetch";
+import { quotaMetaHasMoney, resolveDisplayableQuotaMeta } from "@features/quota-preview/quota-meta";
 import { useStickyDisplayPlans } from "./useStickyDisplayPlans";
 import { QuotaMetricChips } from "../components/QuotaMetricChips";
 import { renderQuotaBarNode } from "./quotaBar";
@@ -461,12 +462,10 @@ export function useAuthFilesFilesPresentation({
         reset && item?.label.startsWith("xai_quota.")
           ? t("xai_quota.reset_at", { time: reset })
           : reset;
-      const rawMeta = item?.meta?.trim() ? translateQuotaText(item.meta) : null;
-      // Drop raw ISO period ranges (e.g. "2026-07-16T06:45:51+00:00 - …").
-      const meta = rawMeta && !/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(rawMeta) ? rawMeta : null;
+      const meta = resolveDisplayableQuotaMeta(item?.meta ? translateQuotaText(item.meta) : null);
       if (resetLabel && meta) {
         // Keep money remaining ("$40 / $50") next to reset; skip other period labels.
-        return meta.includes("$") ? `${meta} · ${resetLabel}` : resetLabel;
+        return quotaMetaHasMoney(meta) ? `${meta} · ${resetLabel}` : resetLabel;
       }
       return resetLabel ?? meta ?? null;
     },
@@ -477,13 +476,12 @@ export function useAuthFilesFilesPresentation({
   // resolved on its own instead of the merged "meta · reset" detail string.
   const resolveQuotaItemMetaText = useCallback(
     (item: QuotaItem | null | undefined) => {
-      const rawMeta = item?.meta?.trim() ? translateQuotaText(item.meta) : null;
-      // Drop raw ISO period ranges (e.g. "2026-07-16T06:45:51+00:00 - …").
-      if (!rawMeta || /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(rawMeta)) return null;
+      const meta = resolveDisplayableQuotaMeta(item?.meta ? translateQuotaText(item.meta) : null);
+      if (!meta) return null;
       const hasReset = typeof item?.resetAtMs === "number" && Number.isFinite(item.resetAtMs);
       // Non-money meta only restates the period the countdown already shows.
-      if (hasReset && !rawMeta.includes("$")) return null;
-      return rawMeta;
+      if (hasReset && !quotaMetaHasMoney(meta)) return null;
+      return meta;
     },
     [translateQuotaText],
   );

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -19,7 +19,7 @@
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,
     "pages/auth-files/components/AuthFilesFilesTab.tsx": 2579,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
-    "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 983,
+    "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 981,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1298,
     "pages/end-users/EndUsersPage.tsx": 1126,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,


### PR DESCRIPTION
## 问题

xai 账号的「月度积分」「按量付费」在没有余额时，上游回的 meta 就是 `$0.00 / $0.00`，卡片照原样渲染：

```
月度积分                              100%
────────────────────────────────────────
              $0.00 / $0.00 · 重置 20天18小时56分3秒
```

这行等于花一行字说「没有额度里的没有额度」，而旁边的重置倒计时已经把这个窗口讲清楚了。

## 改动

把 meta 的可显示判断抽到 `features/quota-preview/quota-meta.ts`，卡片明细行和 chips 的 meta 槽共用同一套规则（原本是两份各自维护的正则）：

- ISO 时间段照旧丢弃；
- **金额全为零的行丢弃**；
- 只要有一侧非零就仍然显示——`$0.00 / $50.00` 表示额度真的花光了，那是必须看见的信息，不能跟"从来没有额度"混为一谈。

抽出后 `useAuthFilesFilesPresentation.tsx` 反而变小，基线同步锁定。

## 验证

本地 `./scripts/ci-pr.sh` 退出码 0（157 文件 1154 用例、build、bundle diff、critical e2e 全过）。

单测覆盖：`$0.00 / $0.00`、`$0 / $0`、`$0.00/$0.00`、带千分位的 `$0 / $0,000.00` 都判定为零并丢弃；`$0.00 / $50.00` 保留；非金额文案与空 meta 行为不变。

新增 `e2e/auth-files-zero-money-meta.spec.ts`：同一张卡片上零额度窗口的金额行消失、倒计时保留，有余额的窗口仍显示 `$12.50 / $50.00`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)