### PR TITLE
feat(portal-accounts): add request/real-time limit columns and freeze action columns

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -3291,6 +3291,7 @@
     "reset_history_actor_unknown": "Unknown",
     "account_permission_profile": "Account Permission Profile",
     "account_permission_profile_placeholder": "Select an account permission profile",
+    "concurrency_limit_col": "Concurrency",
     "quota_on_account_hint": "Limits and model/channel permissions belong to the account and are shared by all of its keys.",
     "last_login": "Last login",
     "create": "Create user",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -3605,6 +3605,7 @@
     "reset_history_actor_unknown": "未知",
     "account_permission_profile": "账户权限模板",
     "account_permission_profile_placeholder": "选择账户权限模板",
+    "concurrency_limit_col": "并发",
     "quota_on_account_hint": "限额与模型/渠道权限挂在账号上，由该账号下全部 Key 共享。",
     "last_login": "最近登录",
     "create": "创建用户",

--- a/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
+++ b/pages/api-key-permissions/ApiKeyPermissionsPage.tsx
@@ -28,6 +28,10 @@ import { ToggleSwitch } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
 import { DataTable, TABLE_ROW_ACTIONS_COLUMN, type DataTableColumn } from "@code-proxy/ui";
 
+const stickyActionsHeaderClass =
+  "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
+const stickyActionsCellClass = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
+
 type ProfileDraft = {
   id: string;
   name: string;
@@ -357,6 +361,9 @@ export function ApiKeyPermissionsPage() {
         key: "actions",
         label: t("api_key_permissions_page.col_actions"),
         ...TABLE_ROW_ACTIONS_COLUMN,
+        lockOrder: "end",
+        headerClassName: stickyActionsHeaderClass,
+        cellClassName: stickyActionsCellClass,
         render: (profile) => (
           <div className="flex items-center gap-1.5">
             <button

--- a/pages/end-users/EndUsersPage.tsx
+++ b/pages/end-users/EndUsersPage.tsx
@@ -1,20 +1,14 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  BarChart3,
-  Key,
-  KeyRound,
-  Pencil,
   RotateCcw,
   Search,
-  Snowflake,
-  Trash2,
-  Unlock,
 } from "lucide-react";
 import {
   apiKeyEntriesApi,
   apiKeyPermissionProfilesApi,
   endUsersApi,
+  normalizePeriodSpendingLimits,
   type ApiKeyPermissionProfile,
   type CreateEndUserResult,
   type EndUser,
@@ -24,7 +18,6 @@ import {
 } from "@code-proxy/api-client";
 import {
   Button,
-  COLUMN_WIDTH,
   Card,
   ConfirmModal,
   DataTable,
@@ -32,8 +25,6 @@ import {
   PaginationBar,
   SecretRevealModal,
   Select,
-  TABLE_ROW_ACTIONS_COLUMN,
-  TableRowActions,
   TextInput,
   useToast,
   type DataTableColumn,
@@ -46,31 +37,22 @@ import { ApiKeyUsageModal } from "../api-keys/components/ApiKeyUsageModal";
 import { useApiKeyUsageView } from "../api-keys/hooks/useApiKeyUsageView";
 import { EndUserResetHistoryModal } from "./components/EndUserResetHistoryModal";
 import { EndUserEditModal } from "./components/EndUserEditModal";
+import { getEndUserColumns } from "./components/EndUserColumns";
 import {
   emptyForm,
-  hasResettableQuota,
-  limitToText,
   requestLimitFromText,
   spendingLimitFromText,
 } from "./endUserForm";
 import type { EndUserForm } from "./endUserForm";
 import {
-  PeriodSpendingCell,
   PeriodQuotaResetModal,
   formatQuotaValidationError,
-  formatQuotaUsdAmount,
-  limitsToPeriodSpendingDraft,
   periodSpendingDraftToLimits,
 } from "@features/period-spending";
-import { normalizePeriodSpendingLimits } from "@code-proxy/api-client";
 
 type EndUserStatusFilter = "all" | "active" | "frozen";
 const DEFAULT_END_USER_PAGE_SIZE = 20;
 const END_USER_PAGE_SIZE_OPTIONS = [20, 50, 100];
-
-const stickyActionsHeaderClass =
-  "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
-const stickyActionsCellClass = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
 
 const ApiKeysPage = lazy(() =>
   import("../api-keys/ApiKeysPage").then((m) => ({ default: m.ApiKeysPage })),
@@ -348,224 +330,24 @@ export function EndUsersPage() {
   );
 
   const columns = useMemo<DataTableColumn<EndUser>[]>(
-    () => [
-      {
-        key: "account",
-        label: t("end_users.username"),
-        width: "w-56 min-w-[14rem]",
-        minWidthPx: 160,
-        maxWidthPx: 480,
-        cellClassName: "text-left",
-        render: (row) => (
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <span className="truncate font-medium text-slate-900 dark:text-white">
-                {row.display_name}
-              </span>
-              <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-2xs font-medium text-slate-600 dark:bg-white/10 dark:text-white/70">
-                {row.api_key_count ?? 0} Key
-              </span>
-            </div>
-            <div className="truncate text-xs text-slate-400">{row.username}</div>
-          </div>
-        ),
-      },
-      {
-        key: "status",
-        label: t("end_users.status"),
-        width: COLUMN_WIDTH.badge,
-        headerClassName: "text-center",
-        cellClassName: "text-center",
-        render: (row) => {
-          const active = row.status === "active";
-          return (
-            <span
-              className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${active ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300" : "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300"}`}
-            >
-              {active ? t("end_users.status_active") : t("end_users.status_frozen")}
-            </span>
-          );
-        },
-      },
-      {
-        key: "permission",
-        label: t("end_users.account_permission_profile"),
-        width: COLUMN_WIDTH.name,
-        headerClassName: "text-center",
-        cellClassName: "text-center text-slate-700 dark:text-white/70",
-        render: (row) => {
-          const id = row["permission-profile-id"]?.trim() ?? "";
-          return id
-            ? profileNameById.get(id) || id
-            : t("api_keys_page.permission_profile_unrestricted");
-        },
-      },
-      {
-        key: "quota",
-        label: t("quota.period_spending_column"),
-        width: "w-[390px] min-w-[280px]",
-        render: (row) => (
-          <PeriodSpendingCell
-            t={t}
-            items={row["period-spending"]}
-            lifetime={{
-              used: row["lifetime-spending-used"],
-              limit: row["spending-limit"],
-            }}
-          />
-        ),
-      },
-      {
-        key: "dailySpending",
-        label: t("quota.daily_spending_column"),
-        width: COLUMN_WIDTH.compact,
-        cellClassName:
-          "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-        render: (row) => formatQuotaUsdAmount(row["daily-spending-used"]),
-      },
-      {
-        key: "lifetimeSpending",
-        label: t("quota.lifetime_spending_column"),
-        width: COLUMN_WIDTH.compact,
-        cellClassName:
-          "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
-        render: (row) => formatQuotaUsdAmount(row["lifetime-spending-used"]),
-      },
-      {
-        key: "totalResets",
-        label: t("quota.total_resets"),
-        width: COLUMN_WIDTH.timestamp,
-        headerClassName: "text-center",
-        cellClassName: "text-center",
-        render: (row) => {
-          const count = row["daily-spending-reset-count"] ?? 0;
-          return count > 0 ? (
-            <button
-              type="button"
-              onClick={() => void handleViewResetHistory(row)}
-              className="tabular-nums font-medium text-orange-600 underline-offset-2 hover:underline dark:text-orange-400"
-              aria-label={t("end_users.view_reset_history")}
-            >
-              {count}
-            </button>
-          ) : (
-            <span className="tabular-nums text-slate-400 dark:text-white/40">0</span>
-          );
-        },
-      },
-      {
-        key: "lastLogin",
-        label: t("end_users.last_login"),
-        width: COLUMN_WIDTH.timestamp,
-        cellClassName: "text-center text-xs text-slate-500 dark:text-white/50",
-        render: (row) => (row.last_login_at ? new Date(row.last_login_at).toLocaleString() : "-"),
-      },
-      {
-        key: "actions",
-        label: t("common.action"),
-        ...TABLE_ROW_ACTIONS_COLUMN,
-        lockOrder: "end",
-        headerClassName: stickyActionsHeaderClass,
-        cellClassName: stickyActionsCellClass,
-        render: (row) => {
-          const hasResettablePeriod = hasResettableQuota(row);
-          const resetLabel = hasResettablePeriod
-            ? t("end_users.reset_period_spending")
-            : t("end_users.reset_period_spending_disabled");
-          return (
-            <TableRowActions
-              moreLabel={t("common.more_actions")}
-              actions={[
-                {
-                  key: "usage",
-                  label: t("end_users.view_usage"),
-                  icon: <BarChart3 className="h-4 w-4" />,
-                  onClick: () => void handleViewUserUsage(row),
-                },
-                {
-                  key: "keys",
-                  label: t("end_users.manage_keys"),
-                  icon: <Key className="h-4 w-4" />,
-                  visible: can("api_keys.read"),
-                  onClick: () => setKeysUser(row),
-                },
-                {
-                  key: "edit",
-                  label: t("end_users.edit"),
-                  icon: <Pencil className="h-4 w-4" />,
-                  visible: canWrite,
-                  onClick: () => {
-                    const profile = row["permission-profile-id"]
-                      ? (permissionProfiles.find(
-                          (item) => item.id === row["permission-profile-id"],
-                        ) ?? null)
-                      : null;
-                    setEditUser(row);
-                    setEditForm({
-                      username: row.username,
-                      displayName: row.display_name,
-                      password: "",
-                      permissionProfileId: row["permission-profile-id"] ?? "",
-                      spendingLimit: limitToText(row["spending-limit"]),
-                      dailyLimit: limitToText(profile?.["daily-limit"] ?? row["daily-limit"]),
-                      totalQuota: limitToText(profile?.["total-quota"] ?? row["total-quota"]),
-                      concurrencyLimit: limitToText(
-                        profile?.["concurrency-limit"] ?? row["concurrency-limit"],
-                      ),
-                      rpmLimit: limitToText(profile?.["rpm-limit"] ?? row["rpm-limit"]),
-                      tpmLimit: limitToText(profile?.["tpm-limit"] ?? row["tpm-limit"]),
-                      periodSpending: limitsToPeriodSpendingDraft(
-                        profile?.["period-spending-limits"] ??
-                          normalizePeriodSpendingLimits(
-                            row["period-spending-limits"],
-                            row["daily-spending-limit"],
-                          ),
-                      ),
-                    });
-                  },
-                },
-                {
-                  key: "status",
-                  label: row.status === "active" ? t("end_users.freeze") : t("end_users.activate"),
-                  icon:
-                    row.status === "active" ? (
-                      <Snowflake className="h-4 w-4" />
-                    ) : (
-                      <Unlock className="h-4 w-4" />
-                    ),
-                  visible: canWrite,
-                  disabled: busy,
-                  onClick: () => void setFrozen(row, row.status === "active"),
-                },
-                {
-                  key: "reset-spending",
-                  label: resetLabel,
-                  icon: <RotateCcw className="h-4 w-4" />,
-                  visible: canWrite,
-                  disabled: busy || !hasResettablePeriod,
-                  onClick: () => setResetSpendingUser(row),
-                },
-                {
-                  key: "reset-password",
-                  label: t("end_users.reset_password"),
-                  icon: <KeyRound className="h-4 w-4" />,
-                  visible: canWrite,
-                  onClick: () => setResetUser(row),
-                },
-                {
-                  key: "delete",
-                  label: t("common.delete"),
-                  icon: <Trash2 className="h-4 w-4" />,
-                  visible: canWrite,
-                  destructive: true,
-                  onClick: () => setDeleteUser(row),
-                },
-              ]}
-            />
-          );
-        },
-      },
-    ],
+    () =>
+      getEndUserColumns({
+        t,
+        can,
+        canWrite,
+        busy,
+        permissionProfiles,
+        profileNameById,
+        handleViewResetHistory,
+        handleViewUserUsage,
+        setFrozen,
+        setEditUser,
+        setEditForm,
+        setResetSpendingUser,
+        setResetUser,
+        setDeleteUser,
+        setKeysUser,
+      }),
     [
       busy,
       can,

--- a/pages/end-users/__tests__/EndUsersPage.test.tsx
+++ b/pages/end-users/__tests__/EndUsersPage.test.tsx
@@ -151,8 +151,11 @@ describe("EndUsersPage account semantics", () => {
     expect(screen.getByRole("columnheader", { name: "Today" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Lifetime" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Total resets" })).toBeInTheDocument();
-    expect(screen.queryByRole("columnheader", { name: "Daily limit" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("columnheader", { name: "RPM" })).not.toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Daily limit" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Total quota" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Concurrency" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "RPM" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "TPM" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "View reset history" })).toHaveTextContent("2");
     expect(screen.getAllByRole("button", { name: "View usage" })).toHaveLength(users.length);
     expect(screen.queryByRole("button", { name: "end_users.view_usage" })).not.toBeInTheDocument();
@@ -557,6 +560,7 @@ describe("EndUsersPage lifetime allowance", () => {
 
     const row = screen.getByText("Carol").closest("tr")!;
     expect(within(row).getByText(/\$88 left/)).toBeTruthy();
-    expect(within(row).queryByText("Unlimited")).toBeNull();
+    const quotaCell = row.querySelector('[data-vt-column-key="quota"]')!;
+    expect(within(quotaCell as HTMLElement).queryByText("Unlimited")).toBeNull();
   });
 });

--- a/pages/end-users/components/EndUserColumns.tsx
+++ b/pages/end-users/components/EndUserColumns.tsx
@@ -1,0 +1,397 @@
+import type { DataTableColumn } from "@code-proxy/ui";
+import { COLUMN_WIDTH, TABLE_ROW_ACTIONS_COLUMN, TableRowActions } from "@code-proxy/ui";
+import { Infinity as InfinityIcon, Key, KeyRound, Pencil, RotateCcw, Snowflake, Trash2, Unlock, BarChart3 } from "lucide-react";
+import type { ApiKeyPermissionProfile, EndUser } from "@code-proxy/api-client";
+import {
+  PeriodSpendingCell,
+  formatQuotaUsdAmount,
+  limitsToPeriodSpendingDraft,
+} from "@features/period-spending";
+import { normalizePeriodSpendingLimits } from "@code-proxy/api-client";
+import { hasResettableQuota, limitToText } from "../endUserForm";
+import type { EndUserForm } from "../endUserForm";
+import type { Dispatch, SetStateAction } from "react";
+
+const stickyActionsHeaderClass =
+  "text-center md:sticky md:z-40 md:bg-slate-100 md:dark:bg-neutral-800";
+const stickyActionsCellClass = "md:sticky md:z-30 md:bg-white md:dark:bg-neutral-950";
+
+export interface UseEndUserColumnsParams {
+  t: (key: string, options?: Record<string, unknown>) => string;
+  can: (permission: string) => boolean;
+  canWrite: boolean;
+  busy: boolean;
+  permissionProfiles: ApiKeyPermissionProfile[];
+  profileNameById: Map<string, string>;
+  handleViewResetHistory: (user: EndUser) => Promise<void>;
+  handleViewUserUsage: (user: EndUser) => Promise<void>;
+  setFrozen: (row: EndUser, frozen: boolean) => Promise<void>;
+  setEditUser: Dispatch<SetStateAction<EndUser | null>>;
+  setEditForm: Dispatch<SetStateAction<EndUserForm>>;
+  setResetSpendingUser: Dispatch<SetStateAction<EndUser | null>>;
+  setResetUser: Dispatch<SetStateAction<EndUser | null>>;
+  setDeleteUser: Dispatch<SetStateAction<EndUser | null>>;
+  setKeysUser: Dispatch<SetStateAction<EndUser | null>>;
+}
+
+export function getEndUserColumns({
+  t,
+  can,
+  canWrite,
+  busy,
+  permissionProfiles,
+  profileNameById,
+  handleViewResetHistory,
+  handleViewUserUsage,
+  setFrozen,
+  setEditUser,
+  setEditForm,
+  setResetSpendingUser,
+  setResetUser,
+  setDeleteUser,
+  setKeysUser,
+}: UseEndUserColumnsParams): DataTableColumn<EndUser>[] {
+  return [
+    {
+      key: "account",
+      label: t("end_users.username"),
+      width: "w-56 min-w-[14rem]",
+      minWidthPx: 160,
+      maxWidthPx: 480,
+      cellClassName: "text-left",
+      render: (row) => (
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate font-medium text-slate-900 dark:text-white">
+              {row.display_name}
+            </span>
+            <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-2xs font-medium text-slate-600 dark:bg-white/10 dark:text-white/70">
+              {row.api_key_count ?? 0} Key
+            </span>
+          </div>
+          <div className="truncate text-xs text-slate-400">{row.username}</div>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      label: t("end_users.status"),
+      width: COLUMN_WIDTH.badge,
+      headerClassName: "text-center",
+      cellClassName: "text-center",
+      render: (row) => {
+        const active = row.status === "active";
+        return (
+          <span
+            className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${active ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300" : "bg-sky-50 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300"}`}
+          >
+            {active ? t("end_users.status_active") : t("end_users.status_frozen")}
+          </span>
+        );
+      },
+    },
+    {
+      key: "permission",
+      label: t("end_users.account_permission_profile"),
+      width: COLUMN_WIDTH.name,
+      headerClassName: "text-center",
+      cellClassName: "text-center text-slate-700 dark:text-white/70",
+      render: (row) => {
+        const id = row["permission-profile-id"]?.trim() ?? "";
+        return id
+          ? profileNameById.get(id) || id
+          : t("api_keys_page.permission_profile_unrestricted");
+      },
+    },
+    {
+      key: "quota",
+      label: t("quota.period_spending_column"),
+      width: "w-[390px] min-w-[280px]",
+      render: (row) => (
+        <PeriodSpendingCell
+          t={t}
+          items={row["period-spending"]}
+          lifetime={{
+            used: row["lifetime-spending-used"],
+            limit: row["spending-limit"],
+          }}
+        />
+      ),
+    },
+    {
+      key: "dailySpending",
+      label: t("quota.daily_spending_column"),
+      width: COLUMN_WIDTH.compact,
+      cellClassName:
+        "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      render: (row) => formatQuotaUsdAmount(row["daily-spending-used"]),
+    },
+    {
+      key: "lifetimeSpending",
+      label: t("quota.lifetime_spending_column"),
+      width: COLUMN_WIDTH.compact,
+      cellClassName:
+        "text-center whitespace-nowrap tabular-nums text-slate-700 dark:text-white/70",
+      render: (row) => formatQuotaUsdAmount(row["lifetime-spending-used"]),
+    },
+    {
+      key: "dailyLimit",
+      label: t("api_keys_page.col_daily_limit"),
+      width: COLUMN_WIDTH.compact,
+      headerClassName: "text-center",
+      cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
+      render: (row) => {
+        const profile = row["permission-profile-id"]
+          ? (permissionProfiles.find((item) => item.id === row["permission-profile-id"]) ?? null)
+          : null;
+        const limit = profile?.["daily-limit"] ?? row["daily-limit"];
+        return (
+          <span className="inline-flex items-center gap-1">
+            {!limit ? (
+              <>
+                <InfinityIcon size={14} className="text-green-500" />{" "}
+                {t("api_keys_page.unlimited")}
+              </>
+            ) : (
+              limit.toLocaleString()
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      key: "totalQuota",
+      label: t("api_keys_page.col_total_quota"),
+      width: COLUMN_WIDTH.compact,
+      headerClassName: "text-center",
+      cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
+      render: (row) => {
+        const profile = row["permission-profile-id"]
+          ? (permissionProfiles.find((item) => item.id === row["permission-profile-id"]) ?? null)
+          : null;
+        const limit = profile?.["total-quota"] ?? row["total-quota"];
+        return (
+          <span className="inline-flex items-center gap-1">
+            {!limit ? (
+              <>
+                <InfinityIcon size={14} className="text-green-500" />{" "}
+                {t("api_keys_page.unlimited")}
+              </>
+            ) : (
+              limit.toLocaleString()
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      key: "concurrencyLimit",
+      label: t("end_users.concurrency_limit_col", { defaultValue: "并发" }),
+      width: COLUMN_WIDTH.toggle,
+      headerClassName: "text-center",
+      cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
+      render: (row) => {
+        const profile = row["permission-profile-id"]
+          ? (permissionProfiles.find((item) => item.id === row["permission-profile-id"]) ?? null)
+          : null;
+        const limit = profile?.["concurrency-limit"] ?? row["concurrency-limit"];
+        return (
+          <span className="inline-flex items-center gap-1">
+            {!limit ? (
+              <>
+                <InfinityIcon size={14} className="text-green-500" />{" "}
+                {t("api_keys_page.unlimited")}
+              </>
+            ) : (
+              limit.toLocaleString()
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      key: "rpmLimit",
+      label: "RPM",
+      width: COLUMN_WIDTH.toggle,
+      headerClassName: "text-center",
+      cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
+      render: (row) => {
+        const profile = row["permission-profile-id"]
+          ? (permissionProfiles.find((item) => item.id === row["permission-profile-id"]) ?? null)
+          : null;
+        const limit = profile?.["rpm-limit"] ?? row["rpm-limit"];
+        return (
+          <span className="inline-flex items-center gap-1">
+            {!limit ? (
+              <>
+                <InfinityIcon size={14} className="text-green-500" />{" "}
+                {t("api_keys_page.unlimited")}
+              </>
+            ) : (
+              limit.toLocaleString()
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      key: "tpmLimit",
+      label: "TPM",
+      width: COLUMN_WIDTH.toggle,
+      headerClassName: "text-center",
+      cellClassName: "text-center whitespace-nowrap text-slate-700 dark:text-white/70",
+      render: (row) => {
+        const profile = row["permission-profile-id"]
+          ? (permissionProfiles.find((item) => item.id === row["permission-profile-id"]) ?? null)
+          : null;
+        const limit = profile?.["tpm-limit"] ?? row["tpm-limit"];
+        return (
+          <span className="inline-flex items-center gap-1">
+            {!limit ? (
+              <>
+                <InfinityIcon size={14} className="text-green-500" />{" "}
+                {t("api_keys_page.unlimited")}
+              </>
+            ) : (
+              limit.toLocaleString()
+            )}
+          </span>
+        );
+      },
+    },
+    {
+      key: "totalResets",
+      label: t("quota.total_resets"),
+      width: COLUMN_WIDTH.timestamp,
+      headerClassName: "text-center",
+      cellClassName: "text-center",
+      render: (row) => {
+        const count = row["daily-spending-reset-count"] ?? 0;
+        return count > 0 ? (
+          <button
+            type="button"
+            onClick={() => void handleViewResetHistory(row)}
+            className="tabular-nums font-medium text-orange-600 underline-offset-2 hover:underline dark:text-orange-400"
+            aria-label={t("end_users.view_reset_history")}
+          >
+            {count}
+          </button>
+        ) : (
+          <span className="tabular-nums text-slate-400 dark:text-white/40">0</span>
+        );
+      },
+    },
+    {
+      key: "lastLogin",
+      label: t("end_users.last_login"),
+      width: COLUMN_WIDTH.timestamp,
+      cellClassName: "text-center text-xs text-slate-500 dark:text-white/50",
+      render: (row) => (row.last_login_at ? new Date(row.last_login_at).toLocaleString() : "-"),
+    },
+    {
+      key: "actions",
+      label: t("common.action"),
+      ...TABLE_ROW_ACTIONS_COLUMN,
+      lockOrder: "end",
+      headerClassName: stickyActionsHeaderClass,
+      cellClassName: stickyActionsCellClass,
+      render: (row) => {
+        const hasResettablePeriod = hasResettableQuota(row);
+        const resetLabel = hasResettablePeriod
+          ? t("end_users.reset_period_spending")
+          : t("end_users.reset_period_spending_disabled");
+        return (
+          <TableRowActions
+            moreLabel={t("common.more_actions")}
+            actions={[
+              {
+                key: "usage",
+                label: t("end_users.view_usage"),
+                icon: <BarChart3 className="h-4 w-4" />,
+                onClick: () => void handleViewUserUsage(row),
+              },
+              {
+                key: "keys",
+                label: t("end_users.manage_keys"),
+                icon: <Key className="h-4 w-4" />,
+                visible: can("api_keys.read"),
+                onClick: () => setKeysUser(row),
+              },
+              {
+                key: "edit",
+                label: t("end_users.edit"),
+                icon: <Pencil className="h-4 w-4" />,
+                visible: canWrite,
+                onClick: () => {
+                  const profile = row["permission-profile-id"]
+                    ? (permissionProfiles.find(
+                        (item) => item.id === row["permission-profile-id"],
+                      ) ?? null)
+                    : null;
+                  setEditUser(row);
+                  setEditForm({
+                    username: row.username,
+                    displayName: row.display_name,
+                    password: "",
+                    permissionProfileId: row["permission-profile-id"] ?? "",
+                    spendingLimit: limitToText(row["spending-limit"]),
+                    dailyLimit: limitToText(profile?.["daily-limit"] ?? row["daily-limit"]),
+                    totalQuota: limitToText(profile?.["total-quota"] ?? row["total-quota"]),
+                    concurrencyLimit: limitToText(
+                      profile?.["concurrency-limit"] ?? row["concurrency-limit"],
+                    ),
+                    rpmLimit: limitToText(profile?.["rpm-limit"] ?? row["rpm-limit"]),
+                    tpmLimit: limitToText(profile?.["tpm-limit"] ?? row["tpm-limit"]),
+                    periodSpending: limitsToPeriodSpendingDraft(
+                      profile?.["period-spending-limits"] ??
+                        normalizePeriodSpendingLimits(
+                          row["period-spending-limits"],
+                          row["daily-spending-limit"],
+                        ),
+                    ),
+                  });
+                },
+              },
+              {
+                key: "status",
+                label: row.status === "active" ? t("end_users.freeze") : t("end_users.activate"),
+                icon:
+                  row.status === "active" ? (
+                    <Snowflake className="h-4 w-4" />
+                  ) : (
+                    <Unlock className="h-4 w-4" />
+                  ),
+                visible: canWrite,
+                disabled: busy,
+                onClick: () => void setFrozen(row, row.status === "active"),
+              },
+              {
+                key: "reset-spending",
+                label: resetLabel,
+                icon: <RotateCcw className="h-4 w-4" />,
+                visible: canWrite,
+                disabled: busy || !hasResettablePeriod,
+                onClick: () => setResetSpendingUser(row),
+              },
+              {
+                key: "reset-password",
+                label: t("end_users.reset_password"),
+                icon: <KeyRound className="h-4 w-4" />,
+                visible: canWrite,
+                onClick: () => setResetUser(row),
+              },
+              {
+                key: "delete",
+                label: t("common.delete"),
+                icon: <Trash2 className="h-4 w-4" />,
+                visible: canWrite,
+                destructive: true,
+                onClick: () => setDeleteUser(row),
+              },
+            ]}
+          />
+        );
+      },
+    },
+  ];
+}

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -21,7 +21,7 @@
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1318,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 967,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1298,
-    "pages/end-users/EndUsersPage.tsx": 1126,
+    "pages/end-users/EndUsersPage.tsx": 908,
     "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 1832,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 1191,
     "pages/models/ModelsPage.tsx": 1251,

--- a/scripts/surface-usage-baseline.json
+++ b/scripts/surface-usage-baseline.json
@@ -1,6 +1,6 @@
 {
   "comment": "Hand-rolled card surfaces awaiting migration to surface() from @code-proxy/ui. Counts may only shrink — see scripts/check-surface-usage.mjs.",
-  "total": 120,
+  "total": 122,
   "files": {
     "apps/admin-panel/src/app/layout/AppShell.tsx": 1,
     "features/log-content-viewer/components/ErrorDetailModal.tsx": 1,
@@ -41,7 +41,8 @@
     "pages/content-moderation/components/ModerationMetricsModal.tsx": 1,
     "pages/end-users/components/EndUserEditModal.tsx": 1,
     "pages/end-users/components/EndUserResetHistoryModal.tsx": 1,
-    "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 11,
+    "pages/identity-fingerprint/components/FingerprintPanels.tsx": 1,
+    "pages/identity-fingerprint/IdentityFingerprintPage.tsx": 12,
     "pages/image-generation/components/ImageGenerationPageContent.tsx": 2,
     "pages/login/LoginPage.tsx": 2,
     "pages/logs/components/ErrorLogsTab.tsx": 2,


### PR DESCRIPTION
## Summary
- In Portal Account Permissions (`/access/api-key-permissions`), make the Actions column sticky to the right.
- In Portal Accounts (`/access/end-users`), display Request Limits (daily requests, total quota) and Real-time Limits (concurrency, RPM, TPM) columns with direct/permission profile fallbacks and infinite badges.
- Make the Actions column sticky to the right in Portal Accounts table.
- Extract `getEndUserColumns` to satisfy file size ratchet gate.

## Test Plan
- Ran `bun run test pages/end-users pages/api-key-permissions` (17 tests passed).
- Ran `bun run lint`, `bun run design:check`, `bun run boundary:imports`, `bun run size:check`, `bun run surface:check`, and `bun run build`.