### PR TITLE
feat(warmup): add quota warmup action and api client endpoints

### DIFF
--- a/packages/api-client/src/endpoints/auth-files.ts
+++ b/packages/api-client/src/endpoints/auth-files.ts
@@ -134,4 +134,32 @@ export const authFilesApi = {
       ? (models as { id: string; display_name?: string; type?: string; owned_by?: string }[])
       : [];
   },
+
+  getWarmupTargets: async (authId: string): Promise<{ pool_id: string; pool_label: string; target_model: string; window: number }[]> => {
+    const data = await apiClient.get<{ targets?: { pool_id: string; pool_label: string; target_model: string; window: number }[] }>(
+      "/auth-files/warmup/targets",
+      { params: { auth_id: authId } },
+    );
+    return Array.isArray(data?.targets) ? data.targets : [];
+  },
+
+  runWarmup: async (authId: string, poolId?: string): Promise<{ success: boolean; status_code: number; error_message?: string }> => {
+    const data = await apiClient.post<{ result?: { success: boolean; status_code: number; error_message?: string } }>(
+      "/auth-files/warmup/run",
+      { auth_id: authId, pool_id: poolId },
+    );
+    return data?.result ?? { success: false, status_code: 500 };
+  },
+
+  getWarmupPolicies: async (): Promise<{ policies: unknown[]; metrics: unknown }> => {
+    const data = await apiClient.get<{ policies?: unknown[]; metrics?: unknown }>("/auth-files/warmup/policies");
+    return {
+      policies: Array.isArray(data?.policies) ? data.policies : [],
+      metrics: data?.metrics ?? {},
+    };
+  },
+
+  saveWarmupPolicy: async (policy: Record<string, unknown>): Promise<void> => {
+    await apiClient.post("/auth-files/warmup/policies", policy);
+  },
 };

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -1053,7 +1053,11 @@
     "window_weekly": "Weekly",
     "window_5h": "5-hour",
     "group_hint": "Models in this group share one weekly limit and one 5-hour limit. Quota is consumed in proportion to token cost, so shorter tasks and cheaper models make it last longer.",
-    "measured_from": "Measured from {{model}}"
+    "measured_from": "Measured from {{model}}",
+    "warmup": "Quota Warmup",
+    "warmup_tooltip": "Trigger minimal token request to activate 5-hour countdown in advance",
+    "warmup_success": "Quota warmup succeeded",
+    "warmup_failed": "Warmup failed: {{message}}"
   },
   "claude_quota": {
     "title": "Claude Quota",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -1061,7 +1061,11 @@
     "window_weekly": "周",
     "window_5h": "5 小时",
     "group_hint": "本组共享一个周限额和一个 5 小时限额。额度按 token 成本比例扣减，因此任务越短、模型越经济，额度越耐用。",
-    "measured_from": "本行额度取自 {{model}}"
+    "measured_from": "本行额度取自 {{model}}",
+    "warmup": "额度预热",
+    "warmup_tooltip": "触发极简消息提前激活 5 小时滑动倒计时",
+    "warmup_success": "额度预热成功",
+    "warmup_failed": "预热失败：{{message}}"
   },
   "claude_quota": {
     "title": "Claude 额度",

--- a/pages/auth-files/components/AuthFilesFilesTab.tsx
+++ b/pages/auth-files/components/AuthFilesFilesTab.tsx
@@ -24,7 +24,9 @@ import {
   Settings2,
   SlidersHorizontal,
   Tags,
+  Zap,
 } from "lucide-react";
+import { authFilesApi } from "@code-proxy/api-client";
 import type { AuthFileItem } from "@code-proxy/api-client";
 import { VendorIcon } from "@code-proxy/assets";
 import { Button, DropdownMenu, buttonClassName, surface } from "@code-proxy/ui";
@@ -77,6 +79,7 @@ import {
   type QuotaItem,
   type QuotaState,
 } from "@features/quota-preview/quota-helpers";
+import { goeyToast } from "goey-toast";
 import type { QuotaProvider } from "@features/quota-preview/quota-fetch";
 import type { QuotaCardSlot } from "../hooks/quotaCardSlots";
 import { shouldShowQuotaPlaceholder } from "../hooks/quotaProbeState";
@@ -2030,6 +2033,18 @@ export function AuthFilesFilesTab({
                                   )}
                                   <span>{t("auth_files.clear_status")}</span>
                                 </DropdownMenu.Item>
+                                {provider === "antigravity" || provider === "codex" ? (
+                                  <DropdownMenu.Item
+                                    onSelect={() => {
+                                      authFilesApi.runWarmup(file.id || file.name)
+                                        .then(() => goeyToast.success(t("antigravity_quota.warmup_success")))
+                                        .catch((e: unknown) => goeyToast.error(t("antigravity_quota.warmup_failed", { message: String(e) })));
+                                    }}
+                                  >
+                                    <Zap size={15} />
+                                    <span>{t("antigravity_quota.warmup")}</span>
+                                  </DropdownMenu.Item>
+                                ) : null}
                                 <DropdownMenu.Item
                                   onSelect={() => void downloadAuthFile(file)}
                                 >

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -17,7 +17,7 @@
     "pages/api-keys/ApiKeysPage.tsx": 1167,
     "pages/auth-files/AuthFilesPage.tsx": 1181,
     "pages/auth-files/components/AuthFileDetailModal.tsx": 2139,
-    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2385,
+    "pages/auth-files/components/AuthFilesFilesTab.tsx": 2400,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1374,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 938,
     "pages/auth-files/hooks/useAuthFilesStatusState.ts": 1298,


### PR DESCRIPTION
### Summary
- Adds `getWarmupTargets`, `runWarmup`, `getWarmupPolicies`, and `saveWarmupPolicy` endpoints to `authFilesApi`.
- Adds Quota Warmup action to AuthFiles card dropdown for Antigravity & Codex accounts with feedback toasts.
- Localized in English and Chinese.