### PR TITLE
fix(xai): consume the attributable weekly quota projection, fix a mislabeled quota bar

### DIFF
--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -76,7 +76,17 @@ export interface AuthFileTrendResponse {
   cycle_request_total: number;
   cycle_cost_total: number;
   cycle_total_tokens?: number | null;
+  /** Pool-wide share of the cycle's quota consumed, across every surface. */
   weekly_quota_used_percent: number | null;
+  /**
+   * Share consumed by traffic the proxy forwards — the only divisor that lines
+   * up with cycle_cost_total. Equal to weekly_quota_used_percent for providers
+   * that bill one pool per surface; smaller for xAI, whose weekly pool is shared
+   * with Grok Chat. Null when the backend found no attributable window.
+   */
+  projection_quota_used_percent?: number | null;
+  /** True when the two percentages above can legitimately differ (xAI). */
+  projection_quota_attributable?: boolean;
   cycle_known?: boolean;
   cycle_start: string;
   daily_usage: AuthFileTrendUsagePoint[];

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -1081,7 +1081,7 @@
     "title": "Grok Quota",
     "weekly_limit": "Weekly limit",
     "product_usage": "Product usage",
-    "product_usage_named": "{{product}} usage",
+    "product_usage_named": "{{product}} remaining",
     "used_percent": "Used {{percent}}",
     "remaining_percent": "Left {{percent}}",
     "reset_at": "Resets {{time}}",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -882,6 +882,8 @@
     "trend_predicted_5h_window_quota": "Predicted 5-hour window quota",
     "trend_predicted_week_window_quota": "Predicted weekly window quota",
     "trend_weekly_quota_used": "Weekly quota used",
+    "trend_predicted_quota_attributable_hint": "Derived from the {{percent}} this proxy consumed",
+    "trend_external_quota_used": "Consumed outside the proxy",
     "trend_cycle_start": "Cycle start",
     "trend_window_title": "Quota and request trends",
     "trend_window_5h": "5 hours",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -928,7 +928,7 @@
     "title": "Квота Grok",
     "weekly_limit": "Недельный лимит",
     "product_usage": "Использование продукта",
-    "product_usage_named": "Использование {{product}}",
+    "product_usage_named": "Остаток {{product}}",
     "used_percent": "Использовано {{percent}}",
     "remaining_percent": "Осталось {{percent}}",
     "reset_at": "Сброс {{time}}",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -821,6 +821,8 @@
     "trend_predicted_5h_window_quota": "Прогноз квоты за 5 часов",
     "trend_predicted_week_window_quota": "Прогноз недельной квоты",
     "trend_weekly_quota_used": "Использовано недельной квоты",
+    "trend_predicted_quota_attributable_hint": "Рассчитано по {{percent}}, израсходованным через прокси",
+    "trend_external_quota_used": "Израсходовано вне прокси",
     "trend_cycle_start": "Начало цикла",
     "trend_window_title": "Тренды квоты и запросов",
     "trend_window_5h": "5 часов",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -892,6 +892,8 @@
     "trend_predicted_5h_window_quota": "预测 5 小时窗口额度",
     "trend_predicted_week_window_quota": "预测周窗口额度",
     "trend_weekly_quota_used": "周额度已消耗",
+    "trend_predicted_quota_attributable_hint": "按本代理消耗的 {{percent}} 折算",
+    "trend_external_quota_used": "非代理消耗",
     "trend_cycle_start": "周期开始",
     "trend_window_title": "额度与请求趋势",
     "trend_window_5h": "5 小时",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -1089,7 +1089,7 @@
     "title": "Grok 额度",
     "weekly_limit": "周限额",
     "product_usage": "产品使用",
-    "product_usage_named": "{{product}} 使用",
+    "product_usage_named": "{{product}} 剩余",
     "used_percent": "已用 {{percent}}",
     "remaining_percent": "剩余 {{percent}}",
     "reset_at": "重置 {{time}}",

--- a/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
+++ b/pages/auth-files/__tests__/AuthFileDetailModal.test.tsx
@@ -571,6 +571,101 @@ describe("AuthFileDetailModal", () => {
     // $7.352 / 6% ≈ $122.5333 full weekly window budget.
     expectSummaryCard("Predicted weekly window quota", "$122.5333");
     expect(screen.queryByText("Predicted 5-hour window quota")).not.toBeInTheDocument();
+    // Without an attributable figure the pool-wide percent is all there is, so
+    // the derivation hint and the external-consumption card stay hidden.
+    expect(screen.queryByText("Consumed outside the proxy")).not.toBeInTheDocument();
+  });
+
+  // Live SuperGrok account: 19% of the shared weekly pool spent, 16% of it by
+  // Grok Build (this proxy) and 3% by Grok Chat on the web. The projection
+  // divides Grok Build cost, so dividing by 19% reported $676.25 for a pool
+  // actually worth ~$803 — and the number sank further the more the account was
+  // used outside the proxy.
+  test("divides xAI weekly projection by attributable usage, not the shared pool", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "xai-user.json",
+        label: "xAI Grok",
+        type: "xai",
+        provider: "xai",
+        size: 256,
+      },
+      modelsFileType: "xai",
+      quotaState: {
+        status: "success",
+        planType: "supergrok",
+        items: [],
+        updatedAt: Date.now(),
+      },
+      detailTrend: {
+        auth_index: "xai-auth",
+        days: 7,
+        hours: 5,
+        request_total: 1848,
+        cycle_request_total: 1213,
+        cycle_cost_total: 128.4874,
+        weekly_quota_used_percent: 19,
+        projection_quota_used_percent: 16,
+        projection_quota_attributable: true,
+        cycle_known: true,
+        cycle_start: "2026-08-20T06:45:51Z",
+        daily_usage: [],
+        hourly_usage: [],
+        quota_series: [],
+      },
+    });
+
+    // Total consumption still reads 19% — that is what the account spent.
+    expectSummaryCard("Weekly quota used", "19%");
+    // $128.4874 / 16% = $803.0462, not the $676.2496 that 19% produced.
+    expectSummaryCard("Predicted weekly window quota", "$803.0462");
+    expect(screen.queryByText("$676.2496")).not.toBeInTheDocument();
+
+    // The two percentages differ on purpose, so the panel says which one the
+    // projection used and how much of the pool went elsewhere.
+    const projectionCard = screen.getByTestId("trend-predicted-weekly-quota");
+    expect(within(projectionCard).getByText("Derived from the 16% this proxy consumed"))
+      .toBeInTheDocument();
+    expectSummaryCard("Consumed outside the proxy", "3%");
+  });
+
+  // No attributable window (upstream sent no product breakdown) must not zero
+  // the projection out — the pool-wide figure is still better than nothing.
+  test("falls back to pool-wide percent when xAI reports no attributable window", () => {
+    renderDetailModal({
+      detailFile: {
+        name: "xai-user.json",
+        label: "xAI Grok",
+        type: "xai",
+        provider: "xai",
+        size: 256,
+      },
+      modelsFileType: "xai",
+      quotaState: { status: "success", planType: "supergrok", items: [], updatedAt: Date.now() },
+      detailTrend: {
+        auth_index: "xai-auth",
+        days: 7,
+        hours: 5,
+        request_total: 180,
+        cycle_request_total: 180,
+        cycle_cost_total: 7.352,
+        weekly_quota_used_percent: 6,
+        projection_quota_used_percent: null,
+        projection_quota_attributable: true,
+        cycle_known: true,
+        cycle_start: "2026-07-12T05:05:02Z",
+        daily_usage: [],
+        hourly_usage: [],
+        quota_series: [],
+      },
+    });
+
+    expectSummaryCard("Predicted weekly window quota", "$122.5333");
+    // Nothing to attribute means nothing to explain or to call external.
+    expect(
+      screen.queryByText("Derived from the 6% this proxy consumed"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Consumed outside the proxy")).not.toBeInTheDocument();
   });
 
   test("enables usage trend with 5h and weekly predictions for Claude files", () => {

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -1578,7 +1578,7 @@ describe("AuthFilesPage files table", () => {
       );
       expect(quota).toHaveTextContent("Weekly limit");
       expect(quota).toHaveTextContent("75%");
-      expect(quota).toHaveTextContent("Grok 4 usage");
+      expect(quota).toHaveTextContent("Grok 4 remaining");
       expect(quota).toHaveTextContent("60%");
       expect(quota).toHaveTextContent("Pay as you go");
       expect(quota).toHaveTextContent("$40.00 / $50.00");

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -67,11 +67,17 @@ import {
   parseBucketKeyMs,
   resolveNearestBucketKey,
 } from "./trendBuckets";
+import {
+  buildTrendQuotaSummary,
+  formatCurrency,
+  formatPercent,
+  toQuotaUsedPercent,
+  FIVE_HOUR_WINDOW_SECONDS,
+  WEEK_WINDOW_SECONDS,
+} from "../hooks/trendQuotaSummary";
 
 type DetailTab = "usage" | "identity" | "fields" | "models";
 type DetailTrendWindow = "5h" | "week";
-type TrendQuotaSeries = AuthFileTrendResponse["quota_series"][number];
-type TrendUsagePoint = AuthFileTrendResponse["hourly_usage"][number];
 type IdentityFingerprintFieldSection = "effective" | "learned" | "observed";
 
 interface IdentityFingerprintFieldRow {
@@ -82,8 +88,6 @@ interface IdentityFingerprintFieldRow {
   source: IdentityFingerprintFieldSource;
 }
 
-const FIVE_HOUR_WINDOW_SECONDS = 18000;
-const WEEK_WINDOW_SECONDS = 604800;
 const TREND_CHART_ANIMATION_MS = 680;
 const TREND_CHART_ANIMATION_GUARD_MS = TREND_CHART_ANIMATION_MS + 120;
 const SUMMARY_CARD_CLASS_NAME =
@@ -114,60 +118,6 @@ const useIdentityDesktopLayout = () => {
   }, []);
 
   return matches;
-};
-
-const formatCurrency = (value: number) => `$${(Number.isFinite(value) ? value : 0).toFixed(4)}`;
-
-const clampPercent = (value: number) => Math.min(100, Math.max(0, value));
-
-const toQuotaUsedPercent = (remainingPercent: number | null | undefined) => {
-  if (typeof remainingPercent !== "number" || !Number.isFinite(remainingPercent)) return null;
-  return clampPercent(100 - clampPercent(remainingPercent));
-};
-
-const formatPercent = (value: number | null | undefined) => {
-  if (typeof value !== "number" || !Number.isFinite(value)) return "--";
-  return `${new Intl.NumberFormat(undefined, {
-    maximumFractionDigits: Number.isInteger(value) ? 0 : 1,
-  }).format(clampPercent(value))}%`;
-};
-
-const sumUsageCost = (points: TrendUsagePoint[]) =>
-  points.reduce((total, point) => {
-    const cost = typeof point.cost === "number" && Number.isFinite(point.cost) ? point.cost : 0;
-    return total + Math.max(0, cost);
-  }, 0);
-
-const latestQuotaUsedPercent = (
-  seriesList: TrendQuotaSeries[],
-  quotaKey: string,
-  matchesWindow: (windowSeconds: number) => boolean,
-) => {
-  let latestTimestamp = -Infinity;
-  let latestUsedPercent: number | null = null;
-
-  seriesList.forEach((series) => {
-    if (!matchesWindow(series.window_seconds) || series.quota_key !== quotaKey) return;
-
-    series.points.forEach((point) => {
-      const usedPercent = toQuotaUsedPercent(point.percent);
-      if (usedPercent === null) return;
-      const timestamp = Date.parse(point.timestamp);
-      if (!Number.isFinite(timestamp) || timestamp < latestTimestamp) return;
-      latestTimestamp = timestamp;
-      latestUsedPercent = usedPercent;
-    });
-  });
-
-  return latestUsedPercent;
-};
-
-const estimateQuotaBudget = (cost: number, usedPercent: number | null | undefined) => {
-  if (!Number.isFinite(cost) || cost <= 0) return 0;
-  if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) return 0;
-  const normalizedUsedPercent = clampPercent(usedPercent);
-  if (normalizedUsedPercent <= 0) return 0;
-  return cost / (normalizedUsedPercent / 100);
 };
 
 interface AuthFileDetailModalProps {
@@ -1224,29 +1174,20 @@ export function AuthFileDetailModal({
     const cycleStart = detailTrend.cycle_start
       ? new Date(detailTrend.cycle_start).toLocaleString()
       : "--";
-    const fiveHourQuotaUsedPercent = fiveHourQuotaKey
-      ? latestQuotaUsedPercent(
-          detailTrend.quota_series,
-          fiveHourQuotaKey,
-          (windowSeconds) => windowSeconds === FIVE_HOUR_WINDOW_SECONDS,
-        )
-      : null;
-    const weeklyQuotaUsedPercent =
-      detailTrend.weekly_quota_used_percent ??
-      (showPredictedWeeklyQuota
-        ? latestQuotaUsedPercent(
-            detailTrend.quota_series,
-            weeklyQuotaKey,
-            (windowSeconds) => windowSeconds >= WEEK_WINDOW_SECONDS,
-          )
-        : null);
-    // Prefer the backend weekly used percent; fall back to the latest weekly_limit snapshot for xAI.
-    const weeklyQuotaUsed = formatPercent(weeklyQuotaUsedPercent);
-    const estimatedFiveHourQuota = estimateQuotaBudget(
-      sumUsageCost(detailTrend.hourly_usage),
-      fiveHourQuotaUsedPercent,
-    );
-    const estimatedWeeklyQuota = estimateQuotaBudget(displayCycleCostTotal, weeklyQuotaUsedPercent);
+    const {
+      weeklyQuotaUsedPercent,
+      projectionQuotaUsedPercent,
+      projectionIsAttributable,
+      externalQuotaUsedPercent,
+      estimatedFiveHourQuota,
+      estimatedWeeklyQuota,
+    } = buildTrendQuotaSummary({
+      trend: detailTrend,
+      fiveHourQuotaKey,
+      weeklyQuotaKey,
+      showPredictedWeeklyQuota,
+      cycleCostTotal: displayCycleCostTotal,
+    });
     // ponytail: hide zero noise; null/"--" is already non-zero display path
     const showLast7DaysRequests = !isCodexDetail && detailTrend.request_total > 0;
     const showCycleRequests = displayCycleRequestTotal > 0;
@@ -1257,6 +1198,10 @@ export function AuthFileDetailModal({
       typeof weeklyQuotaUsedPercent === "number" &&
       Number.isFinite(weeklyQuotaUsedPercent) &&
       weeklyQuotaUsedPercent > 0;
+    // Only worth a card when the account actually spent outside the proxy;
+    // a permanent "0%" would be noise on every well-behaved credential.
+    const showExternalQuotaUsed =
+      typeof externalQuotaUsedPercent === "number" && externalQuotaUsedPercent > 0;
     const showCycleStart = Boolean(detailTrend.cycle_start);
 
     return (
@@ -1301,17 +1246,34 @@ export function AuthFileDetailModal({
             </div>
           ) : null}
           {showWeeklyQuota ? (
-            <div className={SUMMARY_CARD_CLASS_NAME}>
+            <div className={SUMMARY_CARD_CLASS_NAME} data-testid="trend-predicted-weekly-quota">
               <p className={SUMMARY_LABEL_CLASS_NAME}>
                 {t("auth_files.trend_predicted_week_window_quota")}
               </p>
               <p className={SUMMARY_VALUE_CLASS_NAME}>{formatCurrency(estimatedWeeklyQuota)}</p>
+              {projectionIsAttributable ? (
+                <p className="mt-1 text-2xs leading-tight text-slate-500 dark:text-white/50">
+                  {t("auth_files.trend_predicted_quota_attributable_hint", {
+                    percent: formatPercent(projectionQuotaUsedPercent),
+                  })}
+                </p>
+              ) : null}
             </div>
           ) : null}
           {showWeeklyUsed ? (
             <div className={SUMMARY_CARD_CLASS_NAME}>
               <p className={SUMMARY_LABEL_CLASS_NAME}>{t("auth_files.trend_weekly_quota_used")}</p>
-              <p className={SUMMARY_VALUE_CLASS_NAME}>{weeklyQuotaUsed}</p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>{formatPercent(weeklyQuotaUsedPercent)}</p>
+            </div>
+          ) : null}
+          {showExternalQuotaUsed ? (
+            <div className={SUMMARY_CARD_CLASS_NAME} data-testid="trend-external-quota-used">
+              <p className={SUMMARY_LABEL_CLASS_NAME}>
+                {t("auth_files.trend_external_quota_used")}
+              </p>
+              <p className={SUMMARY_VALUE_CLASS_NAME}>
+                {formatPercent(externalQuotaUsedPercent)}
+              </p>
             </div>
           ) : null}
           {showCycleStart ? (

--- a/pages/auth-files/hooks/__tests__/trendQuotaSummary.test.ts
+++ b/pages/auth-files/hooks/__tests__/trendQuotaSummary.test.ts
@@ -1,0 +1,171 @@
+import type { AuthFileTrendResponse } from "@code-proxy/api-client";
+import { describe, expect, test } from "vitest";
+import { buildTrendQuotaSummary, estimateQuotaBudget } from "../trendQuotaSummary";
+
+const baseTrend = (overrides: Partial<AuthFileTrendResponse> = {}): AuthFileTrendResponse => ({
+  auth_index: "auth-1",
+  days: 7,
+  hours: 5,
+  request_total: 0,
+  cycle_request_total: 0,
+  cycle_cost_total: 0,
+  weekly_quota_used_percent: null,
+  cycle_start: "2026-08-20T06:45:51Z",
+  daily_usage: [],
+  hourly_usage: [],
+  quota_series: [],
+  ...overrides,
+});
+
+describe("buildTrendQuotaSummary", () => {
+  // The regression this whole change exists for. A live SuperGrok account spent
+  // 19% of its shared weekly pool: 16% through this proxy (Grok Build) and 3%
+  // through Grok Chat on the web. Dividing $128.4874 of recorded cost by the
+  // pool-wide 19% reported a $676 weekly budget for a pool worth ~$803, and the
+  // figure fell further every time the account was used outside the proxy.
+  test("divides by the attributable share, not the shared pool", () => {
+    const summary = buildTrendQuotaSummary({
+      trend: baseTrend({
+        cycle_cost_total: 128.4874,
+        weekly_quota_used_percent: 19,
+        projection_quota_used_percent: 16,
+        projection_quota_attributable: true,
+      }),
+      fiveHourQuotaKey: null,
+      weeklyQuotaKey: "weekly_limit",
+      showPredictedWeeklyQuota: true,
+      cycleCostTotal: 128.4874,
+    });
+
+    expect(summary.weeklyQuotaUsedPercent).toBe(19);
+    expect(summary.projectionQuotaUsedPercent).toBe(16);
+    expect(summary.projectionIsAttributable).toBe(true);
+    expect(summary.externalQuotaUsedPercent).toBe(3);
+    expect(summary.estimatedWeeklyQuota).toBeCloseTo(803.0462, 4);
+    // The old, pool-wide answer.
+    expect(summary.estimatedWeeklyQuota).not.toBeCloseTo(676.2496, 4);
+  });
+
+  // Chat burning most of the pool used to collapse the projection toward zero.
+  // With the divisor fixed, the projected pool size is stable regardless of how
+  // much was spent elsewhere.
+  test("projection is unmoved by consumption outside the proxy", () => {
+    const budgets = [3, 20, 60].map(
+      (chatPercent) =>
+        buildTrendQuotaSummary({
+          trend: baseTrend({
+            cycle_cost_total: 128.4874,
+            weekly_quota_used_percent: 16 + chatPercent,
+            projection_quota_used_percent: 16,
+            projection_quota_attributable: true,
+          }),
+          fiveHourQuotaKey: null,
+          weeklyQuotaKey: "weekly_limit",
+          showPredictedWeeklyQuota: true,
+          cycleCostTotal: 128.4874,
+        }).estimatedWeeklyQuota,
+    );
+
+    for (const budget of budgets) {
+      expect(budget).toBeCloseTo(budgets[0], 6);
+    }
+  });
+
+  // No attributable window (no product breakdown upstream) must not zero the
+  // projection; the pool-wide figure is still the best available answer.
+  test("falls back to the pool-wide percent when nothing is attributable", () => {
+    const summary = buildTrendQuotaSummary({
+      trend: baseTrend({
+        cycle_cost_total: 7.352,
+        weekly_quota_used_percent: 6,
+        projection_quota_used_percent: null,
+        projection_quota_attributable: true,
+      }),
+      fiveHourQuotaKey: null,
+      weeklyQuotaKey: "weekly_limit",
+      showPredictedWeeklyQuota: true,
+      cycleCostTotal: 7.352,
+    });
+
+    expect(summary.projectionQuotaUsedPercent).toBe(6);
+    expect(summary.projectionIsAttributable).toBe(false);
+    expect(summary.externalQuotaUsedPercent).toBeNull();
+    expect(summary.estimatedWeeklyQuota).toBeCloseTo(122.5333, 4);
+  });
+
+  // Providers that bill one pool per surface are untouched by the change.
+  test("leaves single-pool providers on their existing divisor", () => {
+    const summary = buildTrendQuotaSummary({
+      trend: baseTrend({
+        cycle_cost_total: 1.2,
+        weekly_quota_used_percent: 8,
+        hourly_usage: [{ hour: "2026-07-26 10:00", requests: 5, cost: 0.05 }],
+        quota_series: [
+          {
+            quota_key: "five_hour",
+            quota_label: "claude_quota.five_hour",
+            window_seconds: 18000,
+            points: [{ timestamp: "2026-07-26T10:00:00Z", percent: 80 }],
+          },
+        ],
+      }),
+      fiveHourQuotaKey: "five_hour",
+      weeklyQuotaKey: "seven_day",
+      showPredictedWeeklyQuota: true,
+      cycleCostTotal: 1.2,
+    });
+
+    expect(summary.projectionQuotaUsedPercent).toBe(8);
+    expect(summary.projectionIsAttributable).toBe(false);
+    expect(summary.estimatedWeeklyQuota).toBeCloseTo(15, 4);
+    // 80% remaining => 20% used; $0.05 / 20% = $0.25.
+    expect(summary.fiveHourQuotaUsedPercent).toBe(20);
+    expect(summary.estimatedFiveHourQuota).toBeCloseTo(0.25, 4);
+  });
+
+  // Backend field absent (older server) — the weekly snapshot still drives both.
+  test("reads the weekly snapshot when the backend sends no percentages", () => {
+    const summary = buildTrendQuotaSummary({
+      trend: baseTrend({
+        cycle_cost_total: 10,
+        weekly_quota_used_percent: null,
+        quota_series: [
+          {
+            quota_key: "weekly_limit",
+            quota_label: "xai_quota.weekly_limit",
+            window_seconds: 604800,
+            points: [{ timestamp: "2026-08-24T00:00:00Z", percent: 75 }],
+          },
+        ],
+      }),
+      fiveHourQuotaKey: null,
+      weeklyQuotaKey: "weekly_limit",
+      showPredictedWeeklyQuota: true,
+      cycleCostTotal: 10,
+    });
+
+    expect(summary.weeklyQuotaUsedPercent).toBe(25);
+    expect(summary.projectionQuotaUsedPercent).toBe(25);
+    expect(summary.estimatedWeeklyQuota).toBeCloseTo(40, 4);
+  });
+});
+
+describe("estimateQuotaBudget", () => {
+  test("returns 0 rather than dividing by an unusable percent", () => {
+    expect(estimateQuotaBudget(10, 0)).toBe(0);
+    expect(estimateQuotaBudget(10, null)).toBe(0);
+    expect(estimateQuotaBudget(10, undefined)).toBe(0);
+    expect(estimateQuotaBudget(0, 20)).toBe(0);
+    expect(estimateQuotaBudget(-1, 20)).toBe(0);
+  });
+
+  test("clamps an over-100 percent instead of inflating the budget", () => {
+    expect(estimateQuotaBudget(10, 150)).toBeCloseTo(10, 6);
+  });
+
+  // Fractional percents now reach here unrounded; rounding 2.4 to 2 would have
+  // overstated the budget by 20%.
+  test("uses fractional percents at full precision", () => {
+    expect(estimateQuotaBudget(12, 2.4)).toBeCloseTo(500, 6);
+  });
+});

--- a/pages/auth-files/hooks/trendQuotaSummary.ts
+++ b/pages/auth-files/hooks/trendQuotaSummary.ts
@@ -1,0 +1,153 @@
+import type { AuthFileTrendResponse } from "@code-proxy/api-client";
+
+type TrendQuotaSeries = AuthFileTrendResponse["quota_series"][number];
+type TrendUsagePoint = AuthFileTrendResponse["hourly_usage"][number];
+
+export const FIVE_HOUR_WINDOW_SECONDS = 18000;
+export const WEEK_WINDOW_SECONDS = 604800;
+
+export const clampPercent = (value: number) => Math.min(100, Math.max(0, value));
+
+export const formatCurrency = (value: number) =>
+  `$${(Number.isFinite(value) ? value : 0).toFixed(4)}`;
+
+export const formatPercent = (value: number | null | undefined) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "--";
+  return `${new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: Number.isInteger(value) ? 0 : 1,
+  }).format(clampPercent(value))}%`;
+};
+
+export const toQuotaUsedPercent = (remainingPercent: number | null | undefined) => {
+  if (typeof remainingPercent !== "number" || !Number.isFinite(remainingPercent)) return null;
+  return clampPercent(100 - clampPercent(remainingPercent));
+};
+
+export const sumUsageCost = (points: TrendUsagePoint[]) =>
+  points.reduce((total, point) => {
+    const cost = typeof point.cost === "number" && Number.isFinite(point.cost) ? point.cost : 0;
+    return total + Math.max(0, cost);
+  }, 0);
+
+export const latestQuotaUsedPercent = (
+  seriesList: TrendQuotaSeries[],
+  quotaKey: string,
+  matchesWindow: (windowSeconds: number) => boolean,
+) => {
+  let latestTimestamp = -Infinity;
+  let latestUsedPercent: number | null = null;
+
+  seriesList.forEach((series) => {
+    if (!matchesWindow(series.window_seconds) || series.quota_key !== quotaKey) return;
+
+    series.points.forEach((point) => {
+      const usedPercent = toQuotaUsedPercent(point.percent);
+      if (usedPercent === null) return;
+      const timestamp = Date.parse(point.timestamp);
+      if (!Number.isFinite(timestamp) || timestamp < latestTimestamp) return;
+      latestTimestamp = timestamp;
+      latestUsedPercent = usedPercent;
+    });
+  });
+
+  return latestUsedPercent;
+};
+
+/** cost / (used%/100) → full-window budget; 0 when underdetermined. */
+export const estimateQuotaBudget = (cost: number, usedPercent: number | null | undefined) => {
+  if (!Number.isFinite(cost) || cost <= 0) return 0;
+  if (typeof usedPercent !== "number" || !Number.isFinite(usedPercent)) return 0;
+  const normalizedUsedPercent = clampPercent(usedPercent);
+  if (normalizedUsedPercent <= 0) return 0;
+  return cost / (normalizedUsedPercent / 100);
+};
+
+export type TrendQuotaSummaryInput = {
+  trend: AuthFileTrendResponse;
+  /** Null for providers with no 5h window (xAI reports weekly only). */
+  fiveHourQuotaKey: string | null;
+  weeklyQuotaKey: string;
+  showPredictedWeeklyQuota: boolean;
+  cycleCostTotal: number;
+};
+
+export type TrendQuotaSummary = {
+  fiveHourQuotaUsedPercent: number | null;
+  /** Pool-wide consumption — what the account spent across every surface. */
+  weeklyQuotaUsedPercent: number | null;
+  /** Divisor actually used for the weekly projection. */
+  projectionQuotaUsedPercent: number | null;
+  /** True when the divisor is narrower than the pool-wide figure. */
+  projectionIsAttributable: boolean;
+  /** Pool share spent outside the proxy, or null when not knowable. */
+  externalQuotaUsedPercent: number | null;
+  estimatedFiveHourQuota: number;
+  estimatedWeeklyQuota: number;
+};
+
+/**
+ * Derives the quota figures shown above the trend chart.
+ *
+ * The subtle part is the weekly projection's divisor. It divides cycle cost,
+ * which only covers requests this proxy forwarded, so the divisor has to cover
+ * the same requests. xAI bills Grok Chat against the same weekly pool as Grok
+ * Build: dividing by the pool-wide percentage shrank the projected budget by
+ * however much the account spent on the web, so an account that browsed more
+ * looked like it had less budget. The backend reports the attributable share
+ * separately; the pool-wide figure is only a fallback for when it cannot.
+ */
+export const buildTrendQuotaSummary = ({
+  trend,
+  fiveHourQuotaKey,
+  weeklyQuotaKey,
+  showPredictedWeeklyQuota,
+  cycleCostTotal,
+}: TrendQuotaSummaryInput): TrendQuotaSummary => {
+  const fiveHourQuotaUsedPercent = fiveHourQuotaKey
+    ? latestQuotaUsedPercent(
+        trend.quota_series,
+        fiveHourQuotaKey,
+        (windowSeconds) => windowSeconds === FIVE_HOUR_WINDOW_SECONDS,
+      )
+    : null;
+
+  // Prefer the backend weekly used percent; fall back to the latest weekly
+  // snapshot so xAI cards are not blank before the backend field exists.
+  const weeklyQuotaUsedPercent =
+    trend.weekly_quota_used_percent ??
+    (showPredictedWeeklyQuota
+      ? latestQuotaUsedPercent(
+          trend.quota_series,
+          weeklyQuotaKey,
+          (windowSeconds) => windowSeconds >= WEEK_WINDOW_SECONDS,
+        )
+      : null);
+
+  const projectionQuotaUsedPercent =
+    trend.projection_quota_used_percent ?? weeklyQuotaUsedPercent;
+  const projectionIsAttributable =
+    trend.projection_quota_attributable === true &&
+    typeof trend.projection_quota_used_percent === "number" &&
+    Number.isFinite(trend.projection_quota_used_percent);
+
+  const externalQuotaUsedPercent =
+    projectionIsAttributable &&
+    typeof weeklyQuotaUsedPercent === "number" &&
+    Number.isFinite(weeklyQuotaUsedPercent) &&
+    typeof projectionQuotaUsedPercent === "number"
+      ? Math.max(0, weeklyQuotaUsedPercent - projectionQuotaUsedPercent)
+      : null;
+
+  return {
+    fiveHourQuotaUsedPercent,
+    weeklyQuotaUsedPercent,
+    projectionQuotaUsedPercent,
+    projectionIsAttributable,
+    externalQuotaUsedPercent,
+    estimatedFiveHourQuota: estimateQuotaBudget(
+      sumUsageCost(trend.hourly_usage),
+      fiveHourQuotaUsedPercent,
+    ),
+    estimatedWeeklyQuota: estimateQuotaBudget(cycleCostTotal, projectionQuotaUsedPercent),
+  };
+};

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -16,7 +16,7 @@
     "pages/api-key-lookup/ApiKeyLookupPage.tsx": 1743,
     "pages/api-keys/ApiKeysPage.tsx": 1167,
     "pages/auth-files/AuthFilesPage.tsx": 1210,
-    "pages/auth-files/components/AuthFileDetailModal.tsx": 2070,
+    "pages/auth-files/components/AuthFileDetailModal.tsx": 2032,
     "pages/auth-files/components/AuthFilesFilesTab.tsx": 2514,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 967,


### PR DESCRIPTION
## Summary

- Companion to kittors/CliRelay#936, which fixes the actual math: xAI's weekly quota projection was dividing locally-recorded cost by the pool-wide `weekly_limit` used%, but the cost numerator only covers Grok Build traffic. The backend now exposes an attributable divisor; `trendQuotaSummary.ts` consumes `projection_quota_used_percent` / `projection_quota_attributable` and falls back to the pool-wide figure when the backend can't report one, and the modal shows both numbers plus a hint so they don't read as contradictory (`19% consumed` next to a budget derived from `16%`).
- **New finding from this investigation**: the per-product quota bar (`xai_quota.product_usage_named`, e.g. the "GrokBuild" row on the AI-accounts card) is labelled "{{product}} usage" in all three locales, but `buildXaiItems()` computes it — like every other row on that card — as *remaining* percent. A product sitting at 74% remaining rendered as "GrokBuild usage: 74%": a healthy green bar next to a number a user reads as "74% consumed". This is very likely what made the projection look "fake" in the bug report screenshot (the account's real GrokBuild usage was ~26%, not 74%). Relabelled to "{{product}} remaining" (en) / "{{product}} 剩余" (zh-CN) / "Остаток {{product}}" (ru) to match the data instead of inverting the data to match a wrong label — keeps this row consistent with its `weekly_limit` / `pay_as_you_go` / `monthly_credits` siblings on the same card, which already use the "remaining" convention.
- Live evidence from the production DB during this investigation (account from the bug report): `weekly_limit` 68% remaining (32% used, pool-wide) vs `product:GrokBuild` 73–74% remaining (~26–27% used, attributable) — confirms both the divisor bug and the label bug independently, and that they compound (the projection used the wrong 32%, and the visible "74%" a user would sanity-check it against is itself mislabeled).

## Test plan

- [x] `./scripts/ci-pr.sh` (`bun install`, lint, design tokens, import boundaries, file-size ratchet, surface usage, dependency audit, full `test:ci`, build, bundle-diff, Playwright `@critical` smoke) — all green locally: 172/172 test files (1268/1268 tests), build, bundle-diff, 12/12 critical e2e specs
- [x] Updated `AuthFilesPage.files-table.test.tsx`'s rendered-text assertion for the relabel
- [ ] GitHub Actions full CI gate (required check)

Note: an earlier full local run hit 3 timeout failures in `AuthFilesPage.identity-tab-rbac.test.tsx` and `VideoGenerationPage.test.tsx` — both unrelated to this change. Reran each in isolation (8/8 passed in 11.7s, nowhere near the 30s timeout) and reran the full suite clean; treating as machine-load flakiness from the earlier run, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)