### PR TITLE
fix(ai-accounts): stop painting the healthy state green

### DIFF
--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -1727,7 +1727,7 @@ export function AuthFilesFilesTab({
                     successRate === null
                       ? "text-slate-500 dark:text-white/45"
                       : successRate >= 90
-                        ? "text-emerald-700 dark:text-emerald-200"
+                        ? "text-slate-700 dark:text-white/70"
                         : successRate >= 50
                           ? "text-amber-700 dark:text-amber-200"
                           : "text-rose-700 dark:text-rose-200";

--- a/pages/auth-files/components/QuotaMetricChips.tsx
+++ b/pages/auth-files/components/QuotaMetricChips.tsx
@@ -27,15 +27,19 @@ export const resolveQuotaVisualTone = (percent: number | null | undefined): Quot
     };
   }
 
+  // A healthy quota is the common case, so it gets no colour beyond the ring:
+  // tinting the chip surface, its label and its percent all at once made every
+  // card on the page read as one flat green field, and a green that is always
+  // on cannot signal anything. Amber and rose below keep their full treatment —
+  // they are the states worth spotting from across the grid.
   if (normalized >= 60) {
     return {
       normalized,
       fillClass: "bg-emerald-500",
-      percentClass: "text-emerald-700 dark:text-emerald-200",
+      percentClass: "text-slate-700 dark:text-white/80",
       fillHex: "#10b981",
-      chipClass:
-        "border-emerald-200/70 bg-emerald-50/70 dark:border-emerald-500/20 dark:bg-emerald-500/[0.08]",
-      chipLabelClass: "text-emerald-900/70 dark:text-emerald-100/70",
+      chipClass: "border-slate-900/8 bg-slate-50 dark:border-white/10 dark:bg-white/[0.06]",
+      chipLabelClass: "text-slate-600 dark:text-white/70",
     };
   }
 

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -69,8 +69,10 @@ const KNOWN_QUOTA_TEXT_KEYS = new Set([
 ]);
 
 const SUBSCRIPTION_TONE_CLASSES = {
+  // Neutral on purpose: an active subscription is the resting state of every
+  // card, so colouring it competes with the badges that report a problem.
   active:
-    "border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-500/20 dark:bg-emerald-500/15 dark:text-emerald-200",
+    "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/70",
   warning:
     "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/20 dark:bg-amber-500/15 dark:text-amber-200",
   urgent:

--- a/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
+++ b/pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx
@@ -69,8 +69,6 @@ const KNOWN_QUOTA_TEXT_KEYS = new Set([
 ]);
 
 const SUBSCRIPTION_TONE_CLASSES = {
-  // Neutral on purpose: an active subscription is the resting state of every
-  // card, so colouring it competes with the badges that report a problem.
   active:
     "border-slate-900/8 bg-slate-50 text-slate-700 dark:border-white/10 dark:bg-white/[0.08] dark:text-white/70",
   warning:


### PR DESCRIPTION
Panel-only. No backend change.

## The problem

A card at rest lights **five** emerald surfaces at once:

| Surface | Source | Fires when |
|---|---|---|
| Plan badge | `SUBSCRIPTION_TONE_CLASSES.active` | subscription valid |
| Quota chip border + background | `chipClass` | quota ≥ 60% |
| Quota chip label | `chipLabelClass` | quota ≥ 60% |
| Quota percent | `percentClass` | quota ≥ 60% |
| Success rate | `successRateClass` | rate ≥ 90% |

All five fire for an account in good standing — which is most accounts — so a healthy card renders as one flat green field. Green became the colour of *nothing happening*, and a colour that is always on cannot signal anything. Worse, the amber and rose tones that flag a quota actually worth acting on have to compete with it for attention.

Note this is not a layout problem: the four stat chips (`0` / `4334` / `547.1M` / `99.7%`) were already neutral `slate-100`. They just read as green by association with everything around them.

## The change

All five surfaces return to the neutral slate the stat chips already use. The progress ring keeps its emerald fill, so a healthy quota still reads as healthy — the green is compressed from a full-card background down to a 14px ring.

Untouched on purpose: amber (20–60%), rose (<20%), the warning / urgent / expired subscription tones, and sub-90% success rates. They are now the only coloured things on the grid, which is the whole point.

## Verified

Rendered against the app's own compiled CSS at three states:

- healthy → fully neutral, nothing competes for attention
- 12% + 45% mix → those two rows pop out of an otherwise grey card
- exhausted + degraded success rate → rose reads immediately

Gates: `design:check` ✅ · `lint` 0 errors ✅ · `size:check` ✅ · `surface:check` ✅ · `boundary:imports` ✅ · `build` ✅ · 243 tests / 21 files ✅

The second commit removes a two-line code comment: `useAuthFilesFilesPresentation.tsx` is above the 800-line limit, the gate only lets such files shrink, and the comment pushed it 974 → 976. The reasoning lives in the first commit message instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)