### PR TITLE
fix(auth-files): show every weekly limit in group overview

### DIFF
--- a/packages/api-client/src/endpoints/__tests__/usage-auth-file-trend.test.ts
+++ b/packages/api-client/src/endpoints/__tests__/usage-auth-file-trend.test.ts
@@ -119,4 +119,36 @@ describe("usage auth file trend api", () => {
       ],
     });
   });
+
+  test("keeps every weekly quota_series from the group trend endpoint", async () => {
+    const { usageApi } = await import("@code-proxy/api-client/endpoints/usage");
+    getMock.mockResolvedValue({
+      days: 7,
+      group: "antigravity",
+      points: [{ date: "2026-09-01", requests: 4 }],
+      quota_points: [{ date: "2026-09-01", percent: 57, samples: 2 }],
+      quota_series: [
+        {
+          quota_key: "antigravity:gemini_weekly",
+          quota_label: "Gemini Models",
+          window_seconds: 604800,
+          points: [{ date: "2026-09-01", percent: 57, samples: 2 }],
+        },
+        {
+          quota_key: "antigravity:3p_weekly",
+          quota_label: "Claude and GPT models",
+          window_seconds: 604800,
+          points: [{ date: "2026-09-01", percent: 90, samples: 2 }],
+        },
+      ],
+    });
+
+    const result = await usageApi.getAuthFileGroupTrend("antigravity", 7);
+    expect(getMock).toHaveBeenCalledWith("/usage/auth-file-group-trend?group=antigravity&days=7");
+    expect(result.quota_series.map((item) => item.quota_key)).toEqual([
+      "antigravity:gemini_weekly",
+      "antigravity:3p_weekly",
+    ]);
+    expect(result.quota_series[1]?.points[0]?.percent).toBe(90);
+  });
 });

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -41,11 +41,19 @@ export interface AuthFileQuotaTrendPoint {
   samples: number;
 }
 
+export interface AuthFileQuotaTrendSeries {
+  quota_key: string;
+  quota_label: string;
+  window_seconds: number;
+  points: AuthFileQuotaTrendPoint[];
+}
+
 export interface AuthFileGroupTrendResponse {
   days: number;
   group: string;
   points: AuthFileGroupTrendPoint[];
   quota_points: AuthFileQuotaTrendPoint[];
+  quota_series: AuthFileQuotaTrendSeries[];
 }
 
 export interface AuthFileTrendUsagePoint {
@@ -296,6 +304,7 @@ export const usageApi = {
       group: resp?.group ?? group,
       points: Array.isArray(resp?.points) ? resp.points : [],
       quota_points: Array.isArray(resp?.quota_points) ? resp.quota_points : [],
+      quota_series: Array.isArray(resp?.quota_series) ? resp.quota_series : [],
     };
   },
 

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -993,6 +993,8 @@
     "group_overview_avg_5h_label": "Avg 5h",
     "group_overview_avg_week_label": "Avg weekly",
     "group_overview_avg_week_help": "Based on current weekly quota snapshot",
+    "group_overview_weekly_limits_label": "Weekly limits",
+    "group_overview_weekly_limits_help": "Each weekly window is averaged on its own",
     "group_overview_quota_ready": "Quota samples available",
     "group_overview_channels_title": "Channel Trend",
     "group_overview_channels_desc": "View call counts and 5h/weekly quota averages for each channel in the selected group.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -997,6 +997,8 @@
     "group_overview_avg_5h_label": "平均 5h",
     "group_overview_avg_week_label": "平均周限",
     "group_overview_avg_week_help": "基于当前周限快照",
+    "group_overview_weekly_limits_label": "周限",
+    "group_overview_weekly_limits_help": "每种周限单独平均，互不混合",
     "group_overview_quota_ready": "已获取配额样本",
     "group_overview_channels_title": "渠道趋势",
     "group_overview_channels_desc": "按当前渠道分组查看各渠道的调用次数与 5h/周限均值趋势。",

--- a/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.files-table.test.tsx
@@ -62,6 +62,8 @@ const mocks = vi.hoisted(() => ({
     days: 7,
     group: "all",
     points: [{ date: new Date().toISOString().slice(0, 10), requests: 9 }],
+    quota_points: [],
+    quota_series: [],
   })),
   recordAuthFileQuotaSnapshot: vi.fn(async () => ({})),
   fetchQuota: vi.fn((_provider?: unknown, _file?: { name?: string }) => new Promise(() => {})),
@@ -250,6 +252,8 @@ describe("AuthFilesPage files table", () => {
       days: 7,
       group: "all",
       points: [{ date: new Date().toISOString().slice(0, 10), requests: 9 }],
+      quota_points: [],
+      quota_series: [],
     }));
     mocks.recordAuthFileQuotaSnapshot.mockReset();
     mocks.recordAuthFileQuotaSnapshot.mockImplementation(async () => ({}));

--- a/pages/auth-files/__tests__/AuthFilesPage.identity-tab-rbac.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.identity-tab-rbac.test.tsx
@@ -31,6 +31,8 @@ const mocks = vi.hoisted(() => ({
     days: 7,
     group: "all",
     points: [],
+    quota_points: [],
+    quota_series: [],
   })),
   getModelConfigs: vi.fn(async () => []),
   getModelOwnerPresets: vi.fn(async () => []),
@@ -188,7 +190,13 @@ describe("AuthFilesPage identity tab RBAC", () => {
       quota_series: [],
     }));
     mocks.getAuthFileGroupTrend.mockReset();
-    mocks.getAuthFileGroupTrend.mockResolvedValue({ days: 7, group: "all", points: [] });
+    mocks.getAuthFileGroupTrend.mockResolvedValue({
+      days: 7,
+      group: "all",
+      points: [],
+      quota_points: [],
+      quota_series: [],
+    });
     mocks.getModelConfigs.mockReset();
     mocks.getModelConfigs.mockResolvedValue([]);
     mocks.getModelOwnerPresets.mockReset();

--- a/pages/auth-files/__tests__/AuthFilesPage.status-read-model.test.tsx
+++ b/pages/auth-files/__tests__/AuthFilesPage.status-read-model.test.tsx
@@ -72,7 +72,13 @@ vi.mock("@code-proxy/api-client", async (importOriginal) => {
       getEntityStats: mocks.getEntityStats,
       getAuthFileTrend: mocks.getAuthFileTrend,
       recordAuthFileQuotaSnapshot: mocks.recordAuthFileQuotaSnapshot,
-      getAuthFileGroupTrend: vi.fn(async () => ({ days: 7, group: "all", points: [] })),
+      getAuthFileGroupTrend: vi.fn(async () => ({
+        days: 7,
+        group: "all",
+        points: [],
+        quota_points: [],
+        quota_series: [],
+      })),
       getUsageLogs: vi.fn(async () => ({ items: [], total: 0, page: 1, size: 200 })),
     },
     quotaApi: {

--- a/pages/auth-files/__tests__/groupOverviewWeekly.test.ts
+++ b/pages/auth-files/__tests__/groupOverviewWeekly.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+import type { TFunction } from "i18next";
+import type { QuotaCardSlot } from "../hooks/quotaCardSlots";
+import {
+  collectWeeklyFamilies,
+  formatWeeklySeriesLabel,
+  isWeeklyWindow,
+  normalizeGroupTrendSeries,
+} from "../hooks/groupOverviewWeekly";
+import type { QuotaItem } from "@features/quota-preview/quota-helpers";
+
+const WEEK = 7 * 24 * 60 * 60;
+const FIVE_HOUR = 5 * 60 * 60;
+const t = ((key: string, opts?: { name?: string }) =>
+  opts?.name ? `${key}:${opts.name}` : key) as unknown as TFunction;
+
+const weeklySlot = (id: string, label: string, percent: number, windowSeconds = WEEK): QuotaCardSlot => ({
+  id,
+  label,
+  item: { key: id, label, percent, windowSeconds } as QuotaItem,
+});
+
+describe("group overview weekly families", () => {
+  test("treats seven-day windows as weekly and ignores 5h", () => {
+    expect(isWeeklyWindow(WEEK)).toBe(true);
+    expect(isWeeklyWindow(FIVE_HOUR)).toBe(false);
+    expect(isWeeklyWindow(undefined)).toBe(false);
+  });
+
+  test("averages each Antigravity weekly separately instead of taking the first bar", () => {
+    const files = [
+      [
+        weeklySlot("antigravity:gemini_weekly", "Gemini · 周", 40),
+        weeklySlot("antigravity:gemini_5h", "Gemini · 5h", 10, FIVE_HOUR),
+        weeklySlot("antigravity:3p_weekly", "Claude and GPT · 周", 80),
+      ],
+      [
+        weeklySlot("antigravity:gemini_weekly", "Gemini · 周", 60),
+        weeklySlot("antigravity:3p_weekly", "Claude and GPT · 周", 100),
+      ],
+    ];
+    const families = collectWeeklyFamilies(files);
+    expect(families.map((family) => ({ id: family.id, remainingPercent: family.remainingPercent }))).toEqual([
+      { id: "antigravity:gemini_weekly", remainingPercent: 50 },
+      { id: "antigravity:3p_weekly", remainingPercent: 90 },
+    ]);
+  });
+
+  test("keeps Codex code_week and extra Spark weeks as distinct families", () => {
+    const files = [
+      [
+        weeklySlot("code_week", "代码：周", 70),
+        weeklySlot("additional:codex_bengalfox:week", "Spark：周", 100),
+      ],
+    ];
+    expect(collectWeeklyFamilies(files).map((family) => family.id)).toEqual([
+      "code_week",
+      "additional:codex_bengalfox:week",
+    ]);
+  });
+
+  test("keeps every quota_series line and only falls back to quota_points", () => {
+    const dual = normalizeGroupTrendSeries(
+      [
+        { quota_key: "antigravity:gemini_weekly", points: [{ date: "2026-09-01", percent: 57 }] },
+        { quota_key: "antigravity:3p_weekly", points: [{ date: "2026-09-01", percent: 90 }] },
+      ],
+      [{ date: "2026-09-01", percent: null }],
+    );
+    expect(dual.map((item) => item.quota_key)).toEqual([
+      "antigravity:gemini_weekly",
+      "antigravity:3p_weekly",
+    ]);
+    expect(normalizeGroupTrendSeries([], [{ date: "2026-09-01", percent: 70 }])[0]?.quota_key).toBe(
+      "code_week",
+    );
+  });
+
+  test("formats stored snapshot labels the way the card already does", () => {
+    expect(formatWeeklySeriesLabel("code_week", "", t)).toBe("m_quota.code_weekly");
+    expect(formatWeeklySeriesLabel("antigravity:gemini_weekly", "Gemini Models", t)).toBe(
+      "Gemini · antigravity_quota.window_weekly",
+    );
+    expect(formatWeeklySeriesLabel("antigravity:3p_weekly", "Claude and GPT models", t)).toBe(
+      "Claude and GPT · antigravity_quota.window_weekly",
+    );
+  });
+});

--- a/pages/auth-files/components/GroupOverviewModal.tsx
+++ b/pages/auth-files/components/GroupOverviewModal.tsx
@@ -4,7 +4,8 @@ import { Button, surface } from "@code-proxy/ui";
 import { Modal } from "@code-proxy/ui";
 import { Tabs, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { EChart } from "@code-proxy/ui";
-import type { AuthFilesGroupOverview, AuthFilesGroupOverviewRow } from "@code-proxy/domain";
+import type { AuthFilesGroupOverviewRow } from "@code-proxy/domain";
+import type { GroupOverviewSummary } from "../hooks/groupOverviewWeekly";
 
 interface GroupOverviewModalProps {
   open: boolean;
@@ -19,7 +20,7 @@ interface GroupOverviewModalProps {
   refreshGroupTrend: (targetGroup?: string) => Promise<void>;
   activeGroupTitle: string;
   activeGroupRows: AuthFilesGroupOverviewRow[];
-  activeGroupOverview: AuthFilesGroupOverview;
+  activeGroupOverview: GroupOverviewSummary;
   formatAveragePercent: (value: number | null) => string;
   groupOverviewChartOption: Record<string, unknown>;
 }
@@ -117,13 +118,32 @@ export function GroupOverviewModal({
           </div>
           <div className={[surface({ tone: "raised", radius: "2xl" }), "px-4 py-3"].join(" ")}>
             <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-white/45">
-              {t("auth_files.group_overview_avg_week_label")}
+              {(activeGroupOverview.weeklyFamilies?.length ?? 0) > 1
+                ? t("auth_files.group_overview_weekly_limits_label")
+                : t("auth_files.group_overview_avg_week_label")}
             </p>
-            <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
-              {formatAveragePercent(activeGroupOverview.averageWeekly)}
-            </p>
+            {(activeGroupOverview.weeklyFamilies?.length ?? 0) > 1 ? (
+              <div className="mt-2 space-y-1.5">
+                {activeGroupOverview.weeklyFamilies.map((family) => (
+                  <div key={family.id} className="flex items-baseline justify-between gap-3">
+                    <span className="min-w-0 truncate text-xs text-slate-500 dark:text-white/55">
+                      {family.label}
+                    </span>
+                    <span className="shrink-0 text-lg font-semibold text-slate-900 dark:text-white">
+                      {formatAveragePercent(family.remainingPercent)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+                {formatAveragePercent(activeGroupOverview.weeklyFamilies[0]?.remainingPercent ?? activeGroupOverview.averageWeekly)}
+              </p>
+            )}
             <p className="mt-1 text-xs text-slate-500 dark:text-white/45">
-              {t("auth_files.group_overview_avg_week_help")}
+              {(activeGroupOverview.weeklyFamilies?.length ?? 0) > 1
+                ? t("auth_files.group_overview_weekly_limits_help")
+                : t("auth_files.group_overview_avg_week_help")}
             </p>
           </div>
           <div className={[surface({ tone: "raised", radius: "2xl" }), "px-4 py-3"].join(" ")}>

--- a/pages/auth-files/hooks/groupOverviewWeekly.ts
+++ b/pages/auth-files/hooks/groupOverviewWeekly.ts
@@ -1,0 +1,117 @@
+import type { TFunction } from "i18next";
+import { parseAdditionalQuotaWindowLabel } from "@code-proxy/domain";
+import type { QuotaCardSlot } from "./quotaCardSlots";
+
+export const WEEKLY_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+
+export type GroupWeeklyFamily = {
+  id: string;
+  label: string;
+  remainingPercent: number | null;
+  sampleCount: number;
+};
+
+export type GroupOverviewSummary = {
+  totalCalls: number;
+  averageFiveHour: number | null;
+  averageWeekly: number | null;
+  weeklyFamilies: GroupWeeklyFamily[];
+  quotaSampleCount: number;
+};
+
+export type GroupTrendPoint = {
+  date: string;
+  label: string;
+  calls: number;
+  weeklyPercent: number | null;
+  weeklyPercents: Record<string, number | null>;
+};
+
+// Distinct from the call bars (blue) and from each other so two Antigravity
+// weeklies can sit on the same axis without blending into one "average".
+export const WEEKLY_SERIES_COLORS = ["#0f766e", "#d97706", "#2563eb", "#7c3aed", "#db2777", "#0891b2"];
+
+export const isWeeklyWindow = (windowSeconds: number | null | undefined): boolean =>
+  typeof windowSeconds === "number" && Number.isFinite(windowSeconds) && windowSeconds >= WEEKLY_WINDOW_SECONDS;
+
+const shortenAntigravityGroupName = (name: string): string => {
+  const trimmed = name.trim();
+  return trimmed.replace(/\s+models?$/i, "").trim() || trimmed;
+};
+
+export const collectWeeklyFamilies = (slotsByFile: QuotaCardSlot[][]): GroupWeeklyFamily[] => {
+  const order: string[] = [];
+  const buckets = new Map<string, { label: string; values: number[] }>();
+  for (const slots of slotsByFile) {
+    for (const slot of slots) {
+      if (!isWeeklyWindow(slot.item?.windowSeconds ?? null)) continue;
+      const percent = slot.item?.percent;
+      if (typeof percent !== "number" || !Number.isFinite(percent)) continue;
+      const existing = buckets.get(slot.id);
+      if (!existing) {
+        order.push(slot.id);
+        buckets.set(slot.id, { label: slot.label, values: [percent] });
+        continue;
+      }
+      existing.values.push(percent);
+    }
+  }
+  return order.map((id) => {
+    const bucket = buckets.get(id);
+    if (!bucket) {
+      return { id, label: id, remainingPercent: null, sampleCount: 0 };
+    }
+    const sum = bucket.values.reduce((total, value) => total + value, 0);
+    return {
+      id,
+      label: bucket.label,
+      remainingPercent: sum / bucket.values.length,
+      sampleCount: bucket.values.length,
+    };
+  });
+};
+
+export type RawGroupQuotaSeries = {
+  quota_key?: string;
+  quota_label?: string;
+  window_seconds?: number;
+  points?: { date: string; percent: number | null }[];
+};
+
+export const normalizeGroupTrendSeries = (
+  quotaSeries: RawGroupQuotaSeries[] | undefined,
+  quotaPoints: { date: string; percent: number | null }[] | undefined,
+): RawGroupQuotaSeries[] => {
+  if (Array.isArray(quotaSeries) && quotaSeries.length > 0) return quotaSeries;
+  if (quotaPoints && quotaPoints.length > 0) {
+    return [
+      {
+        quota_key: "code_week",
+        quota_label: "",
+        window_seconds: WEEKLY_WINDOW_SECONDS,
+        points: quotaPoints,
+      },
+    ];
+  }
+  return [];
+};
+
+export const formatWeeklySeriesLabel = (quotaKey: string, quotaLabel: string, t: TFunction): string => {
+  const key = quotaKey.trim();
+  const label = quotaLabel.trim();
+  if (key === "code_week") return t("m_quota.code_weekly");
+  if (key === "review_week") return t("m_quota.review_weekly");
+  if (key.startsWith("antigravity:")) {
+    const group = shortenAntigravityGroupName(label || key);
+    return `${group} · ${t("antigravity_quota.window_weekly")}`;
+  }
+  if (label.startsWith("m_quota.")) return t(label);
+  const additional = parseAdditionalQuotaWindowLabel(label);
+  if (additional) {
+    return t(`m_quota.additional_${additional.window}`, { name: additional.name });
+  }
+  if (label) return label;
+  return key || t("auth_files.group_overview_avg_week_label");
+};
+
+

--- a/pages/auth-files/hooks/useAuthFilesGroupOverview.ts
+++ b/pages/auth-files/hooks/useAuthFilesGroupOverview.ts
@@ -7,13 +7,20 @@ import {
   normalizeProviderKey,
   resolveAuthFileDisplayName,
   resolveFileType,
-  type AuthFilesGroupOverview,
   type AuthFilesGroupOverviewRow,
-  type AuthFilesGroupTrendPoint,
   type UsageIndex,
 } from "@code-proxy/domain";
 import type { QuotaItem, QuotaState } from "@features/quota-preview/quota-helpers";
 import type { QuotaProvider } from "@features/quota-preview/quota-fetch";
+import {
+  collectWeeklyFamilies,
+  formatWeeklySeriesLabel,
+  normalizeGroupTrendSeries,
+  WEEKLY_SERIES_COLORS,
+  type GroupOverviewSummary,
+  type GroupTrendPoint,
+} from "./groupOverviewWeekly";
+import type { QuotaCardSlot } from "./quotaCardSlots";
 
 interface UseAuthFilesGroupOverviewArgs {
   filter: string;
@@ -56,7 +63,10 @@ export function useAuthFilesGroupOverview({
   const [groupOverviewTab, setGroupOverviewTab] = useState("all");
   const [groupOverviewLoading, setGroupOverviewLoading] = useState(false);
   const [groupTrendLoading, setGroupTrendLoading] = useState(false);
-  const [groupTrendPoints, setGroupTrendPoints] = useState<AuthFilesGroupTrendPoint[]>([]);
+  const [groupTrendPoints, setGroupTrendPoints] = useState<GroupTrendPoint[]>([]);
+  const [groupTrendSeries, setGroupTrendSeries] = useState<{ id: string; label: string; color: string }[]>(
+    [],
+  );
   const groupTrendRequestRef = useRef(0);
 
   const formatAveragePercent = useCallback((value: number | null) => {
@@ -89,10 +99,10 @@ export function useAuthFilesGroupOverview({
   const groupOverviewTabs = useMemo(() => ["all", ...providerOptions], [providerOptions]);
 
   const computeGroupOverview = useCallback(
-    (targetFiles: AuthFileItem[]): AuthFilesGroupOverview => {
+    (targetFiles: AuthFileItem[]): GroupOverviewSummary => {
       let totalCalls = 0;
       const fiveHourValues: number[] = [];
-      const weeklyValues: number[] = [];
+      const weeklySlotsByFile: QuotaCardSlot[][] = [];
 
       targetFiles.forEach((file) => {
         const stats = resolveAuthFileStats(file, usageIndex);
@@ -106,13 +116,15 @@ export function useAuthFilesGroupOverview({
         if (items.length === 0) return;
 
         const slots = resolveQuotaCardSlots(provider, items);
+        weeklySlotsByFile.push(slots);
         const fiveHour = resolveSlotWindowPercent(slots, "5h");
-        const weekly = resolveSlotWindowPercent(slots, "week");
-
         if (fiveHour !== null) fiveHourValues.push(fiveHour);
-        if (weekly !== null) weeklyValues.push(weekly);
       });
 
+      const weeklyFamilies = collectWeeklyFamilies(weeklySlotsByFile);
+      const weeklyValues = weeklyFamilies
+        .map((family) => family.remainingPercent)
+        .filter((value): value is number => typeof value === "number");
       const average = (values: number[]) =>
         values.length === 0
           ? null
@@ -121,8 +133,9 @@ export function useAuthFilesGroupOverview({
       return {
         totalCalls,
         averageFiveHour: average(fiveHourValues),
-        averageWeekly: average(weeklyValues),
-        quotaSampleCount: Math.max(fiveHourValues.length, weeklyValues.length),
+        averageWeekly: weeklyFamilies.length === 1 ? weeklyFamilies[0]?.remainingPercent ?? null : average(weeklyValues),
+        weeklyFamilies,
+        quotaSampleCount: Math.max(fiveHourValues.length, ...weeklyFamilies.map((family) => family.sampleCount), 0),
       };
     },
     [
@@ -135,8 +148,8 @@ export function useAuthFilesGroupOverview({
     ],
   );
 
-  const groupOverviewByTab = useMemo<Record<string, AuthFilesGroupOverview>>(() => {
-    const map: Record<string, AuthFilesGroupOverview> = {
+  const groupOverviewByTab = useMemo<Record<string, GroupOverviewSummary>>(() => {
+    const map: Record<string, GroupOverviewSummary> = {
       all: computeGroupOverview(filteredFiles),
     };
     providerOptions.forEach((key) => {
@@ -188,7 +201,7 @@ export function useAuthFilesGroupOverview({
     usageIndex,
   ]);
 
-  const activeGroupOverview = useMemo<AuthFilesGroupOverview>(() => {
+  const activeGroupOverview = useMemo<GroupOverviewSummary>(() => {
     return (
       groupOverviewByTab[groupOverviewTab] ?? groupOverviewByTab.all ?? computeGroupOverview([])
     );
@@ -208,13 +221,34 @@ export function useAuthFilesGroupOverview({
   const groupOverviewChartOption = useMemo<Record<string, unknown>>(() => {
     const labels = groupTrendPoints.map((point) => point.label);
     const calls = groupTrendPoints.map((point) => point.calls);
-    const weekly = groupTrendPoints.map((point) => point.weeklyPercent);
+    const formatPercent = (value: unknown) => {
+      if (typeof value !== "number" || !Number.isFinite(value)) return "-";
+      return `${Math.round(Math.max(0, Math.min(100, value)))}%`;
+    };
+    const weeklySeries = groupTrendSeries.map((series) => ({
+      name: series.label,
+      type: "line",
+      yAxisIndex: 1,
+      smooth: true,
+      symbol: "circle",
+      symbolSize: 7,
+      lineStyle: { width: 3, color: series.color },
+      itemStyle: { color: series.color },
+      connectNulls: false,
+      data: groupTrendPoints.map((point) => point.weeklyPercents[series.id] ?? null),
+    }));
 
     return {
       backgroundColor: "transparent",
       animationDuration: 420,
       animationDurationUpdate: 280,
-      grid: { left: 48, right: 44, top: 36, bottom: 44, containLabel: false },
+      grid: {
+        left: 48,
+        right: 44,
+        top: groupTrendSeries.length > 2 ? 52 : 36,
+        bottom: 44,
+        containLabel: false,
+      },
       tooltip: {
         trigger: "axis",
         axisPointer: { type: "line" },
@@ -225,10 +259,20 @@ export function useAuthFilesGroupOverview({
         backgroundColor: "rgba(15, 23, 42, 0.92)",
         textStyle: { color: "#fff" },
         extraCssText: "z-index: 10000;",
+        formatter: (params: Array<{ seriesName?: string; value?: unknown; axisValueLabel?: string; marker?: string }>) => {
+          const title = params[0]?.axisValueLabel ?? "";
+          const rows = params.map((item) => {
+            const isPercent = item.seriesName !== t("auth_files.group_overview_total_calls_label");
+            const display = isPercent ? formatPercent(item.value) : String(item.value ?? 0);
+            return `${item.marker ?? ""} ${item.seriesName ?? ""}&nbsp;&nbsp;<b>${display}</b>`;
+          });
+          return [title, ...rows].join("<br/>");
+        },
       },
       legend: {
         top: 0,
         left: 0,
+        type: "scroll",
         textStyle: { color: "#64748b", fontSize: 12 },
       },
       xAxis: {
@@ -269,21 +313,10 @@ export function useAuthFilesGroupOverview({
           itemStyle: { color: "rgba(59,130,246,0.88)", borderRadius: [4, 4, 0, 0] },
           data: calls,
         },
-        {
-          name: t("auth_files.group_overview_avg_week_label"),
-          type: "line",
-          yAxisIndex: 1,
-          smooth: true,
-          symbol: "circle",
-          symbolSize: 7,
-          lineStyle: { width: 3, color: "#10b981" },
-          itemStyle: { color: "#10b981" },
-          connectNulls: false,
-          data: weekly,
-        },
+        ...weeklySeries,
       ],
     };
-  }, [groupTrendPoints, t]);
+  }, [groupTrendPoints, groupTrendSeries, t]);
 
   const refreshGroupOverview = useCallback(
     async (targetGroup = groupOverviewTab) => {
@@ -319,27 +352,43 @@ export function useAuthFilesGroupOverview({
       try {
         const axis = buildLast7DayAxis();
         const callsByDay = new Map(axis.map((item) => [item.date, 0]));
-        const weeklyByDay = new Map(axis.map((item) => [item.date, null as number | null]));
         const resp = await usageApi.getAuthFileGroupTrend(targetGroup, 7);
         (resp.points || []).forEach((point) => {
           if (callsByDay.has(point.date)) callsByDay.set(point.date, point.requests ?? 0);
         });
-        (resp.quota_points || []).forEach((point) => {
-          if (!weeklyByDay.has(point.date)) return;
-          const percent = point.percent;
-          weeklyByDay.set(
-            point.date,
-            typeof percent === "number" && Number.isFinite(percent) ? percent : null,
-          );
-        });
-        const points: AuthFilesGroupTrendPoint[] = axis.map((item) => ({
-          date: item.date,
-          label: item.label,
-          calls: callsByDay.get(item.date) ?? 0,
-          weeklyPercent: weeklyByDay.get(item.date) ?? null,
+        const rawSeries = normalizeGroupTrendSeries(resp.quota_series, resp.quota_points);
+        const seriesMeta = rawSeries.map((item, index) => ({
+          id: item.quota_key || `weekly_${index}`,
+          label: formatWeeklySeriesLabel(item.quota_key ?? "", item.quota_label ?? "", t),
+          color: WEEKLY_SERIES_COLORS[index % WEEKLY_SERIES_COLORS.length] ?? WEEKLY_SERIES_COLORS[0],
         }));
+        const percentsBySeries = new Map<string, Map<string, number | null>>();
+        rawSeries.forEach((item, index) => {
+          const id = seriesMeta[index]?.id ?? `weekly_${index}`;
+          const byDay = new Map(axis.map((day) => [day.date, null as number | null]));
+          (item.points || []).forEach((point) => {
+            if (!byDay.has(point.date)) return;
+            const percent = point.percent;
+            byDay.set(point.date, typeof percent === "number" && Number.isFinite(percent) ? percent : null);
+          });
+          percentsBySeries.set(id, byDay);
+        });
+        const points: GroupTrendPoint[] = axis.map((item) => {
+          const weeklyPercents: Record<string, number | null> = {};
+          seriesMeta.forEach((series) => {
+            weeklyPercents[series.id] = percentsBySeries.get(series.id)?.get(item.date) ?? null;
+          });
+          return {
+            date: item.date,
+            label: item.label,
+            calls: callsByDay.get(item.date) ?? 0,
+            weeklyPercent: seriesMeta[0] ? (weeklyPercents[seriesMeta[0].id] ?? null) : null,
+            weeklyPercents,
+          };
+        });
 
         if (groupTrendRequestRef.current === requestId) {
+          setGroupTrendSeries(seriesMeta);
           setGroupTrendPoints(points);
         }
       } finally {
@@ -348,7 +397,7 @@ export function useAuthFilesGroupOverview({
         }
       }
     },
-    [groupOverviewTab],
+    [groupOverviewTab, t],
   );
 
   const openGroupOverview = useCallback(() => {


### PR DESCRIPTION
## Summary
渠道组概览 treated weekly quota as a single remaining-% (first weekly bar, then `code_week` on the chart). Antigravity has two weeklies, so the summary showed only Gemini and the chart hover on 09-01 was `-`.

This reads backend `quota_series[]` (CliRelay #973) and also aggregates live card slots by weekly family (`windowSeconds >= 7d`). The modal lists every weekly together; the chart draws one line per family. Codex `code_week` / extra Spark weeks keep working as distinct series. 5h stays out of this card.

## Verification
- `./scripts/ci-pr.sh` locally except the first `test:ci` pass flaked on an unrelated paste-JSON dialog close; rerun: 175 files / 1293 tests passed
- `bun run build` and `bun run bundle:diff`
- Playwright `@critical` smoke

Depends on CliRelay https://github.com/kittors/CliRelay/pull/973 (expand/contract: backend first).