### PR TITLE
fix(ai-accounts): neutralise the quota bar fill, not just its text

### DIFF
--- a/pages/auth-files/components/QuotaMetricChips.tsx
+++ b/pages/auth-files/components/QuotaMetricChips.tsx
@@ -35,7 +35,12 @@ export const resolveQuotaVisualTone = (percent: number | null | undefined): Quot
   if (normalized >= 60) {
     return {
       normalized,
-      fillClass: "bg-emerald-500",
+      // The card view spends this on renderQuotaBarNode's fill, which is the
+      // row's own background rather than a slim track — at 100% it covers the
+      // whole line, so an emerald fill turned every healthy row into a green
+      // band. fillHex below stays green: it drives the 14px ring, where the
+      // colour costs nothing.
+      fillClass: "bg-slate-400 dark:bg-white/30",
       percentClass: "text-slate-700 dark:text-white/80",
       fillHex: "#10b981",
       chipClass: "border-slate-900/8 bg-slate-50 dark:border-white/10 dark:bg-white/[0.06]",


### PR DESCRIPTION
Follow-up to #936. Panel-only.

## What #936 missed

#936 neutralised `percentClass`, `chipClass` and `chipLabelClass`. Verified on production after deploy, the card still rendered as a green band:

```
pctCls  = "… tabular-nums text-slate-700 dark:text-white/80"   ← #936 landed
fillCls = "absolute inset-y-0 left-0 opacity-20 … bg-emerald-500"  ← the actual green
```

The card view renders quota through `renderQuotaBarNode`, not `QuotaMetricChips` — there is no `auth-file-quota-metric` node on the page at all. It consumes exactly one field from the tone, `fillClass`, and paints it as the row's **own background** rather than a slim track underneath. At 100% that fill covers the entire line, so the row was still fully green no matter what colour the label and percent were.

## The change

`fillClass` moves to neutral slate for the ≥60% branch. `fillHex` keeps its emerald — that one drives the 14px progress ring in `QuotaMetricChips`, where the colour occupies a ring instead of a whole row.

Amber (20–60%) and rose (<20%) fills are untouched, so a bar that changes colour now means something actually changed.

## Verified

Patched the class live on production and re-screenshotted: the three quota rows drop to neutral, and the card reads as a normal card. What #936 already fixed and this PR does not touch: subscription badge (`剩余 6 天`) and success rate (`99.7%`) both render neutral on production now.

Gates: `design:check` ✅ · `size:check` ✅ · `surface:check` ✅ · `lint` 0 errors ✅ · 243 tests / 21 files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)