### PR TITLE
fix(ai-providers): size cards to their content and fix the selection control

### DIFF
--- a/e2e/providers-card-grid.spec.ts
+++ b/e2e/providers-card-grid.spec.ts
@@ -14,7 +14,13 @@ const codexKeys = [
     name: "codex one",
     "base-url": "https://chatgpt.com/backend-api/codex",
   },
-  { "api-key": "sk-codex-beta-1234567890abcdef", name: "codex two" },
+  // Deliberately taller than the first: it adds a badge row and a chip row, so
+  // the two cards must not come out the same height.
+  {
+    "api-key": "sk-codex-beta-1234567890abcdef",
+    name: "codex two",
+    models: [{ name: "gpt-5.2" }, { name: "gpt-5.3-codex" }],
+  },
 ];
 
 const opencodeGoKeys = [
@@ -107,6 +113,7 @@ const readGridMetrics = (page: Page) =>
       containerHeight: Math.round(el.clientHeight),
       display: style.display,
       alignContent: style.alignContent,
+      alignItems: style.alignItems,
       columnCount: style.gridTemplateColumns.split(" ").filter(Boolean).length,
       cards: Array.from(el.children).map((child) => {
         const rect = child.getBoundingClientRect();
@@ -151,15 +158,48 @@ for (const tabCase of [
         `card ${index} must be content height, not the full scroll box`,
       ).toBeLessThan(metrics.containerHeight / 2);
       expect(card.height, `card ${index} must still be a card`).toBeGreaterThan(
-        100,
+        60,
       );
     }
-
-    // Cards in one row end level: that is what h-full plus items-stretch buys.
-    const heights = new Set(metrics.cards.map((card) => card.height));
-    expect(heights.size, "cards in a row should share one height").toBe(1);
   });
 }
+
+/**
+ * Provider cards carry wildly different amounts of content — one may hold just a
+ * key and a base URL, another badges, chips and three quota bars. Levelling a
+ * row padded the short ones out to the tallest, which is where the dead space
+ * under most cards came from.
+ */
+test("AI Providers: cards end where their content ends, not level with the row", async ({
+  page,
+}) => {
+  await setAuthed(page, "codex");
+  await mockManagementApi(page);
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/#/access/ai-providers");
+
+  const list = page.getByTestId("providers-tab-scroll");
+  await expect(list).toBeVisible();
+  await expect.poll(() => list.locator("> *").count()).toBe(codexKeys.length);
+
+  const metrics = await readGridMetrics(page);
+  expect(metrics.alignItems, "the grid must not stretch its items").toMatch(
+    /start$/,
+  );
+  const [shorter, taller] = metrics.cards;
+  expect(
+    taller.height,
+    "the card with badges and chips must be the taller one",
+  ).toBeGreaterThan(shorter.height);
+
+  // And no card carries slack: its scroll height is its rendered height.
+  const overflow = await list.evaluate((el) =>
+    [...el.children].map((c) => c.scrollHeight - c.clientHeight),
+  );
+  for (const [index, slack] of overflow.entries()) {
+    expect(slack, `card ${index} should have no hidden overflow`).toBeLessThanOrEqual(1);
+  }
+});
 
 test("AI Providers: one column on mobile keeps cards inside the viewport", async ({
   page,

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3841,6 +3841,7 @@
     "opencode_go_usage_query": "Check usage",
     "opencode_go_usage_querying": "Checking...",
     "channel_usage_query_failed": "Usage query failed",
+    "channel_usage_refresh": "Refresh usage",
     "opencode_go_usage_rolling": "Rolling usage",
     "opencode_go_usage_weekly": "Weekly usage",
     "opencode_go_usage_monthly": "Monthly usage",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2374,6 +2374,7 @@
   },
   "providers": {
     "channel_usage_query_failed": "Usage query failed",
+    "channel_usage_refresh": "Refresh usage",
     "channel_usage_not_queried": "Usage not queried",
     "opencode_go_usage_compact_rolling": "Скользящее",
     "opencode_go_usage_compact_weekly": "Неделя",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2841,6 +2841,7 @@
     "opencode_go_usage_query": "查询用量",
     "opencode_go_usage_querying": "查询中...",
     "channel_usage_query_failed": "查询用量失败",
+    "channel_usage_refresh": "刷新用量",
     "opencode_go_usage_rolling": "滚动用量",
     "opencode_go_usage_weekly": "每周用量",
     "opencode_go_usage_monthly": "每月用量",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -63,6 +63,7 @@ export { Card } from "./primitives/Card";
 export { Surface, surface } from "./primitives/Surface";
 export type { SurfaceOptions, SurfaceRadius, SurfaceTone } from "./primitives/Surface";
 export { Checkbox } from "./primitives/Checkbox";
+export { CardSelectionCheckbox } from "./primitives/CardSelectionCheckbox";
 export { DateTimePicker } from "./primitives/DateTimePicker";
 export { DropdownMenu } from "./primitives/DropdownMenu";
 export type { DropdownMenuRootProps } from "./primitives/DropdownMenu";

--- a/packages/ui/src/primitives/CardSelectionCheckbox.tsx
+++ b/packages/ui/src/primitives/CardSelectionCheckbox.tsx
@@ -1,0 +1,58 @@
+import { Check } from "lucide-react";
+
+export interface CardSelectionCheckboxProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  /** Announced to assistive tech and shown as the control's title. */
+  label: string;
+  /**
+   * Keep the control on screen even when the card is not hovered. Selected
+   * cards pass true so a selection stays visible once the pointer moves away.
+   */
+  alwaysVisible?: boolean;
+  className?: string;
+}
+
+/**
+ * Per-card selection control for the AI providers and AI accounts card grids.
+ *
+ * A 24px box that matches the power and menu buttons it sits beside, but reads
+ * as a checkbox rather than another button: outlined and empty when unselected,
+ * filled with a tick when selected. Rendered as a tinted square like its
+ * neighbours it was just a blank grey tile, and as a raw `input` it looked like
+ * an unrelated widget wedged into a row of buttons.
+ *
+ * Below `md` it is always visible — there is no hover on touch.
+ */
+export function CardSelectionCheckbox({
+  checked,
+  onCheckedChange,
+  label,
+  alwaysVisible = false,
+  className,
+}: CardSelectionCheckboxProps) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={label}
+      title={label}
+      onClick={() => onCheckedChange(!checked)}
+      className={[
+        "inline-flex h-6 w-6 items-center justify-center rounded-md transition-all",
+        checked
+          ? "bg-slate-900 text-white dark:bg-white dark:text-neutral-950"
+          : "border border-slate-300 bg-white text-transparent hover:border-slate-400 hover:text-slate-300 dark:border-white/20 dark:bg-transparent dark:hover:border-white/35 dark:hover:text-white/30",
+        checked || alwaysVisible
+          ? "opacity-100 pointer-events-auto"
+          : "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <Check size={13} strokeWidth={3} />
+    </button>
+  );
+}

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -5657,18 +5657,23 @@ describe("AuthFilesPage files table", () => {
 
     expect(await screen.findByTestId("auth-files-cards")).toBeInTheDocument();
 
-    const checkbox = screen.getByLabelText("Select qwen.json") as HTMLInputElement;
+    // The control is a role=checkbox button, shared with the AI providers card,
+    // so its state lives on aria-checked rather than input.checked.
+    const checkbox = screen.getByRole("checkbox", { name: "Select qwen.json" });
     expect(checkbox).toBeInTheDocument();
-    expect(checkbox.parentElement).not.toHaveClass("opacity-0");
-    expect(checkbox.parentElement).not.toHaveClass("pointer-events-none");
-    expect(checkbox.checked).toBe(false);
+    expect(checkbox).not.toHaveClass("opacity-0");
+    expect(checkbox).not.toHaveClass("pointer-events-none");
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
 
     fireEvent.click(checkbox);
-    expect(checkbox.checked).toBe(true);
+    expect(
+      screen.getByRole("checkbox", { name: "Select qwen.json" }),
+    ).toHaveAttribute("aria-checked", "true");
 
-    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select qwen.json" }));
 
-    expect(screen.getByLabelText("Select qwen.json")).toBeInTheDocument();
-    expect((screen.getByLabelText("Select qwen.json") as HTMLInputElement).checked).toBe(false);
+    expect(
+      screen.getByRole("checkbox", { name: "Select qwen.json" }),
+    ).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -28,7 +28,7 @@ import {
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { VendorIcon } from "@code-proxy/assets";
 import { Button, DropdownMenu, buttonClassName, surface } from "@code-proxy/ui";
-import { Card } from "@code-proxy/ui";
+import { Card, CardSelectionCheckbox } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
 import { TextInput } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
@@ -1842,29 +1842,16 @@ export function AuthFilesFilesTab({
 
                           <div className="flex h-6 shrink-0 items-center gap-1.5">
                             {runtimeOnly ? null : (
-                              <div
-                                className={[
-                                  "flex h-6 w-6 items-center justify-center transition-opacity",
-                                  showSelectionControl
-                                    ? "opacity-100 pointer-events-auto"
-                                    : "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
-                                ].join(" ")}
-                              >
-                                <input
-                                  type="checkbox"
-                                  aria-label={t("auth_files.select_file", {
-                                    name: displayTitle || file.name,
-                                  })}
-                                  checked={fileSelected}
-                                  onChange={(e) =>
-                                    toggleFileSelection(
-                                      file.name,
-                                      e.currentTarget.checked,
-                                    )
-                                  }
-                                  className="h-4 w-4 rounded border-slate-300 text-slate-900 accent-slate-900 focus-visible:ring-2 focus-visible:ring-slate-400/35 dark:border-neutral-700 dark:bg-neutral-950 dark:text-white dark:accent-white dark:focus-visible:ring-white/15"
-                                />
-                              </div>
+                              <CardSelectionCheckbox
+                                checked={fileSelected}
+                                onCheckedChange={(next) =>
+                                  toggleFileSelection(file.name, next)
+                                }
+                                label={t("auth_files.select_file", {
+                                  name: displayTitle || file.name,
+                                })}
+                                alwaysVisible={showSelectionControl}
+                              />
                             )}
                             {runtimeOnly ? (
                               <span className="text-xs leading-none text-slate-400 dark:text-white/40">

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -1,11 +1,12 @@
 import { useState, type ReactNode } from "react";
 import {
   Card,
+  CardSelectionCheckbox,
   DropdownMenu,
   HoverTooltip,
   OverflowTooltip,
 } from "@code-proxy/ui";
-import { Check, Ellipsis, Power, Settings2, Trash2 } from "lucide-react";
+import { Ellipsis, Power, Settings2, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 export interface ProviderCardProps {
@@ -29,6 +30,10 @@ export interface ProviderCardProps {
   onDelete?: () => void;
   /** Extra elements rendered in the header row, after title */
   headerExtra?: ReactNode;
+  /** Per-card actions rendered in the header's control cluster, before the
+   *  power button. Keeps single actions out of the badge row, where one
+   *  button alone held a whole line open with an empty left half. */
+  headerActions?: ReactNode;
   /** Footer content fixed at card bottom (e.g. status bar) */
   footer?: ReactNode;
   /** Card body content */
@@ -47,6 +52,7 @@ export function ProviderCard({
   onEdit,
   onDelete,
   headerExtra,
+  headerActions,
   footer,
   children,
   className,
@@ -61,11 +67,11 @@ export function ProviderCard({
       padding="default"
       bodyClassName="mt-0 flex min-h-0 flex-1 flex-col"
       className={[
-        // h-full fills the grid row, which content-start on the list keeps at
-        // content height; it is what makes cards in one row end level. Do not
-        // pair it with a max-w override from the caller — md:max-w-none here
-        // wins over any narrower max-width and the card goes full bleed.
-        "group group/card flex h-full w-full max-w-[34rem] flex-col rounded-3xl border-slate-900/8 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
+        // No h-full: with items-start on the grid the card is as tall as its
+        // content. Do not pair the width rules with a max-w override from the
+        // caller — md:max-w-none here wins over any narrower max-width and the
+        // card goes full bleed.
+        "group group/card flex w-full max-w-[34rem] flex-col rounded-3xl border-slate-900/8 shadow-[0_8px_24px_rgb(15_23_42_/_0.04)] transition-colors duration-200 ease-out hover:border-slate-300 hover:bg-white md:max-w-none dark:border-white/[0.08] dark:shadow-[0_8px_24px_rgb(0_0_0_/_0.28)] dark:hover:border-neutral-700 dark:hover:bg-neutral-950/70",
         // No floor height: items-stretch already levels a row, so a minimum
         // only added dead space under the shortest card in every row.
         "min-h-0",
@@ -96,28 +102,14 @@ export function ProviderCard({
         ) : null}
 
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {headerActions}
           {onToggleSelected ? (
-            // Same 24px squared control as the power button beside it. A raw
-            // checkbox next to a rounded tinted button read as two unrelated
-            // widgets sharing a corner.
-            <button
-              type="button"
-              role="checkbox"
-              aria-checked={selected}
-              aria-label={t("providers.select_provider", { name: title })}
-              onClick={() => onToggleSelected(!selected)}
-              className={[
-                "inline-flex h-6 w-6 items-center justify-center rounded-md transition-all",
-                selected
-                  ? "bg-slate-900 text-white dark:bg-white dark:text-neutral-950"
-                  : "bg-slate-100 text-transparent hover:bg-slate-200 hover:text-slate-400 dark:bg-white/10 dark:hover:bg-white/15 dark:hover:text-white/40",
-                showSelectionControl
-                  ? "opacity-100 pointer-events-auto"
-                  : "opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100 md:group-hover/card:pointer-events-auto md:group-focus-within/card:pointer-events-auto",
-              ].join(" ")}
-            >
-              <Check size={13} />
-            </button>
+            <CardSelectionCheckbox
+              checked={selected}
+              onCheckedChange={onToggleSelected}
+              label={t("providers.select_provider", { name: title })}
+              alwaysVisible={showSelectionControl}
+            />
           ) : null}
           {onToggleEnabled ? (
             // Always-on power button, as on the AI account card. The toggle it

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -23,19 +23,24 @@ import { useTranslation } from "react-i18next";
 import { useOptionalAuth } from "@app/providers/AuthProvider";
 
 /**
- * Responsive card grid, mirroring the AI accounts page.
+ * Responsive card grid.
  *
  * `content-start` is load-bearing: this grid is a flex child with a resolved
  * height, so the default `align-content: stretch` hands the single row all of
  * that height and every card is dragged down to the bottom of the scroll box.
- * With `start`, the row is as tall as its tallest card and `items-stretch` (plus
- * the card's own `h-full`) keeps siblings in a row the same height.
+ *
+ * `items-start`, not `items-stretch`: unlike an AI account card — which always
+ * carries three or four quota bars and so is naturally the same height as its
+ * neighbours — a provider card may hold nothing but a key and a base URL, or a
+ * key plus badges, chips and three quota bars. Levelling a row meant padding
+ * the short cards out to the tallest one, which is where the dead space in
+ * every row came from. Cards now end where their content ends.
  *
  * Below `md` cards centre inside one column and cap at `max-w-[34rem]`; from
  * `md` up they stretch to fill their column.
  */
 export const CARD_GRID_CLASS = [
-  "grid min-h-0 flex-1 content-start items-stretch justify-items-center gap-5 pr-1",
+  "grid min-h-0 flex-1 content-start items-start justify-items-center gap-5 pr-1",
   "grid-cols-1 md:grid-cols-2 md:justify-items-stretch xl:grid-cols-[repeat(3,minmax(0,1fr))]",
 ].join(" ");
 
@@ -240,6 +245,11 @@ export function ProviderKeyListCard({
                 onEdit={canWrite ? () => onEdit(idx) : undefined}
                 onDelete={canWrite ? () => onDelete(idx) : undefined}
                 headerExtra={headerBadges}
+                headerActions={
+                  canTest && renderMetricsExtra
+                    ? renderMetricsExtra(item, idx, stats)
+                    : undefined
+                }
                 footer={
                   hasStatusData ? <ProviderStatusBar data={statusData} /> : undefined
                 }
@@ -295,11 +305,6 @@ export function ProviderKeyListCard({
                         count: stats.failure,
                       })}
                     />
-                  ) : null}
-                  {canTest && renderMetricsExtra ? (
-                    <div className="ml-auto">
-                      {renderMetricsExtra(item, idx, stats)}
-                    </div>
                   ) : null}
                 </div>
 

--- a/pages/providers/components/OpenCodeGoUsageCardSection.tsx
+++ b/pages/providers/components/OpenCodeGoUsageCardSection.tsx
@@ -243,32 +243,21 @@ export function OpenCodeGoUsageCardSection({
 
   // One state at a time. A failed probe used to render the "not queried" gauge
   // and a red error line together, which read as two unrelated problems.
+  // One line, not a stacked icon block: this is a status note on a card that is
+  // otherwise two or three lines tall, and a centred 8x8 medallion above a
+  // caption made the note the largest thing on it.
   const renderPlaceholder = (message: string, tone: "muted" | "error") => (
     <div
-      className="flex flex-col items-center justify-center gap-1.5 py-4 text-center"
+      className={[
+        "flex h-6 w-full items-center gap-1.5 rounded-md border px-2 text-xs font-medium",
+        tone === "error"
+          ? "border-rose-200 bg-rose-50/60 text-rose-600 dark:border-rose-500/20 dark:bg-rose-500/[0.08] dark:text-rose-300"
+          : "border-slate-200 bg-slate-50/60 text-slate-500 dark:border-white/10 dark:bg-white/[0.03] dark:text-white/50",
+      ].join(" ")}
       data-testid="opencode-go-usage-footprint"
     >
-      <div
-        className={[
-          "flex h-8 w-8 items-center justify-center rounded-full",
-          tone === "error"
-            ? "bg-rose-50 text-rose-400 dark:bg-rose-500/10 dark:text-rose-300/70"
-            : "bg-slate-100/90 text-slate-400 dark:bg-white/[0.06] dark:text-white/40",
-        ].join(" ")}
-        aria-hidden="true"
-      >
-        <Gauge size={15} strokeWidth={1.5} />
-      </div>
-      <p
-        className={[
-          "text-xs font-medium",
-          tone === "error"
-            ? "text-rose-600 dark:text-rose-300"
-            : "text-slate-500 dark:text-white/50",
-        ].join(" ")}
-      >
-        {message}
-      </p>
+      <Gauge size={12} strokeWidth={1.5} className="shrink-0" aria-hidden="true" />
+      <span className="min-w-0 truncate">{message}</span>
     </div>
   );
 
@@ -345,9 +334,12 @@ export function OpenCodeGoUsageRefreshButton({
   usageStore: OpenCodeGoUsageStore;
   onRefresh: () => void;
 }) {
+  const { t } = useTranslation();
   const snapshot = useOpenCodeGoUsageSnapshot(usageStore, cacheKey);
   const loading = snapshot.loading;
-  const hasError = Boolean(snapshot.usageEntry?.error);
+  // Always visible, like the power and menu buttons beside it. Revealing it on
+  // hover shifted the whole control cluster as the pointer arrived.
+  const refreshLabel = t("providers.channel_usage_refresh");
 
   return (
     <button
@@ -358,15 +350,13 @@ export function OpenCodeGoUsageRefreshButton({
       }}
       disabled={loading}
       className={[
-        "inline-flex h-6 w-6 items-center justify-center rounded-lg transition-all duration-150",
-        "text-slate-400 hover:bg-slate-200/60 hover:text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25",
-        "dark:text-white/40 dark:hover:bg-white/10 dark:hover:text-white/60 dark:focus-visible:ring-white/20",
-        loading || hasError
-          ? "opacity-100"
-          : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+        // Matches the power and menu buttons it now sits beside in the header.
+        "inline-flex h-6 w-6 items-center justify-center rounded-md bg-slate-100 transition-all duration-150",
+        "text-slate-500 hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/25",
+        "dark:bg-white/10 dark:text-white/55 dark:hover:bg-white/15 dark:hover:text-white/80 dark:focus-visible:ring-white/20",
       ].join(" ")}
-      aria-label="Refresh usage"
-      title="Refresh usage"
+      aria-label={refreshLabel}
+      title={refreshLabel}
     >
       <RefreshCcw size={13} className={loading ? "animate-spin" : ""} />
     </button>

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -17,7 +17,7 @@
     "pages/api-keys/ApiKeysPage.tsx": 1167,
     "pages/auth-files/AuthFilesPage.tsx": 1210,
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,
-    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2578,
+    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2565,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 974,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1298,


### PR DESCRIPTION
## 问题

你截图里红框的空白、ClinePass/Ollama Cloud 标题下的空档、以及那个"奇怪的复选框"。这次先量了再改，没有猜。

**实测（1600px 视口，`getBoundingClientRect` 逐层量）**

| 位置 | 量到的值 | 成因 |
|---|---|---|
| tcdmx 卡片底部 | 空 56px | `items-stretch` 把它撑到同行最高卡片的高度 |
| ClinePass 标题下 | 空 30px | 徽章行里只剩一个刷新按钮，`ml-auto` 靠右，左半边全空 |
| ClinePass 卡片总高 | 218px | 上面两条 + 居中的大图标空态 |

## 改动

### 卡片按内容高度，不再同行拉平

AI 账号卡片每张都有 3–4 条配额条，一行天然齐；供应商卡片可能只有一个 key 和 base URL，也可能有徽章 + chips + 3 条配额条。拉平的代价就是把矮卡片垫到最高那张，红框里的空白全是这么来的。改成 `items-start`，卡片到内容为止。

### 刷新按钮移进头部

它单独占着徽章行，左半边空着——ClinePass 标题和 chips 之间那 30px 就是它。移到头部和电源、菜单并排，样式统一，并且**常驻显示**（原来 hover 才出现，指针移过去时整组控件会位移）。标签也不再在别的渠道上写 OpenCode Go。

### 用量占位改成一行

原来是居中的 8×8 圆形图标 + 下方文字。卡片本身才两三行高，这个状态提示反而成了最大的元素。改成一行带边框的提示条。**ClinePass 卡片 218px → 133px。**

### 复选框：现在能看出是复选框

原来是和旁边按钮一样的实心灰方块，未选中时图标透明——就是一块空白灰砖，既不像按钮也不像复选框。改成未选中描边空心、选中填充打勾。

提取为 `CardSelectionCheckbox` 放进 `@code-proxy/ui`，**AI 账号卡片也换成同一个**（原来是原生 `input`），两页选择方式终于一致。共享后 `AuthFilesFilesTab` 还比 baseline 少了 13 行。

## 验证

- `./scripts/ci-pr.sh` 全量通过：lint、design:check、size、surface、1247 vitest、build、bundle:diff、12 个 critical e2e
- 新增 e2e：断言网格不拉伸子项，且"有徽章和 chips 的卡片"必须比"没有的"更高
- 账号卡片复选框测试同步改为 `role=checkbox` + `aria-checked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)