### PR TITLE
feat(dashboard): add tenant throughput selector for platform admins

### DIFF
--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -502,6 +502,7 @@ export interface DashboardSummary {
     total_cost?: DashboardTrendPoint[];
     failed_requests?: DashboardTrendPoint[];
     throughput_series?: DashboardThroughputPoint[];
+    tenants?: DashboardTenantThroughputItem[];
   };
   meta?: {
     generated_at?: string;
@@ -530,6 +531,14 @@ export interface DashboardThroughputPoint {
   label: string;
   rpm: number;
   tpm: number;
+}
+
+export interface DashboardTenantThroughputItem {
+  tenant_id: string;
+  tenant_name?: string;
+  throughput_series: DashboardThroughputPoint[];
+  current_rpm: number;
+  current_tpm: number;
 }
 
 export interface UsageChannelFilterOption {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -229,6 +229,8 @@
     "total_cost_hint": "Based on configured model pricing",
     "throughput_title": "Throughput Trend",
     "throughput_all_tenants_hint": "Shows request throughput across all tenants",
+    "throughput_tenant_all": "All Tenants (Aggregated)",
+    "throughput_tenant_select": "Select Tenant",
     "overview_title": "Resource Overview",
     "overview_hint": "Data updated {{time}}",
     "summary_api_keys": "API Keys",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -305,6 +305,8 @@
     "total_cost_hint": "Основано на настроенной стоимости моделей",
     "throughput_title": "Тренд пропускной способности",
     "throughput_all_tenants_hint": "Отображает пропускную способность запросов по всем арендаторам",
+    "throughput_tenant_all": "Все арендаторы (агрегировано)",
+    "throughput_tenant_select": "Выбор арендатора",
     "overview_hint": "Данные обновлены {{time}}",
     "updated_fallback": "Только что"
   },

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -232,6 +232,8 @@
     "total_cost_hint": "基于已设置的模型单价",
     "throughput_title": "请求吞吐趋势",
     "throughput_all_tenants_hint": "可查看所有租户用户的请求吞吐趋势",
+    "throughput_tenant_all": "全部租户 (汇总)",
+    "throughput_tenant_select": "选择租户",
     "overview_title": "资源总览",
     "overview_hint": "数据更新时间 {{time}}",
     "summary_api_keys": "API Keys",

--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ import type { ECBasicOption } from "echarts/types/dist/shared";
 import {
   usageApi,
   type DashboardSummary,
+  type DashboardTenantThroughputItem,
   type DashboardThroughputPoint,
   type DashboardTrendPoint,
 } from "@code-proxy/api-client/endpoints/usage";
@@ -356,6 +357,9 @@ function ThroughputTrendChart({
   showTPM,
   onToggle,
   allTenantsScope = false,
+  tenants = [],
+  selectedTenant = "all",
+  onSelectTenant,
 }: {
   title: string;
   points: DashboardThroughputPoint[];
@@ -367,6 +371,9 @@ function ThroughputTrendChart({
   onToggle: (key: string) => void;
   /** Platform super-admin: series aggregates every tenant. */
   allTenantsScope?: boolean;
+  tenants?: DashboardTenantThroughputItem[];
+  selectedTenant?: string;
+  onSelectTenant?: (tenantId: string) => void;
 }) {
   const { t } = useTranslation();
   const option = useMemo(
@@ -391,24 +398,43 @@ function ThroughputTrendChart({
     title
   );
 
+  const hasMultipleTenants = allTenantsScope && tenants && tenants.length > 0;
+
   return (
     <Card
       className={PANEL_SURFACE}
       title={titleNode}
       actions={
-        <div
-          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
-            connected
-              ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
-              : "bg-slate-100 text-slate-400 dark:bg-neutral-800 dark:text-white/45"
-          }`}
-        >
-          <span
-            className={`h-2 w-2 rounded-full ${
-              active ? "animate-pulse bg-emerald-500" : "bg-slate-300 dark:bg-neutral-600"
+        <div className="flex items-center gap-2">
+          {hasMultipleTenants && onSelectTenant ? (
+            <select
+              value={selectedTenant}
+              onChange={(e) => onSelectTenant(e.target.value)}
+              className="h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-slate-700 shadow-2xs outline-none transition-colors hover:border-slate-300 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-white/10 dark:bg-neutral-800 dark:text-slate-200 dark:hover:border-white/20"
+              aria-label={t("dashboard.throughput_tenant_select")}
+            >
+              <option value="all">{t("dashboard.throughput_tenant_all")}</option>
+              {tenants.map((item) => (
+                <option key={item.tenant_id} value={item.tenant_id}>
+                  {item.tenant_name || item.tenant_id} (RPM: {formatThroughputValue(item.current_rpm)})
+                </option>
+              ))}
+            </select>
+          ) : null}
+          <div
+            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
+              connected
+                ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
+                : "bg-slate-100 text-slate-400 dark:bg-neutral-800 dark:text-white/45"
             }`}
-          />
-          {connected ? t("system_monitor.live") : t("system_monitor.polling")}
+          >
+            <span
+              className={`h-2 w-2 rounded-full ${
+                active ? "animate-pulse bg-emerald-500" : "bg-slate-300 dark:bg-neutral-600"
+              }`}
+            />
+            {connected ? t("system_monitor.live") : t("system_monitor.polling")}
+          </div>
         </div>
       }
       padding="compact"
@@ -475,6 +501,7 @@ export function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [throughputLegend, setThroughputLegend] = useState({ rpm: true, tpm: true });
+  const [selectedThroughputTenant, setSelectedThroughputTenant] = useState("all");
 
   const refresh = useCallback(
     async (days: DashboardRange, silent = false) => {
@@ -540,6 +567,20 @@ export function DashboardPage() {
   const tenantTpm = latestThroughput?.tpm ?? 0;
   const throughputAllTenants =
     meta.throughput_scope === "all_tenants" || Boolean(principal?.platform_admin);
+  const tenantBreakdown = trends?.tenants ?? [];
+  const activeThroughputSeries = useMemo(() => {
+    if (selectedThroughputTenant !== "all") {
+      const found = tenantBreakdown.find((item) => item.tenant_id === selectedThroughputTenant);
+      if (found) {
+        return found.throughput_series;
+      }
+    }
+    return throughputSeries;
+  }, [selectedThroughputTenant, tenantBreakdown, throughputSeries]);
+
+  const activeLatestThroughput = activeThroughputSeries[activeThroughputSeries.length - 1];
+  const activeRpm = activeLatestThroughput?.rpm ?? tenantRpm;
+  const activeTpm = activeLatestThroughput?.tpm ?? tenantTpm;
 
   const totalRequestOption = useMemo(
     () => createSparklineOption(trends?.request_volume ?? [], "#2563eb"),
@@ -711,14 +752,17 @@ export function DashboardPage() {
 
       <ThroughputTrendChart
         title={t("dashboard.throughput_title")}
-        points={throughputSeries}
-        rpm={tenantRpm}
-        tpm={tenantTpm}
+        points={activeThroughputSeries}
+        rpm={activeRpm}
+        tpm={activeTpm}
         // Series from dashboard-summary polling; latest point is rolling 60s RPM/TPM.
         connected={false}
         showRPM={throughputLegend.rpm}
         showTPM={throughputLegend.tpm}
         allTenantsScope={throughputAllTenants}
+        tenants={tenantBreakdown}
+        selectedTenant={selectedThroughputTenant}
+        onSelectTenant={setSelectedThroughputTenant}
         onToggle={(key) =>
           setThroughputLegend((prev) => ({ ...prev, [key]: !prev[key as "rpm" | "tpm"] }))
         }

--- a/pages/dashboard/__tests__/DashboardCards.test.ts
+++ b/pages/dashboard/__tests__/DashboardCards.test.ts
@@ -20,8 +20,10 @@ describe("dashboard card composition", () => {
     expect(source).toContain("summary?.trends");
     expect(source).toContain('can("system.status.read")');
     expect(source).toContain("useSystemStats(15, canViewSystemMonitor && pageVisible)");
-    expect(source).toContain("rpm={tenantRpm}");
-    expect(source).toContain("tpm={tenantTpm}");
+    expect(source).toContain("rpm={activeRpm}");
+    expect(source).toContain("tpm={activeTpm}");
+    expect(source).toContain("tenants={tenantBreakdown}");
+    expect(source).toContain("onSelectTenant={setSelectedThroughputTenant}");
     expect(source).toContain("canViewSystemMonitor");
     expect(source).toContain("allTenantsScope");
     expect(source).toContain("throughput_all_tenants_hint");


### PR DESCRIPTION
### Summary
- Update `DashboardSummary` api-client type to include per-tenant throughput breakdown items.
- Add multi-language translations (zh-CN, en, ru) for tenant throughput selector.
- Add tenant selector dropdown in `DashboardPage` throughput card for platform admins.
- Update `DashboardCards.test.ts` unit tests.

### Verification
- Tested locally: `bun run vitest run pages/dashboard/__tests__/DashboardCards.test.ts`
- Size check: `bun run size:check`
- Boundary check: `bun run boundary:imports`
- Design check: `bun run design:check`
- Build check: `bun run build`