### PR TITLE
fix(video): grey out generation without a credential, and give the menu its icon

### DIFF
--- a/packages/api-client/src/endpoints/video-generation.ts
+++ b/packages/api-client/src/endpoints/video-generation.ts
@@ -12,10 +12,20 @@ export interface VideoGenerationModel {
   supports_image_to_video: boolean;
   max_duration_seconds?: number;
   price_per_call?: number;
+  /** Credentials of the current tenant that can serve this model. */
+  channels?: string[];
+  /**
+   * False when the tenant has no credential for the model's provider. The page
+   * disables generation in that case: submitting would fail deep in the router
+   * with "auth_not_found: no auth available", which says nothing actionable.
+   */
+  available?: boolean;
 }
 
 export interface VideoGenerationModelsResponse {
   models: VideoGenerationModel[];
+  /** Every usable channel across providers, flattened. */
+  channels?: string[];
 }
 
 export interface VideoGenerationTestRequest {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -5488,6 +5488,8 @@
     "field_duration": "Duration (seconds, max {{max}})",
     "field_aspect_ratio": "Aspect ratio",
     "field_resolution": "Resolution",
-    "result_open_original": "Open the original clip in a new tab"
+    "result_open_original": "Open the original clip in a new tab",
+    "no_channel_hint": "This tenant has no usable xAI account, so video generation is unavailable. Add and enable a Grok account under AI Accounts first.",
+    "unavailable_suffix": "no account"
   }
 }

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -5502,6 +5502,8 @@
     "field_duration": "时长（秒，最多 {{max}}）",
     "field_aspect_ratio": "画面比例",
     "field_resolution": "分辨率",
-    "result_open_original": "在新标签页打开原始视频"
+    "result_open_original": "在新标签页打开原始视频",
+    "no_channel_hint": "当前租户下没有可用的 xAI 账号，无法生成视频。请先在「AI 账号」里添加并启用一个 Grok 账号。",
+    "unavailable_suffix": "无可用账号"
   }
 }

--- a/packages/ui/src/navigation/menuIconMap.ts
+++ b/packages/ui/src/navigation/menuIconMap.ts
@@ -25,6 +25,7 @@ import {
   Store,
   UserRound,
   UsersRound,
+  Video,
   type LucideIcon,
 } from "lucide-react";
 
@@ -58,6 +59,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   store: Store,
   "user-round": UserRound,
   "users-round": UsersRound,
+  video: Video,
 };
 
 export function resolveMenuIcon(name: string | undefined | null): LucideIcon {

--- a/pages/video-generation/__tests__/VideoGenerationPage.test.tsx
+++ b/pages/video-generation/__tests__/VideoGenerationPage.test.tsx
@@ -95,6 +95,29 @@ describe("VideoGenerationPage", () => {
     expect((await screen.findAllByText("请填写提示词")).length).toBeGreaterThan(0);
   });
 
+  // Screenshot regression: with no xAI credential the page still offered a live
+  // button, and the request died deep in the router with "auth_not_found".
+  test("disables generation when the tenant has no credential for the model", async () => {
+    getModelsMock().mockResolvedValue({
+      models: [{ ...videoModel, available: false, channels: [] }],
+      channels: [],
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "测试生成" })).toBeDisabled(),
+    );
+    expect(screen.getByText(/没有可用的 xAI 账号/)).toBeInTheDocument();
+  });
+
+  test("keeps generation enabled when the server omits availability", async () => {
+    // An older server does not send the field; absence must not disable the page.
+    getModelsMock().mockResolvedValue({ models: [videoModel] });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "测试生成" })).toBeEnabled());
+  });
+
   test("plays the clip once the task finishes", async () => {
     const user = userEvent.setup();
     getTaskMock().mockResolvedValue({

--- a/pages/video-generation/components/VideoGenerationPageContent.tsx
+++ b/pages/video-generation/components/VideoGenerationPageContent.tsx
@@ -94,6 +94,13 @@ export function VideoGenerationPageContent() {
     [model, models],
   );
   const maxDuration = selectedModel?.max_duration_seconds || 15;
+  // A model the tenant has no credential for cannot be generated with. Saying so
+  // here — instead of letting the request fail with "auth_not_found" — is the
+  // difference between an actionable message and a dead end. `available` is
+  // undefined on an older server, which must not disable a working page.
+  const modelAvailable = selectedModel?.available !== false;
+  const anyModelAvailable = models.some((entry) => entry.available !== false);
+  const canGenerate = models.length > 0 && modelAvailable;
 
   const pollTask = useCallback(
     (taskId: string) => {
@@ -162,11 +169,14 @@ export function VideoGenerationPageContent() {
 
   const modelOptions = useMemo(
     () =>
-      models.map((entry) => ({
-        value: entry.id,
-        label: entry.display_name ? `${entry.display_name} · ${entry.id}` : entry.id,
-      })),
-    [models],
+      models.map((entry) => {
+        const base = entry.display_name ? `${entry.display_name} · ${entry.id}` : entry.id;
+        return {
+          value: entry.id,
+          label: entry.available === false ? `${base} (${t("video_generation.unavailable_suffix")})` : base,
+        };
+      }),
+    [models, t],
   );
 
   return (
@@ -190,7 +200,7 @@ export function VideoGenerationPageContent() {
               {t("video_generation.call_description")}
             </p>
           </div>
-          <Button onClick={() => setTestOpen(true)} disabled={models.length === 0}>
+          <Button onClick={() => setTestOpen(true)} disabled={models.length === 0 || !anyModelAvailable}>
             {t("video_generation.test_button")}
           </Button>
         </div>
@@ -199,6 +209,13 @@ export function VideoGenerationPageContent() {
           <p className="mt-4 flex items-center gap-2 text-sm text-rose-600 dark:text-rose-300">
             <CircleAlert className="h-4 w-4 shrink-0" />
             {modelsError}
+          </p>
+        ) : null}
+
+        {!modelsError && models.length > 0 && !anyModelAvailable ? (
+          <p className="mt-4 flex items-start gap-2 rounded-xl bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:bg-amber-500/10 dark:text-amber-200">
+            <CircleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+            {t("video_generation.no_channel_hint")}
           </p>
         ) : null}
 
@@ -329,13 +346,18 @@ export function VideoGenerationPageContent() {
           </div>
 
           <div className="flex items-center gap-3">
-            <Button onClick={handleRunTest} disabled={test.running}>
+            <Button onClick={handleRunTest} disabled={test.running || !canGenerate}>
               {test.running ? t("video_generation.test_running") : t("video_generation.test_submit")}
             </Button>
             {test.running ? (
               <span className="text-xs text-slate-500 dark:text-white/45">
                 {t("video_generation.test_running_hint")}
                 {test.phase ? ` · ${test.phase}` : ""}
+              </span>
+            ) : null}
+            {!test.running && !canGenerate ? (
+              <span className="text-xs text-amber-700 dark:text-amber-300">
+                {t("video_generation.no_channel_hint")}
               </span>
             ) : null}
           </div>


### PR DESCRIPTION
## 问题

- 没有 xAI 账号的租户，「测试生成」依然可点，唯一反馈是路由层的 `auth_not_found: no auth available`——属实但无从下手。
- 侧栏「视频模型」显示成空心圆：图标映射表里没有 `video` 键，而 seed 菜单一直在请求它。

## 改动

- `/video-generation/models` 现在按租户返回 `available` 与可用渠道；页面据此置灰「测试生成」，并说明「当前租户下没有可用的 xAI 账号」。模型下拉里不可用的模型带标注。
- 字段缺失时（旧服务端）**不**置灰，避免把本来能用的页面锁死。
- 图标表补 `video`。

## 验证

- `./scripts/ci-pr.sh` 全绿（lint、design:check、全量 vitest、build、bundle:diff、e2e @critical）。
- 新增两条用例：无凭据时按钮禁用并给出提示；服务端未返回该字段时保持可用。

后端 PR：kittors/CliRelay#899

🤖 Generated with [Claude Code](https://claude.com/claude-code)