### PR TITLE
fix(antigravity): render the upstream's own quota buckets

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -164,7 +164,7 @@ describe("fetchQuota for antigravity", () => {
     mocks.downloadText.mockResolvedValueOnce(
       JSON.stringify({ project_id: "bamboo-precept-lgxtn" }),
     );
-    mocks.request.mockResolvedValueOnce({
+    const antigravityModelsResponse = {
       statusCode: 200,
       header: {},
       bodyText: "",
@@ -227,7 +227,15 @@ describe("fetchQuota for antigravity", () => {
           },
         ],
       }),
-    });
+    };
+
+    // The grouped summary is asked for first; this account's upstream does not
+    // serve it, so the flat model list is what the card ends up rendering.
+    mocks.request.mockImplementation(async ({ url }: { url: string }) =>
+      url.includes("retrieveUserQuotaSummary")
+        ? { statusCode: 404, header: {}, bodyText: "", body: "" }
+        : antigravityModelsResponse,
+    );
 
     const result = await fetchQuota("antigravity", {
       name: "antigravity.json",
@@ -236,43 +244,169 @@ describe("fetchQuota for antigravity", () => {
     } as any);
 
     expect(mocks.downloadText).toHaveBeenCalledWith("antigravity.json");
+    // Sandbox is tried first, and the client version must be one the upstream
+    // still serves the full model set to.
     expect(mocks.request).toHaveBeenCalledWith(
       expect.objectContaining({
         authIndex: "ag-1",
         method: "POST",
-        url: "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+        url: "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
         data: JSON.stringify({ project: "bamboo-precept-lgxtn" }),
         header: expect.objectContaining({
           Authorization: "Bearer $TOKEN$",
-          "User-Agent": "antigravity/1.11.5 windows/amd64",
+          "User-Agent": "vscode/1.X.X (Antigravity/4.3.0)",
         }),
       }),
     );
     expect(result.items.map((item) => item.key)).toEqual([
-      "provider:gemini3-pro",
-      "provider:gemini3-flash",
-      "provider:claude",
+      "antigravity:gemini_pro",
+      "antigravity:gemini_flash",
+      "antigravity:claude",
+      "antigravity:model_gpt_oss_120b_medium",
     ]);
     expect(result.items[0]).toEqual(
       expect.objectContaining({
-        label: "antigravity_quota.gemini3_pro",
+        label: "Gemini Pro",
         percent: 80,
         resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
       }),
     );
-    expect(result.items[1]).toEqual(
-      expect.objectContaining({
-        label: "antigravity_quota.gemini3_flash",
-        percent: 70,
-      }),
-    );
-    expect(result.items[2]).toEqual(
-      expect.objectContaining({
-        label: "antigravity_quota.claude",
-        percent: 60,
-      }),
+    expect(result.items[1]).toEqual(expect.objectContaining({ label: "Gemini Flash", percent: 70 }));
+    expect(result.items[2]).toEqual(expect.objectContaining({ label: "Claude", percent: 60 }));
+    expect(result.items[3]).toEqual(
+      expect.objectContaining({ label: "GPT-OSS 120B (Medium)", percent: 50 }),
     );
     expect(result.items[0].meta).toBeUndefined();
+  });
+
+  test("prefers the grouped summary and never falls back when it answers", async () => {
+    mocks.downloadText.mockResolvedValueOnce(JSON.stringify({ project_id: "real-project" }));
+    mocks.request.mockImplementation(async ({ url }: { url: string }) => {
+      if (!url.includes("retrieveUserQuotaSummary")) {
+        throw new Error(`unexpected fallback request to ${url}`);
+      }
+      return {
+        statusCode: 200,
+        header: {},
+        bodyText: "",
+        body: JSON.stringify({
+          groups: [
+            {
+              displayName: "Gemini Models",
+              buckets: [
+                { bucketId: "gemini-5h", window: "5h", remainingFraction: 0.72 },
+                { bucketId: "gemini-weekly", window: "weekly", remainingFraction: 0.51 },
+              ],
+            },
+          ],
+        }),
+      };
+    });
+
+    const result = await fetchQuota("antigravity", {
+      name: "antigravity.json",
+      provider: "antigravity",
+      auth_index: "ag-1",
+    } as any);
+
+    expect(result.items.map((item) => item.key)).toEqual([
+      "antigravity:gemini_5h",
+      "antigravity:gemini_weekly",
+    ]);
+    expect(result.items.map((item) => item.windowSeconds)).toEqual([
+      5 * 60 * 60,
+      7 * 24 * 60 * 60,
+    ]);
+  });
+
+  // A project the account cannot read is rejected outright. Retrying without it
+  // is what the upstream client does, and it is the difference between a card
+  // that reads "forbidden" and one that shows the account's real quota.
+  test("retries without the project field after a 403", async () => {
+    mocks.downloadText.mockResolvedValueOnce(JSON.stringify({ project_id: "foreign-project" }));
+    const seen: Array<{ url: string; data: string }> = [];
+    mocks.request.mockImplementation(async ({ url, data }: { url: string; data: string }) => {
+      seen.push({ url, data });
+      if (url.includes("retrieveUserQuotaSummary")) {
+        if (data.includes("foreign-project")) {
+          return { statusCode: 403, header: {}, bodyText: "", body: "" };
+        }
+        return {
+          statusCode: 200,
+          header: {},
+          bodyText: "",
+          body: JSON.stringify({
+            groups: [
+              {
+                displayName: "Gemini Models",
+                buckets: [{ bucketId: "gemini-5h", window: "5h", remainingFraction: 0.4 }],
+              },
+            ],
+          }),
+        };
+      }
+      return { statusCode: 404, header: {}, bodyText: "", body: "" };
+    });
+
+    const result = await fetchQuota("antigravity", {
+      name: "antigravity.json",
+      provider: "antigravity",
+      auth_index: "ag-1",
+    } as any);
+
+    expect(seen[0].data).toBe(JSON.stringify({ project: "foreign-project" }));
+    expect(seen[1].data).toBe("{}");
+    expect(seen[1].url).toBe(seen[0].url);
+    expect(result.items[0]).toEqual(expect.objectContaining({ percent: 40 }));
+  });
+
+  // Without a stored project the account's own one has to be looked up; guessing
+  // reports some other project's remaining fraction.
+  test("looks the project up via loadCodeAssist when the auth file has none", async () => {
+    mocks.downloadText.mockResolvedValueOnce(JSON.stringify({ client_id: "x" }));
+    const seen: string[] = [];
+    mocks.request.mockImplementation(async ({ url }: { url: string }) => {
+      seen.push(url);
+      if (url.includes("loadCodeAssist")) {
+        return {
+          statusCode: 200,
+          header: {},
+          bodyText: "",
+          body: JSON.stringify({ cloudaicompanionProject: "discovered-project" }),
+        };
+      }
+      if (url.includes("retrieveUserQuotaSummary")) {
+        return {
+          statusCode: 200,
+          header: {},
+          bodyText: "",
+          body: JSON.stringify({
+            groups: [
+              {
+                displayName: "Gemini Models",
+                buckets: [{ bucketId: "gemini-5h", window: "5h", remainingFraction: 0.2 }],
+              },
+            ],
+          }),
+        };
+      }
+      return { statusCode: 404, header: {}, bodyText: "", body: "" };
+    });
+
+    const result = await fetchQuota("antigravity", {
+      name: "antigravity.json",
+      provider: "antigravity",
+      auth_index: "ag-1",
+    } as any);
+
+    expect(seen[0]).toContain("loadCodeAssist");
+    expect(mocks.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining("retrieveUserQuotaSummary"),
+        data: JSON.stringify({ project: "discovered-project" }),
+      }),
+    );
+    expect(result.items[0]).toEqual(expect.objectContaining({ percent: 20 }));
   });
 });
 

--- a/features/quota-preview/__tests__/quota-helpers.test.ts
+++ b/features/quota-preview/__tests__/quota-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   buildAntigravityItems,
+  buildAntigravitySummaryItems,
   buildCodexItems,
   buildKimiItems,
   filterAntigravityQuotaItems,
@@ -300,51 +301,68 @@ describe("buildAntigravityItems", () => {
     const items = buildAntigravityItems(payload!);
     const labels = items.map((item) => item.label);
 
+    // Families are classified by the shape of the model id, so gpt-oss — which
+    // belongs to none of them — is reported under its own name instead of being
+    // dropped for missing from a list.
     expect(items.map((item) => item.key)).toEqual([
-      "provider:gemini3-pro",
-      "provider:gemini3-flash",
-      "provider:gemini-image",
-      "provider:claude",
+      "antigravity:gemini_pro",
+      "antigravity:gemini_flash",
+      "antigravity:gemini_image",
+      "antigravity:claude",
+      "antigravity:model_gpt_oss_120b_medium",
     ]);
     expect(labels).toEqual([
-      "antigravity_quota.gemini3_pro",
-      "antigravity_quota.gemini3_flash",
-      "antigravity_quota.gemini_image",
-      "antigravity_quota.claude",
+      "Gemini Pro",
+      "Gemini Flash",
+      "Gemini Image",
+      "Claude",
+      "GPT-OSS 120B (Medium)",
     ]);
-    expect(labels).not.toContain("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]");
-    expect(labels).not.toContain("GPT-OSS 120B (Medium) [gpt-oss-120b-medium]");
+    // Internal entries are still filtered, by prefix rather than by id.
     expect(labels).not.toContain("chat_20706");
     expect(labels).not.toContain("chat_23310");
     expect(labels).not.toContain("tab_flash_lite_preview");
     expect(labels).not.toContain("tab_jump_flash_lite_preview");
-    expect(labels).not.toContain("Gemini 3.1 Flash Lite [gemini-2.5-flash-thinking]");
-    expect(labels).not.toContain("Gemini 2.5 Pro [gemini-2.5-pro]");
+
+    // Worst remaining within a family: gemini-3.1-pro-low at 50 beats
+    // gemini-3.1-pro-high at 75 and gemini-2.5-pro at 100.
     expect(items[0]).toEqual(
       expect.objectContaining({
         percent: 50,
         resetAtMs: Date.parse("2026-05-09T15:50:29Z"),
+        windowSeconds: 5 * 60 * 60,
       }),
     );
-    expect(items[1]).toEqual(
-      expect.objectContaining({
-        percent: 70,
-      }),
-    );
-    expect(items[2]).toEqual(
-      expect.objectContaining({
-        percent: 60,
-      }),
-    );
-    expect(items[3]).toEqual(
-      expect.objectContaining({
-        percent: 90,
-      }),
-    );
+    expect(items[1]).toEqual(expect.objectContaining({ percent: 70 }));
+    expect(items[2]).toEqual(expect.objectContaining({ percent: 60 }));
+    expect(items[3]).toEqual(expect.objectContaining({ percent: 90 }));
+    expect(items[4]).toEqual(expect.objectContaining({ percent: 80 }));
     expect(items[0].meta).toBeUndefined();
   });
 
-  test("keeps cached sub2api-style Antigravity summaries when cache only has labels", () => {
+  test("groups a model family the upstream ships later without a code change", () => {
+    const payload = parseAntigravityPayload(
+      JSON.stringify({
+        models: {
+          "gemini-4-pro-ultra": { displayName: "Gemini 4 Pro", quotaInfo: { remainingFraction: 0.3 } },
+          "gemini-4-flash-nano": { quotaInfo: { remainingFraction: 0.4 } },
+          "claude-opus-9": { quotaInfo: { remainingFraction: 0.55 } },
+        },
+      }),
+    );
+    const items = buildAntigravityItems(payload!);
+    expect(items.map((item) => item.key)).toEqual([
+      "antigravity:gemini_pro",
+      "antigravity:gemini_flash",
+      "antigravity:claude",
+    ]);
+    expect(items.map((item) => item.percent)).toEqual([30, 40, 55]);
+  });
+
+  // Rows cached under the previous grouping still have to render while they age
+  // out, so the old keys and labels are recognised on read and mapped onto the
+  // current families.
+  test("re-reads cached rows written under the previous Antigravity grouping", () => {
     expect(
       filterAntigravityQuotaItems([
         { label: "antigravity_quota.gemini3_pro", percent: 82 },
@@ -353,31 +371,91 @@ describe("buildAntigravityItems", () => {
         { label: "antigravity_quota.claude", percent: 73 },
       ]),
     ).toEqual([
+      { key: "antigravity:gemini_pro", label: "Gemini Pro", percent: 82, windowSeconds: 5 * 60 * 60 },
       {
-        key: "provider:gemini3-pro",
-        label: "antigravity_quota.gemini3_pro",
-        percent: 82,
-        resetAtMs: undefined,
-      },
-      {
-        key: "provider:gemini3-flash",
-        label: "antigravity_quota.gemini3_flash",
+        key: "antigravity:gemini_flash",
+        label: "Gemini Flash",
         percent: 77,
-        resetAtMs: undefined,
+        windowSeconds: 5 * 60 * 60,
       },
       {
-        key: "provider:gemini-image",
-        label: "antigravity_quota.gemini_image",
+        key: "antigravity:gemini_image",
+        label: "Gemini Image",
         percent: 65,
-        resetAtMs: undefined,
+        windowSeconds: 5 * 60 * 60,
+      },
+      { key: "antigravity:claude", label: "Claude", percent: 73, windowSeconds: 5 * 60 * 60 },
+    ]);
+  });
+
+  test("passes grouped summary rows through untouched", () => {
+    const summaryItems = [
+      {
+        key: "antigravity:gemini_5h",
+        label: "Gemini Models · 5h",
+        percent: 72,
+        windowSeconds: 5 * 60 * 60,
       },
       {
-        key: "provider:claude",
-        label: "antigravity_quota.claude",
-        percent: 73,
-        resetAtMs: undefined,
+        key: "antigravity:gemini_weekly",
+        label: "Gemini Models · weekly",
+        percent: 51,
+        windowSeconds: 7 * 24 * 60 * 60,
+      },
+    ];
+    expect(filterAntigravityQuotaItems(summaryItems)).toEqual(summaryItems);
+  });
+});
+
+describe("buildAntigravitySummaryItems", () => {
+  test("reads the upstream's own buckets and window widths", () => {
+    const items = buildAntigravitySummaryItems({
+      groups: [
+        {
+          displayName: "Gemini Models",
+          buckets: [
+            {
+              bucketId: "gemini-5h",
+              window: "5h",
+              remainingFraction: 0.72,
+              resetTime: "2026-08-19T07:00:00Z",
+            },
+            { bucketId: "gemini-weekly", window: "weekly", remainingFraction: 0.51 },
+          ],
+        },
+        {
+          displayName: "Claude and GPT models",
+          buckets: [{ bucketId: "3p-5h", window: "5h", remainingFraction: 1 }],
+        },
+      ],
+    });
+
+    expect(items).toEqual([
+      {
+        key: "antigravity:gemini_5h",
+        label: "Gemini Models · 5h",
+        percent: 72,
+        resetAtMs: Date.parse("2026-08-19T07:00:00Z"),
+        windowSeconds: 5 * 60 * 60,
+      },
+      {
+        key: "antigravity:gemini_weekly",
+        label: "Gemini Models · weekly",
+        percent: 51,
+        windowSeconds: 7 * 24 * 60 * 60,
+      },
+      {
+        key: "antigravity:3p_5h",
+        label: "Claude and GPT models · 5h",
+        percent: 100,
+        windowSeconds: 5 * 60 * 60,
       },
     ]);
+  });
+
+  test("returns nothing when the payload carries no groups", () => {
+    expect(buildAntigravitySummaryItems({ models: { "gemini-3-pro": {} } })).toEqual([]);
+    expect(buildAntigravitySummaryItems(null)).toEqual([]);
   });
 });
 

--- a/features/quota-preview/index.ts
+++ b/features/quota-preview/index.ts
@@ -1,10 +1,16 @@
 export type { AntigravityModelsPayload } from "./quota-helpers";
 export {
+  ANTIGRAVITY_QUOTA_KEY_PREFIX,
   buildAntigravityGroups,
   buildAntigravityItems,
+  buildAntigravitySummaryItems,
+  categorizeAntigravityModel,
   filterAntigravityQuotaItems,
+  parseAntigravityForwardingRules,
   parseAntigravityPayload,
+  parseAntigravityWindowSeconds,
   shouldSkipAntigravityModelId,
+  type AntigravityQuotaCategory,
 } from "./quota-helpers";
 export { parseIdTokenPayload, type QuotaItem, type QuotaState } from "./quota-helpers";
 export type { QuotaProvider } from "./quota-fetch";

--- a/features/quota-preview/quota-antigravity.ts
+++ b/features/quota-preview/quota-antigravity.ts
@@ -22,6 +22,7 @@ export type AntigravityModelsPayload = Record<string, AntigravityQuotaInfo>;
 
 export type AntigravityFetchAvailableModelsPayload = {
   models?: AntigravityModelsPayload;
+  deprecatedModelIds?: unknown;
   defaultAgentModelId?: unknown;
   agentModelSorts?: unknown;
   commandModelIds?: unknown;
@@ -41,173 +42,200 @@ const MODEL_ID_LISTS: Array<keyof AntigravityFetchAvailableModelsPayload> = [
   "commitMessageModelIds",
 ];
 
-const REFERENCE_SKIPPED_MODEL_IDS = new Set([
-  "chat_20706",
-  "chat_23310",
-  "tab_flash_lite_preview",
-  "tab_jump_flash_lite_preview",
-  "gemini-2.5-flash-thinking",
-  "gemini-2.5-pro",
-]);
+export const ANTIGRAVITY_QUOTA_KEY_PREFIX = "antigravity:";
+
+const FIVE_HOUR_SECONDS = 5 * 60 * 60;
+const WEEK_SECONDS = 7 * 24 * 60 * 60;
+const DAY_SECONDS = 24 * 60 * 60;
+const MONTH_SECONDS = 30 * 24 * 60 * 60;
 
 const normalizeModelId = (value: unknown): string | null => normalizeStringValue(value);
 
 const normalizeModelIdList = (value: unknown): string[] =>
   Array.isArray(value) ? value.map(normalizeModelId).filter((id): id is string => Boolean(id)) : [];
 
-export const shouldSkipAntigravityModelId = (id: string): boolean =>
-  REFERENCE_SKIPPED_MODEL_IDS.has(id);
-
-const ANTIGRAVITY_MODEL_KEY_PREFIX = "model:";
-const ANTIGRAVITY_SUMMARY_KEY_PREFIX = "provider:";
-
-type AntigravityQuotaGroup = "gemini3Pro" | "gemini3Flash" | "gemini3Image" | "claude";
-
-const ANTIGRAVITY_QUOTA_GROUPS: Array<{
-  group: AntigravityQuotaGroup;
-  key: string;
-  label: string;
-}> = [
-  { group: "gemini3Pro", key: "provider:gemini3-pro", label: "antigravity_quota.gemini3_pro" },
-  {
-    group: "gemini3Flash",
-    key: "provider:gemini3-flash",
-    label: "antigravity_quota.gemini3_flash",
-  },
-  { group: "gemini3Image", key: "provider:gemini-image", label: "antigravity_quota.gemini_image" },
-  { group: "claude", key: "provider:claude", label: "antigravity_quota.claude" },
-];
-
-const ANTIGRAVITY_QUOTA_GROUP_MODEL_IDS: Record<AntigravityQuotaGroup, ReadonlySet<string>> = {
-  gemini3Pro: new Set([
-    "gemini-3-pro-low",
-    "gemini-3-pro-high",
-    "gemini-3-pro-preview",
-    "gemini-3.1-pro-low",
-    "gemini-3.1-pro-high",
-    "gemini-3.1-pro-preview",
-  ]),
-  gemini3Flash: new Set(["gemini-3-flash", "gemini-3-flash-agent"]),
-  gemini3Image: new Set([
-    "gemini-2.5-flash-image",
-    "gemini-3.1-flash-image",
-    "gemini-3-pro-image",
-    "gemini-3-pro-image-preview",
-  ]),
-  claude: new Set([
-    "claude-fable-5",
-    "claude-sonnet-4-5",
-    "claude-sonnet-4-5-thinking",
-    "claude-opus-4-5-thinking",
-    "claude-sonnet-4-6",
-    "claude-opus-4-6",
-    "claude-opus-4-6-thinking",
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-  ]),
-};
-
-const normalizeAntigravityModelIdForGroup = (value: string): string => {
+const normalizeAntigravityModelId = (value: string): string => {
   const normalized = value.trim().toLowerCase();
   return normalized.startsWith("models/") ? normalized.slice("models/".length) : normalized;
 };
 
-const resolveAntigravityModelIdFromQuotaItem = (item: QuotaItem): string | null => {
-  const key = typeof item.key === "string" ? item.key.trim() : "";
-  if (key.startsWith(ANTIGRAVITY_MODEL_KEY_PREFIX)) {
-    return key.slice(ANTIGRAVITY_MODEL_KEY_PREFIX.length).trim() || null;
+/**
+ * The upstream's non-conversational entries. Matched by shape rather than by id
+ * so a newly added internal model does not surface as a user-visible row.
+ */
+export const shouldSkipAntigravityModelId = (id: string): boolean => {
+  const normalized = normalizeAntigravityModelId(id);
+  return normalized.startsWith("chat_") || normalized.startsWith("tab_");
+};
+
+export type AntigravityQuotaCategory =
+  | "gemini_pro"
+  | "gemini_flash"
+  | "gemini_image"
+  | "claude"
+  | "other";
+
+/**
+ * Group a model by the shape of its id rather than by membership in a list.
+ *
+ * A list has to be edited every time the upstream ships a model, and until it
+ * is, the new model's quota is dropped on the floor — it does not render as
+ * "unknown", it renders as nothing at all. The shapes below already cover the
+ * models that do not exist yet, and anything they still miss lands in `other`
+ * and is shown under its own name.
+ */
+export const categorizeAntigravityModel = (rawId: string): AntigravityQuotaCategory => {
+  const id = normalizeAntigravityModelId(rawId);
+  const isGemini = id.startsWith("gemini");
+  if ((isGemini && id.includes("image")) || id.startsWith("image") || id.startsWith("imagen")) {
+    return "gemini_image";
   }
-  if (key && shouldSkipAntigravityModelId(key)) return key;
-
-  const label = String(item.label ?? "").trim();
-  const bracketModelId = label.match(/\[([^\]]+)\]\s*$/)?.[1]?.trim();
-  if (bracketModelId) return bracketModelId;
-  return label && shouldSkipAntigravityModelId(label) ? label : null;
-};
-
-const resolveAntigravityQuotaGroupFromModelId = (id: string): AntigravityQuotaGroup | null => {
-  const modelId = normalizeAntigravityModelIdForGroup(id);
-  const match = ANTIGRAVITY_QUOTA_GROUPS.find(({ group }) =>
-    ANTIGRAVITY_QUOTA_GROUP_MODEL_IDS[group].has(modelId),
-  );
-  return match?.group ?? null;
-};
-
-const resolveAntigravityQuotaGroupFromSummaryValue = (
-  value: string,
-): AntigravityQuotaGroup | null =>
-  ANTIGRAVITY_QUOTA_GROUPS.find((group) => group.key === value || group.label === value)?.group ??
-  null;
-
-const resolveAntigravityQuotaGroupFromItem = (item: QuotaItem): AntigravityQuotaGroup | null => {
-  const key = typeof item.key === "string" ? item.key.trim() : "";
-  if (key.startsWith(ANTIGRAVITY_SUMMARY_KEY_PREFIX)) {
-    const group = resolveAntigravityQuotaGroupFromSummaryValue(key);
-    if (group) return group;
+  if (isGemini && id.includes("flash")) return "gemini_flash";
+  if (isGemini && id.includes("pro")) return "gemini_pro";
+  if (
+    id.includes("claude") ||
+    id.includes("opus") ||
+    id.includes("sonnet") ||
+    id.includes("haiku")
+  ) {
+    return "claude";
   }
-  const label = String(item.label ?? "").trim();
-  const labelGroup = resolveAntigravityQuotaGroupFromSummaryValue(label);
-  if (labelGroup) return labelGroup;
-  const modelId = resolveAntigravityModelIdFromQuotaItem(item);
-  return modelId ? resolveAntigravityQuotaGroupFromModelId(modelId) : null;
+  return "other";
 };
 
-const resolveAntigravityQuotaGroupFromModel = (id: string): AntigravityQuotaGroup | null =>
-  resolveAntigravityQuotaGroupFromModelId(id);
-
-const earlierResetAtMs = (current: number | undefined, next: number | undefined) => {
-  if (typeof next !== "number" || !Number.isFinite(next)) return current;
-  if (typeof current !== "number" || !Number.isFinite(current)) return next;
-  return Math.min(current, next);
+const CATEGORY_LABELS: Record<Exclude<AntigravityQuotaCategory, "other">, string> = {
+  gemini_pro: "Gemini Pro",
+  gemini_flash: "Gemini Flash",
+  gemini_image: "Gemini Image",
+  claude: "Claude",
 };
 
-export const summarizeAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] => {
-  const grouped = new Map<
-    AntigravityQuotaGroup,
-    { percent: number | null; resetAtMs?: number; count: number }
-  >();
+const CATEGORY_RANK: Record<AntigravityQuotaCategory, number> = {
+  gemini_pro: 0,
+  gemini_flash: 1,
+  gemini_image: 2,
+  claude: 3,
+  other: 4,
+};
 
-  items.forEach((item) => {
-    const modelId = resolveAntigravityModelIdFromQuotaItem(item);
-    if (modelId && shouldSkipAntigravityModelId(modelId)) return;
+const normalizeKeyPart = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "_")
+    .replaceAll(/^_+|_+$/g, "");
 
-    const group = resolveAntigravityQuotaGroupFromItem(item);
-    if (!group) return;
+/**
+ * Map the upstream's window token onto a duration. An unrecognised token yields
+ * `undefined` rather than a guess, so a window we cannot classify is still shown
+ * — it just never claims to be the weekly cycle.
+ */
+export const parseAntigravityWindowSeconds = (
+  window: string | undefined,
+  bucketId?: string,
+): number | undefined => {
+  const candidates = [window, bucketId]
+    .map((value) => (value ?? "").toLowerCase().replaceAll(/[\s_-]/g, ""))
+    .filter(Boolean);
 
-    const existing = grouped.get(group) ?? { percent: null, count: 0 };
-    const percent =
-      typeof item.percent === "number" && Number.isFinite(item.percent)
-        ? clampPercent(item.percent)
-        : null;
+  for (const candidate of candidates) {
+    if (candidate.includes("week")) return WEEK_SECONDS;
+    if (candidate.includes("month")) return MONTH_SECONDS;
+    if (candidate.includes("day") || candidate.includes("daily")) return DAY_SECONDS;
+    const hours = candidate.match(/(\d+)h/)?.[1];
+    if (hours) {
+      const parsed = Number.parseInt(hours, 10);
+      if (Number.isFinite(parsed) && parsed > 0 && parsed <= 24 * 31) return parsed * 60 * 60;
+    }
+  }
+  return undefined;
+};
 
-    grouped.set(group, {
-      percent:
-        percent === null
-          ? existing.percent
-          : existing.percent === null
-            ? percent
-            : Math.min(existing.percent, percent),
-      resetAtMs: earlierResetAtMs(existing.resetAtMs, item.resetAtMs),
-      count: existing.count + 1,
+// ── retrieveUserQuotaSummary ────────────────────────────────────────────────
+
+/**
+ * Read the grouped summary. Every label and every grouping comes from the
+ * payload: the account's real buckets are `gemini-weekly`, `gemini-5h`,
+ * `3p-weekly` and `3p-5h`, and splitting them further by model id is what made
+ * one bucket render as several rows all showing the same number.
+ */
+export const buildAntigravitySummaryItems = (payload: unknown): QuotaItem[] => {
+  if (!isRecord(payload)) return [];
+  const groups = payload.groups ?? payload.quotaGroups ?? payload.quota_groups;
+  if (!Array.isArray(groups)) return [];
+
+  const items: QuotaItem[] = [];
+  const seen = new Set<string>();
+
+  groups.forEach((rawGroup, groupIndex) => {
+    if (!isRecord(rawGroup)) return;
+    const groupName =
+      normalizeStringValue(rawGroup.displayName ?? rawGroup.display_name) ?? undefined;
+    const buckets = rawGroup.buckets ?? rawGroup.quotaBuckets ?? rawGroup.quota_buckets;
+    if (!Array.isArray(buckets)) return;
+
+    buckets.forEach((rawBucket, bucketIndex) => {
+      if (!isRecord(rawBucket)) return;
+      const fraction = normalizeQuotaFraction(
+        rawBucket.remainingFraction ?? rawBucket.remaining_fraction ?? rawBucket.remaining,
+      );
+      const resetTimeRaw = rawBucket.resetTime ?? rawBucket.reset_time;
+      const resetAtMs =
+        typeof resetTimeRaw === "string" ? parseResetTimeToMs(resetTimeRaw) : undefined;
+      if (fraction === null && resetAtMs === undefined) return;
+
+      const bucketId =
+        normalizeStringValue(rawBucket.bucketId ?? rawBucket.bucket_id ?? rawBucket.id) ?? "";
+      const window = normalizeStringValue(rawBucket.window) ?? "";
+      const bucketName =
+        normalizeStringValue(rawBucket.displayName ?? rawBucket.display_name) ?? undefined;
+
+      let keyPart = normalizeKeyPart(bucketId);
+      if (!keyPart) {
+        const windowPart = normalizeKeyPart(window);
+        keyPart = windowPart ? `g${groupIndex}_${windowPart}` : `g${groupIndex}_b${bucketIndex}`;
+      }
+      const key = `${ANTIGRAVITY_QUOTA_KEY_PREFIX}${keyPart}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+
+      items.push({
+        key,
+        label: buildSummaryLabel(groupName, bucketName, bucketId, window),
+        percent: fraction === null ? null : Math.round(clampPercent(fraction * 100)),
+        ...(resetAtMs === undefined ? {} : { resetAtMs }),
+        ...(parseAntigravityWindowSeconds(window, bucketId) === undefined
+          ? {}
+          : { windowSeconds: parseAntigravityWindowSeconds(window, bucketId) }),
+      });
     });
   });
 
-  return ANTIGRAVITY_QUOTA_GROUPS.flatMap(({ group, key, label }) => {
-    const summary = grouped.get(group);
-    if (!summary || summary.count === 0) return [];
-    return [
-      {
-        key,
-        label,
-        percent: summary.percent,
-        resetAtMs: summary.resetAtMs,
-      },
-    ];
-  });
+  return items;
 };
 
-export const filterAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] =>
-  summarizeAntigravityQuotaItems(items);
+/**
+ * Keep the upstream's own wording. Translating it here would mean maintaining a
+ * table of names the upstream is free to change without telling us.
+ */
+const buildSummaryLabel = (
+  groupName: string | undefined,
+  bucketName: string | undefined,
+  bucketId: string,
+  window: string,
+): string => {
+  if (bucketName) {
+    if (groupName && groupName.toLowerCase() !== bucketName.toLowerCase()) {
+      return `${groupName} · ${bucketName}`;
+    }
+    return bucketName;
+  }
+  const base = groupName || bucketId;
+  if (!base) return window;
+  return window ? `${base} · ${window}` : base;
+};
+
+// ── fetchAvailableModels ────────────────────────────────────────────────────
 
 const resolvePayloadAndModels = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
@@ -266,15 +294,16 @@ const collectPayloadModelOrder = (payload: AntigravityFetchAvailableModelsPayloa
   return order;
 };
 
-const buildModelLabel = (id: string, entry: AntigravityQuotaInfo): string => {
-  const displayName = normalizeStringValue(entry.displayName);
-  if (!displayName || displayName === id) return id;
-  return `${displayName} [${id}]`;
+type ModelEntry = {
+  id: string;
+  displayName?: string;
+  percent: number | null;
+  resetAtMs?: number;
 };
 
-const buildAntigravityModelItems = (
+const collectModelEntries = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
-): QuotaItem[] => {
+): ModelEntry[] => {
   const { payload, models } = resolvePayloadAndModels(input);
   const order = collectPayloadModelOrder(payload);
   const orderedIds = new Set(order);
@@ -291,28 +320,199 @@ const buildAntigravityModelItems = (
   return order.flatMap((id) => {
     const entry = models[id];
     if (!entry) return [];
-    if (!resolveAntigravityQuotaGroupFromModel(id)) return [];
     const info = quotaInfo(entry);
     if (info.remainingFraction === null && !info.resetTime) return [];
-    const percent =
-      info.remainingFraction === null
-        ? null
-        : Math.round(clampPercent(info.remainingFraction * 100));
-
+    const resetAtMs = parseResetTimeToMs(info.resetTime);
     return [
       {
-        key: `model:${id}`,
-        label: buildModelLabel(id, entry),
-        percent,
-        resetAtMs: parseResetTimeToMs(info.resetTime),
+        id: normalizeAntigravityModelId(id),
+        displayName: normalizeStringValue(entry.displayName) ?? undefined,
+        percent:
+          info.remainingFraction === null
+            ? null
+            : Math.round(clampPercent(info.remainingFraction * 100)),
+        ...(resetAtMs === undefined ? {} : { resetAtMs }),
       },
     ];
   });
 };
 
+const earlierResetAtMs = (current: number | undefined, next: number | undefined) => {
+  if (typeof next !== "number" || !Number.isFinite(next)) return current;
+  if (typeof current !== "number" || !Number.isFinite(current)) return next;
+  return Math.min(current, next);
+};
+
+type GroupAccumulator = {
+  key: string;
+  label: string;
+  rank: number;
+  percent: number | null;
+  resetAtMs?: number;
+  count: number;
+};
+
+const groupModelEntries = (entries: ModelEntry[]): QuotaItem[] => {
+  const grouped = new Map<string, GroupAccumulator>();
+
+  entries.forEach((entry) => {
+    const category = categorizeAntigravityModel(entry.id);
+    const key =
+      category === "other"
+        ? `${ANTIGRAVITY_QUOTA_KEY_PREFIX}model_${normalizeKeyPart(entry.id)}`
+        : `${ANTIGRAVITY_QUOTA_KEY_PREFIX}${category}`;
+    const label = category === "other" ? (entry.displayName ?? entry.id) : CATEGORY_LABELS[category];
+
+    const existing = grouped.get(key) ?? {
+      key,
+      label,
+      rank: CATEGORY_RANK[category],
+      percent: null,
+      count: 0,
+    };
+
+    grouped.set(key, {
+      ...existing,
+      // Worst remaining in the group: a family shares one bucket upstream, so
+      // the pessimistic reading is the one that reflects what is left.
+      percent:
+        entry.percent === null
+          ? existing.percent
+          : existing.percent === null
+            ? entry.percent
+            : Math.min(existing.percent, entry.percent),
+      resetAtMs: earlierResetAtMs(existing.resetAtMs, entry.resetAtMs),
+      count: existing.count + 1,
+    });
+  });
+
+  return [...grouped.values()]
+    .filter((group) => group.count > 0)
+    .sort((a, b) => a.rank - b.rank)
+    .map((group) => ({
+      key: group.key,
+      label: group.label,
+      percent: group.percent,
+      ...(group.resetAtMs === undefined ? {} : { resetAtMs: group.resetAtMs }),
+      windowSeconds: FIVE_HOUR_SECONDS,
+    }));
+};
+
+/**
+ * Keys and labels written by the previous grouping, kept only so cached rows
+ * still render while they age out. Nothing new is ever written in these shapes,
+ * and unlike the id list this replaced, a model missing from here is classified
+ * by shape rather than dropped.
+ */
+const LEGACY_GROUP_ALIASES: Record<string, Exclude<AntigravityQuotaCategory, "other">> = {
+  "provider:gemini3-pro": "gemini_pro",
+  "provider:gemini3-flash": "gemini_flash",
+  "provider:gemini-image": "gemini_image",
+  "provider:claude": "claude",
+  "antigravity_quota.gemini3_pro": "gemini_pro",
+  "antigravity_quota.gemini3_flash": "gemini_flash",
+  "antigravity_quota.gemini_image": "gemini_image",
+  "antigravity_quota.claude": "claude",
+};
+
+const resolveLegacyCategory = (
+  item: QuotaItem,
+): Exclude<AntigravityQuotaCategory, "other"> | null => {
+  const key = String(item.key ?? "").trim();
+  if (key && LEGACY_GROUP_ALIASES[key]) return LEGACY_GROUP_ALIASES[key];
+  const label = String(item.label ?? "").trim();
+  return label && LEGACY_GROUP_ALIASES[label] ? LEGACY_GROUP_ALIASES[label] : null;
+};
+
+export const summarizeAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] => {
+  // Items already carrying an antigravity key have been grouped upstream (or by
+  // the fetch layer) and must pass through untouched — re-grouping them by
+  // parsing model ids back out of their labels is what let a summary bucket be
+  // mistaken for a model row.
+  if (items.some((item) => String(item.key ?? "").startsWith(ANTIGRAVITY_QUOTA_KEY_PREFIX))) {
+    return items.filter((item) => String(item.key ?? "").startsWith(ANTIGRAVITY_QUOTA_KEY_PREFIX));
+  }
+
+  const legacyGrouped = new Map<string, QuotaItem>();
+  const modelEntries: ModelEntry[] = [];
+
+  items.forEach((item) => {
+    const percent =
+      typeof item.percent === "number" && Number.isFinite(item.percent)
+        ? clampPercent(item.percent)
+        : null;
+
+    const legacy = resolveLegacyCategory(item);
+    if (legacy) {
+      const key = `${ANTIGRAVITY_QUOTA_KEY_PREFIX}${legacy}`;
+      const existing = legacyGrouped.get(key);
+      legacyGrouped.set(key, {
+        key,
+        label: CATEGORY_LABELS[legacy],
+        percent:
+          percent === null
+            ? (existing?.percent ?? null)
+            : existing?.percent == null
+              ? percent
+              : Math.min(existing.percent, percent),
+        ...(earlierResetAtMs(existing?.resetAtMs, item.resetAtMs) === undefined
+          ? {}
+          : { resetAtMs: earlierResetAtMs(existing?.resetAtMs, item.resetAtMs) }),
+        windowSeconds: FIVE_HOUR_SECONDS,
+      });
+      return;
+    }
+
+    const id = resolveModelIdFromQuotaItem(item);
+    if (!id || shouldSkipAntigravityModelId(id)) return;
+    modelEntries.push({
+      id,
+      displayName: extractDisplayNameFromLabel(item.label),
+      percent,
+      ...(item.resetAtMs === undefined ? {} : { resetAtMs: item.resetAtMs }),
+    });
+  });
+
+  const fromModels = groupModelEntries(modelEntries);
+  if (legacyGrouped.size === 0) return fromModels;
+
+  const ordered = [...legacyGrouped.values()].sort(
+    (a, b) =>
+      CATEGORY_RANK[categoryFromKey(a.key)] - CATEGORY_RANK[categoryFromKey(b.key)],
+  );
+  return [...ordered, ...fromModels.filter((item) => !legacyGrouped.has(String(item.key)))];
+};
+
+const categoryFromKey = (key: string | undefined): AntigravityQuotaCategory => {
+  const suffix = String(key ?? "").slice(ANTIGRAVITY_QUOTA_KEY_PREFIX.length);
+  return suffix in CATEGORY_RANK ? (suffix as AntigravityQuotaCategory) : "other";
+};
+
+const MODEL_KEY_PREFIX = "model:";
+
+const resolveModelIdFromQuotaItem = (item: QuotaItem): string | null => {
+  const key = typeof item.key === "string" ? item.key.trim() : "";
+  if (key.startsWith(MODEL_KEY_PREFIX)) {
+    return key.slice(MODEL_KEY_PREFIX.length).trim() || null;
+  }
+  const label = String(item.label ?? "").trim();
+  const bracketModelId = label.match(/\[([^\]]+)\]\s*$/)?.[1]?.trim();
+  if (bracketModelId) return bracketModelId;
+  return key || label || null;
+};
+
+const extractDisplayNameFromLabel = (label: string): string | undefined => {
+  const trimmed = String(label ?? "").trim();
+  const withoutId = trimmed.replace(/\s*\[[^\]]+\]\s*$/, "").trim();
+  return withoutId || undefined;
+};
+
+export const filterAntigravityQuotaItems = (items: QuotaItem[]): QuotaItem[] =>
+  summarizeAntigravityQuotaItems(items);
+
 export const buildAntigravityItems = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
-): QuotaItem[] => summarizeAntigravityQuotaItems(buildAntigravityModelItems(input));
+): QuotaItem[] => groupModelEntries(collectModelEntries(input));
 
 export const buildAntigravityGroups = (
   input: AntigravityFetchAvailableModelsPayload | AntigravityModelsPayload,
@@ -329,6 +529,27 @@ export const buildAntigravityGroups = (
       ...(resetTime ? { resetTime } : {}),
     };
   });
+
+/**
+ * Deprecated model ids the upstream reports alongside the model list, as
+ * `{ oldId: { newModelId } }`. The upstream drives its own retirements; nothing
+ * here needs a table of which model replaced which.
+ */
+export const parseAntigravityForwardingRules = (payload: unknown): Record<string, string> => {
+  if (!isRecord(payload)) return {};
+  const deprecated = payload.deprecatedModelIds ?? payload.deprecated_model_ids;
+  if (!isRecord(deprecated)) return {};
+
+  const rules: Record<string, string> = {};
+  Object.entries(deprecated).forEach(([oldId, info]) => {
+    const target = isRecord(info)
+      ? normalizeStringValue(info.newModelId ?? info.new_model_id)
+      : normalizeStringValue(info);
+    const source = normalizeStringValue(oldId);
+    if (source && target) rules[source] = target;
+  });
+  return rules;
+};
 
 export const parseAntigravityPayload = (payload: unknown): Record<string, unknown> | null => {
   if (payload === undefined || payload === null) return null;

--- a/features/quota-preview/quota-fetch.ts
+++ b/features/quota-preview/quota-fetch.ts
@@ -1,6 +1,8 @@
 import { apiCallApi, authFilesApi, getApiCallErrorMessage } from "@code-proxy/api-client";
 import type { ApiCallResult, AuthFileItem } from "@code-proxy/api-client";
 import {
+  ANTIGRAVITY_LOAD_CODE_ASSIST_URLS,
+  ANTIGRAVITY_QUOTA_SUMMARY_URLS,
   ANTIGRAVITY_QUOTA_URLS,
   ANTIGRAVITY_REQUEST_HEADERS,
   CLAUDE_REQUEST_HEADERS,
@@ -21,6 +23,7 @@ import {
   XAI_BILLING_WEEKLY_URL,
   XAI_REQUEST_HEADERS,
   buildAntigravityItems,
+  buildAntigravitySummaryItems,
   buildClaudeItems,
   buildCodexItems,
   buildGeminiCliBuckets,
@@ -130,11 +133,11 @@ export const consumeCodexResetCredit = async (file: AuthFileItem): Promise<void>
   }
 };
 
-const resolveAntigravityProjectId = async (file: AuthFileItem): Promise<string> => {
+const resolveStoredAntigravityProjectId = async (file: AuthFileItem): Promise<string | null> => {
   try {
     const text = await authFilesApi.downloadText(file.name);
     const trimmed = text.trim();
-    if (!trimmed) return DEFAULT_ANTIGRAVITY_PROJECT_ID;
+    if (!trimmed) return null;
     const parsed = JSON.parse(trimmed) as Record<string, unknown>;
     const top = normalizeStringValue(parsed.project_id ?? parsed.projectId);
     if (top) return top;
@@ -149,9 +152,85 @@ const resolveAntigravityProjectId = async (file: AuthFileItem): Promise<string> 
     const webId = web ? normalizeStringValue(web.project_id ?? web.projectId) : null;
     if (webId) return webId;
   } catch {
-    return DEFAULT_ANTIGRAVITY_PROJECT_ID;
+    return null;
   }
-  return DEFAULT_ANTIGRAVITY_PROJECT_ID;
+  return null;
+};
+
+/**
+ * Ask the upstream which project this account actually owns.
+ *
+ * Quota is reported per project, so querying under a project the account does
+ * not own reports that project's remaining fraction — an exhausted account can
+ * come back reading 100%. The shared fallback id is only reached when the
+ * account genuinely has no project of its own.
+ */
+const fetchAntigravityProjectId = async (authIndex: string): Promise<string | null> => {
+  const body = JSON.stringify({
+    metadata: { ideType: "ANTIGRAVITY", platform: "PLATFORM_UNSPECIFIED", pluginType: "GEMINI" },
+  });
+  for (const url of ANTIGRAVITY_LOAD_CODE_ASSIST_URLS) {
+    try {
+      const result = await apiCallApi.request({
+        authIndex,
+        method: "POST",
+        url,
+        header: { ...ANTIGRAVITY_REQUEST_HEADERS },
+        data: body,
+      });
+      if (result.statusCode < 200 || result.statusCode >= 300) continue;
+      const parsed = parseAntigravityPayload(result.body ?? result.bodyText);
+      if (!parsed) continue;
+      const project = parsed.cloudaicompanionProject;
+      const id = isRecord(project)
+        ? normalizeStringValue(project.id)
+        : normalizeStringValue(project);
+      if (id) return id;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+};
+
+const resolveAntigravityProjectId = async (
+  file: AuthFileItem,
+  authIndex: string,
+): Promise<string> => {
+  const stored = await resolveStoredAntigravityProjectId(file);
+  if (stored) return stored;
+  const fetched = await fetchAntigravityProjectId(authIndex);
+  return fetched ?? DEFAULT_ANTIGRAVITY_PROJECT_ID;
+};
+
+/**
+ * POST the project-scoped body and, on 403, retry once without the project
+ * field. A project the account cannot read is rejected outright, and the
+ * projectless form is what the upstream falls back to internally.
+ */
+const requestAntigravityQuota = async (
+  authIndex: string,
+  urls: string[],
+  projectId: string,
+): Promise<{ result: ApiCallResult | null; payload: Record<string, unknown> | null }> => {
+  let last: ApiCallResult | null = null;
+  for (const url of urls) {
+    for (const body of [JSON.stringify({ project: projectId }), "{}"]) {
+      const result = await apiCallApi.request({
+        authIndex,
+        method: "POST",
+        url,
+        header: { ...ANTIGRAVITY_REQUEST_HEADERS },
+        data: body,
+      });
+      last = result;
+      if (result.statusCode >= 200 && result.statusCode < 300) {
+        return { result, payload: parseAntigravityPayload(result.body ?? result.bodyText) };
+      }
+      if (result.statusCode !== 403) break;
+    }
+  }
+  return { result: last, payload: null };
 };
 
 const isClaudeOAuthLikeFile = (file: AuthFileItem): boolean => {
@@ -186,28 +265,28 @@ export const fetchQuota = async (
   const authIndex = resolveAuthIndex(file);
 
   if (type === "antigravity") {
-    const projectId = await resolveAntigravityProjectId(file);
-    const requestBody = JSON.stringify({ project: projectId });
-    let last: ApiCallResult | null = null;
-    for (const url of ANTIGRAVITY_QUOTA_URLS) {
-      const result = await apiCallApi.request({
-        authIndex,
-        method: "POST",
-        url,
-        header: { ...ANTIGRAVITY_REQUEST_HEADERS },
-        data: requestBody,
-      });
-      last = result;
-      if (result.statusCode >= 200 && result.statusCode < 300) {
-        const parsed = parseAntigravityPayload(result.body ?? result.bodyText);
-        const models = parsed?.models;
-        if (!models || !isRecord(models)) throw new Error("no_model_quota");
-        return {
-          items: buildAntigravityItems(parsed),
-        };
-      }
+    const projectId = await resolveAntigravityProjectId(file, authIndex);
+
+    // The grouped summary is the authoritative view — it carries both the weekly
+    // and the 5h window and groups them the way the upstream does. The flat
+    // model list is the fallback: 5h only, grouped by us.
+    const summary = await requestAntigravityQuota(
+      authIndex,
+      ANTIGRAVITY_QUOTA_SUMMARY_URLS,
+      projectId,
+    );
+    if (summary.payload) {
+      const items = buildAntigravitySummaryItems(summary.payload);
+      if (items.length > 0) return { items };
     }
-    if (last) throw new Error(getApiCallErrorMessage(last));
+
+    const models = await requestAntigravityQuota(authIndex, ANTIGRAVITY_QUOTA_URLS, projectId);
+    if (models.payload) {
+      if (!isRecord(models.payload.models)) throw new Error("no_model_quota");
+      return { items: buildAntigravityItems(models.payload) };
+    }
+    if (models.result) throw new Error(getApiCallErrorMessage(models.result));
+    if (summary.result) throw new Error(getApiCallErrorMessage(summary.result));
     throw new Error("request_failed");
   }
 

--- a/features/quota-preview/quota-helpers.ts
+++ b/features/quota-preview/quota-helpers.ts
@@ -2,11 +2,18 @@ import type { AuthFileItem } from "@code-proxy/api-client";
 
 export { type AntigravityModelsPayload } from "@features/quota-preview/quota-antigravity";
 export {
+  ANTIGRAVITY_QUOTA_KEY_PREFIX,
   buildAntigravityGroups,
   buildAntigravityItems,
+  buildAntigravitySummaryItems,
+  categorizeAntigravityModel,
   filterAntigravityQuotaItems,
+  parseAntigravityForwardingRules,
   parseAntigravityPayload,
+  parseAntigravityWindowSeconds,
   shouldSkipAntigravityModelId,
+  summarizeAntigravityQuotaItems,
+  type AntigravityQuotaCategory,
 } from "@features/quota-preview/quota-antigravity";
 export { type CodexUsagePayload } from "@features/quota-preview/quota-codex";
 export {
@@ -53,18 +60,57 @@ export {
 } from "@features/quota-preview/quota-normalizers";
 export type { QuotaItem, QuotaState, QuotaStatus } from "@features/quota-preview/quota-types";
 
+/**
+ * The shared project the upstream accepts for accounts that have none of their
+ * own. It is a last resort, not a default: asking for quota under a project that
+ * is not yours reports that project's remaining fraction, which is how an
+ * exhausted account comes back reading 100%.
+ */
 export const DEFAULT_ANTIGRAVITY_PROJECT_ID = "bamboo-precept-lgxtn";
 
-export const ANTIGRAVITY_QUOTA_URLS = [
-  "https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
-  "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:fetchAvailableModels",
-  "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
+/**
+ * Ordered sandbox-first: the sandbox host stays reachable while the production
+ * host is shedding load with 429s.
+ */
+const ANTIGRAVITY_HOSTS = [
+  "https://daily-cloudcode-pa.sandbox.googleapis.com",
+  "https://daily-cloudcode-pa.googleapis.com",
+  "https://cloudcode-pa.googleapis.com",
 ];
+
+/**
+ * The grouped view. The upstream reports one bucket per model family per window
+ * (weekly and 5h) and names them itself, so nothing here has to guess which
+ * models share a quota.
+ */
+export const ANTIGRAVITY_QUOTA_SUMMARY_URLS = ANTIGRAVITY_HOSTS.map(
+  (host) => `${host}/v1internal:retrieveUserQuotaSummary`,
+);
+
+/** The flat view. Only carries the 5h window and leaves grouping to the caller. */
+export const ANTIGRAVITY_QUOTA_URLS = ANTIGRAVITY_HOSTS.map(
+  (host) => `${host}/v1internal:fetchAvailableModels`,
+);
+
+export const ANTIGRAVITY_LOAD_CODE_ASSIST_URLS = ANTIGRAVITY_HOSTS.map(
+  (host) => `${host}/v1internal:loadCodeAssist`,
+);
+
+/**
+ * The client version the upstream gates its answer on. An outdated version is
+ * served a reduced model set and a coarser quota view, so this must track the
+ * real Antigravity client rather than whatever version happened to be current
+ * when the header was first written.
+ *
+ * The literal `1.X.X` is not an unfilled placeholder — that is the string the
+ * Antigravity client itself sends.
+ */
+export const ANTIGRAVITY_CLIENT_VERSION = "4.3.0";
 
 export const ANTIGRAVITY_REQUEST_HEADERS = {
   Authorization: "Bearer $TOKEN$",
   "Content-Type": "application/json",
-  "User-Agent": "antigravity/1.11.5 windows/amd64",
+  "User-Agent": `vscode/1.X.X (Antigravity/${ANTIGRAVITY_CLIENT_VERSION})`,
 };
 
 export const GEMINI_CLI_QUOTA_URL =

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -1020,11 +1020,7 @@
     "missing_auth_index": "Auth file missing auth_index",
     "empty_models": "No quota data available",
     "refresh_button": "Refresh Quota",
-    "fetch_all": "Fetch All",
-    "gemini3_pro": "Gemini 3 Pro",
-    "gemini3_flash": "Gemini 3 Flash",
-    "gemini_image": "Gemini 3.1 Flash Image",
-    "claude": "Claude"
+    "fetch_all": "Fetch All"
   },
   "claude_quota": {
     "title": "Claude Quota",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -891,11 +891,7 @@
     "missing_auth_index": "В файле авторизации отсутствует auth_index",
     "empty_models": "Данные по квоте отсутствуют",
     "refresh_button": "Обновить квоту",
-    "fetch_all": "Получить все",
-    "gemini3_pro": "Gemini 3 Pro",
-    "gemini3_flash": "Gemini 3 Flash",
-    "gemini_image": "Gemini 3.1 Flash Image",
-    "claude": "Claude"
+    "fetch_all": "Получить все"
   },
   "claude_quota": {
     "title": "Квота Claude",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -1028,11 +1028,7 @@
     "missing_auth_index": "认证文件缺少 auth_index",
     "empty_models": "暂无额度数据",
     "refresh_button": "刷新额度",
-    "fetch_all": "获取全部",
-    "gemini3_pro": "Gemini 3 Pro",
-    "gemini3_flash": "Gemini 3 Flash",
-    "gemini_image": "Gemini 3.1 Flash Image",
-    "claude": "Claude"
+    "fetch_all": "获取全部"
   },
   "claude_quota": {
     "title": "Claude 额度",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -3784,9 +3784,9 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("Gemini 3 Pro")).toBeInTheDocument();
-    expect(within(cards).getByText("Gemini 3 Flash")).toBeInTheDocument();
-    expect(within(cards).getByText("Gemini 3.1 Flash Image")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini Pro")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini Flash")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini Image")).toBeInTheDocument();
     expect(within(cards).getByText("Claude")).toBeInTheDocument();
     expect(within(cards).getByText("82%")).toBeInTheDocument();
     expect(within(cards).getByText("77%")).toBeInTheDocument();
@@ -3873,7 +3873,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("Gemini 3 Pro")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini Pro")).toBeInTheDocument();
     expect(
       within(cards).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
     ).not.toBeInTheDocument();
@@ -3940,7 +3940,7 @@ describe("AuthFilesPage files table", () => {
     expect(await screen.findByText("antigravity.json")).toBeInTheDocument();
     const cards = screen.getByTestId("auth-files-cards");
 
-    expect(within(cards).getByText("Gemini 3 Pro")).toBeInTheDocument();
+    expect(within(cards).getByText("Gemini Pro")).toBeInTheDocument();
     expect(within(cards).getByText("91%")).toBeInTheDocument();
     expect(
       within(cards).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
@@ -4009,7 +4009,7 @@ describe("AuthFilesPage files table", () => {
     expect(row).not.toBeNull();
 
     const cell = within(row as HTMLElement);
-    expect(cell.getByText("Gemini 3 Pro")).toBeInTheDocument();
+    expect(cell.getByText("Gemini Pro")).toBeInTheDocument();
     expect(
       cell.queryByText("Gemini 3.1 Pro (Low) [gemini-3.1-pro-low]"),
     ).not.toBeInTheDocument();
@@ -4082,7 +4082,7 @@ describe("AuthFilesPage files table", () => {
     expect(row).not.toBeNull();
 
     // Both metrics are readable in the row itself, so no overlay is needed.
-    const geminiChip = within(row as HTMLElement).getByText("Gemini 3 Pro");
+    const geminiChip = within(row as HTMLElement).getByText("Gemini Pro");
     expect(within(row as HTMLElement).getByText("Claude")).toBeInTheDocument();
 
     fireEvent.mouseEnter(geminiChip);
@@ -4156,7 +4156,7 @@ describe("AuthFilesPage files table", () => {
     const row = screen.getByText("antigravity.json").closest("tr");
     expect(row).not.toBeNull();
     expect(within(row as HTMLElement).queryByText("chat_20706")).not.toBeInTheDocument();
-    expect(within(row as HTMLElement).getByText("Gemini 3 Pro")).toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText("Gemini Pro")).toBeInTheDocument();
     expect(
       within(row as HTMLElement).queryByText("Gemini 3.1 Pro (High) [gemini-3.1-pro-high]"),
     ).not.toBeInTheDocument();

--- a/pages/auth-files/hooks/quotaCardSlots.ts
+++ b/pages/auth-files/hooks/quotaCardSlots.ts
@@ -16,6 +16,22 @@ export type QuotaCardSlot = {
   item: QuotaItem | null;
 };
 
+const WEEK_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Keep the windows narrower than a week.
+ *
+ * Items with no declared window come from the flat model view, which only ever
+ * reports the 5h window — dropping them would empty the card for accounts whose
+ * grouped summary is unavailable.
+ */
+export const selectAntigravityShortWindowItems = (items: QuotaItem[]): QuotaItem[] => {
+  const short = items.filter(
+    (item) => typeof item.windowSeconds !== "number" || item.windowSeconds < WEEK_SECONDS,
+  );
+  return short.length > 0 ? short : items;
+};
+
 /**
  * Map a provider's quota windows onto the fixed slots a card renders.
  *
@@ -50,11 +66,17 @@ export const resolveQuotaCardSlots = (
       }));
     }
     if (provider === "antigravity") {
-      return filterAntigravityQuotaItems(items).map((item, index) => ({
-        id: item.key ?? item.label ?? `antigravity-${index + 1}`,
-        label: translateQuotaLabel(item.label),
-        item,
-      }));
+      // The card shows the short window only. The upstream reports both a 5h and
+      // a weekly bucket per family, and stacking all of them here doubles the row
+      // count for a card that has room for a handful; the weekly figures are on
+      // the detail panel.
+      return selectAntigravityShortWindowItems(filterAntigravityQuotaItems(items)).map(
+        (item, index) => ({
+          id: item.key ?? item.label ?? `antigravity-${index + 1}`,
+          label: translateQuotaLabel(item.label),
+          item,
+        }),
+      );
     }
     if (provider === "xai") {
       return items.map((item, index) => ({


### PR DESCRIPTION
## What was wrong

The Antigravity card split one upstream quota bucket into four rows by matching model ids against a hand-written list, then labelled those rows with four hard-coded strings from the translation catalogue.

The visible symptom: three Gemini rows showing an identical percentage and an identical reset time down to the second — because upstream they are one bucket (`gemini-5h`), not three. Claude sat in a different bucket (`3p-5h`), which is why it showed a different number.

The invisible symptom is worse: a model missing from the id list was not rendered as unknown, it was dropped. `resolveAntigravityQuotaGroupFromModel` returned null and the item was skipped, so a newly shipped model family showed up as nothing at all.

## What changed

- Read `retrieveUserQuotaSummary` first — it reports the weekly and 5h buckets per family and names them itself — and fall back to `fetchAvailableModels`.
- Classify models for that fallback by the shape of their id rather than by list membership, keeping unclassified ones under their own display name.
- Drop the four hard-coded family names from the locales. A mapping for keys written by the previous grouping stays behind so cached rows still render while they age out.
- The direct fetch path resolves the account's own project through `loadCodeAssist` instead of assuming the shared fallback id, retries once without the `project` field on a 403, announces a client version the upstream still serves in full, and tries the sandbox host first.

## What the card looks like now

The card keeps showing the 5h window only. With the summary endpoint available it renders one row per family instead of four rows for two buckets, labelled with whatever the upstream calls them. The weekly buckets reach the detail panel, which already splits its trend by window width and needed no change once the backend started reporting `window_seconds`.

Pairs with kittors/CliRelay#904 — the backend has to report the buckets before this can render them.

## Testing

- `tsc --noEmit` clean, `oxlint` clean
- import-boundaries / file-size / design-tokens / surface-usage gates all pass
- 277 tests across `features/quota-preview` and `pages/auth-files` green, with new cases for summary parsing, the 403 retry, `loadCodeAssist` project resolution, unknown-model retention, and re-reading rows cached under the previous grouping

A full-suite run shows unrelated timeouts under parallel load; re-running those 8 files on their own passes 308/308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)