### PR TITLE
fix(ui): 修复图表浮层遮挡、列表初始骨架屏与弹窗输入框对比度

### DIFF
--- a/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
+++ b/features/ccswitch-import/components/CcSwitchImportConfigModal.tsx
@@ -74,7 +74,7 @@ const iconByType: Record<CcSwitchClientType, string> = {
 const labelClassName = "text-sm font-medium text-slate-700 dark:text-white/80";
 const fieldClassName = "flex flex-col gap-1.5";
 const sectionClassName =
-  "rounded-2xl bg-white p-4 ring-1 ring-slate-900/8 dark:bg-white/[0.03] dark:ring-white/8";
+  "rounded-2xl bg-slate-50/70 p-4 ring-1 ring-slate-900/8 dark:bg-white/[0.03] dark:ring-white/8";
 
 const MODEL_MAPPING_LOADING_ROWS = ["short", "medium", "long"];
 const CONFIG_MODAL_CLIENTS = CC_SWITCH_CLIENTS.filter((client) => client.type !== "gemini");
@@ -846,7 +846,7 @@ export function CcSwitchImportConfigModal({
           </label>
         </section>
 
-        <section className="overflow-hidden rounded-2xl bg-white ring-1 ring-slate-900/8 dark:bg-white/[0.03] dark:ring-white/8">
+        <section className="overflow-hidden rounded-2xl bg-slate-50/70 ring-1 ring-slate-900/8 dark:bg-white/[0.03] dark:ring-white/8">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-900/8 px-4 py-3 dark:border-white/8">
             <div>
               <div className="text-sm font-semibold text-slate-950 dark:text-white">

--- a/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
+++ b/pages/ccswitch-import-settings/CcSwitchImportSettingsPage.tsx
@@ -105,6 +105,7 @@ export function CcSwitchImportSettingsPage() {
   const auth = useOptionalAuth();
   const { notify } = useToast();
   const [configs, setConfigs] = useState<CcSwitchImportConfigListItem[]>([]);
+  const [loading, setLoading] = useState(true);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<"create" | "edit">("create");
   const [draft, setDraft] = useState<CcSwitchImportConfigListItem>(() => createDraft());
@@ -164,6 +165,7 @@ export function CcSwitchImportSettingsPage() {
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
 
     ccSwitchImportConfigsApi
       .list()
@@ -178,6 +180,11 @@ export function CcSwitchImportSettingsPage() {
           message: error instanceof Error ? error.message : t("common.load_failed"),
         });
         setConfigs([]);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
       });
 
     return () => {
@@ -341,6 +348,7 @@ export function CcSwitchImportSettingsPage() {
           rows={configs}
           columns={columns}
           rowKey={(row) => row.id}
+          loading={loading}
           virtualize={false}
           minWidth="min-w-[1100px]"
           height="h-[420px] md:h-auto md:flex-1"

--- a/pages/dashboard/DashboardMetrics.tsx
+++ b/pages/dashboard/DashboardMetrics.tsx
@@ -110,9 +110,13 @@ export function createSparklineOption(points: DashboardTrendPoint[], color: stri
     grid: { left: 0, right: 0, top: 6, bottom: 0 },
     tooltip: {
       trigger: "axis",
+      renderMode: "html",
+      appendToBody: true,
+      confine: true,
       borderWidth: 0,
       backgroundColor: "rgba(15, 23, 42, 0.9)",
       textStyle: { color: "#fff", fontSize: 12 },
+      extraCssText: "z-index: 10000;",
       formatter: (params: any) => {
         const first = Array.isArray(params) ? params[0] : params;
         return `${first?.axisValueLabel ?? ""}<br/>${formatDashboardTooltipNumber(Number(first?.data ?? 0))}`;

--- a/pages/dashboard/ThroughputTrendChart.tsx
+++ b/pages/dashboard/ThroughputTrendChart.tsx
@@ -97,9 +97,13 @@ function createThroughputOption(
     animationDurationUpdate: 80,
     tooltip: {
       trigger: "axis",
+      renderMode: "html",
+      appendToBody: true,
+      confine: true,
       borderWidth: 0,
       backgroundColor: "rgba(15, 23, 42, 0.92)",
       textStyle: { color: "#fff" },
+      extraCssText: "z-index: 10000;",
       formatter: formatThroughputTooltip,
     },
     grid: { left: 12, right: 12, top: 12, bottom: 22, containLabel: true },


### PR DESCRIPTION
## 修改范围

1. **仪表盘图表 Tooltip 遮挡修复**：在 `ThroughputTrendChart` 与 `DashboardMetrics` 中补全 `renderMode: 'html'`, `appendToBody: true`, `confine: true` 和 `extraCssText: 'z-index: 10000;'`，防止多租户吞吐曲线的浮层在特定容器或视口边缘被裁剪/遮挡。
2. **CC Switch 配置列表初始加载体验**：在 `CcSwitchImportSettingsPage` 增加 `loading` 状态并接入 `DataTable`，避免进入页面时无骨架屏直接呈现空列表闪烁。
3. **CC Switch 配置弹窗输入框对比度优化**：调整表单分块底色为 `bg-slate-50/70`（深色模式 `dark:bg-white/[0.03]`），使 `TextInput` 输入框在静止态与聚焦态均保持清晰舒适的层次对比。

## 验证情况

- 本地执行 `./scripts/ci-pr.sh` 全量通过（包含 `oxlint`, `design:check`, `check-import-boundaries`, `check-file-size`, `check-surface-usage`, `check-dependency-audit`, 全量 `test:ci` 556 tests, `build`, `bundle:diff`, 12 核心 e2e 场景）。