### PR TITLE
feat(ai-providers): give provider cards the AI account card's visual language

### DIFF
--- a/features/quota-preview/QuotaBar.tsx
+++ b/features/quota-preview/QuotaBar.tsx
@@ -1,0 +1,204 @@
+import type { ReactNode } from "react";
+import { Clock, Info } from "lucide-react";
+import { HoverTooltip } from "@code-proxy/ui";
+import { clampPercent } from "./quota-helpers";
+
+export type QuotaVisualTone = {
+  normalized: number | null;
+  /**
+   * Bar fill: a light tint plus a 2px rule down its right edge. The rule is
+   * what marks the percentage, which frees the tint to stay light enough to
+   * read text over.
+   */
+  fillClass: string;
+  percentClass: string;
+  fillHex: string;
+  /** Chip surface (border + background) mirroring the percent tone. */
+  chipClass: string;
+  /** Muted label color that stays legible on the chip surface. */
+  chipLabelClass: string;
+  /** Bar track: border, plus the background showing left of the fill. */
+  barTrackClass: string;
+  /** Bar label, which sits over the fill and has to read against it. */
+  barLabelClass: string;
+  /** Bar countdown: quieter than the label, still legible over the fill. */
+  barMetaClass: string;
+};
+
+export const resolveQuotaVisualTone = (
+  percent: number | null | undefined,
+): QuotaVisualTone => {
+  const normalized = percent === null || percent == null ? null : clampPercent(percent);
+
+  if (normalized === null) {
+    return {
+      normalized,
+      fillClass:
+        "border-r-2 border-slate-300 bg-slate-100 dark:border-white/20 dark:bg-white/[0.07]",
+      percentClass: "text-slate-900 dark:text-white",
+      fillHex: "#cbd5e1",
+      chipClass: "border-slate-900/8 bg-slate-50 dark:border-white/10 dark:bg-white/[0.06]",
+      chipLabelClass: "text-slate-600 dark:text-white/70",
+      barTrackClass: "border-slate-200 bg-white dark:border-white/10 dark:bg-white/[0.03]",
+      barLabelClass: "text-slate-700 dark:text-white/80",
+      barMetaClass: "text-slate-500 dark:text-white/50",
+    };
+  }
+
+  // The bar's fill is the row's own background, so at 100% it covers the entire
+  // line — and repeated down a grid of cards, a saturated fill becomes a wall of
+  // colour that is tiring to look at and, being always on, signals nothing.
+  //
+  // So the tint stays light and a 2px rule at the fill's right edge carries the
+  // percentage instead. The edge marks the value more precisely than a block
+  // boundary does, and the label keeps its contrast because it is no longer
+  // sitting on a saturated ground.
+  if (normalized >= 60) {
+    return {
+      normalized,
+      fillClass:
+        "border-r-2 border-emerald-400 bg-emerald-100 dark:border-emerald-400/70 dark:bg-emerald-500/20",
+      percentClass: "text-emerald-900 dark:text-emerald-100",
+      fillHex: "#10b981",
+      chipClass:
+        "border-emerald-200/70 bg-emerald-50/70 dark:border-emerald-500/20 dark:bg-emerald-500/[0.08]",
+      chipLabelClass: "text-emerald-900 dark:text-emerald-100/80",
+      barTrackClass: "border-emerald-200 bg-white dark:border-emerald-500/20 dark:bg-white/[0.03]",
+      barLabelClass: "text-emerald-900 dark:text-emerald-50",
+      barMetaClass: "text-emerald-700 dark:text-emerald-200/70",
+    };
+  }
+
+  if (normalized >= 20) {
+    return {
+      normalized,
+      fillClass:
+        "border-r-2 border-amber-400 bg-amber-100 dark:border-amber-400/70 dark:bg-amber-500/20",
+      percentClass: "text-amber-900 dark:text-amber-100",
+      fillHex: "#f59e0b",
+      chipClass:
+        "border-amber-200/70 bg-amber-50/70 dark:border-amber-500/20 dark:bg-amber-500/[0.08]",
+      chipLabelClass: "text-amber-900 dark:text-amber-100/80",
+      barTrackClass: "border-amber-200 bg-white dark:border-amber-500/20 dark:bg-white/[0.03]",
+      barLabelClass: "text-amber-900 dark:text-amber-50",
+      barMetaClass: "text-amber-700 dark:text-amber-200/70",
+    };
+  }
+
+  return {
+    normalized,
+    fillClass: "border-r-2 border-rose-400 bg-rose-100 dark:border-rose-400/70 dark:bg-rose-500/20",
+    percentClass: "text-rose-900 dark:text-rose-100",
+    fillHex: "#f43f5e",
+    chipClass: "border-rose-200/70 bg-rose-50/70 dark:border-rose-500/20 dark:bg-rose-500/[0.08]",
+    chipLabelClass: "text-rose-900 dark:text-rose-100/80",
+    barTrackClass: "border-rose-200 bg-white dark:border-rose-500/20 dark:bg-white/[0.03]",
+    barLabelClass: "text-rose-900 dark:text-rose-50",
+    barMetaClass: "text-rose-700 dark:text-rose-200/70",
+  };
+};
+
+export interface QuotaBarProps {
+  label: string;
+  /** Remaining percent, 0-100. `null` renders the neutral "unknown" tone. */
+  percent: number | null | undefined;
+  /** Percent text, when the source has its own formatting (e.g. "3.2%"). */
+  percentText?: string;
+  /** Countdown or reset hint, shown beside a clock icon. */
+  detailText?: string | null;
+  /** Explains what the window means; rendered as a hoverable info icon. */
+  hint?: string;
+  compact?: boolean;
+  testId?: string;
+}
+
+/**
+ * One quota window as a labelled bar.
+ *
+ * The fill is the row's own background rather than a separate track underneath
+ * it, so a card fits twice as many windows at the same height. Label, countdown
+ * and percentage share the line, which is what makes the numbers scannable down
+ * a column instead of hunting between two rows.
+ *
+ * Shared by the AI accounts and AI providers cards so the two pages read as one
+ * component set; neither page should grow its own bar.
+ */
+export function QuotaBar({
+  label,
+  percent,
+  percentText,
+  detailText,
+  hint,
+  compact = false,
+  testId,
+}: QuotaBarProps): ReactNode {
+  const tone = resolveQuotaVisualTone(percent);
+  const normalized = tone.normalized;
+  const shownPercent =
+    percentText ?? (normalized === null ? "--" : `${Math.round(normalized)}%`);
+
+  return (
+    <div
+      data-testid={testId}
+      className={[
+        "relative flex w-full items-center overflow-hidden rounded-md border",
+        tone.barTrackClass,
+        compact ? "h-[22px] px-1.5" : "h-6 px-2",
+      ].join(" ")}
+    >
+      {/* No opacity wrapper: the tone ships a tint already light enough to read
+          text over, and dimming it further was what made the fill edge — the
+          thing that actually encodes the percentage — impossible to locate. */}
+      <div
+        className={["absolute inset-y-0 left-0", tone.fillClass].join(" ")}
+        style={{ width: `${normalized ?? 0}%` }}
+        aria-hidden="true"
+      />
+      <div
+        className={[
+          "relative z-10 flex w-full items-center gap-1.5 leading-none",
+          compact ? "text-2xs" : "text-xs",
+        ].join(" ")}
+      >
+        <span
+          className={[
+            "inline-flex min-w-0 flex-1 items-center gap-1 font-medium",
+            tone.barLabelClass,
+          ].join(" ")}
+        >
+          <span className="min-w-0 truncate">{label}</span>
+          {hint ? (
+            <HoverTooltip content={hint} placement="top" className="shrink-0">
+              <span
+                className={[
+                  "inline-flex shrink-0 cursor-help transition-opacity hover:opacity-100",
+                  tone.barMetaClass,
+                ].join(" ")}
+                data-testid="quota-bar-hint"
+                aria-label={hint}
+              >
+                <Info size={compact ? 10 : 11} aria-hidden />
+              </span>
+            </HoverTooltip>
+          ) : null}
+        </span>
+        {detailText ? (
+          <span
+            className={[
+              "inline-flex max-w-[46%] shrink-0 items-center gap-0.5 truncate tabular-nums",
+              tone.barMetaClass,
+            ].join(" ")}
+          >
+            <Clock size={compact ? 9 : 10} className="shrink-0" aria-hidden />
+            {detailText}
+          </span>
+        ) : null}
+        <span
+          className={["shrink-0 font-semibold tabular-nums", tone.percentClass].join(" ")}
+        >
+          {shownPercent}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3855,6 +3855,7 @@
     "opencode_go_usage_no_data": "No data",
     "opencode_go_usage_refresh": "Refresh OpenCode Go usage",
     "opencode_go_usage_not_queried": "Not queried",
+    "opencode_go_usage_not_configured": "No usage credentials configured",
     "proxy_pool_label": "Proxy pool binding",
     "proxy_pool_hint": "Select a managed proxy when this key must use a fixed egress IP. Proxy URL below is used as fallback.",
     "header_name_placeholder": "Header name",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2855,6 +2855,7 @@
     "opencode_go_usage_no_data": "暂无数据",
     "opencode_go_usage_refresh": "刷新 OpenCode Go 用量",
     "opencode_go_usage_not_queried": "未查询",
+    "opencode_go_usage_not_configured": "未配置用量查询凭据",
     "proxy_pool_label": "代理池绑定",
     "proxy_pool_hint": "需要固定出口 IP 时选择已管理的代理；下方 Proxy URL 会作为回退使用。",
     "header_name_placeholder": "Header 名称",

--- a/pages/auth-files/components/QuotaMetricChips.tsx
+++ b/pages/auth-files/components/QuotaMetricChips.tsx
@@ -1,99 +1,13 @@
 import type { ReactNode } from "react";
 import { Clock } from "lucide-react";
-import { clampPercent, type QuotaItem } from "@features/quota-preview/quota-helpers";
+import { type QuotaItem } from "@features/quota-preview/quota-helpers";
+// Tone and bar live in the quota-preview feature so the AI accounts and AI
+// providers cards render the same quota visual; re-exported here for the
+// existing call sites on this page.
+import { resolveQuotaVisualTone, type QuotaVisualTone } from "@features/quota-preview/QuotaBar";
 
-export type QuotaVisualTone = {
-  normalized: number | null;
-  /**
-   * Bar fill: a light tint plus a 2px rule down its right edge. The rule is
-   * what marks the percentage, which frees the tint to stay light enough to
-   * read text over.
-   */
-  fillClass: string;
-  percentClass: string;
-  fillHex: string;
-  /** Chip surface (border + background) mirroring the percent tone. */
-  chipClass: string;
-  /** Muted label color that stays legible on the chip surface. */
-  chipLabelClass: string;
-  /** Bar track: border, plus the background showing left of the fill. */
-  barTrackClass: string;
-  /** Bar label, which sits over the fill and has to read against it. */
-  barLabelClass: string;
-  /** Bar countdown: quieter than the label, still legible over the fill. */
-  barMetaClass: string;
-};
-
-export const resolveQuotaVisualTone = (percent: number | null | undefined): QuotaVisualTone => {
-  const normalized = percent === null || percent == null ? null : clampPercent(percent);
-
-  if (normalized === null) {
-    return {
-      normalized,
-      fillClass:
-        "border-r-2 border-slate-300 bg-slate-100 dark:border-white/20 dark:bg-white/[0.07]",
-      percentClass: "text-slate-900 dark:text-white",
-      fillHex: "#cbd5e1",
-      chipClass: "border-slate-900/8 bg-slate-50 dark:border-white/10 dark:bg-white/[0.06]",
-      chipLabelClass: "text-slate-600 dark:text-white/70",
-      barTrackClass: "border-slate-200 bg-white dark:border-white/10 dark:bg-white/[0.03]",
-      barLabelClass: "text-slate-700 dark:text-white/80",
-      barMetaClass: "text-slate-500 dark:text-white/50",
-    };
-  }
-
-  // The bar's fill is the row's own background, so at 100% it covers the entire
-  // line — and repeated down a grid of cards, a saturated fill becomes a wall of
-  // colour that is tiring to look at and, being always on, signals nothing.
-  //
-  // So the tint stays light and a 2px rule at the fill's right edge carries the
-  // percentage instead. The edge marks the value more precisely than a block
-  // boundary does, and the label keeps its contrast because it is no longer
-  // sitting on a saturated ground.
-  if (normalized >= 60) {
-    return {
-      normalized,
-      fillClass:
-        "border-r-2 border-emerald-400 bg-emerald-100 dark:border-emerald-400/70 dark:bg-emerald-500/20",
-      percentClass: "text-emerald-900 dark:text-emerald-100",
-      fillHex: "#10b981",
-      chipClass:
-        "border-emerald-200/70 bg-emerald-50/70 dark:border-emerald-500/20 dark:bg-emerald-500/[0.08]",
-      chipLabelClass: "text-emerald-900 dark:text-emerald-100/80",
-      barTrackClass: "border-emerald-200 bg-white dark:border-emerald-500/20 dark:bg-white/[0.03]",
-      barLabelClass: "text-emerald-900 dark:text-emerald-50",
-      barMetaClass: "text-emerald-700 dark:text-emerald-200/70",
-    };
-  }
-
-  if (normalized >= 20) {
-    return {
-      normalized,
-      fillClass:
-        "border-r-2 border-amber-400 bg-amber-100 dark:border-amber-400/70 dark:bg-amber-500/20",
-      percentClass: "text-amber-900 dark:text-amber-100",
-      fillHex: "#f59e0b",
-      chipClass:
-        "border-amber-200/70 bg-amber-50/70 dark:border-amber-500/20 dark:bg-amber-500/[0.08]",
-      chipLabelClass: "text-amber-900 dark:text-amber-100/80",
-      barTrackClass: "border-amber-200 bg-white dark:border-amber-500/20 dark:bg-white/[0.03]",
-      barLabelClass: "text-amber-900 dark:text-amber-50",
-      barMetaClass: "text-amber-700 dark:text-amber-200/70",
-    };
-  }
-
-  return {
-    normalized,
-    fillClass: "border-r-2 border-rose-400 bg-rose-100 dark:border-rose-400/70 dark:bg-rose-500/20",
-    percentClass: "text-rose-900 dark:text-rose-100",
-    fillHex: "#f43f5e",
-    chipClass: "border-rose-200/70 bg-rose-50/70 dark:border-rose-500/20 dark:bg-rose-500/[0.08]",
-    chipLabelClass: "text-rose-900 dark:text-rose-100/80",
-    barTrackClass: "border-rose-200 bg-white dark:border-rose-500/20 dark:bg-white/[0.03]",
-    barLabelClass: "text-rose-900 dark:text-rose-50",
-    barMetaClass: "text-rose-700 dark:text-rose-200/70",
-  };
-};
+export { resolveQuotaVisualTone };
+export type { QuotaVisualTone };
 
 /** Ring that mirrors the percent without spending a full progress-bar row. */
 export function QuotaProgressRing({ percent }: { percent: number | null }) {

--- a/pages/auth-files/hooks/quotaBar.tsx
+++ b/pages/auth-files/hooks/quotaBar.tsx
@@ -1,8 +1,7 @@
 import { useCallback, type ReactNode } from "react";
-import { Clock, Info } from "lucide-react";
 import { HoverTooltip } from "@code-proxy/ui";
 import type { QuotaItem } from "@features/quota-preview/quota-helpers";
-import { resolveQuotaVisualTone } from "../components/QuotaMetricChips";
+import { QuotaBar, resolveQuotaVisualTone } from "@features/quota-preview/QuotaBar";
 
 export type QuotaBarDeps = {
   translateQuotaText: (text: string) => string;
@@ -39,70 +38,15 @@ export const renderQuotaBarNode = (
   const detailText = formatQuotaItemDetailText(item);
   const tooltipParts = [translatedLabel, percentText];
   if (detailText) tooltipParts.push(detailText);
-  // One line per quota: the fill is the row's background rather than a separate
-  // track underneath it, so a card fits twice as many windows at the same
-  // height. Label, countdown and percentage share the line, which is what makes
-  // the numbers scannable down a column instead of hunting between two rows.
   const bar = (
-    <div
-      className={[
-        "relative flex w-full items-center overflow-hidden rounded-md border",
-        tone.barTrackClass,
-        compact ? "h-[22px] px-1.5" : "h-6 px-2",
-      ].join(" ")}
-    >
-      {/* No opacity wrapper: the tone ships a tint already light enough to read
-          text over, and dimming it further was what made the fill edge — the
-          thing that actually encodes the percentage — impossible to locate. */}
-      <div
-        className={["absolute inset-y-0 left-0", tone.fillClass].join(" ")}
-        style={{ width: `${normalized ?? 0}%` }}
-        aria-hidden="true"
-      />
-      <div
-        className={[
-          "relative z-10 flex w-full items-center gap-1.5 leading-none",
-          compact ? "text-2xs" : "text-xs",
-        ].join(" ")}
-      >
-        <span
-          className={[
-            "inline-flex min-w-0 flex-1 items-center gap-1 font-medium",
-            tone.barLabelClass,
-          ].join(" ")}
-        >
-          <span className="min-w-0 truncate">{translatedLabel}</span>
-          {hint ? (
-            <HoverTooltip content={hint} placement="top" className="shrink-0">
-              <span
-                className={[
-                  "inline-flex shrink-0 cursor-help transition-opacity hover:opacity-100",
-                  tone.barMetaClass,
-                ].join(" ")}
-                data-testid="quota-bar-hint"
-                aria-label={hint}
-              >
-                <Info size={compact ? 10 : 11} aria-hidden />
-              </span>
-            </HoverTooltip>
-          ) : null}
-        </span>
-        {detailText ? (
-          <span
-            className={[
-              "inline-flex max-w-[46%] shrink-0 items-center gap-0.5 truncate tabular-nums",
-              tone.barMetaClass,
-            ].join(" ")}
-          >
-            <Clock size={compact ? 9 : 10} className="shrink-0" aria-hidden />
-            {detailText}
-          </span>
-        ) : null}
-        <span className={["shrink-0 font-semibold tabular-nums", tone.percentClass].join(" ")}>
-          {percentText}
-        </span>
-      </div>
-    </div>
+    <QuotaBar
+      label={translatedLabel}
+      percent={item?.percent}
+      percentText={percentText}
+      detailText={detailText}
+      hint={hint}
+      compact={compact}
+    />
   );
 
   // ponytail: compact drops reset line; full detail stays in tooltip.

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -2,8 +2,8 @@ import { useState, type ReactNode } from "react";
 import {
   Card,
   DropdownMenu,
+  HoverTooltip,
   OverflowTooltip,
-  ToggleSwitch,
   buttonClassName,
 } from "@code-proxy/ui";
 import { Ellipsis, Power, Settings2, Trash2 } from "lucide-react";
@@ -114,20 +114,29 @@ export function ProviderCard({
             </div>
           ) : null}
           {onToggleEnabled ? (
-            <div
-              className={[
-                "flex h-6 items-center justify-center transition-opacity",
-                "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
-              ].join(" ")}
+            // Always-on power button, as on the AI account card. The toggle it
+            // replaces only appeared on hover, so whether a channel was enabled
+            // was invisible until you moved the mouse over it.
+            <HoverTooltip
+              content={enabled ? t("providers.disable") : t("providers.enable")}
             >
-              <ToggleSwitch
-                ariaLabel={
+              <button
+                type="button"
+                className={[
+                  "inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors",
+                  enabled
+                    ? "bg-emerald-50 text-emerald-600 hover:bg-emerald-100 dark:bg-emerald-500/15 dark:text-emerald-300"
+                    : "bg-slate-100 text-slate-400 hover:bg-slate-200 dark:bg-white/10 dark:text-white/45",
+                ].join(" ")}
+                aria-label={
                   enabled ? t("providers.disable") : t("providers.enable")
                 }
-                checked={enabled}
-                onCheckedChange={onToggleEnabled}
-              />
-            </div>
+                aria-pressed={enabled}
+                onClick={() => onToggleEnabled(!enabled)}
+              >
+                <Power size={13} />
+              </button>
+            </HoverTooltip>
           ) : null}
         </div>
       </div>

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { Loader2, Zap } from "lucide-react";
 import type {
   ProviderModel,
   ProviderSimpleConfig,
@@ -14,10 +13,11 @@ import {
   maskApiKey,
   stripDisableAllModelsRule,
 } from "./providers-helpers";
-import { formatLatency } from "@features/provider-latency";
 import { ProviderConnectionRows } from "./components/ProviderConnectionRows";
 import { ProviderMetricChip } from "./components/ProviderMetricChip";
 import { ProviderModelChips } from "./components/ProviderModelChips";
+import { ProviderIdCopyButton } from "./components/ProviderIdCopyButton";
+import { ProviderLatencyButton } from "./components/ProviderLatencyButton";
 
 import { useTranslation } from "react-i18next";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
@@ -187,6 +187,31 @@ export function ProviderKeyListCard({
               : item.models || [];
             const stats = getStats(item);
             const statusData = getStatusBar(item);
+            const latencyEntry =
+              canUseAPITools && checkLatency
+                ? (getLatencyEntry?.(item.apiKey) ?? {
+                    latencyMs: null,
+                    loading: false,
+                    error: false,
+                  })
+                : null;
+            // Built up front so the header only renders a badge row when there
+            // is a badge to put in it.
+            const headerBadges =
+              item.id || latencyEntry ? (
+                <>
+                  {item.id ? <ProviderIdCopyButton id={item.id} /> : null}
+                  {latencyEntry && checkLatency ? (
+                    <ProviderLatencyButton
+                      entry={latencyEntry}
+                      baseUrl={item.baseUrl || ""}
+                      onCheck={() =>
+                        checkLatency(item.apiKey, item.baseUrl || "")
+                      }
+                    />
+                  ) : null}
+                </>
+              ) : undefined;
 
             return (
               <ProviderCard
@@ -209,66 +234,9 @@ export function ProviderKeyListCard({
                 }
                 onEdit={canWrite ? () => onEdit(idx) : undefined}
                 onDelete={canWrite ? () => onDelete(idx) : undefined}
-                headerExtra={
-                  canUseAPITools && checkLatency
-                    ? (() => {
-                        const latencyKey = item.apiKey;
-                        const entry = getLatencyEntry?.(latencyKey) ?? {
-                          latencyMs: null,
-                          loading: false,
-                          error: false,
-                        };
-                        const providerBaseUrl = item.baseUrl || "";
-                        const latencyMs = entry.latencyMs;
-                        const latencyColor =
-                          latencyMs === null
-                            ? "text-slate-400 dark:text-white/40"
-                            : latencyMs < 200
-                              ? "text-emerald-600 dark:text-emerald-400"
-                              : latencyMs < 500
-                                ? "text-amber-600 dark:text-amber-400"
-                                : "text-rose-600 dark:text-rose-400";
-                        return (
-                          <button
-                            type="button"
-                            className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs tabular-nums font-medium transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 dark:hover:bg-white/10 dark:focus-visible:ring-white/20 ${entry.loading ? "text-slate-500" : entry.error ? "text-rose-500" : latencyColor}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (providerBaseUrl)
-                                checkLatency(latencyKey, providerBaseUrl);
-                            }}
-                            aria-label={
-                              providerBaseUrl
-                                ? `Check latency: ${providerBaseUrl}`
-                                : "No base URL configured"
-                            }
-                            title={
-                              providerBaseUrl
-                                ? `Check latency: ${providerBaseUrl}`
-                                : "No base URL configured"
-                            }
-                          >
-                            {entry.loading ? (
-                              <Loader2 size={10} className="animate-spin" />
-                            ) : entry.error ? (
-                              <span>×</span>
-                            ) : latencyMs !== null ? (
-                              <span>{formatLatency(latencyMs)}</span>
-                            ) : (
-                              <Zap size={10} />
-                            )}
-                          </button>
-                        );
-                      })()
-                    : undefined
-                }
+                headerExtra={headerBadges}
                 footer={<ProviderStatusBar data={statusData} />}
               >
-                {item.id ? (
-                  <p className="mt-1 truncate font-mono text-xs text-slate-500 dark:text-white/50" title={item.id}>
-                    ID: {item.id}
-                  </p>
-                ) : null}
                 {showConnectionRows ? (
                   <ProviderConnectionRows
                     apiKey={item.apiKey}

--- a/pages/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/pages/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
-import { RefreshCcw } from "lucide-react";
+import { Gauge, RefreshCcw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { OpenCodeGoUsageItem } from "@code-proxy/api-client";
+import { QuotaBar } from "@features/quota-preview/QuotaBar";
 
 export interface OpenCodeGoUsageCacheEntry {
   sourceId?: string;
@@ -163,36 +164,6 @@ const formatPercent = (value: number): string =>
     ? String(value)
     : value.toFixed(1).replace(/\.0$/, "");
 
-const resolveRemainingTone = (
-  remaining: number | null,
-): { fillClass: string; percentClass: string } => {
-  if (remaining === null) {
-    return {
-      fillClass: "bg-slate-300/50 dark:bg-white/10",
-      percentClass: "text-slate-600 dark:text-white/65",
-    };
-  }
-
-  if (remaining >= 60) {
-    return {
-      fillClass: "bg-emerald-500",
-      percentClass: "text-emerald-700 dark:text-emerald-200",
-    };
-  }
-
-  if (remaining >= 20) {
-    return {
-      fillClass: "bg-amber-500",
-      percentClass: "text-amber-700 dark:text-amber-200",
-    };
-  }
-
-  return {
-    fillClass: "bg-rose-500",
-    percentClass: "text-rose-700 dark:text-rose-200",
-  };
-};
-
 const DEFAULT_TYPE_LABELS = ["rolling", "weekly", "monthly"] as const;
 
 const TYPE_COMPACT_LABEL_KEYS: Record<string, string> = {
@@ -264,60 +235,50 @@ export function OpenCodeGoUsageCardSection({
 
   const hasUsage = Boolean(usageEntry && usageEntry.usage.length > 0);
 
+  // Same bar as an AI account card: fill is the row's own background, label,
+  // countdown and percentage share one line. Both pages import it from
+  // @features/quota-preview so neither can drift.
+  // Same empty state as an AI account card with no quota: a quiet gauge and one
+  // line, centred in the space the bars would occupy. An invisible placeholder
+  // used to sit here, which read as a rendering fault rather than "this
+  // credential has no dashboard login configured".
   if (!queryReady) {
     return (
       <div
-        className="mt-3 min-h-[3.375rem]"
+        className="mt-3 flex min-h-[5.25rem] flex-col items-center justify-center gap-2 text-center"
         data-testid="opencode-go-usage-footprint"
-        aria-hidden="true"
       >
-        <div className="invisible mx-auto w-full max-w-[20rem] space-y-1.5">
-          {windowTypes.map((type) => (
-            <div
-              key={type}
-              className="grid min-w-0 grid-cols-1 gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center sm:gap-2"
-            >
-              <span className="truncate text-xs font-semibold">
-                {getCompactUsageLabel(type, usageByType, t)}
-              </span>
-              <div className="h-1.5 rounded-full bg-slate-200/70 dark:bg-white/8" />
-              <span className="text-right text-xs tabular-nums">
-                {remainingUnknownText}
-              </span>
-            </div>
-          ))}
+        <div
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100/90 text-slate-400 dark:bg-white/[0.06] dark:text-white/40"
+          aria-hidden="true"
+        >
+          <Gauge size={16} strokeWidth={1.5} />
         </div>
+        <p className="text-xs font-medium text-slate-500 dark:text-white/50">
+          {t("providers.opencode_go_usage_not_configured")}
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="mt-3 min-h-[3.375rem]">
+    <div className="mt-3 min-h-[5.25rem]">
       {isLoading && !hasUsage ? (
-        <div className="space-y-2">
+        <div className="w-full space-y-1.5 motion-safe:animate-pulse">
           {windowTypes.map((type) => (
-            <div
+            <QuotaBar
               key={type}
-              className="grid min-w-0 grid-cols-1 gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center sm:gap-2"
-            >
-              <span className="truncate text-xs font-semibold text-slate-400 dark:text-white/45">
-                {getCompactUsageLabel(type, usageByType, t)}
-              </span>
-              <div className="relative h-1.5 overflow-hidden rounded-full bg-slate-200/70 dark:bg-white/8">
-                <div className="absolute inset-y-0 -left-full w-1/2 animate-pulse rounded-full bg-slate-300/50 dark:bg-white/20" />
-              </div>
-              <span className="text-right text-xs tabular-nums text-slate-400 dark:text-white/45">
-                {remainingUnknownText}
-              </span>
-            </div>
+              label={getCompactUsageLabel(type, usageByType, t)}
+              percent={null}
+              percentText={remainingUnknownText}
+            />
           ))}
         </div>
       ) : hasUsage ? (
-        <div className="mx-auto w-full max-w-[20rem] space-y-1.5">
+        <div className="w-full space-y-1.5">
           {windowTypes.map((type) => {
             const item = getUsageItemForType(type, usageByType);
             const remaining = resolveRemainingPercent(item?.percentage);
-            const tone = resolveRemainingTone(remaining);
             const remainingText =
               remaining === null
                 ? remainingUnknownText
@@ -326,38 +287,28 @@ export function OpenCodeGoUsageCardSection({
                   });
 
             return (
-              <div
+              <QuotaBar
                 key={type}
-                className="grid min-w-0 grid-cols-1 gap-1 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center sm:gap-2"
-              >
-                <span className="truncate text-xs font-semibold text-slate-600 dark:text-white/65">
-                  {getCompactUsageLabel(type, usageByType, t)}
-                </span>
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200/80 dark:bg-white/10">
-                  <div
-                    className={["h-full rounded-full", tone.fillClass].join(
-                      " ",
-                    )}
-                    style={{ width: `${remaining ?? 0}%` }}
-                    aria-hidden="true"
-                  />
-                </div>
-                <span
-                  className={[
-                    "truncate text-right text-xs font-semibold tabular-nums",
-                    tone.percentClass,
-                  ].join(" ")}
-                >
-                  {remainingText}
-                </span>
-              </div>
+                label={getCompactUsageLabel(type, usageByType, t)}
+                percent={remaining}
+                percentText={remainingText}
+                detailText={item?.resets_in?.trim() || null}
+              />
             );
           })}
         </div>
       ) : !isLoading ? (
-        <p className="text-xs text-slate-400 dark:text-white/45">
-          {t("providers.opencode_go_usage_not_queried")}
-        </p>
+        <div className="flex min-h-[5.25rem] flex-col items-center justify-center gap-2 text-center">
+          <div
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-100/90 text-slate-400 dark:bg-white/[0.06] dark:text-white/40"
+            aria-hidden="true"
+          >
+            <Gauge size={16} strokeWidth={1.5} />
+          </div>
+          <p className="text-xs font-medium text-slate-500 dark:text-white/50">
+            {t("providers.opencode_go_usage_not_queried")}
+          </p>
+        </div>
       ) : null}
 
       {usageEntry?.error ? (

--- a/pages/providers/components/ProviderIdCopyButton.tsx
+++ b/pages/providers/components/ProviderIdCopyButton.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { Check, Hash } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { HoverTooltip, copyTextToClipboard } from "@code-proxy/ui";
+
+/**
+ * Channel id as a copy affordance beside the title.
+ *
+ * The id used to own a full row of every card just to print a UUID nobody reads
+ * at a glance — the single biggest reason a provider card looked busier than an
+ * AI account card, which has no such row. It is still one click away when an
+ * operator needs it for a channel binding.
+ */
+export function ProviderIdCopyButton({ id }: { id: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <HoverTooltip content={`ID: ${id}`} placement="top">
+      <button
+        type="button"
+        className="inline-flex h-5 shrink-0 items-center gap-0.5 rounded-md bg-slate-100 px-1 text-2xs font-semibold text-slate-500 transition-colors hover:bg-slate-200 hover:text-slate-700 dark:bg-white/10 dark:text-white/55 dark:hover:bg-white/15 dark:hover:text-white/80"
+        aria-label={t("providers.copy_channel_id")}
+        onClick={(event) => {
+          event.stopPropagation();
+          void copyTextToClipboard(id).then((ok) => {
+            if (!ok) return;
+            setCopied(true);
+            // Revert on the next hover instead of a timer: a timer that fires
+            // after the card unmounts sets state on a dead component.
+          });
+        }}
+        onMouseLeave={() => setCopied(false)}
+      >
+        {copied ? <Check size={11} /> : <Hash size={11} />}
+      </button>
+    </HoverTooltip>
+  );
+}

--- a/pages/providers/components/ProviderLatencyButton.tsx
+++ b/pages/providers/components/ProviderLatencyButton.tsx
@@ -1,0 +1,67 @@
+import { Loader2, Zap } from "lucide-react";
+import { formatLatency } from "@features/provider-latency";
+
+export interface ProviderLatencyEntry {
+  latencyMs: number | null;
+  loading: boolean;
+  error: boolean;
+}
+
+/**
+ * Latency probe badge, styled like the card's other header badges.
+ *
+ * Extracted from ProviderKeyListCard so the header can decide whether it has
+ * anything to render before it renders a row for it.
+ */
+export function ProviderLatencyButton({
+  entry,
+  baseUrl,
+  onCheck,
+}: {
+  entry: ProviderLatencyEntry;
+  baseUrl: string;
+  onCheck: () => void;
+}) {
+  const { latencyMs } = entry;
+  const latencyColor =
+    latencyMs === null
+      ? "text-slate-500 dark:text-white/55"
+      : latencyMs < 200
+        ? "text-emerald-700 dark:text-emerald-300"
+        : latencyMs < 500
+          ? "text-amber-700 dark:text-amber-300"
+          : "text-rose-700 dark:text-rose-300";
+  const label = baseUrl
+    ? `Check latency: ${baseUrl}`
+    : "No base URL configured";
+
+  return (
+    <button
+      type="button"
+      className={[
+        "inline-flex h-5 shrink-0 items-center gap-1 rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none tabular-nums transition-colors hover:bg-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25 dark:bg-white/10 dark:hover:bg-white/15 dark:focus-visible:ring-white/20",
+        entry.loading
+          ? "text-slate-500 dark:text-white/55"
+          : entry.error
+            ? "text-rose-700 dark:text-rose-300"
+            : latencyColor,
+      ].join(" ")}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (baseUrl) onCheck();
+      }}
+      aria-label={label}
+      title={label}
+    >
+      {entry.loading ? (
+        <Loader2 size={10} className="animate-spin" />
+      ) : entry.error ? (
+        <span>×</span>
+      ) : latencyMs !== null ? (
+        <span>{formatLatency(latencyMs)}</span>
+      ) : (
+        <Zap size={10} />
+      )}
+    </button>
+  );
+}

--- a/pages/providers/components/ProviderMetricChip.tsx
+++ b/pages/providers/components/ProviderMetricChip.tsx
@@ -10,14 +10,15 @@ interface ProviderMetricChipProps {
   title?: string;
 }
 
+// Squared corners, 2xs type, flat tint: the badge language of the AI accounts
+// card, so a provider card and an account card read as the same component.
 const toneClass: Record<MetricTone, string> = {
-  slate: "bg-slate-600/10 text-slate-700 dark:bg-white/10 dark:text-white/65",
+  slate: "bg-slate-100 text-slate-700 dark:bg-white/10 dark:text-white/70",
   emerald:
-    "bg-emerald-600/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200",
-  rose: "bg-rose-600/10 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200",
-  amber:
-    "bg-amber-500/15 text-amber-700 dark:bg-amber-500/15 dark:text-amber-200",
-  blue: "bg-blue-600/10 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200",
+    "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200",
+  rose: "bg-rose-50 text-rose-700 dark:bg-rose-500/15 dark:text-rose-200",
+  amber: "bg-amber-50 text-amber-700 dark:bg-amber-500/15 dark:text-amber-200",
+  blue: "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200",
 };
 
 export function ProviderMetricChip({
@@ -29,7 +30,7 @@ export function ProviderMetricChip({
 }: ProviderMetricChipProps) {
   return (
     <span
-      className={`inline-flex min-w-0 max-w-full items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${toneClass[tone]}`}
+      className={`inline-flex h-5 min-w-0 max-w-full shrink-0 items-center gap-1 rounded-md px-1.5 text-2xs font-semibold leading-none ${toneClass[tone]}`}
       title={title}
     >
       {icon ? <span className="shrink-0">{icon}</span> : null}

--- a/pages/providers/components/ProviderModelChips.tsx
+++ b/pages/providers/components/ProviderModelChips.tsx
@@ -26,8 +26,11 @@ export function ProviderModelChips({
     return model.alias && model.alias !== name ? `${name} ${arrow} ${model.alias}` : name;
   };
 
+  // Same flat, squared, 2xs badge as the metric chips and the AI account card.
+  // The old inverted pill (black on white) was the loudest thing on the card
+  // and made a row of model names read as a warning.
   return (
-    <div className="grid max-h-[3.25rem] grid-cols-3 gap-1 overflow-hidden">
+    <div className="grid max-h-[2.75rem] grid-cols-3 gap-1 overflow-hidden">
       {visible.map((model) => {
         const modelLabel = formatModelLabel(model, "→");
         return (
@@ -39,7 +42,7 @@ export function ProviderModelChips({
             placement="top"
             className="min-w-0"
           >
-            <span className="inline-flex w-full min-w-0 cursor-default rounded-full bg-slate-900 px-2 py-0.5 text-xs text-white dark:bg-white dark:text-neutral-950">
+            <span className="inline-flex h-5 w-full min-w-0 cursor-default items-center rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none text-slate-700 dark:bg-white/10 dark:text-white/70">
               <span className="min-w-0 truncate">{modelLabel}</span>
             </span>
           </OverflowTooltip>
@@ -54,7 +57,7 @@ export function ProviderModelChips({
           placement="top"
           className="min-w-0"
         >
-          <span className="inline-flex min-w-0 cursor-default justify-center rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold tabular-nums text-slate-500 dark:bg-neutral-800 dark:text-white/55">
+          <span className="inline-flex h-5 min-w-0 cursor-default items-center justify-center rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none tabular-nums text-slate-500 dark:bg-white/10 dark:text-white/55">
             +{remaining}
           </span>
         </HoverTooltip>


### PR DESCRIPTION
（替代 #943：那个分支基于 #942 合并前的历史，与 dev 冲突；内容不变，重新基于最新 dev。）

## 背景

#942 修好了卡片被拉伸和保存丢失，但用户反馈**卡片内部的展示语言仍是老样子**，和 AI 账号卡片不统一——#941 只对齐了外壳（圆角、边框、阴影、底部行），没动内容。

## 改动

### 配额条：现在是同一个组件

账号卡片那条 bar（填充色就是整行背景、右边缘 2px 竖线标记百分比、左标签 + 中倒计时 + 右百分比同处一行）提取到 `@features/quota-preview/QuotaBar`，和 `resolveQuotaVisualTone` 一起。两个页面都从那里 import，谁也没法再各自漂移。

供应商侧原样传入自己的「剩余百分比」，并顺带用上了它一直在取、却从没显示过的 `resets_in` 倒计时。

### 徽章：去掉胶囊和反色

指标 chips、模型 chips 改成账号卡片那种扁平方角 `2xs` 徽章。原来那排黑底白字的模型胶囊是卡片上最抢眼的东西，看起来像警告。

### 启用状态：常驻电源按钮

替换掉 hover 才出现的开关——不移动鼠标根本看不出渠道是开是关。和账号卡片一致。

### 渠道 ID：让出整整一行

改为标题旁的复制按钮。一整行只为打印一个没人会一眼去读的 UUID，是供应商卡片比账号卡片显得杂乱的最大单一原因（账号卡片根本没这一行）。需要拿它做渠道绑定时，仍然一次点击可得。

### 空态

没有面板凭据的凭据卡，改用账号卡片同款空态（安静的 gauge + 一行说明）。原来那里是一个 invisible 占位，看起来像渲染坏了。

### 顺带

延迟探测按钮提取为 `ProviderLatencyButton`，让头部能在渲染徽章行之前先判断有没有徽章要放。

## 验证

- `./scripts/ci-pr.sh` 全量通过：lint、design:check、1247 vitest、build、bundle:diff、12 个 critical e2e。
- `pages/providers` + `pages/auth-files` + `features/quota-preview` 共 401 个用例一起通过（共享化改动会同时影响两页）。
- 两页的卡片 e2e（`providers-card-grid`、`opencode-go-layout`、`providers-card-border`、`openai-providers`、`auth-files-card-layout`）逐个通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)