### PR TITLE
fix(ip-access): show the forwarding chain so proxies can be declared, not guessed

### DIFF
--- a/packages/api-client/src/endpoints/ip-access.ts
+++ b/packages/api-client/src/endpoints/ip-access.ts
@@ -64,6 +64,12 @@ export interface IpAccessStatus {
   trusted_proxies?: string[];
   /** Where that list came from: panel-managed, config.yaml, or nothing. */
   trusted_proxies_source?: "database" | "config" | "none";
+  /** The direct TCP peer, before any forwarding header is considered. */
+  peer?: string;
+  /** The forwarding chain as received, left to right. */
+  forwarded_chain?: string[];
+  /** True when the request carried no forwarding header at all. */
+  direct_peer?: boolean;
 }
 
 export type AutoBanMode = "off" | "observe" | "enforce";

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5438,6 +5438,8 @@
     "lockdown_confirm_ok": "Enable",
     "portal_recent_logins": "Recent sign-ins",
     "portal_recent_logins_hint": "Sign-ins to your account over the last 30 days. If you see one that was not you, change your password immediately.",
-    "portal_no_logins": "No sign-ins in the last 30 days"
+    "portal_no_logins": "No sign-ins in the last 30 days",
+    "chain_title": "Forwarding chain for this request (rightmost is the hop talking to this service)",
+    "chain_hint": "Every hop must be declared before resolution reaches the real client on the left. Currently resolving to: {{client}}. A loopback result means one hop is still undeclared."
   }
 }

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -3329,6 +3329,8 @@
     "lockdown_confirm_ok": "Enable",
     "portal_recent_logins": "Recent sign-ins",
     "portal_recent_logins_hint": "Sign-ins to your account over the last 30 days. If you see one that was not you, change your password immediately.",
-    "portal_no_logins": "No sign-ins in the last 30 days"
+    "portal_no_logins": "No sign-ins in the last 30 days",
+    "chain_title": "Forwarding chain for this request (rightmost is the hop talking to this service)",
+    "chain_hint": "Every hop must be declared before resolution reaches the real client on the left. Currently resolving to: {{client}}. A loopback result means one hop is still undeclared."
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -5452,6 +5452,8 @@
     "lockdown_confirm_ok": "确认开启",
     "portal_recent_logins": "最近登录记录",
     "portal_recent_logins_hint": "近 30 天你账号的登录记录。发现不是本人的记录请立即修改密码。",
-    "portal_no_logins": "近 30 天没有登录记录"
+    "portal_no_logins": "近 30 天没有登录记录",
+    "chain_title": "当前请求的转发链（右侧为直连本服务的一跳）",
+    "chain_hint": "每一跳都要声明为可信代理，解析才能走到最左侧的真实客户端。当前解析结果：{{client}}。若结果落在回环地址，说明还有一跳没声明。"
   }
 }

--- a/pages/ip-access/ProtectionPolicyTab.tsx
+++ b/pages/ip-access/ProtectionPolicyTab.tsx
@@ -133,6 +133,22 @@ export function ProtectionPolicyTab({ status, onPolicySaved }: ProtectionPolicyT
             ))
           )}
         </div>
+        {status?.forwarded_chain && status.forwarded_chain.length > 0 ? (
+          // Without this an operator is guessing which hops to declare, and a
+          // chain declared one hop short resolves to loopback and silently
+          // exempts everyone.
+          <div className="mt-3 rounded-xl bg-slate-50 px-3 py-2 dark:bg-white/5">
+            <p className="text-xs font-medium text-slate-700 dark:text-white/80">
+              {t("ip_access.chain_title")}
+            </p>
+            <p className="mt-1 font-mono text-xs text-slate-600 dark:text-white/70">
+              {[...status.forwarded_chain, status.peer].filter(Boolean).join("  ←  ")}
+            </p>
+            <p className="mt-1 text-xs text-slate-500">
+              {t("ip_access.chain_hint", { client: status.client_ip || "-" })}
+            </p>
+          </div>
+        ) : null}
         <PermissionGate permission="platform.ip_access.write">
           <div className="mt-3 flex flex-wrap items-center gap-2">
             <div className="w-full min-[480px]:w-[220px]">


### PR DESCRIPTION
## 起因

配套 kittors/CliRelay#878。

面板只提供了一个「添加检测到的代理」按钮，却没有任何方式看到转发链**实际长什么样**。两跳的链路只声明了一跳，解析就停在回环地址上，而后端当时把它当作本机请求——豁免了所有外部客户端。

运维完全无从察觉：页面显示的是一个看起来合理的地址，也没有链路信息。

## 改动

「防护策略」页现在渲染收到的完整转发链（最右侧是直连本服务的那一跳），并标注当前解析到哪个地址，以及一句提示：解析结果落在回环地址说明还有一跳没声明。

## 验证

完整 `ci-pr.sh` 退出码 0，`test:ci` 1159 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)