### PR TITLE
feat(ai-providers): draw the success rate as a bar, like the quota windows

### DIFF
--- a/e2e/providers-card-grid.spec.ts
+++ b/e2e/providers-card-grid.spec.ts
@@ -83,7 +83,18 @@ const mockManagementApi = async (page: Page) => {
     if (managementPath === "/config") return fulfillJson({});
     if (managementPath === "/proxy-pool") return fulfillJson({ items: [] });
     if (managementPath.startsWith("/usage/entity-stats"))
-      return fulfillJson({ source: [], auth_index: [] });
+      // Only the first OpenCode Go credential has traffic; the codex ones have
+      // none, which is what the empty-state case below relies on.
+      return fulfillJson({
+        source: [
+          {
+            entity_name: "sk-opencode-go-alpha-1234567890abcdef",
+            requests: 5864,
+            failed: 98,
+          },
+        ],
+        auth_index: [],
+      });
     if (managementPath === "/codex-api-key" && request.method() === "GET")
       return fulfillJson({ "codex-api-key": codexKeys });
     if (managementPath === "/opencode-go-api-key" && request.method() === "GET")
@@ -260,7 +271,7 @@ test("AI Providers: a channel with no traffic shows no status bar, rate or zero 
   await expect.poll(() => list.locator("> *").count()).toBe(codexKeys.length);
 
   // No usage stats are mocked, so neither codex channel has traffic.
-  await expect(list.getByRole("status")).toHaveCount(0);
+  await expect(list.getByTestId("provider-success-rate")).toHaveCount(0);
   await expect(list).not.toContainText("--");
   await expect(list).not.toContainText("Success 0");
   await expect(list).not.toContainText("Failed 0");
@@ -280,4 +291,39 @@ test("AI Providers: a channel with no traffic shows no status bar, rate or zero 
       }).length,
   );
   expect(dividerCount, "cards should carry no internal rules").toBe(0);
+});
+
+/**
+ * With traffic, the rate is a labelled bar like the quota windows above it. It
+ * used to be a strip of ~21 blocks in a footer sized to its content — about 95px
+ * wide, so each block was 4px and only the percentage was readable.
+ */
+test("AI Providers: a channel with traffic shows a full-width success-rate bar", async ({
+  page,
+}) => {
+  await setAuthed(page, "opencode-go");
+  await mockManagementApi(page);
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto("/#/access/ai-providers");
+
+  const list = page.getByTestId("providers-tab-scroll");
+  await expect(list).toBeVisible();
+
+  const bar = list.getByTestId("provider-success-rate").first();
+  await expect(bar).toBeVisible();
+
+  const metrics = await bar.evaluate((el) => {
+    const card = el.closest(".group");
+    return {
+      width: Math.round(el.getBoundingClientRect().width),
+      cardWidth: Math.round((card as HTMLElement).getBoundingClientRect().width),
+      text: (el.textContent || "").replace(/\s+/g, " ").trim(),
+    };
+  });
+
+  expect(
+    metrics.width,
+    "the bar should span the card, not shrink to its content",
+  ).toBeGreaterThan(metrics.cardWidth * 0.7);
+  expect(metrics.text, "the bar labels itself and reports the rate").toMatch(/%$/);
 });

--- a/features/quota-preview/QuotaBar.tsx
+++ b/features/quota-preview/QuotaBar.tsx
@@ -98,14 +98,33 @@ export const resolveQuotaVisualTone = (
   };
 };
 
+/**
+ * Colour band, when the caller's thresholds differ from a quota's.
+ *
+ * A quota is healthy above 60% remaining; a success rate is not healthy until
+ * about 90%, and is alarming below 50%. `auto` derives the band from `percent`,
+ * which is right for quotas.
+ */
+export type QuotaBarTone = "auto" | "positive" | "caution" | "critical";
+
+const TONE_SAMPLE: Record<Exclude<QuotaBarTone, "auto">, number> = {
+  positive: 100,
+  caution: 40,
+  critical: 10,
+};
+
 export interface QuotaBarProps {
   label: string;
   /** Remaining percent, 0-100. `null` renders the neutral "unknown" tone. */
   percent: number | null | undefined;
+  /** Colour band. Defaults to deriving it from `percent`. */
+  tone?: QuotaBarTone;
   /** Percent text, when the source has its own formatting (e.g. "3.2%"). */
   percentText?: string;
-  /** Countdown or reset hint, shown beside a clock icon. */
+  /** Countdown or reset hint, shown beside `detailIcon`. */
   detailText?: string | null;
+  /** Icon before `detailText`. Defaults to a clock, which suits a countdown. */
+  detailIcon?: ReactNode;
   /** Explains what the window means; rendered as a hoverable info icon. */
   hint?: string;
   compact?: boolean;
@@ -126,14 +145,19 @@ export interface QuotaBarProps {
 export function QuotaBar({
   label,
   percent,
+  tone: toneBand = "auto",
   percentText,
   detailText,
+  detailIcon,
   hint,
   compact = false,
   testId,
 }: QuotaBarProps): ReactNode {
-  const tone = resolveQuotaVisualTone(percent);
-  const normalized = tone.normalized;
+  // Fill width always tracks `percent`; only the colour band can be overridden.
+  const tone = resolveQuotaVisualTone(
+    toneBand === "auto" ? percent : TONE_SAMPLE[toneBand],
+  );
+  const normalized = resolveQuotaVisualTone(percent).normalized;
   const shownPercent =
     percentText ?? (normalized === null ? "--" : `${Math.round(normalized)}%`);
 
@@ -189,7 +213,9 @@ export function QuotaBar({
               tone.barMetaClass,
             ].join(" ")}
           >
-            <Clock size={compact ? 9 : 10} className="shrink-0" aria-hidden />
+            {detailIcon ?? (
+              <Clock size={compact ? 9 : 10} className="shrink-0" aria-hidden />
+            )}
             {detailText}
           </span>
         ) : null}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3842,6 +3842,7 @@
     "opencode_go_usage_querying": "Checking...",
     "channel_usage_query_failed": "Usage query failed",
     "channel_usage_refresh": "Refresh usage",
+    "request_total": "{{count}} requests",
     "opencode_go_usage_rolling": "Rolling usage",
     "opencode_go_usage_weekly": "Weekly usage",
     "opencode_go_usage_monthly": "Monthly usage",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -2375,6 +2375,7 @@
   "providers": {
     "channel_usage_query_failed": "Usage query failed",
     "channel_usage_refresh": "Refresh usage",
+    "request_total": "{{count}} requests",
     "channel_usage_not_queried": "Usage not queried",
     "opencode_go_usage_compact_rolling": "Скользящее",
     "opencode_go_usage_compact_weekly": "Неделя",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2842,6 +2842,7 @@
     "opencode_go_usage_querying": "查询中...",
     "channel_usage_query_failed": "查询用量失败",
     "channel_usage_refresh": "刷新用量",
+    "request_total": "{{count}} 次请求",
     "opencode_go_usage_rolling": "滚动用量",
     "opencode_go_usage_weekly": "每周用量",
     "opencode_go_usage_monthly": "每月用量",

--- a/pages/providers/ProviderKeyListCard.tsx
+++ b/pages/providers/ProviderKeyListCard.tsx
@@ -6,7 +6,7 @@ import type {
 import { Card, entityCardGridClass } from "@code-proxy/ui";
 import { ProviderCard, ProviderCardSkeleton } from "./ProviderCard";
 import { EmptyState } from "@code-proxy/ui";
-import { ProviderStatusBar } from "@features/provider-latency";
+import { ProviderSuccessRateBar } from "./components/ProviderSuccessRateBar";
 import type { KeyStatBucket, StatusBarData } from "@code-proxy/domain";
 import {
   hasDisableAllModelsRule,
@@ -245,7 +245,7 @@ export function ProviderKeyListCard({
                     : undefined
                 }
                 footer={
-                  hasStatusData ? <ProviderStatusBar data={statusData} /> : undefined
+                  hasStatusData ? <ProviderSuccessRateBar data={statusData} /> : undefined
                 }
                 header={
                   <>

--- a/pages/providers/components/OpenAIProvidersTab.tsx
+++ b/pages/providers/components/OpenAIProvidersTab.tsx
@@ -6,7 +6,7 @@ import { Card } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
 import { ProviderCard, ProviderCardSkeleton } from "../ProviderCard";
 import { CARD_GRID_CLASS } from "../ProviderKeyListCard";
-import { ProviderStatusBar } from "@features/provider-latency";
+import { ProviderSuccessRateBar } from "./ProviderSuccessRateBar";
 import { ProviderMetricChip } from "./ProviderMetricChip";
 import { ProviderModelChips } from "./ProviderModelChips";
 import { OpenAIKeyEntrySummary } from "./OpenAIKeyEntrySummary";
@@ -219,7 +219,7 @@ export function OpenAIProvidersTab({
                   </div>
                 ) : null}
 
-                {hasStatusData ? <ProviderStatusBar data={statusData} /> : null}
+                {hasStatusData ? <ProviderSuccessRateBar data={statusData} /> : null}
               </ProviderCard>
             );
           })}

--- a/pages/providers/components/ProviderSuccessRateBar.tsx
+++ b/pages/providers/components/ProviderSuccessRateBar.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from "react-i18next";
+import { Activity } from "lucide-react";
+import { HoverTooltip } from "@code-proxy/ui";
+import type { StatusBarData } from "@code-proxy/domain";
+import { QuotaBar } from "@features/quota-preview/QuotaBar";
+
+/**
+ * Recent-request success rate, drawn as the card's quota bars are.
+ *
+ * It used to be a strip of ~21 one-pixel-ish blocks plus a percentage. In a
+ * footer sized to its content that strip came out 95px wide, so the blocks were
+ * about 4px each — unreadable, and all that was left to read was a percentage
+ * floating on its own. The same bar the quota windows use gives the number a
+ * shape: a full-width row whose fill is the rate and whose label says what it
+ * is. The per-window detail moves into the tooltip, where it is legible.
+ *
+ * Thresholds are the success-rate ones (90 / 50), not a quota's (60 / 20): a
+ * channel failing one call in four is in trouble, while a quota at 75% is fine.
+ */
+export function ProviderSuccessRateBar({ data }: { data: StatusBarData }) {
+  const { t } = useTranslation();
+  const total = data.totalSuccess + data.totalFailure;
+  if (total === 0) return null;
+
+  const rate = data.successRate;
+  const tone = rate >= 90 ? "positive" : rate >= 50 ? "caution" : "critical";
+
+  return (
+    <HoverTooltip
+      content={[
+        t("providers.success_stats", { count: data.totalSuccess }),
+        t("providers.failed_stats", { count: data.totalFailure }),
+      ].join(" · ")}
+      placement="top"
+      className="w-full min-w-0"
+    >
+      <div className="w-full min-w-0">
+        <QuotaBar
+          label={t("common.success_rate")}
+          percent={rate}
+          tone={tone}
+          percentText={`${rate.toFixed(1)}%`}
+          detailText={t("providers.request_total", { count: total })}
+          detailIcon={<Activity size={10} className="shrink-0" aria-hidden />}
+          testId="provider-success-rate"
+        />
+      </div>
+    </HoverTooltip>
+  );
+}


### PR DESCRIPTION
## 问题

你红箭头指的那个 `97.5%`。

原来底部是「一排 ~21 个小方块 + 百分比」。共享卡片组件后 footer 不再强制撑满宽度，这排方块实测只有 **95px 宽**——每个方块约 4px，等于什么都没表达，只剩一个百分比孤零零浮在配额条下面。

而上面的配额条（整行色块 + 左标签 + 右数值）就很清楚。

## 改动

成功率改用**同一个 `QuotaBar`**：整行、自带标签、显示请求数、填充到实际比率。同一张卡上实测 **95px → 399px**。原来那排方块的明细移进 tooltip，在那里才读得清。

为此给 `QuotaBar` 加了两个可选项，避免两边互相将就：

- **`tone`** —— 覆盖配色档位。配额是「剩余 60% 以上算健康」，成功率则要到 90% 才算健康、低于 50% 就该报警。填充宽度仍按真实值走。
- **`detailIcon`** —— 替换默认的时钟图标。时钟适合倒计时，不适合请求数。

## 验证

- `./scripts/ci-pr.sh` 全量通过：lint、design:check、size、surface、**482 个** 供应商/账号/feature 用例、build、bundle:diff、12 个 critical e2e
- 新增 e2e：断言这条 bar 跨越卡片宽度（> 卡宽 70%）且自带标签
- 原「无流量不显示」的用例改为以这条 bar 的 test id 为准

🤖 Generated with [Claude Code](https://claude.com/claude-code)