### PR TITLE
feat(quota): harden codex reset with FIFO credit selection and official desktop headers

### DIFF
--- a/features/quota-preview/__tests__/quota-fetch.test.ts
+++ b/features/quota-preview/__tests__/quota-fetch.test.ts
@@ -122,6 +122,14 @@ describe("fetchQuota for codex", () => {
 
 describe("consumeCodexResetCredit", () => {
   test("posts a redeem request id to the ChatGPT reset-credit consume endpoint", async () => {
+    // Details query returns empty credits
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: { credits: [] },
+    });
+    // Consume returns success
     mocks.request.mockResolvedValueOnce({
       statusCode: 200,
       header: {},
@@ -137,8 +145,8 @@ describe("consumeCodexResetCredit", () => {
       id_token: buildSyntheticCodexIdToken("acct-111"),
     } as any);
 
-    expect(mocks.request).toHaveBeenCalledTimes(1);
-    const payload = mocks.request.mock.calls[0]?.[0];
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    const payload = mocks.request.mock.calls[1]?.[0];
     expect(payload).toEqual(
       expect.objectContaining({
         authIndex: "auth-codex-alpha",
@@ -157,6 +165,42 @@ describe("consumeCodexResetCredit", () => {
       ),
     });
   });
+  test("consumes specific credit_id in FIFO order when credits are available", async () => {
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: {
+        credits: [
+          { id: "credit-later", expires_at: "2026-08-10T00:00:00Z" },
+          { id: "credit-earlier", expires_at: "2026-08-01T00:00:00Z" },
+        ],
+      },
+    });
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      header: {},
+      bodyText: "",
+      body: { code: "success", windows_reset: 1 },
+    });
+
+    await consumeCodexResetCredit({
+      name: "codex-alpha@example.test-plus.json",
+      type: "codex",
+      provider: "codex",
+      auth_index: "auth-codex-alpha",
+    } as any);
+
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    const consumePayload = mocks.request.mock.calls[1]?.[0];
+    expect(JSON.parse(consumePayload.data)).toEqual({
+      redeem_request_id: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      ),
+      credit_id: "credit-earlier",
+    });
+  });
+
 });
 
 describe("fetchQuota for antigravity", () => {

--- a/features/quota-preview/quota-codex.ts
+++ b/features/quota-preview/quota-codex.ts
@@ -187,6 +187,34 @@ export const resolveCodexResetCreditExpirations = (payload: unknown): string[] =
     });
   return [...new Set(sorted)];
 };
+export type CodexResetCreditCandidate = {
+  id?: string;
+  expiresAt?: string;
+};
+
+export const resolveCodexResetCreditCandidates = (payload: unknown): CodexResetCreditCandidate[] => {
+  const rawList = readCodexResetCreditList(payload);
+  const items: CodexResetCreditCandidate[] = [];
+  for (const credit of rawList) {
+    if (!isRecord(credit)) continue;
+    const id = normalizeStringValue(credit.id ?? credit.credit_id ?? credit.creditId) ?? undefined;
+    const expiresAt = normalizeStringValue(credit.expires_at ?? credit.expiresAt) ?? undefined;
+    const resetType = normalizeStringValue(credit.reset_type ?? credit.resetType);
+    if (resetType && resetType.toLowerCase() !== "codex_rate_limits") continue;
+    const status = normalizeStringValue(credit.status);
+    if (status && status.toLowerCase() !== "available") continue;
+    items.push({ id, expiresAt });
+  }
+  return items.sort((left, right) => {
+    const leftMs = left.expiresAt ? Date.parse(left.expiresAt) : Number.POSITIVE_INFINITY;
+    const rightMs = right.expiresAt ? Date.parse(right.expiresAt) : Number.POSITIVE_INFINITY;
+    const leftSort = Number.isNaN(leftMs) ? Number.POSITIVE_INFINITY : leftMs;
+    const rightSort = Number.isNaN(rightMs) ? Number.POSITIVE_INFINITY : rightMs;
+    if (leftSort === rightSort) return 0;
+    return leftSort < rightSort ? -1 : 1;
+  });
+};
+
 
 const resolveCodexResetAtMs = (window?: CodexUsageWindow | null): number | undefined => {
   if (!window) return undefined;

--- a/features/quota-preview/quota-fetch.ts
+++ b/features/quota-preview/quota-fetch.ts
@@ -51,6 +51,7 @@ import {
   resolveCodexChatgptAccountId,
   resolveCodexResetCreditExpirations,
   resolveCodexResetCreditCount,
+  resolveCodexResetCreditCandidates,
   resolveXaiPlanType,
   resolveGeminiCliProjectId,
   resolveXaiUserId,
@@ -120,13 +121,47 @@ export const resolveQuotaProvider = (file: AuthFileItem): QuotaProvider | null =
 export const isQuotaSupportedAuthFile = (file: AuthFileItem): boolean =>
   resolveQuotaProvider(file) !== null;
 
-export const consumeCodexResetCredit = async (file: AuthFileItem): Promise<void> => {
+export const consumeCodexResetCredit = async (
+  file: AuthFileItem,
+  options?: { creditId?: string },
+): Promise<void> => {
+  const authIndex = resolveAuthIndex(file);
+  const header = buildCodexRequestHeaders(file);
+
+  let targetCreditId = options?.creditId;
+  if (!targetCreditId) {
+    // FIFO: query candidate credits to pick the earliest expiring credit if available
+    try {
+      const details = await apiCallApi.request({
+        authIndex,
+        method: "GET",
+        url: CODEX_RESET_CREDITS_URL,
+        header,
+      });
+      if (details.statusCode >= 200 && details.statusCode < 300) {
+        const candidates = resolveCodexResetCreditCandidates(details.body ?? details.bodyText);
+        if (candidates.length > 0 && candidates[0]?.id) {
+          targetCreditId = candidates[0].id;
+        }
+      }
+    } catch {
+      // Fall back to untargeted reset if candidates query fails
+    }
+  }
+
+  const payload: Record<string, string> = {
+    redeem_request_id: createRedeemRequestId(),
+  };
+  if (targetCreditId) {
+    payload.credit_id = targetCreditId;
+  }
+
   const result = await apiCallApi.request({
-    authIndex: resolveAuthIndex(file),
+    authIndex,
     method: "POST",
     url: CODEX_RESET_CREDITS_CONSUME_URL,
-    header: buildCodexRequestHeaders(file),
-    data: JSON.stringify({ redeem_request_id: createRedeemRequestId() }),
+    header,
+    data: JSON.stringify(payload),
   });
   if (result.statusCode < 200 || result.statusCode >= 300) {
     throw new Error(getApiCallErrorMessage(result));

--- a/features/quota-preview/quota-helpers.ts
+++ b/features/quota-preview/quota-helpers.ts
@@ -22,6 +22,8 @@ export {
   resolveCodexResetCreditExpirations,
   resolveCodexResetCreditCount,
   resolveCodexChatgptAccountId,
+  resolveCodexResetCreditCandidates,
+  type CodexResetCreditCandidate,
 } from "@features/quota-preview/quota-codex";
 export { type ClaudeUsagePayload } from "@features/quota-preview/quota-claude";
 export { buildClaudeItems, parseClaudeUsagePayload } from "@features/quota-preview/quota-claude";
@@ -128,7 +130,13 @@ export const CODEX_RESET_CREDITS_CONSUME_URL =
 export const CODEX_REQUEST_HEADERS = {
   Authorization: "Bearer $TOKEN$",
   "Content-Type": "application/json",
-  "User-Agent": "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+  "User-Agent": "codex_cli_rs/0.149.1 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9",
+  Originator: "Codex Desktop",
+  "OpenAI-Beta": "codex-1",
+  Accept: "application/json",
+  "Sec-Fetch-Site": "none",
+  "Sec-Fetch-Mode": "no-cors",
+  "Sec-Fetch-Dest": "empty",
 };
 
 export const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";

--- a/packages/domain/src/quota/constants.ts
+++ b/packages/domain/src/quota/constants.ts
@@ -136,7 +136,13 @@ export const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 export const CODEX_REQUEST_HEADERS = {
   Authorization: "Bearer $TOKEN$",
   "Content-Type": "application/json",
-  "User-Agent": "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal",
+  "User-Agent": "codex_cli_rs/0.149.1 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9",
+  Originator: "Codex Desktop",
+  "OpenAI-Beta": "codex-1",
+  Accept: "application/json",
+  "Sec-Fetch-Site": "none",
+  "Sec-Fetch-Mode": "no-cors",
+  "Sec-Fetch-Dest": "empty",
 };
 
 // Kiro (AWS CodeWhisperer) API configuration


### PR DESCRIPTION
### Summary
- Aligns Codex headers with official Codex Desktop client profile (`Originator: Codex Desktop`, modern user agent, `OpenAI-Beta: codex-1`, and `Sec-Fetch-*` headers).
- Implements FIFO (first-in-first-out) candidate credit selection in `consumeCodexResetCredit`, consuming the earliest-expiring credit ID rather than relying on arbitrary upstream deduction.
- Maintains strict frozen file size baseline and boundary checks.

### Verification
- Ran `bun run lint` (PASS)
- Ran `bun run design:check` (PASS)
- Ran `bun run boundary:imports` (PASS)
- Ran `bun run size:check` (PASS)
- Ran `vitest run quota-fetch.test.ts quota-helpers.test.ts` (PASS)
- Ran `bun run build` (PASS)