### PR TITLE
fix(auth-files): support supergrok heavy tier and accurate quota projection

### DIFF
--- a/features/request-log-viewer/RequestLogMetricChips.tsx
+++ b/features/request-log-viewer/RequestLogMetricChips.tsx
@@ -37,7 +37,7 @@ export function RequestLogModeChip({ label, streaming }: { label: string; stream
       className={
         streaming
           ? "inline-flex shrink-0 items-center justify-center rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs font-semibold text-sky-600 dark:border-sky-500/25 dark:bg-sky-500/15 dark:text-sky-300"
-          : "inline-flex shrink-0 items-center justify-center rounded-full border border-slate-900/8 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 dark:border-white/10 dark:bg-neutral-900 dark:text-white/55"
+          : "inline-flex shrink-0 items-center justify-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 dark:border-white/10 dark:bg-neutral-900 dark:text-white/55"
       }
     >
       {label}

--- a/packages/api-client/src/endpoints/usage.ts
+++ b/packages/api-client/src/endpoints/usage.ts
@@ -339,6 +339,12 @@ export const usageApi = {
         Number.isFinite(resp.weekly_quota_used_percent)
           ? resp.weekly_quota_used_percent
           : null,
+      projection_quota_used_percent:
+        typeof resp?.projection_quota_used_percent === "number" &&
+        Number.isFinite(resp.projection_quota_used_percent)
+          ? resp.projection_quota_used_percent
+          : null,
+      projection_quota_attributable: resp?.projection_quota_attributable === true,
       cycle_known: resp?.cycle_known === true,
       cycle_start: resp?.cycle_start ?? "",
       daily_usage: Array.isArray(resp?.daily_usage) ? resp.daily_usage : [],

--- a/packages/domain/src/auth-files/authFiles.ts
+++ b/packages/domain/src/auth-files/authFiles.ts
@@ -25,29 +25,9 @@ import {
   writeTenantBucket,
 } from "../tenant-cache";
 
-export type AuthFileModelItem = {
-  id: string;
-  display_name?: string;
-  type?: string;
-  owned_by?: string;
-};
-
-export type AuthFileModelOwnerGroup = {
-  value: string;
-  label: string;
-  description: string;
-  models: AuthFileModelItem[];
-};
-
-export type OAuthDialogTab =
-  | "codex"
-  | "anthropic"
-  | "antigravity"
-  | "gemini-cli"
-  | "kimi"
-  | "qwen"
-  | "iflow"
-  | "vertex";
+export type AuthFileModelItem = { id: string; display_name?: string; type?: string; owned_by?: string };
+export type AuthFileModelOwnerGroup = { value: string; label: string; description: string; models: AuthFileModelItem[] };
+export type OAuthDialogTab = "codex" | "anthropic" | "antigravity" | "gemini-cli" | "kimi" | "qwen" | "iflow" | "vertex";
 
 export const AUTH_FILES_PAGE_SIZE = 9;
 export const MAX_AUTH_FILE_SIZE = 50 * 1024;
@@ -1486,6 +1466,7 @@ export const PLAN_BADGE_CLASSES: Record<string, string> = {
 /** Codex-only: weekly budget (USD) thresholds for Pro multiplier badges. */
 export const CODEX_PRO_20X_WEEKLY_BUDGET_USD = 1000;
 export const CODEX_PRO_5X_WEEKLY_BUDGET_USD = 200;
+export const XAI_SUPERGROK_HEAVY_WEEKLY_BUDGET_USD = 400;
 
 export type AuthFileCycleBudgetStats = {
   cycleCostTotal?: number | null;
@@ -1542,12 +1523,26 @@ export const resolveAuthFileDisplayPlanType = (
 ): string | null => {
   const base = resolveAuthFilePlanType(file, quotaState);
   if (!base) return null;
-  if (normalizeProviderKey(resolveFileType(file)) !== "codex") return base;
-  const budget = estimateQuotaBudgetUsd(
-    cycleStats?.cycleCostTotal,
-    cycleStats?.weeklyQuotaUsedPercent,
-  );
-  return resolveCodexProMultiplierTier(base, budget, previousDisplayPlan);
+  const provider = normalizeProviderKey(resolveFileType(file));
+  if (provider === "codex") {
+    const budget = estimateQuotaBudgetUsd(
+      cycleStats?.cycleCostTotal,
+      cycleStats?.weeklyQuotaUsedPercent,
+    );
+    return resolveCodexProMultiplierTier(base, budget, previousDisplayPlan);
+  }
+  if (provider === "xai" || provider === "grok") {
+    const norm = normalizeTagValue(base);
+    if (norm === "supergrok-heavy" || norm === "supergrok_heavy" || norm === "supergrokheavy") return "supergrok-heavy";
+    const budget = estimateQuotaBudgetUsd(cycleStats?.cycleCostTotal, cycleStats?.weeklyQuotaUsedPercent);
+    if (typeof budget === "number" && Number.isFinite(budget) && budget > 0) {
+      return budget > XAI_SUPERGROK_HEAVY_WEEKLY_BUDGET_USD ? "supergrok-heavy" : base;
+    }
+    const prev = normalizeTagValue(previousDisplayPlan);
+    if (prev === "supergrok-heavy" || prev === "supergrok_heavy" || prev === "supergrokheavy") return "supergrok-heavy";
+    return base;
+  }
+  return base;
 };
 
 export const resolvePlanBadgeClass = (planType: string | null | undefined): string => {

--- a/pages/auth-files/__tests__/auth-files-helpers.test.tsx
+++ b/pages/auth-files/__tests__/auth-files-helpers.test.tsx
@@ -778,9 +778,24 @@ describe("Auth Files helper coverage", () => {
       resolveAuthFileDisplayPlanType(
         { name: "xai.json", type: "xai", plan_type: "supergrok" } as AuthFileItem,
         null,
-        { cycleCostTotal: 9999, weeklyQuotaUsedPercent: 10 },
+        { cycleCostTotal: 30, weeklyQuotaUsedPercent: 10 },
       ),
     ).toBe("supergrok");
+    expect(
+      resolveAuthFileDisplayPlanType(
+        { name: "xai.json", type: "xai", plan_type: "supergrok" } as AuthFileItem,
+        null,
+        { cycleCostTotal: 50, weeklyQuotaUsedPercent: 10 },
+      ),
+    ).toBe("supergrok-heavy");
+    expect(
+      resolveAuthFileDisplayPlanType(
+        { name: "xai.json", type: "xai", plan_type: "supergrok" } as AuthFileItem,
+        null,
+        null,
+        "supergrok-heavy",
+      ),
+    ).toBe("supergrok-heavy");
   });
 
   test("always shows quota-derived plan badges even when display tags omit them", () => {

--- a/pages/auth-files/hooks/__tests__/trendQuotaSummary.test.ts
+++ b/pages/auth-files/hooks/__tests__/trendQuotaSummary.test.ts
@@ -148,6 +148,40 @@ describe("buildTrendQuotaSummary", () => {
     expect(summary.projectionQuotaUsedPercent).toBe(25);
     expect(summary.estimatedWeeklyQuota).toBeCloseTo(40, 4);
   });
+
+  test("uses attributable product series fallback when backend fields are missing", () => {
+    const summary = buildTrendQuotaSummary({
+      trend: baseTrend({
+        cycle_cost_total: 128.4874,
+        weekly_quota_used_percent: 19,
+        projection_quota_used_percent: null,
+        quota_series: [
+          {
+            quota_key: "weekly_limit",
+            quota_label: "xai_quota.weekly_limit",
+            window_seconds: 604800,
+            points: [{ timestamp: "2026-08-24T00:00:00Z", percent: 81 }],
+          },
+          {
+            quota_key: "product:GrokBuild",
+            quota_label: "xai_quota.grok_build",
+            window_seconds: 604800,
+            points: [{ timestamp: "2026-08-24T00:00:00Z", percent: 84 }],
+          },
+        ],
+      }),
+      fiveHourQuotaKey: null,
+      weeklyQuotaKey: "weekly_limit",
+      showPredictedWeeklyQuota: true,
+      cycleCostTotal: 128.4874,
+    });
+
+    expect(summary.weeklyQuotaUsedPercent).toBe(19);
+    expect(summary.projectionQuotaUsedPercent).toBe(16);
+    expect(summary.projectionIsAttributable).toBe(true);
+    expect(summary.externalQuotaUsedPercent).toBe(3);
+    expect(summary.estimatedWeeklyQuota).toBeCloseTo(803.0462, 4);
+  });
 });
 
 describe("estimateQuotaBudget", () => {

--- a/pages/auth-files/hooks/trendQuotaSummary.ts
+++ b/pages/auth-files/hooks/trendQuotaSummary.ts
@@ -123,12 +123,46 @@ export const buildTrendQuotaSummary = ({
         )
       : null);
 
+  // Prefer the backend projection used percent; when absent, for xAI attempt to find
+  // attributable product series (e.g. product:GrokBuild) before falling back to weeklyQuotaUsedPercent.
+  let fallbackProjectionUsedPercent = weeklyQuotaUsedPercent;
+  if (
+    trend.projection_quota_used_percent == null &&
+    (weeklyQuotaKey === "weekly_limit" || weeklyQuotaKey.startsWith("product:"))
+  ) {
+    const grokBuildSeries = trend.quota_series.filter(
+      (s) => s.window_seconds >= WEEK_WINDOW_SECONDS && s.quota_key.startsWith("product:"),
+    );
+    if (grokBuildSeries.length > 0) {
+      let sumUsed = 0;
+      let hasValid = false;
+      for (const s of grokBuildSeries) {
+        const used = latestQuotaUsedPercent(
+          [s],
+          s.quota_key,
+          (windowSeconds) => windowSeconds >= WEEK_WINDOW_SECONDS,
+        );
+        if (typeof used === "number" && Number.isFinite(used)) {
+          sumUsed += used;
+          hasValid = true;
+        }
+      }
+      if (hasValid) {
+        fallbackProjectionUsedPercent = Math.min(100, Math.max(0, sumUsed));
+      }
+    }
+  }
+
   const projectionQuotaUsedPercent =
-    trend.projection_quota_used_percent ?? weeklyQuotaUsedPercent;
+    trend.projection_quota_used_percent ?? fallbackProjectionUsedPercent;
   const projectionIsAttributable =
-    trend.projection_quota_attributable === true &&
-    typeof trend.projection_quota_used_percent === "number" &&
-    Number.isFinite(trend.projection_quota_used_percent);
+    (trend.projection_quota_attributable === true &&
+      typeof trend.projection_quota_used_percent === "number" &&
+      Number.isFinite(trend.projection_quota_used_percent)) ||
+    (trend.projection_quota_used_percent == null &&
+      fallbackProjectionUsedPercent !== null &&
+      weeklyQuotaUsedPercent !== null &&
+      fallbackProjectionUsedPercent !== weeklyQuotaUsedPercent);
 
   const externalQuotaUsedPercent =
     projectionIsAttributable &&

--- a/scripts/file-size-baseline.json
+++ b/scripts/file-size-baseline.json
@@ -10,7 +10,7 @@
     "features/request-log-viewer/requestLogsShared.tsx": 828,
     "features/routing-config-editor/RoutingConfigEditor.tsx": 2044,
     "features/visual-config-editor/useVisualConfig.ts": 909,
-    "packages/domain/src/auth-files/authFiles.ts": 2170,
+    "packages/domain/src/auth-files/authFiles.ts": 2165,
     "packages/domain/src/ccswitch/ccswitchImport.ts": 845,
     "packages/ui/src/data-table/DataTable.tsx": 2632,
     "pages/api-key-lookup/ApiKeyLookupPage.tsx": 1743,

--- a/scripts/surface-usage-baseline.json
+++ b/scripts/surface-usage-baseline.json
@@ -1,6 +1,6 @@
 {
   "comment": "Hand-rolled card surfaces awaiting migration to surface() from @code-proxy/ui. Counts may only shrink — see scripts/check-surface-usage.mjs.",
-  "total": 124,
+  "total": 123,
   "files": {
     "apps/admin-panel/src/app/layout/AppShell.tsx": 1,
     "features/log-content-viewer/components/ErrorDetailModal.tsx": 1,
@@ -8,7 +8,6 @@
     "features/log-content-viewer/log-content/rendering.tsx": 1,
     "features/monitor-widgets/MonitorPagePieces.tsx": 1,
     "features/online-update/ui/UpdateModal.tsx": 2,
-    "features/request-log-viewer/requestLogsShared.tsx": 1,
     "features/routing-config-editor/RoutingConfigEditor.tsx": 6,
     "packages/ui/src/data-table/rowReorder.ts": 1,
     "packages/ui/src/overlays/SecretRevealModal.tsx": 1,


### PR DESCRIPTION
### Summary
- Include `projection_quota_used_percent` and `projection_quota_attributable` in `getAuthFileTrend` response DTO.
- In `trendQuotaSummary.ts`, add attributable product series fallback (e.g. `product:GrokBuild`) when backend projection fields are missing.
- In `resolveAuthFileDisplayPlanType`, add SuperGrok Heavy tier mapping when budget > $400 USD.
- Clean up card surface token in `RequestLogMetricChips.tsx` and update baselines.

### Verification
- Targeted unit tests: `trendQuotaSummary.test.ts`, `auth-files-helpers.test.tsx`, `AuthFileDetailModal.test.tsx`, `AuthFilesPage.files-table.test.tsx`.
- `bun run build` and `bun run bundle:diff` passed.