### PR TITLE
fix(auth-files): filter out missing or null series in trend chart tooltip

### DIFF
--- a/pages/auth-files/__tests__/trendTooltipFormatter.test.ts
+++ b/pages/auth-files/__tests__/trendTooltipFormatter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import { formatTrendChartTooltip } from "../components/trendTooltipFormatter";
+
+describe("formatTrendChartTooltip", () => {
+  const mockFormatCurrency = (val: number) => `$${val.toFixed(4)}`;
+
+  test("filters out items with null, undefined, empty, or '--' values", () => {
+    const params = [
+      {
+        axisValueLabel: "09-04 16:00",
+        marker: "<span style='color:blue'>●</span>",
+        seriesName: "请求数",
+        seriesType: "bar",
+        seriesIndex: 0,
+        value: 115,
+      },
+      {
+        axisValueLabel: "09-04 16:00",
+        marker: "<span style='color:pink'>●</span>",
+        seriesName: "费用消耗",
+        seriesType: "line",
+        seriesIndex: 1,
+        value: 0.4295,
+      },
+      {
+        axisValueLabel: "09-04 16:00",
+        marker: "<span style='color:green'>●</span>",
+        seriesName: "Claude 已消耗",
+        seriesType: "line",
+        seriesIndex: 2,
+        value: null,
+      },
+      {
+        axisValueLabel: "09-04 16:00",
+        marker: "<span style='color:purple'>●</span>",
+        seriesName: "Gemini Flash 已消耗",
+        seriesType: "line",
+        seriesIndex: 3,
+        value: undefined,
+      },
+      {
+        axisValueLabel: "09-04 16:00",
+        marker: "<span style='color:teal'>●</span>",
+        seriesName: "Gemini Image 已消耗",
+        seriesType: "line",
+        seriesIndex: 4,
+        value: "--",
+      },
+      {
+        axisValueLabel: "09-04 16:00",
+        marker: "<span style='color:red'>●</span>",
+        seriesName: "Claude and GPT... 已消耗",
+        seriesType: "line",
+        seriesIndex: 5,
+        value: 21,
+      },
+    ];
+
+    const html = formatTrendChartTooltip(params, mockFormatCurrency);
+    expect(html).toContain("09-04 16:00");
+    expect(html).toContain("请求数");
+    expect(html).toContain("115");
+    expect(html).toContain("费用消耗");
+    expect(html).toContain("$0.4295");
+    expect(html).toContain("Claude and GPT... 已消耗");
+    expect(html).toContain("21.0%");
+    expect(html).not.toContain("Claude 已消耗");
+    expect(html).not.toContain("Gemini Flash 已消耗");
+    expect(html).not.toContain("Gemini Image 已消耗");
+    expect(html).not.toContain("--");
+  });
+
+  test("returns empty title when all series are empty", () => {
+    const params = [
+      {
+        axisValueLabel: "09-04 17:00",
+        seriesName: "Claude",
+        value: null,
+      },
+    ];
+    const html = formatTrendChartTooltip(params, mockFormatCurrency);
+    expect(html).toBe("09-04 17:00");
+  });
+});

--- a/pages/auth-files/components/AuthFileDetailModal.tsx
+++ b/pages/auth-files/components/AuthFileDetailModal.tsx
@@ -28,6 +28,7 @@ import { Modal } from "@code-proxy/ui";
 import { Select } from "@code-proxy/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@code-proxy/ui";
 import { ToggleSwitch } from "@code-proxy/ui";
+import { formatTrendChartTooltip } from "./trendTooltipFormatter";
 import { EChart } from "@code-proxy/ui";
 import { ProxyPoolSelect } from "@features/proxy-pool";
 import { useProxyPoolChecks } from "@features/proxy-pool";
@@ -426,7 +427,11 @@ export function AuthFileDetailModal({
       animationDurationUpdate: 0,
       animationEasing: "cubicOut" as const,
       grid: { left: 46, right: 108, top: 74, bottom: 38 },
-      tooltip: { trigger: "axis", confine: true },
+      tooltip: {
+        trigger: "axis",
+        confine: true,
+        formatter: (params: unknown) => formatTrendChartTooltip(params, formatCurrency),
+      },
       legend: {
         top: 8,
         left: 8,
@@ -508,9 +513,6 @@ export function AuthFileDetailModal({
           lineStyle: { width: 2.2, color: "#db2777" },
           itemStyle: { color: "#db2777" },
           areaStyle: { color: "rgba(219, 39, 119, 0.08)" },
-          tooltip: {
-            valueFormatter: (value: number) => formatCurrency(Number(value)),
-          },
           data: sortedKeys.map((key) => costByKey.get(key) ?? 0),
         },
         ...quotaBySeries.map(({ series, values }, index) => ({
@@ -527,10 +529,6 @@ export function AuthFileDetailModal({
           smooth: true,
           lineStyle: { width: 2, color: palette[(index + 2) % palette.length] },
           itemStyle: { color: palette[(index + 2) % palette.length] },
-          tooltip: {
-            valueFormatter: (value: number) =>
-              typeof value === "number" && Number.isFinite(value) ? `${value.toFixed(1)}%` : "--",
-          },
           data: sortedKeys.map((key) => values.get(key) ?? null),
         })),
       ],

--- a/pages/auth-files/components/trendTooltipFormatter.ts
+++ b/pages/auth-files/components/trendTooltipFormatter.ts
@@ -1,0 +1,36 @@
+export interface TrendChartTooltipItem {
+  marker?: string;
+  seriesName?: string;
+  seriesType?: string;
+  seriesIndex?: number;
+  value?: unknown;
+  axisValueLabel?: string;
+}
+
+export const formatTrendChartTooltip = (
+  params: unknown,
+  formatCurrency: (value: number) => string,
+): string => {
+  const items: TrendChartTooltipItem[] = Array.isArray(params) ? params : [params as TrendChartTooltipItem];
+  const title = items[0]?.axisValueLabel ?? "";
+  const activeItems = items.filter((item) => {
+    const val = item?.value;
+    return val !== null && val !== undefined && val !== "" && val !== "--";
+  });
+  if (activeItems.length === 0) return title;
+  const lines = activeItems.map((item) => {
+    const marker = item?.marker ?? "";
+    const name = item?.seriesName ?? "";
+    const val = item?.value;
+    let displayVal = String(val ?? "");
+    if (item?.seriesType === "bar") {
+      displayVal = String(val ?? 0);
+    } else if (item?.seriesIndex === 1) {
+      displayVal = formatCurrency(Number(val));
+    } else if (typeof val === "number" && Number.isFinite(val)) {
+      displayVal = `${val.toFixed(1)}%`;
+    }
+    return `<div style="display:flex;align-items:center;justify-content:space-between;gap:16px;"><span>${marker}${name}</span><b>${displayVal}</b></div>`;
+  });
+  return `<div><div style="font-weight:600;margin-bottom:4px;">${title}</div>${lines.join("")}</div>`;
+};

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -16,7 +16,7 @@
     "pages/api-key-lookup/ApiKeyLookupPage.tsx": 1743,
     "pages/api-keys/ApiKeysPage.tsx": 1167,
     "pages/auth-files/AuthFilesPage.tsx": 1137,
-    "pages/auth-files/components/AuthFileDetailModal.tsx": 2139,
+    "pages/auth-files/components/AuthFileDetailModal.tsx": 2137,
     "pages/auth-files/components/AuthFilesFilesTab.tsx": 2370,
     "pages/auth-files/hooks/useAuthFilesDetailEditors.ts": 1374,
     "pages/auth-files/hooks/useAuthFilesFilesPresentation.tsx": 938,


### PR DESCRIPTION
Custom formatter for trend chart axis tooltip to hide series rows that have null, undefined, or empty values instead of displaying dangling '--' lines.