### PR TITLE
feat(providers): sort credentials by remaining quota

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3948,7 +3948,11 @@
     "anthropic_processing_label": "Anthropic Processing",
     "anthropic_processing_hint": "When enabled, applies Anthropic-specific processing (cloaking, cache control, tool prefix). Disable for third-party Claude-compatible APIs (e.g. Kimi) to improve performance.",
     "claude_models_discovery_hint": "Fetches Anthropic-compatible GET /v1/models using this key (x-api-key + Bearer). Empty Base URL defaults to https://api.anthropic.com.",
-    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead."
+    "codex_models_discovery_hint": "Fetches OpenAI-compatible GET /v1/models using this key. Empty Base URL defaults to https://api.openai.com. For ChatGPT OAuth accounts, use Auth Files → Models → Refresh instead.",
+    "credential_sort_label": "Sort credentials",
+    "credential_sort_config": "Configured order",
+    "credential_sort_remaining_asc": "Least quota left first",
+    "credential_sort_remaining_desc": "Most quota left first"
   },
   "logs_page": {
     "error_log_files": "Error Log Files",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2373,7 +2373,11 @@
     "opencode_go_usage_compact_five_hour": "5 часов",
     "opencode_go_usage_compact_session": "Скользящее",
     "opencode_go_usage_remaining_unknown": "Left --",
-    "opencode_go_usage_remaining_percent": "Left {{percent}}%"
+    "opencode_go_usage_remaining_percent": "Left {{percent}}%",
+    "credential_sort_label": "Сортировка учётных данных",
+    "credential_sort_config": "Порядок из конфигурации",
+    "credential_sort_remaining_asc": "Сначала с наименьшим остатком",
+    "credential_sort_remaining_desc": "Сначала с наибольшим остатком"
   },
   "log_content": {
     "detail_label_request": "Request",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2948,7 +2948,11 @@
     "anthropic_processing_label": "Anthropic 专有处理",
     "anthropic_processing_hint": "开启时将执行 Anthropic 专有处理（伪装、缓存控制、工具前缀等）。如 Base URL 指向第三方 Claude 兼容 API（如 Kimi），建议关闭以提升性能。",
     "claude_models_discovery_hint": "使用当前密钥请求 Anthropic 兼容的 GET /v1/models（x-api-key + Bearer）。Base URL 为空时默认 https://api.anthropic.com。",
-    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。"
+    "codex_models_discovery_hint": "使用当前密钥请求 OpenAI 兼容的 GET /v1/models。Base URL 为空时默认 https://api.openai.com。ChatGPT OAuth 账号请在「认证文件 → 模型 → 刷新」拉取上游清单。",
+    "credential_sort_label": "凭证排序",
+    "credential_sort_config": "默认顺序",
+    "credential_sort_remaining_asc": "剩余额度少的在前",
+    "credential_sort_remaining_desc": "剩余额度多的在前"
   },
   "request_logs": {
     "title": "请求日志",

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -22,6 +22,29 @@ import { ProviderModelChips } from "./components/ProviderModelChips";
 import { useTranslation } from "react-i18next";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 
+/**
+ * Validate a caller-supplied order before rendering with it.
+ *
+ * A malformed order must degrade to configured order rather than dropping or
+ * duplicating credentials: this list is how an operator edits and deletes them,
+ * and a card that silently disappears is worse than one shown out of order.
+ */
+function resolveRenderOrder(
+  count: number,
+  displayOrder: readonly number[] | undefined,
+): number[] {
+  const natural = Array.from({ length: count }, (_, index) => index);
+  if (!displayOrder || displayOrder.length !== count) return natural;
+  const seen = new Set<number>();
+  for (const index of displayOrder) {
+    if (!Number.isInteger(index) || index < 0 || index >= count || seen.has(index)) {
+      return natural;
+    }
+    seen.add(index);
+  }
+  return [...displayOrder];
+}
+
 export function ProviderKeyListCard({
   items,
   loading = false,
@@ -44,6 +67,7 @@ export function ProviderKeyListCard({
   showModelMetric = true,
   showExcludedModels = true,
   renderMetricsExtra,
+  displayOrder,
 }: {
   items: ProviderSimpleConfig[];
   loading?: boolean;
@@ -76,6 +100,15 @@ export function ProviderKeyListCard({
   showConnectionRows?: boolean;
   showModelMetric?: boolean;
   showExcludedModels?: boolean;
+  /**
+   * Positions into `items`, in the order the cards should appear.
+   *
+   * Reordering `items` itself is not an option: the index handed to onEdit,
+   * onDelete and renderExtra identifies the credential in the saved config and
+   * keys its usage cache, so a shuffled array would edit one credential while
+   * showing another's usage. Omit to render in configured order.
+   */
+  displayOrder?: readonly number[];
 }) {
   const { t } = useTranslation();
   const auth = useOptionalAuth();
@@ -142,7 +175,9 @@ export function ProviderKeyListCard({
                 }
           }
         >
-          {items.map((item, idx) => {
+          {resolveRenderOrder(items.length, displayOrder).map((idx) => {
+            const item = items[idx];
+            if (!item) return null;
             const selectionKey = `${item.apiKey.trim().toLowerCase()}:${idx}`;
             const selected = selectedKeys?.has(selectionKey) ?? false;
             const disabled = !(isItemEnabled

--- a/pages/providers/__tests__/ProviderKeyListCard.display-order.test.tsx
+++ b/pages/providers/__tests__/ProviderKeyListCard.display-order.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import type { ProviderSimpleConfig } from "@code-proxy/api-client";
+import { ThemeProvider, ToastProvider } from "@code-proxy/ui";
+import { ProviderKeyListCard } from "@pages/providers/ProviderKeyListCard";
+
+const items: ProviderSimpleConfig[] = [
+  { name: "alpha", apiKey: "key-alpha", models: [] } as unknown as ProviderSimpleConfig,
+  { name: "bravo", apiKey: "key-bravo", models: [] } as unknown as ProviderSimpleConfig,
+  { name: "charlie", apiKey: "key-charlie", models: [] } as unknown as ProviderSimpleConfig,
+];
+
+const renderList = (displayOrder?: number[], onEdit = vi.fn()) => {
+  render(
+    <ThemeProvider>
+      <ToastProvider>
+        <ProviderKeyListCard
+          items={items}
+          onEdit={onEdit}
+          onDelete={vi.fn()}
+          getStats={() => ({ success: 0, failure: 0 })}
+          getStatusBar={() => ({
+            blocks: [],
+            blockDetails: [],
+            successRate: 0,
+            totalSuccess: 0,
+            totalFailure: 0,
+          })}
+          {...(displayOrder ? { displayOrder } : {})}
+        />
+      </ToastProvider>
+    </ThemeProvider>,
+  );
+  return onEdit;
+};
+
+const renderedNames = (): string[] =>
+  items
+    .map((item) => item.name as string)
+    .map((name) => ({ name, node: screen.queryByTitle(name) }))
+    .filter((entry) => entry.node !== null)
+    .sort(
+      (left, right) =>
+        (left.node!.compareDocumentPosition(right.node!) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+          ? -1
+          : 1),
+    )
+    .map((entry) => entry.name);
+
+describe("ProviderKeyListCard displayOrder", () => {
+  test("renders in configured order when no order is supplied", () => {
+    renderList();
+    expect(renderedNames()).toEqual(["alpha", "bravo", "charlie"]);
+  });
+
+  test("renders in the supplied order", () => {
+    renderList([2, 0, 1]);
+    expect(renderedNames()).toEqual(["charlie", "alpha", "bravo"]);
+  });
+
+  // The index handed to callbacks identifies the credential in the saved config,
+  // and also keys its usage cache. If reordering shifted it, the operator would
+  // edit whichever credential occupied that screen position and read another
+  // one's quota — a silent wrong-target edit.
+  test("keeps callback indices pointing at the original config entries", () => {
+    const seen: Array<[string, number]> = [];
+    render(
+      <ThemeProvider>
+        <ToastProvider>
+          <ProviderKeyListCard
+            items={items}
+            displayOrder={[2, 0, 1]}
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+            getStats={() => ({ success: 0, failure: 0 })}
+            getStatusBar={() => ({
+              blocks: [],
+              blockDetails: [],
+              successRate: 0,
+              totalSuccess: 0,
+              totalFailure: 0,
+            })}
+            getDisplayModels={(item, index) => {
+              seen.push([String(item.name), index]);
+              return [];
+            }}
+          />
+        </ToastProvider>
+      </ThemeProvider>,
+    );
+
+    // Visited in display order, but each carries its configured position.
+    expect(seen).toEqual([
+      ["charlie", 2],
+      ["alpha", 0],
+      ["bravo", 1],
+    ]);
+  });
+
+  // A malformed order must not drop or duplicate credentials: a card that
+  // silently disappears is worse than one shown out of order.
+  test.each([
+    ["too short", [1, 0]],
+    ["out of range", [0, 1, 5]],
+    ["duplicated", [0, 0, 1]],
+  ])("falls back to configured order when the order is %s", (_label, order) => {
+    renderList(order as number[]);
+    expect(renderedNames()).toEqual(["alpha", "bravo", "charlie"]);
+  });
+});

--- a/pages/providers/__tests__/provider-usage-sort.test.ts
+++ b/pages/providers/__tests__/provider-usage-sort.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "vitest";
+import type { OpenCodeGoUsageItem } from "@code-proxy/api-client";
+import {
+  isCredentialUsageSortMode,
+  resolveCredentialDisplayOrder,
+  resolveCredentialRemaining,
+  resolveEntryRemaining,
+  resolveWindowRemaining,
+} from "../provider-usage-sort";
+
+const window = (percentage: number, type = "weekly"): OpenCodeGoUsageItem => ({
+  type,
+  label: type,
+  percentage,
+  resets_in: "1h",
+});
+
+describe("resolveWindowRemaining", () => {
+  test("reports the complement of consumption", () => {
+    expect(resolveWindowRemaining(0)).toBe(100);
+    expect(resolveWindowRemaining(30)).toBe(70);
+    expect(resolveWindowRemaining(100)).toBe(0);
+  });
+
+  test("clamps readings outside 0-100 rather than propagating them", () => {
+    expect(resolveWindowRemaining(140)).toBe(0);
+    expect(resolveWindowRemaining(-20)).toBe(100);
+  });
+
+  test("treats unusable readings as unknown", () => {
+    expect(resolveWindowRemaining(undefined)).toBeNull();
+    expect(resolveWindowRemaining(Number.NaN)).toBeNull();
+    expect(resolveWindowRemaining(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe("resolveCredentialRemaining", () => {
+  // A comfortable monthly allowance does not help when the 5-hour window is
+  // spent: the credential is unusable right now, and must sort that way.
+  test("takes the tightest window, not the most flattering", () => {
+    expect(
+      resolveCredentialRemaining([
+        window(5, "monthly"),
+        window(95, "five_hour"),
+        window(40, "weekly"),
+      ]),
+    ).toBe(5);
+  });
+
+  test("ignores unusable windows but keeps the rest", () => {
+    expect(
+      resolveCredentialRemaining([
+        { ...window(0), percentage: Number.NaN },
+        window(25),
+      ]),
+    ).toBe(75);
+  });
+
+  test("is unknown when nothing is readable", () => {
+    expect(resolveCredentialRemaining([])).toBeNull();
+    expect(resolveCredentialRemaining(undefined)).toBeNull();
+    expect(
+      resolveCredentialRemaining([{ ...window(0), percentage: Number.NaN }]),
+    ).toBeNull();
+  });
+});
+
+describe("resolveEntryRemaining", () => {
+  test("reads through a healthy cache entry", () => {
+    expect(
+      resolveEntryRemaining({ usage: [window(20)], updatedAt: 1 }),
+    ).toBe(80);
+  });
+
+  // A failed refresh must not sort on whatever response happened to be attached
+  // before it: that number is no longer known to be true.
+  test("discards a reading attached to a failed entry", () => {
+    expect(
+      resolveEntryRemaining({ usage: [window(20)], updatedAt: 1, error: "boom" }),
+    ).toBeNull();
+    expect(resolveEntryRemaining(undefined)).toBeNull();
+  });
+});
+
+describe("resolveCredentialDisplayOrder", () => {
+  const remaining: Record<number, number | null> = {
+    0: 60,
+    1: 10,
+    2: null,
+    3: 90,
+  };
+  const read = (index: number) => remaining[index] ?? null;
+
+  test("config mode preserves the configured order", () => {
+    expect(resolveCredentialDisplayOrder(4, "config", read)).toEqual([0, 1, 2, 3]);
+  });
+
+  test("ascending puts the most exhausted credential first", () => {
+    expect(resolveCredentialDisplayOrder(4, "remaining_asc", read)).toEqual([
+      1, 0, 3, 2,
+    ]);
+  });
+
+  test("descending puts the most available credential first", () => {
+    expect(resolveCredentialDisplayOrder(4, "remaining_desc", read)).toEqual([
+      3, 0, 1, 2,
+    ]);
+  });
+
+  // Unknown is neither empty nor full. Floating it to the top of either order
+  // would bury the credentials the operator opened this view to find.
+  test("parks unknown readings last in both directions", () => {
+    const allUnknownButOne = (index: number) => (index === 2 ? 50 : null);
+    expect(
+      resolveCredentialDisplayOrder(4, "remaining_asc", allUnknownButOne)[0],
+    ).toBe(2);
+    expect(
+      resolveCredentialDisplayOrder(4, "remaining_desc", allUnknownButOne)[0],
+    ).toBe(2);
+  });
+
+  // The returned positions index the original array — the card list uses them
+  // for edit, delete and the usage cache key, so they must stay a permutation.
+  test("returns a permutation of the original positions", () => {
+    const order = resolveCredentialDisplayOrder(4, "remaining_desc", read);
+    expect([...order].sort((a, b) => a - b)).toEqual([0, 1, 2, 3]);
+  });
+
+  test("ties and equal unknowns keep configured order", () => {
+    const flat = () => 50;
+    expect(resolveCredentialDisplayOrder(3, "remaining_asc", flat)).toEqual([0, 1, 2]);
+    const none = () => null;
+    expect(resolveCredentialDisplayOrder(3, "remaining_desc", none)).toEqual([0, 1, 2]);
+  });
+
+  test("handles empty and degenerate counts", () => {
+    expect(resolveCredentialDisplayOrder(0, "remaining_asc", read)).toEqual([]);
+    expect(resolveCredentialDisplayOrder(-1, "remaining_asc", read)).toEqual([]);
+  });
+});
+
+describe("isCredentialUsageSortMode", () => {
+  test("accepts known modes and rejects anything else", () => {
+    expect(isCredentialUsageSortMode("config")).toBe(true);
+    expect(isCredentialUsageSortMode("remaining_asc")).toBe(true);
+    expect(isCredentialUsageSortMode("remaining_desc")).toBe(true);
+    expect(isCredentialUsageSortMode("remaining")).toBe(false);
+    expect(isCredentialUsageSortMode(null)).toBe(false);
+  });
+});

--- a/pages/providers/__tests__/useCredentialSortMode.test.tsx
+++ b/pages/providers/__tests__/useCredentialSortMode.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  resetCredentialSortModeForTests,
+  useCredentialSortMode,
+} from "../hooks/useCredentialSortMode";
+
+beforeEach(() => {
+  localStorage.clear();
+  resetCredentialSortModeForTests();
+});
+
+describe("useCredentialSortMode", () => {
+  test("starts in configured order", () => {
+    const { result } = renderHook(() => useCredentialSortMode());
+    expect(result.current[0]).toBe("config");
+  });
+
+  // The four usage tabs render separate instances. If they held independent
+  // state, switching tabs would silently drop the order the operator chose.
+  test("shares the selection across instances", () => {
+    const first = renderHook(() => useCredentialSortMode());
+    const second = renderHook(() => useCredentialSortMode());
+
+    act(() => first.result.current[1]("remaining_asc"));
+
+    expect(first.result.current[0]).toBe("remaining_asc");
+    expect(second.result.current[0]).toBe("remaining_asc");
+  });
+
+  test("persists the selection for the next visit", () => {
+    const { result, unmount } = renderHook(() => useCredentialSortMode());
+    act(() => result.current[1]("remaining_desc"));
+    unmount();
+
+    resetCredentialSortModeForTests();
+    const reopened = renderHook(() => useCredentialSortMode());
+    expect(reopened.result.current[0]).toBe("remaining_desc");
+  });
+
+  // A value written by a newer build, or hand-edited, must not select a mode
+  // the sorter does not implement.
+  test("ignores an unrecognised stored value", () => {
+    localStorage.setItem("providers-page:credential-usage-sort", "by_vibes");
+    const { result } = renderHook(() => useCredentialSortMode());
+    expect(result.current[0]).toBe("config");
+  });
+});

--- a/pages/providers/components/CredentialUsageSortMenu.tsx
+++ b/pages/providers/components/CredentialUsageSortMenu.tsx
@@ -1,0 +1,76 @@
+import { useTranslation } from "react-i18next";
+import { ArrowDownWideNarrow, ArrowUpNarrowWide, ListOrdered } from "lucide-react";
+import { Button, DropdownMenu } from "@code-proxy/ui";
+import {
+  CREDENTIAL_USAGE_SORT_MODES,
+  type CredentialUsageSortMode,
+} from "../provider-usage-sort";
+
+const MODE_LABEL_KEYS: Record<CredentialUsageSortMode, string> = {
+  config: "providers.credential_sort_config",
+  remaining_asc: "providers.credential_sort_remaining_asc",
+  remaining_desc: "providers.credential_sort_remaining_desc",
+};
+
+const MODE_ICONS: Record<CredentialUsageSortMode, typeof ListOrdered> = {
+  config: ListOrdered,
+  remaining_asc: ArrowUpNarrowWide,
+  remaining_desc: ArrowDownWideNarrow,
+};
+
+/**
+ * Sort control for a channel's credential cards.
+ *
+ * Only rendered for channels that report plan usage — sorting by remaining quota
+ * is meaningless where no quota is reported, and an option that never changes
+ * anything is worse than no option.
+ */
+export function CredentialUsageSortMenu({
+  mode,
+  onChange,
+  disabled = false,
+}: {
+  mode: CredentialUsageSortMode;
+  onChange: (mode: CredentialUsageSortMode) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  const ActiveIcon = MODE_ICONS[mode];
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-8! px-2 text-xs"
+          disabled={disabled}
+          data-testid="credential-usage-sort-trigger"
+          aria-label={t("providers.credential_sort_label")}
+        >
+          <ActiveIcon size={14} />
+          {t(MODE_LABEL_KEYS[mode])}
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content align="start" sideOffset={6}>
+          {CREDENTIAL_USAGE_SORT_MODES.map((candidate) => {
+            const Icon = MODE_ICONS[candidate];
+            return (
+              <DropdownMenu.Item
+                key={candidate}
+                onSelect={() => onChange(candidate)}
+                data-testid={`credential-usage-sort-${candidate}`}
+              >
+                <Icon size={14} />
+                <span className={candidate === mode ? "font-semibold" : undefined}>
+                  {t(MODE_LABEL_KEYS[candidate])}
+                </span>
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/pages/providers/components/ProviderUsageTabContent.tsx
+++ b/pages/providers/components/ProviderUsageTabContent.tsx
@@ -17,6 +17,9 @@ import {
   OpenCodeGoUsageRefreshButton,
   type OpenCodeGoUsageStore,
 } from "./OpenCodeGoUsageCardSection";
+import { useCredentialUsageOrder } from "../hooks/useCredentialUsageOrder";
+import { CredentialUsageSortMenu } from "./CredentialUsageSortMenu";
+import { useCredentialSortMode } from "../hooks/useCredentialSortMode";
 
 type ListCardProps = ComponentProps<typeof ProviderKeyListCard>;
 
@@ -61,9 +64,20 @@ export function ProviderUsageTabContent({
   selectedKeys,
   onToggleSelected,
 }: ProviderUsageTabContentProps) {
+  const [sortMode, setSortMode] = useCredentialSortMode();
+  const displayOrder = useCredentialUsageOrder(provider, items, usageStore, sortMode);
+
   return (
     <TabsContent value={provider} className="min-h-0 flex flex-1 flex-col">
+      <div className="mb-2 flex items-center justify-end">
+        <CredentialUsageSortMenu
+          mode={sortMode}
+          onChange={setSortMode}
+          disabled={items.length < 2}
+        />
+      </div>
       <ProviderKeyListCard
+        displayOrder={displayOrder}
         items={items}
         loading={loading}
         onEdit={onEdit}

--- a/pages/providers/hooks/useCredentialSortMode.ts
+++ b/pages/providers/hooks/useCredentialSortMode.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  readSavedCredentialSortMode,
+  saveCredentialSortMode,
+  type CredentialUsageSortMode,
+} from "../provider-usage-sort";
+
+/**
+ * The credential sort preference, shared by every usage channel on the page.
+ *
+ * Module-scoped rather than lifted into the page component: the preference
+ * belongs to this feature, and the page component is already past its size
+ * budget. A shared value also means the four usage tabs cannot disagree — an
+ * operator who sorted by remaining quota expects that order on whichever
+ * channel they open next, not just the one they were looking at.
+ */
+let sharedMode: CredentialUsageSortMode | null = null;
+const listeners = new Set<(mode: CredentialUsageSortMode) => void>();
+
+const currentMode = (): CredentialUsageSortMode =>
+  (sharedMode ??= readSavedCredentialSortMode());
+
+export function useCredentialSortMode(): [
+  CredentialUsageSortMode,
+  (mode: CredentialUsageSortMode) => void,
+] {
+  const [mode, setMode] = useState<CredentialUsageSortMode>(currentMode);
+
+  useEffect(() => {
+    // Adopt any change made while this tab was unmounted.
+    setMode(currentMode());
+    const listener = (next: CredentialUsageSortMode) => setMode(next);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const change = useCallback((next: CredentialUsageSortMode) => {
+    sharedMode = next;
+    saveCredentialSortMode(next);
+    listeners.forEach((listener) => listener(next));
+  }, []);
+
+  return [mode, change];
+}
+
+/** Test seam: drops the in-memory value so a case starts from storage. */
+export function resetCredentialSortModeForTests(): void {
+  sharedMode = null;
+  listeners.clear();
+}

--- a/pages/providers/hooks/useCredentialUsageOrder.ts
+++ b/pages/providers/hooks/useCredentialUsageOrder.ts
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from "react";
+import type { ProviderSimpleConfig } from "@code-proxy/api-client";
+import type { OpenCodeGoUsageStore } from "../components/OpenCodeGoUsageCardSection";
+import { getProviderUsageCacheKey, type ProviderUsageProvider } from "../provider-usage-config";
+import {
+  resolveCredentialDisplayOrder,
+  resolveEntryRemaining,
+  type CredentialUsageSortMode,
+} from "../provider-usage-sort";
+
+/**
+ * Display order for a channel's credentials, following live usage readings.
+ *
+ * Usage arrives asynchronously and per credential — each card refreshes on its
+ * own — so the order has to react as readings land rather than being computed
+ * once. This subscribes to every credential's cache slot and recomputes when any
+ * of them changes.
+ *
+ * In `config` mode nothing is subscribed and the natural order is returned, so
+ * the default view costs nothing.
+ */
+export function useCredentialUsageOrder(
+  provider: ProviderUsageProvider,
+  items: ProviderSimpleConfig[],
+  usageStore: OpenCodeGoUsageStore,
+  mode: CredentialUsageSortMode,
+): number[] {
+  const cacheKeys = useMemo(
+    () => items.map((item, index) => getProviderUsageCacheKey(provider, item, index)),
+    [provider, items],
+  );
+
+  // Bumped on any subscribed change; the order itself is derived below so a
+  // reading that does not move anything does not re-render the list.
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    if (mode === "config") return;
+    const unsubscribes = cacheKeys.map((cacheKey) =>
+      usageStore.subscribe(cacheKey, () => setRevision((value) => value + 1)),
+    );
+    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }, [cacheKeys, mode, usageStore]);
+
+  return useMemo(
+    () =>
+      resolveCredentialDisplayOrder(cacheKeys.length, mode, (index) =>
+        resolveEntryRemaining(usageStore.getSnapshot(cacheKeys[index]).usageEntry),
+      ),
+    // revision is a change signal, not a value the computation reads directly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cacheKeys, mode, usageStore, revision],
+  );
+}

--- a/pages/providers/provider-usage-sort.ts
+++ b/pages/providers/provider-usage-sort.ts
@@ -1,0 +1,129 @@
+import type { OpenCodeGoUsageItem } from "@code-proxy/api-client";
+import type { OpenCodeGoUsageCacheEntry } from "./components/OpenCodeGoUsageCardSection";
+
+export type CredentialUsageSortMode = "config" | "remaining_asc" | "remaining_desc";
+
+export const CREDENTIAL_USAGE_SORT_MODES: readonly CredentialUsageSortMode[] = [
+  "config",
+  "remaining_asc",
+  "remaining_desc",
+];
+
+export const isCredentialUsageSortMode = (
+  value: unknown,
+): value is CredentialUsageSortMode =>
+  typeof value === "string" &&
+  (CREDENTIAL_USAGE_SORT_MODES as readonly string[]).includes(value);
+
+const clampPercent = (value: number): number => Math.max(0, Math.min(100, value));
+
+/**
+ * The remaining headroom of a single window, as a percentage.
+ *
+ * The upstream reports consumption, so remaining is its complement. Mirrors
+ * the arithmetic the usage card renders with, so a credential can never sort by
+ * one number and display another.
+ */
+export const resolveWindowRemaining = (
+  usagePercentage: number | undefined,
+): number | null => {
+  if (typeof usagePercentage !== "number" || !Number.isFinite(usagePercentage)) {
+    return null;
+  }
+  return clampPercent(100 - clampPercent(usagePercentage));
+};
+
+/**
+ * The headroom that decides a credential's position: the tightest window it has.
+ *
+ * A credential with a comfortable monthly allowance but an exhausted 5-hour
+ * window is exhausted right now, and sorting it as though it were plentiful is
+ * the failure this feature exists to prevent. Taking the minimum answers the
+ * question an operator is actually asking — "which key can I use next" — rather
+ * than the more flattering one.
+ *
+ * Returns null when no window carries a usable number; callers park those
+ * credentials rather than treating unknown as full or as empty.
+ */
+export const resolveCredentialRemaining = (
+  usage: readonly OpenCodeGoUsageItem[] | undefined,
+): number | null => {
+  if (!usage || usage.length === 0) return null;
+  let tightest: number | null = null;
+  for (const window of usage) {
+    const remaining = resolveWindowRemaining(window?.percentage);
+    if (remaining === null) continue;
+    if (tightest === null || remaining < tightest) tightest = remaining;
+  }
+  return tightest;
+};
+
+export const resolveEntryRemaining = (
+  entry: OpenCodeGoUsageCacheEntry | undefined,
+): number | null => {
+  // An entry that failed to load carries no usable reading even if a previous
+  // response is still attached to it.
+  if (!entry || entry.error) return null;
+  return resolveCredentialRemaining(entry.usage);
+};
+
+/**
+ * Order credentials for display without disturbing their identity.
+ *
+ * Returns positions into the original array rather than reordered items: the
+ * card list uses that index for edit, delete and the usage cache key, so a
+ * genuinely reordered array would edit the wrong credential and read another
+ * one's usage.
+ *
+ * Credentials with no reading always sort last, in both directions. They are
+ * unknown, not empty and not full, and floating them to the top of either order
+ * would push the credentials an operator wants to see off the first screen.
+ * Ties keep their configured order, so repeated renders do not shuffle.
+ */
+export const resolveCredentialDisplayOrder = (
+  count: number,
+  mode: CredentialUsageSortMode,
+  readRemaining: (index: number) => number | null,
+): number[] => {
+  const positions = Array.from({ length: Math.max(0, count) }, (_, index) => index);
+  if (mode === "config") return positions;
+
+  const remainingByIndex = positions.map(readRemaining);
+  const direction = mode === "remaining_asc" ? 1 : -1;
+
+  return positions.sort((left, right) => {
+    const leftValue = remainingByIndex[left];
+    const rightValue = remainingByIndex[right];
+    if (leftValue === null && rightValue === null) return left - right;
+    if (leftValue === null) return 1;
+    if (rightValue === null) return -1;
+    if (leftValue === rightValue) return left - right;
+    return (leftValue - rightValue) * direction;
+  });
+};
+
+const SORT_MODE_STORAGE_KEY = "providers-page:credential-usage-sort";
+
+/**
+ * The chosen order survives reloads, following the same pattern as the active
+ * tab. An operator who sorted by remaining quota to find a usable key is still
+ * looking for one after a refresh.
+ */
+export const readSavedCredentialSortMode = (): CredentialUsageSortMode => {
+  try {
+    const saved = localStorage.getItem(SORT_MODE_STORAGE_KEY);
+    if (isCredentialUsageSortMode(saved)) return saved;
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies); the default
+    // order is a fine answer and is not worth failing the page over.
+  }
+  return "config";
+};
+
+export const saveCredentialSortMode = (mode: CredentialUsageSortMode): void => {
+  try {
+    localStorage.setItem(SORT_MODE_STORAGE_KEY, mode);
+  } catch {
+    // ignore
+  }
+};


### PR DESCRIPTION
## What

Channels that report plan usage — `opencode-go`, `cline`, `ollama-cloud`, `commandcode` — can hold many credentials, and the one an operator wants is whichever still has headroom. Finding it meant reading every card.

Adds a sort control to those tabs: **configured order** (default), **least quota left first**, **most quota left first**.

## Design decisions worth reviewing

**Position is decided by the tightest window, not the average.** A key with a comfortable monthly allowance but a spent 5-hour window is unusable *right now*. Sorting it as plentiful would defeat the point.

**Unknown sorts last in both directions.** Usage is fetched per credential on demand, so "no reading yet" is the common state. Treating it as full or as empty would push the credentials worth looking at off the first screen. A failed refresh also counts as unknown rather than reusing whatever response was attached before it.

**Reordering is by position, not by array.** This is the part most likely to bite:

```ts
getProviderUsageCacheKey(provider, item, index)   // index is in the key
onEdit(index) / onDelete(index)                    // index identifies the saved config entry
```

The index the card list hands to its callbacks identifies the credential in the saved config *and* keys its usage cache. A genuinely reordered array would edit one credential while displaying another's quota. So `ProviderKeyListCard` takes an optional `displayOrder` — positions into `items` — and keeps handing out configured indices. A malformed order (wrong length, out of range, duplicated) degrades to configured order rather than dropping or duplicating cards.

**The preference is module-scoped, not lifted into the page.** `ProvidersPageContent.tsx` is already past the file-size gate baseline (1647 lines, and the gate only permits shrinking). Putting the state in a small shared hook keeps that file untouched, and means the four usage tabs cannot disagree about the order. Persisted to `localStorage`, following the active-tab pattern.

## No backend change

Plan usage is fetched client-side per credential and cached in the browser; the server only proxies the upstream call. Ordering is a view concern with no server-side input, so there is nothing meaningful to add on the backend. Flagging this explicitly since the request mentioned front and back end.

## Testing

26 new tests across three files:

- `provider-usage-sort.test.ts` (16) — the sort arithmetic: tightest-window selection, clamping, unknown handling, stable ties, and that the result is always a permutation of the original positions
- `ProviderKeyListCard.display-order.test.tsx` (6) — render order follows `displayOrder`, **callback indices still point at the original config entries**, and malformed orders fall back safely
- `useCredentialSortMode.test.tsx` (4) — shared across instances, persisted, and an unrecognised stored value is ignored

`tsc`, `oxlint`, and all four structure gates (file-size / import-boundaries / surface-usage / design-tokens) pass. Full `pages/providers` suite green at 96 tests.

## Not verified in a browser

I started the dev server but stopped at the login screen — I don't enter credentials. The sort control's live appearance and the drop-down interaction are covered by tests but not by eye; worth a look when you run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)