### PR TITLE
fix: add last-dash suffix stripping to pricing lookup fallback chain

### DIFF
--- a/features/model-availability/modelCapabilities.test.ts
+++ b/features/model-availability/modelCapabilities.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  modelConfigLookupIds,
   modelHasTextCapability,
   resolveModelCapabilities,
 } from "./modelCapabilities";
@@ -87,5 +88,51 @@ describe("resolveModelCapabilities", () => {
         outputModalities: ["text", "image"],
       }),
     ).toEqual(["text", "image"]);
+  });
+});
+
+describe("modelConfigLookupIds", () => {
+  test("returns exact id for simple model", () => {
+    expect(modelConfigLookupIds("gpt-4o")).toEqual(["gpt-4o", "4o", "gpt"]);
+  });
+
+  test("strips provider prefix", () => {
+    const ids = modelConfigLookupIds("ollama/deepseek-v4-flash");
+    expect(ids).toContain("ollama/deepseek-v4-flash");
+    expect(ids).toContain("deepseek-v4-flash");
+  });
+
+  test("strips variant suffix after colon", () => {
+    const ids = modelConfigLookupIds("deepseek-v4-flash:free");
+    expect(ids).toContain("deepseek-v4-flash:free");
+    expect(ids).toContain("deepseek-v4-flash");
+  });
+
+  test("strips last dash-segment for thinking suffix", () => {
+    const ids = modelConfigLookupIds("claude-opus-4-6-thinking");
+    expect(ids).toContain("claude-opus-4-6");
+  });
+
+  test("strips last dash-segment for agent suffix", () => {
+    const ids = modelConfigLookupIds("some-model-agent");
+    expect(ids).toContain("some-model");
+  });
+
+  test("strips last dash-segment for tier suffixes", () => {
+    for (const suffix of ["high", "low", "medium", "tiered"]) {
+      const ids = modelConfigLookupIds(`gemini-2.5-flash-${suffix}`);
+      expect(ids).toContain("gemini-2.5-flash");
+    }
+  });
+
+  test("strips last dash-segment from providerless id for provider-prefixed models", () => {
+    const ids = modelConfigLookupIds("ollama/gemini-2.5-flash-thinking");
+    expect(ids).toContain("gemini-2.5-flash");
+  });
+
+  test("extra-low strips to extra then to base via last-dash", () => {
+    const ids = modelConfigLookupIds("some-model-extra-low");
+    // last dash strip produces "some-model-extra"
+    expect(ids).toContain("some-model-extra");
   });
 });

--- a/features/model-availability/modelCapabilities.ts
+++ b/features/model-availability/modelCapabilities.ts
@@ -41,6 +41,13 @@ export function modelConfigLookupIds(modelId: string): string[] {
     if (prefixSeparator > 0) add(exact.slice(prefixSeparator + 1));
   }
 
+  // Strip the last dash-segment from the providerless ID so models with
+  // variant/tier suffixes like "-thinking", "-agent", "-high", "-low",
+  // "-medium", "-extra-low", "-tiered" can inherit pricing from the base model.
+  const providerless = providerSeparator > 0 ? exact.slice(providerSeparator + 1) : exact;
+  const lastDash = providerless.lastIndexOf("-");
+  if (lastDash > 0) add(providerless.slice(0, lastDash));
+
   return candidates;
 }
 


### PR DESCRIPTION
## 问题

模型名包含 `-thinking`、`-agent`、`-high`、`-low`、`-medium`、`-extra-low`、`-tiered` 等后缀时，定价查找无法回退到基础模型，导致显示「未定价」。

## 根因

`modelConfigLookupIds` 的回退候选链只有 prefix stripping（剥离第一个 `-` 前的部分），缺少 suffix stripping（剥离最后一个 `-` 后的部分）。

例如 `claude-opus-4-6-thinking`：
- 现有候选：`claude-opus-4-6-thinking`、`opus-4-6-thinking`
- 缺失候选：`claude-opus-4-6`（基础模型，有定价）

## 修复

在 lookup 链末尾新增最低优先级候选：从 providerless model ID 的最后一个 `-` 处截断。

- `claude-opus-4-6-thinking` → 新增候选 `claude-opus-4-6`
- `ollama/gemini-2.5-flash-thinking` → 新增候选 `gemini-2.5-flash`

候选顺序与 CliRelay `modelPricingLookupModelIDs` 保持对齐。

## 验证

```
bunx vitest run features/model-availability/modelCapabilities.test.ts   # 14 PASS
```