### PR TITLE
fix(ai-providers): level the cards in a row, size model chips by their text

### DIFF
--- a/e2e/providers-card-grid.spec.ts
+++ b/e2e/providers-card-grid.spec.ts
@@ -166,11 +166,13 @@ for (const tabCase of [
 
 /**
  * Provider cards carry wildly different amounts of content — one may hold just a
- * key and a base URL, another badges, chips and three quota bars. Levelling a
- * row padded the short ones out to the tallest, which is where the dead space
- * under most cards came from.
+ * key and a base URL, another badges, chips and three quota bars. Letting each
+ * end at its own content does not remove empty space, it moves it: the row is
+ * still as tall as its tallest card, so a short card leaves a gap between its
+ * bottom edge and the next row. Levelling keeps that space inside the card,
+ * where it reads as padding, and the rows stay flush.
  */
-test("AI Providers: cards end where their content ends, not level with the row", async ({
+test("AI Providers: every card in a row ends on the same line", async ({
   page,
 }) => {
   await setAuthed(page, "codex");
@@ -182,15 +184,26 @@ test("AI Providers: cards end where their content ends, not level with the row",
   await expect(list).toBeVisible();
   await expect.poll(() => list.locator("> *").count()).toBe(codexKeys.length);
 
-  const metrics = await readGridMetrics(page);
-  expect(metrics.alignItems, "the grid must not stretch its items").toMatch(
-    /start$/,
-  );
-  const [shorter, taller] = metrics.cards;
-  expect(
-    taller.height,
-    "the card with badges and chips must be the taller one",
-  ).toBeGreaterThan(shorter.height);
+  const rows = await list.evaluate((el) => {
+    const byTop = new Map<number, number[]>();
+    for (const child of el.children) {
+      const rect = child.getBoundingClientRect();
+      const top = Math.round(rect.top);
+      byTop.set(top, [...(byTop.get(top) ?? []), Math.round(rect.bottom)]);
+    }
+    return [...byTop.entries()].map(([top, bottoms]) => ({
+      top,
+      raggedBy: Math.max(...bottoms) - Math.min(...bottoms),
+    }));
+  });
+
+  expect(rows.length, "the fixture should produce at least one row").toBeGreaterThan(0);
+  for (const row of rows) {
+    expect(
+      row.raggedBy,
+      `cards in the row at y=${row.top} must end level`,
+    ).toBeLessThanOrEqual(1);
+  }
 
   // And no card carries slack: its scroll height is its rendered height.
   const overflow = await list.evaluate((el) =>

--- a/pages/providers/ProviderCard.tsx
+++ b/pages/providers/ProviderCard.tsx
@@ -79,7 +79,6 @@ export function ProviderCard({
       selectionLabel={t("providers.select_provider", { name: title })}
       titleAdornment={headerExtra}
       header={header}
-      fill={false}
       headerControls={
         <>
           {headerActions}

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -29,15 +29,15 @@ import { useOptionalAuth } from "@app/providers/AuthProvider";
  * a resolved height: the default `align-content: stretch` would hand its single
  * row all of that height and drag every card to the bottom of the scroll box.
  *
- * `align: start` rather than the accounts page's stretch. An account card
- * always carries three or four quota bars and so is naturally the height of its
- * neighbours; a provider card may hold nothing but a key and a base URL, or a
- * key plus badges, chips and three quota bars. Levelling a row padded the short
- * cards out to the tallest one.
+ * Cards are levelled within a row, as on the accounts page. Letting each end at
+ * its own content does not remove empty space, it only moves it: the row is
+ * still as tall as its tallest card, so a short card leaves a gap between its
+ * bottom edge and the next row. Levelling keeps that space inside the card,
+ * where it reads as padding rather than as a hole in the grid.
  */
 export const CARD_GRID_CLASS = [
   "min-h-0 flex-1 content-start pr-1",
-  entityCardGridClass({ columns: 3, dense: true, align: "start" }),
+  entityCardGridClass({ columns: 3, dense: true }),
 ].join(" ");
 
 /**
@@ -308,7 +308,7 @@ export function ProviderKeyListCard({
                     {headerEntries.map(([k, v]) => (
                       <span
                         key={k}
-                        className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-slate-900/8 bg-white px-2 py-0.5 text-xs text-slate-700 dark:border-white/8 dark:bg-neutral-950/60 dark:text-white/75"
+                        className="inline-flex h-5 max-w-full min-w-0 items-center gap-1 rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none text-slate-700 dark:bg-white/10 dark:text-white/70"
                         title={`${k}: ${String(v)}`}
                       >
                         <span className="shrink-0 font-semibold">{k}:</span>
@@ -327,7 +327,7 @@ export function ProviderKeyListCard({
                     {excludedModels.map((model) => (
                       <span
                         key={model}
-                        className="inline-flex max-w-full min-w-0 rounded-full bg-rose-600/10 px-2 py-0.5 text-xs text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
+                        className="inline-flex h-5 max-w-full min-w-0 items-center rounded-md bg-rose-50 px-1.5 text-2xs font-semibold leading-none text-rose-700 dark:bg-rose-500/15 dark:text-rose-200"
                         title={model}
                       >
                         <span className="min-w-0 truncate">{model}</span>

--- a/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
+++ b/pages/providers/__tests__/ProvidersPage.opencode-go.test.tsx
@@ -1009,11 +1009,11 @@ describe("ProvidersPage Cline tab", () => {
     expect(await screen.findByText("Cline Tooltip")).toBeInTheDocument();
     await waitFor(() => expect(mocks.getModelDefinitions).toHaveBeenCalledWith("cline"));
 
-    // Chips are capped at one row (2 chips + the count), so 8 models leave 6
+    // Chips are capped at one row (3 chips + the count), so 8 models leave 5
     // behind the badge — all of which the tooltip must still list.
-    await user.hover(screen.getByText("+6"));
+    await user.hover(screen.getByText("+5"));
     const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip).toHaveTextContent("cline-pass/qwen3.7-max");
+    expect(tooltip).toHaveTextContent("cline-pass/qwen3-coder");
     expect(tooltip).toHaveTextContent("cline-pass/deepseek-v4");
     expect(tooltip).toHaveTextContent("cline-pass/kimi-k2.6");
     expect(tooltip).toHaveTextContent("cline-pass/gpt-5.2");

--- a/pages/providers/components/ProviderModelChips.tsx
+++ b/pages/providers/components/ProviderModelChips.tsx
@@ -9,7 +9,7 @@ interface ProviderModelChipsProps {
 
 export function ProviderModelChips({
   models,
-  maxVisible = 3,
+  maxVisible = 4,
   emptyLabel,
 }: ProviderModelChipsProps) {
   if (!models.length) {
@@ -27,27 +27,26 @@ export function ProviderModelChips({
   };
 
   // Same flat, squared, 2xs badge as the metric chips and the AI account card.
-  // The old inverted pill (black on white) was the loudest thing on the card
-  // and made a row of model names read as a warning.
   //
-  // Capped at one row: a second row of chips only appeared on the channels with
-  // the most models, and because a grid row levels every card in it, those cards
-  // pushed their whole row taller for a list nobody reads chip by chip. The
-  // overflow count carries the rest, with the full list in its tooltip.
+  // Chips are sized by their text, not by an equal-width track. On a 3-column
+  // grid every chip was as wide as a third of the card, so "gpt-5.2" sat in a
+  // box with more empty space than label and the "+3" count was stretched to
+  // match. One row: names shrink and truncate to share it, the count never
+  // does, and the full list stays in the tooltip.
   return (
-    <div className="grid max-h-5 grid-cols-3 gap-1 overflow-hidden">
+    <div className="flex max-h-5 items-center gap-1 overflow-hidden">
       {visible.map((model) => {
         const modelLabel = formatModelLabel(model, "→");
         return (
-          // Overflow-only: the chip is often truncated by the 3-column grid, but when
-          // it fits, a tooltip would just repeat the mapping already on screen.
+          // Overflow-only: a chip that fits needs no tooltip, since it would
+          // just repeat the mapping already on screen.
           <OverflowTooltip
             key={model.name}
             content={formatModelLabel(model, "=>")}
             placement="top"
             className="min-w-0"
           >
-            <span className="inline-flex h-5 w-full min-w-0 cursor-default items-center rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none text-slate-700 dark:bg-white/10 dark:text-white/70">
+            <span className="inline-flex h-5 min-w-0 max-w-full cursor-default items-center rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none text-slate-700 dark:bg-white/10 dark:text-white/70">
               <span className="min-w-0 truncate">{modelLabel}</span>
             </span>
           </OverflowTooltip>
@@ -60,9 +59,9 @@ export function ProviderModelChips({
             .map((model) => formatModelLabel(model, "=>"))
             .join("\n")}
           placement="top"
-          className="min-w-0"
+          className="shrink-0"
         >
-          <span className="inline-flex h-5 min-w-0 cursor-default items-center justify-center rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none tabular-nums text-slate-500 dark:bg-white/10 dark:text-white/55">
+          <span className="inline-flex h-5 shrink-0 cursor-default items-center rounded-md bg-slate-100 px-1.5 text-2xs font-semibold leading-none tabular-nums text-slate-500 dark:bg-white/10 dark:text-white/55">
             +{remaining}
           </span>
         </HoverTooltip>


### PR DESCRIPTION
## 问题

两件事。

**1. 行与行之间的空隙**（你上一张截图的红箭头）

上一版我把卡片改成按内容高度（`fill={false}`），后果是**空白没有消失，只是从卡片内部挪到了行与行之间**——行高仍由该行最高的卡片决定，矮卡片下边缘到下一行之间就是个洞。账号页一直是同行等高的，是对的。

**2. 模型 chip 展示难看**

3 列等宽格子，每个 chip 占满整格：`gpt-5.2` 这么短的名字，box 里空白比文字还多，`+3` 也被拉宽。

## 改动

- 供应商页不再传 `fill={false}`，`EntityCard` 像在账号页一样填满行。行与行贴合，同行卡片底部齐平，余量留在矮卡片内部当内边距。
- 模型 chip 改为一行 flex、按内容宽度：名字可收缩截断，`+N` 不收缩，完整列表仍在 tooltip 里。chip 不再被撑宽后，一行能放 4 个（原来 3 个）。
- 补两个漏掉的徽章：自定义请求头（`X-Trace: on`）和排除模型，仍是旧的圆角描边胶囊，现在统一成方角 `2xs`。

## 这次系统性过了数据组合

固定夹具矩阵，不是只看一个 tab：

**Codex**：只有 key+地址 / 一个模型 / 五个模型 / 没有 base URL / 超长渠道名 / 已禁用 / 带自定义头 / 有流量统计
**OpenCode Go**：配额齐全 / 配额齐全但无模型 / 未配置用量凭据 / 用量查询失败

每一行实测 `raggedBy: 0`（同行所有卡片底部在同一条线上）。

## 验证

- `./scripts/ci-pr.sh` 全量通过：lint、design:check、size、surface、353 个供应商+账号用例、build、bundle:diff、12 个 critical e2e
- e2e 断言从「卡片各自内容高度」改为「同行卡片底部齐平」，方向反过来锁住

🤖 Generated with [Claude Code](https://claude.com/claude-code)