### PR TITLE
fix(ai-providers): keep saved cards and match account card chrome

### DIFF
--- a/e2e/providers-card-border.spec.ts
+++ b/e2e/providers-card-border.spec.ts
@@ -14,18 +14,22 @@ const openProviders = async (page: Page) => {
       }),
     );
     localStorage.setItem("cli-proxy-language", JSON.stringify("zh-CN"));
+    localStorage.setItem("providers-page:tab", "openai");
   });
   await page.route("**/v0/management/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
     const json = (body: unknown) =>
       route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
-    if (path.endsWith("/config")) {
+    if (path.endsWith("/openai-compatibility")) {
       return json({
-        config: {
-          "opencode-go": [
-            { name: "opencode go", api_key: "sk-test", disabled: false, models: ["glm-5.2"] },
-          ],
-        },
+        "openai-compatibility": [
+          {
+            name: "OpenAI Compatible",
+            "base-url": "https://example.com/v1",
+            models: [{ name: "gpt-4.1" }],
+            "api-key-entries": [{ "api-key": "sk-test" }],
+          },
+        ],
       });
     }
     if (path.endsWith("/update/check")) return json({ has_update: false });
@@ -38,8 +42,7 @@ test("provider list card renders a border, not a clipped ring", async ({ page })
   await page.setViewportSize({ width: 1600, height: 900 });
   await openProviders(page);
 
-  // Card always sets aria-busy; the notifications region does not.
-  const card = page.locator("section[aria-busy]").first();
+  const card = page.locator("section.group\\/card").first();
   await expect(card).toBeVisible();
 
   const style = await card.evaluate((el) => {

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -1,6 +1,12 @@
 import { useState, type ReactNode } from "react";
-import { DropdownMenu } from "@code-proxy/ui";
-import { EllipsisVertical, Power, Settings2, Trash2 } from "lucide-react";
+import {
+  Card,
+  DropdownMenu,
+  OverflowTooltip,
+  ToggleSwitch,
+  buttonClassName,
+} from "@code-proxy/ui";
+import { Ellipsis, Power, Settings2, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 export interface ProviderCardProps {
@@ -49,121 +55,142 @@ export function ProviderCard({
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const hasActionMenu = Boolean(onEdit || onDelete || onToggleEnabled);
-  const hasHeaderExtra = Boolean(headerExtra);
+  const showSelectionControl = Boolean(onToggleSelected) && selected;
 
   return (
-    <div
+    <Card
+      padding="default"
+      bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
       className={[
-        "group relative flex min-w-0 flex-col rounded-xl border px-4 py-3 shadow-sm transition-all duration-200 ease-out",
-        naturalHeight
-          ? "h-fit self-start min-h-0"
-          : "min-h-[220px] max-h-[260px]",
+        "group group/card flex h-full w-full max-w-[34rem] flex-col rounded-3xl border-slate-900/8 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+        naturalHeight ? "h-fit self-start min-h-0" : "min-h-[220px]",
         selected
-          ? "border-indigo-400 bg-indigo-50/50 ring-1 ring-indigo-200 dark:border-indigo-500/50 dark:bg-indigo-950/20 dark:ring-indigo-500/20"
-          : "border-slate-900/8 bg-white/70 hover:border-slate-300 hover:bg-white hover:shadow-md dark:border-white/8 dark:bg-neutral-950/60 dark:hover:border-neutral-700 dark:hover:bg-neutral-950/80 dark:hover:shadow-lg dark:hover:shadow-black/20",
-        dimmed ? "opacity-50" : "",
+          ? "border-slate-900 ring-1 ring-slate-300 dark:border-white dark:ring-white/20"
+          : "",
+        dimmed ? "opacity-85" : "",
         className,
       ]
         .filter(Boolean)
         .join(" ")}
     >
-      {/* Header */}
-      <div className="flex min-w-0 items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center">
-          {onToggleSelected ? (
-            <div
-              className={[
-                "flex shrink-0 items-center justify-center overflow-hidden transition-[width,opacity,margin] duration-200 ease-out",
-                selected
-                  ? "mr-2 w-7 opacity-100"
-                  : "mr-0 w-0 opacity-0 group-hover:mr-2 group-hover:w-7 group-hover:opacity-100 max-md:mr-2 max-md:w-7 max-md:opacity-100",
-              ].join(" ")}
-            >
-              <input
-                type="checkbox"
-                aria-label={t("providers.select_provider", { name: title })}
-                checked={selected}
-                onChange={(e) => onToggleSelected(e.currentTarget.checked)}
-                className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-              />
-            </div>
-          ) : null}
-          <p
-            className="min-w-0 max-w-[180px] truncate text-sm font-semibold text-slate-900 dark:text-white"
+      <div className="space-y-2.5">
+        <div className="flex items-center justify-between gap-2">
+          <OverflowTooltip
+            content={title}
             title={title}
+            className="min-w-0 flex-1 truncate text-sm leading-5 font-semibold tracking-tight text-slate-900 dark:text-white"
           >
             {title}
-          </p>
-          {hasHeaderExtra ? (
-            <div className="ml-2 flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-              {headerExtra}
-            </div>
-          ) : null}
-        </div>
-        {hasActionMenu ? (
-          <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
-            <DropdownMenu.Trigger asChild>
-              <button
-                type="button"
+          </OverflowTooltip>
+
+          <div className="flex h-6 shrink-0 items-center gap-1.5">
+            {onToggleSelected ? (
+              <div
                 className={[
-                  "inline-flex h-5 w-5 flex-none items-center justify-center rounded-full border-0 bg-transparent p-0 text-slate-500 shadow-none outline-none ring-0 transition-[color,opacity] duration-150 ease-out hover:bg-transparent hover:text-slate-950 focus-visible:ring-2 focus-visible:ring-slate-400/35 active:bg-transparent dark:text-white/55 dark:hover:bg-transparent dark:hover:text-white dark:focus-visible:ring-white/15",
-                  menuOpen
-                    ? "pointer-events-auto opacity-100"
-                    : "pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 max-md:pointer-events-auto max-md:opacity-100",
+                  "flex h-6 w-6 items-center justify-center transition-opacity",
+                  showSelectionControl
+                    ? "opacity-100 pointer-events-auto"
+                    : "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
                 ].join(" ")}
-                aria-label={t("providers.more_actions")}
-                title={t("providers.more_actions")}
-                data-tooltip-placement="left"
               >
-                <EllipsisVertical size={13} />
-              </button>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Portal>
-              <DropdownMenu.Content align="end" sideOffset={8}>
-                {onToggleEnabled ? (
-                  <DropdownMenu.Item onSelect={() => onToggleEnabled(!enabled)}>
-                    <Power size={15} />
-                    <span>
-                      {enabled ? t("providers.disable") : t("providers.enable")}
-                    </span>
-                  </DropdownMenu.Item>
-                ) : null}
-                {onEdit ? (
-                  <DropdownMenu.Item onSelect={() => onEdit()}>
-                    <Settings2 size={15} />
-                    <span>{t("providers.edit")}</span>
-                  </DropdownMenu.Item>
-                ) : null}
-                {onDelete ? (
-                  <DropdownMenu.Item
-                    className="text-rose-600 focus:text-rose-700 dark:text-rose-300"
-                    onSelect={() => onDelete()}
-                  >
-                    <Trash2 size={15} />
-                    <span>{t("providers.delete")}</span>
-                  </DropdownMenu.Item>
-                ) : null}
-              </DropdownMenu.Content>
-            </DropdownMenu.Portal>
-          </DropdownMenu.Root>
+                <input
+                  type="checkbox"
+                  aria-label={t("providers.select_provider", { name: title })}
+                  checked={selected}
+                  onChange={(e) => onToggleSelected(e.currentTarget.checked)}
+                  className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
+                />
+              </div>
+            ) : null}
+            {onToggleEnabled ? (
+              <div
+                className={[
+                  "flex h-6 items-center justify-center transition-opacity",
+                  "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
+                ].join(" ")}
+              >
+                <ToggleSwitch
+                  ariaLabel={
+                    enabled ? t("providers.disable") : t("providers.enable")
+                  }
+                  checked={enabled}
+                  onCheckedChange={onToggleEnabled}
+                />
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {headerExtra ? (
+          <div className="min-w-0 flex flex-wrap items-center gap-1">
+            {headerExtra}
+          </div>
         ) : null}
       </div>
 
-      {/* Content */}
       {children ? (
         <div
           className={[
-            "mt-2 min-w-0 flex-1",
+            "min-h-0 min-w-0 flex-1 touch-pan-y px-0.5 mt-3 py-1",
             naturalHeight ? "" : "overflow-y-auto",
           ].join(" ")}
         >
           {children}
         </div>
       ) : null}
-      {footer ? (
-        <div className={naturalHeight ? "pt-3" : "mt-auto pt-3"}>{footer}</div>
+
+      {footer || hasActionMenu ? (
+        <div className="mt-auto flex items-center justify-between gap-2 border-t border-slate-100 pt-3 dark:border-white/[0.06]">
+          <div className="min-w-0 flex-1">{footer}</div>
+          {hasActionMenu ? (
+            <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
+              <DropdownMenu.Trigger asChild>
+                <button
+                  type="button"
+                  className={buttonClassName({
+                    variant: "ghost",
+                    size: "sm",
+                    iconOnly: true,
+                  })}
+                  aria-label={t("providers.more_actions")}
+                  title={t("providers.more_actions")}
+                  data-tooltip-placement="top"
+                >
+                  <Ellipsis size={16} />
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content align="end" sideOffset={8} className="min-w-44">
+                  {onToggleEnabled ? (
+                    <DropdownMenu.Item onSelect={() => onToggleEnabled(!enabled)}>
+                      <Power size={15} />
+                      <span>
+                        {enabled ? t("providers.disable") : t("providers.enable")}
+                      </span>
+                    </DropdownMenu.Item>
+                  ) : null}
+                  {onEdit ? (
+                    <DropdownMenu.Item onSelect={() => onEdit()}>
+                      <Settings2 size={15} />
+                      <span>{t("providers.edit")}</span>
+                    </DropdownMenu.Item>
+                  ) : null}
+                  {onDelete ? (
+                    <DropdownMenu.Item
+                      className="text-rose-600 focus:text-rose-700 dark:text-rose-300"
+                      onSelect={() => onDelete()}
+                    >
+                      <Trash2 size={15} />
+                      <span>{t("providers.delete")}</span>
+                    </DropdownMenu.Item>
+                  ) : null}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+          ) : null}
+        </div>
       ) : null}
-    </div>
+    </Card>
   );
 }
 
@@ -173,34 +200,37 @@ export function ProviderCardSkeleton({
   naturalHeight?: boolean;
 }) {
   return (
-    <div
-      className={[
-        "flex flex-col rounded-xl border border-slate-900/8 bg-white/70 px-4 py-3 shadow-sm dark:border-white/8 dark:bg-neutral-950/60",
-        naturalHeight
-          ? "h-fit min-h-[220px] w-full max-w-[22rem] flex-none self-start"
-          : "h-[220px]",
-      ].join(" ")}
-      aria-hidden="true"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div className="h-4 w-32 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
-        <div className="h-5 w-5 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
-      </div>
-      <div className="mt-4 space-y-2">
-        <div className="h-3 w-11/12 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
-        <div className="h-3 w-3/4 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
-      </div>
-      <div className="mt-4 flex flex-wrap gap-1.5">
-        {Array.from({ length: 4 }, (_, index) => (
-          <div
-            key={index}
-            className="h-5 w-20 animate-pulse rounded-full bg-slate-200 dark:bg-white/10"
-          />
-        ))}
-      </div>
-      <div className="mt-auto pt-3">
-        <div className="h-2 w-full animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
-      </div>
+    <div aria-hidden="true">
+      <Card
+        padding="default"
+        bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
+        className={[
+          "flex h-full w-full max-w-[34rem] flex-col rounded-3xl border-slate-900/8 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)]",
+          naturalHeight
+            ? "h-fit min-h-[220px] w-full max-w-[22rem] flex-none self-start"
+            : "min-h-[220px]",
+        ].join(" ")}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="h-4 w-32 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+          <div className="h-6 w-12 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+        </div>
+        <div className="mt-4 space-y-2">
+          <div className="h-3 w-11/12 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+          <div className="h-3 w-3/4 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+        </div>
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {Array.from({ length: 4 }, (_, index) => (
+            <div
+              key={index}
+              className="h-5 w-20 animate-pulse rounded-full bg-slate-200 dark:bg-white/10"
+            />
+          ))}
+        </div>
+        <div className="mt-auto border-t border-slate-100 pt-3 dark:border-white/[0.06]">
+          <div className="h-2 w-full animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+        </div>
+      </Card>
     </div>
   );
 }

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -135,17 +135,11 @@ export function ProviderKeyListCard({
           aria-label={t("common.loading")}
           data-testid="providers-list-skeleton"
           className={[
-            "min-h-0 flex-1 overflow-hidden pr-1 gap-3 items-start content-start justify-start",
-            naturalHeight ? "flex flex-wrap" : "grid",
-          ].join(" ")}
-          style={
+            "min-h-0 flex-1 overflow-hidden gap-5 items-stretch justify-items-center",
             naturalHeight
-              ? undefined
-              : {
-                  gridTemplateColumns:
-                    "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))",
-                }
-          }
+              ? "flex flex-wrap"
+              : "grid grid-cols-1 md:grid-cols-2 md:justify-items-stretch xl:grid-cols-[repeat(3,minmax(0,1fr))]",
+          ].join(" ")}
         >
           {Array.from({ length: 6 }, (_, index) => (
             <ProviderCardSkeleton key={index} naturalHeight={naturalHeight} />
@@ -163,17 +157,11 @@ export function ProviderKeyListCard({
         <div
           data-testid="providers-tab-scroll"
           className={[
-            "min-h-0 flex-1 overflow-y-auto pr-1 gap-3 items-start content-start justify-start",
-            naturalHeight ? "flex flex-wrap" : "grid",
-          ].join(" ")}
-          style={
+            "min-h-0 flex-1 overflow-y-auto gap-5 items-stretch justify-items-center",
             naturalHeight
-              ? undefined
-              : {
-                  gridTemplateColumns:
-                    "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))",
-                }
-          }
+              ? "flex flex-wrap"
+              : "grid grid-cols-1 md:grid-cols-2 md:justify-items-stretch xl:grid-cols-[repeat(3,minmax(0,1fr))]",
+          ].join(" ")}
         >
           {resolveRenderOrder(items.length, displayOrder).map((idx) => {
             const item = items[idx];

--- a/pages/providers/__tests__/ProvidersPage.openai.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.openai.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen, waitFor, within } from "@testing-library/react
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { ProviderSimpleConfig } from "@code-proxy/api-client";
+import type { OpenAIProvider, ProviderSimpleConfig } from "@code-proxy/api-client";
 import {
   DEFAULT_CACHE_TENANT_ID,
   setActiveCacheTenantId,
@@ -536,5 +536,56 @@ describe("ProvidersPage openai tab", () => {
       expect(mocks.patchOpenAIProviderDisabled).toHaveBeenCalledWith(0, true);
     });
     expect(mocks.saveOpenAIProviders).not.toHaveBeenCalled();
+  });
+
+  test("keeps a newly saved OpenAI card visible while refresh still returns the old list", async () => {
+    const user = userEvent.setup();
+    const existing: OpenAIProvider = {
+      name: "OpenAI Main",
+      baseUrl: "https://example.com/v1",
+      apiKeyEntries: [{ apiKey: "sk-openai-provider-1234567890" }],
+      models: [{ name: "gpt-4.1" }],
+    };
+    mocks.getOpenAIProviders.mockImplementation(async () => [existing]);
+
+    render(
+      <MemoryRouter initialEntries={["/access/ai-providers/openai/new"]}>
+        <ThemeProvider>
+          <ToastProvider>
+            <Routes>
+              <Route path="/access/ai-providers/*" element={<ProvidersPage />} />
+            </Routes>
+          </ToastProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Add OpenAI-compatible provider/i,
+    });
+    await user.type(within(dialog).getByPlaceholderText("Name"), "New OpenAI Channel");
+    await user.type(
+      within(dialog).getByPlaceholderText("e.g. https://api.openai.com"),
+      "https://new.example.com/v1",
+    );
+
+    mocks.getOpenAIProviders.mockImplementation(
+      () => new Promise<OpenAIProvider[]>(() => {}),
+    );
+    await user.click(within(dialog).getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => {
+      expect(mocks.saveOpenAIProviders).toHaveBeenCalledWith([
+        expect.objectContaining({ name: "OpenAI Main" }),
+        expect.objectContaining({
+          name: "New OpenAI Channel",
+          baseUrl: "https://new.example.com/v1",
+        }),
+      ]);
+    });
+    expect(await screen.findByText("New OpenAI Channel")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
   });
 });

--- a/pages/providers/components/OpenAIProvidersTab.tsx
+++ b/pages/providers/components/OpenAIProvidersTab.tsx
@@ -82,11 +82,7 @@ export function OpenAIProvidersTab({
           role="status"
           aria-label={t("common.loading")}
           data-testid="providers-list-skeleton"
-          className="min-h-0 flex-1 overflow-hidden pr-1 grid gap-3 items-start content-start justify-start"
-          style={{
-            gridTemplateColumns:
-              "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))",
-          }}
+          className="min-h-0 flex-1 overflow-hidden grid grid-cols-1 items-stretch justify-items-center gap-5 sm:px-1 md:grid-cols-2 md:justify-items-stretch xl:grid-cols-[repeat(3,minmax(0,1fr))]"
         >
           {Array.from({ length: 6 }, (_, index) => (
             <ProviderCardSkeleton key={index} />
@@ -100,11 +96,7 @@ export function OpenAIProvidersTab({
       ) : (
         <div
           data-testid="providers-tab-scroll"
-          className="min-h-0 flex-1 overflow-y-auto pr-1 grid gap-3 items-start content-start justify-start"
-          style={{
-            gridTemplateColumns:
-              "repeat(auto-fill, minmax(min(100%, 18rem), 22rem))",
-          }}
+          className="min-h-0 flex-1 overflow-y-auto grid grid-cols-1 items-stretch justify-items-center gap-5 sm:px-1 md:grid-cols-2 md:justify-items-stretch xl:grid-cols-[repeat(3,minmax(0,1fr))]"
         >
           {providers.map((provider, idx) => {
             const selectionKey = `${provider.name.trim().toLowerCase()}:${idx}`;

--- a/pages/providers/components/ProvidersPageContent.tsx
+++ b/pages/providers/components/ProvidersPageContent.tsx
@@ -449,83 +449,66 @@ export function ProvidersPage() {
   ]);
 
   const loadProviderTab = useCallback(async (tabId: ProviderTab) => {
+    // Cold paint already seeds from tenant cache in useState. Overlaying that
+    // cache again on every refresh races the optimistic list written by Save:
+    // a 7-day-old snapshot can wipe a just-added card until GET returns, and
+    // if GET is empty/slow the card never comes back.
     switch (tabId) {
       case "gemini": {
-        const cachedG = getCachedData<ProviderSimpleConfig[]>("gemini");
-        if (cachedG) setGeminiKeys(cachedG);
         const freshG = await providersApi.getGeminiKeys();
         setGeminiKeys(freshG);
         setCachedData("gemini", freshG);
         break;
       }
       case "claude": {
-        const cachedC = getCachedData<ProviderSimpleConfig[]>("claude");
-        if (cachedC) setClaudeKeys(cachedC);
         const freshC = await providersApi.getClaudeConfigs();
         setClaudeKeys(freshC);
         setCachedData("claude", freshC);
         break;
       }
       case "codex": {
-        const cachedX = getCachedData<ProviderSimpleConfig[]>("codex");
-        if (cachedX) setCodexKeys(cachedX);
         const freshX = await providersApi.getCodexConfigs();
         setCodexKeys(freshX);
         setCachedData("codex", freshX);
         break;
       }
       case "opencode-go": {
-        const cachedO = getCachedData<ProviderSimpleConfig[]>("opencode-go");
-        if (cachedO) setOpenCodeGoKeys(cachedO);
         const freshO = await providersApi.getOpenCodeGoConfigs();
         setOpenCodeGoKeys(freshO);
         setCachedData("opencode-go", freshO);
         break;
       }
       case "cline": {
-        const cachedCl = getCachedData<ProviderSimpleConfig[]>("cline");
-        if (cachedCl) setClineKeys(cachedCl);
         const freshCl = await providersApi.getClineConfigs();
         setClineKeys(freshCl);
         setCachedData("cline", freshCl);
         break;
       }
       case "ollama-cloud": {
-        const cachedOl = getCachedData<ProviderSimpleConfig[]>("ollama-cloud");
-        if (cachedOl) setOllamaCloudKeys(cachedOl);
         const freshOl = await providersApi.getOllamaCloudConfigs();
         setOllamaCloudKeys(freshOl);
         setCachedData("ollama-cloud", freshOl);
         break;
       }
       case "commandcode": {
-        const cachedCc =
-          getCachedData<ProviderSimpleConfig[]>("commandcode");
-        if (cachedCc) setCommandCodeKeys(cachedCc);
         const freshCc = await providersApi.getCommandCodeConfigs();
         setCommandCodeKeys(freshCc);
         setCachedData("commandcode", freshCc);
         break;
       }
       case "vertex": {
-        const cachedV = getCachedData<ProviderSimpleConfig[]>("vertex");
-        if (cachedV) setVertexKeys(cachedV);
         const freshV = await providersApi.getVertexConfigs();
         setVertexKeys(freshV);
         setCachedData("vertex", freshV);
         break;
       }
       case "bedrock": {
-        const cachedB = getCachedData<BedrockProviderConfig[]>("bedrock");
-        if (cachedB) setBedrockKeys(cachedB);
         const freshB = await providersApi.getBedrockConfigs();
         setBedrockKeys(freshB);
         setCachedData("bedrock", freshB);
         break;
       }
       case "openai": {
-        const cachedA = getCachedData<OpenAIProvider[]>("openai");
-        if (cachedA) setOpenaiProviders(cachedA);
         const freshA = await providersApi.getOpenAIProviders();
         setOpenaiProviders(freshA);
         setCachedData("openai", freshA);

--- a/pages/providers/hooks/useOpenAIProviderEditor.ts
+++ b/pages/providers/hooks/useOpenAIProviderEditor.ts
@@ -6,6 +6,7 @@ import { useToast } from "@code-proxy/ui";
 import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 import { keyValueEntriesToRecord } from "../KeyValueInputList";
 import { createEmptyModelEntry } from "../ModelInputList";
+import { setCachedData } from "../provider-cache";
 import {
   buildModelsEndpoint,
   buildOpenAIDraft,
@@ -129,8 +130,8 @@ export function useOpenAIProviderEditor({
           : openaiProviders.map((provider, providerIndex) =>
               providerIndex === index ? value : provider,
             );
-
       setOpenaiProviders(next);
+      setCachedData("openai", next);
       await providersApi.saveOpenAIProviders(next);
       invalidateConfiguredModelAvailability();
       notify({ type: "success", message: t("providers.saved") });
@@ -161,7 +162,11 @@ export function useOpenAIProviderEditor({
       try {
         await providersApi.deleteOpenAIProvider(entry.name);
         invalidateConfiguredModelAvailability();
-        setOpenaiProviders((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+        setOpenaiProviders((prev) => {
+          const next = prev.filter((_, itemIndex) => itemIndex !== index);
+          setCachedData("openai", next);
+          return next;
+        });
         notify({ type: "success", message: t("providers.deleted") });
       } catch (err: unknown) {
         notify({
@@ -193,6 +198,7 @@ export function useOpenAIProviderEditor({
       });
 
       setOpenaiProviders(next);
+      setCachedData("openai", next);
       try {
         await providersApi.saveOpenAIProviders(next);
         invalidateConfiguredModelAvailability();
@@ -291,6 +297,7 @@ export function useOpenAIProviderEditor({
         const latest = await providersApi.getOpenAIProviders();
         invalidateConfiguredModelAvailability();
         setOpenaiProviders(latest);
+        setCachedData("openai", latest);
         notify({
           type: "success",
           message: enabled ? t("providers.toggle_enabled") : t("providers.toggle_disabled"),

--- a/pages/providers/hooks/useProviderKeyEditor.ts
+++ b/pages/providers/hooks/useProviderKeyEditor.ts
@@ -14,6 +14,7 @@ import type {
 import { providersApi } from "@code-proxy/api-client";
 import { invalidateConfiguredModelAvailability } from "@features/model-availability";
 import { keyValueEntriesToRecord } from "../KeyValueInputList";
+import { setCachedData } from "../provider-cache";
 import {
   buildProviderKeyDraft,
   commitModelEntries,
@@ -335,14 +336,17 @@ export function useProviderKeyEditor({
         const next = apply(geminiKeys);
         await providersApi.saveGeminiKeys(next);
         setGeminiKeys(next);
+        setCachedData("gemini", next);
       } else if (type === "claude") {
         const next = apply(claudeKeys);
         await providersApi.saveClaudeConfigs(next);
         setClaudeKeys(next);
+        setCachedData("claude", next);
       } else if (type === "codex") {
         const next = apply(codexKeys);
         await providersApi.saveCodexConfigs(next);
         setCodexKeys(next);
+        setCachedData("codex", next);
       } else if (type === "opencode-go") {
         const next = apply(openCodeGoKeys);
         if (index === null) {
@@ -351,6 +355,7 @@ export function useProviderKeyEditor({
           await providersApi.patchOpenCodeGoConfig(index, value);
         }
         setOpenCodeGoKeys(next);
+        setCachedData("opencode-go", next);
       } else if (type === "cline") {
         const next = apply(clineKeys);
         if (index === null) {
@@ -359,6 +364,7 @@ export function useProviderKeyEditor({
           await providersApi.patchClineConfig(index, value);
         }
         setClineKeys(next);
+        setCachedData("cline", next);
       } else if (type === "ollama-cloud") {
         const next = apply(ollamaCloudKeys);
         if (index === null) {
@@ -367,6 +373,7 @@ export function useProviderKeyEditor({
           await providersApi.patchOllamaCloudConfig(index, value);
         }
         setOllamaCloudKeys(next);
+        setCachedData("ollama-cloud", next);
       } else if (type === "commandcode") {
         const next = apply(commandCodeKeys);
         if (index === null) {
@@ -375,14 +382,17 @@ export function useProviderKeyEditor({
           await providersApi.patchCommandCodeConfig(index, value);
         }
         setCommandCodeKeys(next);
+        setCachedData("commandcode", next);
       } else if (type === "vertex") {
         const next = apply(vertexKeys);
         await providersApi.saveVertexConfigs(next);
         setVertexKeys(next);
+        setCachedData("vertex", next);
       } else {
         const next = apply(bedrockKeys) as BedrockProviderConfig[];
         await providersApi.saveBedrockConfigs(next);
         setBedrockKeys(next);
+        setCachedData("bedrock", next);
       }
       invalidateConfiguredModelAvailability();
       notify({ type: "success", message: t("providers.saved") });
@@ -401,6 +411,7 @@ export function useProviderKeyEditor({
     clineKeys,
     closeKeyEditor,
     codexKeys,
+    commandCodeKeys,
     commitKeyDraft,
     editKeyIndex,
     editKeyType,
@@ -413,6 +424,7 @@ export function useProviderKeyEditor({
     setCodexKeys,
     setBedrockKeys,
     setClineKeys,
+    setCommandCodeKeys,
     setGeminiKeys,
     setOllamaCloudKeys,
     setOpenCodeGoKeys,
@@ -431,49 +443,67 @@ export function useProviderKeyEditor({
       try {
         if (type === "gemini") {
           await providersApi.deleteGeminiKey(entry.apiKey);
-          setGeminiKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setGeminiKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("gemini", next);
+            return next;
+          });
         } else if (type === "claude") {
           await providersApi.deleteClaudeConfig(entry.apiKey);
-          setClaudeKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setClaudeKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("claude", next);
+            return next;
+          });
         } else if (type === "codex") {
           await providersApi.deleteCodexConfig(entry.apiKey);
-          setCodexKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setCodexKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("codex", next);
+            return next;
+          });
         } else if (type === "opencode-go") {
           await providersApi.deleteOpenCodeGoConfig(entry.apiKey);
-          setOpenCodeGoKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setOpenCodeGoKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("opencode-go", next);
+            return next;
+          });
         } else if (type === "cline") {
           await providersApi.deleteClineConfig(entry.apiKey);
-          setClineKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setClineKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("cline", next);
+            return next;
+          });
         } else if (type === "ollama-cloud") {
           await providersApi.deleteOllamaCloudConfig(entry.apiKey);
-          setOllamaCloudKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setOllamaCloudKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("ollama-cloud", next);
+            return next;
+          });
         } else if (type === "commandcode") {
           await providersApi.deleteCommandCodeConfig(entry.apiKey);
-          setCommandCodeKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setCommandCodeKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("commandcode", next);
+            return next;
+          });
         } else if (type === "vertex") {
           await providersApi.deleteVertexConfig(entry.apiKey);
-          setVertexKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setVertexKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("vertex", next);
+            return next;
+          });
         } else {
           await providersApi.deleteBedrockConfig(index);
-          setBedrockKeys((prev) =>
-            prev.filter((_, itemIndex) => itemIndex !== index),
-          );
+          setBedrockKeys((prev) => {
+            const next = prev.filter((_, itemIndex) => itemIndex !== index);
+            setCachedData("bedrock", next);
+            return next;
+          });
         }
         invalidateConfiguredModelAvailability();
         notify({ type: "success", message: t("providers.deleted") });
@@ -492,6 +522,7 @@ export function useProviderKeyEditor({
       setClaudeKeys,
       setClineKeys,
       setCodexKeys,
+      setCommandCodeKeys,
       setGeminiKeys,
       setOllamaCloudKeys,
       setOpenCodeGoKeys,
@@ -555,39 +586,47 @@ export function useProviderKeyEditor({
       try {
         if (type === "gemini") {
           setGeminiKeys(nextList);
+          setCachedData("gemini", nextList);
           await providersApi.saveGeminiKeys(nextList);
         } else if (type === "claude") {
           setClaudeKeys(nextList);
+          setCachedData("claude", nextList);
           await providersApi.saveClaudeConfigs(nextList);
         } else if (type === "codex") {
           setCodexKeys(nextList);
+          setCachedData("codex", nextList);
           await providersApi.saveCodexConfigs(nextList);
         } else if (type === "opencode-go") {
           setOpenCodeGoKeys(nextList);
+          setCachedData("opencode-go", nextList);
           await providersApi.patchOpenCodeGoConfig(index, {
             apiKey: "",
             disabled: !enabled,
           });
         } else if (type === "cline") {
           setClineKeys(nextList);
+          setCachedData("cline", nextList);
           await providersApi.patchClineConfig(index, {
             apiKey: "",
             disabled: !enabled,
           });
         } else if (type === "ollama-cloud") {
           setOllamaCloudKeys(nextList);
+          setCachedData("ollama-cloud", nextList);
           await providersApi.patchOllamaCloudConfig(index, {
             apiKey: "",
             disabled: !enabled,
           });
         } else if (type === "commandcode") {
           setCommandCodeKeys(nextList);
+          setCachedData("commandcode", nextList);
           await providersApi.patchCommandCodeConfig(index, {
             apiKey: "",
             disabled: !enabled,
           });
         } else {
           setBedrockKeys(nextList as BedrockProviderConfig[]);
+          setCachedData("bedrock", nextList);
           await providersApi.saveBedrockConfigs(
             nextList as BedrockProviderConfig[],
           );
@@ -619,6 +658,7 @@ export function useProviderKeyEditor({
       claudeKeys,
       bedrockKeys,
       clineKeys,
+      commandCodeKeys,
       codexKeys,
       geminiKeys,
       notify,
@@ -629,6 +669,7 @@ export function useProviderKeyEditor({
       setCodexKeys,
       setBedrockKeys,
       setClineKeys,
+      setCommandCodeKeys,
       setGeminiKeys,
       setOllamaCloudKeys,
       setOpenCodeGoKeys,

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -25,6 +25,6 @@
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1880,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 1191,
     "pages/models/ModelsPage.tsx": 1251,
-    "pages/providers/components/ProvidersPageContent.tsx": 1647
+    "pages/providers/components/ProvidersPageContent.tsx": 1630
   }
 }

--- a/scripts/surface-usage-baseline.json
+++ b/scripts/surface-usage-baseline.json
@@ -1,6 +1,6 @@
 {
   "comment": "Hand-rolled card surfaces awaiting migration to surface() from @code-proxy/ui. Counts may only shrink — see scripts/check-surface-usage.mjs.",
-  "total": 122,
+  "total": 121,
   "files": {
     "apps/admin-panel/src/app/layout/AppShell.tsx": 1,
     "features/log-content-viewer/components/ErrorDetailModal.tsx": 1,
@@ -66,7 +66,6 @@
     "pages/providers/components/ProviderKeyStatusBadges.tsx": 3,
     "pages/providers/components/ProvidersPageContent.tsx": 2,
     "pages/providers/components/ProviderWorkspace.tsx": 1,
-    "pages/providers/ProviderCard.tsx": 1,
     "pages/providers/ProviderKeyListCard.tsx": 1,
     "pages/proxies/ProxiesPage.tsx": 1,
     "pages/request-logs/RequestLogsPage.tsx": 4


### PR DESCRIPTION
## 问题
在 `/manage/access/ai-providers` 保存新渠道后，列表不会出现新卡片。渠道卡片也和 AI 账号卡片不是同一套表面。

## 根因
`loadProviderTab` 在每次 refresh 时会先把 7 天 TTL 的租户缓存写回 state。保存成功后立刻 `refreshAll()`，乐观新增被旧缓存盖掉；保存路径又没 `setCachedData`，GET 慢或旧时新卡片就不会回来。

## 修复
- 保存 / 删除 / 开关后立刻写入列表缓存
- `loadProviderTab` 不再用缓存覆盖当前列表，只写 GET 结果
- ProviderCard 复用 AI 账号 Card：rounded-3xl、1px 边框、头部开关、底部操作行
- 功能仍按渠道走，不引入账号额度逻辑

## 验证
- `bun run --filter @code-proxy/admin-panel test -- pages/providers/__tests__/ProvidersPage.openai.test.tsx pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx pages/providers/__tests__/ProviderKeyListCard.display-order.test.tsx`（45 passed）
- `bun run lint`（仅既有 warning）
- `node scripts/check-surface-usage.mjs` / `node scripts/check-file-size.mjs`
- 本地 mock 预览：渠道卡片已是账号页同款 chrome