### PR TITLE
feat(auth-files): treat kimi as a shared-discovery provider in the model panel

### DIFF
--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -94,8 +94,8 @@ export const authFilesApi = {
   }> => {
     const params: Record<string, string> = { name };
     // refresh=1 forces a re-fetch from upstream.
-    // claude/codex/xai: backend keeps a provider-level discovery cache (shared
-    // by same-type accounts); open auto-warms once, force refreshes the cache.
+    // claude/codex/xai/kimi: backend keeps a provider-level discovery cache
+    // (shared by same-type accounts); open auto-warms once, force refreshes it.
     // antigravity may still update the runtime registry on force refresh.
     if (options?.force) {
       params.refresh = "1";

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,6 +6,7 @@ export * from "./ccswitch/ccswitchImportSettings";
 export * from "./auth-files/authFiles";
 export * from "./auth-files/types";
 export * from "./auth-files/zip";
+export * from "./models/discovery";
 export * from "./models/modelIdentity";
 export * from "./quota";
 export * from "./usage";

--- a/packages/domain/src/models/discovery.ts
+++ b/packages/domain/src/models/discovery.ts
@@ -1,0 +1,21 @@
+// Live model discovery contract, mirrored from the backend.
+//
+// The provider set has to match internal/management/authfiles/models.go: a
+// provider missing here silently loses the shared discovery cache and falls back
+// to the per-file registry list, which is how kimi kept showing a stale
+// compiled-in catalog after the backend had started serving the live one.
+
+/** Mirrors backend normalizeDiscoveryProvider (x-ai / grok → xai). */
+export const normalizeDiscoveryProviderKey = (provider: string): string => {
+  const key = provider.trim().toLowerCase();
+  return key === "x-ai" || key === "grok" ? "xai" : key;
+};
+
+const SHARED_DISCOVERY_PROVIDERS = new Set(["claude", "codex", "xai", "kimi"]);
+
+/**
+ * Mirrors backend supportsSharedDiscovery: accounts of these providers share one
+ * live model list per tenant, so opening any of them warms the same cache.
+ */
+export const supportsSharedModelDiscovery = (provider: string): boolean =>
+  SHARED_DISCOVERY_PROVIDERS.has(normalizeDiscoveryProviderKey(provider));

--- a/pages/auth-files/hooks/__tests__/useAuthFilesDetailEditors.models.test.tsx
+++ b/pages/auth-files/hooks/__tests__/useAuthFilesDetailEditors.models.test.tsx
@@ -1,0 +1,113 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { AuthFileItem } from "@code-proxy/api-client";
+
+type ModelsResponse = {
+  models: { id: string; display_name?: string; type?: string; owned_by?: string }[];
+  source: "registry" | "upstream" | string;
+};
+
+const mocks = vi.hoisted(() => ({
+  getModelsForAuthFile: vi.fn(),
+  notify: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@code-proxy/ui", () => ({
+  useToast: () => ({ notify: mocks.notify }),
+}));
+
+vi.mock("@code-proxy/api-client", () => ({
+  authFilesApi: {
+    getModelsForAuthFile: mocks.getModelsForAuthFile,
+    getFile: vi.fn(),
+    patchFields: vi.fn(),
+  },
+  identityFingerprintApi: {
+    getAccount: vi.fn(),
+  },
+  usageApi: {
+    getAuthFileTrend: vi.fn(),
+  },
+}));
+
+import { useAuthFilesDetailEditors } from "../useAuthFilesDetailEditors";
+
+const kimiFile = (name: string): AuthFileItem =>
+  ({ name, type: "kimi", provider: "kimi" }) as AuthFileItem;
+
+const renderEditors = () =>
+  renderHook(() =>
+    useAuthFilesDetailEditors(async (): Promise<AuthFileItem[]> => [], undefined, false),
+  );
+
+describe("useAuthFilesDetailEditors kimi model discovery", () => {
+  beforeEach(() => {
+    mocks.getModelsForAuthFile.mockReset();
+    mocks.notify.mockReset();
+  });
+
+  // Kimi used to fall outside the shared-discovery set, so every account paid for
+  // its own upstream round trip and reopening a panel fell back to the per-file
+  // cache instead of the live list.
+  it("reuses the provider discovery cache across kimi accounts", async () => {
+    mocks.getModelsForAuthFile.mockImplementation(
+      async (): Promise<ModelsResponse> => ({
+        models: [{ id: "kimi-k2.7", display_name: "Kimi K2.7", owned_by: "moonshot" }],
+        source: "upstream",
+      }),
+    );
+
+    const { result } = renderEditors();
+
+    await act(async () => {
+      await result.current.loadModelsForDetail(kimiFile("kimi-a.json"));
+    });
+    expect(mocks.getModelsForAuthFile).toHaveBeenCalledTimes(1);
+    expect(result.current.modelsList.map((model) => model.id)).toEqual(["kimi-k2.7"]);
+
+    await act(async () => {
+      await result.current.loadModelsForDetail(kimiFile("kimi-b.json"));
+    });
+    expect(mocks.getModelsForAuthFile).toHaveBeenCalledTimes(1);
+    expect(result.current.modelsList.map((model) => model.id)).toEqual(["kimi-k2.7"]);
+  });
+
+  it("refetches upstream for kimi when the operator forces a refresh", async () => {
+    mocks.getModelsForAuthFile
+      .mockImplementationOnce(
+        async (): Promise<ModelsResponse> => ({
+          models: [{ id: "kimi-k2.6" }],
+          source: "upstream",
+        }),
+      )
+      .mockImplementationOnce(
+        async (): Promise<ModelsResponse> => ({
+          models: [{ id: "kimi-k2.6" }, { id: "kimi-k2.7" }],
+          source: "upstream",
+        }),
+      );
+
+    const { result } = renderEditors();
+
+    await act(async () => {
+      await result.current.loadModelsForDetail(kimiFile("kimi-a.json"));
+    });
+    await act(async () => {
+      await result.current.loadModelsForDetail(kimiFile("kimi-a.json"), { force: true });
+    });
+
+    expect(mocks.getModelsForAuthFile).toHaveBeenCalledTimes(2);
+    expect(mocks.getModelsForAuthFile).toHaveBeenLastCalledWith("kimi-a.json", {
+      force: true,
+    });
+    expect(result.current.modelsList.map((model) => model.id)).toEqual([
+      "kimi-k2.6",
+      "kimi-k2.7",
+    ]);
+  });
+});

--- a/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
+++ b/pages/auth-files/hooks/useAuthFilesDetailEditors.ts
@@ -19,8 +19,10 @@ import {
   MAX_AUTH_FILE_SIZE,
   canRenameAuthFileChannel,
   normalizeAuthIndexValue,
+  normalizeDiscoveryProviderKey,
   normalizeProviderKey,
   normalizeAuthFileSubscriptionPeriod,
+  supportsSharedModelDiscovery,
   readAuthFileChannelName,
   resolveFileType,
   type AuthFileModelItem,
@@ -287,7 +289,7 @@ export function useAuthFilesDetailEditors(
   const { notify } = useToast();
   // Per-auth-file list cache (any provider).
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
-  // Shared live discovery list for claude/codex/xai (same-type accounts reuse).
+  // Shared live discovery list for claude/codex/xai/kimi (same-type accounts reuse).
   const providerDiscoveryCacheRef = useRef<Map<string, AuthFileModelItem[]>>(
     new Map(),
   );
@@ -345,14 +347,8 @@ export function useAuthFilesDetailEditors(
     async (file: AuthFileItem, options?: { force?: boolean }) => {
       const force = Boolean(options?.force);
       const fileType = resolveFileType(file);
-      const provider = normalizeProviderKey(fileType);
-      // Align with backend normalizeDiscoveryProvider (x-ai/grok → xai).
-      const discoveryProvider =
-        provider === "x-ai" || provider === "grok" ? "xai" : provider;
-      const sharedDiscovery =
-        discoveryProvider === "claude" ||
-        discoveryProvider === "codex" ||
-        discoveryProvider === "xai";
+      const discoveryProvider = normalizeDiscoveryProviderKey(fileType);
+      const sharedDiscovery = supportsSharedModelDiscovery(discoveryProvider);
       setModelsFileType(fileType);
       setModelsError(null);
 
@@ -373,8 +369,8 @@ export function useAuthFilesDetailEditors(
         if (cached && cached.length > 0) {
           setModelsList(cached);
           // For non-discovery providers, file cache is enough.
-          // For claude/codex/xai, still call the API so backend can auto-warm the
-          // shared provider cache; keep showing the file cache meanwhile.
+          // For claude/codex/xai/kimi, still call the API so backend can auto-warm
+          // the shared provider cache; keep showing the file cache meanwhile.
           if (!sharedDiscovery) {
             setModelsLoading(false);
             return;

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -18,7 +18,7 @@
     "pages/auth-files/AuthFilesPage.tsx": 1210,
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2032,
     "pages/auth-files/components/AuthFilesFilesTab.tsx": 2476,
-    "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1286,
+    "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1282,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 967,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1298,
     "pages/end-users/EndUsersPage.tsx": 1126,


### PR DESCRIPTION
## 问题

后端已把 kimi 渠道的模型改为从 Kimi coding 网关实时发现（见 kittors/CliRelay#942），但管理面板仍把 kimi 归类为「非发现型」供应商：

- 每个 kimi 账号打开「模型」面板都要各自往返一次上游，同租户账号无法共享；
- 重新打开弹窗时优先回落到 per-file 缓存，而不是实时列表。

判定逻辑原本是 hook 里手写的一串 `||` 比较，正是它和后端 `supportsSharedDiscovery` 漂移的地方。

## 改动

- 新增 `packages/domain/src/models/discovery.ts`：`normalizeDiscoveryProviderKey`（对齐后端 `normalizeDiscoveryProvider`，x-ai/grok → xai）与 `supportsSharedModelDiscovery`（对齐后端 `supportsSharedDiscovery`，含 kimi）。契约集中一处，下次再有供应商接入发现只需两边各改一行。
- `useAuthFilesDetailEditors` 改用该 helper，kimi 因此进入共享发现缓存路径。
- 同步 `getModelsForAuthFile` 的注释。

## 影响面

- 目录：`codeProxy/`（前端）。后端对应 PR：kittors/CliRelay#942。
- 无接口契约变化：`/auth-files/models` 的请求与响应格式不变。前端此改动不依赖后端先合——后端未合时行为等价于改动前（多一次请求，结果正确）。

## 已执行的验证

在 `codeProxy-wt-kimi-models` worktree 内执行 `./scripts/ci-pr.sh`，完整通过（exit 0）：`bun install --frozen-lockfile`、`bun run lint`、`design:check`、`boundary:imports`、`size:check`、`audit:deps`、`bun run test:ci`（全量 vitest）、`bun run build`、`bundle:diff`、e2e（12 passed）。

新增 `pages/auth-files/hooks/__tests__/useAuthFilesDetailEditors.models.test.tsx`：两个 kimi 账号复用同一份发现缓存（只请求一次）、force 刷新仍重新拉取上游。已反向验证——把 kimi 从判定里移除后第一条用例会失败。

`scripts/file-size-baseline.json` 中 `useAuthFilesDetailEditors.ts` 由 1286 收紧到 1282：判定下沉到 domain 后该文件净减 4 行，按棘轮规则更新基线锁定收益（未放宽任何门禁）。