### PR TITLE
refactor(quota): drop the retired 5h projection warming error

### DIFF
--- a/features/period-spending/formatQuotaValidationError.ts
+++ b/features/period-spending/formatQuotaValidationError.ts
@@ -23,8 +23,5 @@ export const formatQuotaValidationError = (error: unknown, t: TFunction): string
   if (parsed.code === "period_day_legacy_conflict") {
     return t("quota.validation.period_day_legacy_conflict");
   }
-  if (parsed.code === "five_hour_quota_projection_warming") {
-    return t("quota.validation.five_hour_projection_warming");
-  }
   return parsed.message || t("common.operation_failed");
 };

--- a/packages/api-client/src/endpoints/period-spending.ts
+++ b/packages/api-client/src/endpoints/period-spending.ts
@@ -55,8 +55,7 @@ export interface CappedKey {
 
 export type QuotaValidationErrorCode =
   | "key_period_limit_exceeds_account"
-  | "period_day_legacy_conflict"
-  | "five_hour_quota_projection_warming";
+  | "period_day_legacy_conflict";
 
 export interface QuotaValidationErrorDetails {
   period?: PeriodSpendingPeriod;

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -4790,8 +4790,7 @@
     },
     "validation": {
       "key_exceeds_account": "Key {{period}} quota {{keyLimit}} exceeds the account {{period}} quota {{accountLimit}}",
-      "period_day_legacy_conflict": "Daily quota conflicts with the legacy daily spending limit.",
-      "five_hour_projection_warming": "The 5-hour quota is temporarily unavailable while usage projection warms up."
+      "period_day_legacy_conflict": "Daily quota conflicts with the legacy daily spending limit."
     },
     "lifetime_usage_hint": "{{used}} used this cycle · {{remaining}} left; grant again from Reset quota"
   },

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -4807,8 +4807,7 @@
     },
     "validation": {
       "key_exceeds_account": "Key {{period}}额度 {{keyLimit}} 超过账号{{period}}额度 {{accountLimit}}",
-      "period_day_legacy_conflict": "每日额度与旧版每日消费限额冲突。",
-      "five_hour_projection_warming": "5 小时配额正在准备使用数据，请稍后再试。"
+      "period_day_legacy_conflict": "每日额度与旧版每日消费限额冲突。"
     },
     "lifetime_usage_hint": "本轮已用 {{used}} · 剩余 {{remaining}}；用完后可在「重置配额」中重新发放"
   },


### PR DESCRIPTION
后端不再返回 `five_hour_quota_projection_warming`，删掉前端对它的处理与文案。

## 背景

5h 配额过去是滚动窗口，回看过去五小时的分钟桶。因为回看需要足够历史，后端在分钟桶覆盖不足五小时时禁止配置 5h 限额，返回 409 `five_hour_quota_projection_warming`。

窗口改成「首次计费消费锚定的固定窗口」后，anchor 与分钟桶在同一事务写入，不可能早于覆盖起点，用量不会被低估——门禁已无技术必要，只会让全新部署的实例在前五小时无法配置 5h 限额。CliRelay kittors/CliRelay#1014 已移除该门禁并停止返回这个错误码，这里的分支和两条文案随之不可达。

## 改了什么

- `QuotaValidationErrorCode` 移除 `five_hour_quota_projection_warming`
- `formatQuotaValidationError` 移除对应分支
- 删除 en / zh-CN 的 `quota.validation.five_hour_projection_warming`（ru 本来就没有这条）

`formatQuotaValidationError` 现有测试没有覆盖这个错误码，所以没有测试需要改。

## 兼容性

未识别的 code 会落到 `parsed.message || t("common.operation_failed")`。万一遇到尚未升级的旧后端返回这个码，界面会显示服务端英文原文而不是空白错误，不会退化成崩溃或静默失败。

按 expand/contract 顺序，本 PR 在 kittors/CliRelay#1014 合入 `dev` 之后再合。

## 验证

rebase 到最新 `dev`（含 5h 倒计时 PR #999，它改了本 PR 涉及的同三个文件，rebase 无冲突）**之前**跑过一次完整 `./scripts/ci-pr.sh`，退出码 0 全绿。

rebase **之后**重跑完整 `./scripts/ci-pr.sh`，退出码 1。逐步结果：

- 绿：lint、design:check、boundary:imports、size:check、surface:check、audit:deps、`test:ci`（182 文件 / 1340 测试全过）、build、bundle:diff
- 红：e2e 3 个用例 —— `multi-tenant-auth.spec.ts` 的 307、647、791

这 3 个 e2e 失败与本 PR 无关，依据是基线对照：把本 PR 改过的 4 个文件全部 `git checkout origin/dev --` 还原后，在同一台机器跑同样的命令，失败的是**逐字相同**的 3 个用例（23 passed / 3 failed）。属于本机环境固有失败。

GHA 侧 `quality-build-e2e`、`vitest-1/2`、`vitest-2/2`、`test-build` 全部 SUCCESS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)