### PR TITLE
fix(ui): stop repeating model names as tooltips and alias-only "real model ID" hints

### DIFF
--- a/features/model-tags/index.tsx
+++ b/features/model-tags/index.tsx
@@ -365,7 +365,10 @@ export function ModelTag({
 
   return (
     <span
-      title={title ?? id}
+      // No implicit title: it repeated the visible model id as a second, native
+      // tooltip stacked on top of the managed one. Callers that truncate the tag
+      // wrap it in OverflowTooltip, which only opens when the text is cut off.
+      title={title}
       className={cn(
         "inline-flex max-w-full items-center border font-mono font-semibold leading-none",
         sizeClasses.wrapper,

--- a/features/request-log-viewer/RequestLogModelCell.tsx
+++ b/features/request-log-viewer/RequestLogModelCell.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from "react-i18next";
+import { isDistinctModelIdentity } from "@code-proxy/domain";
+import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
+import { ModelTag } from "@features/model-tags";
+import type { RequestLogsRow } from "./requestLogsShared";
+
+function ModelHintDot({
+  label,
+  value,
+  toneClass,
+}: {
+  label: string;
+  value: string;
+  toneClass: string;
+}) {
+  return (
+    <HoverTooltip content={`${label}\n${value}`} placement="top">
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${toneClass}`} aria-label={label} />
+    </HoverTooltip>
+  );
+}
+
+/**
+ * Model column of the request log table.
+ *
+ * The hint dots only appear for a genuinely different model. An account alias that
+ * merely adds a routing prefix (`ollama/deepseek-v4-flash:0731` for upstream
+ * `deepseek-v4-flash:0731`) is the same model under two names, and announcing it as
+ * a "real model ID" was noise on every single row of an aliased provider.
+ */
+export function RequestLogModelCell({ row }: { row: RequestLogsRow }) {
+  const { t } = useTranslation();
+  if (!row.model) {
+    return <span className="text-xs text-slate-400 dark:text-white/30">--</span>;
+  }
+
+  const label = row.displayModel || row.model;
+  return (
+    <span className="inline-flex max-w-full items-center justify-center gap-1 align-middle">
+      <OverflowTooltip content={label} className="min-w-0">
+        <ModelTag id={label} size="sm" className="align-middle" />
+      </OverflowTooltip>
+      {isDistinctModelIdentity(row.model, row.upstreamModel) ? (
+        <ModelHintDot
+          label={t("request_logs.real_model_id")}
+          value={row.upstreamModel}
+          toneClass="bg-amber-500"
+        />
+      ) : null}
+      {isDistinctModelIdentity(row.model, row.visionFallbackModel) ? (
+        <ModelHintDot
+          label={t("request_logs.vision_fallback_model_id")}
+          value={row.visionFallbackModel}
+          toneClass="bg-sky-500"
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/features/request-log-viewer/requestLogsShared.tsx
+++ b/features/request-log-viewer/requestLogsShared.tsx
@@ -16,7 +16,7 @@ import { SearchableCheckboxMultiSelect, Tabs, TabsList, TabsTrigger } from "@cod
 import type { SearchableCheckboxMultiSelectOption } from "@code-proxy/ui";
 import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
 import { PaginationBar } from "@code-proxy/ui";
-import { ModelTag } from "@features/model-tags";
+import { RequestLogModelCell } from "./RequestLogModelCell";
 
 export type TimeRange = 1 | 7 | 14 | 30;
 export type StatusFilterValue = "success" | "failed";
@@ -940,38 +940,7 @@ export function buildRequestLogsColumns(
       width: "w-44",
       headerClassName: CENTERED_REQUEST_LOG_HEADER_CLASS,
       cellClassName: "text-center",
-      render: (row) =>
-        row.model ? (
-          <span className="inline-flex max-w-full items-center justify-center gap-1 align-middle">
-            <OverflowTooltip content={row.displayModel || row.model} className="min-w-0">
-              <ModelTag id={row.displayModel || row.model} size="sm" className="align-middle" />
-            </OverflowTooltip>
-            {row.upstreamModel && row.upstreamModel !== row.model ? (
-              <HoverTooltip
-                content={`${t("request_logs.real_model_id")}\n${row.upstreamModel}`}
-                placement="top"
-              >
-                <span
-                  className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
-                  aria-label={t("request_logs.real_model_id")}
-                />
-              </HoverTooltip>
-            ) : null}
-            {row.visionFallbackModel && row.visionFallbackModel !== row.model ? (
-              <HoverTooltip
-                content={`${t("request_logs.vision_fallback_model_id")}\n${row.visionFallbackModel}`}
-                placement="top"
-              >
-                <span
-                  className="h-1.5 w-1.5 shrink-0 rounded-full bg-sky-500"
-                  aria-label={t("request_logs.vision_fallback_model_id")}
-                />
-              </HoverTooltip>
-            ) : null}
-          </span>
-        ) : (
-          <span className="text-xs text-slate-400 dark:text-white/30">--</span>
-        ),
+      render: (row) => <RequestLogModelCell row={row} />,
     },
   );
   return identityColumn === "none"

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,6 +6,7 @@ export * from "./ccswitch/ccswitchImportSettings";
 export * from "./auth-files/authFiles";
 export * from "./auth-files/types";
 export * from "./auth-files/zip";
+export * from "./models/modelIdentity";
 export * from "./quota";
 export * from "./usage";
 export * from "./tenant-cache";

--- a/packages/domain/src/models/__tests__/modelIdentity.test.ts
+++ b/packages/domain/src/models/__tests__/modelIdentity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { isDistinctModelIdentity, isSameModelIdentity } from "../modelIdentity";
+
+describe("isSameModelIdentity", () => {
+  test.each([
+    ["deepseek-v4-flash:0731", "deepseek-v4-flash:0731"],
+    ["ollama/deepseek-v4-flash:0731", "deepseek-v4-flash:0731"],
+    ["deepseek-v4-flash:0731", "ollama/deepseek-v4-flash:0731"],
+    ["cline-pass/deepseek-v4-flash", "deepseek-v4-flash"],
+    ["group/ollama/gpt-oss:20b", "gpt-oss:20b"],
+    ["Ollama/GPT-OSS:20B", "gpt-oss:20b"],
+  ])("treats %s and %s as one model", (requested, upstream) => {
+    expect(isSameModelIdentity(requested, upstream)).toBe(true);
+  });
+
+  test.each([
+    ["fast", "claude-sonnet-4"],
+    ["gpt-oss:20b", "gpt-oss:120b"],
+    ["xdeepseek-v4-flash", "deepseek-v4-flash"],
+    ["deepseek-v4-flash", ""],
+    ["", "deepseek-v4-flash"],
+  ])("keeps %s and %s apart", (requested, upstream) => {
+    expect(isSameModelIdentity(requested, upstream)).toBe(false);
+  });
+});
+
+describe("isDistinctModelIdentity", () => {
+  test("is false when either side is missing", () => {
+    expect(isDistinctModelIdentity("deepseek-v4-flash", "")).toBe(false);
+    expect(isDistinctModelIdentity("  ", "deepseek-v4-flash")).toBe(false);
+  });
+
+  test("is true only for a genuinely different upstream model", () => {
+    expect(isDistinctModelIdentity("ollama/gpt-oss:20b", "gpt-oss:20b")).toBe(false);
+    expect(isDistinctModelIdentity("fast", "claude-sonnet-4")).toBe(true);
+  });
+});

--- a/packages/domain/src/models/modelIdentity.ts
+++ b/packages/domain/src/models/modelIdentity.ts
@@ -1,0 +1,27 @@
+/**
+ * Whether a requested model name and the model actually used upstream denote the
+ * same model.
+ *
+ * Provider aliases normally only add a routing segment — an Ollama Cloud account
+ * exposing `deepseek-v4-flash:0731` as `ollama/deepseek-v4-flash:0731` makes the
+ * request log carry the prefixed name and the upstream field the bare one. Those
+ * are one model under two names, so surfacing a "real model ID" hint for them is
+ * pure noise. Aliases that rename the model (`fast` -> `claude-sonnet-4`) stay
+ * different and remain worth showing.
+ *
+ * The backend stopped recording alias-only upstream names, but request logs are
+ * kept for months, so the UI normalizes historical rows the same way.
+ */
+export const isSameModelIdentity = (requested: string, upstream: string): boolean => {
+  const a = requested.trim().toLowerCase();
+  const b = upstream.trim().toLowerCase();
+  if (!a || !b) return false;
+  if (a === b) return true;
+  return a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+};
+
+/** Inverse of {@link isSameModelIdentity}, for "should we disclose this name?" checks. */
+export const isDistinctModelIdentity = (requested: string, upstream: string): boolean =>
+  Boolean(requested.trim()) &&
+  Boolean(upstream.trim()) &&
+  !isSameModelIdentity(requested, upstream);

--- a/packages/ui/src/overlays/Tooltip.tsx
+++ b/packages/ui/src/overlays/Tooltip.tsx
@@ -172,8 +172,18 @@ function resolveTooltipPosition({
   };
 }
 
+// scrollWidth/clientWidth are rounded to integers, so text that fits with a
+// sub-pixel remainder (a 188.4px label in a 188px box) reports a 1px overflow
+// while rendering in full, with no ellipsis. Without this tolerance the tooltip
+// pops up repeating the text already on screen — which reads as the UI showing
+// an "alias" that is identical to the name next to it.
+const OVERFLOW_TOLERANCE_PX = 1;
+
 function isElementOverflowing(element: HTMLElement) {
-  return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
+  return (
+    element.scrollWidth - element.clientWidth > OVERFLOW_TOLERANCE_PX ||
+    element.scrollHeight - element.clientHeight > OVERFLOW_TOLERANCE_PX
+  );
 }
 
 function hasOverflowingContent(element: HTMLElement) {

--- a/packages/ui/src/overlays/__tests__/Tooltip.overflow.test.tsx
+++ b/packages/ui/src/overlays/__tests__/Tooltip.overflow.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test } from "vitest";
+import { OverflowTooltip } from "../Tooltip";
+
+// jsdom has no layout, so overflow has to be dictated element by element.
+const mockMetrics = (metrics: { scrollWidth: number; clientWidth: number }) => {
+  const originals = {
+    scrollWidth: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollWidth"),
+    clientWidth: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth"),
+  };
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get: () => metrics.scrollWidth,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => metrics.clientWidth,
+  });
+  return () => {
+    if (originals.scrollWidth) {
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", originals.scrollWidth);
+    }
+    if (originals.clientWidth) {
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", originals.clientWidth);
+    }
+  };
+};
+
+describe("OverflowTooltip", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  test("stays closed for a 1px rounding overflow", async () => {
+    // A 188.4px label in a 188px box: scrollWidth rounds up to 189 while the text
+    // still renders in full. Opening here repeats the visible text for no reason.
+    restore = mockMetrics({ scrollWidth: 189, clientWidth: 188 });
+    const user = userEvent.setup();
+
+    render(
+      <OverflowTooltip content="ollama/deepseek-v4-flash:0731">
+        <span>ollama/deepseek-v4-flash:0731</span>
+      </OverflowTooltip>,
+    );
+
+    await user.hover(screen.getByText("ollama/deepseek-v4-flash:0731"));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  test("still opens when the text is genuinely truncated", async () => {
+    restore = mockMetrics({ scrollWidth: 320, clientWidth: 188 });
+    const user = userEvent.setup();
+
+    render(
+      <OverflowTooltip content="ollama/deepseek-v4-flash:0731">
+        <span>ollama/deepseek-v4-flash:0731</span>
+      </OverflowTooltip>,
+    );
+
+    await user.hover(screen.getByText("ollama/deepseek-v4-flash:0731"));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "ollama/deepseek-v4-flash:0731",
+    );
+  });
+});

--- a/pages/providers/components/ProviderModelChips.tsx
+++ b/pages/providers/components/ProviderModelChips.tsx
@@ -1,5 +1,5 @@
 import type { ProviderModel } from "@code-proxy/api-client";
-import { HoverTooltip } from "@code-proxy/ui";
+import { HoverTooltip, OverflowTooltip } from "@code-proxy/ui";
 
 interface ProviderModelChipsProps {
   models: ProviderModel[];
@@ -31,7 +31,9 @@ export function ProviderModelChips({
       {visible.map((model) => {
         const modelLabel = formatModelLabel(model, "→");
         return (
-          <HoverTooltip
+          // Overflow-only: the chip is often truncated by the 3-column grid, but when
+          // it fits, a tooltip would just repeat the mapping already on screen.
+          <OverflowTooltip
             key={model.name}
             content={formatModelLabel(model, "=>")}
             placement="top"
@@ -40,7 +42,7 @@ export function ProviderModelChips({
             <span className="inline-flex w-full min-w-0 cursor-default rounded-full bg-slate-900 px-2 py-0.5 text-xs text-white dark:bg-white dark:text-neutral-950">
               <span className="min-w-0 truncate">{modelLabel}</span>
             </span>
-          </HoverTooltip>
+          </OverflowTooltip>
         );
       })}
       {remaining > 0 ? (

--- a/pages/providers/components/__tests__/ProviderModelChips.test.tsx
+++ b/pages/providers/components/__tests__/ProviderModelChips.test.tsx
@@ -1,9 +1,47 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import { ProviderModelChips } from "../ProviderModelChips";
 
+// jsdom reports every layout box as 0x0, so overflow-gated tooltips need explicit
+// metrics to be exercised at all.
+const mockChipOverflow = ({
+  scrollWidth,
+  clientWidth,
+}: {
+  scrollWidth: number;
+  clientWidth: number;
+}) => {
+  const original = {
+    scrollWidth: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollWidth"),
+    clientWidth: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth"),
+  };
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get: () => scrollWidth,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => clientWidth,
+  });
+  return () => {
+    if (original.scrollWidth) {
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", original.scrollWidth);
+    }
+    if (original.clientWidth) {
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", original.clientWidth);
+    }
+  };
+};
+
 describe("ProviderModelChips", () => {
+  let restoreOverflow: (() => void) | null = null;
+
+  afterEach(() => {
+    restoreOverflow?.();
+    restoreOverflow = null;
+  });
+
   test("keeps overflow models behind the final summary chip", async () => {
     const user = userEvent.setup();
     const models = [
@@ -34,6 +72,7 @@ describe("ProviderModelChips", () => {
 
   test("shows the full model mapping for visible truncated chips", async () => {
     const user = userEvent.setup();
+    restoreOverflow = mockChipOverflow({ scrollWidth: 400, clientWidth: 120 });
 
     render(
       <ProviderModelChips
@@ -46,5 +85,18 @@ describe("ProviderModelChips", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
       "very-long-upstream-model-name => very-long-downstream-alias",
     );
+  });
+
+  test("stays quiet when the chip is fully visible", async () => {
+    const user = userEvent.setup();
+    // A chip that fits has nothing to add: repeating its text as a tooltip is the
+    // "why is it showing me the alias again?" noise this component used to emit.
+    restoreOverflow = mockChipOverflow({ scrollWidth: 120, clientWidth: 120 });
+
+    render(<ProviderModelChips models={[{ name: "short-model", alias: "short-alias" }]} />);
+
+    await user.hover(screen.getByText("short-model → short-alias"));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 });

--- a/pages/request-logs/__tests__/RequestLogsPage.test.tsx
+++ b/pages/request-logs/__tests__/RequestLogsPage.test.tsx
@@ -396,6 +396,34 @@ describe("RequestLogsPage", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Real model ID real-model");
   });
 
+  test("hides the real-model marker when the upstream name is only the alias prefix", async () => {
+    await i18n.changeLanguage("en");
+
+    mocks.getUsageLogs.mockResolvedValue(
+      responseWithRows([
+        buildUsageLogItem({
+          id: 1,
+          // How an Ollama Cloud account alias reaches the log: same model, two names.
+          model: "ollama/deepseek-v4-flash:0731",
+          upstream_model: "deepseek-v4-flash:0731",
+          vision_fallback_model: "",
+        }),
+      ]),
+    );
+
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <RequestLogsPage />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    const table = await screen.findByRole("table", { name: "Request Logs Table" });
+    expect(within(table).getByText("ollama/deepseek-v4-flash:0731")).toBeInTheDocument();
+    expect(within(table).queryByLabelText("Real model ID")).not.toBeInTheDocument();
+  });
+
   test("renders empty state with normalized empty filter arrays", async () => {
     await i18n.changeLanguage("en");
 

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -7,7 +7,7 @@
     "features/log-content-viewer/components/LogContentModal.tsx": 1534,
     "features/model-availability/modelAvailability.ts": 1275,
     "features/oauth-login/components/OAuthLoginDialog.tsx": 912,
-    "features/request-log-viewer/requestLogsShared.tsx": 1020,
+    "features/request-log-viewer/requestLogsShared.tsx": 989,
     "features/routing-config-editor/RoutingConfigEditor.tsx": 2044,
     "features/visual-config-editor/useVisualConfig.ts": 957,
     "packages/domain/src/auth-files/authFiles.ts": 2181,
@@ -25,6 +25,6 @@
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 1193,
     "pages/models/ModelsPage.tsx": 1251,
-    "pages/providers/components/ProvidersPageContent.tsx": 1853
+    "pages/providers/components/ProvidersPageContent.tsx": 1845
   }
 }


### PR DESCRIPTION
## 问题

请求日志的模型列：模型「原名和别名都叫这个」，界面还额外提示一次别名。三处同源问题。

## 根因

**1. 未截断也弹浮层**：`OverflowTooltip` 用 `scrollWidth > clientWidth` 判断截断，两者都是整数。文本宽 188.4px、容器 188px 时 `scrollWidth` 进位成 189 判为溢出，但渲染时文字完整、无省略号——浮层原样重复了屏幕上已有的文字。（`packages/ui/src/data-table/scrollMetrics.ts` 早就用 `+1` 容差处理同一舍入问题。）

**2. `ModelTag` 的原生 `title`**：默认等于模型 id，与受管浮层叠加，同一串文字提示两次。

**3.「真实模型 ID」提示点**：只要 `upstream_model !== model` 就亮。账号别名只是加了路由前缀（`ollama/deepseek-v4-flash:0731` 对上游 `deepseek-v4-flash:0731`），于是走别名的渠道**每一行**都亮这个点。线上实测该点悬停内容为「真实模型 ID / deepseek-v4-flash:0731」。

## 改动

- `OverflowTooltip` 溢出判定加 1px 容差 —— 全站生效的根因修复。
- `ModelTag` 仅在调用方显式传入时输出原生 `title`；会截断的调用点本来就套了 `OverflowTooltip`。
- 新增 `isSameModelIdentity` / `isDistinctModelIdentity`（`@code-proxy/domain`）：只差路由前缀 / 大小写视为同一模型；重命名式别名（`fast` → `claude-sonnet-4`）仍视为不同并继续提示。用于请求日志的「真实模型 ID」与「视觉补位模型」两个点。后端已停止记录这类别名（见 CliRelay PR #896），但日志留存数月，前端同样归一化以覆盖历史行。
- AI 供应商卡片的模型 chip 改用 `OverflowTooltip`：截断才提示，放得下时不再重复。
- 模型列抽成 `RequestLogModelCell`，`requestLogsShared.tsx` 1020 → 989 行，按门禁提示更新基线锁定收益。

## 有意不改

模型广场卡片的来源摘要（`ClinePass · cline → cline-pass/mimo-v2.5-pro`）保持原样：那是模型目录信息，告诉用户该来源上要用的模型 id；请求日志的提示点是每行重复的运行时噪音。两者语义不同。

## 验证

- `./scripts/ci-pr.sh`（lint、design:check、全量 vitest 1176 项、build、bundle:diff、e2e 12 项）通过。
- 反向验证：把请求日志判定改回字符串 `!==` → 新增的别名用例失败。
- 新增用例：1px 舍入不弹浮层 / 真截断仍弹；chip 放得下不弹、截断才弹；`isSameModelIdentity` 前缀与重命名两类。

## 联动

后端 PR：kittors/CliRelay#896（停止记录别名式 upstream model + Ollama Cloud 缓存估算）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)