### PR TITLE
feat(quota): show when the 5h window resets

### DIFF
--- a/features/period-spending/PeriodSpendingCell.tsx
+++ b/features/period-spending/PeriodSpendingCell.tsx
@@ -55,6 +55,20 @@ const orderedItems = (items: PeriodSpendingItem[] | undefined): PeriodSpendingIt
   });
 };
 
+/**
+ * 只有 5h 是服务端锚定的窗口，到点整窗清零，因此它能给出确切的恢复时刻。
+ * 缺少 resets_at（未开窗，或日历周期）时不编造倒计时。
+ */
+const resetHint = (
+  t: (key: string, options?: Record<string, unknown>) => string,
+  item: PeriodSpendingItem,
+): string | null => {
+  if (!item.resets_at) return null;
+  const resetsAt = new Date(item.resets_at);
+  if (Number.isNaN(resetsAt.getTime())) return null;
+  return t("quota.window_resets_at", { time: resetsAt.toLocaleString() });
+};
+
 const chipTone = (ratio: number) => {
   if (ratio >= 1) {
     return "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200";
@@ -96,15 +110,17 @@ export function PeriodSpendingCell({
         const ratio = item.limit > 0 ? item.used / item.limit : 0;
         const danger = ratio >= 1;
         const warning = ratio >= 0.9 && !danger;
+        const usage = t("quota.used_of_limit", {
+          period: periodLabel(t, item.period),
+          used: formatQuotaUsd(item.used),
+          limit: formatQuotaUsd(item.limit),
+        });
+        const reset = resetHint(t, item);
         return (
           <span
             key={item.period}
             className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium tabular-nums ${chipTone(ratio)}`}
-            title={t("quota.used_of_limit", {
-              period: periodLabel(t, item.period),
-              used: formatQuotaUsd(item.used),
-              limit: formatQuotaUsd(item.limit),
-            })}
+            title={reset ? `${usage} · ${reset}` : usage}
           >
             {danger ? <AlertCircle size={13} aria-hidden="true" /> : null}
             {warning ? <AlertTriangle size={13} aria-hidden="true" /> : null}
@@ -123,7 +139,7 @@ export function PeriodSpendingCell({
 }
 
 /**
- * Rolling periods are shown as used/limit because they refill on their own; the
+ * Windowed periods are shown as used/limit because they refill on their own; the
  * lifetime cap only ever counts down, so what operators need from it is how much
  * is left before the account stops.
  */

--- a/features/period-spending/__tests__/PeriodSpendingCell.test.tsx
+++ b/features/period-spending/__tests__/PeriodSpendingCell.test.tsx
@@ -58,6 +58,58 @@ describe("PeriodSpendingCell", () => {
     expect(screen.getByText("Unlimited")).toBeInTheDocument();
   });
 
+  test("surfaces the 5h reset instant, and only where the backend anchors one", () => {
+    const tooltipT = (key: string, options?: Record<string, unknown>) => {
+      const labels: Record<string, string> = {
+        "quota.period.5h": "5 hours",
+        "quota.period.day": "Day",
+        "quota.used_of_limit": `${String(options?.period ?? "")} usage`,
+        "quota.window_resets_at": `resets ${String(options?.time ?? "")}`,
+      };
+      return labels[key] ?? key;
+    };
+    const resetsAt = new Date("2026-07-22T17:00:00Z");
+    render(
+      <PeriodSpendingCell
+        t={tooltipT}
+        items={[
+          {
+            period: "5h",
+            limit: 100,
+            used: 39,
+            remaining: 61,
+            window_start: "2026-07-22T12:00:00Z",
+            resets_at: resetsAt.toISOString(),
+          },
+          { period: "day", limit: 300, used: 39, remaining: 261 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTitle(`5 hours usage · resets ${resetsAt.toLocaleString()}`)).toBeTruthy();
+    // 日历周期没有服务端锚定的窗口，不能凭空造一个恢复时刻。
+    expect(screen.getByTitle("Day usage")).toBeTruthy();
+  });
+
+  test("ignores an unparsable reset instant instead of rendering Invalid Date", () => {
+    const tooltipT = (key: string, options?: Record<string, unknown>) => {
+      const labels: Record<string, string> = {
+        "quota.period.5h": "5 hours",
+        "quota.used_of_limit": `${String(options?.period ?? "")} usage`,
+        "quota.window_resets_at": `resets ${String(options?.time ?? "")}`,
+      };
+      return labels[key] ?? key;
+    };
+    render(
+      <PeriodSpendingCell
+        t={tooltipT}
+        items={[{ period: "5h", limit: 100, used: 39, remaining: 61, resets_at: "not-a-date" }]}
+      />,
+    );
+
+    expect(screen.getByTitle("5 hours usage")).toBeTruthy();
+  });
+
   test("renders template limits without fake used values", () => {
     const { container } = render(
       <PeriodSpendingLimitsCell t={t} limits={{ "5h": 100, day: 300, week: 0, month: 4000 }} />,

--- a/packages/api-client/src/endpoints/period-spending.ts
+++ b/packages/api-client/src/endpoints/period-spending.ts
@@ -7,9 +7,10 @@ export type PeriodSpendingPeriod = (typeof PERIOD_SPENDING_PERIODS)[number];
 
 /**
  * The cumulative allowance is resettable like a period, but it is not one of the
- * rolling periods: it has no window, and its limit lives in `spending-limit`
- * rather than the period limits. Keeping it out of PERIOD_SPENDING_PERIODS keeps
- * the four-field limit editors and per-period cells untouched.
+ * windowed periods: it has no window at all, and its limit lives in
+ * `spending-limit` rather than the period limits. Keeping it out of
+ * PERIOD_SPENDING_PERIODS keeps the four-field limit editors and per-period
+ * cells untouched.
  */
 export const LIFETIME_QUOTA_PERIOD = "lifetime" as const;
 
@@ -34,6 +35,15 @@ export interface PeriodSpendingItem {
   limit: number;
   used: number;
   remaining: number;
+  /**
+   * Only the 5h window is anchored server-side: it opens on the first billed
+   * spend and clears five hours later, so the backend sends its real boundaries.
+   * Calendar periods (day/week/month) carry neither field — their boundaries are
+   * derivable, and inventing one here would show a countdown that isn't real.
+   * Both are RFC 3339 strings, absent while no window is open.
+   */
+  window_start?: string;
+  resets_at?: string;
 }
 
 export interface CappedKey {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4768,6 +4768,7 @@
     "account_limit_value": "Account limit {{value}}",
     "account_unlimited": "Account unlimited",
     "used_of_limit": "{{period}}: {{used}} of {{limit}} used",
+    "window_resets_at": "Resets at {{time}}",
     "lifetime_label": "Lifetime",
     "remaining_value": "{{remaining}} left",
     "lifetime_remaining_detail": "Lifetime: {{used}} used, {{limit}} cap, {{remaining}} left",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4785,6 +4785,7 @@
     "account_limit_value": "账号上限 {{value}}",
     "account_unlimited": "账号不限制",
     "used_of_limit": "{{period}}：已用 {{used}}，上限 {{limit}}",
+    "window_resets_at": "{{time}} 重置",
     "lifetime_label": "累计",
     "remaining_value": "剩 {{remaining}}",
     "lifetime_remaining_detail": "累计：已用 {{used}}，上限 {{limit}}，剩余 {{remaining}}",


### PR DESCRIPTION
## 背景

配套后端 [kittors/CliRelay#1013](https://github.com/kittors/CliRelay/pull/1013)。

5h 子配额过去是滚动窗口，只能回看「过去五小时」，没有可展示的重置时刻。后端已改成首次计费消费锚定的固定窗口——窗口到点整体清零，因此能给出真实边界。本 PR 把这个边界露给用户。

这正是客户反馈的痛点所在：被限流之后，用户无从得知什么时候能恢复。

## 改动

`PeriodSpendingItem` 增加可选的 `window_start` / `resets_at`（RFC 3339），5h chip 的 tooltip 追加重置时刻。

两个刻意的边界处理：

- **日历周期不显示。** day/week/month 后端不下发窗口，它们的边界本就可推导；给一个服务端并未锚定的倒计时是误导。
- **`resets_at` 解析不出来就直接不显示**，而不是渲染成 `Invalid Date`。

`ru.json` 未动：它的 `quota` 段在上游就是空的，单独加一个键只会制造半吊子翻译。

## 兼容性

两个字段都是可选的。后端未部署时前端不显示提示，不会报错——所以本 PR 可以在后端合入后任意时间合并，无强顺序要求。

## 影响目录

仅 `codeProxy/`：`features/period-spending`、`packages/api-client`、`packages/i18n`。

## 验证

- `bun run lint`：0 errors（18 个预存在 warning，均与本次改动无关）
- `bun run design:check`、`bun run build`、`bun run bundle:diff`：通过
- `bun run test:ci`：1339/1340

关于那 1 个失败：`ApiKeysPage.test.tsx` 的 30 秒超时，与本改动无关（整轮耗时 698 秒，并行压满）。单独跑该文件 18/18 通过、耗时 47 秒，按并行超时误报处理。

新增测试覆盖：5h 显示重置时刻、日历周期不显示、非法 `resets_at` 不渲染成 Invalid Date。

🤖 Generated with [Claude Code](https://claude.com/claude-code)