### PR TITLE
chore: remove production host details from public sources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 15
     env:
       PANEL_RELEASE: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-      PUBLIC_PANEL_BASE: ${{ vars.RELAY_PUBLIC_PANEL_BASE || 'https://relay.07230805.xyz' }}
+      PUBLIC_PANEL_BASE: ${{ secrets.RELAY_PUBLIC_PANEL_BASE || vars.RELAY_PUBLIC_PANEL_BASE }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL || 'https://relay.07230805.xyz/v1' }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL }}
       OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || vars.OPENAI_MODEL || 'grok-4.5' }}
       TRIAGE_ISSUE_NUMBER: ${{ github.event.inputs.issue_number || '' }}
       # Auto-comment on newly opened issues (not on every edit) unless bot:quiet.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL || 'https://relay.07230805.xyz/v1' }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL || vars.OPENAI_BASE_URL }}
       OPENAI_MODEL: ${{ secrets.OPENAI_MODEL || vars.OPENAI_MODEL || 'grok-4.5' }}
       REVIEW_PR_NUMBER: ${{ github.event.inputs.pr_number || '' }}
     steps:

--- a/pages/api-key-lookup/components/landing/landingCopy.ts
+++ b/pages/api-key-lookup/components/landing/landingCopy.ts
@@ -58,7 +58,7 @@ export interface LandingCopy {
 /** 部署域名即 API 根地址；SSR / 测试环境下退回到线上默认值，保证文案永远可读。 */
 export function resolveApiBaseUrl(): string {
   if (typeof window === "undefined" || !window.location?.origin) {
-    return "https://relay.07230805.xyz/v1";
+    return "https://relay.example.com/v1";
   }
   return `${window.location.origin}/v1`;
 }

--- a/pages/ip-access/ProtectionPolicyTab.tsx
+++ b/pages/ip-access/ProtectionPolicyTab.tsx
@@ -162,7 +162,7 @@ export function ProtectionPolicyTab({ status, onPolicySaved }: ProtectionPolicyT
                     setProxyDraft("");
                   }
                 }}
-                placeholder="104.194.69.137 / 10.0.0.0/24"
+                placeholder="203.0.113.10 / 10.0.0.0/24"
                 size="sm"
                 className="font-mono"
               />

--- a/pages/ip-access/__tests__/AccessRulesTab.test.tsx
+++ b/pages/ip-access/__tests__/AccessRulesTab.test.tsx
@@ -151,11 +151,11 @@ describe("AccessRulesTab", () => {
   test("protected addresses are listed so a refused ban is explainable", async () => {
     renderTab({
       protectedEntries: [
-        { cidr: "104.194.69.137/32", reason: "trusted_proxy" },
+        { cidr: "203.0.113.10/32", reason: "trusted_proxy" },
         { cidr: "10.0.0.5/32", reason: "local_address" },
       ],
     });
-    expect(await screen.findByText("104.194.69.137/32")).toBeInTheDocument();
+    expect(await screen.findByText("203.0.113.10/32")).toBeInTheDocument();
     expect(screen.getByText("10.0.0.5/32")).toBeInTheDocument();
   });
 });

--- a/scripts/issue_triage_agent.py
+++ b/scripts/issue_triage_agent.py
@@ -463,7 +463,7 @@ def call_model(system, user_payload):
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is not set")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.07230805.xyz/v1").rstrip("/")
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.example.com/v1").rstrip("/")
     model = os.environ.get("OPENAI_MODEL", "grok-4.5")
     data = {
         "model": model,

--- a/scripts/pr_review_agent.py
+++ b/scripts/pr_review_agent.py
@@ -180,7 +180,7 @@ def call_model(system: str, user_payload: str, max_tokens: int = 3500) -> str:
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY is not set")
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.07230805.xyz/v1").rstrip("/")
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://relay.example.com/v1").rstrip("/")
     model = os.environ.get("OPENAI_MODEL", "grok-4.5")
     data = {
         "model": model,


### PR DESCRIPTION
## Summary
- Remove live relay host from landing fallback, tests, and workflow defaults
- `RELAY_PUBLIC_PANEL_BASE` is now a secret; `OPENAI_BASE_URL` stays a secret

## Test plan
- [x] No `104.194.69.137` or `07230805` in the changed files
- [ ] Browser landing still uses `window.location.origin`