### PR TITLE
chore(bundle): align the AuthFilesPage baseline with dev

### DIFF
--- a/docs/internal-review/bundle-baseline.md
+++ b/docs/internal-review/bundle-baseline.md
@@ -20,7 +20,7 @@ bun run build
 | `index`              |  396.29 kB | 121.04 kB | 多账号切换（AuthProvider vault + AppShell 账号菜单）进入 shell 入口；后续可再拆 account menu |
 | `index.css`          |  430.02 kB |  86.34 kB | 入口样式表；含 114 条自托管字体 @font-face 分片声明（Inter / Noto Sans SC / JetBrains Mono），字体文件本身按 unicode-range 懒加载不计入此行 |
 | `ConfigPage`         |  119.60 kB |  33.35 kB | 页面 chunk 低于预算                                                         |
-| `AuthFilesPage`      |  216.81 kB |  58.90 kB | 身份多档案与出站策略交互加入后仍低于页面 gzip 预算                          |
+| `AuthFilesPage`      |  234.90 kB |  64.36 kB | 与 dev 现状对齐（原记 58.90 kB 已落后约 5.5 kB）；仍低于 `< 80 kB gzip` 页面预算，余量约 15 kB |
 | `ProvidersPage`      |  121.98 kB |  30.85 kB | 已低于 `< 80 kB gzip` 页面预算                                              |
 | `MonitorPage`        |   24.33 kB |   6.80 kB | 已拆为 toolbar / state hook / dashboard sections                            |
 | `LogsPage`           |   22.15 kB |   6.51 kB | 已拆为 live logs / error logs / helpers                                     |
@@ -37,7 +37,7 @@ bun run build
 
 | 页面/模块         |                  当前体积 | 预算状态       | 最近治理结果                                                                                                    |
 | ----------------- | ------------------------: | -------------- | --------------------------------------------------------------------------------------------------------------- |
-| `AuthFilesPage`   | 216.81 kB / 58.90 kB gzip | 通过           | 新增 Codex 身份多档案与出站选择后仍低于页面 gzip 预算，后续继续关注 chunk 治理 |
+| `AuthFilesPage`   | 234.90 kB / 64.36 kB gzip | 通过           | 基线与 dev 现状对齐；仍低于页面 gzip 预算，余量约 15 kB，chunk 治理继续关注 |
 | `ConfigPage`      | 119.60 kB / 33.35 kB gzip | 通过           | 已拆出 runtime panel / visual payload editors，并复用 feature 侧 visual config hook |
 | `ProvidersPage`   | 121.98 kB / 30.85 kB gzip | 通过且低于预算 | OpenAI tab、usage summary、provider editor hooks 已完成拆分 |
 | `MonitorPage`     |  24.33 kB /  6.80 kB gzip | 通过且低于预算 | 拆出 `MonitorToolbarSection`、`MonitorDashboardSections`、`useMonitorDashboardState` |


### PR DESCRIPTION
## Why

The bundle gate fails on every PR opened against `dev` right now, and the branch under review is not the cause.

`AuthFilesPage` is recorded at **58.90 kB** gzip while `dev` actually builds it at **64.36 kB** — 5.46 kB past the 5 kB delta tolerance.

Verified by building `dev` with every local change stashed, including untracked files:

```
| `AuthFilesPage` | 234.90 kB | 64.36 kB | 58.90 kB | +5.46 kB | over delta tolerance |
Result: FAIL (1 tracked chunk budget issue)
```

Byte-identical to the failure on my feature branch, which is how I found it — I had assumed my own change caused it and went looking for 5 kB I could not account for.

## What this does and does not change

The drift is in the **record**, not in the budget. At 64.36 kB the chunk is still comfortably under the **80 kB** page budget, with roughly 15 kB of headroom.

Nothing here relaxes the budget or the tolerance. The recorded number is brought up to what `dev` produces, so the tolerance starts measuring *new* growth again instead of re-reporting growth that already landed.

## Still worth doing separately

`AuthFilesPage` is the largest page chunk in the app, and 5.46 kB arrived without anyone noticing. Chunk governance for it is worth a look — but that is a different change from unblocking the gate, and doing it here would bury this one-line record fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)