### PR TITLE
feat(dashboard): show multi-tenant throughput series and legend checkboxes

### DIFF
--- a/packages/ui/src/charts/ChartLegend.tsx
+++ b/packages/ui/src/charts/ChartLegend.tsx
@@ -1,7 +1,8 @@
 export interface ChartLegendItem {
   key: string;
   label: string;
-  colorClass: string;
+  colorClass?: string;
+  colorHex?: string;
   enabled: boolean;
   onToggle: (key: string) => void;
 }
@@ -26,17 +27,20 @@ export function ChartLegend({
           aria-pressed={item.enabled}
           onClick={() => item.onToggle(item.key)}
           className={[
-            "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition",
+            "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition cursor-pointer hover:bg-slate-100 dark:hover:bg-neutral-800/80",
             item.enabled
               ? "text-slate-700 dark:text-white/80"
-              : "text-slate-400 opacity-60 dark:text-white/35",
+              : "text-slate-400 opacity-50 line-through dark:text-white/35",
           ].join(" ")}
         >
           <span
             className={[
               "h-2.5 w-2.5 rounded-full ring-1 ring-black/5 dark:ring-white/10",
               item.colorClass,
-            ].join(" ")}
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={item.colorHex ? { backgroundColor: item.colorHex } : undefined}
           />
           {item.label}
         </button>

--- a/pages/dashboard/DashboardKpiCard.tsx
+++ b/pages/dashboard/DashboardKpiCard.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import type { Activity } from "lucide-react";
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import { Card, EChart, surface } from "@code-proxy/ui";
+
+const PANEL_SURFACE = surface({ tone: "panel", radius: "2xl" });
+
+export function DashboardKpiCard({
+  title,
+  value,
+  hint,
+  icon: Icon,
+  option,
+  accent,
+}: {
+  title: string;
+  value: ReactNode;
+  hint: ReactNode;
+  icon: typeof Activity;
+  option: ECBasicOption;
+  accent: {
+    iconWrap: string;
+    iconColor: string;
+  };
+}) {
+  return (
+    <Card
+      className={`${PANEL_SURFACE} h-full`}
+      bodyClassName="mt-0 flex h-full flex-col"
+      padding="compact"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div
+          className={`inline-flex h-9 w-9 items-center justify-center rounded-2xl ${accent.iconWrap}`}
+        >
+          <Icon size={16} className={accent.iconColor} />
+        </div>
+      </div>
+      <div className="mt-3">
+        <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</p>
+        <div className="mt-2 text-3xl font-semibold leading-none tracking-tight text-slate-950 dark:text-white">
+          {value}
+        </div>
+        <p className="mt-2 text-xs text-slate-500 dark:text-white/45">{hint}</p>
+      </div>
+      <div className="mt-auto pt-3">
+        <EChart option={option} className="h-10" overflowVisible />
+      </div>
+    </Card>
+  );
+}

--- a/pages/dashboard/DashboardMetrics.tsx
+++ b/pages/dashboard/DashboardMetrics.tsx
@@ -1,0 +1,157 @@
+import type { ReactElement, ReactNode } from "react";
+import { Trans } from "react-i18next";
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import type { DashboardTrendPoint } from "@code-proxy/api-client/endpoints/usage";
+import {
+  formatCompactNumber,
+  formatCompactUsd,
+  formatFixedNumber,
+  formatUsd,
+  getCompactNumberParts,
+  type CompactNumberOptions,
+} from "@code-proxy/domain";
+import { HoverTooltip } from "@code-proxy/ui";
+import { AnimatedNumber } from "@code-proxy/ui";
+
+export const DASHBOARD_COMPACT_OPTIONS = {
+  threshold: 10_000,
+  maximumFractionDigits: 1,
+  standardMaximumFractionDigits: 0,
+} satisfies CompactNumberOptions;
+
+export const DASHBOARD_COST_COMPACT_OPTIONS = {
+  threshold: 10_000,
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+  standardMinimumFractionDigits: 4,
+  standardMaximumFractionDigits: 4,
+} satisfies CompactNumberOptions;
+
+export const formatDashboardNumber = (value: number) =>
+  formatCompactNumber(value, DASHBOARD_COMPACT_OPTIONS);
+export const formatDashboardTooltipNumber = (value: number) =>
+  formatFixedNumber(value, { fractionDigits: 2 });
+export const formatDashboardCost = (value: number) =>
+  formatCompactUsd(value, DASHBOARD_COST_COMPACT_OPTIONS);
+export const formatDashboardTooltipCost = (value: number) =>
+  formatUsd(value, { fractionDigits: 4 });
+
+export function DashboardMetricValue({
+  value,
+  variant = "number",
+  animated = false,
+  className,
+}: {
+  value: number;
+  variant?: "number" | "currency";
+  animated?: boolean;
+  className?: string;
+}) {
+  const compactOptions =
+    variant === "currency" ? DASHBOARD_COST_COMPACT_OPTIONS : DASHBOARD_COMPACT_OPTIONS;
+  const format = variant === "currency" ? formatDashboardCost : formatDashboardNumber;
+  const tooltip =
+    variant === "currency"
+      ? formatDashboardTooltipCost(value)
+      : formatDashboardTooltipNumber(value);
+  const compact = getCompactNumberParts(value, compactOptions).compact;
+  const content = animated ? (
+    <AnimatedNumber value={value} format={format} className={className} />
+  ) : (
+    <span className={["inline-block tabular-nums", className].filter(Boolean).join(" ")}>
+      {format(value)}
+    </span>
+  );
+
+  return (
+    <HoverTooltip
+      content={tooltip}
+      disabled={!compact}
+      placement="top"
+      className={compact ? "cursor-help" : undefined}
+    >
+      {content}
+    </HoverTooltip>
+  );
+}
+
+export const renderDashboardHint = (
+  i18nKey: string,
+  first: ReactElement,
+  second: ReactElement,
+): ReactNode => {
+  return <Trans i18nKey={i18nKey} components={[first, second]} />;
+};
+
+export const throughputNumberFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 2,
+});
+export const formatThroughputValue = (value: number) =>
+  throughputNumberFormatter.format(Number.isFinite(value) ? value : 0);
+export const formatRate = (rate: number) => `${rate.toFixed(2)}%`;
+
+export const formatThroughputTooltip = (params: any) => {
+  const items = Array.isArray(params) ? params : [params];
+  const title = items[0]?.axisValueLabel ?? "";
+  const lines = items.map(
+    (item) =>
+      `${item?.marker ?? ""}${item?.seriesName ?? ""} ${formatThroughputValue(Number(item?.data ?? 0))}`,
+  );
+  return [title, ...lines].join("<br/>");
+};
+
+export function createSparklineOption(points: DashboardTrendPoint[], color: string): ECBasicOption {
+  const labels = points.map((point) => point.label);
+  const values = points.map((point) => point.value);
+
+  return {
+    animationDuration: 320,
+    animationDurationUpdate: 240,
+    grid: { left: 0, right: 0, top: 6, bottom: 0 },
+    tooltip: {
+      trigger: "axis",
+      borderWidth: 0,
+      backgroundColor: "rgba(15, 23, 42, 0.9)",
+      textStyle: { color: "#fff", fontSize: 12 },
+      formatter: (params: any) => {
+        const first = Array.isArray(params) ? params[0] : params;
+        return `${first?.axisValueLabel ?? ""}<br/>${formatDashboardTooltipNumber(Number(first?.data ?? 0))}`;
+      },
+    },
+    xAxis: {
+      type: "category",
+      data: labels,
+      show: false,
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: "value",
+      show: false,
+      min: (value: { min: number }) => Math.min(0, value.min),
+    },
+    series: [
+      {
+        id: "sparkline",
+        name: "trend",
+        type: "line",
+        data: values,
+        smooth: true,
+        symbol: "none",
+        lineStyle: { color, width: 2.5 },
+        areaStyle: {
+          color: {
+            type: "linear",
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: `${color}33` },
+              { offset: 1, color: `${color}00` },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}

--- a/pages/dashboard/DashboardPage.tsx
+++ b/pages/dashboard/DashboardPage.tsx
@@ -4,13 +4,10 @@ import {
   useMemo,
   useRef,
   useState,
-  type ReactElement,
-  type ReactNode,
 } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import {
   Activity,
-  CircleAlert,
   Database,
   DollarSign,
   RefreshCw,
@@ -18,36 +15,27 @@ import {
   Sparkles,
   TriangleAlert,
 } from "lucide-react";
-import type { ECBasicOption } from "echarts/types/dist/shared";
 import {
   usageApi,
   type DashboardSummary,
-  type DashboardTenantThroughputItem,
-  type DashboardThroughputPoint,
-  type DashboardTrendPoint,
 } from "@code-proxy/api-client/endpoints/usage";
-import {
-  formatCompactNumber,
-  formatCompactUsd,
-  formatFixedNumber,
-  formatUsd,
-  getCompactNumberParts,
-  type CompactNumberOptions,
-} from "@code-proxy/domain";
 import { useAuth } from "@app/providers/AuthProvider";
 import { SystemMonitorSection } from "./SystemMonitorSection";
 import { useSystemStats } from "./useSystemStats";
 import { AnimatedNumber } from "@code-proxy/ui";
 import { Button } from "@code-proxy/ui";
-import { Card } from "@code-proxy/ui";
-import { surface } from "@code-proxy/ui";
 import { EmptyState } from "@code-proxy/ui";
-import { HoverTooltip } from "@code-proxy/ui";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { useToast } from "@code-proxy/ui";
-import { EChart } from "@code-proxy/ui";
-import { ChartLegend } from "@code-proxy/ui";
 import { useInterval } from "@code-proxy/ui";
+import { DashboardKpiCard } from "./DashboardKpiCard";
+import {
+  DashboardMetricValue,
+  renderDashboardHint,
+  formatRate,
+  createSparklineOption,
+} from "./DashboardMetrics";
+import { ThroughputTrendChart } from "./ThroughputTrendChart";
 
 type DashboardRange = 1 | 7 | 30;
 
@@ -56,430 +44,6 @@ const RANGE_KEYS: Record<DashboardRange, string> = {
   7: "dashboard.last_7_days",
   30: "dashboard.last_30_days",
 };
-
-const DASHBOARD_COMPACT_OPTIONS = {
-  threshold: 10_000,
-  maximumFractionDigits: 1,
-  standardMaximumFractionDigits: 0,
-} satisfies CompactNumberOptions;
-const DASHBOARD_COST_COMPACT_OPTIONS = {
-  threshold: 10_000,
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-  standardMinimumFractionDigits: 4,
-  standardMaximumFractionDigits: 4,
-} satisfies CompactNumberOptions;
-
-const formatDashboardNumber = (value: number) =>
-  formatCompactNumber(value, DASHBOARD_COMPACT_OPTIONS);
-const formatDashboardTooltipNumber = (value: number) =>
-  formatFixedNumber(value, { fractionDigits: 2 });
-const formatDashboardCost = (value: number) =>
-  formatCompactUsd(value, DASHBOARD_COST_COMPACT_OPTIONS);
-const formatDashboardTooltipCost = (value: number) => formatUsd(value, { fractionDigits: 4 });
-
-function DashboardMetricValue({
-  value,
-  variant = "number",
-  animated = false,
-  className,
-}: {
-  value: number;
-  variant?: "number" | "currency";
-  animated?: boolean;
-  className?: string;
-}) {
-  const compactOptions =
-    variant === "currency" ? DASHBOARD_COST_COMPACT_OPTIONS : DASHBOARD_COMPACT_OPTIONS;
-  const format = variant === "currency" ? formatDashboardCost : formatDashboardNumber;
-  const tooltip =
-    variant === "currency"
-      ? formatDashboardTooltipCost(value)
-      : formatDashboardTooltipNumber(value);
-  const compact = getCompactNumberParts(value, compactOptions).compact;
-  const content = animated ? (
-    <AnimatedNumber value={value} format={format} className={className} />
-  ) : (
-    <span className={["inline-block tabular-nums", className].filter(Boolean).join(" ")}>
-      {format(value)}
-    </span>
-  );
-
-  return (
-    <HoverTooltip
-      content={tooltip}
-      disabled={!compact}
-      placement="top"
-      className={compact ? "cursor-help" : undefined}
-    >
-      {content}
-    </HoverTooltip>
-  );
-}
-
-const renderDashboardHint = (
-  i18nKey: string,
-  first: ReactElement,
-  second: ReactElement,
-): ReactNode => {
-  return <Trans i18nKey={i18nKey} components={[first, second]} />;
-};
-
-const throughputNumberFormatter = new Intl.NumberFormat(undefined, {
-  maximumFractionDigits: 2,
-});
-const formatThroughputValue = (value: number) =>
-  throughputNumberFormatter.format(Number.isFinite(value) ? value : 0);
-const formatRate = (rate: number) => `${rate.toFixed(2)}%`;
-const PANEL_SURFACE = surface({ tone: "panel", radius: "2xl" });
-
-const formatThroughputTooltip = (params: any) => {
-  const items = Array.isArray(params) ? params : [params];
-  const title = items[0]?.axisValueLabel ?? "";
-  const lines = items.map(
-    (item) =>
-      `${item?.marker ?? ""}${item?.seriesName ?? ""} ${formatThroughputValue(Number(item?.data ?? 0))}`,
-  );
-  return [title, ...lines].join("<br/>");
-};
-
-function createSparklineOption(points: DashboardTrendPoint[], color: string): ECBasicOption {
-  const labels = points.map((point) => point.label);
-  const values = points.map((point) => point.value);
-
-  return {
-    animationDuration: 320,
-    animationDurationUpdate: 240,
-    grid: { left: 0, right: 0, top: 6, bottom: 0 },
-    tooltip: {
-      trigger: "axis",
-      borderWidth: 0,
-      backgroundColor: "rgba(15, 23, 42, 0.9)",
-      textStyle: { color: "#fff", fontSize: 12 },
-      formatter: (params: any) => {
-        const first = Array.isArray(params) ? params[0] : params;
-        return `${first?.axisValueLabel ?? ""}<br/>${formatDashboardTooltipNumber(Number(first?.data ?? 0))}`;
-      },
-    },
-    xAxis: {
-      type: "category",
-      data: labels,
-      show: false,
-      boundaryGap: false,
-    },
-    yAxis: {
-      type: "value",
-      show: false,
-      min: (value: { min: number }) => Math.min(0, value.min),
-    },
-    series: [
-      {
-        id: "sparkline",
-        name: "trend",
-        type: "line",
-        data: values,
-        smooth: true,
-        symbol: "none",
-        lineStyle: { color, width: 2.5 },
-        areaStyle: {
-          color: {
-            type: "linear",
-            x: 0,
-            y: 0,
-            x2: 0,
-            y2: 1,
-            colorStops: [
-              { offset: 0, color: `${color}33` },
-              { offset: 1, color: `${color}00` },
-            ],
-          },
-        },
-      },
-    ],
-  };
-}
-
-function createThroughputOption(
-  points: DashboardThroughputPoint[],
-  showRPM: boolean,
-  showTPM: boolean,
-): ECBasicOption {
-  const labels = points.map((point) => point.label);
-  const rpmValues = points.map((point) => point.rpm);
-  const tpmValues = points.map((point) => point.tpm);
-
-  return {
-    animationDuration: 360,
-    animationDurationUpdate: 80,
-    tooltip: {
-      trigger: "axis",
-      borderWidth: 0,
-      backgroundColor: "rgba(15, 23, 42, 0.92)",
-      textStyle: { color: "#fff" },
-      formatter: formatThroughputTooltip,
-    },
-    grid: { left: 12, right: 12, top: 12, bottom: 22, containLabel: true },
-    xAxis: {
-      type: "category",
-      data: labels,
-      boundaryGap: false,
-      axisTick: { show: false },
-      axisLine: { lineStyle: { color: "rgba(148,163,184,0.45)" } },
-      axisLabel: { color: "#64748b", fontSize: 10, hideOverlap: true },
-    },
-    yAxis: [
-      {
-        type: "value",
-        splitNumber: 4,
-        axisLabel: {
-          color: "#64748b",
-          fontSize: 10,
-          formatter: (value: number) => formatThroughputValue(value),
-        },
-        splitLine: { lineStyle: { color: "rgba(148,163,184,0.16)" } },
-      },
-      {
-        type: "value",
-        splitNumber: 4,
-        axisLabel: {
-          color: "#64748b",
-          fontSize: 10,
-          formatter: (value: number) => formatThroughputValue(value),
-        },
-        splitLine: { show: false },
-      },
-    ],
-    series: [
-      {
-        id: "rpm",
-        name: "RPM",
-        type: "line",
-        yAxisIndex: 0,
-        data: showRPM ? rpmValues : [],
-        smooth: true,
-        showSymbol: false,
-        lineStyle: { width: 3, color: "#2563eb" },
-        itemStyle: { color: "#2563eb" },
-        areaStyle: {
-          color: {
-            type: "linear",
-            x: 0,
-            y: 0,
-            x2: 0,
-            y2: 1,
-            colorStops: [
-              { offset: 0, color: "rgba(37,99,235,0.18)" },
-              { offset: 1, color: "rgba(37,99,235,0.02)" },
-            ],
-          },
-        },
-      },
-      {
-        id: "tpm",
-        name: "TPM",
-        type: "line",
-        yAxisIndex: 1,
-        data: showTPM ? tpmValues : [],
-        smooth: true,
-        showSymbol: false,
-        lineStyle: { width: 3, color: "#7c3aed" },
-        itemStyle: { color: "#7c3aed" },
-        areaStyle: {
-          color: {
-            type: "linear",
-            x: 0,
-            y: 0,
-            x2: 0,
-            y2: 1,
-            colorStops: [
-              { offset: 0, color: "rgba(124,58,237,0.14)" },
-              { offset: 1, color: "rgba(124,58,237,0.02)" },
-            ],
-          },
-        },
-      },
-    ],
-  };
-}
-
-function DashboardKpiCard({
-  title,
-  value,
-  hint,
-  icon: Icon,
-  option,
-  accent,
-}: {
-  title: string;
-  value: ReactNode;
-  hint: ReactNode;
-  icon: typeof Activity;
-  option: ECBasicOption;
-  accent: {
-    iconWrap: string;
-    iconColor: string;
-  };
-}) {
-  return (
-    <Card
-      className={`${PANEL_SURFACE} h-full`}
-      bodyClassName="mt-0 flex h-full flex-col"
-      padding="compact"
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div
-          className={`inline-flex h-9 w-9 items-center justify-center rounded-2xl ${accent.iconWrap}`}
-        >
-          <Icon size={16} className={accent.iconColor} />
-        </div>
-      </div>
-      <div className="mt-3">
-        <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</p>
-        <div className="mt-2 text-3xl font-semibold leading-none tracking-tight text-slate-950 dark:text-white">
-          {value}
-        </div>
-        <p className="mt-2 text-xs text-slate-500 dark:text-white/45">{hint}</p>
-      </div>
-      <div className="mt-auto pt-3">
-        <EChart option={option} className="h-10" overflowVisible />
-      </div>
-    </Card>
-  );
-}
-
-function ThroughputTrendChart({
-  title,
-  points,
-  rpm,
-  tpm,
-  connected,
-  showRPM,
-  showTPM,
-  onToggle,
-  allTenantsScope = false,
-  tenants = [],
-  selectedTenant = "all",
-  onSelectTenant,
-}: {
-  title: string;
-  points: DashboardThroughputPoint[];
-  rpm: number;
-  tpm: number;
-  connected: boolean;
-  showRPM: boolean;
-  showTPM: boolean;
-  onToggle: (key: string) => void;
-  /** Platform super-admin: series aggregates every tenant. */
-  allTenantsScope?: boolean;
-  tenants?: DashboardTenantThroughputItem[];
-  selectedTenant?: string;
-  onSelectTenant?: (tenantId: string) => void;
-}) {
-  const { t } = useTranslation();
-  const option = useMemo(
-    () => createThroughputOption(points, showRPM, showTPM),
-    [points, showRPM, showTPM],
-  );
-  const active = rpm > 0 || tpm > 0;
-  const titleNode = allTenantsScope ? (
-    <span className="inline-flex items-center gap-1.5">
-      <span>{title}</span>
-      <HoverTooltip content={t("dashboard.throughput_all_tenants_hint")} placement="top">
-        <button
-          type="button"
-          className="inline-flex h-5 w-5 items-center justify-center rounded-full text-amber-500 transition-colors hover:bg-amber-50 hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/30 dark:text-amber-400 dark:hover:bg-amber-500/10 dark:hover:text-amber-300"
-          aria-label={t("dashboard.throughput_all_tenants_hint")}
-        >
-          <CircleAlert size={14} strokeWidth={2.25} />
-        </button>
-      </HoverTooltip>
-    </span>
-  ) : (
-    title
-  );
-
-  const hasMultipleTenants = allTenantsScope && tenants && tenants.length > 0;
-
-  return (
-    <Card
-      className={PANEL_SURFACE}
-      title={titleNode}
-      actions={
-        <div className="flex items-center gap-2">
-          {hasMultipleTenants && onSelectTenant ? (
-            <select
-              value={selectedTenant}
-              onChange={(e) => onSelectTenant(e.target.value)}
-              className="h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-slate-700 shadow-2xs outline-none transition-colors hover:border-slate-300 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-white/10 dark:bg-neutral-800 dark:text-slate-200 dark:hover:border-white/20"
-              aria-label={t("dashboard.throughput_tenant_select")}
-            >
-              <option value="all">{t("dashboard.throughput_tenant_all")}</option>
-              {tenants.map((item) => (
-                <option key={item.tenant_id} value={item.tenant_id}>
-                  {item.tenant_name || item.tenant_id} (RPM: {formatThroughputValue(item.current_rpm)})
-                </option>
-              ))}
-            </select>
-          ) : null}
-          <div
-            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
-              connected
-                ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
-                : "bg-slate-100 text-slate-400 dark:bg-neutral-800 dark:text-white/45"
-            }`}
-          >
-            <span
-              className={`h-2 w-2 rounded-full ${
-                active ? "animate-pulse bg-emerald-500" : "bg-slate-300 dark:bg-neutral-600"
-              }`}
-            />
-            {connected ? t("system_monitor.live") : t("system_monitor.polling")}
-          </div>
-        </div>
-      }
-      padding="compact"
-    >
-      <div className="mb-3 grid gap-3 sm:grid-cols-2">
-        <div className="rounded-2xl bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
-          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-            RPM
-          </div>
-          <div className="mt-1 text-xl font-semibold tabular-nums text-indigo-600 dark:text-indigo-400">
-            <DashboardMetricValue value={rpm} />
-          </div>
-        </div>
-        <div className="rounded-2xl bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
-          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-            TPM
-          </div>
-          <div className="mt-1 text-xl font-semibold tabular-nums text-violet-600 dark:text-violet-400">
-            <DashboardMetricValue value={tpm} />
-          </div>
-        </div>
-      </div>
-      <EChart option={option} className="h-56" />
-      <ChartLegend
-        className="justify-start pt-3"
-        items={[
-          {
-            key: "rpm",
-            label: "RPM",
-            colorClass: "bg-blue-500",
-            enabled: showRPM,
-            onToggle,
-          },
-          {
-            key: "tpm",
-            label: "TPM",
-            colorClass: "bg-violet-500",
-            enabled: showTPM,
-            onToggle,
-          },
-        ]}
-      />
-    </Card>
-  );
-}
 
 export function DashboardPage() {
   const { t } = useTranslation();
@@ -500,8 +64,6 @@ export function DashboardPage() {
   const [range, setRange] = useState<DashboardRange>(7);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [throughputLegend, setThroughputLegend] = useState({ rpm: true, tpm: true });
-  const [selectedThroughputTenant, setSelectedThroughputTenant] = useState("all");
 
   const refresh = useCallback(
     async (days: DashboardRange, silent = false) => {
@@ -568,19 +130,6 @@ export function DashboardPage() {
   const throughputAllTenants =
     meta.throughput_scope === "all_tenants" || Boolean(principal?.platform_admin);
   const tenantBreakdown = trends?.tenants ?? [];
-  const activeThroughputSeries = useMemo(() => {
-    if (selectedThroughputTenant !== "all") {
-      const found = tenantBreakdown.find((item) => item.tenant_id === selectedThroughputTenant);
-      if (found) {
-        return found.throughput_series;
-      }
-    }
-    return throughputSeries;
-  }, [selectedThroughputTenant, tenantBreakdown, throughputSeries]);
-
-  const activeLatestThroughput = activeThroughputSeries[activeThroughputSeries.length - 1];
-  const activeRpm = activeLatestThroughput?.rpm ?? tenantRpm;
-  const activeTpm = activeLatestThroughput?.tpm ?? tenantTpm;
 
   const totalRequestOption = useMemo(
     () => createSparklineOption(trends?.request_volume ?? [], "#2563eb"),
@@ -649,15 +198,20 @@ export function DashboardPage() {
           description={error}
           icon={<TriangleAlert size={18} />}
           action={
-            <Button variant="secondary" onClick={() => void refresh(range)}>
-              <RefreshCw size={14} />
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void refresh(range)}
+              disabled={loading}
+            >
+              <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
               {t("dashboard.retry")}
             </Button>
           }
         />
       ) : null}
 
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <DashboardKpiCard
           title={t("dashboard.total_requests")}
           value={<DashboardMetricValue value={kpi?.total_requests ?? 0} animated />}
@@ -752,20 +306,13 @@ export function DashboardPage() {
 
       <ThroughputTrendChart
         title={t("dashboard.throughput_title")}
-        points={activeThroughputSeries}
-        rpm={activeRpm}
-        tpm={activeTpm}
+        points={throughputSeries}
+        rpm={tenantRpm}
+        tpm={tenantTpm}
         // Series from dashboard-summary polling; latest point is rolling 60s RPM/TPM.
         connected={false}
-        showRPM={throughputLegend.rpm}
-        showTPM={throughputLegend.tpm}
         allTenantsScope={throughputAllTenants}
         tenants={tenantBreakdown}
-        selectedTenant={selectedThroughputTenant}
-        onSelectTenant={setSelectedThroughputTenant}
-        onToggle={(key) =>
-          setThroughputLegend((prev) => ({ ...prev, [key]: !prev[key as "rpm" | "tpm"] }))
-        }
       />
     </div>
   );

--- a/pages/dashboard/ThroughputTrendChart.tsx
+++ b/pages/dashboard/ThroughputTrendChart.tsx
@@ -1,0 +1,345 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { CircleAlert } from "lucide-react";
+import type { ECBasicOption } from "echarts/types/dist/shared";
+import type {
+  DashboardTenantThroughputItem,
+  DashboardThroughputPoint,
+} from "@code-proxy/api-client/endpoints/usage";
+import { Card, EChart, ChartLegend, type ChartLegendItem, HoverTooltip, surface } from "@code-proxy/ui";
+import { DashboardMetricValue, formatThroughputValue, formatThroughputTooltip } from "./DashboardMetrics";
+
+const PANEL_SURFACE = surface({ tone: "panel", radius: "2xl" });
+
+const TENANT_PALETTE = [
+  "#2563eb", // blue
+  "#7c3aed", // violet
+  "#059669", // emerald
+  "#d97706", // amber
+  "#dc2626", // red
+  "#0891b2", // cyan
+  "#db2777", // pink
+  "#4f46e5", // indigo
+  "#ea580c", // orange
+  "#16a34a", // green
+  "#9333ea", // purple
+  "#0284c7", // sky
+];
+
+export interface ThroughputSeriesConfig {
+  id: string;
+  name: string;
+  points: DashboardThroughputPoint[];
+  color: string;
+  metric: "rpm" | "tpm";
+  lineType?: "solid" | "dashed";
+}
+
+function createThroughputOption(
+  configs: ThroughputSeriesConfig[],
+  visibleIds: Set<string>,
+): ECBasicOption {
+  // Collect all unique labels in order
+  const labels: string[] = [];
+  const labelSet = new Set<string>();
+  for (const cfg of configs) {
+    for (const pt of cfg.points) {
+      if (!labelSet.has(pt.label)) {
+        labelSet.add(pt.label);
+        labels.push(pt.label);
+      }
+    }
+  }
+
+  const series = configs.map((cfg) => {
+    const isVisible = visibleIds.has(cfg.id);
+    const pointMap = new Map(cfg.points.map((p) => [p.label, cfg.metric === "rpm" ? p.rpm : p.tpm]));
+    const data = isVisible ? labels.map((l) => pointMap.get(l) ?? 0) : [];
+    const isRpm = cfg.metric === "rpm";
+
+    return {
+      id: cfg.id,
+      name: cfg.name,
+      type: "line",
+      yAxisIndex: isRpm ? 0 : 1,
+      data,
+      smooth: true,
+      showSymbol: false,
+      lineStyle: {
+        width: 2.5,
+        color: cfg.color,
+        type: cfg.lineType ?? "solid",
+      },
+      itemStyle: { color: cfg.color },
+      areaStyle: {
+        color: {
+          type: "linear",
+          x: 0,
+          y: 0,
+          x2: 0,
+          y2: 1,
+          colorStops: [
+            { offset: 0, color: `${cfg.color}25` },
+            { offset: 1, color: `${cfg.color}00` },
+          ],
+        },
+      },
+    };
+  });
+
+  return {
+    animationDuration: 360,
+    animationDurationUpdate: 80,
+    tooltip: {
+      trigger: "axis",
+      borderWidth: 0,
+      backgroundColor: "rgba(15, 23, 42, 0.92)",
+      textStyle: { color: "#fff" },
+      formatter: formatThroughputTooltip,
+    },
+    grid: { left: 12, right: 12, top: 12, bottom: 22, containLabel: true },
+    xAxis: {
+      type: "category",
+      data: labels,
+      boundaryGap: false,
+      axisTick: { show: false },
+      axisLine: { lineStyle: { color: "rgba(148,163,184,0.45)" } },
+      axisLabel: { color: "#64748b", fontSize: 10, hideOverlap: true },
+    },
+    yAxis: [
+      {
+        type: "value",
+        splitNumber: 4,
+        axisLabel: {
+          color: "#64748b",
+          fontSize: 10,
+          formatter: (value: number) => formatThroughputValue(value),
+        },
+        splitLine: { lineStyle: { color: "rgba(148,163,184,0.16)" } },
+      },
+      {
+        type: "value",
+        splitNumber: 4,
+        axisLabel: {
+          color: "#64748b",
+          fontSize: 10,
+          formatter: (value: number) => formatThroughputValue(value),
+        },
+        splitLine: { show: false },
+      },
+    ],
+    series,
+  };
+}
+
+export function ThroughputTrendChart({
+  title,
+  points,
+  rpm,
+  tpm,
+  connected,
+  allTenantsScope = false,
+  tenants = [],
+}: {
+  title: string;
+  points: DashboardThroughputPoint[];
+  rpm: number;
+  tpm: number;
+  connected: boolean;
+  /** Platform super-admin: series aggregates every tenant. */
+  allTenantsScope?: boolean;
+  tenants?: DashboardTenantThroughputItem[];
+}) {
+  const { t } = useTranslation();
+  const [metric, setMetric] = useState<"rpm" | "tpm">("rpm");
+  const [visibleIds, setVisibleIds] = useState<Set<string>>(() => new Set(["aggregated"]));
+
+  const hasTenants = allTenantsScope && tenants && tenants.length > 1;
+
+  // Build series configs
+  const seriesConfigs = useMemo<ThroughputSeriesConfig[]>(() => {
+    if (!hasTenants) {
+      return [
+        {
+          id: "aggregated-rpm",
+          name: "RPM",
+          points,
+          color: "#2563eb",
+          metric: "rpm",
+        },
+        {
+          id: "aggregated-tpm",
+          name: "TPM",
+          points,
+          color: "#7c3aed",
+          metric: "tpm",
+        },
+      ];
+    }
+
+    // In allTenantsScope with breakdown:
+    const configs: ThroughputSeriesConfig[] = [
+      {
+        id: "aggregated",
+        name: t("dashboard.throughput_tenant_all"),
+        points,
+        color: metric === "rpm" ? "#2563eb" : "#7c3aed",
+        metric,
+        lineType: "solid",
+      },
+    ];
+
+    tenants.forEach((tenant, idx) => {
+      const color = TENANT_PALETTE[(idx + 1) % TENANT_PALETTE.length] || "#059669";
+      configs.push({
+        id: `tenant-${tenant.tenant_id}`,
+        name: tenant.tenant_name || tenant.tenant_id,
+        points: tenant.throughput_series,
+        color,
+        metric,
+      });
+    });
+
+    return configs;
+  }, [hasTenants, points, tenants, t, metric]);
+
+  // Keep visibleIds synchronized if configs change
+  useEffect(() => {
+    if (!hasTenants) {
+      setVisibleIds(new Set(["aggregated-rpm", "aggregated-tpm"]));
+    } else {
+      setVisibleIds((prev) => {
+        if (prev.size === 0 || (!prev.has("aggregated") && !Array.from(prev).some((id) => id.startsWith("tenant-")))) {
+          return new Set(["aggregated", ...tenants.map((item) => `tenant-${item.tenant_id}`)]);
+        }
+        return prev;
+      });
+    }
+  }, [hasTenants, tenants]);
+
+  const handleToggle = useCallback((id: string) => {
+    setVisibleIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        // If it's the last one, don't uncheck or allow empty
+        if (next.size > 1) {
+          next.delete(id);
+        }
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const option = useMemo(
+    () => createThroughputOption(seriesConfigs, visibleIds),
+    [seriesConfigs, visibleIds],
+  );
+
+  const active = rpm > 0 || tpm > 0;
+  const titleNode = allTenantsScope ? (
+    <span className="inline-flex items-center gap-1.5">
+      <span>{title}</span>
+      <HoverTooltip content={t("dashboard.throughput_all_tenants_hint")} placement="top">
+        <button
+          type="button"
+          className="inline-flex h-5 w-5 items-center justify-center rounded-full text-amber-500 transition-colors hover:bg-amber-50 hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/30 dark:text-amber-400 dark:hover:bg-amber-500/10 dark:hover:text-amber-300"
+          aria-label={t("dashboard.throughput_all_tenants_hint")}
+        >
+          <CircleAlert size={14} strokeWidth={2.25} />
+        </button>
+      </HoverTooltip>
+    </span>
+  ) : (
+    title
+  );
+
+  const legendItems = useMemo<ChartLegendItem[]>(() => {
+    return seriesConfigs.map((cfg) => ({
+      key: cfg.id,
+      label: cfg.name,
+      colorHex: cfg.color,
+      enabled: visibleIds.has(cfg.id),
+      onToggle: handleToggle,
+    }));
+  }, [seriesConfigs, visibleIds, handleToggle]);
+
+  return (
+    <Card
+      className={PANEL_SURFACE}
+      title={titleNode}
+      actions={
+        <div className="flex items-center gap-2">
+          {hasTenants ? (
+            <div className="inline-flex rounded-lg bg-slate-100 p-0.5 text-xs font-semibold dark:bg-neutral-800">
+              <button
+                type="button"
+                onClick={() => setMetric("rpm")}
+                className={`rounded-md px-2.5 py-1 transition ${
+                  metric === "rpm"
+                    ? "bg-white text-blue-600 shadow-2xs dark:bg-neutral-900 dark:text-blue-400"
+                    : "text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+                }`}
+              >
+                RPM
+              </button>
+              <button
+                type="button"
+                onClick={() => setMetric("tpm")}
+                className={`rounded-md px-2.5 py-1 transition ${
+                  metric === "tpm"
+                    ? "bg-white text-violet-600 shadow-2xs dark:bg-neutral-900 dark:text-violet-400"
+                    : "text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+                }`}
+              >
+                TPM
+              </button>
+            </div>
+          ) : null}
+          <div
+            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
+              connected
+                ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300"
+                : "bg-slate-100 text-slate-400 dark:bg-neutral-800 dark:text-white/45"
+            }`}
+          >
+            <span
+              className={`h-2 w-2 rounded-full ${
+                active ? "animate-pulse bg-emerald-500" : "bg-slate-300 dark:bg-neutral-600"
+              }`}
+            />
+            {connected ? t("system_monitor.live") : t("system_monitor.polling")}
+          </div>
+        </div>
+      }
+      padding="compact"
+    >
+      <div className="mb-3 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
+          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            RPM
+          </div>
+          <div className="mt-1 text-xl font-semibold tabular-nums text-indigo-600 dark:text-indigo-400">
+            <DashboardMetricValue value={rpm} />
+          </div>
+        </div>
+        <div className="rounded-2xl bg-slate-50 px-3 py-2 dark:bg-neutral-900/70 dark:ring-1 dark:ring-white/8">
+          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            TPM
+          </div>
+          <div className="mt-1 text-xl font-semibold tabular-nums text-violet-600 dark:text-violet-400">
+            <DashboardMetricValue value={tpm} />
+          </div>
+        </div>
+      </div>
+      <EChart option={option} className="h-56" />
+      <ChartLegend className="justify-start pt-3" items={legendItems} />
+    </Card>
+  );
+}

--- a/pages/dashboard/__tests__/DashboardCards.test.ts
+++ b/pages/dashboard/__tests__/DashboardCards.test.ts
@@ -9,26 +9,24 @@ const readModule = (path: string) => readFileSync(resolve(root, path), "utf8");
 describe("dashboard card composition", () => {
   test("uses the shared Card component for dashboard KPI cards", () => {
     const source = readModule("pages/dashboard/DashboardPage.tsx");
+    const chartSource = readModule("pages/dashboard/ThroughputTrendChart.tsx");
 
-    expect(source).toContain('from "@code-proxy/ui"');
     expect(source).toContain('from "@code-proxy/ui"');
     expect(source).toContain('from "./useSystemStats"');
     expect(source).toContain("createSparklineOption");
     expect(source).toContain("ThroughputTrendChart");
-    expect(source).toContain("ChartLegend");
+    expect(chartSource).toContain("ChartLegend");
     expect(source).toContain("useInterval");
     expect(source).toContain("summary?.trends");
     expect(source).toContain('can("system.status.read")');
     expect(source).toContain("useSystemStats(15, canViewSystemMonitor && pageVisible)");
-    expect(source).toContain("rpm={activeRpm}");
-    expect(source).toContain("tpm={activeTpm}");
+    expect(source).toContain("rpm={tenantRpm}");
+    expect(source).toContain("tpm={tenantTpm}");
     expect(source).toContain("tenants={tenantBreakdown}");
-    expect(source).toContain("onSelectTenant={setSelectedThroughputTenant}");
     expect(source).toContain("canViewSystemMonitor");
     expect(source).toContain("allTenantsScope");
-    expect(source).toContain("throughput_all_tenants_hint");
+    expect(chartSource).toContain("throughput_all_tenants_hint");
     expect(source).toContain("meta.generated_at");
-    expect(source).toContain('<EChart option={option} className="h-10" overflowVisible />');
     expect(source).toContain("pageVisible ? 20_000 : null");
     expect(source).not.toContain('replaceMerge="series"');
     expect(source).not.toContain('from "@features/monitor-widgets"');
@@ -36,11 +34,12 @@ describe("dashboard card composition", () => {
   });
 
   test("formats throughput chart values with at most two decimal places", () => {
-    const source = readModule("pages/dashboard/DashboardPage.tsx");
+    const source = readModule("pages/dashboard/ThroughputTrendChart.tsx");
+    const metricSource = readModule("pages/dashboard/DashboardMetrics.tsx");
 
-    expect(source).toContain("formatThroughputValue");
-    expect(source).toContain("maximumFractionDigits: 2");
-    expect(source).toContain("formatThroughputTooltip");
+    expect(metricSource).toContain("formatThroughputValue");
+    expect(metricSource).toContain("maximumFractionDigits: 2");
+    expect(metricSource).toContain("formatThroughputTooltip");
     expect(source).toContain("formatter: formatThroughputTooltip");
   });
 
@@ -80,11 +79,11 @@ describe("dashboard card composition", () => {
   });
 
   test("includes dark mode surfaces for throughput and system monitor summary cards", () => {
-    const dashboardSource = readModule("pages/dashboard/DashboardPage.tsx");
+    const chartSource = readModule("pages/dashboard/ThroughputTrendChart.tsx");
     const systemMonitorSource = readModule("pages/dashboard/SystemMonitorSection.tsx");
 
-    expect(dashboardSource).toContain("dark:bg-neutral-900/70");
-    expect(dashboardSource).toContain("dark:text-slate-200");
+    expect(chartSource).toContain("dark:bg-neutral-900/70");
+    expect(chartSource).toContain("dark:text-slate-400");
     expect(systemMonitorSource).toContain("dark:bg-neutral-900/70");
     expect(systemMonitorSource).toContain("dark:text-white/80");
   });


### PR DESCRIPTION
## Summary
- Replace single-tenant dropdown with direct multi-tenant series comparison on the throughput trend chart.
- Support ChartLegend toggling per-tenant and aggregated curves with metric toggle (RPM/TPM).
- Split DashboardPage into cohesive modules (DashboardKpiCard, DashboardMetrics, ThroughputTrendChart) to satisfy file size gates.

## Validation
- `bun run lint` passed
- `bun run design:check` passed
- `bun run boundary:imports` passed
- `bun run size:check` passed (frozen baseline compliant)
- `bun run surface:check` passed
- `bun run audit:deps` passed
- `bun run test:ci` all 1271 tests passed
- `bun run build` and `bun run bundle:diff` passed