### PR TITLE
feat(image-generation): offer the GPT Image 2.5 quality levels

### DIFF
--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -2211,7 +2211,7 @@
     "param_image_desc": "Image file to edit, uploaded with multipart/form-data.",
     "param_images_desc": "Image files to edit. Repeat the multipart/form-data `image` field, up to 5 images.",
     "param_size_desc": "Optional size. Use a preset or a positive integer widthxheight value, for example 4096x2304. The longest edge must be 8192 or less, and total pixels must not exceed 8192x8192.",
-    "param_quality_desc": "Optional quality: low, medium, or high.",
+    "param_quality_desc": "Optional quality: low, medium, high, xhigh, max, or auto.",
     "param_n_desc": "Number of images to generate. Recommended range: 1-4.",
     "param_response_format_desc": "Use b64_json so request logs can preview the generated image directly.",
     "response_created_desc": "Server-side creation timestamp.",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -1880,7 +1880,7 @@
     "param_image_desc": "Файл изображения для редактирования, загружается через multipart/form-data.",
     "param_images_desc": "Файлы изображения для редактирования. Повторяйте поле `image` в multipart/form-data, максимум 5 файлов.",
     "param_size_desc": "Опциональный размер: пресет или положительные целые числа widthxheight, например 4096x2304. Длинная сторона не больше 8192, всего пикселей не больше 8192x8192.",
-    "param_quality_desc": "Опциональное качество: low, medium или high.",
+    "param_quality_desc": "Опциональное качество: low, medium, high, xhigh, max или auto.",
     "param_n_desc": "Количество изображений. Рекомендуемый диапазон: 1-4.",
     "param_response_format_desc": "Используйте b64_json, чтобы request logs могли показать preview.",
     "response_created_desc": "Timestamp создания на сервере.",

--- a/packages/i18n/src/locales/zh-CN.json
+++ b/packages/i18n/src/locales/zh-CN.json
@@ -2228,7 +2228,7 @@
     "param_image_desc": "要编辑的图片文件，使用 multipart/form-data 上传。",
     "param_images_desc": "要编辑的图片文件，使用 multipart/form-data 的 image 字段重复上传，最多 5 张。",
     "param_size_desc": "可选分辨率，支持预设或正整数 宽x高，例如 4096x2304；最长边不超过 8192，总像素不超过 8192x8192。",
-    "param_quality_desc": "可选质量：low、medium、high。",
+    "param_quality_desc": "可选质量：low、medium、high、xhigh、max、auto。",
     "param_n_desc": "生成数量，当前建议 1-4 张。",
     "param_response_format_desc": "建议传 b64_json，便于直接在请求日志中预览图片。",
     "response_created_desc": "服务端创建时间戳。",

--- a/pages/image-generation/components/ImageGenerationPageContent.tsx
+++ b/pages/image-generation/components/ImageGenerationPageContent.tsx
@@ -21,6 +21,19 @@ import {
 } from "@features/image-model-picker";
 import { imageStageClassName } from "./stageStyles";
 import { VISIBLE_ENDPOINT_DOCS, type EndpointDoc, type SpecRow } from "./apiDocs";
+import {
+  COUNT_OPTIONS,
+  DEFAULT_QUALITY,
+  DEFAULT_SIZE_OPTION,
+  DEFAULT_SIZE_OPTIONS,
+  IMAGE_GENERATION_MAX_SIZE_EDGE,
+  IMAGE_GENERATION_MAX_SIZE_PIXELS,
+  IMAGE_GENERATION_SIZE_PATTERN,
+  MAX_UPLOAD_IMAGES,
+  QUALITY_OPTIONS,
+  SIZE_OPTIONS,
+  type QualityOption,
+} from "./generationOptions";
 
 /**
  * Fallback model id, used only until the server's catalog arrives and as the tab
@@ -48,22 +61,6 @@ const IMAGE_GENERATION_PHASE_STATUS_INDEX: Record<string, number> = {
   image_download: 3,
   completed: 3,
 };
-const DEFAULT_SIZE_OPTION = "1024x1024";
-const SIZE_OPTIONS = [
-  DEFAULT_SIZE_OPTION,
-  "1792x1024",
-  "1024x1792",
-  "2560x1440",
-  "2160x3840",
-] as const;
-const DEFAULT_SIZE_OPTIONS = new Set<string>(SIZE_OPTIONS);
-const QUALITY_OPTIONS = ["low", "medium", "high"] as const;
-const COUNT_OPTIONS = [1, 2, 3, 4] as const;
-const MAX_UPLOAD_IMAGES = 5;
-const IMAGE_GENERATION_SIZE_PATTERN = /^[1-9]\d*x[1-9]\d*$/;
-const IMAGE_GENERATION_MAX_SIZE_EDGE = 8192;
-const IMAGE_GENERATION_MAX_SIZE_PIXELS =
-  IMAGE_GENERATION_MAX_SIZE_EDGE * IMAGE_GENERATION_MAX_SIZE_EDGE;
 
 type ImageMode = "generations" | "edits";
 type GeneratedImage = { src: string; revisedPrompt?: string };
@@ -378,7 +375,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
   const [sizePresets, setSizePresets] = useState<string[]>(() =>
     mergeImageGenerationSizePresets([]),
   );
-  const [quality, setQuality] = useState<(typeof QUALITY_OPTIONS)[number]>("medium");
+  const [quality, setQuality] = useState<QualityOption>(DEFAULT_QUALITY);
   const [count, setCount] = useState<(typeof COUNT_OPTIONS)[number]>(1);
   const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -864,7 +861,7 @@ function ImageGenerationTestModal({ open, onClose }: { open: boolean; onClose: (
               fullWidth={false}
               aria-label={t("image_generation.quality_label")}
               value={quality}
-              onChange={(value) => setQuality(value as (typeof QUALITY_OPTIONS)[number])}
+              onChange={(value) => setQuality(value as QualityOption)}
               options={QUALITY_OPTIONS.map((value) => ({
                 value,
                 label: value,

--- a/pages/image-generation/components/generationOptions.ts
+++ b/pages/image-generation/components/generationOptions.ts
@@ -1,0 +1,43 @@
+/**
+ * Selectable request options for the image generation page.
+ *
+ * These are plain choice lists with no dependency on page state, extracted so the
+ * page component can keep shrinking under the file size gate — it is already over
+ * the limit and may only get smaller.
+ */
+
+export const DEFAULT_SIZE_OPTION = "1024x1024";
+
+export const SIZE_OPTIONS = [
+  DEFAULT_SIZE_OPTION,
+  "1792x1024",
+  "1024x1792",
+  "2560x1440",
+  "2160x3840",
+] as const;
+
+export const DEFAULT_SIZE_OPTIONS = new Set<string>(SIZE_OPTIONS);
+
+/**
+ * Quality levels offered by the picker.
+ *
+ * xhigh, max and auto arrived with GPT Image 2.5. The server accepts all six and
+ * leaves it to the upstream endpoint to decide what it honours, so the picker
+ * offers the same set rather than a narrower one the server would have allowed.
+ */
+export const QUALITY_OPTIONS = ["low", "medium", "high", "xhigh", "max", "auto"] as const;
+
+export type QualityOption = (typeof QUALITY_OPTIONS)[number];
+
+export const DEFAULT_QUALITY: QualityOption = "medium";
+
+export const COUNT_OPTIONS = [1, 2, 3, 4] as const;
+
+export const MAX_UPLOAD_IMAGES = 5;
+
+export const IMAGE_GENERATION_SIZE_PATTERN = /^[1-9]\d*x[1-9]\d*$/;
+
+export const IMAGE_GENERATION_MAX_SIZE_EDGE = 8192;
+
+export const IMAGE_GENERATION_MAX_SIZE_PIXELS =
+  IMAGE_GENERATION_MAX_SIZE_EDGE * IMAGE_GENERATION_MAX_SIZE_EDGE;


### PR DESCRIPTION
配合后端 [kittors/CliRelay#1018](https://github.com/kittors/CliRelay/pull/1018)（注册 GPT Image 2.5）。

## 改动

`xhigh` / `max` / `auto` 是 GPT Image 2.5 新增的质量档位。后端已接受全部六档，由上游端点决定实际认哪些，因此选择器不应该比 API 更窄。

选项常量移到 `generationOptions.ts`：`ImageGenerationPageContent.tsx` 已超过文件大小门禁、只能缩小，而这些是与页面状态无关的纯选项列表，抽出去正好腾出空间（1191 → 1187 行）。

同步更新 en / zh-CN / ru 三处 quality 参数说明。

## 影响目录

仅 `codeProxy/`。后端在独立 PR。

## 验证

`./scripts/ci-pr.sh` — exit 0，含 lint、design:check、1340 个 vitest 用例、build、bundle:diff、文件大小门禁、e2e。